### PR TITLE
Fix #1924 $ npm run serve - python2,3 [GCI]

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('python -m http.server 3000');\"",
-    "winserve": "py -c \"import os, sys; os.system('py -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('py -m http.server 3000');\"",
-
+    "winserve": "py -c \"import os, sys; os.system('py -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('py -m http.server 3000');\""
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     }
   },
   "scripts": {
-    "serve": "python -m SimpleHTTPServer 3000"
+    "serve": "python -c \"import os, sys; os.system('python{} -m SimpleHTTPServer'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 5000'.format(sys.version_info.major));\""
+
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     }
   },
   "scripts": {
-    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 5000'.format(sys.version_info.major));\""
+    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 3000'.format(sys.version_info.major));\""
 
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     }
   },
   "scripts": {
-    "serve": "python -c \"import os, sys; os.system('python{} -m SimpleHTTPServer'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 5000'.format(sys.version_info.major));\""
+    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 5000'.format(sys.version_info.major));\""
 
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     }
   },
   "scripts": {
-    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000'.format(sys.version_info.major)) if sys.version_info.major==2 else os.system('python{} -m http.server 3000'.format(sys.version_info.major));\""
+    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('python -m http.server 3000');\""
 
   },
   "devDependencies": {


### PR DESCRIPTION
A fix for the #1924 in using npm serve.
Tested on Fedora 31. Fedora 31 uses python defaults to python3. So the circumstances for testing this was right. Tested also with aliases of python as python2 and python3. PR works for all versions. 

It runs python, checks if the `python` is actually `python2` or `python3`. If it is python2 execute python -m .... and if its python3 execute python -m .... Both should work with python executable existing in the PATH.

~ wrt GCI