### PR TITLE
Fix #1344

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -362,7 +362,7 @@ function SaveInterface(PlanetInterface) {
                         }
                     }.bind(this);
                     xhr.send();
-                }.bind(this), 500);
+                }.bind(this));
 
                 e.preventDefault();
                 e.returnValue = '';


### PR DESCRIPTION
This PR prompts the user if they would like to save their current project if they click "Cancel", instead of automatically saving it. Detecting if the user selected "Cancel" proved to be a problem, as calls to `confirm` made prior to the end of `onbeforeunload` are still displayed even if the user does not select cancel. To remedy this, a blocked action is performed, and only in the event of a success is the user prompted to save. The blocked action used is a GET request to the current page, which should almost always succeed (and quickly!) in a normal environment. This is unfortunately a sub-optimal solution, and comes as a byproduct of there not currently existing a way to prompt for user input within musicblocks itself.