### PR TITLE
Fixed issue #1221 - chrome security error

### DIFF
--- a/planet/index.html
+++ b/planet/index.html
@@ -42,8 +42,8 @@
                 <ul class="right"><li><a id="planet-open-file" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip="Open project from file"><i class="material-icons">folder_open</i></a></li></ul>
                 <ul class="right"><li><a id="planet-new-project" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip="New project"><i class="material-icons">note_add</i></a></li></ul>
                 <ul class="right tabs tabs-transparent" id="localglobal">
-                    <li class="tab"><a class="active" id="local-tab" href="#local" onclick="toggleSearch(false);">Local</a></li>
-                    <li class="tab"><a id="global-tab" href="#global" onclick="toggleSearch(true);">Global</a></li>
+                    <li class="tab"><a class="active" id="local-tab" href="#local">Local</a></li>
+                    <li class="tab"><a id="global-tab" href="#global">Global</a></li>
                 </ul>
             </div>
             <div class="nav-content" id="searchcontainer" style="display: none;">
@@ -138,7 +138,7 @@
                         </div>
                         <div class="flexchips", id="morechips">
                         </div>
-                        <a class="waves-effect btn-flat centre-button" id="view-more-chips" onclick="toggleExpandable('morechips','flexchips');toggleText('view-more-chips','View More','View Less');">View More</a>
+                        <a class="waves-effect btn-flat centre-button" id="view-more-chips">View More</a>
                     </div>
                 </div>
                 <div class="container">

--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -129,4 +129,14 @@ $(document).ready(function() {
             document.getElementById('search-close').style.display = 'none';
         }
     });
+    document.getElementById('local-tab').addEventListener('click', function (evt) {
+        toggleSearch(false);
+    });
+    document.getElementById('global-tab').addEventListener('click', function (evt) {
+        toggleSearch(true);
+    });
+    document.getElementById('view-more-chips').addEventListener('click', function (evt) {
+        toggleExpandable('morechips','flexchips');
+        toggleText('view-more-chips','View More','View Less');
+    });
 });


### PR DESCRIPTION
The search bar did not appear on some versions of Chromium due to a security policy preventing the execution of inline JS (index.html:46 Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self' blob: filesystem: chrome-extension-resource:". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.)

I moved a few instances of inline JS in index.html into the helper.js file, which should (hopefully) solve the problem.

(nb. I have been unable to reproduce the bug so cannot verify that it is fixed myself, but MB still appears to work)