### PR TITLE
Left-aligned Planet logo (Fixes #1631)

### DIFF
--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -1,103 +1,118 @@
-#planeticon{
+#planeticon {
 	font-size: 3rem;
 }
 
-#localglobal{
+#localglobal {
 	width: -webkit-max-content !important;
 	width: -moz-max-content !important;
 	width: max-content !important;
 }
 
-#tagsadd{
+#tagsadd {
 	padding-top: 10px;
 }
-.no-margin-left{
+
+.no-margin-left {
 	margin-left: 0 !important;
 }
-.project-image{
+
+.project-image {
 	background-color: #96D3F3;
 }
-.project-card-image{
+
+.project-card-image {
 	position: absolute !important;
-    top: 0 !important;
-    bottom: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    height: 100% !important;
+	top: 0 !important;
+	bottom: 0 !important;
+	left: 0 !important;
+	right: 0 !important;
+	height: 100% !important;
 }
-.no-padding{
+
+.no-padding {
 	padding: 0rem;
 }
-.project-icon{
+
+.project-icon {
 	margin-right: 3px !important;
 }
-.projectscontainer{
+
+.projectscontainer {
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: row;
-            flex-direction: row;
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-    margin: 0 auto;
-    -webkit-box-pack: left;
-        -ms-flex-pack: left;
-            justify-content: left;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: row;
+	flex-direction: row;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	margin: 0 auto;
+	-webkit-box-pack: left;
+	-ms-flex-pack: left;
+	justify-content: left;
 }
-.flexcontainer{
+
+.flexcontainer {
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
 	-webkit-box-pack: justify;
-	    -ms-flex-pack: justify;
-	        justify-content: space-between;
+	-ms-flex-pack: justify;
+	justify-content: space-between;
 }
-.flexchips{
+
+.flexchips {
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
 	-ms-flex-wrap: wrap;
-	    flex-wrap: wrap;
+	flex-wrap: wrap;
 	-webkit-box-pack: justify;
-	    -ms-flex-pack: justify;
-	        justify-content: center;
+	-ms-flex-pack: justify;
+	justify-content: center;
 }
-.close-button{
-	position:absolute;
-	top:0;
-	right:0;
+
+.close-button {
+	position: absolute;
+	top: 0;
+	right: 0;
 	padding-top: 15px;
 	padding-right: 15px;
 	color: #343434;
 }
-.share-card{
-	position:  absolute;
-    z-index:  200;
-    left:  50%;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    min-width: 350px;
+
+.share-card {
+	position: absolute;
+	z-index: 200;
+	left: 50%;
+	-webkit-transform: translateX(-50%);
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
+	min-width: 350px;
 }
-.shareurltext{
+
+.shareurltext {
 	padding-bottom: 0px !important;
 }
-.shareurltitle{
+
+.shareurltitle {
 	font-size: 1.2rem;
 	font-weight: 500;
 }
-.shareurlinput{
+
+.shareurlinput {
 	margin-top: 5px;
 	width: 90% !important;
 	text-align: left;
 	visibility: visible;
 }
+
 .shareurl-advanced {
 	display: none;
-    padding-bottom: 20px;
+	padding-bottom: 20px;
 }
+
 .shareurl-advanced.open {
 	display: block;
 }
@@ -106,182 +121,214 @@
 	position: absolute;
 	margin: 4.5% 0.05% 0 4.5% !important;
 }
+
 #morechips {
 	display: none;
 }
+
 #morechips.open {
 	display: -webkit-box;
 	display: -ms-flexbox;
 	display: flex;
 	-ms-flex-wrap: wrap;
-	    flex-wrap: wrap;
+	flex-wrap: wrap;
 }
-.shareurl-advanced-title{
+
+.shareurl-advanced-title {
 	font-size: 1.2rem;
 	font-weight: 500;
 	margin-bottom: 10px;
 }
+
 /* label color */
 .search label {
 	color: #fff !important;
 }
+
 /* label focus color */
-.search input[type=text]:focus + label {
+.search input[type=text]:focus+label {
 	color: #fff !important;
 }
+
 /* label underline focus color */
 .search input[type=text]:focus {
 	border-bottom: 1px solid #fff !important;
 	-webkit-box-shadow: 0 1px 0 0 #fff !important;
-	        box-shadow: 0 1px 0 0 #fff !important;
+	box-shadow: 0 1px 0 0 #fff !important;
 }
+
 /* icon prefix focus color */
 #global-search .prefix.active {
 	color: #fff !important;
 }
+
 #global-search::-webkit-input-placeholder {
-	color: rgba(255,255,255,0.7) !important;
+	color: rgba(255, 255, 255, 0.7) !important;
 }
- 
-#global-search:-moz-placeholder { /* Firefox 18- */
-	color: rgba(255,255,255,0.7) !important;  
+
+#global-search:-moz-placeholder {
+	/* Firefox 18- */
+	color: rgba(255, 255, 255, 0.7) !important;
 }
- 
-#global-search:-moz-placeholder {  /* Firefox 19+ */
-	color: rgba(255,255,255,0.7) !important;  
+
+#global-search:-moz-placeholder {
+	/* Firefox 19+ */
+	color: rgba(255, 255, 255, 0.7) !important;
 }
- 
-#global-search:-ms-input-placeholder {  
-	color: rgba(255,255,255,0.7) !important;  
+
+#global-search:-ms-input-placeholder {
+	color: rgba(255, 255, 255, 0.7) !important;
 }
-#searchicon{
+
+#searchicon {
 	top: -4px;
 	color: #fff !important;
 }
-.chipselect{
+
+.chipselect {
 	display: inline-block;
-    height: 32px;
-    font-size: 13px;
-    font-weight: 500;
-    color: rgba(0,0,0,0.6);
-    line-height: 32px;
-    padding: 0 12px;
-    border-radius: 16px;
-    background-color: #e4e4e4;
-    margin-bottom: 5px;
-    margin-right: 5px;
+	height: 32px;
+	font-size: 13px;
+	font-weight: 500;
+	color: rgba(0, 0, 0, 0.6);
+	line-height: 32px;
+	padding: 0 12px;
+	border-radius: 16px;
+	background-color: #e4e4e4;
+	margin-bottom: 5px;
+	margin-right: 5px;
 }
-.chipselect.selected{
+
+.chipselect.selected {
 	background-color: #26a69a;
-    color: #fff;
+	color: #fff;
 }
-.chipselect.selected-special{
+
+.chipselect.selected-special {
 	background-color: #26a69a;
-    color: #fff;
+	color: #fff;
 }
-.chipselect.cursor:not(.selected-special){
+
+.chipselect.cursor:not(.selected-special) {
 	cursor: pointer;
 }
-.centre-button{
+
+.centre-button {
 	left: 50%;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    margin-top: 10px;
+	-webkit-transform: translateX(-50%);
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
+	margin-top: 10px;
 }
+
 .global-title {
 	white-space: nowrap;
-    overflow: hidden;
-    -o-text-overflow: ellipsis;
-       text-overflow: ellipsis;
+	overflow: hidden;
+	-o-text-overflow: ellipsis;
+	text-overflow: ellipsis;
 }
+
 .subheading {
 	font-weight: 300;
-    font-size: 1.1rem;
+	font-size: 1.1rem;
 }
+
 .no-margin-bottom {
 	margin-bottom: 0px !important;
 }
+
 .likes-count {
 	position: relative;
-    top: -7px;
+	top: -7px;
 }
+
 #search-close {
 	display: none;
-    position:  absolute;
-    top:  -4px;
-    cursor:  pointer;
+	position: absolute;
+	top: -4px;
+	cursor: pointer;
 }
-#localglobal{
+
+#localglobal {
 	top: 7px;
 }
 
-	#logo-container {
-		left: initial !important;
-		-webkit-transform: initial !important;
-		    -ms-transform: initial !important;
-				transform: initial !important;
-	}
+#logo-container {
+	left: initial !important;
+	-webkit-transform: initial !important;
+	-ms-transform: initial !important;
+	transform: initial !important;
+}
 
-	@media only screen and (max-width: 655px)  {
-		#logo-container{
-			font-size: 0;
-		}
+@media only screen and (max-width: 655px) {
+	#logo-container {
+		font-size: 0;
 	}
+}
+
 a {
 	cursor: pointer;
 }
-.error-message{
+
+.error-message {
 	margin-bottom: 10px;
-    color: #f44337;
-}
-.published-cloud{
-	position: absolute;
-    z-index: 100;
-    margin-left: 15px;
-    margin-top: 15px;
-    color: #fff;
+	color: #f44337;
 }
 
-.centre-load{
+.published-cloud {
+	position: absolute;
+	z-index: 100;
+	margin-left: 15px;
+	margin-top: 15px;
+	color: #fff;
+}
+
+.centre-load {
 	left: calc(50% - 18px);
 }
-.absolute{
+
+.absolute {
 	position: absolute;
 }
-.card-image{
+
+.card-image {
 	width: 100%;
-    padding-bottom: 75%;
+	padding-bottom: 75%;
 }
-.report-project-div{
+
+.report-project-div {
 	position: absolute;
 }
-.report-card{
-    position: absolute;
-    left: 0;
-    -webkit-transform: translateX(-50%);
-    -ms-transform: translateX(-50%);
-    transform: translateX(10%);
-    min-width: 350px;
-    bottom: 40px;
-    text-align: left;
+
+.report-card {
+	position: absolute;
+	left: 0;
+	-webkit-transform: translateX(-50%);
+	-ms-transform: translateX(-50%);
+	transform: translateX(10%);
+	min-width: 350px;
+	bottom: 40px;
+	text-align: left;
 }
-.reporttitle{
+
+.reporttitle {
 	font-size: 1.2rem;
 	font-weight: 500;
 }
-.reportinput{
+
+.reportinput {
 	margin-top: 5px;
 	width: 350px;
 	text-align: left;
 	visibility: visible;
 }
-.reportprogress{
+
+.reportprogress {
 	width: calc(100% + 48px);
-    left: -24px;
+	left: -24px;
 }
 
 .material-tooltip {
-	border-radius:23px;
+	border-radius: 23px;
 	max-width: calc(100% - 2px);
 }

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -332,3 +332,8 @@ a {
 	border-radius: 23px;
 	max-width: calc(100% - 2px);
 }
+
+.inactiveLink {
+	pointer-events: none;
+	cursor: default;
+ }

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -215,14 +215,19 @@
 #localglobal{
 	top: 7px;
 }
-@media only screen and (max-width: 500px)  {
+
 	#logo-container {
 		left: initial !important;
 		-webkit-transform: initial !important;
 		    -ms-transform: initial !important;
-		        transform: initial !important;
+				transform: initial !important;
 	}
-}
+
+	@media only screen and (max-width: 655px)  {
+		#logo-container{
+			font-size: 0;
+		}
+	}
 a {
 	cursor: pointer;
 }

--- a/planet/index.html
+++ b/planet/index.html
@@ -42,7 +42,7 @@
     <body>
         <nav class="nav-extended light-green lighten-1" role="navigation">
             <div class="nav-wrapper container">
-                <a id="logo-container" href="#" class="brand-logo"><i class="material-icons" id="planeticon">public</i></a>
+                <a id="logo-container" class="brand-logo inactiveLink"><i class="material-icons" id="planeticon">public</i></a>
                 <ul class="right"><li><a id="close-planet" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">close</i></a></li></ul>
                 <ul class="right"><li><a id="planet-open-file" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">folder_open</i></a></li></ul>
                 <ul class="right"><li><a id="planet-new-project" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">note_add</i></a></li></ul>


### PR DESCRIPTION
When the window is resized, the Planet code becomes central resulting in an overlap as in #1631 

To combat this, I made the Planet logo stay left aligned on resize:
![image](https://user-images.githubusercontent.com/31069982/49754283-938f8b80-fcad-11e8-91fe-31bf4f550493.png)

When the window is very small (<655px wide), in order to prevent further overlap, I made the "Planet" text disappear (I feel this is a good enough compromise as resizing to this extent is very rare):
![image](https://user-images.githubusercontent.com/31069982/49754446-fed95d80-fcad-11e8-8fe8-41636dfd27dd.png)


