### PR TITLE
Add MIDI compatibilty (usb)

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2651,6 +2651,7 @@ function MusicKeyboard() {
         for (let idx = 0; idx < this.layout.length; idx++) {
             key = this.layout[idx];
             this.getElement[key.noteName.toString()+ key.noteOctave.toString()] = key.objId;
+            this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] = key.objId ; //convet solfege to alphabetic.
         }
 
         let __startNote = (event, element) => { 
@@ -2715,8 +2716,9 @@ function MusicKeyboard() {
         let numberToPitch = (num) => {
             let offset = 4;
             let octave = offset + Math.floor((num - 60) / 12);
-            let pitch = PITCHES[num % 12];
-            return [pitch, octave];
+            let pitch1 = NOTESSHARP[num % 12];
+            let pitch2 = NOTESFLAT[num % 12];
+            return [pitch1, pitch2, octave];
         }
 
         //event attributes : timeStamp , data 
@@ -2725,15 +2727,18 @@ function MusicKeyboard() {
         //                 [2] : velocity ,(currently not used).
  
         let onMIDIMessage = (event) => {
-            let pitch = numberToPitch(event.data[1] )[0];
-            let octave = numberToPitch(event.data[1] )[1];
-            console.debug(pitch, octave);
+            let pitchOctave = numberToPitch(event.data[1]);
+            let pitch1 = pitchOctave[0];
+            let pitch2 = pitchOctave[1];
+            let octave = pitchOctave[2];
+            let key = this.getElement[pitch1 +""+ octave] || this.getElement[pitch2 +"" + octave];
+            console.debug(pitch1, octave);
             if (event.data[0] == 144 && event.data[2] != 0) {
-                __startNote(event, docById(this.getElement[pitch + "" + octave]));
+                __startNote(event, docById(key));
 
             }
             else {
-                __endNote(event, docById(this.getElement[pitch + "" + octave]));
+                __endNote(event, docById(key));
             }
         }
 

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -453,17 +453,13 @@ function MusicKeyboard() {
             that._createAddRowPieSubmenu();
         };
 
-        let midiButton = widgetWindow.addButton(
+        this.midiButton = widgetWindow.addButton(
             null,
             ICONSIZE,
             _("MIDI")
         )
-        midiButton.onclick = function () {
-            if (navigator.requestMIDIAccess) {
-                that.doMIDI();
-            } else {
-                logo.textMsg(' MIDI is not supported in this browser.');
-            }
+        this.midiButton.onclick = function () {
+            that.doMIDI();
         };
 
         // var cell = this._addButton(row1, 'table.svg', ICONSIZE, _('Table'));
@@ -2743,14 +2739,28 @@ function MusicKeyboard() {
         }
 
         let onMIDISuccess = ( midiAccess) => {
+            // re-init widget 
+            if (this.midiON){
+                this.midiButton.style.background = "#00FF00" ;
+                logo.textMsg("MIDI device present")
+                return ;
+            }
             midiAccess.inputs.forEach((input) => { input.onmidimessage = onMIDIMessage; });
+            if (midiAccess.inputs.size) {
+                this.midiButton.style.background = "#00FF00" ;
+                logo.textMsg("MIDI device present")
+                this.midiON =true ;
+            }
+            else logo.textMsg("MIDI device not present");
         }
 
-        if (this.midiON) return;
-        this.midiON = true;
+        let  onMIDIFailure= () => {
+            logo.errorMsg( "Failed to get MIDI access in browser");
+            this.midiON =false ;
+        }
 
         navigator.requestMIDIAccess()
-            .then(onMIDISuccess);
+            .then(onMIDISuccess,onMIDIFailure);
 
     }
 }


### PR DESCRIPTION
I am using the web Midi api available on https://www.w3.org/TR/webmidi/ 
to communicate with a physical midi keyboard ,
I have added a button(MIDI) in the music Keyboard widget , (to be pressed once connected with keyboard ) ,I would like to add a svg for this button also .
Currently this works with alphabet pitches (only FLATS ) u can use this keyboard for testing -

[midi (1).zip](https://github.com/sugarlabs/musicblocks/files/4741160/midi.1.zip)

