### PR TITLE
Re-init Status and Phrase Maker Widget Window

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5560,6 +5560,8 @@ function Block(protoblock, blocks, overrideName) {
                 case 'rhythm maker':
                 case 'pitch slider':
                 case 'pitch staircase':
+                case 'status':
+                case 'phrase maker':
                   lockInit = true;
                   this.blocks.reInitWidget(topBlock, 5000);
                   break;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1384,6 +1384,8 @@ function Blocks (activity) {
                   case 'rhythm maker':
                   case 'pitch slider':
                   case 'pitch staircase':
+                  case 'status':
+                  case 'phrase maker':
                     lockInit = true;
                     this.reInitWidget(initialTopBlock, 1500);
                     break;
@@ -1748,6 +1750,8 @@ function Blocks (activity) {
                       case 'rhythm maker':
                       case 'pitch slider':
                       case 'pitch staircase':
+                      case 'status':
+                      case 'phrase maker':
                         lockInit = true;
                         this.reInitWidget(that.findTopBlock(thisBlock), 1500);
                         break;


### PR DESCRIPTION
Status and Phrase Maker Widget Window should now be able to re-init when user changes the label or add/deletes a block inside the widget clamp.

Let me know what you think!