### PR TITLE
Fix set drum overriding set instrument issue

### DIFF
--- a/js/blocks/DrumBlocks.js
+++ b/js/blocks/DrumBlocks.js
@@ -123,11 +123,11 @@ function setupDrumBlocks() {
     function _createPlayDrumMacros() {
         class PlayDrumMacroBlock extends FlowBlock {
             constructor(name, displayName, isDrum, drumName) {
-		if (displayName === undefined) {
+                if (displayName === undefined) {
                     super(name, _(name));
-		} else {
+                } else {
                     super(name, _(displayName));
-		}
+                }
                 this.setPalette("drum");
                 this.formBlock({ args: 1 });
                 this.makeMacro((x, y) => [

--- a/js/logo.js
+++ b/js/logo.js
@@ -3462,7 +3462,9 @@ function Logo() {
                                     for (var d = 0; d < notes.length; d++) {
                                         if (
                                             notes[d] in
-                                            that.pitchDrumTable[turtle]
+                                            that.pitchDrumTable[turtle] &&
+                                            // Don't play drum if settimbre encountered
+                                            !hasSetTimbreInSetDrum
                                         ) {
                                             if (!that.suppressOutput[turtle]) {
                                                 console.debug(

--- a/js/logo.js
+++ b/js/logo.js
@@ -3336,6 +3336,33 @@ function Logo() {
                                     neighborArgCurrentBeat: neighborArgCurrentBeat
                                 };
 
+                                // For case when note block is inside a
+                                // settimbre block, which in turn is inside a
+                                // setdrum block
+                                let hasSetTimbreInSetDrum = false;
+                                // This case is only applicable if the note
+                                // block is at all inside a setdrum block
+                                if (that.drumStyle[turtle].length > 0) {
+                                    // Start from the note block's parent
+                                    let par =
+                                        that.blocks.blockList[blk]
+                                        .connections[0];
+                                    par = that.blocks.blockList[par];
+                                    // Keep looking for all parents up in order
+                                    while (par.name != "setdrum") {
+                                        // If settimbre encountered before
+                                        // setdrum, the said case is true
+                                        if (par.name === "settimbre") {
+                                            hasSetTimbreInSetDrum = true;
+                                            break;
+                                        }
+                                        par = par.connections[0];
+                                        if (par === null)
+                                            break;
+                                        par = that.blocks.blockList[par];
+                                    }
+                                }
+
                                 if (that.oscList[turtle][thisBlk].length > 0) {
                                     if (notes.length > 1) {
                                         that.errorMsg(
@@ -3373,7 +3400,11 @@ function Logo() {
                                             null
                                         ]);
                                     }
-                                } else if (that.drumStyle[turtle].length > 0) {
+                                } else if (
+                                    that.drumStyle[turtle].length > 0 &&
+                                    // Don't play drum if settimbre encountered
+                                    !hasSetTimbreInSetDrum
+                                ) {
                                     if (!that.suppressOutput[turtle]) {
                                         that.synth.trigger(
                                             turtle,


### PR DESCRIPTION
Fixes #2162. Previously, if there was a "drum style" set for a note block, it wouldn't check whether it also has an "instrument name" set. The issue originated due to this; here both of them were set.

I've added a case check to find if there is a `settimbre` block before the lowest `setdrum` block among the note block's parent blocks. If the case is found to be true, the drum won't be played, rather the synth with the set instrument would be played.