### PR TITLE
Minor regression with rawgit

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -22,8 +22,8 @@ class HelpWidget {
 
         let widgetWindow = window.widgetWindows.windowFor(this, "help", "help");
         widgetWindow.getWidgetBody().style.overflowY = "auto";
-        const canvasHeight = docById("myCanvas").getBoundingClientRect().height;
-        widgetWindow.getWidgetBody().style.maxHeight = `${0.75 * canvasHeight}px`;
+        // const canvasHeight = docById("myCanvas").getBoundingClientRect().height;
+        widgetWindow.getWidgetBody().style.maxHeight = "500px";
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();


### PR DESCRIPTION
![Error](https://user-images.githubusercontent.com/50985033/102902531-21a1cd80-4495-11eb-94aa-6723bf858e19.jpg)

The Tour window upon loading at the inception, showcases regression. 
The regression arises, as the current method of calculating height of help widget is dynamic

`widgetWindow.getWidgetBody().style.maxHeight = ${0.75 * canvasHeight}px;`

Initially canvasHeight is 0 when the DOM is loaded
To solve, 500px is the threshold

This PR solves the aforementioned minor regression