### PR TITLE
Not setting the display to none on duplicating.

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5910,7 +5910,7 @@ function Block(protoblock, blocks, overrideName) {
             that.blocks.activeBlock = thisBlock;
             that.blocks.prepareStackForCopy();
             that.blocks.pasteStack();
-            docById('contextWheelDiv').style.display = '';
+            // docById('contextWheelDiv').style.display = 'none';
         };
 
         wheel.navItems[1].navigateFunction = function () {

--- a/js/block.js
+++ b/js/block.js
@@ -5910,7 +5910,7 @@ function Block(protoblock, blocks, overrideName) {
             that.blocks.activeBlock = thisBlock;
             that.blocks.prepareStackForCopy();
             that.blocks.pasteStack();
-            docById('contextWheelDiv').style.display = 'none';
+            docById('contextWheelDiv').style.display = '';
         };
 
         wheel.navItems[1].navigateFunction = function () {


### PR DESCRIPTION
Context wheel remains open after pressing the duplicate button. 
Fixes #1984 