### PR TITLE
Rotate Mouse Container instead of Image

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -1072,7 +1072,7 @@ function Turtle (name, turtles, drum) {
         }
 
         this.orientation %= 360;
-        this.bitmap.rotation = this.orientation;
+        this.container.rotation = this.orientation;
         // We cannot update the cache during the 'tween'.
         if (this.blinkFinished) {
             this.updateCache();


### PR DESCRIPTION
This should fix #2047. The container of the mouse should be rotated instead of the actual mouse image.

![mouse](https://user-images.githubusercontent.com/44361130/73713934-2741d800-474a-11ea-9d01-8ae5d74d025d.gif)
