### PR TITLE
Add wrap button to aux menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,8 +694,8 @@
                                 <li>
                                     <a 
                                         id="wrapTurtle" 
-                                        class="left tooltipped"
-                                        data-positin="bottom"
+                                        class="tooltipped"
+                                        data-position="bottom"
                                         ><i class="material-icons md-48"
                                             >wrap_text</i
                                         ></a

--- a/index.html
+++ b/index.html
@@ -691,6 +691,16 @@
                                         ></a
                                     >
                                 </li>
+                                <li>
+                                    <a 
+                                        id="wrapTurtle" 
+                                        class="left tooltipped"
+                                        data-positin="bottom"
+                                        ><i class="material-icons md-48"
+                                            >wrap_text</i
+                                        ></a
+                                    >
+                                </li>
                                 <li
                                     class="filler"
                                     id="aligns_merge_under_load"

--- a/js/activity.js
+++ b/js/activity.js
@@ -1031,16 +1031,6 @@ function Activity() {
         refreshCanvas();
     };
 
-    //  = function() {
-    //     WRAP = !WRAP;
-    //     let data = "";
-    //     if(WRAP) {
-    //         data = "off"
-    //     } else {
-    //         data = "on";
-    //     }
-    // }
-
     // DEPRECATED
     doStopButton = function() {
         blocks.activeBlock = null;

--- a/js/activity.js
+++ b/js/activity.js
@@ -1031,6 +1031,16 @@ function Activity() {
         refreshCanvas();
     };
 
+    //  = function() {
+    //     WRAP = !WRAP;
+    //     let data = "";
+    //     if(WRAP) {
+    //         data = "off"
+    //     } else {
+    //         data = "on";
+    //     }
+    // }
+
     // DEPRECATED
     doStopButton = function() {
         blocks.activeBlock = null;
@@ -5064,6 +5074,7 @@ function Activity() {
         toolbar.renderMergeIcon(_doMergeLoad);
         toolbar.renderRestoreIcon(_restoreTrash);
         toolbar.renderLanguageSelectIcon(languageBox);
+        toolbar.renderWrapIcon();
 
         if (planet != undefined) {
             saveLocally = planet.saveLocally.bind(planet);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -89,7 +89,6 @@ function Toolbar() {
 
         wrapIcon.onclick = () => {
             WRAP = !WRAP;
-            console.log(WRAP);
             if (WRAP) {
                 wrapButtonTooltipData = "Turtle Wrap Off";
             } else {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -78,11 +78,29 @@ function Toolbar() {
     // let wrapTurtleTooltipData = "Wrap Turtle Off";
     
     this.renderWrapIcon = function() {
-        var wrapIcon = docById("wrapTurtle");
+        let wrapIcon = docById("wrapTurtle");
+        let wrapButtonTooltipData = "Turtle Wrap Off";
+
+        wrapIcon.setAttribute("data-tooltip", wrapButtonTooltipData);
+        $j(".tooltipped").tooltip({
+            html: true,
+            delay: 100
+        });
 
         wrapIcon.onclick = () => {
             WRAP = !WRAP;
             console.log(WRAP);
+            if (WRAP) {
+                wrapButtonTooltipData = "Turtle Wrap Off";
+            } else {
+                wrapButtonTooltipData = "Turle Wrap On";
+            }
+
+            wrapIcon.setAttribute("data-tooltip", wrapButtonTooltipData);
+            $j(".tooltipped").tooltip({
+                html: true,
+                delay: 100
+            });
         }
     }
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -8,6 +8,7 @@
 // You should have received a copy of the GNU Affero General Public
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+let WRAP = true;
 
 function Toolbar() {
     var $j = jQuery.noConflict();
@@ -73,6 +74,17 @@ function Toolbar() {
             onclick();
         };
     };
+
+    // let wrapTurtleTooltipData = "Wrap Turtle Off";
+    
+    this.renderWrapIcon = function() {
+        var wrapIcon = docById("wrapTurtle");
+
+        wrapIcon.onclick = () => {
+            WRAP = !WRAP;
+            console.log(WRAP);
+        }
+    }
 
     this.renderSaveIcons = function(
         html_onclick,

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -912,58 +912,75 @@ function Turtle(name, turtles, drum) {
             ctx.moveTo(this.container.x, this.container.y);
         }
 
-        var angleRadians = (this.orientation * Math.PI) / 180.0;
-
-        var w = ctx.canvas.width;
-        var h = ctx.canvas.height;
-
-        var ox, oy, nx, ny;
-
-        var stepUnit = 10;
-
-	if (steps > 0) {
-            var xIncrease = stepUnit * Math.sin(angleRadians);
-            var yIncrease = stepUnit * Math.cos(angleRadians);
-	} else {
-            var xIncrease = -stepUnit * Math.sin(angleRadians);
-            var yIncrease = -stepUnit * Math.cos(angleRadians);
-	    steps = -steps;
-	}
-
-        while (steps >= 0) {
-            if (this.container.x > w) {
-                this.container.x = 0;
-                ctx.moveTo(this.container.x, this.container.y);
-            }
-            if (this.container.x < 0) {
-                this.container.x = w;
-                ctx.moveTo(this.container.x, this.container.y);
-            }
-            if (this.container.y > h) {
-                this.container.y = 0;
-                ctx.moveTo(this.container.x, this.container.y);
-            }
-            if (this.container.y < 0) {
-                this.container.y = h;
-                ctx.moveTo(this.container.x, this.container.y);
-            }
-
+        if (!WRAP) {
+            
             // old turtle point
-            oy = this.turtles.screenY2turtleY(this.container.y);
-            ox = this.turtles.screenX2turtleX(this.container.x);
+            var ox = this.turtles.screenX2turtleX(this.container.x);
+            var oy = this.turtles.screenY2turtleY(this.container.y);
 
-            // new turtle point increment;
-            nx = ox + xIncrease;
-            ny = oy + yIncrease;
+            var angleRadians = (this.orientation * Math.PI) / 180.0;
 
-            this.move(ox, oy, nx, ny, true)
-            this.container.x = this.turtles.turtleX2screenX(nx);
-            this.container.y = this.turtles.turtleY2screenY(ny);
-            ctx.moveTo(this.container.x, this.container.y);
+            // new turtle point
+            var nx = ox + Number(steps) * Math.sin(angleRadians);
+            var ny = oy + Number(steps) * Math.cos(angleRadians);
+            this.move(ox, oy, nx, ny, true);
+            this.turtles.refreshCanvas();   
+        
+        } else {
+            var angleRadians = (this.orientation * Math.PI) / 180.0
+            var w = ctx.canvas.width;
+            var h = ctx.canvas.height;
 
-            steps -= stepUnit;
+            var ox, oy, nx, ny;
+
+            var stepUnit = 10;
+
+            if (steps > 0) {
+                var xIncrease = stepUnit * Math.sin(angleRadians);
+                var yIncrease = stepUnit * Math.cos(angleRadians);
+            } else {
+                var xIncrease = -stepUnit * Math.sin(angleRadians);
+                var yIncrease = -stepUnit * Math.cos(angleRadians);
+            steps = -steps;
+
+             }
+
+            while (steps >= 0) {
+                if (this.container.x > w) {
+                    this.container.x = 0;
+                    ctx.moveTo(this.container.x, this.container.y);
+                }
+                if (this.container.x < 0) {
+                    this.container.x = w;
+                    ctx.moveTo(this.container.x, this.container.y);
+                }
+                if (this.container.y > h) {
+                    this.container.y = 0;
+                    ctx.moveTo(this.container.x, this.container.y);
+                }
+                if (this.container.y < 0) {
+                    this.container.y = h;
+                    ctx.moveTo(this.container.x, this.container.y);
+                }
+
+                // old turtle point
+                oy = this.turtles.screenY2turtleY(this.container.y);
+                ox = this.turtles.screenX2turtleX(this.container.x);
+
+                // new turtle point increment;
+                nx = ox + xIncrease;
+                ny = oy + yIncrease;
+
+                this.move(ox, oy, nx, ny, true)
+                this.container.x = this.turtles.turtleX2screenX(nx);
+                this.container.y = this.turtles.turtleY2screenY(ny);
+                ctx.moveTo(this.container.x, this.container.y);
+
+                steps -= stepUnit;
+            }
+            this.turtles.refreshCanvas();
+
         }
-        this.turtles.refreshCanvas();
     };
 
     /**


### PR DESCRIPTION
There are a few things up for discussion:

- As per discussion in https://github.com/sugarlabs/musicblocks/issues/2143#issuecomment-606122383 , I've added the button to the Aux menu. We can add it alongside clean, collapse buttons. 
Also if the aux menu is decided, is the position correct or it needs changing?

- Does the icon work? In the icon library we use, I couldn't find any other suitable icon for wrapping. We can use a custom one if this doesn't seem apt.

![The one adjacent to Merge icon](https://user-images.githubusercontent.com/44023445/78360095-ddebf880-75d3-11ea-94be-82ca4f5b6b96.png)

- Do we want this as an advanced mode option?

I think we can discuss these points and make changes accordingly, if any.

- Regarding the feature, by default the wrapping is turned on, turning it off implements the previous logic of turtle movement. ( Before #2169 was merged )

- Also there needs to be an indication to the user if the wrapping is turned on or not, for that same reason I've added a conditional tooltip which changes suitably.

![tooltip1](https://user-images.githubusercontent.com/44023445/78360649-c19c8b80-75d4-11ea-8241-dd8dad5554b0.png)

![tooltip2](https://user-images.githubusercontent.com/44023445/78360669-c6f9d600-75d4-11ea-9b25-23ea28e6c489.png)


