### PR TITLE
Octave calculation fix for scale degree block (nth modal pitch)

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -205,9 +205,9 @@ function _playPitch(args, logo, turtle, blk) {
                     scaleDegree
                 );
                 logo.currentNote = note;
-                deltaOctave = Math.floor(
-                    (arg0 + modeLength - 2) / modeLength
-                );
+                // deltaOctave = Math.floor(
+                //     (arg0 + modeLength - 2) / modeLength
+                // );
                 octave =
                     Math.floor(
                         calcOctave(
@@ -216,15 +216,18 @@ function _playPitch(args, logo, turtle, blk) {
                             logo.lastNotePlayed[turtle],
                             logo.currentNote
                         )
-                    ) - deltaOctave;
+                    );
             } else {
                 note = scaleDegreeToPitch(
                     logo.keySignature[turtle],
                     scaleDegree
                 );
                 logo.currentNote = note;
-                deltaOctave = Math.floor((arg0 - 1) / modeLength);
-                octave =
+                // deltaOctave = Math.floor((arg0 - 1) / modeLength);
+                if(logo.lastNotePlayed[turtle] != null && logo.currentNote === logo.lastNotePlayed[turtle][0].substr(0,1) && logo.lastNotePlayed[turtle][0].substr(1).length <= 1) {
+                    octave = arg1;
+                } else {
+                    octave =
                     Math.floor(
                         calcOctave(
                             logo.currentOctave[turtle],
@@ -232,7 +235,8 @@ function _playPitch(args, logo, turtle, blk) {
                             logo.lastNotePlayed[turtle],
                             logo.currentNote
                         )
-                    ) + deltaOctave;
+                    );
+                }
             }
 
             console.debug("logo.currentNote = " + logo.currentNote);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -203,9 +203,9 @@ function _playPitch(args, logo, turtle, blk) {
             let ref = NOTESTEP[obj[0].substr(0,1)] -1;
             
             //adjust reference if sharps/flats are present
-            if(obj[0].substr(1) === '♭') {
+            if(obj[0].substr(1) === FLAT) {
                 ref--;
-            } else if(obj[0].substr(1) === '♯') {
+            } else if(obj[0].substr(1) === SHARP) {
                 ref++;
             }
 

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -192,17 +192,25 @@ function _playPitch(args, logo, turtle, blk) {
             let obj = keySignatureToMode(logo.keySignature[turtle]);
             let modeLength = MUSICALMODES[obj[1]].length;
             let scaleDegree = Math.floor(arg0 - 1) % modeLength;
-            let deltaOctave, semitones, deltaSemi;
+
+            /* deltaOctave calculates changes in reference octave which occur a semitone before the reference key
+               deltaSemi calculates changes in octave when crossing B.
+             */
+            let deltaOctave, deltaSemi;
             scaleDegree += 1;
+
+            // Choose a reference based on the key selected
             let ref = NOTESTEP[obj[0].substr(0,1)] -1;
             
+            //adjust reference if sharps/flats are present
             if(obj[0].substr(1) === '♭') {
                 ref--;
             } else if(obj[0].substr(1) === '♯') {
                 ref++;
             }
 
-            semitones = ref;
+            let semitones = ref;
+
             if (neg) {  
                 if (scaleDegree > 1) {
                     scaleDegree = modeLength - scaleDegree + 2;

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -192,10 +192,11 @@ function _playPitch(args, logo, turtle, blk) {
             let obj = keySignatureToMode(logo.keySignature[turtle]);
             let modeLength = MUSICALMODES[obj[1]].length;
             let scaleDegree = Math.floor(arg0 - 1) % modeLength;
-            let deltaOctave;
+            let deltaOctave, semitones, deltaSemi;
             scaleDegree += 1;
-
-            if (neg) {
+            let ref = NOTESTEP[obj[0]] -1;
+            semitones = ref;
+            if (neg) {  
                 if (scaleDegree > 1) {
                     scaleDegree = modeLength - scaleDegree + 2;
                 }
@@ -205,9 +206,17 @@ function _playPitch(args, logo, turtle, blk) {
                     scaleDegree
                 );
                 logo.currentNote = note;
-                // deltaOctave = Math.floor(
-                //     (arg0 + modeLength - 2) / modeLength
-                // );
+                
+                if(NOTESFLAT.indexOf(note) !== -1) {
+                    semitones += (NOTESFLAT.indexOf(note) - ref);
+                } else {
+                    semitones += (NOTESSHARP.indexOf(note) - ref);
+                }
+
+                deltaSemi = semitones > ref ? 1 : 0;
+                deltaOctave = Math.floor(
+                    (arg0 - 1) / modeLength
+                );
                 octave =
                     Math.floor(
                         calcOctave(
@@ -216,18 +225,21 @@ function _playPitch(args, logo, turtle, blk) {
                             logo.lastNotePlayed[turtle],
                             logo.currentNote
                         )
-                    );
+                    ) - deltaOctave - deltaSemi;
             } else {
                 note = scaleDegreeToPitch(
                     logo.keySignature[turtle],
                     scaleDegree
                 );
                 logo.currentNote = note;
-                // deltaOctave = Math.floor((arg0 - 1) / modeLength);
-                if(logo.lastNotePlayed[turtle] != null && logo.currentNote === logo.lastNotePlayed[turtle][0].substr(0,1) && logo.lastNotePlayed[turtle][0].substr(1).length <= 1) {
-                    octave = arg1;
+                if(NOTESFLAT.indexOf(note) !== -1) {
+                    semitones += (NOTESFLAT.indexOf(note) - ref);
                 } else {
-                    octave =
+                    semitones += (NOTESSHARP.indexOf(note) - ref);
+                }
+                deltaSemi = semitones < ref? 1:0;
+                deltaOctave = Math.floor((arg0 - 1) / modeLength);  
+                octave =
                     Math.floor(
                         calcOctave(
                             logo.currentOctave[turtle],
@@ -235,8 +247,7 @@ function _playPitch(args, logo, turtle, blk) {
                             logo.lastNotePlayed[turtle],
                             logo.currentNote
                         )
-                    );
-                }
+                    ) + deltaOctave + deltaSemi;
             }
 
             console.debug("logo.currentNote = " + logo.currentNote);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -194,7 +194,14 @@ function _playPitch(args, logo, turtle, blk) {
             let scaleDegree = Math.floor(arg0 - 1) % modeLength;
             let deltaOctave, semitones, deltaSemi;
             scaleDegree += 1;
-            let ref = NOTESTEP[obj[0]] -1;
+            let ref = NOTESTEP[obj[0].substr(0,1)] -1;
+            
+            if(obj[0].substr(1) === '♭') {
+                ref--;
+            } else if(obj[0].substr(1) === '♯') {
+                ref++;
+            }
+
             semitones = ref;
             if (neg) {  
                 if (scaleDegree > 1) {
@@ -249,7 +256,6 @@ function _playPitch(args, logo, turtle, blk) {
                         )
                     ) + deltaOctave + deltaSemi;
             }
-
             console.debug("logo.currentNote = " + logo.currentNote);
             cents = 0;
         } else {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1808,7 +1808,7 @@ function scaleDegreeToPitch(keySignature, scaleDegree) {
     // Scale degree is specified as do === 1, re === 2, etc., so we need
     // to subtract 1 to make it zero-based.
     scaleDegree -= 1;
-
+    console.log(scale, scaleDegree);
     // We mod to ensure we don't run out of notes.
     // FixMe: bump octave if we wrap.
     scaleDegree %= scale.length - 1;
@@ -2594,7 +2594,7 @@ calcOctave = function(currentOctave, arg, lastNotePlayed, currentNote) {
     // which can be a number, a 'number' as a string, 'current',
     // 'previous', or 'next'.
 
-    if (typeof arg === "number" && lastNotePlayed === null) {
+    if (typeof arg === "number") {
         return Math.max(1, Math.min(Math.floor(arg), 9));
     }
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2594,7 +2594,7 @@ calcOctave = function(currentOctave, arg, lastNotePlayed, currentNote) {
     // which can be a number, a 'number' as a string, 'current',
     // 'previous', or 'next'.
 
-    if (typeof arg === "number") {
+    if (typeof arg === "number" && lastNotePlayed === null) {
         return Math.max(1, Math.min(Math.floor(arg), 9));
     }
 
@@ -2618,7 +2618,7 @@ calcOctave = function(currentOctave, arg, lastNotePlayed, currentNote) {
         // strip off octave from end of note
         lastNotePlayed = lastNotePlayed.substring(0, lastNotePlayed.length - 1);
     } else {
-        lastNotePlated = "G";
+        lastNotePlayed = "G";
     }
 
     stepLastNotePlayed = getNumber(lastNotePlayed, currentOctave);
@@ -2655,7 +2655,8 @@ calcOctave = function(currentOctave, arg, lastNotePlayed, currentNote) {
             return Math.max(changedCurrent - 1, 1);
         default:
             try {
-                return Math.floor(Number(arg));
+                if(changedCurrent) return changedCurrent;
+                else return Math.floor(Number(arg));
             } catch (e) {
                 console.debug("cannot convert " + arg + " to a number");
                 return currentOctave;

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1808,7 +1808,6 @@ function scaleDegreeToPitch(keySignature, scaleDegree) {
     // Scale degree is specified as do === 1, re === 2, etc., so we need
     // to subtract 1 to make it zero-based.
     scaleDegree -= 1;
-    console.log(scale, scaleDegree);
     // We mod to ensure we don't run out of notes.
     // FixMe: bump octave if we wrap.
     scaleDegree %= scale.length - 1;


### PR DESCRIPTION
- Defined a new variable `deltaSemi` alongside `deltaOctave` which looks for changes in Octave that we play and adapts according to the key selected.

- `deltaOctave` calculates changes in reference octave which occur a semitone before the key selected.

- Fixes #2238 