### PR TITLE
Drag icon disappear fix

### DIFF
--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -775,6 +775,7 @@ function TimbreWidget () {
         };
 
         canvas.ondragover = function (e) {
+            that._dragging = true;
             e.preventDefault();
         };
 
@@ -790,6 +791,7 @@ function TimbreWidget () {
         };
 
         timbreDiv.ondragover = function (e) {
+            that._dragging = true;
             e.preventDefault();
         };
 
@@ -805,12 +807,7 @@ function TimbreWidget () {
         };
 
         timbreDiv.onmousedown = function (e) {
-            that._dragging = true;
             that._target = e.target;
-        };
-        
-        timbreDiv.onmouseup = function (e) {
-            that._dragging = false;
         };
 
         timbreDiv.ondragstart = function (e) {

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -808,6 +808,10 @@ function TimbreWidget () {
             that._dragging = true;
             that._target = e.target;
         };
+        
+        timbreDiv.onmouseup = function (e) {
+            that._dragging = false;
+        };
 
         timbreDiv.ondragstart = function (e) {
             if (dragCell.contains(that._target)) {


### PR DESCRIPTION
Open timbre widget menu
![mb_drag-icon-error1](https://user-images.githubusercontent.com/24709420/51072362-7facc000-1685-11e9-8f11-dedb3b5748e2.png)

Single click on drag icon.
Drag icon will disappear.
![mb_drag-icon-error](https://user-images.githubusercontent.com/24709420/51072367-a8cd5080-1685-11e9-80fd-5f91223ab22e.png)

This PR fix that issue

