### PR TITLE
Make preview volume louder

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3499,8 +3499,8 @@ function Block(protoblock, blocks, overrideName) {
                 that.blocks.logo.synth.loadSynth(0, 'default');
             }
 
-            that.blocks.logo.synth.setMasterVolume(DEFAULTVOLUME);
-            that.blocks.logo.setSynthVolume(0, 'default', DEFAULTVOLUME);
+            that.blocks.logo.synth.setMasterVolume(PREVIEWVOLUME);
+            that.blocks.logo.setSynthVolume(0, 'default', PREVIEWVOLUME);
             that.blocks.logo.synth.trigger(0, [obj[0] + obj[1]], 1 / 8, 'default', null, null);
 
             __selectionChanged();

--- a/js/logo.js
+++ b/js/logo.js
@@ -11,6 +11,7 @@
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
 const DEFAULTVOLUME = 50;
+const PREVIEWVOLUME = 80;
 const TONEBPM = 240;  // Seems to be the default.
 const TARGETBPM = 90;  // What we'd like to use for beats per minute
 const DEFAULTDELAY = 500;  // milleseconds


### PR DESCRIPTION
Fixes issue #1423. I made a new constant, `PREVIEWVOLUME` and the `__pitchPreview` function now uses this instead of `DEFAULTVOLUME`.

Note: something strange happened when I force pushed, and my old PR (#1604) didn't update the commits after that. So I opened this one.