### PR TITLE
fixes issue #1898

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -5693,7 +5693,7 @@ function Block(protoblock, blocks, overrideName) {
             let cblk2 = that.blocks.blockList[cblk1].connections[0];
 
             // Check if the number block is connected to a note value and prevent the value to go below zero
-            if((that.blocks.blockList[cblk1].name === 'newnote' || that.blocks.blockList[cblk2].name == 'newnote') && that.value < 1) {
+            if ((that.value < 1) && (that.blocks.blockList[cblk1].name === 'newnote' || (cblk2 && that.blocks.blockList[cblk2].name == 'newnote'))) {
                 that.value = 0;
             } else {
                 that.value -= 1;

--- a/js/blocks/RhythmBlocks.js
+++ b/js/blocks/RhythmBlocks.js
@@ -63,7 +63,6 @@ function _playNote(args, logo, turtle, blk, receivedArg) {
             );
             logo.parentFlowQueue[turtle].push(blk);
             logo.turtles.turtleList[turtle].queue.push(queueBlock);
-            childFlow = null;
 
             let eventName = "__everybeat_" + turtle + "__";
             logo.stage.dispatchEvent(eventName);
@@ -78,7 +77,6 @@ function _playNote(args, logo, turtle, blk, receivedArg) {
             );
             logo.parentFlowQueue[turtle].push(blk);
             logo.turtles.turtleList[turtle].queue.push(queueBlock);
-            childFlow = null;
 
             let eventName = "__beat_" + beatValue + "_" + turtle + "__";
             logo.stage.dispatchEvent(eventName);
@@ -94,7 +92,6 @@ function _playNote(args, logo, turtle, blk, receivedArg) {
             );
             logo.parentFlowQueue[turtle].push(blk);
             logo.turtles.turtleList[turtle].queue.push(queueBlock);
-            childFlow = null;
 
             let eventName = "__offbeat_" + turtle + "__";
             logo.stage.dispatchEvent(eventName);
@@ -114,7 +111,6 @@ function _playNote(args, logo, turtle, blk, receivedArg) {
                 );
                 logo.parentFlowQueue[turtle].push(blk);
                 logo.turtles.turtleList[turtle].queue.push(queueBlock);
-                childFlow = null;
 
                 let eventName =
                     "__beat_" +
@@ -125,6 +121,7 @@ function _playNote(args, logo, turtle, blk, receivedArg) {
                 logo.stage.dispatchEvent(eventName);
             }
         }
+        childFlow = null;
     }
 
     // A note can contain multiple pitch blocks to create


### PR DESCRIPTION
null was being pushed to queue .(when both "on strong "and "on every beat" were  #used).
this can help until we look for better "on beat" blocks 