### PR TITLE
#2067 Animation removed from statisics

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1028,7 +1028,7 @@ function Activity() {
       var ctx = myChart.getContext('2d');
         loading = true;
         document.body.style.cursor = 'wait';
-        doLoadAnimation();
+        
       var myRadarChart = null;
       var  scores = analyzeProject(blocks);
       var data = scoreToChartData(scores);


### PR DESCRIPTION
As discussed with @AndreaGon  , load animation should not be  called in doAnalytics .
It is causing infinite loading animation .So, removed it from that patch.