### PR TITLE
Add z-index for printed text

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1413,6 +1413,7 @@ input.timbreName {
 
  #printText {
     border: 2px solid rgb(150, 150, 150);
+    z-index: 100;
   }
 
   #errorText {


### PR DESCRIPTION
I've added z-index so that widgets in fullscreen mode can see printed message, as said in #2018 

![fix2](https://user-images.githubusercontent.com/44361130/74328231-85b12b00-4dc8-11ea-921b-8073dfdf58ff.PNG)