### PR TITLE
Add markup for print block

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -858,10 +858,10 @@ function setupExtrasBlocks() {
                                 logo.textMsg(args[0].toString());
                             }
                         } else if (logo.runningLilypond) {
-			    if (logo.inNoteBlock[turtle].length > 0) {
-				logo.notation.notationMarkup(turtle, args[0].toString());
-			    }
-			}
+                            if (logo.inNoteBlock[turtle].length > 0) {
+                                logo.notation.notationMarkup(turtle, args[0].toString());
+                            }
+                        }
                     }
                 }
             }

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -859,7 +859,7 @@ function setupExtrasBlocks() {
                             }
                         } else if (logo.runningLilypond) {
 			    if (logo.inNoteBlock[turtle].length > 0) {
-				logo.notation._markup[turtle] = args[0].toString();
+				logo.notation.notationMarkup(turtle, args[0].toString());
 			    }
 			}
                     }

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -859,7 +859,6 @@ function setupExtrasBlocks() {
                             }
                         } else if (logo.runningLilypond) {
 			    if (logo.inNoteBlock[turtle].length > 0) {
-				console.log('LYRIC: ' + args[0]);
 				logo.notation._markup[turtle] = args[0].toString();
 			    }
 			}

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -857,7 +857,12 @@ function setupExtrasBlocks() {
                             } else {
                                 logo.textMsg(args[0].toString());
                             }
-                        }
+                        } else if (logo.runningLilypond) {
+			    if (logo.inNoteBlock[turtle].length > 0) {
+				console.log('LYRIC: ' + args[0]);
+				logo.notation._markup[turtle] = args[0].toString();
+			    }
+			}
                     }
                 }
             }

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -2498,7 +2498,7 @@ function setupPitchBlocks() {
                 ].push(logo.beatFactor[turtle]);
                 logo.pushedNote[turtle] = true;
                 if (logo.runningLilypond) {
-		    logo.notation._markup[turtle] = pitchToFrequency(noteObj1[0], noteObj1[1], cents, logo.keySignature[turtle]);
+		    logo.notation.notationMarkup(turtle, pitchToFrequency(noteObj1[0], noteObj1[1], cents, logo.keySignature[turtle]));
 		}
             } else if (logo.inPitchStaircase) {
                 let frequency = arg;

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -2497,6 +2497,9 @@ function setupPitchBlocks() {
                     last(logo.inNoteBlock[turtle])
                 ].push(logo.beatFactor[turtle]);
                 logo.pushedNote[turtle] = true;
+                if (logo.runningLilypond) {
+		    logo.notation._markup[turtle] = pitchToFrequency(noteObj1[0], noteObj1[1], cents, logo.keySignature[turtle]);
+		}
             } else if (logo.inPitchStaircase) {
                 let frequency = arg;
                 let note = frequencyToPitch(arg);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -2498,8 +2498,8 @@ function setupPitchBlocks() {
                 ].push(logo.beatFactor[turtle]);
                 logo.pushedNote[turtle] = true;
                 if (logo.runningLilypond) {
-		    logo.notation.notationMarkup(turtle, pitchToFrequency(noteObj1[0], noteObj1[1], cents, logo.keySignature[turtle]));
-		}
+                    logo.notation.notationMarkup(turtle, pitchToFrequency(noteObj1[0], noteObj1[1], cents, logo.keySignature[turtle]));
+                }
             } else if (logo.inPitchStaircase) {
                 let frequency = arg;
                 let note = frequencyToPitch(arg);

--- a/js/notation.js
+++ b/js/notation.js
@@ -184,17 +184,33 @@ class Notation {
         this._pickupPoint[turtle] = null;
 
         if (typeof note === "object") {
-            let markup = "";
 	    if (turtle in this._markup) {
-		markup = this._markup[turtle];
-                if (typeof markup === "number") { // Hertz block
-                    this._notationMarkup(turtle, toFixed2(markup), false);
-		} else if (markup.length > 0) { // Print block
-                    this._notationMarkup(turtle, markup, true);
-		    this._markup[turtle] = "";
+		for (let i = 0; i < this._markup[turtle].length; i++) {
+		    let markup = this._markup[turtle][i];
+                    if (typeof markup === "number") { // Hertz block
+			this._notationMarkup(turtle, toFixed2(markup), false);
+		    } else if (markup.length > 0) { // Print block
+			this._notationMarkup(turtle, markup, true);
+		    }
 		}
+		this._markup[turtle] = [];
             }
         }
+    }
+
+    /**
+     * Adds a markup.
+     *
+     * @param turtle
+     * @param arg
+     * @returns {void}
+     */
+    notationMarkup(turtle, arg) {
+	if (turtle in this._markup) {
+	    this._markup[turtle].push(arg);
+	} else {
+	    this._markup[turtle] = [arg];
+	}
     }
 
     /**

--- a/js/notation.js
+++ b/js/notation.js
@@ -31,8 +31,12 @@ class Notation {
     constructor(logo) {
         this._logo = logo;
 
+	// _notationStaging is used to aggregate all of the notes played in a performance.
         this._notationStaging = {};
         this._notationDrumStaging = {};
+	// _markup is used to aggregate markup for individual notes.
+	this._markup = {};
+	// _pickup is used to manage the specification of a pickup.
         this._pickupPOW2 = {};
         this._pickupPoint = {};
     }
@@ -69,6 +73,20 @@ class Notation {
      */
     get notationDrumStaging() {
         return this._notationDrumStaging;
+    }
+
+    /**
+     * @param {Object.<String[]>} notationMarkup
+     */
+    set notationMarkup(notationMarkup) {
+        this._notationMarkup = notationMarkup;
+    }
+
+    /**
+     * @returns {Object.<String[]>}
+     */
+    get notationMarkup() {
+        return this._notationMarkup;
     }
 
     /**
@@ -183,6 +201,12 @@ class Notation {
                 }
             } catch (e) {
                 console.debug(e);
+            }
+	    
+	    markup = this._markup[turtle];
+	    if (markup.length > 0) {
+                this._notationMarkup(turtle, markup, true);
+		this._markup[turtle] = "";
             }
         }
     }

--- a/js/notation.js
+++ b/js/notation.js
@@ -184,29 +184,15 @@ class Notation {
         this._pickupPoint[turtle] = null;
 
         if (typeof note === "object") {
-            // If it is hertz, add a markup
             let markup = "";
-            try {
-                for (let i = 0; i < note.length; i++) {
-                    if (typeof note[i] === "number") {
-                        if ((markup = "")) {
-                            markup = toFixed2(note[i]);
-                            break;
-                        }
-                    }
-                }
-
-                if (markup.length > 0) {
-                    this._notationMarkup(turtle, markup, false);
-                }
-            } catch (e) {
-                console.debug(e);
-            }
-	    
-	    markup = this._markup[turtle];
-	    if (markup.length > 0) {
-                this._notationMarkup(turtle, markup, true);
-		this._markup[turtle] = "";
+	    if (turtle in this._markup) {
+		markup = this._markup[turtle];
+                if (typeof markup === "number") { // Hertz block
+                    this._notationMarkup(turtle, toFixed2(markup), false);
+		} else if (markup.length > 0) { // Print block
+                    this._notationMarkup(turtle, markup, true);
+		    this._markup[turtle] = "";
+		}
             }
         }
     }

--- a/js/notation.js
+++ b/js/notation.js
@@ -31,12 +31,12 @@ class Notation {
     constructor(logo) {
         this._logo = logo;
 
-	// _notationStaging is used to aggregate all of the notes played in a performance.
+        // _notationStaging is used to aggregate all of the notes played in a performance.
         this._notationStaging = {};
         this._notationDrumStaging = {};
-	// _markup is used to aggregate markup for individual notes.
-	this._markup = {};
-	// _pickup is used to manage the specification of a pickup.
+        // _markup is used to aggregate markup for individual notes.
+        this._markup = {};
+        // _pickup is used to manage the specification of a pickup.
         this._pickupPOW2 = {};
         this._pickupPoint = {};
     }
@@ -184,16 +184,16 @@ class Notation {
         this._pickupPoint[turtle] = null;
 
         if (typeof note === "object") {
-	    if (turtle in this._markup) {
-		for (let i = 0; i < this._markup[turtle].length; i++) {
-		    let markup = this._markup[turtle][i];
+            if (turtle in this._markup) {
+                for (let i = 0; i < this._markup[turtle].length; i++) {
+                    let markup = this._markup[turtle][i];
                     if (typeof markup === "number") { // Hertz block
-			this._notationMarkup(turtle, toFixed2(markup), false);
-		    } else if (markup.length > 0) { // Print block
-			this._notationMarkup(turtle, markup, true);
-		    }
-		}
-		this._markup[turtle] = [];
+                        this._notationMarkup(turtle, toFixed2(markup), false);
+                    } else if (markup.length > 0) { // Print block
+                        this._notationMarkup(turtle, markup, true);
+                    }
+                }
+                this._markup[turtle] = [];
             }
         }
     }
@@ -206,11 +206,11 @@ class Notation {
      * @returns {void}
      */
     notationMarkup(turtle, arg) {
-	if (turtle in this._markup) {
-	    this._markup[turtle].push(arg);
-	} else {
-	    this._markup[turtle] = [arg];
-	}
+        if (turtle in this._markup) {
+            this._markup[turtle].push(arg);
+        } else {
+            this._markup[turtle] = [arg];
+        }
     }
 
     /**


### PR DESCRIPTION
This is a partial fix to #2326 (It addresses the regression for using the Print block for lyrics in Lilypond output but does not yet address the regression with the Hertz block.)

- [x] added a _markup dictionary to capture markup on a note-by-note basis in notation.js
- [x] added lyrics to that dictionary from the print block flow code when that block is used inside of a note and exporting to Lilypond
- [x] updated the markup processing to include the strings in the _markup dictionary
- [x] chased down the regression in the Hertz marksdown

@meganindya Am I using the notation syntax as you intended?