### PR TITLE
Replaced "Report Project" with an icon (Fixes #1639)

### DIFF
--- a/lib/materialize-iso.css
+++ b/lib/materialize-iso.css
@@ -3407,8 +3407,8 @@ i.left {
   }
 }
 
-@media only screen and (max-width: 500px) {
-   .materialize-iso .filler, .materialize-iso .logo {
+@media only screen and (max-width: 550px) {
+  .materialize-iso .filler, .materialize-iso .logo {
     display: none;
   }
 
@@ -3427,24 +3427,6 @@ i.left {
   }
 }
 
-@media only screen and (max-width: 600px) {
-  .materialize-iso .filler, .materialize-iso .logo {
-    display: none;
-  }
-  .materialize-iso nav .main i.material-icons {
-    font-size: 22px;  
-    position: relative;
-    margin: 0;
-    padding: 0;
-  }
-
-  .materialize-iso nav .aux i.material-icons {
-    font-size: 22px;  
-    position: relative;
-    margin: 0;
-    padding: 0;
-  }
-}
 
 @media only screen and (max-width: 400px) {
   .materialize-iso .filler, .materialize-iso .logo {

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -297,7 +297,11 @@ a {
 }
 
 .report-project-div {
-	position: absolute;
+	position: relative;
+}
+
+.modal {
+	width: 80% !important;
 }
 
 .report-card {

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -297,7 +297,18 @@ a {
 }
 
 #projectviewer-report-project {
-	padding: 1%;
+	padding-top: 10px;
+	padding-right: 5px;
+}
+
+#projectviewer-download-file, #projectviewer-open-mb {
+	margin-left: -1%;
+}
+
+@media only screen and (max-width: 560px) {
+	#projectviewer-download-file,#projectviewer-open-mb {
+		margin-left: -30px !important;
+	}
 }
 
 .report-project-div {

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -296,12 +296,12 @@ a {
 	padding-bottom: 75%;
 }
 
-.report-project-div {
-	position: relative;
+#projectviewer-report-project {
+	padding: 1%;
 }
 
-.modal {
-	width: 80% !important;
+.report-project-div {
+	position: relative;
 }
 
 .report-card {

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -296,7 +296,7 @@ a {
 	padding-bottom: 75%;
 }
 
-#projectviewer-report-project {
+#projectviewer-report-project, #projectviewer-report-project-disabled {
 	padding-top: 10px;
 	padding-right: 5px;
 }

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -305,9 +305,26 @@ a {
 	margin-left: -1%;
 }
 
-@media only screen and (max-width: 560px) {
-	#projectviewer-download-file,#projectviewer-open-mb {
-		margin-left: -30px !important;
+@media only screen and (max-width: 1100px) {
+	#projectviewer-download-file, #projectviewer-open-mb {
+		margin-left: -25px !important;
+	}
+
+	#projectviewer-report-project, #projectviewer-report-project-disabled {
+		padding-left: 0px;
+		padding-right: 0px;
+	}
+}
+
+@media only screen and (max-width: 650px) {
+	#projectviewer-download-file, #projectviewer-open-mb {
+		font-size: 70%;
+	}
+}
+
+@media only screen and (max-width: 550px) {
+	#projectviewer-download-file, #projectviewer-open-mb {
+		font-size: 60%;
 	}
 }
 

--- a/planet/index.html
+++ b/planet/index.html
@@ -254,7 +254,7 @@
                 </div>
                 <div class="modal-footer">
                     <div class="report-project-div">
-                        <a class="btn-flat left modal-action waves-effect waves-red" id="projectviewer-report-project"></a>
+                        <a class="left tooltipped" id="projectviewer-report-project"><i class="material-icons red-text">error</i></a>
                         <div class="card report-card" id="projectviewer-report-card" style="display: none;">
                             <div id="projectviewer-report-content" style="display: none;">
                                 <div class="card-content">

--- a/planet/index.html
+++ b/planet/index.html
@@ -254,7 +254,8 @@
                 </div>
                 <div class="modal-footer">
                     <div class="report-project-div">
-                        <a class="left tooltipped" id="projectviewer-report-project"><i class="material-icons red-text">error</i></a>
+                        <a class="left tooltipped" id="projectviewer-report-project"><i class="material-icons red-text" id="report-icon" >error</i></a>
+                        <a class="left tooltipped" id="projectviewer-report-project-disabled"><i class="material-icons grey-text" id="report-icon" >error</i></a>
                         <div class="card report-card" id="projectviewer-report-card" style="display: none;">
                             <div id="projectviewer-report-content" style="display: none;">
                                 <div class="card-content">

--- a/planet/js/ProjectViewer.js
+++ b/planet/js/ProjectViewer.js
@@ -49,13 +49,13 @@ function ProjectViewer(Planet) {
             tagcontainer.appendChild(chip);
         }
 
-        // if (Planet.ProjectStorage.isReported(this.id)){
-        //     document.getElementById('projectviewer-report-project').classList.add('disabled');
-        //     document.getElementById('projectviewer-report-project').textContent = this.ReportDisabledButton;
-        // } else {
-        //     document.getElementById('projectviewer-report-project').classList.remove('disabled');
-        //     document.getElementById('projectviewer-report-project').textContent = this.ReportEnabledButton;
-        // }
+        if (Planet.ProjectStorage.isReported(this.id)){
+            document.getElementById('projectviewer-report-project').style.display = 'none';
+            document.getElementById('projectviewer-report-project-disabled').style.display = 'block';
+        } else {
+            document.getElementById('projectviewer-report-project').style.display = 'block';
+            document.getElementById('projectviewer-report-project-disabled').style.display = 'none';
+        }
 
         jQuery('#projectviewer').modal('open');
     };
@@ -109,8 +109,8 @@ function ProjectViewer(Planet) {
         if (data.success) {
             document.getElementById('submittext').textContent = this.ReportSuccess;
             Planet.ProjectStorage.report(this.id,true);
-            document.getElementById('projectviewer-report-project').classList.add('disabled');
-            document.getElementById('projectviewer-report-project').value = this.ReportDisabledButton;
+            document.getElementById('projectviewer-report-project').style.display = 'none';
+            document.getElementById('projectviewer-report-project-disabled').style.display = 'block';
         } else {
             document.getElementById('submittext').textContent = this.ReportError;
         }

--- a/planet/js/ProjectViewer.js
+++ b/planet/js/ProjectViewer.js
@@ -49,13 +49,13 @@ function ProjectViewer(Planet) {
             tagcontainer.appendChild(chip);
         }
 
-        if (Planet.ProjectStorage.isReported(this.id)){
-            document.getElementById('projectviewer-report-project').classList.add('disabled');
-            document.getElementById('projectviewer-report-project').textContent = this.ReportDisabledButton;
-        } else {
-            document.getElementById('projectviewer-report-project').classList.remove('disabled');
-            document.getElementById('projectviewer-report-project').textContent = this.ReportEnabledButton;
-        }
+        // if (Planet.ProjectStorage.isReported(this.id)){
+        //     document.getElementById('projectviewer-report-project').classList.add('disabled');
+        //     document.getElementById('projectviewer-report-project').textContent = this.ReportDisabledButton;
+        // } else {
+        //     document.getElementById('projectviewer-report-project').classList.remove('disabled');
+        //     document.getElementById('projectviewer-report-project').textContent = this.ReportEnabledButton;
+        // }
 
         jQuery('#projectviewer').modal('open');
     };

--- a/planet/js/StringHelper.js
+++ b/planet/js/StringHelper.js
@@ -45,7 +45,7 @@ function StringHelper(Planet) {
         ["projectviewer-likes-heading",_("Number of Likes:")],
         ["projectviewer-tags-heading",_("Tags:")],
         ["projectviewer-description-heading",_("Description")],
-        ["projectviewer-report-project",_("Report Project")],
+        ["projectviewer-report-project",_("Report Project"), "data-tooltip"],
         ["projectviewer-report-title",_("Report Project")],
         ["projectviewer-report-conduct",_("Report projects which violate the <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\">Sugar Labs Code of Conduct</a>.")],
         ["projectviewer-report-reason",_("Reason for reporting project")],

--- a/planet/js/StringHelper.js
+++ b/planet/js/StringHelper.js
@@ -46,6 +46,7 @@ function StringHelper(Planet) {
         ["projectviewer-tags-heading",_("Tags:")],
         ["projectviewer-description-heading",_("Description")],
         ["projectviewer-report-project",_("Report Project"), "data-tooltip"],
+        ["projectviewer-report-project-disabled",_("Project Reported"), "data-tooltip"],
         ["projectviewer-report-title",_("Report Project")],
         ["projectviewer-report-conduct",_("Report projects which violate the <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\">Sugar Labs Code of Conduct</a>.")],
         ["projectviewer-report-reason",_("Reason for reporting project")],


### PR DESCRIPTION
In order to reduce overlap and stop the user having to scroll the "modal footer" in a project's description, I replaced the button with an icon:

Here's an example of a reported project (observe the icon):
![image](https://user-images.githubusercontent.com/31069982/49900528-b6a96f00-fe56-11e8-8b13-5834f00962a7.png)


Here's an example of an unreported project when the window width is as small as possible (in Japanese):
![image](https://user-images.githubusercontent.com/31069982/49901663-b363b280-fe59-11e8-904b-309dbcb60318.png)

Please note there is also a "Report Project" tooltip for the icon (enabled for translation too)

I think using an icon in place for the previous icon not only prevents overlaps but also betters the responsiveness - previously a scrollbar would be needed for the modal footer (observe the footer scrollbar below):
![image](https://user-images.githubusercontent.com/31069982/49901855-3b49bc80-fe5a-11e8-9c56-755aab6895d1.png)