### PR TITLE
Enter advanced mode with only one click

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -912,7 +912,7 @@ function Activity() {
         'onMouseOut=\'this.style.opacity = 1\'>';
         const MSGSuffix = '</a>';
 
-        if (mode === null || mode === 'true') {
+        if (mode === null || mode === undefined || mode === 'true') {
             textMsg(_(MSGPrefix + _('Refresh your browser to change to advanced mode.') + MSGSuffix));
             localStorage.setItem('beginnerMode', false);
         } else {


### PR DESCRIPTION
Resolves #1854 

When a user loads MB for the first time or clears the browser cache, "localStorage.getItem('beginnerMode')" is undefined and bypasses the strict equality check to null.

This PR fixes it.