### PR TITLE
Small Fix Regarding Cropped Avatar Img when used Set Heading

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -1269,7 +1269,7 @@ function Turtle(name, turtles, drum) {
         }
 
         this.orientation %= 360;
-        this.bitmap.rotation = this.orientation;
+        this.container.rotation = this.orientation;
         // We cannot update the cache during the 'tween'.
         if (this.blinkFinished) {
             this.updateCache();


### PR DESCRIPTION
Mouse (avatar) image is cropped when rotating mouse using the setheading block. I've changed the code from 'this.bitmap.orientation' to 'this.container.orientation'.