### PR TITLE
Re-init Rhythm Ruler Widget Window

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5553,11 +5553,12 @@ function Block(protoblock, blocks, overrideName) {
         for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++) {
             if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo'){
                 if (closeInput === false) {
-                    var that = this;
-                    setTimeout(function () {
-                        that.blocks.logo.runLogoCommands(topBlock);
-                        console.debug('VALUE: ' + that.value);
-                    }, 5000);
+                  this.blocks.reInitWidget(topBlock, 5000);
+                }
+            }
+            if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'rhythm maker'){
+                if (closeInput === false) {
+                  this.blocks.reInitWidget(topBlock, 5000);
                 }
             }
         }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1268,6 +1268,15 @@ function Blocks (activity) {
             return thisBlockobj.connections[0];
         }
     };
+    
+    //To make everything cleaner, use this function to reinit widget
+    //when it's widget windows is open
+    this.reInitWidget = function(topBlock, timeout){
+      var that = this;
+      setTimeout(function () {
+          that.logo.runLogoCommands(topBlock);
+      }, timeout);
+    };
 
     /*
      * When a block is moved, we have to check the following:
@@ -1365,13 +1374,12 @@ function Blocks (activity) {
             // Check if we are disconnecting blocks from widget blocks;
             // then reinit if widget windows is open.
             for (var x = 0; x < document.getElementsByClassName('wftTitle').length; x++){
+              console.log(initialTopBlock);
                 if (document.getElementsByClassName('wftTitle')[x].innerHTML === 'tempo'){
-                    if (this.blockList[initialTopBlock].name === 'tempo'){
-                        var that = this;
-                        setTimeout(function () {
-                            that.logo.runLogoCommands(initialTopBlock);
-                        }, 1500);
-                    }
+                  this.reInitWidget(initialTopBlock, 1500);
+                }
+                if (document.getElementsByClassName('wftTitle')[x].innerHTML === 'rhythm maker'){
+                  this.reInitWidget(initialTopBlock, 1500);
                 }
             }
         }
@@ -1723,12 +1731,12 @@ function Blocks (activity) {
             if (c === null){
                 for (var i = 0; i < document.getElementsByClassName('wftTitle').length; i++) {
                     if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'tempo') {
-                        if (this.blockList[this.findTopBlock(thisBlock)].name === 'tempo') {
-                            var that = this;
-                            setTimeout(function () {
-                                that.logo.runLogoCommands(that.findTopBlock(thisBlock));
-                            }, 1500);
-                        }
+                      var that = this;
+                      this.reInitWidget(that.findTopBlock(thisBlock), 1500);
+                    }
+                    if (document.getElementsByClassName('wftTitle')[i].innerHTML === 'rhythm maker'){
+                      var that = this;
+                      this.reInitWidget(that.findTopBlock(thisBlock), 1500);
                     }
                 }
             }

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -180,6 +180,9 @@ function RhythmRuler () {
         }
 
         // this._piemenuRuler(this._rulerSelected);
+        
+        //Save dissect history everytime user dissects ruler
+        this.saveDissectHistory();
     };
 
     this.__startTapping = function (noteValues, interval) {
@@ -1507,35 +1510,6 @@ function RhythmRuler () {
             // docById('wheelDiv').style.display = 'none';
             // docById('contextWheelDiv').style.display = 'none';
 
-            // Save the new dissect history.
-            var dissectHistory = [];
-            var drums = [];
-            for (var i = 0; i < that.Rulers.length; i++) {
-                if (that.Drums[i] === null) {
-                    continue;
-                }
-
-                var history = [];
-                for (var j = 0; j < that.Rulers[i][1].length; j++) {
-                    history.push(that.Rulers[i][1][j]);
-                }
-
-                that._dissectNumber.classList.add('hasKeyboard');
-                dissectHistory.push([history, that.Drums[i]]);
-                drums.push(that.Drums[i]);
-            }
-
-            // Look for any old entries that we may have missed.
-            for (var i = 0; i < that._dissectHistory.length; i++) {
-                var drum = that._dissectHistory[i][1];
-                if (drums.indexOf(drum) === -1) {
-                    var history = JSON.parse(JSON.stringify(that._dissectHistory[i][0]));
-                    dissectHistory.push([history, drum]);
-                }
-            }
-
-            that._dissectHistory = JSON.parse(JSON.stringify(dissectHistory));
-
             that._playing = false;
             that._playingOne = false;
             that._playingAll = false;
@@ -1823,6 +1797,39 @@ function RhythmRuler () {
 
         this._logo.textMsg(_('Click on the ruler to divide it.'));
         // this._piemenuRuler(this._rulerSelected);
+    };
+    
+    this.saveDissectHistory = function() {
+      // Save the new dissect history.
+      var that = this;
+      var dissectHistory = [];
+      var drums = [];
+      for (var i = 0; i < that.Rulers.length; i++) {
+          if (that.Drums[i] === null) {
+              continue;
+          }
+
+          var history = [];
+          for (var j = 0; j < that.Rulers[i][1].length; j++) {
+              history.push(that.Rulers[i][1][j]);
+          }
+
+          that._dissectNumber.classList.add('hasKeyboard');
+          dissectHistory.push([history, that.Drums[i]]);
+          drums.push(that.Drums[i]);
+      }
+
+      // Look for any old entries that we may have missed.
+      for (var i = 0; i < that._dissectHistory.length; i++) {
+          var drum = that._dissectHistory[i][1];
+          if (drums.indexOf(drum) === -1) {
+              var history = JSON.parse(JSON.stringify(that._dissectHistory[i][0]));
+              dissectHistory.push([history, drum]);
+          }
+      }
+
+      that._dissectHistory = JSON.parse(JSON.stringify(dissectHistory));
+
     };
 
     this._piemenuRuler = function (selectedRuler) {


### PR DESCRIPTION
Rhythm Ruler should now be able to re-initialize (as said in #1725 ) when user changes blocks/label while widget windows is open:

![reinit3](https://user-images.githubusercontent.com/44361130/72046685-e47c1400-32f3-11ea-9eb0-d9f5cfc9a14e.gif)

I also created `this.reInitWidget` function to save up lines of code.

