### PR TITLE
add minor to MUSICALMODES

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -863,6 +863,7 @@ const MUSICALMODES = {
     phrygian: [1, 2, 2, 2, 1, 2, 2],
     lydian: [2, 2, 2, 1, 2, 2, 1],
     mixolydian: [2, 2, 1, 2, 2, 1, 2],
+    minor: [2, 1, 2, 2, 1, 2, 2],
     aeolian: [2, 1, 2, 2, 1, 2, 2],
     locrian: [1, 2, 2, 1, 2, 2, 2],
 


### PR DESCRIPTION
- add an alias for `minor` in MUSICALMODES alongside `aeolian`. Both produce the same result but this provides more flexibility.

- Fixed #2237 