### PR TITLE
Possible fix for Issue #1782

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
   <script src="lib/reqwest.js" defer></script>
 
-  <script src="lib/jquery-2.1.4.js" defer></script>
+  <script src="lib/jquery-2.1.4.js"></script>
 
   <script src="lib/jquery-ui.js" defer></script>
 
@@ -97,6 +97,12 @@
 		});
 	}
     }
+  </script>
+	
+  <script type="text/javascript">
+    $(document).ready(function(){
+      doSearch();
+    });
   </script>
 
 </head>


### PR DESCRIPTION
It seemed as though the autocomplete handler must be called on page load. I also removed the "defer" in the JQuery link file as it doesn't run $(document).ready();

![possible](https://user-images.githubusercontent.com/44361130/71716292-2c5fee80-2e4f-11ea-9efc-4b2691d9ad14.gif)


This is more of a work in progress PR, as I have never seen MB's search autocompletion, and thus, I don't know what it should look like. As always, let me know what you think!