### PR TITLE
Preview Sound for Pitch Number Block

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -5133,7 +5133,12 @@ function Logo () {
 
                     if (that.blocks.blockList[blk].name == 'scaledegree') {
                         var noteObj = getNote(that.currentNote, calcOctave(that.currentCalculatedOctave[turtle], arg1, that.lastPitchPlayed[turtle], that.currentNote), 0, that.keySignature[turtle], that.moveable[turtle], null, that.errorMsg);
-                    } else {
+                    } else if (that.blocks.blockList[blk].name == 'pitchnumber'){
+                        //For pitch number, need to translate number value to pitch
+                        var getNumberToPitch = numberToPitch(Math.floor(arg0 + that.pitchNumberOffset[turtle]), that.synth.inTemperament, that.synth.startingPitch, that.pitchNumberOffset[turtle]);
+                        var noteObj = getNote(getNumberToPitch[0], calcOctave(that.currentCalculatedOctave[turtle], getNumberToPitch[1], that.lastPitchPlayed[turtle], getNumberToPitch[0]), 0, that.keySignature[turtle], that.moveable[turtle], null, that.errorMsg);
+                    }
+                    else {
                         var noteObj = getNote(arg0, calcOctave(that.currentCalculatedOctave[turtle], arg1, that.lastPitchPlayed[turtle], arg0), 0, that.keySignature[turtle], that.moveable[turtle], null, that.errorMsg);
                     }
 


### PR DESCRIPTION
Pitch Number block should now have a sound preview. This should fix #1903 

In my opinion, this is more of a bug fix than an enhancement, as Pitch Number block do actually run a sound preview. However, it tries to run a number, not a pitch, and hence it throws this error:

![bug 144](https://user-images.githubusercontent.com/44361130/71541743-ab10e380-2998-11ea-8b5c-60c8174ed2de.png)

This fix should first translate the number into pitch before passing the values to getNote function.