### PR TITLE
Fixes #1719 (Crab Canon) | On "weak beat do" is one arg block

### DIFF
--- a/js/basicblocks.js
+++ b/js/basicblocks.js
@@ -1541,18 +1541,11 @@ function initBasicProtoBlocks(palettes, blocks, beginnerMode) {
     newblock.palette = palettes.dict['meter'];
     blocks.protoBlockDict['offbeatdo'] = newblock;
     // #TRANS: on musical 'offbeat' do some action
-    if (language === 'ja') {
-        newblock.staticLabels.push(_('on weak beat'), _('beat'));
-        //.TRANS: do1 is do (take) an action (JAPANESE ONLY)
-        newblock.staticLabels.push(_('do1'));
-    } else {
-        // #TRANS: 'on' musical 'beat' 'do' some action
-        newblock.staticLabels.push(_('on weak beat'), _('beat'), _('do'));
-    }
-    newblock.twoArgBlock();
+    newblock.staticLabels.push(_('on weak beat do'));
+    newblock.oneArgBlock();
     newblock.defaults.push(_('action'));
-    newblock.adjustWidthToLabel();
     newblock.dockTypes[1] = 'textin';
+    newblock.adjustWidthToLabel();
     if (beginnerMode && !beginnerBlock('offbeatdo')) {
         newblock.hidden = true;
     }


### PR DESCRIPTION
I think that the issue stemmed from one of the following two:

1) attempt to correct something for JA translation (although I wonder why, as "on weak beat do" should be a unique string)

2) an attempt to resize the block

At any rate, at some point this one arg block was made into a two arg block, which is why crab canon was not "rendering correctly".