### PR TITLE
Hide the Palette when clicked again

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -569,7 +569,12 @@ function Palettes () {
             }, 500);
 
             that.dict[name]._moveMenu(that.initial_x, that.initial_y);
-            that.showPalette(name);
+            
+            if (!that.dict[name].visible) {
+                that.showPalette(name);
+            } else {
+                that.dict[name].hide();
+            }
             that.refreshCanvas();
         });
     };


### PR DESCRIPTION
During the MB workshop in Tokyo, I saw many teachers trying to close the palette by clicking the icon on the menu which totally makes sense to me while nothing happens. Currently, the only way to close the palette is by clicking the X button which is not intuitive. Therefore, I would like to propose to give users another way of closing the palette by the icon on the menu.

This is only a few lines of change but it should improve the usability of the MB significantly.