### PR TITLE
Quick fix to 'do_5' not showing bellset in phrasemaker

### DIFF
--- a/js/widgets/pitchtimematrix.js
+++ b/js/widgets/pitchtimematrix.js
@@ -442,6 +442,8 @@ function PitchTimeMatrix () {
                     cell.innerHTML = '<img src="' + 'images/8_bellset_key_' + BELLSETIDX[noteName] + '.svg' + '" width="' + cell.style.width + '" vertical-align="middle">';
                 } else if (noteName === 'C' && this.rowArgs[i] === 5) {
                     cell.innerHTML = '<img src="' + 'images/8_bellset_key_8.svg' + '" width="' + cell.style.width + '" vertical-align="middle">';
+                } else if (noteName === 'do' && this.rowArgs[i] === 5) {
+                    cell.innerHTML = '<img src="' + 'images/8_bellset_key_8.svg' + '" width="' + cell.style.width + '" vertical-align="middle">';
                 }
             }
 


### PR DESCRIPTION
Before (no 'do_5'):
![Screenshot at 2019-10-23 09:25:19 Do_5 has no bellset icon](https://user-images.githubusercontent.com/13454579/67403390-5e2c1d80-f5a1-11e9-984e-caa12c6a7c27.png)
After:
![Screenshot at 2019-10-23 10:24:34 do_5 works](https://user-images.githubusercontent.com/13454579/67403401-61bfa480-f5a1-11e9-8f12-851c68b7cc17.png)

I just tried things until the problem was fixed in a superficial way. Please feel free to modify my code to make it more robust/readable/etc