### PR TITLE
phrase maker tuplet display error

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -4069,7 +4069,7 @@ function Logo () {
                         switch (that.tupletRhythms[i][0]) {
                         case 'notes':
                         case 'simple':
-                            var tupletParam = [that.tupletParams[that.tupletRhythms[i][1]]];
+                            var tupletParam = [that.tupletParams[i]];
                             tupletParam.push([]);
                             for (var j = 2; j < that.tupletRhythms[i].length; j++) {
                                 tupletParam[1].push(that.tupletRhythms[i][j]);


### PR DESCRIPTION
As you can seen from the images phrase maker doesn't show correct tables for tuplets. This fixes that.
![pmerror](https://user-images.githubusercontent.com/24709420/55185093-a628c480-51b9-11e9-8716-d6689a6d1f37.png)
![pmerrorcorrected](https://user-images.githubusercontent.com/24709420/55185111-ab860f00-51b9-11e9-8010-9f0973774a02.png)

 