### PR TITLE
handles cblk2 is null error

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5693,7 +5693,7 @@ function Block(protoblock, blocks, overrideName) {
             let cblk2 = that.blocks.blockList[cblk1].connections[0];
 
             // Check if the number block is connected to a note value and prevent the value to go below zero
-            if((that.blocks.blockList[cblk1].name === 'newnote' || that.blocks.blockList[cblk2].name == 'newnote') && that.value < 1) {
+            if ((that.value < 1) && (that.blocks.blockList[cblk1].name === 'newnote' || (cblk2 && that.blocks.blockList[cblk2].name == 'newnote'))) {
                 that.value = 0;
             } else {
                 that.value -= 1;


### PR DESCRIPTION
decrement function will work even when cblk2 : null
This allows user to decrement values in pie menu when the block is not connected to another.
