### PR TITLE
PitchSlider and Status port to ES6

### DIFF
--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -18,8 +18,7 @@ function PitchSlider() {
     this._delta = 0;
     const SEMITONE = Math.pow(2,1/12);
 
-    this._save = function(frequency) {
-        let that = this;
+    this._save = (frequency) => {
 
         for (let name in this._logo.blocks.palettes.dict) {
             this._logo.blocks.palettes.dict[name].hideMenu(true);
@@ -44,10 +43,10 @@ function PitchSlider() {
                        0, 0, [hertzIdx]]);
         newStack.push([hiddenIdx, "hidden", 0, 0, [hertzIdx, null]]);
 
-        that._logo.blocks.loadNewBlocks(newStack);
+        this._logo.blocks.loadNewBlocks(newStack);
     };
 
-    this.init = function(logo) {
+    this.init = (logo) => {
         if (window.widgetWindows.openWindows["slider"])return;
         if (!this.frequencies || !this.frequencies.length) this.frequencies = [392];
         this._logo = logo;

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -21,7 +21,7 @@ function StatusMatrix() {
     const FONTSCALEFACTOR = 75;
     let x, y; //Drop coordinates of statusDiv
 
-    this.init = function(logo) {
+    this.init = (logo) => {
         // Initializes the status matrix. First removes the
         // previous matrix and them make another one in DOM (document
         // object model)
@@ -39,14 +39,13 @@ function StatusMatrix() {
         widgetWindow.show();
 
         // For the button callbacks
-        let that = this;
         let cell;
 
         // The status table
         this._statusTable = document.createElement("table");
         widgetWindow.getWidgetBody().append(this._statusTable);
-        widgetWindow.onclose = function() {
-            that.isOpen = false;
+        widgetWindow.onclose = () => {
+            this.isOpen = false;
             this.destroy();
         };
 
@@ -201,7 +200,7 @@ function StatusMatrix() {
         widgetWindow.sendToCenter();
     };
 
-    this.updateAll = function() {
+    this.updateAll = () => {
         // Update status of all of the voices in the matrix.
         this._logo.updatingStatusMatrix = true;
 


### PR DESCRIPTION
In continuation of #2656

and part of fix as proposed in #2609

@meganindya `js/widgets/status.js`  and `js/widgets/pitchslider.js `are now completely cleaned up. No traces of var or that were there.
Only functions needed some porting, So I did that accordingly.
pls review.