### PR TITLE
fix #2334

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -415,7 +415,6 @@ function Blocks(activity) {
             this.blockMoved(blk);
 
             if (adjustDock && firstConnection != null) {
-                this.blockMoved(firstConnection);
                 this.adjustDocks(firstConnection, true);
                 if (clampList.length > 0) {
                     this.clampBlocksToCheck = clampList;


### PR DESCRIPTION
#2334 
blockMoved statement was causing problems for clamped notes .
If I am right the blockmoved statement shoud only be used for targeted block not the first connection.