### PR TITLE
Fixing Help widget overlapping

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -149,6 +149,7 @@ function Toolbar() {
             planetIcon.onclick = function () {
                 docById('toolbars').style.display = 'none';
                 docById('wheelDiv').style.display = 'none';
+                docById('helpDiv').style.display = 'none';
                 onclick();
             };
         } else {


### PR DESCRIPTION
The Help widgets in the project space used to remain even when the planet is opened and covers the planet until the user clicks. (In PR #1679 @Aniket21mathur fixed the issue #1676  for pie menus but it is observed with Help widgets also).

![image](https://user-images.githubusercontent.com/44440524/50425053-60482180-0895-11e9-9d9e-04e59c0d2e54.png)
![image](https://user-images.githubusercontent.com/44440524/50425059-853c9480-0895-11e9-8af1-ac0e918d58d4.png)

Making the display of the help widget "none" when planetIcon is clicked fixed the issue.