### PR TITLE
Fix pointer clicks on Chromium/Win10

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2267,7 +2267,9 @@ function Block(protoblock, blocks, overrideName) {
             }
 
             if (window.hasMouse) {
-                moved = true;
+                if (event.stageX / that.blocks.getStageScale() !== that.original.x ||
+                    event.stageY / that.blocks.getStageScale() !== that.original.y)
+                    moved = true;
             } else {
                 // Make it eaiser to select text on mobile.
                 setTimeout(function () {


### PR DESCRIPTION
The detection method for if the cursor had moved during a click was broken in Chromium-based browsers running on Windows. Also adding a check to compare the pointer location fixes this issue.