### PR TITLE
Correct evaluation of createjs.Tween.hasActiveTweens()

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2880,7 +2880,7 @@ define(MYDEFINES, function (compatibility) {
         function __tick(event) {
             // This set makes it so the stage only re-renders when an
             // event handler indicates a change has happened.
-            if (update || createjs.Tween.hasActiveTweens) {
+            if (update || createjs.Tween.hasActiveTweens()) {
                 update = false; // Only update once
                 stage.update(event);
             }


### PR DESCRIPTION
This was evaluating a function as if it was an attribute, which always returns true. That causes the ticker to redraw the screen continuously, resulting in high cpu usage and out-of-sync playback.