### PR TITLE
palette scroll issue

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -538,17 +538,16 @@ function Palettes() {
         this.hideSearchWidget(true);
 
         for (var i in this.dict) {
-            if (this.dict[i] === this.dict[name]) {
-                this.dict[name]._resetLayout();
-                this.dict[name].showMenu();
-                this.dict[name]._showMenuItems();
-            } else {
+            if (this.dict[i] !== this.dict[name]) {
                 if (this.dict[i].visible) {
                     this.dict[i].hideMenu();
                     this.dict[i]._hideMenuItems();
                 }
             }
         }
+        this.dict[name]._resetLayout();
+        this.dict[name].showMenu();
+        this.dict[name] ._showMenuItems();
     };
 
     this._showMenus = function() {


### PR DESCRIPTION
executing showmenu() "after" all visible palettes are closed .
this fixes a issue mentioned  in pr #2060  (https://github.com/sugarlabs/musicblocks/pull/2060#issuecomment-577365620),
 continued from #2052 