### PR TITLE
Fixed issue of notes being inside repeat block in phrase maker

### DIFF
--- a/js/widgets/pitchtimematrix.js
+++ b/js/widgets/pitchtimematrix.js
@@ -56,7 +56,7 @@ function PitchTimeMatrix() {
         chorusDepth: 0
     };
 
-    // rowLabels can contain either a pitch, a drum, or a grphics command
+    // rowLabels can contain either a pitch, a drum, or a graphics commands
     this.rowLabels = [];
     // rowArgs can contain an octave or the arg(s) to a graphics command
     this.rowArgs = [];
@@ -606,7 +606,6 @@ function PitchTimeMatrix() {
 
             var ptmCell = ptmTableRow.insertCell();
             // Create tables to store individual notes.
-
             var ptmCellTable = document.createElement("table");
             ptmCellTable.setAttribute("cellpadding", "0px");
             ptmCell.append(ptmCellTable);
@@ -2217,12 +2216,10 @@ function PitchTimeMatrix() {
                     thisRow.push(i);
                 }
             }
-
             this._markedColsInRow.push(thisRow);
         }
 
         var sortableList = [];
-
         // Make a list to sort, skipping drums and graphics.
         // frequency;label;arg;row index
         for (var i = 0; i < this.rowLabels.length; i++) {
@@ -2337,20 +2334,22 @@ function PitchTimeMatrix() {
                     "skipping " + obj[1] + " " + last(this.rowLabels)
                 );
                 this._sortedRowMap.push(last(this._sortedRowMap));
-                setTimeout(
-                    this._removePitchBlock(
-                        oldColumnBlockMap[sortedList[lastObj][3]][0]
-                    ),
-                    500
-                );
-                this.columnBlocksMap = this.columnBlocksMap.filter(function(
-                    ele
-                ) {
-                    return (
-                        ele[0] !== oldColumnBlockMap[sortedList[lastObj][3]][0]
+                if (oldColumnBlockMap[sortedList[lastObj][3]] != undefined) {
+                    setTimeout(
+                        this._removePitchBlock(
+                            oldColumnBlockMap[sortedList[lastObj][3]][0]
+                        ),
+                        500
                     );
-                });
-                lastObj = i;
+                    this.columnBlocksMap = this.columnBlocksMap.filter(function(
+                        ele
+                    ) {
+                        return (
+                            ele[0] !== oldColumnBlockMap[sortedList[lastObj][3]][0]
+                        );
+                    });
+                    lastObj = i;
+                }
                 // skip duplicates
                 for (var j = this._rowMap[i]; j < this._rowMap.length; j++) {
                     this._rowOffset[j] -= 1;

--- a/js/widgets/pitchtimematrix.js
+++ b/js/widgets/pitchtimematrix.js
@@ -653,7 +653,16 @@ function PitchTimeMatrix() {
         this._noteValueRow = tempTable.insertRow();
         ptmTableRow.insertCell().append(tempTable);
 
+        // ***************
+        /* If there are note blocks we may sort them to remove
+           duplicates, but by using note blocks (we could also
+           be using them inside activities) we might rather be
+           interested in seeing corresponding note on the matrix
+           (and possibly change it too: this feature hasn't
+           been added yet). */
+
         // Sort them if there are note blocks.
+        /*
         this._lookForNoteBlocks();
         if (!this.sorted && this._noteBlocks) {
             setTimeout(function() {
@@ -663,6 +672,9 @@ function PitchTimeMatrix() {
         } else {
             this.sorted = false;
         }
+        */
+
+        // ***************
 
         this._logo.textMsg(_("Click on the table to add notes."));
 
@@ -4041,13 +4053,21 @@ function PitchTimeMatrix() {
                     var rIdx = null;
                     // Look in the rowBlocks for the nth match
                     for (var j = 0; j < this._rowBlocks.length; j++) {
-                        if (this._rowBlocks[j] === obj[0]) {
-                            if (c === n) {
-                                var rIdx = j;
+                        /* for note blocks within repeat block
+                           their ids are added with a larger number
+                           e.g. 11 becomes 1000011 or 2000011 */
+
+                        // Slice length of comparing id from end
+                        // of augmented id and compare
+                        var idsliced =
+                            this._rowBlocks[j]
+                            .toString()
+                            .slice(-obj[0].toString().length);
+                        if (idsliced === obj[0].toString()) {
+                            if ((c++) === n) {
+                                rIdx = j;
                                 break;
                             }
-
-                            c += 1;
                         }
                     }
 
@@ -4239,7 +4259,7 @@ function PitchTimeMatrix() {
             for (var j = 0; j < this.rowLabels.length; j++) {
                 var row = this._rows[j];
                 var cell = row.cells[i];
-                if (cell.style.backgroundColor == "black") {
+                if (cell.style.backgroundColor === "black") {
                     if (this.rowLabels[j] === "hertz") {
                         // if pitch specified in hertz
                         note.push(this.rowArgs[j]);


### PR DESCRIPTION
@pikurasa This fixes #2051. The repeats were being skipped because the IDs of note blocks inside repeat blocks were getting augmented and so weren't producing a match.<br/>
For example, in
![x2](https://user-images.githubusercontent.com/33328728/77794998-d3d96f80-7092-11ea-9ff1-d90ec7843338.png)
the block IDs were like
![x1](https://user-images.githubusercontent.com/33328728/77795028-e0f65e80-7092-11ea-8071-5ceea4aa65f2.png)
The IDs were getting added to a larger number. I fixed the comparison by comparing the trailing characters only, which would then match.<br/>
I've removed the sort when the phrase maker matrix is created and it contains note blocks. This is because we might want to see the corresponding note in the matrix when the note is part of some other block, e.g. `action`. Also, this could be a step towards being able to change the corresponding note from the phrase maker itself, which would be reflected on the blocks. However, this feature isn't added yet. Irrespective, we can sort the matrix by clicking on the sort button anytime.<br/>
In addition, I've fixed an invalid access case which was producing error.