### PR TITLE
Fixes the rendering of collapsed timbre block

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -922,11 +922,11 @@ function initBasicProtoBlocks(palettes, blocks, beginnerMode) {
     blocks.protoBlockDict['timbre'] = newblock;
     //.TRANS: timbre is the character or quality of a musical sound
     newblock.staticLabels.push(_('timbre'));
-    newblock.extraWidth = 20;
+    newblock.extraWidth = 50;
     newblock.adjustWidthToLabel();
     newblock.labelOffset = 15;
     newblock.stackClampOneArgBlock();
-    newblock.defaults.push(_('custom'));
+    /*newblock.defaults.push(_('custom'));*/ // <--removing this seems to fix what timbre looks like when collapsed. Any reason for it?
     if (beginnerMode && !beginnerBlock('timbre')) {
         newblock.hidden = true;
     }


### PR DESCRIPTION
* Fix what Timbre block looks like when collapsed. I found an inconsistent part of the code and commented it out.
