### PR TITLE
Additional `bool` property for flows.left 

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -696,9 +696,9 @@ function setupEnsembleBlocks() {
 
     class FoundTurtleBlock extends BooleanBlock {
         constructor() {
-            super("foundturtle", _("found mouse"));
+            super("foundturtle");
             this.setPalette("ensemble");
-	    this.extraWidth = 20;
+	        // this.extraWidth = 20;
             this.setHelpString([
                 _(
                     "The Found mouse block will return true if the specified mouse can be found."
@@ -708,6 +708,10 @@ function setupEnsembleBlocks() {
             ]);
 
             this.formBlock({
+                name: _("found mouse"),
+                flows: {
+                    left: "bool"
+                },
                 args: 1,
                 argTypes: ["anyin"],
                 defaults: [_("Mr. Mouse")]

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -1687,6 +1687,13 @@ class BaseBlock extends ProtoBlock {
                     ][1];
             else clickHeight = svg.getHeight();
             if (this.size === 0) return [artwork, svg.docks, 0, 0, 0];
+
+            // Special case for one argument boolean output blocks e.g found mouse
+            
+            if(this._style.flows.left === "bool") {
+                artwork = svg.booleanNot(true); // OneArg
+            }
+
             return [
                 artwork,
                 svg.docks,


### PR DESCRIPTION
- Added a third property, `bool` apart from the currently existing true/false.

- This property can be used for constructing `one-argument boolean-output` e,g found mouse block

- Fixed #2210 

![Screenshot from 2020-04-08 23-48-00](https://user-images.githubusercontent.com/44023445/78819471-ea1cef00-79f3-11ea-9dfa-514c6b2245ec.png)
