### PR TITLE
Linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,56 @@
+{
+    "parser": "babel-eslint",
+    "env": { 
+        "es6": true, 
+        "browser": true,
+        "node": true
+    },
+    "rules": {
+        "indent": [
+            "error", 
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "no-mixed-spaces-and-tabs": "warn",
+        // "no-unused-vars": "warn",
+        "quotes": [
+            "error",
+            "double",
+            { 
+                "avoidEscape": true 
+            }
+        ],
+        "semi": [
+            "error",
+            "always",
+            { 
+                "omitLastInOneLineBlock": true 
+            }
+        ],
+        "max-len": [
+            "warn",
+            {
+                "code": 100,
+                "ignoreTrailingComments": true,
+                "ignoreComments": true,
+                "ignoreStrings": true,
+                "ignoreTemplateLiterals": true
+            }
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-trailing-spaces": [
+            "error",
+            {
+                "skipBlankLines": true,
+                "ignoreComments": true
+            }
+        ],
+        "no-duplicate-case": "error",
+        "no-irregular-whitespace": "error"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,15 +8,18 @@
     }
   },
   "scripts": {
+    "lint": "eslint",
     "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000 --bind 127.0.0.1') if sys.version_info.major==2 else os.system('python -m http.server 3000 --bind 127.0.0.1');\"",
     "winserve": "py -c \"import os, sys; os.system('py -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('py -m http.server 3000 --bind 127.0.0.1');\""
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",
+    "babel-eslint": "^10.1.0",
     "clean-css": "^4.2.1",
-    "eslint": "^4.18.2",
+    "eslint": "^6.8.0",
     "eslint-config-standard": "^7.1.0",
+    "eslint-plugin-import": "^2.21.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.1.1",
     "gulp": "^4.0.2",


### PR DESCRIPTION
This commit adds some basic linting rules. 

- Upgraded ESLint, added some basic rules in `eslintrc` and added a `babel-eslint` parser to avoid some errors related to ES6 JS.

- Added a `lint` script in `package.json` which can be used in TravisCI later.

- To bring all current code to specified standards, a lot of files would change, so this would need to be planned to avoid merge conflicts.