### PR TITLE
Fix #1985

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4037,30 +4037,12 @@ function Activity() {
             this.hideMusicBlocks = function () {
                 hideSearchWidget();
                 if (_THIS_IS_MUSIC_BLOCKS_) {
-                    // storage.setItem('isMatrixHidden', docById('ptmDiv').style.visibility);
-                    // storage.setItem('isStaircaseHidden', docById('pscDiv').style.visibility);
                     storage.setItem('isTimbreHidden', docById('timbreDiv').style.visibility);
-                    storage.setItem('isPitchDrumMatrixHidden', docById('pdmDiv').style.visibility);
                     storage.setItem('isMusicKeyboardHidden', docById('mkbDiv').style.visibility);
                     storage.setItem('isModeWidgetHidden', docById('modeDiv').style.visibility);
                     storage.setItem('isMeterWidgetHidden', docById('meterDiv').style.visibility);
-                    // storage.setItem('isSliderHidden', docById('sliderDiv').style.visibility);
                     storage.setItem('isTemperamentHidden', docById('temperamentDiv').style.visibility);
-                    storage.setItem('isTempoHidden', docById('tempoDiv').style.visibility);
 
-                    /*
-                    if (docById('ptmDiv').style.visibility !== 'hidden') {
-                        docById('ptmDiv').style.visibility = 'hidden';
-                        docById('ptmTableDiv').style.visibility = 'hidden';
-                        docById('ptmButtonsDiv').style.visibility = 'hidden';
-                    }
-
-                    if (docById('pdmDiv').style.visibility !== 'hidden') {
-                        docById('pdmDiv').style.visibility = 'hidden';
-                        docById('pdmButtonsDiv').style.visibility = 'hidden';
-                        docById('pdmTableDiv').style.visibility = 'hidden';
-                    }
-                    */
                     if (docById('mkbDiv').style.visibility !== 'hidden') {
                         docById('mkbDiv').style.visibility = 'hidden';
                         docById('mkbButtonsDiv').style.visibility = 'hidden';
@@ -4085,9 +4067,6 @@ function Activity() {
                         docById('temperamentButtonsDiv').style.visibility = 'hidden';
                     }
 
-                    window.widgetWindows.clear('status');
-                    window.widgetWindows.clear('slider');
-
                     if (docById('modeDiv').style.visibility !== 'hidden') {
                         docById('modeDiv').style.visibility = 'hidden';
                         docById('modeButtonsDiv').style.visibility = 'hidden';
@@ -4101,7 +4080,8 @@ function Activity() {
                     }
                 }
 
-                storage.setItem('isStatusHidden', window.widgetWindows.isOpen('status'));
+                widgetWindows.hideWindows();
+
                 logo.doStopTurtle();
                 docById('helpElem').style.visibility = 'hidden';
                 document.querySelector('.canvasHolder').classList.add('hide');
@@ -4117,44 +4097,24 @@ function Activity() {
             this.showMusicBlocks = function () {
                 document.getElementById('toolbars').style.display = "block";
 
-                if (storage.getItem('isStatusHidden')) {
-                    logo.statusMatrix = new StatusMatrix();
-                    logo.statusMatrix.init(logo);
-                }
+                widgetWindows.showWindows();
 
                 if (_THIS_IS_MUSIC_BLOCKS_) {
-                    // docById('ptmDiv').style.visibility = storage.getItem('isMatrixHidden');
-                    // docById('ptmButtonsDiv').style.visibility = storage.getItem('isMatrixHidden');
-                    // docById('ptmTableDiv').style.visibility = storage.getItem('isMatrixHidden');
-                    // docById('pscDiv').style.visibility = storage.getItem('isStaircaseHidden');
-                    // docById('pscButtonsDiv').style.visibility = storage.getItem('isStaircaseHidden');
-                    // docById('pscTableDiv').style.visibility = storage.getItem('isStaircaseHidden');
                     docById('timbreDiv').style.visibility = storage.getItem('isTimbreHidden');
                     docById('timbreButtonsDiv').style.visibility = storage.getItem('isTimbreHidden');
                     docById('timbreTableDiv').style.visibility = storage.getItem('isTimbreHidden');
                     docById('temperamentDiv').style.visibility = storage.getItem('isTemperamentHidden');
                     docById('temperamentButtonsDiv').style.visibility = storage.getItem('isTemperamentHidden');
                     docById('temperamentTableDiv').style.visibility = storage.getItem('isTemperamentHidden');
-                    // docById('sliderDiv').style.visibility = storage.getItem('isSliderHidden');
-                    // docById('sliderButtonsDiv').style.visibility = storage.getItem('isSliderHidden');
-                    // docById('sliderTableDiv').style.visibility = storage.getItem('isSliderHidden');
-                    docById('pdmDiv').style.visibility = storage.getItem('isPitchDrumMatrixHidden');
-                    docById('pdmButtonsDiv').style.visibility = storage.getItem('isPitchDrumMatrixHidden');
-                    docById('pdmTableDiv').style.visibility = storage.getItem('isPitchDrumMatrixHidden');
                     docById('mkbDiv').style.visibility = storage.getItem('isMusicKeyboardHidden');
                     docById('mkbButtonsDiv').style.visibility = storage.getItem('isMusicKeyboardHidden');
                     docById('mkbTableDiv').style.visibility = storage.getItem('isMusicKeyboardHidden');
-                    // docById('rulerButtonsDiv').style.visibility = storage.getItem('isRhythmRulerHidden');
-                    // docById('rulerTableDiv').style.visibility = storage.getItem('isRhythmRulerHidden');
                     docById('modeDiv').style.visibility = storage.getItem('isModeWidgetHidden');
                     docById('modeButtonsDiv').style.visibility = storage.getItem('isModeWidgetHidden');
                     docById('modeTableDiv').style.visibility = storage.getItem('isModeWidgetHidden');
                     docById('meterDiv').style.visibility = storage.getItem('isMeterWidgetHidden');
                     docById('meterButtonsDiv').style.visibility = storage.getItem('isMeterWidgetHidden');
                     docById('meterTableDiv').style.visibility = storage.getItem('isMeterWidgetHidden');
-                    // Don't reopen the tempo widget since we didn't just hide it, but also closed it.
-                    // docById('tempoDiv').style.visibility = localStorage.getItem('isTempoHidden');
-                    // docById('tempoButtonsDiv').style.visibility = localStorage.getItem('isTempoHidden');
                 }
                 document.querySelector('.canvasHolder').classList.remove('hide');
                 document.querySelector('#canvas').style.display = '';

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -154,6 +154,8 @@ function StatusMatrix() {
 
             activeTurtles += 1;
         }
+
+        widgetWindow.sendToCenter();
     };
 
     this.updateAll = function() {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -180,20 +180,16 @@ function WidgetWindow(key, title) {
     };
 
     this.sendToCenter = function () {
-        let rect = this._frame.getBoundingClientRect();
-        let width = rect.right - rect.left;
-        let height = rect.bottom - rect.top;
+        let fRect = this._frame.getBoundingClientRect();
+        let cRect = canvas.getBoundingClientRect();
 
-        rect = canvas.getBoundingClientRect();
-        let cw = rect.right - rect.left;
-        let ch = rect.bottom - rect.top;
-
-        if (cw === 0 || ch === 0) {
+        if (cRect.width === 0 || cRect.height === 0) {
             // The canvas isn't shown so we don't know how large it really is
             return this;
         }
 
-        this.setPosition((cw - width) / 2, (ch - height) / 2);
+        this.setPosition((cRect.width - fRect.width) / 2,
+                         (cRect.height - fRect.height) / 2);
 
         return this;
     };
@@ -285,5 +281,17 @@ window.widgetWindows.clear = function (name) {
 };
 
 window.widgetWindows.isOpen = function (name) {
-    return !!window.widgetWindows.openWindows[name];
+    return window.widgetWindows.openWindows[name] ? true : "";
+};
+
+window.widgetWindows.hideWindows = function (name) {
+    Object.values(window.widgetWindows.openWindows).forEach(win => {
+        win._frame.style.display = 'none';
+    });
+};
+
+window.widgetWindows.showWindows = function (name) {
+    Object.values(window.widgetWindows.openWindows).forEach(win => {
+        win._frame.style.display = 'block';
+    });
 };


### PR DESCRIPTION
This will hide and restore all widget windows in their original location when the planet it opened then closed. For testing
```js
new StatusMatrix().init(logo);
```
can be used to open a widget, as the palette is still broken.