### PR TITLE
On EveryBeat Block

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -892,7 +892,7 @@ function Activity() {
 
         if (!turtles.running()) {
             console.debug("RUNNING");
-            if (!turtles.isShrunk()) {
+            if (!turtles.isShrunk) {
                 logo.hideBlocks(true);
             }
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -892,7 +892,7 @@ function Activity() {
 
         if (!turtles.running()) {
             console.debug("RUNNING");
-            if (!turtles.isShrunk) {
+            if (!turtles.isShrunk()) {
                 logo.hideBlocks(true);
             }
 
@@ -3805,6 +3805,11 @@ function Activity() {
                             count: window.savedMatricesCount
                         };
                         hasMatrixDataBlock = true;
+                        break;
+                    case "everybeatdonew":
+                        args ={
+                            turtleID: myBlock.turtleID
+                        }
                         break;
                     default:
                         break;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6521,6 +6521,29 @@ function Blocks(activity) {
                         [thisBlock, value]
                     );
                     break;
+                case "everybeatdonew":
+                    var postProcess = (args) => {
+                        if (args[1].turtleID==null) {
+                            setTimeout(() => {
+                                console.log(args[1] , last(turtles.turtleList));
+                                that.blockList[args[0]].turtleID = last(turtles.turtleList).id;
+                            }
+                            ,2000);
+                        }
+                        //wait for some time to let the beat turtle load . 
+                        else {
+                            console.log(args[0],args[1]);
+                            that.blockList[args[0]].turtleID = args[1]["turtleID"] ;
+                        }
+                    }
+                    this._makeNewBlockWithConnections(
+                        name,
+                        blockOffset,
+                        blkData[4],
+                        postProcess,
+                        [thisBlock, blkInfo[1]]
+                    );
+                    break;
                 default:
                     // Check that name is in the proto list
                     if (

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6525,14 +6525,12 @@ function Blocks(activity) {
                     var postProcess = (args) => {
                         if (args[1].turtleID==null) {
                             setTimeout(() => {
-                                console.log(args[1] , last(turtles.turtleList));
                                 that.blockList[args[0]].turtleID = last(turtles.turtleList).id;
                             }
                             ,2000);
                         }
                         //wait for some time to let the beat turtle load . 
                         else {
-                            console.log(args[0],args[1]);
                             that.blockList[args[0]].turtleID = args[1]["turtleID"] ;
                         }
                     }
@@ -7089,10 +7087,14 @@ function Blocks(activity) {
             this.addDefaultBlock(parentBlock, thisBlock);
         }
 
+        // send associated beat Turtle to stash . 
         if (myBlock.name == "everybeatdonew"){
             let turtleID = myBlock.turtleID ;
             let tur;
-            for(tur of turtles.getTurtleList())if (turtleID == tur.id)break;
+            for(tur of turtles.turtleList) {
+                if (turtleID == tur.id) 
+                    break;
+            }
             this.sendStackToTrash(tur.startBlock);
         }
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7089,6 +7089,13 @@ function Blocks(activity) {
             this.addDefaultBlock(parentBlock, thisBlock);
         }
 
+        if (myBlock.name == "everybeatdonew"){
+            let turtleID = myBlock.turtleID ;
+            let tur;
+            for(tur of turtles.getTurtleList())if (turtleID == tur.id)break;
+            this.sendStackToTrash(tur.startBlock);
+        }
+
         if (myBlock.name === "start" || myBlock.name === "drum") {
             turtle = myBlock.value;
             var turtleNotInTrash = 0;

--- a/js/blocks/MeterBlocks.js
+++ b/js/blocks/MeterBlocks.js
@@ -579,10 +579,9 @@ function setupMeterBlocks() {
             });
 
             this.makeMacro((x, y) => {
-                this.linkTurtle =
-                    turtles.turtleList.length;
+
                 return [
-                    [0, ["start", { "collapsed": true, "name": "Beat" }], x + 100, y + 100, [null, 3, null]],
+                    [0, ["start", { "collapsed": true, "name": "beat" }], x + 100, y + 100, [null, 3, null]],
 
                     [1, "dispatch", 0, 0, [8, 2, null]],
                     [2, ["text", { "value": "__everybeat_" + this.linkTurtle + "__" }], 0, 0, [1]],
@@ -595,7 +594,7 @@ function setupMeterBlocks() {
                     [7, ["number", { "value": 4 }], 0, 0, [5]],
                     [8, "vspace", 0, 0, [4, 1]],
 
-                    [9, "everybeatdonew", x, y, [null, 10, null]],
+                    [9, ["everybeatdonew", {"turtleID": null} ], x, y, [null, 10, null]],
                     [10, ["text", { "value": "action" }], 0, 0, [9]]
 
                 ]
@@ -606,8 +605,37 @@ function setupMeterBlocks() {
 
         flow(args, logo, turtle, blk, receivedArg, actionArgs, isflow) {
             // Set up a listener for every beat for this turtle.
-            turtle = this.linkTurtle;
-            console.log(turtle)
+            let findTurtle=(id)=>{
+                for(let tur in turtles.getTurtleList()){
+                    if (id == turtles.getTurtleList()[tur].id) return tur;
+                }
+            };
+            let org =turtle ;
+            let turtleID =logo.blocks.blockList[blk].turtleID ;
+            turtle = findTurtle(turtleID);
+            console.log(turtle,turtleID);
+
+            let ans = null ;
+            let done = {} ;
+            let findBlock = (bk, blockName) => { // dfs 
+                if (!bk) return ;
+                if (bk in done) return ;
+                done[bk]= true ;
+                if (logo.blocks.blockList[bk].name == blockName){ans = bk; return ;}
+                for ( let con of blocks.blockList[bk].connections ){
+                    findBlock(con,blockName);
+                }
+            }
+            done ={};
+            findBlock(logo.blocks.blockList.indexOf(turtles.turtleList[turtle].startBlock),"dispatch");
+            let dispatchTextBlock  = logo.blocks.blockList[ans].connections[1];
+            done ={};
+            findBlock(logo.blocks.blockList.indexOf(turtles.turtleList[turtle].startBlock),"newnote");
+            let divideBlock  = logo.blocks.blockList[ans].connections[1];
+            let den = logo.blocks.blockList[divideBlock].connections[2];
+            console.log(dispatchTextBlock,divideBlock,den);
+
+            logo.blocks.blockList[den].value = logo.noteValuePerBeat[org];
             if (!(args[0] in logo.actions)) {
                 logo.errorMsg(NOACTIONERRORMSG, blk, args[1]);
             } else {
@@ -644,10 +672,10 @@ function setupMeterBlocks() {
                     }
                 };
 
-                let eventName = "__everybeat_" + this.linkTurtle + "__";
+                let eventName = "__everybeat_" + turtleID + "__";
+                logo.blocks.blockList[dispatchTextBlock].value = eventName ;
                 logo._setListener(turtle, eventName, __listener);
-                console.log("send " + this.linkTurtle);
-                logo.beatList[turtle].push("everybeat");
+                console.log("send " +this.turtleID);
             }
         }
     }

--- a/js/blocks/MeterBlocks.js
+++ b/js/blocks/MeterBlocks.js
@@ -606,22 +606,27 @@ function setupMeterBlocks() {
         flow(args, logo, turtle, blk, receivedArg, actionArgs, isflow) {
             // Set up a listener for every beat for this turtle.
             let findTurtle=(id)=>{
-                for(let tur in turtles.getTurtleList()){
-                    if (id == turtles.getTurtleList()[tur].id) return tur;
+                for(let tur in turtles.turtleList){
+                    if (id == turtles.turtleList[tur].id) 
+                        return tur;
                 }
             };
             let org =turtle ;
             let turtleID =logo.blocks.blockList[blk].turtleID ;
             turtle = findTurtle(turtleID);
-            console.log(turtle,turtleID);
+            console.debug("beat Turtle : ",turtle,turtleID);
 
+            // 2 things need to be changed everytime we play this block in logo: note duration and deispatch event .
             let ans = null ;
             let done = {} ;
             let findBlock = (bk, blockName) => { // dfs 
                 if (!bk) return ;
                 if (bk in done) return ;
                 done[bk]= true ;
-                if (logo.blocks.blockList[bk].name == blockName){ans = bk; return ;}
+                if (logo.blocks.blockList[bk].name == blockName){
+                    ans = bk; 
+                    return ;
+                }
                 for ( let con of blocks.blockList[bk].connections ){
                     findBlock(con,blockName);
                 }
@@ -633,7 +638,6 @@ function setupMeterBlocks() {
             findBlock(logo.blocks.blockList.indexOf(turtles.turtleList[turtle].startBlock),"newnote");
             let divideBlock  = logo.blocks.blockList[ans].connections[1];
             let den = logo.blocks.blockList[divideBlock].connections[2];
-            console.log(dispatchTextBlock,divideBlock,den);
 
             logo.blocks.blockList[den].value = logo.noteValuePerBeat[org];
             if (!(args[0] in logo.actions)) {
@@ -675,7 +679,7 @@ function setupMeterBlocks() {
                 let eventName = "__everybeat_" + turtleID + "__";
                 logo.blocks.blockList[dispatchTextBlock].value = eventName ;
                 logo._setListener(turtle, eventName, __listener);
-                console.log("send " +this.turtleID);
+                console.debug("set listener",eventName);
             }
         }
     }


### PR DESCRIPTION
Added everybeatdonew in meter palette
this block opens up a new collapsed start block which contains a broadcast block. 
All the "action " duties are transferred to this new mouse. 
following snippet is a way we can use it 

![Screenshot (85)](https://user-images.githubusercontent.com/55449862/83629314-7e03d500-a5b7-11ea-88a8-488f3cc5aaa8.png)
 
currently , the beats per measure data is not transferred , everything is working in default bpm  