### PR TITLE
Refactor Timbre Widget to Widget Windows + Re-init Functionality

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5567,6 +5567,7 @@ function Block(protoblock, blocks, overrideName) {
                 case 'pitch drum':
                 case 'meter':
 		case 'temperament':
+		case 'timbre':
                   lockInit = true;
                   this.blocks.reInitWidget(topBlock, 5000);
                   break;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1391,6 +1391,7 @@ function Blocks (activity) {
                   case 'pitch drum':
                   case 'meter':
                   case 'temperament':
+                  case 'timbre':
                     lockInit = true;
                     this.reInitWidget(initialTopBlock, 1500);
                     break;
@@ -1762,6 +1763,7 @@ function Blocks (activity) {
                       case 'pitch drum':
                       case 'meter':
                       case 'temperament':
+                      case 'timbre':
                         lockInit = true;
                         this.reInitWidget(that.findTopBlock(thisBlock), 1500);
                         break;


### PR DESCRIPTION
Timbre widget should now adhere to the new widget windows design:

![design7](https://user-images.githubusercontent.com/44361130/73152077-597b8600-4109-11ea-9098-c4ebd782ef3c.gif)
