### PR TITLE
fixed the drag issue in help

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -141,9 +141,9 @@ function HelpWidget () {
         canvas.ondrop = function(e) {
             if (that._dragging) {
                 that._dragging = false;
-                var x = e.clientX - that._dx;
+                var x = e.clientX - (dragCell.getBoundingClientRect().left - helpDiv.getBoundingClientRect().left) - BUTTONSIZE/2;
                 helpDiv.style.left = x + 'px';
-                var y = e.clientY - that._dy;
+                var y = e.clientY - (dragCell.getBoundingClientRect().top - helpDiv.getBoundingClientRect().top) - BUTTONSIZE/2;
                 helpDiv.style.top = y + 'px';
                 dragCell.innerHTML = that._dragCellHTML;
             }
@@ -156,9 +156,9 @@ function HelpWidget () {
         helpDiv.ondrop = function(e) {
             if (that._dragging) {
                 that._dragging = false;
-                var x = e.clientX - that._dx;
+                var x = e.clientX - (dragCell.getBoundingClientRect().left - helpDiv.getBoundingClientRect().left) - BUTTONSIZE/2;
                 helpDiv.style.left = x + 'px';
-                var y = e.clientY - that._dy;
+                var y = e.clientY - (dragCell.getBoundingClientRect().top - helpDiv.getBoundingClientRect().top) - BUTTONSIZE/2;
                 helpDiv.style.top = y + 'px';
                 dragCell.innerHTML = that._dragCellHTML;
             }


### PR DESCRIPTION
The drag feature in help was not working properly

Before:
![before](https://user-images.githubusercontent.com/24709420/50137384-fe018680-02c0-11e9-9fde-2e97a5d3992a.gif)

After:
![after](https://user-images.githubusercontent.com/24709420/50137435-25585380-02c1-11e9-8c1d-8259aca8ab6b.gif)
