### PR TITLE
fix regression in nth modal pitch

### DIFF
--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -315,8 +315,8 @@ function setupPitchActions() {
                 note = nthDegreeToPitch(tur.singer.keySignature, scaleDegree);
             }
 
-            let semitones =
-                ref +
+            let semitones = ref;
+            semitones +=
                 NOTESFLAT.indexOf(note) !== -1 ?
                     NOTESFLAT.indexOf(note) - ref : NOTESSHARP.indexOf(note) - ref;
             /** calculates changes in reference octave which occur a semitone before the reference key */


### PR DESCRIPTION
- The misbehavior of a ternary expression led to incorrect calculations of octave.
