### PR TITLE
Fixed misterious div

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@
     <div class="materialize-iso" tabindex="-1">
       <nav id="toolbars" class="nav-wrapper" role="navigation">
         <div class="blue nav-wrapper" tabindex="-1">
-          <a id="mb-logo" class="logo left tooltipped" data-position="bottom"><img style="width: 100%;" src="images/logo.svg"></a>
+          <div id="mb-logo" class="logo left tooltipped" style="line-height: 0; height: 100%" data-position="bottom"><img style="width: 100%;" src="images/logo.svg"></div>
           <ul class="main left">
             <li><a id="play" class="left tooltipped"><i class="material-icons main">play_circle_filled</i></a></li>
             <li><a id="stop" class="left tooltipped"><i class="material-icons main">stop</i></a></li>


### PR DESCRIPTION
The issue was caused because the logo was an <a> component with line line-height: 64, which caused overflow when showing the focus or shadow on the nav bar, so I changed it with {line-height: 64;} and height 100% so it didn't stop occupying al posible space