### PR TITLE
Allow 'play back' block to accept 'load file' block

### DIFF
--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -200,7 +200,7 @@ function setupMediaBlocks() {
             this.formBlock({
                 args: 1,
                 defaults: [null],
-                argTypes: ["medain"]
+                argTypes: ["mediain"]
             });
 
             this.hidden = true;


### PR DESCRIPTION
Fix a typo from "medain" to "mediain" allowing the play back media block to accept a load file block as an argument. Now when a .wav file is imported to a load file block used as an argument for a play back block, the sound file is played.