### PR TITLE
Animation removed from loadPlugin

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5416,7 +5416,7 @@ function Activity() {
                 reader.onload = function(theFile) {
                     loading = true;
                     document.body.style.cursor = "wait";
-                    doLoadAnimation();
+                    //doLoadAnimation();
 
                     setTimeout(function() {
                         obj = processRawPluginData(


### PR DESCRIPTION
![removedanimation](https://user-images.githubusercontent.com/45814442/75573419-ceccd480-5a82-11ea-8070-f87289a5cb8a.gif)
It gets into infinite loop of loading animation when I chose a plugin .
So , I removed **doLoadAnimation();**

@walterbender  . Please review this.