### PR TITLE
Meet Mr.Mouse LOGO changed to LOGODEFAULT

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -185,7 +185,7 @@ function createHelpContent() {
 	console.log(TITLESTRING);
         HELPCONTENT = [
             [_('Welcome to Music Blocks'), TITLESTRING, 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGO)))],
-            [_('Meet Mr. Mouse!'), _('Mr Mouse is our Music Blocks conductor.') + ' ' + _('Mr Mouse encourages you to explore Music Blocks.') + ' ' + _('Let us start our tour!'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGO)))],
+            [_('Meet Mr. Mouse!'), _('Mr Mouse is our Music Blocks conductor.') + ' ' + _('Mr Mouse encourages you to explore Music Blocks.') + ' ' + _('Let us start our tour!'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGODEFAULT)))],
             [_('Play'), _('Click the run button to run the project in fast mode.'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(RUNBUTTON)))],
             [_('Stop'), _('Stop the music (and the mice).') + ' ' + _('You can also type Alt-S to stop.'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(STOPTURTLEBUTTON)))],
             [_('New project'), _('Initialize a new project.'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(NEWBUTTON)))],
@@ -221,7 +221,7 @@ function createHelpContent() {
     } else {
         HELPCONTENT = [
             [_('Welcome to Music Blocks'), TITLESTRING, 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGO)))],
-            [_('Meet Mr. Mouse!'), _('Mr Mouse is our Music Blocks conductor.') + ' ' + _('Mr Mouse encourages you to explore Music Blocks.') + ' ' + _('Let us start our tour!'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGO)))],
+            [_('Meet Mr. Mouse!'), _('Mr Mouse is our Music Blocks conductor.') + ' ' + _('Mr Mouse encourages you to explore Music Blocks.') + ' ' + _('Let us start our tour!'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(LOGODEFAULT)))],
             [_('Run fast'), _('Click the run button to run the project in fast mode.'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(RUNBUTTON)))],
             [_('Stop'), _('Stop the music (and the mice).') + ' ' + _('You can also type Alt-S to stop.'), 'data:image/svg+xml;base64,' + window.btoa(unescape(encodeURIComponent(STOPTURTLEBUTTON)))],
 


### PR DESCRIPTION
In offline version of MB, if we select any language other than japanese 'Meet Mr. Mouse!' page of the help widget shows the default logo of mouse -

![image](https://user-images.githubusercontent.com/44440524/50291033-6738f380-0493-11e9-85f8-ee6f381dcfef.png)

However, in Japanese, the same page shows the following image which I don't think suits the title of page -

![image](https://user-images.githubusercontent.com/44440524/50291334-4d4be080-0494-11e9-9cbc-7de1bbb64dc9.png)

With this commit I am suggesting that the image should be the  default logo of mouse as shown below-

![image](https://user-images.githubusercontent.com/44440524/50291575-fc88b780-0494-11e9-91ff-6a541d20d20b.png)
