### PR TITLE
Reinit Tempo Widget Window

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5548,6 +5548,18 @@ function Block(protoblock, blocks, overrideName) {
     this._labelChanged = function (closeInput, notPieMenu) {
         // Update the block values as they change in the DOM label.
         console.debug('LABEL CHANGED ' + this.name);
+        
+        //Detect if label is changed, then reinit widget windows
+        //if open
+        var thisBlock = this.blocks.blockList.indexOf(this);
+        var topBlock = this.blocks.findTopBlock(thisBlock);
+        for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++){
+          if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo'){
+            if (closeInput === false){
+              this.blocks.logo.runLogoCommands(topBlock);
+            }
+          }
+        }
 
         if (this === null || this.label === null) {
             this._labelLock = false;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1350,6 +1350,16 @@ function Blocks (activity) {
 
         // Disconnect from connection[0] (both sides of the connection).
         if (c != null) {
+            //Check if we are disconnecting blocks from widget blocks
+            //then reinit if windget windows is open
+            for (var x = 0; x < document.getElementsByClassName('wftTitle').length; x++){
+              console.log(document.getElementsByClassName('wftTitle')[x].innerHTML);
+              if (document.getElementsByClassName('wftTitle')[x].innerHTML === 'tempo'){
+                if (this.blockList[this.findTopBlock(thisBlock)].name === 'tempo'){
+                  this.logo.runLogoCommands(this.findTopBlock(thisBlock));
+                }
+              }
+            }
             // Disconnect both ends of the connection.
             for (var i = 1; i < cBlock.connections.length; i++) {
                 if (cBlock.connections[i] === thisBlock) {
@@ -1704,6 +1714,15 @@ function Blocks (activity) {
             // console.debug('Adjust Docks: ' + this.blockList[newBlock].name);
             this.adjustDocks(newBlock, true);
             // TODO: some graphical feedback re new connection?
+            
+            //Check if block is one of the widget blocks
+            for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++){
+              if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo'){
+                if (this.blockList[this.findTopBlock(thisBlock)].name === 'tempo'){
+                  this.logo.runLogoCommands(this.findTopBlock(thisBlock));
+                }
+              }
+            }
         }
 
         // If it is an arg block, where is it coming from?

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1716,9 +1716,10 @@ function Blocks (activity) {
             // TODO: some graphical feedback re new connection?
             
             //Check if block is one of the widget blocks
-            for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++){
-              if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo'){
-                if (this.blockList[this.findTopBlock(thisBlock)].name === 'tempo'){
+            //and run only when not disconnecting blocks
+            if (c === null){
+              for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++){
+                if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo'){
                   this.logo.runLogoCommands(this.findTopBlock(thisBlock));
                 }
               }

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -231,7 +231,7 @@ function Tempo () {
         var w = window.innerWidth;
         var iconSize = ICONSIZE;
 
-        var widgetWindow = window.widgetWindows.windowFor(this, "phrase maker");
+        var widgetWindow = window.widgetWindows.windowFor(this, "tempo");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
 


### PR DESCRIPTION
This is a work in progress PR. It detects if the user changes something in the argument block. If the widget windows is open, it is re-initialized. 

![reinit](https://user-images.githubusercontent.com/44361130/71878429-91288b00-3166-11ea-96f6-92ea77d41138.gif)

This is a work in progress PR, as there is a bug when re-initializing after detecting block addition/deletion from widget clamp:

![reinit2](https://user-images.githubusercontent.com/44361130/71879762-d39f9700-3169-11ea-83bf-f6acd4125e4e.gif)

