### PR TITLE
Clearing error text more obvious. Follow on from issue #1726 (PR #1804)

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1359,15 +1359,14 @@ input.timbreName {
     cursor: default !important;
  }
 
- #printText {
+ .popupMsg {
     width: 1000px;
     height: 30px;
     position: absolute;
     top: 130px;
     left: 50%;
     margin-left: -500px;
-    padding-top: 2px;
-    border: 2px solid rgb(150, 150, 150);
+    padding-top: 2px; 
     border-radius: 8px;
     background-color: white;
     font-family: Arial, Helvetica, sans-serif;
@@ -1377,19 +1376,28 @@ input.timbreName {
     text-overflow: ellipsis;
     cursor: pointer;
     visibility: hidden;
+}
+
+ #printText {
+    border: 2px solid rgb(150, 150, 150);
   }
 
-  #printText.show {
+  #errorText {
+    border: 2px solid red;
+    background-color: pink;
+  }
+
+  #printText.show, #errorText.show {
     visibility: visible;
   }
 
-  #printText #printTextContent {
+ #printTextContent, #errorTextContent {
     display: inline-block;
     width: 940px;
     vertical-align: 7px;
   }
 
-  #printText #closeIcon {
+  .msgCloseIcon {
     width: 28px;
     height: 28px;
     filter: invert(100%);

--- a/index.html
+++ b/index.html
@@ -207,15 +207,25 @@
 
     <div class="canvasHolder" id="canvasHolder">
 
-      <div id="printText" onclick="hidePrintText()">
+      <div class="popupMsg" id="printText" onclick="hidePrintText()">
         <span id="printTextContent"></span>
-        <img id="closeIcon" src="images/close.svg" alt="Close">
+        <img class="msgCloseIcon" src="images/close.svg" alt="Close">
+      </div>
+
+      <div class="popupMsg" id="errorText" onclick="hideErrorText()">
+        <span id="errorTextContent"></span>
+        <img class="msgCloseIcon" src="images/close.svg" alt="Close">
       </div>
 
       <script>
         function hidePrintText() {
           var printText = document.getElementById("printText");
           printText.classList.remove("show");
+        }
+
+        function hideErrorText() {
+          var errorText = document.getElementById("errorText");
+          errorText.classList.remove("show");
         }
       </script>
 

--- a/index.html
+++ b/index.html
@@ -226,6 +226,7 @@
         function hideErrorText() {
           var errorText = document.getElementById("errorText");
           errorText.classList.remove("show");
+          hideArrows(); // This function is declared in js/activity.js
         }
       </script>
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -2838,7 +2838,7 @@ function Activity() {
             var line = new createjs.Shape();
             errorMsgArrow.addChild(line);
             line.graphics.setStrokeStyle(4).beginStroke('#ff0031').moveTo(fromX, fromY).lineTo(toX, toY);
-            stage.setChildIndex(errorMsgArrow, stage.children.length - 2);
+            stage.setChildIndex(errorMsgArrow, stage.children.length - 1);
 
             var angle = Math.atan2(toX - fromX, fromY - toY) / Math.PI * 180;
             var head = new createjs.Shape();

--- a/js/activity.js
+++ b/js/activity.js
@@ -2838,7 +2838,7 @@ function Activity() {
             var line = new createjs.Shape();
             errorMsgArrow.addChild(line);
             line.graphics.setStrokeStyle(4).beginStroke('#ff0031').moveTo(fromX, fromY).lineTo(toX, toY);
-            stage.setChildIndex(errorMsgArrow, stage.children.length - 1);
+            stage.setChildIndex(errorMsgArrow, stage.children.length - 2);
 
             var angle = Math.atan2(toX - fromX, fromY - toY) / Math.PI * 180;
             var head = new createjs.Shape();

--- a/js/activity.js
+++ b/js/activity.js
@@ -2776,10 +2776,7 @@ function Activity() {
      */
     hideMsgs = function () {
         errorMsgText.parent.visible = false;
-        if (errorMsgArrow != null) {
-            errorMsgArrow.removeAllChildren();
-            refreshCanvas();
-        }
+        hideArrows();
 
         msgText.parent.visible = false;
         for (var i in errorArtwork) {
@@ -2788,6 +2785,13 @@ function Activity() {
 
         refreshCanvas();
     };
+
+    hideArrows = function() {
+        if (errorMsgArrow != null) {
+            errorMsgArrow.removeAllChildren();
+            refreshCanvas();
+        }
+    }
 
 
     textMsg = function (msg) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -2899,11 +2899,11 @@ function Activity() {
                 stage.setChildIndex(errorArtwork['noinput'], stage.children.length - 1);
                 break;
             default:
-                var errorMsgContainer = errorMsgText.parent;
-                errorMsgContainer.visible = true;
-                errorMsgText.text = msg;
-                stage.setChildIndex(errorMsgContainer, stage.children.length - 1);
-                errorMsgContainer.updateCache();
+                // Show and populate errorText div
+                var errorText = document.getElementById("errorText");
+                errorText.classList.add("show");
+                var errorTextContent = document.getElementById("errorTextContent");
+                errorTextContent.innerHTML = msg;
                 break;
         }
 


### PR DESCRIPTION
Replaced canvas text box with HTML div and added close icon as per @walterbender comment on PR #1804

<img width="1207" alt="Screenshot 2019-07-30 21 32 19" src="https://user-images.githubusercontent.com/19372409/62163105-965cf080-b311-11e9-9db7-fa2de696345c.png">

Behaviour is slightly different now in that the red arrows coming from the error box with the artwork are no longer hidden when the error text box is clicked on due to it not being a canvas container any more. I can look at recreating this but it may be more helpful to keep it as it is i.e. arrows stay visible until the artwork box disappears.