### PR TITLE
naming for scale degree 1st, 2nd, 3rd, 4th and above; fixes bug

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1448,10 +1448,19 @@ function Block(protoblock, blocks, overrideName) {
             var c1 = this.blocks.blockList[c].connections[1];
             var c2 = this.blocks.blockList[c].connections[2];
             if (this.blocks.blockList[c2].name === 'number') {
-                if (this.blocks.blockList[c1].name === 'number') {
-                    //.TRANS: scale degree
-                    return _('degree') + ' ' + _(this.blocks.blockList[c1].value) + ' ' + this.blocks.blockList[c2].value;
-                }
+                if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value === 1 ) {
+                    //.TRANS: scale degree = 1st
+                    return this.blocks.blockList[c1].value + _('st, ') + this.blocks.blockList[c2].value;
+		} else if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value === 2 ) {
+                    //.TRANS: scale degree = 2nd
+                    return this.blocks.blockList[c1].value + _('nd, ') + this.blocks.blockList[c2].value;
+		} else if (this.blocks.blockList[c1].name === 'number' && this.blocks.blockList[c1].value === 3 ) {
+		    //.TRANS: scale degree = 3rd
+		    return this.blocks.blockList[c1].value + _('rd, ') + this.blocks.blockList[c2].value;
+		} else if (this.blocks.blockList[c1].name === 'number') {
+		    //.TRANS: scale degree = 4th and above
+                    return this.blocks.blockList[c1].value + _('th, ') + this.blocks.blockList[c2].value;
+		}
             }
             break;
         case 'hertz':


### PR DESCRIPTION
I am unsure of whether or not the translation is implemented correctly.

What compounded my confusion, and I think this is what caused the bug in the first place, is the current master has `_(this.blocks.blockList[c1].value)` in the code (as if it is to be translated), but I do not see anything else like it in the code... actually now I see `_(this.blocks.blockList[c1].value)` whose code seems to run just fine...

Does _(this.*) also have something to do with the translation?

At any rate adding _(this.*) seems to break the program (tried it now)...

Otherwise, this patch fixes the current bug and gets us 1st, 2nd, 3rd, 4th and up in English.