### PR TITLE
Make 'all projects' the fallback tag

### DIFF
--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -391,7 +391,7 @@ function GlobalPlanet(Planet) {
             if (Planet.IsMusicBlocks){
                 this.defaultMainTags = ["Music"];
                 this.specialTags = 
-                [{'name': 'All Projects', 'func': this.searchAllProjects.bind(this), 'defaultTag': false}, 
+                [{'name': 'All Projects', 'func': this.searchAllProjects.bind(this), 'defaultTag': true}, 
                  {'name': 'My Projects', 'func': this.searchMyProjects.bind(this), 'defaultTag': false}];
             } else {
                 this.defaultMainTags = [];


### PR DESCRIPTION
I have attempted to make this clear in this gif:
![peek 2018-12-16 16-03](https://user-images.githubusercontent.com/31069982/50055866-451a3b00-014c-11e9-813a-01b595e2d8cb.gif)


(1) After clicking off multiple tags, there is always one last tag which is last to be 'clicked off'
(2) After this click off, only the projects containing last selected tag are being shown. 

This causes the console to throw:

![image](https://user-images.githubusercontent.com/31069982/50055909-e30e0580-014c-11e9-822c-05eb213e6708.png)


In order to resolve this (and keep it line with how Turtle Blocks handles this) I have made "All Projects" the 'fallback' tag if no others are selected.

I think this patch is possibly related to @pikurasa comment in #1655 
