### PR TITLE
remove Save alert

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -480,37 +480,18 @@ function SaveInterface(PlanetInterface) {
 
     this.init = function() {
         this.timeLastSaved = -100;
-        window.onbeforeunload = function(e) {
+        let $j = jQuery.noConflict();
+        $j(window).bind("beforeunload",(event) => {
+            var saveButton = beginnerMode ? "#saveButton" : "#saveButtonAdvanced";
             if (
                 this.PlanetInterface !== undefined &&
                 this.PlanetInterface.getTimeLastSaved() !== this.timeLastSaved
             ) {
-                // The following section of code is a bit of a hack. In order to detect the user selecting
-                // "Cancel", we attempt to perform an action that would otherwise be blocked. That is, if the
-                // user does not cancel the navigation, the HTTP request will fail, and the prompt never shown.
-                setTimeout(
-                    function() {
-                        var xhr = new XMLHttpRequest();
-                        xhr.open("GET", document.location.href, true);
-                        xhr.onreadystatechange = function() {
-                            if (xhr.readyState === xhr.DONE) {
-                                if (
-                                    confirm(
-                                        _("Do you want to save your project?")
-                                    )
-                                ) {
-                                    this.saveHTMLNoPrompt();
-                                    this.timeLastSaved = this.PlanetInterface.getTimeLastSaved();
-                                }
-                            }
-                        }.bind(this);
-                        xhr.send();
-                    }.bind(this)
-                );
-
-                e.preventDefault();
-                e.returnValue = "";
+                event.preventDefault();
+                event.returnValue = "";
+                $j(saveButton).trigger("mouseenter") //will trigger when exit/reload cancelled.
+                return "";
             }
-        }.bind(this);
+        });
     };
 }


### PR DESCRIPTION
#2458 
most browsers dont allow alerts in "beforeunload" and force exit/reload window ,
previously implemented "hack" doesn't work anymore.
more info(https://stackoverflow.com/questions/38879742/is-it-possible-to-display-a-custom-message-in-the-beforeunload-popup)

If the user cancels the reload/exit,
the save Icon tooltip will be opened to indicate the save option to the user.