### PR TITLE
Fixing Pie menu overlapping

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -148,6 +148,7 @@ function Toolbar() {
         if (planet) {
             planetIcon.onclick = function () {
                 docById('toolbars').style.display = 'none';
+                docById('wheelDiv').style.display = 'none';
                 onclick();
             };
         } else {


### PR DESCRIPTION
The pie menu in the project space used to remain even when the planet is
opened and covers the planet until the user clicks.

Making the display of the pie menu "none" when planetIcon is clicked fixed
the issue.

Fixes https://github.com/sugarlabs/musicblocks/issues/1676