### PR TITLE
Fixed broken po strings | Removed quotation marks

### DIFF
--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -1386,7 +1386,7 @@ msgstr "アート"
 
 #: js/turtledefs.js:144
 #: js/turtledefs.js:175
-## Maybe just have "Music Blocks" in roman. Otherwise, ミュージック・ブロックス
+## Maybe just have Music Blocks in roman. Otherwise, ミュージック・ブロックス
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへ ようこそ"
 
@@ -1679,7 +1679,7 @@ msgstr "もっとくわしく しるには"
 #: js/turtledefs.js:207
 ## しょうさい＝詳細
 msgid "A detailed guide to Music Blocks is available."
-msgstr "インターネットから、 ミュージック・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。<a href="https://github.com/sugarlabs/musicblocks/tree/master/guide-ja">https://github.com/sugarlabs/musicblocks/tree/master/guide-ja</a>"
+msgstr "インターネットから、 ミュージック・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
 
 #: js/turtledefs.js:169
 #: js/turtledefs.js:207

--- a/po/ja.po
+++ b/po/ja.po
@@ -1387,7 +1387,7 @@ msgstr "アート"
 
 #: js/turtledefs.js:144
 #: js/turtledefs.js:175
-## Maybe just have "Music Blocks" in roman. Otherwise, ミュージック・ブロックス
+## Maybe just have Music Blocks in roman. Otherwise, ミュージック・ブロックス
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへようこそ"
 
@@ -1680,7 +1680,7 @@ msgstr "もっとくわしく知るには"
 #: js/turtledefs.js:207
 ## しょうさい＝詳細
 msgid "A detailed guide to Music Blocks is available."
-msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。<br><a href=\\"https://github.com/sugarlabs/musicblocks/tree/master/guide-ja\\" target=\\"_blank\\">https://github.com/sugarlabs/musicblocks/tree/master/guide-ja</a>"
+msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
 #: js/turtledefs.js:169
 #: js/turtledefs.js:207
@@ -1691,7 +1691,7 @@ msgstr "ミュージック・ブロックスガイド"
 #: js/turtledefs.js:170
 #: js/turtledefs.js:208
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
-msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、<a href=\\"https://www.gnu.org/philosophy/free-sw.ja.html\\" target=\\"_blank\\">オープンソース</a>のツールだ。"
+msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
 
 #: js/turtledefs.js:170
 #: js/turtledefs.js:208


### PR DESCRIPTION
These strings seemed to be broken.

In this PR, I remove links and found some quotations that may have been confusing the po conversion.

Saved HTML file:
![screenshot at 2018-12-11 13 41 37 colection of manip](https://user-images.githubusercontent.com/13454579/49825252-e2a3f200-fd7b-11e8-8548-a179f675ecec.png)

Help Dialogue:
![screenshot at 2018-12-11 13 42 05 mb is a collection](https://user-images.githubusercontent.com/13454579/49825254-e2a3f200-fd7b-11e8-9f95-966928510764.png)
