### PR TITLE
fix 2521

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7094,11 +7094,12 @@ function Blocks(activity) {
                     break;
                 }
             }
+            let parentExpandableBlk = this.insideExpandableBlock(thisBlock);
             myBlock.connections[0] = null;
 
             // Add default block if user deletes all blocks from
             // inside the note block.
-            this.addDefaultBlock(parentBlock, thisBlock);
+            this.addDefaultBlock(parentExpandableBlk, thisBlock);
         }
 
         if (myBlock.name === "start" || myBlock.name === "drum") {


### PR DESCRIPTION
#2521 
use Nearest parent Expandable Block when adding default blocks for pitch BLocks