### PR TITLE
Adds delay to resize (Fixes #1452)

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,11 @@
                 };
 
                 function resizeFixed() {
+                  setTimeout(function () { 
                     $t_fixed.find("th").each(function(index) {
                         $(this).css("width", $this.find("th").eq(index).outerWidth() + "px");
                     });
+                  }, 100);
                 };
 
                 function scrollFixed() {


### PR DESCRIPTION
I *think* the problem is that when the maximise button is clicked the resize functions gets the width of the screen before the maximise button is pressed.
It then resizes the window to this width (which is the window size prior to the maximise button press).

I added a delay to make sure this doesn't happen.