### PR TITLE
Update all synth volumes on encountering "set master volume" block

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -2218,6 +2218,15 @@ function Logo() {
 
         if (_THIS_IS_MUSIC_BLOCKS_) {
             this.synth.setMasterVolume(volume);
+            for (
+                let turtle = 0;
+                turtle < this.turtles.turtleList.length;
+                turtle++
+            ) {
+                for (let synth in this.synthVolume[turtle]) {
+                    this.synthVolume[turtle][synth].push(volume);
+                }
+            }
         }
     };
 


### PR DESCRIPTION
Fixes #2228.

I found that the `SynthVolumeBlock` in `VolumeBlocks.js` returns `synthVolume` for a particular synth. However, `setMasterVolume(...)` in `synthUtils.js` updates `instruments[..][..].volume.value` and not `synthVolume`. I've added `synthVolume` update in `_setMasterVolume(...)` in `logo.js`.

@pikurasa "Set Master Volume" now sets the synth volumes across the canvas. I've tested for your test case.
![mb10](https://user-images.githubusercontent.com/33328728/79731270-aab5a300-830f-11ea-9486-2554d77a0fe7.png)
