### PR TITLE
Feature: Cycling through block help after introductory help 

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -12,6 +12,8 @@
 
 function HelpWidget() {
     const ICONSIZE = 32;
+    var beginnerBlocks = [];
+    var index = 1;
 
     this.init = function(blocks) {
         this.isOpen = true;
@@ -259,6 +261,18 @@ function HelpWidget() {
                 '" target="_blank">' +
                 HELPCONTENT[page][4] +
                 "</a></p>";
+        }
+
+        if (
+            [
+                _("Congratulations.")
+            ].indexOf(HELPCONTENT[page][0]) !== -1
+        ) {
+            var cell = docById("right-arrow");
+            var that = this;
+            cell.onclick = function() {
+                alert("clicked")
+            }
         }
 
         helpBody.style.color = "#505050";

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -272,7 +272,7 @@ function HelpWidget() {
             var cell = docById("right-arrow");
             var that = this;
             cell.onclick = function() {
-                this._prepareBlockList(blocks);
+                that._prepareBlockList(blocks);
             }
         }
 
@@ -296,7 +296,161 @@ function HelpWidget() {
     }
         console.log(beginnerBlocks);
         console.log(advancedBlocks);
+        this._blockHelp(blocks.protoBlockDict[beginnerBlocks[0]], blocks)
+
     }
+
+    // Function to display help related to a single block
+    // called recursively to cycle through help string of all blocks (Beginner Blocks First)
+
+    this._blockHelp = function(block, blocks) {
+        var iconSize = ICONSIZE;
+    
+        console.log("called")
+        // this.widgetWindow.onClose();
+        var widgetWindow = window.widgetWindows.windowFor(this, "help", "help");
+        this.widgetWindow = widgetWindow;
+        widgetWindow.clear();
+        this._helpDiv = document.createElement("div");
+    
+        this._helpDiv.style.width = iconSize * 2 + 495 + "px";
+        this._helpDiv.style.height = iconSize * 2 + 495 + "px";
+        this._helpDiv.style.backgroundColor = "#e8e8e8";
+        this._helpDiv.innerHTML =
+            '<div id="right-arrow" class="hover" tabindex="-1"></div><div id="left-arrow" class="hover" tabindex="-1"></div><div id="helpButtonsDiv" tabindex="-1"></div><div id="helpBodyDiv" tabindex="-1"></div>';
+    
+        this.widgetWindow.getWidgetBody().append(this._helpDiv);
+        var cell = docById("right-arrow");
+        var that = this;
+        cell.onclick = function() {
+            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks)
+            index += 1;
+        }
+        if (block.name !== null) {
+                var label =
+                    block
+                        .staticLabels[0];
+                this.widgetWindow.updateTitle(_(label));
+            }
+    
+        // display help menu
+        // docById("helpBodyDiv").style.height = "325px";
+        // docById("helpBodyDiv").style.width = "400px";
+        // this._showPage(0);
+    
+        if (block.name !== null) {
+            var name = block.name;
+            console.log("called 2");
+            var message =
+                block.helpString;
+            console.log(message);
+            var helpBody = docById("helpBodyDiv");
+                helpBody.style.height = "";
+            if (message) {
+    
+                var body = "";
+                if (message.length > 1) {
+                    var path = message[1];
+                    // We need to add a case here whenever we add
+                    // help artwort support for a new language.
+                    // e.g., documentation-es
+                    var language = localStorage.languagePreference;
+                    if (language === undefined) {
+                        language = navigator.language;
+                    }
+    
+                    switch (language) {
+                        case "ja":
+                            if (localStorage.kanaPreference == "kana") {
+                                path = path + "-kana";
+                            } else {
+                                path = path + "-ja";
+                            }
+                            break;
+                        case "es":
+                            path = path + "-es";
+                            break;
+                        case "pt":
+                            path = path + "-pt";
+                            break;
+                        default:
+                            break;
+                    }
+    
+                    body =
+                        body +
+                        '<p><img src="' +
+                        path +
+                        "/" +
+                        name +
+                        '_block.svg"></p>';
+                }
+    
+                body = body + "<p>" + message[0] + "</p>";
+    
+                body +=
+                    '<img src="header-icons/export-chunk.svg" id="loadButton" width="32" height="32" alt=' +
+                    _("Load blocks") +
+                    "/>";
+    
+                helpBody.innerHTML = body;
+                console.log(body);
+                var loadButton = docById("loadButton");
+                if (loadButton !== null) {
+                    loadButton.onclick = function() {
+                        if (message.length < 4) {
+                            // If there is nothing specified, just
+                            // load the block.
+                            console.debug("CLICK: " + name);
+                            var obj = blocks.palettes.getProtoNameAndPalette(
+                                name
+                            );
+                            var protoblk = obj[0];
+                            var paletteName = obj[1];
+                            var protoName = obj[2];
+    
+                            var protoResult = blocks.protoBlockDict.hasOwnProperty(
+                                protoName
+                            );
+                            if (protoResult) {
+                                blocks.palettes.dict[
+                                    paletteName
+                                ].makeBlockFromSearch(
+                                    protoblk,
+                                    protoName,
+                                    function(newBlock) {
+                                        blocks.moveBlock(
+                                            newBlock,
+                                            100,
+                                            100
+                                        );
+                                    }
+                                );
+                            }
+                        } else if (typeof message[3] === "string") {
+                            // If it is a string, load the macro
+                            // assocuated with this block
+                            var blocksToLoad = getMacroExpansion(
+                                message[3],
+                                100,
+                                100
+                            );
+                            console.debug("CLICK: " + blocksToLoad);
+                            blocks.loadNewBlocks(blocksToLoad);
+                        } else {
+                            // Load the blocks.
+                            var blocksToLoad = message[3];
+                            console.debug("CLICK: " + blocksToLoad);
+                            blocks.loadNewBlocks(blocksToLoad);
+                        }
+                    };
+                }
+            }
+        }
+    
+    this.widgetWindow.takeFocus();
+    }
+    
 
     this.showPageByName = function(pageName) {
         for (var i = 0; i < HELPCONTENT.length; i++) {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -14,7 +14,7 @@ function HelpWidget() {
     const ICONSIZE = 32;
     var beginnerBlocks = [];
     var advancedBlocks = [];
-    var index = 1;
+    var index = 0;
 
     this.init = function(blocks) {
         this.isOpen = true;
@@ -118,8 +118,7 @@ function HelpWidget() {
                 // the help output.
                 var message =
                     blocks.blockList[blocks.activeBlock].protoblock.helpString;
-                // console.log(message);
-                // console.log(BLOCKHELP[name]);
+                
                 if (message) {
                     var helpBody = docById("helpBodyDiv");
                     helpBody.style.height = "";
@@ -282,6 +281,8 @@ function HelpWidget() {
         this.widgetWindow.takeFocus();
     };
 
+    // Prepare a list of beginner and advanced blocks and cycle through their help
+
     this._prepareBlockList = function(blocks) {
         for (var key in blocks.protoBlockDict){
             if(blocks.protoBlockDict[key].beginnerModeBlock === true && blocks.protoBlockDict[key].helpString !== undefined && blocks.protoBlockDict[key].helpString.length !== 0) {
@@ -306,15 +307,13 @@ function HelpWidget() {
     this._blockHelp = function(block, blocks) {
         var iconSize = ICONSIZE;
     
-        console.log("called")
-        // this.widgetWindow.onClose();
         var widgetWindow = window.widgetWindows.windowFor(this, "help", "help");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         this._helpDiv = document.createElement("div");
     
-        this._helpDiv.style.width = iconSize * 2 + 495 + "px";
-        this._helpDiv.style.height = iconSize * 2 + 495 + "px";
+        this._helpDiv.style.width = "500px";
+        this._helpDiv.style.height = "500px";
         this._helpDiv.style.backgroundColor = "#e8e8e8";
         this._helpDiv.innerHTML =
             '<div id="right-arrow" class="hover" tabindex="-1"></div><div id="left-arrow" class="hover" tabindex="-1"></div><div id="helpButtonsDiv" tabindex="-1"></div><div id="helpBodyDiv" tabindex="-1"></div>';
@@ -323,8 +322,18 @@ function HelpWidget() {
         var cell = docById("right-arrow");
         var that = this;
         cell.onclick = function() {
-            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks)
             index += 1;
+            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks)
+        }
+
+        var cell = docById("left-arrow");
+        
+        cell.onclick = function() {
+            if(index !== 0){
+                index -= 1;
+            }
+            
+            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks);
         }
         if (block.name !== null) {
                 var label =
@@ -340,10 +349,10 @@ function HelpWidget() {
     
         if (block.name !== null) {
             var name = block.name;
-            console.log("called 2");
+
             var message =
                 block.helpString;
-            console.log(message);
+
             var helpBody = docById("helpBodyDiv");
                 helpBody.style.height = "";
             if (message) {
@@ -394,7 +403,7 @@ function HelpWidget() {
                     "/>";
     
                 helpBody.innerHTML = body;
-                console.log(body);
+
                 var loadButton = docById("loadButton");
                 if (loadButton !== null) {
                     loadButton.onclick = function() {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -14,6 +14,7 @@ function HelpWidget() {
     const ICONSIZE = 32;
     var beginnerBlocks = [];
     var advancedBlocks = [];
+    var appendedBlockList = [];
     var index = 0;
 
     this.init = function(blocks) {
@@ -295,9 +296,13 @@ function HelpWidget() {
                 advancedBlocks.push(key);
         }
     }
-        console.log(beginnerBlocks);
-        console.log(advancedBlocks);
-        this._blockHelp(blocks.protoBlockDict[beginnerBlocks[0]], blocks)
+
+        // Array containing list of all blocks (Beginner blocks first)
+        
+        appendedBlockList.push(...beginnerBlocks);
+        appendedBlockList.push(...advancedBlocks);
+
+        this._blockHelp(blocks.protoBlockDict[appendedBlockList[0]], blocks)
 
     }
 
@@ -319,11 +324,14 @@ function HelpWidget() {
             '<div id="right-arrow" class="hover" tabindex="-1"></div><div id="left-arrow" class="hover" tabindex="-1"></div><div id="helpButtonsDiv" tabindex="-1"></div><div id="helpBodyDiv" tabindex="-1"></div>';
     
         this.widgetWindow.getWidgetBody().append(this._helpDiv);
+        this.widgetWindow.sendToCenter();
         var cell = docById("right-arrow");
         var that = this;
         cell.onclick = function() {
-            index += 1;
-            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks)
+            if(index !== appendedBlockList.length - 1) {
+                index += 1;
+        }
+            that._blockHelp(blocks.protoBlockDict[appendedBlockList[index]], blocks)
         }
 
         var cell = docById("left-arrow");
@@ -333,7 +341,7 @@ function HelpWidget() {
                 index -= 1;
             }
             
-            that._blockHelp(blocks.protoBlockDict[beginnerBlocks[index]], blocks);
+            that._blockHelp(blocks.protoBlockDict[appendedBlockList[index]], blocks);
         }
         if (block.name !== null) {
                 var label =

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -13,6 +13,7 @@
 function HelpWidget() {
     const ICONSIZE = 32;
     var beginnerBlocks = [];
+    var advancedBlocks = [];
     var index = 1;
 
     this.init = function(blocks) {
@@ -271,7 +272,7 @@ function HelpWidget() {
             var cell = docById("right-arrow");
             var that = this;
             cell.onclick = function() {
-                alert("clicked")
+                this._prepareBlockList(blocks);
             }
         }
 
@@ -280,6 +281,22 @@ function HelpWidget() {
 
         this.widgetWindow.takeFocus();
     };
+
+    this._prepareBlockList = function(blocks) {
+        for (var key in blocks.protoBlockDict){
+            if(blocks.protoBlockDict[key].beginnerModeBlock === true && blocks.protoBlockDict[key].helpString !== undefined && blocks.protoBlockDict[key].helpString.length !== 0) {
+                beginnerBlocks.push(key);
+            }
+        }
+
+        for(var key in blocks.protoBlockDict) {
+            if(blocks.protoBlockDict[key].beginnerModeBlock === false && blocks.protoBlockDict[key].helpString !== undefined && blocks.protoBlockDict[key].helpString.length !== 0) {
+                advancedBlocks.push(key);
+        }
+    }
+        console.log(beginnerBlocks);
+        console.log(advancedBlocks);
+    }
 
     this.showPageByName = function(pageName) {
         for (var i = 0; i < HELPCONTENT.length; i++) {


### PR DESCRIPTION
- After introductory help regarding palette buttons and toolbar, go through block help of all blocks.

- Beginner blocks are shown first.

- (WIP) Showing more info regarding each block like : Whether or not the block is beginnerMode or not and incorporating a show button which opens up the palette which contains the block.

- Fixes #1670 