### PR TITLE
Fixing Context Wheel overlapping

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -150,6 +150,7 @@ function Toolbar() {
                 docById('toolbars').style.display = 'none';
                 docById('wheelDiv').style.display = 'none';
                 docById('helpDiv').style.display = 'none';
+                docById('contextWheelDiv').style.display = 'none';
                 onclick();
             };
         } else {


### PR DESCRIPTION
The Context Wheel in the project space also used to remain even when the planet is opened and covers the planet until the user clicks. 

![image](https://user-images.githubusercontent.com/44440524/50486287-50f4df80-0a1f-11e9-9216-af831df1c643.png)
As done in previous PR #1684, the display of the Context Wheel should also be made "none".