### PR TITLE
fixed typo in timer

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -2460,7 +2460,7 @@ function Logo() {
             );
             this.timbre.notesToPlay.push([
                 noteObj[0] + noteObj[1],
-                1 / noteBeatVvalue
+                1 / noteBeatValue
             ]);
             this.previousNotePlayed[turtle] = this.lastNotePlayed[turtle];
             this.lastNotePlayed[turtle] = [


### PR DESCRIPTION
@walterbender  In this PR, due to a spelling mistake , the timber widget  was not running.
I have fixed the typo. Please take a look.
