### PR TITLE
fix(widgets): Ported widgets/oscilliscope.js to ES6+ syntax 

### DIFF
--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -48,8 +48,9 @@ function Oscilloscope() {
         zoomInButton.onclick = () => {
             this.zoomFactor += step;
         };
-        zoomInButton.children[0].src =
-            "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(SMALLERBUTTON)));
+        zoomInButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
+            unescape(encodeURIComponent(SMALLERBUTTON))
+        )}`;
 
         let zoomOutButton = widgetWindow.addButton("", ICONSIZE, _("ZOOM OUT"));
 
@@ -57,8 +58,9 @@ function Oscilloscope() {
             this.zoomFactor -= step;
         };
 
-        zoomOutButton.children[0].src =
-            "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(BIGGERBUTTON)));
+        zoomOutButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
+            unescape(encodeURIComponent(BIGGERBUTTON))
+        )}`;
 
         widgetWindow.sendToCenter();
         this.widgetWindow = widgetWindow;


### PR DESCRIPTION
Fix for one of the files mentioned in #2629.

`widgets/oscilliscope.js` was mostly up to date with ES6+ syntax. There was just one place where I found we could use the newer template strings syntax instead of the older one.

Please let me know if you have any further suggestions. Thanks.