### PR TITLE
Change x default for scrollxy to 100; 100 is more obvious than 10

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -3118,7 +3118,7 @@ function initBasicProtoBlocks(palettes, blocks, beginnerMode) {
     }
     newblock.adjustWidthToLabel();
     newblock.twoArgBlock();
-    newblock.defaults.push(0);
+    newblock.defaults.push(100);
     newblock.defaults.push(0);
     newblock.dockTypes[1] = 'numberin';
     if (beginnerMode && !beginnerBlock('scrollxy')) {


### PR DESCRIPTION
To have a default for https://github.com/sugarlabs/musicblocks/issues/1421

I do not think number other than 0 is required for y as well. Just 100 for x is enough to get the idea.