### PR TITLE
Remove deprecated content and rework on accessibility of variables in Turtles

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1461,7 +1461,7 @@ function Activity() {
         }
 
         __heightBasedScroll();
-		
+
 		let closeAnyOpenMenusAndLabels = function () {
             if (docById("wheelDiv")!= null) docById("wheelDiv").style.display = "none";
             if (docById("contextWheelDiv")!= null) docById("contextWheelDiv").style.display = "none";
@@ -4576,7 +4576,7 @@ function Activity() {
          */
 
         doBrowserCheck();
-        
+
         if(!jQuery.browser.mozilla){
             window.onblur = function() {
                 that.doHardStopButton(true);
@@ -4685,8 +4685,6 @@ function Activity() {
             .setSetPlaybackStatus(setPlaybackStatus)
             .setErrorMsg(errorMsg)
             .setHomeContainers(setHomeContainers, boundary);
-
-        turtles.setBlocks(blocks);
 
         palettes = new Palettes();
         palettes

--- a/js/activity.js
+++ b/js/activity.js
@@ -886,7 +886,7 @@ function Activity() {
 
         if (!turtles.running()) {
             console.debug("RUNNING");
-            if (!turtles.isShrunk) {
+            if (!turtles.isShrunk()) {
                 logo.hideBlocks(true);
             }
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -1462,7 +1462,7 @@ function Activity() {
 
         __heightBasedScroll();
 
-		let closeAnyOpenMenusAndLabels = function () {
+        let closeAnyOpenMenusAndLabels = function () {
             if (docById("wheelDiv")!= null) docById("wheelDiv").style.display = "none";
             if (docById("contextWheelDiv")!= null) docById("contextWheelDiv").style.display = "none";
             if (docById("textLabel") != null) docById("textLabel").style.display = "none";
@@ -1471,7 +1471,7 @@ function Activity() {
 
         let __wheelHandler = function(event) {
             if (event.deltaY !== 0 && event.axis === event.VERTICAL_AXIS) {
-				closeAnyOpenMenusAndLabels();// closes all wheelnavs when scrolling .
+                closeAnyOpenMenusAndLabels();// closes all wheelnavs when scrolling .
                 if (palettes.paletteVisible) {
                     if (event.clientX > cellSize + MENUWIDTH) {
                         blocksContainer.y -= event.deltaY;
@@ -1486,7 +1486,7 @@ function Activity() {
             // horizontal scroll
             if (scrollBlockContainer) {
                 if (event.deltaX !== 0 && event.axis === event.HORIZONTAL_AXIS) {
-					closeAnyOpenMenusAndLabels();
+                    closeAnyOpenMenusAndLabels();
                     if (palettes.paletteVisible) {
                         if (event.clientX > cellSize + MENUWIDTH) {
                             blocksContainer.x -= event.deltaX;
@@ -2823,8 +2823,8 @@ function Activity() {
 
         update = true;
 
-	// Close any open widgets.
-	closeWidgets();
+        // Close any open widgets.
+        closeWidgets();
     };
 
     // function _changePaletteVisibility() {
@@ -3276,7 +3276,7 @@ function Activity() {
     textMsg = function(msg) {
         if (msgTimeoutID !== null) {
             clearTimeout(msgTimeoutID);
-	    msgTimeoutID = null;
+            msgTimeoutID = null;
         }
 
         if (msgText == null) {
@@ -3294,7 +3294,7 @@ function Activity() {
 
         msgTimeoutID = setTimeout(function() {
             printText.classList.remove("show");
-	    msgTimeoutID = null;
+            msgTimeoutID = null;
         }, _MSGTIMEOUT_);
     };
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3270,14 +3270,6 @@ function Blocks(activity) {
             };
 
             postProcessArg = thisBlock;
-        } else if (name === "drum") {
-            var postProcess = function(thisBlock) {
-                that.blockList[thisBlock].value =
-                    that.turtles.turtleList.length;
-                that.turtles.addDrum(that.blockList[thisBlock]);
-            };
-
-            postProcessArg = thisBlock;
         } else if (name === "text") {
             postProcessArg = [thisBlock, _("text")];
         } else if (name === "boolean") {
@@ -5901,33 +5893,6 @@ function Blocks(activity) {
                         postProcess,
                         [thisBlock, blkInfo[1]]
                     );
-                    break;
-                case "drum":
-                    blkData[4][0] = null;
-                    blkData[4][2] = null;
-                    var postProcess = function(args) {
-                        var thisBlock = args[0];
-                        var blkInfo = args[1];
-                        that.blockList[thisBlock].value =
-                            that.turtles.turtleList.length;
-                        that.turtles.addDrum(
-                            that.blockList[thisBlock],
-                            blkInfo
-                        );
-                    };
-
-                    this._makeNewBlockWithConnections(
-                        name,
-                        blockOffset,
-                        blkData[4],
-                        postProcess,
-                        [thisBlock, blkInfo[1]]
-                    );
-
-                    if (_THIS_IS_MUSIC_BLOCKS_) {
-                        // Load the synth for this drum
-                        this.logo.synth.loadSynth(0, DEFAULTDRUM);
-                    }
                     break;
                 case "action":
                 case "hat":

--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -22,12 +22,12 @@ function setupMediaBlocks() {
 
         updateParameter(logo, turtle, blk) {
             return toFixed2(
-                logo.turtles._canvas.width / (2.0 * logo.turtles.scale)
+                logo.turtles._canvas.width / (2.0 * logo.turtles.getScale())
             );
         }
 
         arg(logo) {
-            return logo.turtles._canvas.width / (2.0 * logo.turtles.scale);
+            return logo.turtles._canvas.width / (2.0 * logo.turtles.getScale());
         }
     }
 
@@ -54,13 +54,13 @@ function setupMediaBlocks() {
 
         updateParameter(logo, turtle, blk) {
             return toFixed2(
-                -1 * (logo.turtles._canvas.width / (2.0 * logo.turtles.scale))
+                -1 * (logo.turtles._canvas.width / (2.0 * logo.turtles.getScale()))
             );
         }
 
         arg(logo) {
             return (
-                -1 * (logo.turtles._canvas.width / (2.0 * logo.turtles.scale))
+                -1 * (logo.turtles._canvas.width / (2.0 * logo.turtles.getScale()))
             );
         }
     }
@@ -87,12 +87,12 @@ function setupMediaBlocks() {
 
         updateParameter(logo, turtle, blk) {
             return toFixed2(
-                logo.turtles._canvas.height / (2.0 * logo.turtles.scale)
+                logo.turtles._canvas.height / (2.0 * logo.turtles.getScale())
             );
         }
 
         arg(logo) {
-            return logo.turtles._canvas.height / (2.0 * logo.turtles.scale);
+            return logo.turtles._canvas.height / (2.0 * logo.turtles.getScale());
         }
     }
 
@@ -118,13 +118,13 @@ function setupMediaBlocks() {
 
         updateParameter(logo, turtle, blk) {
             return toFixed2(
-                -1 * (logo.turtles._canvas.height / (2.0 * logo.turtles.scale))
+                -1 * (logo.turtles._canvas.height / (2.0 * logo.turtles.getScale()))
             );
         }
 
         arg(logo) {
             return (
-                -1 * (logo.turtles._canvas.height / (2.0 * logo.turtles.scale))
+                -1 * (logo.turtles._canvas.height / (2.0 * logo.turtles.getScale()))
             );
         }
     }
@@ -143,11 +143,11 @@ function setupMediaBlocks() {
         }
 
         updateParameter(logo, turtle, blk) {
-            return toFixed2(logo.turtles._canvas.width / logo.turtles.scale);
+            return toFixed2(logo.turtles._canvas.width / logo.turtles.getScale());
         }
 
         arg(logo) {
-            return logo.turtles._canvas.width / logo.turtles.scale;
+            return logo.turtles._canvas.width / logo.turtles.getScale();
         }
     }
 
@@ -165,11 +165,11 @@ function setupMediaBlocks() {
         }
 
         updateParameter(logo, turtle, blk) {
-            return toFixed2(logo.turtles._canvas.height / logo.turtles.scale);
+            return toFixed2(logo.turtles._canvas.height / logo.turtles.getScale());
         }
 
         arg(logo) {
-            return logo.turtles._canvas.height / logo.turtles.scale;
+            return logo.turtles._canvas.height / logo.turtles.getScale();
         }
     }
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -1569,7 +1569,7 @@ class Logo {
 
     /**
      * If we clear the delay timeout, we need to requeue the runBlock.
-     * 
+     *
      * @param turtle
      * @returns {void}
      */
@@ -4310,8 +4310,8 @@ class Logo {
                 this.turtles.turtleList[turtle].canvasColor;
 
         // docById('myCanvas').style.background = c;
-        this.turtles.backgroundColor = c;
-        this.turtles.makeBackground(this.turtles.isShrunk);
+        this.turtles.setBackgroundColor(c);
+        this.turtles.makeBackground(this.turtles.isShrunk());
 
         this.svgOutput = "";
     }

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -454,6 +454,7 @@ class Turtle {
             let dxi, dyi, dxf, dyf;
 
             let turtles = this.getTurtles();
+            let turtlesScale = turtles.getScale();
 
             if (this.penState && this.hollowState) {
                 // Convert from turtle coordinates to screen coordinates
@@ -506,26 +507,26 @@ class Turtle {
                 // The four 'corners'
                 ax = ix - dxi;
                 ay = iy - dyi;
-                let axScaled = ax * turtles.scale;
-                let ayScaled = ay * turtles.scale;
+                let axScaled = ax * turtlesScale;
+                let ayScaled = ay * turtlesScale;
                 bx = fx - dxf;
                 by = fy - dyf;
-                let bxScaled = bx * turtles.scale;
-                let byScaled = by * turtles.scale;
+                let bxScaled = bx * turtlesScale;
+                let byScaled = by * turtlesScale;
                 cx = fx + dxf;
                 cy = fy + dyf;
-                let cxScaled = cx * turtles.scale;
-                let cyScaled = cy * turtles.scale;
+                let cxScaled = cx * turtlesScale;
+                let cyScaled = cy * turtlesScale;
                 dx = ix + dxi;
                 dy = iy + dyi;
-                let dxScaled = dx * turtles.scale;
-                let dyScaled = dy * turtles.scale;
+                let dxScaled = dx * turtlesScale;
+                let dyScaled = dy * turtlesScale;
 
                 // Control points scaled for SVG output
-                let cx1Scaled = (cx1 + dxi) * turtles.scale;
-                let cy1Scaled = (cy1 + dyi) * turtles.scale;
-                let cx2Scaled = (cx2 + dxf) * turtles.scale;
-                let cy2Scaled = (cy2 + dyf) * turtles.scale;
+                let cx1Scaled = (cx1 + dxi) * turtlesScale;
+                let cy1Scaled = (cy1 + dyi) * turtlesScale;
+                let cx2Scaled = (cx2 + dxf) * turtlesScale;
+                let cy2Scaled = (cy2 + dyf) * turtlesScale;
 
                 this.svgPath = true;
 
@@ -538,9 +539,9 @@ class Turtle {
                 this.ctx.arc(arccx, arccy, step, sa, ea, false);
                 this._svgArc(
                     steps,
-                    arccx * turtles.scale,
-                    arccy * turtles.scale,
-                    step * turtles.scale,
+                    arccx * turtlesScale,
+                    arccy * turtlesScale,
+                    step * turtlesScale,
                     sa,
                     ea
                 );
@@ -554,17 +555,17 @@ class Turtle {
                 this.ctx.arc(arccx, arccy, step, sa, ea, false);
                 this._svgArc(
                     steps,
-                    arccx * turtles.scale,
-                    arccy * turtles.scale,
-                    step * turtles.scale,
+                    arccx * turtlesScale,
+                    arccy * turtlesScale,
+                    step * turtlesScale,
                     sa,
                     ea
                 );
 
                 fx = turtles.turtleX2screenX(x2);
                 fy = turtles.turtleY2screenY(y2);
-                let fxScaled = fx * turtles.scale;
-                let fyScaled = fy * turtles.scale;
+                let fxScaled = fx * turtlesScale;
+                let fyScaled = fy * turtlesScale;
 
                 this.ctx.stroke();
                 this.ctx.closePath();
@@ -614,18 +615,18 @@ class Turtle {
                     this.svgPath = true;
                     let ix = turtles.turtleX2screenX(this.x);
                     let iy = turtles.turtleY2screenY(this.y);
-                    let ixScaled = ix * turtles.scale;
-                    let iyScaled = iy * turtles.scale;
+                    let ixScaled = ix * turtlesScale;
+                    let iyScaled = iy * turtlesScale;
                     this.svgOutput +=
                         '<path d="M ' + ixScaled + "," + iyScaled + " ";
                 }
 
-                let cx1Scaled = cx1 * turtles.scale;
-                let cy1Scaled = cy1 * turtles.scale;
-                let cx2Scaled = cx2 * turtles.scale;
-                let cy2Scaled = cy2 * turtles.scale;
-                let fxScaled = fx * turtles.scale;
-                let fyScaled = fy * turtles.scale;
+                let cx1Scaled = cx1 * turtlesScale;
+                let cy1Scaled = cy1 * turtlesScale;
+                let cx2Scaled = cx2 * turtlesScale;
+                let cy2Scaled = cy2 * turtlesScale;
+                let fxScaled = fx * turtlesScale;
+                let fyScaled = fy * turtlesScale;
 
                 // Curve to: ControlPointX1, ControlPointY1 >> ControlPointX2, ControlPointY2 >> X, Y
                 this.svgOutput +=
@@ -697,6 +698,7 @@ class Turtle {
             let nx, ny, sa, ea;
 
             let turtles = this.getTurtles();
+            let turtlesScale = turtles.getScale();
 
             if (invert) {
                 cx = turtles.turtleX2screenX(cx);
@@ -740,12 +742,12 @@ class Turtle {
                 let oxScaled, oyScaled;
                 if (anticlockwise) {
                     this.ctx.moveTo(ox + dx, oy + dy);
-                    oxScaled = (ox + dx) * turtles.scale;
-                    oyScaled = (oy + dy) * turtles.scale;
+                    oxScaled = (ox + dx) * turtlesScale;
+                    oyScaled = (oy + dy) * turtlesScale;
                 } else {
                     this.ctx.moveTo(ox - dx, oy - dy);
-                    oxScaled = (ox - dx) * turtles.scale;
-                    oyScaled = (oy - dy) * turtles.scale;
+                    oxScaled = (ox - dx) * turtlesScale;
+                    oyScaled = (oy - dy) * turtlesScale;
                 }
                 this.svgOutput += '<path d="M ' + oxScaled + "," + oyScaled + " ";
 
@@ -755,9 +757,9 @@ class Turtle {
 
                 this._svgArc(
                     nsteps,
-                    cx * turtles.scale,
-                    cy * turtles.scale,
-                    (radius + step) * turtles.scale,
+                    cx * turtlesScale,
+                    cy * turtlesScale,
+                    (radius + step) * turtlesScale,
                     sa,
                     ea
                 );
@@ -773,18 +775,18 @@ class Turtle {
                 this.ctx.arc(cx1, cy1, step, sa1, ea1, anticlockwise);
                 this._svgArc(
                     steps,
-                    cx1 * turtles.scale,
-                    cy1 * turtles.scale,
-                    step * turtles.scale,
+                    cx1 * turtlesScale,
+                    cy1 * turtlesScale,
+                    step * turtlesScale,
                     sa1,
                     ea1
                 );
                 this.ctx.arc(cx, cy, radius - step, ea, sa, !anticlockwise);
                 this._svgArc(
                     nsteps,
-                    cx * turtles.scale,
-                    cy * turtles.scale,
-                    (radius - step) * turtles.scale,
+                    cx * turtlesScale,
+                    cy * turtlesScale,
+                    (radius - step) * turtlesScale,
                     ea,
                     sa
                 );
@@ -795,9 +797,9 @@ class Turtle {
                 this.ctx.arc(cx2, cy2, step, sa2, ea2, anticlockwise);
                 this._svgArc(
                     steps,
-                    cx2 * turtles.scale,
-                    cy2 * turtles.scale,
-                    step * turtles.scale,
+                    cx2 * turtlesScale,
+                    cy2 * turtlesScale,
+                    step * turtlesScale,
                     sa2,
                     ea2
                 );
@@ -815,17 +817,17 @@ class Turtle {
                 this.ctx.arc(cx, cy, radius, sa, ea, anticlockwise);
                 if (!this.svgPath) {
                     this.svgPath = true;
-                    let oxScaled = ox * turtles.scale;
-                    let oyScaled = oy * turtles.scale;
+                    let oxScaled = ox * turtlesScale;
+                    let oyScaled = oy * turtlesScale;
                     this.svgOutput +=
                         '<path d="M ' + oxScaled + "," + oyScaled + " ";
                 }
 
                 let sweep = anticlockwise ? 0 : 1;
 
-                let nxScaled = nx * turtles.scale;
-                let nyScaled = ny * turtles.scale;
-                let radiusScaled = radius * turtles.scale;
+                let nxScaled = nx * turtlesScale;
+                let nyScaled = ny * turtlesScale;
+                let radiusScaled = radius * turtlesScale;
                 this.svgOutput +=
                     "A " +
                     radiusScaled +
@@ -1015,6 +1017,7 @@ class Turtle {
      */
         _move(ox, oy, x, y, invert) {
             let turtles = this.getTurtles();
+            let turtlesScale = turtles.getScale();
 
             let nx, ny;
             if (invert) {
@@ -1047,13 +1050,13 @@ class Turtle {
                 let dy = -step * Math.cos(capAngleRadians);
 
                 this.ctx.moveTo(ox + dx, oy + dy);
-                let oxScaled = (ox + dx) * turtles.scale;
-                let oyScaled = (oy + dy) * turtles.scale;
+                let oxScaled = (ox + dx) * turtlesScale;
+                let oyScaled = (oy + dy) * turtlesScale;
                 this.svgOutput += '<path d="M ' + oxScaled + "," + oyScaled + " ";
 
                 this.ctx.lineTo(nx + dx, ny + dy);
-                let nxScaled = (nx + dx) * turtles.scale;
-                let nyScaled = (ny + dy) * turtles.scale;
+                let nxScaled = (nx + dx) * turtlesScale;
+                let nyScaled = (ny + dy) * turtlesScale;
                 this.svgOutput += nxScaled + "," + nyScaled + " ";
 
                 capAngleRadians = ((this.orientation + 90) * Math.PI) / 180.0;
@@ -1067,10 +1070,10 @@ class Turtle {
                 let ea = oAngleRadians;
                 this.ctx.arc(cx, cy, step, sa, ea, false);
 
-                nxScaled = (nx + dx) * turtles.scale;
-                nyScaled = (ny + dy) * turtles.scale;
+                nxScaled = (nx + dx) * turtlesScale;
+                nyScaled = (ny + dy) * turtlesScale;
 
-                let radiusScaled = step * turtles.scale;
+                let radiusScaled = step * turtlesScale;
 
                 // Simulate an arc with line segments since Tinkercad
                 // cannot import SVG arcs reliably.
@@ -1081,16 +1084,16 @@ class Turtle {
                 let steps = Math.max(Math.floor(savedStroke, 1));
                 this._svgArc(
                     steps,
-                    cx * turtles.scale,
-                    cy * turtles.scale,
+                    cx * turtlesScale,
+                    cy * turtlesScale,
                     radiusScaled,
                     sa
                 );
                 this.svgOutput += nxScaled + "," + nyScaled + " ";
 
                 this.ctx.lineTo(ox + dx, oy + dy);
-                nxScaled = (ox + dx) * turtles.scale;
-                nyScaled = (oy + dy) * turtles.scale;
+                nxScaled = (ox + dx) * turtlesScale;
+                nyScaled = (oy + dy) * turtlesScale;
                 this.svgOutput += nxScaled + "," + nyScaled + " ";
 
                 capAngleRadians = ((this.orientation - 90) * Math.PI) / 180.0;
@@ -1104,14 +1107,14 @@ class Turtle {
                 ea = oAngleRadians;
                 this.ctx.arc(cx, cy, step, sa, ea, false);
 
-                nxScaled = (ox + dx) * turtles.scale;
-                nyScaled = (oy + dy) * turtles.scale;
+                nxScaled = (ox + dx) * turtlesScale;
+                nyScaled = (oy + dy) * turtlesScale;
 
-                radiusScaled = step * turtles.scale;
+                radiusScaled = step * turtlesScale;
                 this._svgArc(
                     steps,
-                    cx * turtles.scale,
-                    cy * turtles.scale,
+                    cx * turtlesScale,
+                    cy * turtlesScale,
                     radiusScaled,
                     sa
                 );
@@ -1131,13 +1134,13 @@ class Turtle {
                 this.ctx.lineTo(nx, ny);
                 if (!this.svgPath) {
                     this.svgPath = true;
-                    let oxScaled = ox * turtles.scale;
-                    let oyScaled = oy * turtles.scale;
+                    let oxScaled = ox * turtlesScale;
+                    let oyScaled = oy * turtlesScale;
                     this.svgOutput +=
                         '<path d="M ' + oxScaled + "," + oyScaled + " ";
                 }
-                let nxScaled = nx * turtles.scale;
-                let nyScaled = ny * turtles.scale;
+                let nxScaled = nx * turtlesScale;
+                let nyScaled = ny * turtlesScale;
                 this.svgOutput += nxScaled + "," + nyScaled + " ";
                 this.ctx.stroke();
                 if (!this.fillState) {

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -54,17 +54,12 @@ const TURTLEBASEPATH = "images/";       // unused
 class Turtle {
     /**
      * @constructor
-     * @param {boolean} drum - whether Turtle is a drum
+     * @param {String} name - name of Turtle
+     * @param {Object} turtles - Turtles object (common to all turtles)
      */
-    constructor(name, turtles, drum) {
+    constructor(name, turtles) {
         // Import members of model and view (arguments only for model)
         importMembers(this, [ name, turtles ]);
-
-        this.drum = drum;               // phase out
-
-        if (drum) {
-            console.debug("turtle " + name + " is a drum.");
-        }
 
         // Things used for drawing the turtle
         this.container = null;
@@ -410,11 +405,7 @@ class Turtle {
             // Use the name on the label of the start block
             if (this.startBlock != null) {
                 this.startBlock.overrideName = this.name;
-                if (this.name === _("start drum")) {
-                    this.startBlock.collapseText.text = _("drum");
-                } else {
-                    this.startBlock.collapseText.text = this.name;
-                }
+                this.startBlock.collapseText.text = this.name;
                 this.startBlock.regenerateArtwork(false);
                 this.startBlock.value =
                     this.getTurtles().getTurtleList().indexOf(this);
@@ -902,14 +893,8 @@ class Turtle {
             this.container.y = turtles.turtleY2screenY(this.y);
 
             if (resetSkin) {
-                if (this.drum) {
-                    if (this.name !== _("start drum")) {
-                        this.rename(_("start drum"));
-                    }
-                } else {
-                    if (this.name !== _("start")) {
-                        this.rename(_("start"));
-                    }
+                if (this.name !== _("start")) {
+                    this.rename(_("start"));
                 }
 
                 if (this.skinChanged) {

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -282,7 +282,7 @@ class Turtles {
             this._masterStage = null;       // createjs stage
             this._stage = null;             // createjs container for turtle
 
-            this.canvas = null;             // DOM canvas element
+            this._canvas = null;            // DOM canvas element
 
             // These functions are directly called by TurtlesView
             this.hideMenu = null;           // function to hide aux menu

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -386,17 +386,6 @@ class Turtles {
         }
 
         /**
-         * Returns block object.
-         *
-         * @param blocks
-         * @returns {this}
-         */
-        setBlocks(blocks) {
-            this.blocks = blocks;
-            return this;
-        }
-
-        /**
          * @returns {Object[]} list of Turtle objects
          */
         getTurtleList() {

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -62,7 +62,7 @@ class Turtles {
      */
     addTurtle(startBlock, infoDict) {
         this.add(startBlock, infoDict);
-        if (this.isShrunk) {
+        if (this.isShrunk()) {
             let t = last(this.getTurtleList());
             t.container.scaleX = SCALEFACTOR;
             t.container.scaleY = SCALEFACTOR;
@@ -430,49 +430,44 @@ class Turtles {
          * @constructor
          */
         constructor() {
-            this.scale = 1.0;               // scale factor in [0, 1]
+            this._scale = 1.0;              // scale factor in [0, 1]
             this._w = 1200;                 // stage width
             this._h = 900;                  // stage height
 
-            // these 3 are used by outer code only
+            /**
+             * These 3 are used by Turtle only.
+             *
+             * @todo reorganize position of these
+             */
             this.gx = null;
             this.gy = null;
             this.canvas1 = null;
+
+            this._isShrunk = false;         // whether canvas is collapsed
 
             /**
              * @todo write comments to describe each variable
              */
             this._expandedBoundary = null;
             this._collapsedBoundary = null;
-            this.isShrunk = false;
-            this._expandButton = null;
+            this._expandButton = null;      // add method
             this._expandLabel = null;
             this._expandLabelBG = null;
-            this._collapseButton = null;
+            this._collapseButton = null;    // add method
             this._collapseLabel = null;
             this._collapseLabelBG = null;
-            this._clearButton = null;
+            this._clearButton = null;       // add method
             this._clearLabel = null;
             this._clearLabelBG = null;
-            this._gridButton = null;
+            this._gridButton = null;        // add method
             this._gridLabel = null;
             this._gridLabelBG = null;
 
             // canvas background color
-            this.backgroundColor = platformColor.background;
+            this._backgroundColor = platformColor.background;
 
             this._locked = false;
             this._queue = [];               // temporarily stores [w, h, scale]
-        }
-
-        /**
-         * @param {String} text
-         * @returns {void}
-         */
-        setGridLabel(text) {
-            if (this._gridLabel !== null) {
-                this._gridLabel.text = text;
-            }
         }
 
         /**
@@ -499,7 +494,7 @@ class Turtles {
             if (this._locked) {
                 this._queue = [w, h, scale];
             } else {
-                this.scale = scale;
+                this._scale = scale;
                 this._w = w / scale;
                 this._h = h / scale;
             }
@@ -511,7 +506,31 @@ class Turtles {
          * @returns {Number} scale factor
          */
         getScale() {
-            return this.scale;
+            return this._scale;
+        }
+
+        /**
+         * @returns {Boolean} - whether canvas is collapsed
+         */
+        isShrunk() {
+            return this._isShrunk;
+        }
+
+        /**
+         * @param {String} text
+         * @returns {void}
+         */
+        setGridLabel(text) {
+            if (this._gridLabel !== null) {
+                this._gridLabel.text = text;
+            }
+        }
+
+        /**
+         * @param {String} color - background color
+         */
+        setBackgroundColor(color) {
+            this._backgroundColor = color;
         }
 
         /**
@@ -532,7 +551,7 @@ class Turtles {
          * @returns {Number} inverted y coordinate
          */
         _invertY(y) {
-            return this.getCanvas().height / (2.0 * this.scale) - y;
+            return this.getCanvas().height / (2.0 * this._scale) - y;
         }
 
         /**
@@ -542,7 +561,7 @@ class Turtles {
          * @returns {Number} turtle x coordinate
          */
         screenX2turtleX(x) {
-            return x - this.getCanvas().width / (2.0 * this.scale);
+            return x - this.getCanvas().width / (2.0 * this._scale);
         }
 
         /**
@@ -562,7 +581,7 @@ class Turtles {
          * @returns {Number} screen x coordinate
          */
         turtleX2screenX(x) {
-            return this.getCanvas().width / (2.0 * this.scale) + x;
+            return this.getCanvas().width / (2.0 * this._scale) + x;
         }
 
         /**
@@ -628,7 +647,7 @@ class Turtles {
                 this._collapseButton.visible = false;
                 turtlesStage.x = (this._w * 3) / 4 - 10;
                 turtlesStage.y = 55 + LEADING + 6;
-                this.isShrunk = true;
+                this._isShrunk = true;
 
                 let turtleList = this.getTurtleList();
                 for (let i = 0; i < turtleList.length; i++) {
@@ -751,9 +770,9 @@ class Turtles {
 
                     this._locked = false;
                     if (this._queue.length === 3) {
-                        this.scale = this._queue[2];
-                        this._w = this._queue[0] / this.scale;
-                        this._h = this._queue[1] / this.scale;
+                        this._scale = this._queue[2];
+                        this._w = this._queue[0] / this._scale;
+                        this._h = this._queue[1] / this._scale;
                         this._queue = [];
                         this.makeBackground();
                     }
@@ -1065,8 +1084,8 @@ class Turtles {
                     this._expandButton.removeAllEventListeners("pressmove");
                     this._expandButton.on("pressmove", event => {
                         let w = (this._w - 10 - SCALEFACTOR * 55) / SCALEFACTOR;
-                        let x = event.stageX / this.scale - w;
-                        let y = event.stageY / this.scale - 16;
+                        let x = event.stageX / this._scale - w;
+                        let y = event.stageY / this._scale - 16;
                         turtlesStage.x = Math.max(0, Math.min((this._w * 3) / 4, x));
                         turtlesStage.y = Math.max(55, Math.min((this._h * 3) / 4, y));
                         this.refreshCanvas();
@@ -1090,7 +1109,7 @@ class Turtles {
                         this._expandButton.visible = false;
                         turtlesStage.x = 0;
                         turtlesStage.y = 0;
-                        this.isShrunk = false;
+                        this._isShrunk = false;
 
                         let turtleList = this.getTurtleList();
                         for (let i = 0; i < turtleList.length; i++) {
@@ -1161,7 +1180,7 @@ class Turtles {
                                         "stroke_color",
                                         platformColor.ruleColor
                                     )
-                                    .replace("fill_color", this.backgroundColor)
+                                    .replace("fill_color", this._backgroundColor)
                                     .replace("STROKE", 20)
                             )
                         )
@@ -1204,7 +1223,7 @@ class Turtles {
                                         "stroke_color",
                                         platformColor.ruleColor
                                     )
-                                    .replace("fill_color", this.backgroundColor)
+                                    .replace("fill_color", this._backgroundColor)
                                     .replace("STROKE", 20 / SCALEFACTOR)
                             )
                         )

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -42,8 +42,6 @@ class Turtles {
         importMembers(this);
 
         this.refreshCanvas = null;      // function to refresh canvas
-
-        this._drum = false;
     }
 
     /**
@@ -56,18 +54,6 @@ class Turtles {
     }
 
     /**
-     * Adds drum to start block.
-     *
-     * @param {Object} startBlock - name of startBlock
-     * @param {Object} infoDict - contains turtle color, shade, pensize, x, y, heading, etc.
-     * @returns {void}
-     */
-    addDrum(startBlock, infoDict) {
-        this._drum = true;
-        this.add(startBlock, infoDict);
-    }
-
-    /**
      * Adds turtle to start block.
      *
      * @param {Object} startBlock - name of startBlock
@@ -75,7 +61,6 @@ class Turtles {
      * @returns {void}
      */
     addTurtle(startBlock, infoDict) {
-        this._drum = false;
         this.add(startBlock, infoDict);
         if (this.isShrunk) {
             let t = last(this.turtleList);
@@ -115,7 +100,7 @@ class Turtles {
         let turtleName =
             blkInfoAvailable && "name" in infoDict ?
                 infoDict["name"] : _("start");
-        let newTurtle = new Turtle(turtleName, this, this._drum);
+        let newTurtle = new Turtle(turtleName, this);
 
         if (blkInfoAvailable) {
             if ("xcor" in infoDict) {
@@ -159,7 +144,7 @@ class Turtles {
         hitArea.y = 0;
         newTurtle.container.hitArea = hitArea;
 
-        let artwork = this._drum ? DRUMSVG : TURTLESVG;
+        let artwork = TURTLESVG;
 
         if (sugarizerCompatibility.isInsideSugarizer()) {
             artwork = artwork

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -63,7 +63,7 @@ class Turtles {
     addTurtle(startBlock, infoDict) {
         this.add(startBlock, infoDict);
         if (this.isShrunk) {
-            let t = last(this.turtleList);
+            let t = last(this.getTurtleList());
             t.container.scaleX = SCALEFACTOR;
             t.container.scaleY = SCALEFACTOR;
             t.container.scale = SCALEFACTOR;
@@ -80,8 +80,8 @@ class Turtles {
     add(startBlock, infoDict) {
         if (startBlock != null) {
             console.debug("adding a new turtle " + startBlock.name);
-            if (startBlock.value !== this.turtleList.length) {
-                startBlock.value = this.turtleList.length;
+            if (startBlock.value !== this.getTurtleList().length) {
+                startBlock.value = this.getTurtleList().length;
                 console.debug("turtle #" + startBlock.value);
             }
         } else {
@@ -96,7 +96,7 @@ class Turtles {
             }
         }
 
-        let i = this.turtleList.length % 10;
+        let i = this.getTurtleList().length % 10;
         let turtleName =
             blkInfoAvailable && "name" in infoDict ?
                 infoDict["name"] : _("start");
@@ -111,7 +111,7 @@ class Turtles {
             }
         }
 
-        this.turtleList.push(newTurtle);
+        this.getTurtleList().push(newTurtle);
 
         let turtlesStage = this.getStage();
 
@@ -259,7 +259,7 @@ class Turtles {
         for (let turtle in this.getTurtleList()) {
             this.getTurtleList()[turtle].running = false;
             // Make sure the blink is really stopped
-            // this.turtleList[turtle].stopBlink();
+            // getTurtleList()[turtle].stopBlink();
         }
 
         this.refreshCanvas();
@@ -282,14 +282,14 @@ class Turtles {
             this._masterStage = null;       // createjs stage
             this._stage = null;             // createjs container for turtle
 
-            this._canvas = null;            // DOM canvas element
+            this.canvas = null;             // DOM canvas element
 
+            // These functions are directly called by TurtlesView
+            this.hideMenu = null;           // function to hide aux menu
+            this.doClear = null;            // function to clear the canvas
             this.hideGrids = null;          // function to hide all grids
             this.doGrid = null;             // function that renders Cartesian/Polar
                                             //  grids and changes button labels
-
-            this.hideMenu = null;           // function to hide aux menu
-            this.doClear = null;            // function to clear the canvas
 
             // createjs border container
             this._borderContainer = new createjs.Container();
@@ -305,6 +305,13 @@ class Turtles {
         setMasterStage(stage) {
             this._masterStage = stage;
             return this;
+        }
+
+        /**
+         * @returns {Object} - master stage object
+         */
+        getMasterStage() {
+            return this._masterStage;
         }
 
         /**
@@ -398,8 +405,8 @@ class Turtles {
          * @return {Boolean} - running
          */
         running() {
-            for (let turtle in this.getTurtleList()) {
-                if (this.getTurtleList()[turtle].running) {
+            for (let turtle in this.turtleList) {
+                if (this.turtleList[turtle].running) {
                     return true;
                 }
             }
@@ -622,10 +629,12 @@ class Turtles {
                 turtlesStage.x = (this._w * 3) / 4 - 10;
                 turtlesStage.y = 55 + LEADING + 6;
                 this.isShrunk = true;
-                for (let i = 0; i < this.turtleList.length; i++) {
-                    this.turtleList[i].container.scaleX = SCALEFACTOR;
-                    this.turtleList[i].container.scaleY = SCALEFACTOR;
-                    this.turtleList[i].container.scale = SCALEFACTOR;
+
+                let turtleList = this.getTurtleList();
+                for (let i = 0; i < turtleList.length; i++) {
+                    turtleList[i].container.scaleX = SCALEFACTOR;
+                    turtleList[i].container.scaleY = SCALEFACTOR;
+                    turtleList[i].container.scale = SCALEFACTOR;
                 }
 
                 this._clearButton.scaleX = SCALEFACTOR;
@@ -642,8 +651,8 @@ class Turtles {
                 }
 
                 // remove the stage and add it back at the top
-                this._masterStage.removeChild(turtlesStage);
-                this._masterStage.addChild(turtlesStage);
+                this.getMasterStage().removeChild(turtlesStage);
+                this.getMasterStage().addChild(turtlesStage);
 
                 this.refreshCanvas();
             }
@@ -1082,10 +1091,12 @@ class Turtles {
                         turtlesStage.x = 0;
                         turtlesStage.y = 0;
                         this.isShrunk = false;
-                        for (let i = 0; i < this.turtleList.length; i++) {
-                            this.turtleList[i].container.scaleX = 1;
-                            this.turtleList[i].container.scaleY = 1;
-                            this.turtleList[i].container.scale = 1;
+
+                        let turtleList = this.getTurtleList();
+                        for (let i = 0; i < turtleList.length; i++) {
+                            turtleList[i].container.scaleX = 1;
+                            turtleList[i].container.scaleY = 1;
+                            turtleList[i].container.scale = 1;
                         }
 
                         this._clearButton.scaleX = 1;
@@ -1102,8 +1113,8 @@ class Turtles {
                         }
 
                         // remove the stage and add it back in position 0
-                        this._masterStage.removeChild(turtlesStage);
-                        this._masterStage.addChildAt(turtlesStage, 0);
+                        this.getMasterStage().removeChild(turtlesStage);
+                        this.getMasterStage().addChildAt(turtlesStage, 0);
                     });
 
                     __makeCollapseButton();


### PR DESCRIPTION
This branch is forked from [meganindya/musicblocks/turtle-component](https://github.com/meganindya/musicblocks/tree/turtle-component) and contains commits pushed on that branch, so, should be merged after #2312.

- [x] remove start as `drum`
- [x] remove `setBlocks`
- [x] add `getters`
- [x] replace `inter class` variable access by `getters`
- [x] rename `private` variables