### PR TITLE
Correct note value not displayed

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1517,11 +1517,13 @@ function calcNoteValueToDisplay(a, b, scale) {
     if (parseInt(noteValue) < noteValue) {
         noteValueToDisplay = parseInt((noteValue * 1.5))
         if (noteValueToDisplay in NSYMBOLS) {
-            noteValueToDisplay = '1.5<br>&mdash;<br>' + noteValueToDisplay.toString() + '<br>' + NSYMBOLS[noteValueToDisplay] + '.';
+            var value = b/a*noteValueToDisplay;
+            noteValueToDisplay = value.toFixed(2)+'<br>&mdash;<br>' + noteValueToDisplay.toString() + '<br>' + NSYMBOLS[noteValueToDisplay] + '.';
         } else {
             noteValueToDisplay = parseInt((noteValue * 1.75))
             if (noteValueToDisplay in NSYMBOLS) {
-                noteValueToDisplay = '1.75<br>&mdash;<br>' + noteValueToDisplay.toString() + '<br>' + NSYMBOLS[noteValueToDisplay] + '.,';
+                var value = b/a*noteValueToDisplay;
+                noteValueToDisplay = value.toFixed(2)+'<br>&mdash;<br>' + noteValueToDisplay.toString() + '<br>' + NSYMBOLS[noteValueToDisplay] + '.,';
             } else {
                 noteValueToDisplay = reducedFraction(b, a);
             }


### PR DESCRIPTION
As you can seen from the images the note value displayed is not correct it should be 1.25/2 instead of 1.5/2
Should be [1/4 1/8 1.25/2] but is [1/4 1/8 1.5/2]
![notedisplayerror](https://user-images.githubusercontent.com/24709420/54940185-3b288500-4f50-11e9-88f6-7a1f3f1964d5.png)
![notedisplaycorrect](https://user-images.githubusercontent.com/24709420/54940188-3ebc0c00-4f50-11e9-8b11-bfa4afe54b23.png)

