### PR TITLE
fix regression in mode pie menu

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -790,7 +790,7 @@ const MODE_PIE_MENUS = {
     ],
     "7b": [
         "jazz minor",
-        "",
+        " ",
         "arabic",
         "byzantine",
         "enigmatic",


### PR DESCRIPTION
Usually, empty positions in MODE_PIE_MENUS are denoted by a single space : " "

In the case of 7b, it was "" without the spaces. 

- Fixes #2335 