### PR TITLE
Replaced placeholder translation function in Planet

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1620,7 +1620,7 @@ define(MYDEFINES, function (compatibility) {
                 this.init = function () {
                     this.iframe = document.getElementById('planet-iframe');
                     try {
-                        this.iframe.contentWindow.makePlanet(_THIS_IS_MUSIC_BLOCKS_, storage);
+                        this.iframe.contentWindow.makePlanet(_THIS_IS_MUSIC_BLOCKS_, storage, window._);
                         this.planet = this.iframe.contentWindow.p;
                         this.planet.setLoadProjectFromData(this.loadProjectFromData.bind(this));
                         this.planet.setPlanetClose(this.closePlanet.bind(this));

--- a/planet/js/main.js
+++ b/planet/js/main.js
@@ -1,10 +1,7 @@
 window.p;
 
-function _(text) {
-    return text;
-};
-
-window.makePlanet = function(isMusicBlocks,storage) {
+window.makePlanet = function(isMusicBlocks,storage,translationFunction) {
+    window._=translationFunction;
     window.p = new Planet(isMusicBlocks,storage);
     window.p.init();
 };


### PR DESCRIPTION
Previously, there was a placeholder i18n function in planet/js/main.js which prevented i18n from working properly on Planet - this has now been removed, and the 'main' i18n function for MB is now passed to Planet through the PlanetInterface.