### PR TITLE
Port status widget to widget windows

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4049,19 +4049,9 @@ function Activity() {
                         docById('temperamentButtonsDiv').style.visibility = 'hidden';
                     }
 
-                    if (docById('statusDiv').style.visibility !== 'hidden') {
-                        docById('statusDiv').style.visibility = 'hidden';
-                        docById('statusButtonsDiv').style.visibility = 'hidden';
-                        docById('statusTableDiv').style.visibility = 'hidden';
-                    }
+                    window.widgetWindows.clear('status');
+                    window.widgetWindows.clear('slider');
 
-                    /*
-                    if (docById('sliderDiv').style.visibility !== 'hidden') {
-                        docById('sliderDiv').style.visibility = 'hidden';
-                        docById('sliderButtonsDiv').style.visibility = 'hidden';
-                        docById('sliderTableDiv').style.visibility = 'hidden';
-                    }
-                    */
                     if (docById('modeDiv').style.visibility !== 'hidden') {
                         docById('modeDiv').style.visibility = 'hidden';
                         docById('modeButtonsDiv').style.visibility = 'hidden';
@@ -4075,7 +4065,7 @@ function Activity() {
                     }
                 }
 
-                storage.setItem('isStatusHidden', docById('statusDiv').style.visibility);
+                storage.setItem('isStatusHidden', window.widgetWindows.isOpen('status'));
                 logo.doStopTurtle();
                 docById('helpElem').style.visibility = 'hidden';
                 document.querySelector('.canvasHolder').classList.add('hide');
@@ -4091,9 +4081,10 @@ function Activity() {
             this.showMusicBlocks = function () {
                 document.getElementById('toolbars').style.display = "block";
 
-                docById('statusDiv').style.visibility = storage.getItem('isStatusHidden');
-                docById('statusButtonsDiv').style.visibility = storage.getItem('isStatusHidden');
-                docById('statusTableDiv').style.visibility = storage.getItem('isStatusHidden');
+                if (storage.getItem('isStatusHidden')) {
+                    logo.statusMatrix = new StatusMatrix();
+                    logo.statusMatrix.init(logo);
+                }
 
                 if (_THIS_IS_MUSIC_BLOCKS_) {
                     // docById('ptmDiv').style.visibility = storage.getItem('isMatrixHidden');

--- a/js/logo.js
+++ b/js/logo.js
@@ -1481,7 +1481,7 @@ function Logo () {
         }
 
         // Set up status block
-        if (docById('statusDiv').style.visibility === 'visible') {
+        if (window.widgetWindows.isOpen('status')) {
             // Ensure widget has been created before trying to
             // initialize it.
             if (this.statusMatrix === null) {
@@ -7837,10 +7837,8 @@ function Logo () {
             console.log('Ignoring block on overlapped start.');
         }
 
-        if (docById('statusDiv').style.visibility === 'visible') {
-            if (!that.inStatusMatrix) {
-                that.statusMatrix.updateAll();
-            }
+        if (that.statusMatrix && that.statusMatrix.isOpen && !that.inStatusMatrix) {
+            that.statusMatrix.updateAll();
         }
 
         // If there is a child flow, queue it.

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -185,7 +185,7 @@ function PitchSlider() {
         this._cellScale = 1.0;
         var iconSize = ICONSIZE;
 
-        var widgetWindow = window.widgetWindows.windowFor(this, "pitch slider");
+        var widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
 

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -21,150 +21,36 @@ function StatusMatrix() {
     const INNERWINDOWWIDTH = OUTERWINDOWWIDTH - BUTTONSIZE * 1.5;
     var x, y;  //Drop coordinates of statusDiv
 
-    docById('statusDiv').style.visibility = 'hidden';
-
     this.init = function(logo) {
         // Initializes the status matrix. First removes the
         // previous matrix and them make another one in DOM (document
         // object model)
         this._logo = logo;
+        this.isOpen = true;
 
         var w = window.innerWidth;
         this._cellScale = w / 1200;
         var iconSize = ICONSIZE * this._cellScale;
 
-        var canvas = docById('myCanvas');
-
-        // Position the widget and make it visible.
-        var statusDiv = docById('statusDiv');
-        statusDiv.style.visibility = 'visible';
-        statusDiv.setAttribute('draggable', 'true');
-
-        // The status buttons
-        var statusButtonsDiv = docById('statusButtonsDiv');
-        statusButtonsDiv.style.display = 'inline';
-        statusButtonsDiv.style.visibility = 'visible';
-        statusButtonsDiv.style.width = BUTTONDIVWIDTH;
-        statusButtonsDiv.innerHTML = '<table cellpadding="0px" id="statusButtonTable"></table>';
-
-        var buttonTable = docById('statusButtonTable');
-        var header = buttonTable.createTHead();
-        var row = header.insertRow(0);
+        var widgetWindow = window.widgetWindows.windowFor(this, 'status', 'status');
+        this.widgetWindow = widgetWindow;
+        widgetWindow.clear();
 
         // For the button callbacks
         var that = this;
 
-        var cell = this._addButton(row, 'close-button.svg', ICONSIZE, _('Close'));
-
-        cell.onclick=function() {
-            statusTableDiv.style.visibility = 'hidden';
-            statusButtonsDiv.style.visibility = 'hidden';
-            statusDiv.style.visibility = 'hidden';
-        }
-
-        // We use this cell as a handle for dragging.
-        var dragCell = this._addButton(row, 'grab.svg', ICONSIZE, _('Drag'));
-        dragCell.style.cursor = 'move';
-
-        this._dx = dragCell.getBoundingClientRect().left - statusDiv.getBoundingClientRect().left;
-        this._dy = dragCell.getBoundingClientRect().top - statusDiv.getBoundingClientRect().top;
-        this._dragging = false;
-        this._target = false;
-        this._dragCellHTML = dragCell.innerHTML;
-
-        dragCell.onmouseover = function(e) {
-            // In order to prevent the dragged item from triggering a
-            // browser reload in Firefox, we empty the cell contents
-            // before dragging.
-            dragCell.innerHTML = '';
-        };
-
-        dragCell.onmouseout = function(e) {
-            if (!that._dragging) {
-                dragCell.innerHTML = that._dragCellHTML;
-            }
-        };
-
-        canvas.ondragover = function(e) {
-            that._dragging = true;
-            e.preventDefault();
-        };
-
-        canvas.ondrop = function(e) {
-            if (that._dragging) {
-                that._dragging = false;
-                x = e.clientX - that._dx;
-                statusDiv.style.left = x + 'px';
-                y = e.clientY - that._dy;
-                statusDiv.style.top = y + 'px';
-                dragCell.innerHTML = that._dragCellHTML;
-            }
-        };
-
-        statusDiv.ondragover = function(e) {
-            that._dragging = true;
-            e.preventDefault();
-        };
-
-        statusDiv.ondrop = function(e) {
-            if (that._dragging) {
-                that._dragging = false;
-                x = e.clientX - that._dx;
-                statusDiv.style.left = x + 'px';
-                y = e.clientY - that._dy;
-                statusDiv.style.top = y + 'px';
-                dragCell.innerHTML = that._dragCellHTML;
-            }
-        };
-
-        statusDiv.onmousedown = function(e) {
-            that._target = e.target;
-        };
-
-        statusDiv.ondragstart = function(e) {
-            if (dragCell.contains(that._target)) {
-                e.dataTransfer.setData('text/plain', '');
-            } else {
-                e.preventDefault();
-            }
-        };
-
         // The status table
-        var statusTableDiv = docById('statusTableDiv');
-        statusTableDiv.style.display = 'inline';
-        statusTableDiv.style.visibility = 'visible';
-        statusTableDiv.style.border = '0px';
+        this._statusTable = document.createElement('table');
+        widgetWindow.getWidgetBody().append(this._statusTable);
+        widgetWindow.onclose = function() {
+            that.isOpen = false;
 
-        // We use an outer div to scroll vertically and an inner div to
-        // scroll horizontally.
-        statusTableDiv.innerHTML = '<div id="statusOuterDiv"><div id="statusInnerDiv"><table cellpadding="0px" id="statusTable"></table></div></div>';
-
-        var n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 8);
-        var outerDiv = docById('statusOuterDiv');
-        if (this._logo.turtles.turtleList.length > n) {
-            outerDiv.style.height = this._cellScale * MATRIXSOLFEHEIGHT * (n + 2) + 'px';
-            var w = Math.max(Math.min(window.innerWidth, this._cellScale * OUTERWINDOWWIDTH), BUTTONDIVWIDTH);
-            outerDiv.style.width = w + 'px';
-        } else {
-            if (this._logo.statusFields.length > 4) { // Assume we need a horizontal slider
-                outerDiv.style.height = this._cellScale * (MATRIXBUTTONHEIGHT2 + (2 + MATRIXSOLFEHEIGHT) * this._logo.turtles.turtleList.length) + 30 + 'px';
-            } else {
-                outerDiv.style.height = this._cellScale * (MATRIXBUTTONHEIGHT2 + (2 + MATRIXSOLFEHEIGHT) * this._logo.turtles.turtleList.length) + 'px';
-            }
-            var w = Math.max(Math.min(window.innerWidth, this._cellScale * OUTERWINDOWWIDTH - 20), BUTTONDIVWIDTH);
-            outerDiv.style.width = w + 'px';
+            this.destroy();
         }
-
-        var w = Math.max(Math.min(window.innerWidth, this._cellScale * INNERWINDOWWIDTH), BUTTONDIVWIDTH - BUTTONSIZE);
-        var innerDiv = docById('statusInnerDiv');
-        innerDiv.style.width = w + 'px';
-        innerDiv.style.marginLeft = (BUTTONSIZE * this._cellScale) + 'px';
 
         // Each row in the status table contains a note label in the
         // first column and a table of buttons in the second column.
-        var statusTable = docById('statusTable');
-
-        var header = statusTable.createTHead();
+        var header = this._statusTable.createTHead();
         var row = header.insertRow();
 
         var iconSize = Math.floor(this._cellScale * 24);
@@ -213,7 +99,7 @@ function StatusMatrix() {
                 break;
             }
 
-            cell.innerHTML = '&nbsp;<b>' + label + '</b>&nbsp;'
+            cell.innerHTML = '<b>' + label + '</b>'
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
             cell.style.backgroundColor = platformColor.selectorBackground;
         }
@@ -221,7 +107,7 @@ function StatusMatrix() {
         if (_THIS_IS_MUSIC_BLOCKS_) {
             var cell = row.insertCell();
             cell.style.fontSize = Math.floor(this._cellScale * 100) + '%';
-            cell.innerHTML = '&nbsp;<b>' + _('note') + '</b>&nbsp;'
+            cell.innerHTML = '<b>' + _('note') + '</b>'
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + 'px';
             cell.style.backgroundColor = platformColor.selectorBackground;
         }
@@ -272,10 +158,6 @@ function StatusMatrix() {
 
     this.updateAll = function() {
         // Update status of all of the voices in the matrix.
-        var table = docById('statusTable');
-        statusDiv.style.top = y + 'px';
-        statusDiv.style.left = x + 'px';
-
         this._logo.updatingStatusMatrix = true;
 
         var activeTurtles = 0;
@@ -346,7 +228,7 @@ function StatusMatrix() {
 
                 this._logo.inStatusMatrix = saveStatus;
 
-                var cell = table.rows[activeTurtles + 1].cells[i + 1];
+                var cell = this._statusTable.rows[activeTurtles + 1].cells[i + 1];
                 if (cell != null) {
                     cell.innerHTML = innerHTML;
                 }
@@ -372,7 +254,7 @@ function StatusMatrix() {
                     note += obj[1] + '/' + obj[0];
                 }
 
-                var cell = table.rows[activeTurtles + 1].cells[i + 1];
+                var cell = this._statusTable.rows[activeTurtles + 1].cells[i + 1];
                 if (cell != null) {
                     cell.innerHTML = note.replace(/#/g, '♯').replace(/b/g, '♭');
                 }

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -1,4 +1,4 @@
-window.widgetWindows = { openWindows: {} };
+window.widgetWindows = { openWindows: {}, _posCache: {} };
 
 function WidgetWindow(key, title) {
     // Keep a refernce to the object within handlers
@@ -120,7 +120,7 @@ function WidgetWindow(key, title) {
         e.stopImmediatePropagation();
     };
 
-    this.takeFocus = function() {
+    this.takeFocus = function () {
         let siblings = windows.children;
         for (let i = 0; i < siblings.length; i++) {
             siblings[i].style.zIndex = "0";
@@ -143,7 +143,7 @@ function WidgetWindow(key, title) {
         return el.querySelector("input");
     };
 
-    this.addDivider = function() {
+    this.addDivider = function () {
         let el = create("div", "wfbtHR", this._toolbar);
         return el;
     };
@@ -174,6 +174,7 @@ function WidgetWindow(key, title) {
     this.setPosition = function (x, y) {
         this._frame.style.left = x + "px";
         this._frame.style.top = Math.max(y, 64) + "px";
+        window.widgetWindows._posCache[this._key] = [x, Math.max(y, 64)];
 
         return this;
     };
@@ -186,6 +187,11 @@ function WidgetWindow(key, title) {
         rect = canvas.getBoundingClientRect();
         let cw = rect.right - rect.left;
         let ch = rect.bottom - rect.top;
+
+        if (cw === 0 || ch === 0) {
+            // The canvas isn't shown so we don't know how large it really is
+            return this;
+        }
 
         this.setPosition((cw - width) / 2, (ch - height) / 2);
 
@@ -244,20 +250,24 @@ function WidgetWindow(key, title) {
         this._frame.style.height = "auto";
     };
 
-    this.close = function() {
+    this.close = function () {
         this.onclose();
     }
 
+    if (!!window.widgetWindows._posCache[this._key]) {
+        let _pos = window.widgetWindows._posCache[this._key];
+        this.setPosition(_pos[0], _pos[1]);
+    }
     this.takeFocus();
 };
 
-window.widgetWindows.windowFor = function (widget, title) {
+window.widgetWindows.windowFor = function (widget, title, saveAs) {
     let key = undefined;
     // Check for a blockNo attribute
     if (typeof widget.blockNo !== "undefined")
         key = widget.blockNo;
     // Fall back on the next best thing we have
-    else key = title;
+    else key = saveAs || title;
 
     if (typeof window.widgetWindows.openWindows[key] === "undefined") {
         let win = new WidgetWindow(key, title).sendToCenter();
@@ -265,4 +275,15 @@ window.widgetWindows.windowFor = function (widget, title) {
     }
 
     return window.widgetWindows.openWindows[key].unroll();
+};
+
+window.widgetWindows.clear = function (name) {
+    let win = window.widgetWindows.openWindows[name];
+    if (!win) return;
+    if (typeof win.onclose === "function")
+        win.onclose();
+};
+
+window.widgetWindows.isOpen = function (name) {
+    return !!window.widgetWindows.openWindows[name];
 };


### PR DESCRIPTION
As well as porting the status widget, this also has some boilerplate work towards restoring widgets after opening the planet. It's only implemented for the status widget so far, but starting to move some of the other things in `activity.js` (~ln4000) over to using the functions `widgetWindows` exposes instead of querying CSS styles should be fairly trivial.