### PR TITLE
2018 10 06 scale degree

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1450,7 +1450,7 @@ function Block(protoblock, blocks, overrideName) {
             if (this.blocks.blockList[c2].name === 'number') {
                 if (this.blocks.blockList[c1].name === 'number') {
                     //.TRANS: scale degree
-                    return _('degree') + ' ' + _(this.blocks.blockList[c1].value) + ' ' + this.blocks.blockList[c2].value;
+                    return this.blocks.blockList[c1].value + 'th,' + ' ' + this.blocks.blockList[c2].value;
                 }
             }
             break;

--- a/js/block.js
+++ b/js/block.js
@@ -1450,7 +1450,7 @@ function Block(protoblock, blocks, overrideName) {
             if (this.blocks.blockList[c2].name === 'number') {
                 if (this.blocks.blockList[c1].name === 'number') {
                     //.TRANS: scale degree
-                    return this.blocks.blockList[c1].value + 'th,' + ' ' + this.blocks.blockList[c2].value;
+                    return this.blocks.blockList[c1].value + '°,' + ' ' + this.blocks.blockList[c2].value;
                 }
             }
             break;


### PR DESCRIPTION
This adds degree symbol and comma between scale degree and octave when scale degree is collapsed in note block. (picture below)

It also consequently fixes a bug.

Output of console when trying to collapse "scale degree" in note block before patch:
<pre>
utils.js:233 Uncaught TypeError: replaced.replace is not a function
    at _ (utils.js:233)
    at Block._getPitch (block.js:1453)
    at Block._newNoteLabel (block.js:1413)
    at Block.collapseToggle (block.js:1248)
    at a.<anonymous> (block.js:1685)
    at VM878 easeljs.min.js:12
    at a.b._dispatchEvent (VM878 easeljs.min.js:12)
    at a.b._dispatchEvent (VM878 easeljs.min.js:12)
    at a.b.dispatchEvent (VM878 easeljs.min.js:12)
    at a.b._dispatchMouseEvent (VM878 easeljs.min.js:13)
</pre>

New look of Scale Degree:
![screenshot at 2018-10-06 21 18 40 scale degree collapsed with degree symbol](https://user-images.githubusercontent.com/13454579/46577193-7d640700-c9ae-11e8-946d-644131fefea4.png)
