### PR TITLE
Change collapsed step pitch from "+/- value" to "up/down value"

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1464,9 +1464,9 @@ function Block(protoblock, blocks, overrideName) {
             var c1 = this.blocks.blockList[c].connections[1];
             if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value < 0) {
                 //.TRANS: scalar step
-                return _('step') + ' down' + ' ' + Math.abs(this.blocks.blockList[c1].value);
+                return _('down') + ' ' + Math.abs(this.blocks.blockList[c1].value);
 	    } else
-                return _('step') + ' up' + ' ' + this.blocks.blockList[c1].value;
+                return _('up') + ' ' + this.blocks.blockList[c1].value;
             break;
         case 'pitchnumber':
             var c1 = this.blocks.blockList[c].connections[1];

--- a/js/block.js
+++ b/js/block.js
@@ -1462,10 +1462,11 @@ function Block(protoblock, blocks, overrideName) {
             break;
         case 'steppitch':
             var c1 = this.blocks.blockList[c].connections[1];
-            if (this.blocks.blockList[c1].name === 'number') {
+            if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value < 0) {
                 //.TRANS: scalar step
-                return _('step') + ' ' + this.blocks.blockList[c1].value;
-            }
+                return _('step') + ' down' + ' ' + Math.abs(this.blocks.blockList[c1].value);
+	    } else
+                return _('step') + ' up' + ' ' + this.blocks.blockList[c1].value;
             break;
         case 'pitchnumber':
             var c1 = this.blocks.blockList[c].connections[1];


### PR DESCRIPTION
This patch explicitly display "up" and "down" for step pitch when collapsed.

I think up and down is consistent with forward/back and crescendo/decrescendo

In Japanese, it wil be 上 and 下 or うえ and した