### PR TITLE
2018 10 06 scale step

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1464,9 +1464,9 @@ function Block(protoblock, blocks, overrideName) {
             var c1 = this.blocks.blockList[c].connections[1];
             if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value < 0) {
                 //.TRANS: scalar step
-                return _('step') + ' down' + ' ' + Math.abs(this.blocks.blockList[c1].value);
+                return _('down') + ' ' + Math.abs(this.blocks.blockList[c1].value);
 	    } else
-                return _('step') + ' up' + ' ' + this.blocks.blockList[c1].value;
+                return _('up') + ' ' + this.blocks.blockList[c1].value;
             break;
         case 'pitchnumber':
             var c1 = this.blocks.blockList[c].connections[1];

--- a/js/block.js
+++ b/js/block.js
@@ -1462,10 +1462,11 @@ function Block(protoblock, blocks, overrideName) {
             break;
         case 'steppitch':
             var c1 = this.blocks.blockList[c].connections[1];
-            if (this.blocks.blockList[c1].name === 'number') {
+            if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value < 0) {
                 //.TRANS: scalar step
-                return _('step') + ' ' + this.blocks.blockList[c1].value;
-            }
+                return _('step') + ' down' + ' ' + Math.abs(this.blocks.blockList[c1].value);
+	    } else
+                return _('step') + ' up' + ' ' + this.blocks.blockList[c1].value;
             break;
         case 'pitchnumber':
             var c1 = this.blocks.blockList[c].connections[1];


### PR DESCRIPTION
This adds degree symbol and comma between scale degree and octave when scale degree is collapsed in note block. (picture below)

It also consequently fixes a bug.

Output of console when trying to collapse "scale degree" in note block before patch:
<pre>
utils.js:233 Uncaught TypeError: replaced.replace is not a function
    at _ (utils.js:233)
    at Block._getPitch (block.js:1453)
    at Block._newNoteLabel (block.js:1413)
    at Block.collapseToggle (block.js:1248)
    at a.<anonymous> (block.js:1685)
    at VM878 easeljs.min.js:12
    at a.b._dispatchEvent (VM878 easeljs.min.js:12)
    at a.b._dispatchEvent (VM878 easeljs.min.js:12)
    at a.b.dispatchEvent (VM878 easeljs.min.js:12)
    at a.b._dispatchMouseEvent (VM878 easeljs.min.js:13)
</pre>

New look of Scale Degree:
![screenshot at 2018-10-06 21 18 40 scale degree collapsed with degree symbol](https://user-images.githubusercontent.com/13454579/46577193-7d640700-c9ae-11e8-946d-644131fefea4.png)
