### PR TITLE
fixes #2112 distance labels shown

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -212,9 +212,7 @@ class DistanceBlock extends LeftBlock {
             defaults: [0, 0, 100, 100],
             argTypes: ['anyin', 'anyin', 'anyin', 'anyin'],
 	    outType: 'anyout',
-            argLabels: [
-		_('x1'), _('y1'), _('x2'), _('y2')
-            ]
+            argLabels: [('x1'), ('y1'), ('x2'), ('y2')]
         });
 
         this.makeMacro((x, y) => [

--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -212,7 +212,7 @@ class DistanceBlock extends LeftBlock {
             defaults: [0, 0, 100, 100],
             argTypes: ['anyin', 'anyin', 'anyin', 'anyin'],
 	    outType: 'anyout',
-            argLabels: [('x1'), ('y1'), ('x2'), ('y2')]
+            argLabels: ['x1', 'y1', 'x2', 'y2']
         });
 
         this.makeMacro((x, y) => [


### PR DESCRIPTION
![dist_pp](https://user-images.githubusercontent.com/45814442/75066739-85740680-5511-11ea-8e61-62a698e465cd.png)
Now labels are shown properly in firefox.
@walterbender  Please take a look.