### PR TITLE
Fixed Gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
 const replace = require('gulp-replace');
 const minifyCSS = require("gulp-minify-css");
-const cleanCSS = require('gulp-clean-css');
 const gulp = require('gulp'); 
 
 


### PR DESCRIPTION
There was an unused **const cleanCSS** package. I have removed its declaration from _gulpfile.js._
This will reduce some overhead time for the compilation of the code.