### PR TITLE
Fix regression on fullscreen button for widget windows

### DIFF
--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -54,21 +54,6 @@ function MeterWidget() {
             this.destroy();
         }
 
-        widgetWindow.onmaximize = function(){
-          if(widgetWindow._maximized){
-            widgetWindow.getWidgetBody().style.position = "absolute";
-            widgetWindow.getWidgetBody().style.height = "calc(100vh - 80px)";
-            widgetWindow.getWidgetBody().style.width = "200vh";
-            widgetWindow.getWidgetBody().style.left = "70px";
-
-          } else{
-            widgetWindow.getWidgetBody().style.position = "relative";
-            widgetWindow.getWidgetBody().style.left = "0px";
-            widgetWindow.getWidgetBody().style.height = "410px";
-            widgetWindow.getWidgetBody().style.width = "410px";
-          }
-        }
-
 
         this._click_lock = false;
         widgetWindow.addButton('play-button.svg', ICONSIZE, _('Play')).onclick = function() {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -173,7 +173,7 @@ function WidgetWindow(key, title) {
     };
     
     this.onmaximize = function() {
-        this.maximize();
+        return this;
     };
 
     this.setPosition = function (x, y) {


### PR DESCRIPTION
This should fix #2057 , where the introduction of `this.onmaximize` caused the fullscreen button functionality to misbehave when returning to unfullscreen mode.