### PR TITLE
fixing the regression with camera block error

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -792,8 +792,7 @@ function doUseCamera(
                 if (navigator.mozGetUserMedia) {
                     video.mozSrcObject = stream;
                 } else {
-                    let vendorURL = window.URL || window.webkitURL;
-                    video.src = vendorURL.createObjectURL(stream);
+                    video.srcObject = stream;
                 }
 
                 video.play();


### PR DESCRIPTION
The issue #2574 finds it's fix in here, the error was because the code previously used deprecated methods.