### PR TITLE
Fix regression in Turtles

### DIFF
--- a/js/turtles.js
+++ b/js/turtles.js
@@ -96,7 +96,7 @@ class Turtles {
             }
         }
 
-        let i = this.getTurtleList().length % 10;
+        let i = this.turtleList.length % 10;
 
         // Unique ID of turtle is time of instantiation for the first time
         let id =


### PR DESCRIPTION
`getTurtleList()` was replaced by `turtleList` (`getter`) - missed that during merge conflict resolving.