### PR TITLE
Refactor Pitch Drum to widget windows + Re-init Functionality

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5564,6 +5564,7 @@ function Block(protoblock, blocks, overrideName) {
                 case 'phrase maker':
                 case 'custom mode':
                 case 'music keyboard':
+                case 'pitch drum':
                   lockInit = true;
                   this.blocks.reInitWidget(topBlock, 5000);
                   break;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1388,6 +1388,7 @@ function Blocks (activity) {
                   case 'phrase maker':
                   case 'custom mode':
                   case 'music keyboard':
+                  case 'pitch drum':
                     lockInit = true;
                     this.reInitWidget(initialTopBlock, 1500);
                     break;
@@ -1756,6 +1757,7 @@ function Blocks (activity) {
                       case 'phrase maker':
                       case 'custom mode':
                       case 'music keyboard':
+                      case 'pitch drum':
                         lockInit = true;
                         this.reInitWidget(that.findTopBlock(thisBlock), 1500);
                         break;


### PR DESCRIPTION
Pitch drum should now adhere to the widget windows design:

![design3](https://user-images.githubusercontent.com/44361130/72693575-53673180-3b6c-11ea-85e2-7ed321822c84.gif)


Let me know what you think!