### PR TITLE
Refactor, Documentation and Bug Fix: widgets/widgetWindow

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -81,7 +81,7 @@ class WidgetWindow {
      * @param {HTMLElement} parent
      * @returns {HTMLElement}
      */
-    _create = (base, className, parent) => {
+    _create(base, className, parent) {
         const el = document.createElement(base);
         if (className) el.className = className;
         if (parent) parent.append(el);
@@ -92,7 +92,7 @@ class WidgetWindow {
      * @private
      * @returns {void}
      */
-    _createUIelements = () => {
+    _createUIelements() {
         const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
 
@@ -206,7 +206,7 @@ class WidgetWindow {
      * @param {HTMLElement} parent 
      * @returns {HTMLElement}
      */
-    addInputButton = (initial, parent) => {
+    addInputButton(initial, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<input value="' + initial + '" />';
         return el.querySelector("input");
@@ -221,7 +221,7 @@ class WidgetWindow {
      * @param {string} classNm 
      * @returns {HTMLElement}
      */
-    addRangeSlider = (initial, parent, min, max, classNm) => {
+    addRangeSlider(initial, parent, min, max, classNm) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.style.height = "250px";
         el.innerHTML =
@@ -242,7 +242,7 @@ class WidgetWindow {
     /**
      * @deprecated
      */
-    addSelectorButton = (list, initial, parent) => {
+    addSelectorButton(list, initial, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<select value="' + initial + '" />';
         const selector = el.querySelector("select");
@@ -257,7 +257,7 @@ class WidgetWindow {
      * @public
      * @returns {HTMLElement}
      */
-    addDivider = () => {
+    addDivider() {
         const el = this._create("div", "wfbtHR", this._toolbar);
         return el;
     }
@@ -270,7 +270,7 @@ class WidgetWindow {
      * @param {string} label 
      * @returns {HTMLElement}
      */
-    modifyButton = (index, icon, iconSize, label) => {
+    modifyButton(index, icon, iconSize, label) {
         this._buttons[index].innerHTML =
             '<img src="header-icons/' +
             icon +
@@ -290,7 +290,7 @@ class WidgetWindow {
      * @public
      * @returns {void}
      */
-    close = () => {
+    close() {
         this.onclose();
     }
 
@@ -299,7 +299,7 @@ class WidgetWindow {
      * @public
      * @returns {void}
      */
-    updateTitle = (title) => {
+    updateTitle(title) {
         const wftTitle = docById(this._key + "WidgetID");
         wftTitle.innerHTML = title;
     }
@@ -308,7 +308,7 @@ class WidgetWindow {
      * @public
      * @returns {void}
      */
-    takeFocus = () => {
+    takeFocus() {
         const windows = docById("floatingWindows");
         const siblings = windows.children;
         for (let i = 0; i < siblings.length; i++) {
@@ -327,7 +327,7 @@ class WidgetWindow {
      * @param {HTMLElement} parent
      * @returns {HTMLElement} 
      */
-    addButton = (icon, iconSize, label, parent) => {
+    addButton(icon, iconSize, label, parent) {
         console.log("From WidgetWindow addButton");
         console.log(`type of icon = ${typeof(icon)}`);
         console.log(`type of iconSize = ${typeof(iconSize)}`);
@@ -354,7 +354,7 @@ class WidgetWindow {
      * @public
      * @returns {WidgetWindow} this
      */
-    sendToCenter = () => {
+    sendToCenter() {
         const canvas = docById("myCanvas");
         const fRect = this._frame.getBoundingClientRect();
         const cRect = canvas.getBoundingClientRect();
@@ -378,7 +378,7 @@ class WidgetWindow {
      * @private
      * @returns {void}
      */
-    _restore = () => {
+    _restore() {
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
         this._maximized = false;
 
@@ -395,7 +395,7 @@ class WidgetWindow {
      * @private
      * @returns {void}
      */
-    _maximize = () => {
+    _maximize() {
         this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
         this._maximized = true;
         this.unroll();
@@ -412,14 +412,14 @@ class WidgetWindow {
      * @public
      * @returns {HTMLElement}
      */
-    getWidgetBody = () => {
+    getWidgetBody() {
         return this._widget;
     }
 
     /**
      * @deprecated
      */
-    getDragElement = () => {
+    getDragElement() {
         return this._drag;
     }
 
@@ -427,7 +427,7 @@ class WidgetWindow {
      * @public
      * @returns {void}
      */
-    onclose = () => {
+    onclose() {
         this.destroy();
     }
 
@@ -435,7 +435,7 @@ class WidgetWindow {
      * @public
      * @returns {void}
      */
-    destroy = () => {
+    destroy() {
         this._frame.remove();
         window.widgetWindows.openWindows[this._key] = undefined;
     }
@@ -444,14 +444,14 @@ class WidgetWindow {
      * @public
      * @returns {WidgetWindow} this
      */
-    onmaximize = () => {
+    onmaximize() {
         return this;
     }
 
     /**
      * @returns {void}
      */
-    show = () => {
+    show() {
         this._frame.style.display = "block";
     }
 
@@ -461,7 +461,7 @@ class WidgetWindow {
      * @param {number} y 
      * @returns {WidgetWindow} this
      */
-    setPosition = (x, y) => {
+    setPosition(x, y) {
         this._frame.style.left = x + "px";
         this._frame.style.top = Math.max(y, 64) + "px";
         window.widgetWindows._posCache[this._key] = [x, Math.max(y, 64)];
@@ -472,7 +472,7 @@ class WidgetWindow {
      * @public
      * @returns {boolean}
      */
-    isVisible = () => {
+    isVisible() {
         return this._visible;
     }
 
@@ -480,7 +480,7 @@ class WidgetWindow {
      * @public
      * @return {WidgetWindow} this
      */
-    clear = () => {
+    clear() {
         this._widget.innerHTML = "";
         this._toolbar.innerHTML = "";
         return this;
@@ -490,7 +490,7 @@ class WidgetWindow {
      * @private
      * @return {WidgetWindow} this
      */
-    _rollup = () => {
+    _rollup() {
         this._rolled = true;
         this._body.style.display = "none";
         return this;
@@ -500,7 +500,7 @@ class WidgetWindow {
      * @public
      * @return {WidgetWindow} this
      */
-    unroll = () => {
+    unroll() {
         this._rolled = false;
         this._body.style.display = "flex";
         return this;

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -237,7 +237,7 @@ class WidgetWindow {
             initial +
             '">';
         const slider = el.querySelector("input");
-        slider.style = " position:absolute;transform:rotate(270deg);height:10px;width:57%;";
+        slider.style = " position:absolute;transform:rotate(270deg);height:10px;width:250px;";
         return slider;
     }
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -72,6 +72,8 @@ class WidgetWindow {
         }
 
         this.takeFocus();
+
+        this.sendToCenter = this.sendToCenter.bind(this);
     }
 
     /**
@@ -328,11 +330,6 @@ class WidgetWindow {
      * @returns {HTMLElement} 
      */
     addButton(icon, iconSize, label, parent) {
-        console.log("From WidgetWindow addButton");
-        console.log(`type of icon = ${typeof(icon)}`);
-        console.log(`type of iconSize = ${typeof(iconSize)}`);
-        console.log(`type of label = ${typeof(label)}`);
-
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML =
             '<img src="header-icons/' +

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -507,6 +507,13 @@ class WidgetWindow {
     }
 }
 
+/**
+ * 
+ * @param {Object} widget 
+ * @param {string} title 
+ * @param {string} saveAs 
+ * @returns {WidgetWindow} this
+ */
 window.widgetWindows.windowFor = (widget, title, saveAs) => {
     let key = undefined;
     // Check for a blockNo attribute
@@ -522,28 +529,47 @@ window.widgetWindows.windowFor = (widget, title, saveAs) => {
     return window.widgetWindows.openWindows[key].unroll();
 };
 
+/**
+ * @deprecated
+ */
 window.widgetWindows.clear = (name) => {
     const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     if (typeof win.onclose === "function") win.onclose();
 };
 
+/**
+ * @public
+ * @param {string} name
+ * @returns {boolean} 
+ */
 window.widgetWindows.isOpen = (name) => {
     return window.widgetWindows.openWindows[name] ? true : "";
 };
 
+/**
+ * @public
+ * @returns {void}
+ */
 window.widgetWindows.hideAllWindows = () => {
     Object.values(window.widgetWindows.openWindows).forEach((win) => {
         if (win !== undefined) win._frame.style.display = "none";
     });
 };
 
+/**
+ * @public
+ * @param {string} name 
+ */
 window.widgetWindows.hideWindow = (name) => {
     const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     win._frame.style.display = "none";
 };
 
+/**
+ * @returns {void}
+ */
 window.widgetWindows.showWindows = () => {
     Object.values(window.widgetWindows.openWindows).forEach((win) => {
         if (win !== undefined) win._frame.style.display = "block";

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -16,33 +16,26 @@ class WidgetWindow {
         // Keep a refernce to the object within handlers
         this._key = key;
 
-        const create = (base, className, parent) => {
-            let el = document.createElement(base);
-            if (className) el.className = className;
-            if (parent) parent.append(el);
-            return el;
-        };
-
         let windows = docById("floatingWindows");
-        this._frame = create("div", "windowFrame", windows);
+        this._frame = this._create("div", "windowFrame", windows);
 
-        this._drag = create("div", "wfTopBar", this._frame);
-        this._handle = create("div", "wfHandle", this._drag);
+        this._drag = this._create("div", "wfTopBar", this._frame);
+        this._handle = this._create("div", "wfHandle", this._drag);
 
-        let closeButton = create("div", "wftButton close", this._drag);
-        let rollButton = create("div", "wftButton rollup", this._drag);
+        let closeButton = this._create("div", "wftButton close", this._drag);
+        let rollButton = this._create("div", "wftButton rollup", this._drag);
 
-        let titleEl = create("div", "wftTitle", this._drag);
+        let titleEl = this._create("div", "wftTitle", this._drag);
         titleEl.innerHTML = _(title);
         titleEl.id = key + "WidgetID";
 
-        let maxminButton = create("div", "wftButton wftMaxmin", this._drag);
-        this._maxminIcon = create("img", undefined, maxminButton);
+        let maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
+        this._maxminIcon = this._create("img", undefined, maxminButton);
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
 
-        this._body = create("div", "wfWinBody", this._frame);
-        this._toolbar = create("div", "wfbToolbar", this._body);
-        this._widget = create("div", "wfbWidget", this._body);
+        this._body = this._create("div", "wfWinBody", this._frame);
+        this._toolbar = this._create("div", "wfbToolbar", this._body);
+        this._widget = this._create("div", "wfbWidget", this._body);
 
         let language = localStorage.languagePreference;
         if (language === undefined) {
@@ -71,9 +64,6 @@ class WidgetWindow {
         // Drag offset for correct positioning
         this._dx = this._dy = 0;
         this._dragging = false;
-
-        // Needed to keep things canvas-relative
-        let canvas = docById("myCanvas");
 
         // Scrolling in window body .
         // this.top = 0;
@@ -124,12 +114,6 @@ class WidgetWindow {
                 this._frame.style.zIndex = "0";
             }
         });
-
-        // The title may change, as with the Help Widget.
-        this.updateTitle = (title) => {
-            let wftTitle = docById(this._key + "WidgetID");
-            wftTitle.innerHTML = title;
-        };
 
         // The handle needs the events bound as it's a sibling of the dragging div
         // not a relative in either direciton.
@@ -187,201 +171,215 @@ class WidgetWindow {
             e.stopImmediatePropagation();
         };
 
-        this.takeFocus = () => {
-            let siblings = windows.children;
-            for (let i = 0; i < siblings.length; i++) {
-                siblings[i].style.zIndex = "0";
-                siblings[i].style.opacity = ".7";
-            }
-            this._frame.style.zIndex = "1";
-            this._frame.style.opacity = "1";
-        };
-
-        this.addButton = (icon, iconSize, label, parent) => {
-            let el = create("div", "wfbtItem", parent || this._toolbar);
-            el.innerHTML =
-                '<img src="header-icons/' +
-                icon +
-                '" title="' +
-                label +
-                '" alt="' +
-                label +
-                '" height="' +
-                iconSize +
-                '" width="' +
-                iconSize +
-                '" />';
-            this._buttons.push(el);
-            return el;
-        };
-
-        this.addInputButton = (initial, parent) => {
-            let el = create("div", "wfbtItem", parent || this._toolbar);
-            el.innerHTML = '<input value="' + initial + '" />';
-            return el.querySelector("input");
-        };
-
-        this.addRangeSlider = (initial, parent, min, max, classNm) => {
-            let el = create("div", "wfbtItem", parent || this._toolbar);
-            el.style.height = "250px";
-            el.innerHTML =
-                '<input type="range" class="' +
-                classNm +
-                '"  min="' +
-                min +
-                '" max="' +
-                max +
-                '" value="' +
-                initial +
-                '">';
-            let slider = el.querySelector("input");
-            slider.style = " position:absolute;transform:rotate(270deg);height:10px;width:57%;";
-            return slider;
-        };
-
-        this.addSelectorButton = (list, initial, parent) => {
-            let el = create("div", "wfbtItem", parent || this._toolbar);
-            el.innerHTML = '<select value="' + initial + '" />';
-            let selector = el.querySelector("select");
-            for (let i of list) {
-                let newOption = new Option("turtle " + i, i);
-                selector.add(newOption);
-            }
-            return selector;
-        };
-
-        this.addDivider = () => {
-            let el = create("div", "wfbtHR", this._toolbar);
-            return el;
-        };
-
-        this.modifyButton = (index, icon, iconSize, label) => {
-            this._buttons[index].innerHTML =
-                '<img src="header-icons/' +
-                icon +
-                '" title="' +
-                label +
-                '" alt="' +
-                label +
-                '" height="' +
-                iconSize +
-                '" width="' +
-                iconSize +
-                '" />';
-            return this._buttons[index];
-        };
-
-        this.getWidgetBody = () => {
-            return this._widget;
-        };
-
-        this.getDragElement = () => {
-            return this._drag;
-        };
-
-        this.onclose = () => {
-            this.destroy();
-        };
-
-        this.destroy = () => {
-            this._frame.remove();
-
-            window.widgetWindows.openWindows[this._key] = undefined;
-        };
-
-        this.onmaximize = () => {
-            return this;
-        };
-
-        this.show = () => {
-            this._frame.style.display = "block";
-        };
-
-        this.setPosition = (x, y) => {
-            this._frame.style.left = x + "px";
-            this._frame.style.top = Math.max(y, 64) + "px";
-            window.widgetWindows._posCache[this._key] = [x, Math.max(y, 64)];
-
-            return this;
-        };
-
-        this.sendToCenter = () => {
-            let fRect = this._frame.getBoundingClientRect();
-            let cRect = canvas.getBoundingClientRect();
-
-            if (cRect.width === 0 || cRect.height === 0) {
-                // The canvas isn't shown so we set some approximate numbers
-                this.setPosition(200, 140);
-                return this;
-            }
-
-            const navHeight = document.querySelector("nav").offsetHeight;
-            this.setPosition(
-                (cRect.width - fRect.width) / 2,
-                (cRect.height - fRect.height + navHeight) / 2
-            );
-
-            return this;
-        };
-
-        this.isVisible = () => {
-            return this._visible;
-        };
-
-        this.clear = () => {
-            this._widget.innerHTML = "";
-            this._toolbar.innerHTML = "";
-
-            return this;
-        };
-
-        this.rollup = () => {
-            this._rolled = true;
-            this._body.style.display = "none";
-            return this;
-        };
-
-        this.unroll = () => {
-            this._rolled = false;
-            this._body.style.display = "flex";
-            return this;
-        };
-
-        this.maximize = () => {
-            this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
-            this._maximized = true;
-            this.unroll();
-            this.takeFocus();
-
-            this._savedPos = [this._frame.style.left, this._frame.style.top];
-            this._frame.style.width = "100vw";
-            this._frame.style.height = "calc(100vh - 64px)";
-            this._frame.style.left = "0";
-            this._frame.style.top = "64px";
-        };
-
-        this.restore = () => {
-            this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
-            this._maximized = false;
-
-            if (this._savedPos) {
-                this._frame.style.left = this._savedPos[0];
-                this._frame.style.top = this._savedPos[1];
-                this._savedPos = null;
-            }
-            this._frame.style.width = "auto";
-            this._frame.style.height = "auto";
-        };
-
-        this.close = () => {
-            this.onclose();
-        };
-
         if (!!window.widgetWindows._posCache[this._key]) {
             let _pos = window.widgetWindows._posCache[this._key];
             this.setPosition(_pos[0], _pos[1]);
         }
         this.takeFocus();
+    }
+
+    _create = (base, className, parent) => {
+        let el = document.createElement(base);
+        if (className) el.className = className;
+        if (parent) parent.append(el);
+        return el;
+    };
+
+    addInputButton = (initial, parent) => {
+        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        el.innerHTML = '<input value="' + initial + '" />';
+        return el.querySelector("input");
+    }
+
+    addRangeSlider = (initial, parent, min, max, classNm) => {
+        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        el.style.height = "250px";
+        el.innerHTML =
+            '<input type="range" class="' +
+            classNm +
+            '"  min="' +
+            min +
+            '" max="' +
+            max +
+            '" value="' +
+            initial +
+            '">';
+        let slider = el.querySelector("input");
+        slider.style = " position:absolute;transform:rotate(270deg);height:10px;width:57%;";
+        return slider;
+    }
+
+    addSelectorButton = (list, initial, parent) => {
+        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        el.innerHTML = '<select value="' + initial + '" />';
+        let selector = el.querySelector("select");
+        for (let i of list) {
+            let newOption = new Option("turtle " + i, i);
+            selector.add(newOption);
+        }
+        return selector;
+    }
+
+    addDivider = () => {
+        let el = this._create("div", "wfbtHR", this._toolbar);
+        return el;
+    }
+
+    modifyButton = (index, icon, iconSize, label) => {
+        this._buttons[index].innerHTML =
+            '<img src="header-icons/' +
+            icon +
+            '" title="' +
+            label +
+            '" alt="' +
+            label +
+            '" height="' +
+            iconSize +
+            '" width="' +
+            iconSize +
+            '" />';
+        return this._buttons[index];
+    }
+
+    close = () => {
+        this.onclose();
+    }
+
+    // The title may change, as with the Help Widget.
+    updateTitle = (title) => {
+        let wftTitle = docById(this._key + "WidgetID");
+        wftTitle.innerHTML = title;
+    }
+
+    takeFocus = () => {
+        let windows = docById("floatingWindows");
+        let siblings = windows.children;
+        for (let i = 0; i < siblings.length; i++) {
+            siblings[i].style.zIndex = "0";
+            siblings[i].style.opacity = ".7";
+        }
+        this._frame.style.zIndex = "1";
+        this._frame.style.opacity = "1";
+    }
+
+    addButton = (icon, iconSize, label, parent) => {
+        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        el.innerHTML =
+            '<img src="header-icons/' +
+            icon +
+            '" title="' +
+            label +
+            '" alt="' +
+            label +
+            '" height="' +
+            iconSize +
+            '" width="' +
+            iconSize +
+            '" />';
+        this._buttons.push(el);
+        return el;
+    }
+
+    sendToCenter = () => {
+        let canvas = docById("myCanvas");
+        let fRect = this._frame.getBoundingClientRect();
+        let cRect = canvas.getBoundingClientRect();
+
+        if (cRect.width === 0 || cRect.height === 0) {
+            // The canvas isn't shown so we set some approximate numbers
+            this.setPosition(200, 140);
+            return this;
+        }
+
+        const navHeight = document.querySelector("nav").offsetHeight;
+        this.setPosition(
+            (cRect.width - fRect.width) / 2,
+            (cRect.height - fRect.height + navHeight) / 2
+        );
+
+        return this;
+    }
+
+    restore = () => {
+        this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
+        this._maximized = false;
+
+        if (this._savedPos) {
+            this._frame.style.left = this._savedPos[0];
+            this._frame.style.top = this._savedPos[1];
+            this._savedPos = null;
+        }
+        this._frame.style.width = "auto";
+        this._frame.style.height = "auto";
+    }
+
+    maximize = () => {
+        this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
+        this._maximized = true;
+        this.unroll();
+        this.takeFocus();
+
+        this._savedPos = [this._frame.style.left, this._frame.style.top];
+        this._frame.style.width = "100vw";
+        this._frame.style.height = "calc(100vh - 64px)";
+        this._frame.style.left = "0";
+        this._frame.style.top = "64px";
+    }
+
+    getWidgetBody = () => {
+        return this._widget;
+    }
+
+    getDragElement = () => {
+        return this._drag;
+    }
+
+    onclose = () => {
+        this.destroy();
+    }
+
+    destroy = () => {
+        this._frame.remove();
+        window.widgetWindows.openWindows[this._key] = undefined;
+    }
+
+    onmaximize = () => {
+        return this;
+    }
+
+    show = () => {
+        this._frame.style.display = "block";
+    }
+
+    setPosition = (x, y) => {
+        this._frame.style.left = x + "px";
+        this._frame.style.top = Math.max(y, 64) + "px";
+        window.widgetWindows._posCache[this._key] = [x, Math.max(y, 64)];
+
+        return this;
+    }
+
+    isVisible = () => {
+        return this._visible;
+    }
+
+    clear = () => {
+        this._widget.innerHTML = "";
+        this._toolbar.innerHTML = "";
+
+        return this;
+    }
+
+    rollup = () => {
+        this._rolled = true;
+        this._body.style.display = "none";
+        return this;
+    }
+
+    unroll = () => {
+        this._rolled = false;
+        this._body.style.display = "flex";
+        return this;
     }
 }
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -83,8 +83,8 @@ class WidgetWindow {
         // };
         const disableScroll = () => {
             // Get the current page scroll position
-            scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-            scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+            const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+            const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
             // if any scroll is attempted,
             // set this to the previous value
             window.onscroll = () => {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -20,6 +20,10 @@
 window.widgetWindows = { openWindows: {}, _posCache: {} };
 
 class WidgetWindow {
+    /**
+     * @param {string} key 
+     * @param {string} title 
+     */
     constructor(key, title) {
         // Keep a refernce to the object within handlers
         this._key = key;
@@ -70,6 +74,13 @@ class WidgetWindow {
         this.takeFocus();
     }
 
+    /**
+     * @private
+     * @param {string} base 
+     * @param {string} className 
+     * @param {HTMLElement} parent
+     * @returns {HTMLElement}
+     */
     _create = (base, className, parent) => {
         const el = document.createElement(base);
         if (className) el.className = className;
@@ -77,6 +88,10 @@ class WidgetWindow {
         return el;
     }
 
+    /**
+     * @private
+     * @returns {void}
+     */
     _createUIelements = () => {
         const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
@@ -94,7 +109,7 @@ class WidgetWindow {
                 let dx = (bcr.left - e.clientX) / (bcr.right - bcr.left);
                 const dy = bcr.top - e.clientY;
 
-                this.restore();
+                this._restore();
                 this.onmaximize();
 
                 bcr = this._drag.getBoundingClientRect();
@@ -120,7 +135,7 @@ class WidgetWindow {
         const rollButton = this._create("div", "wftButton rollup", this._drag);
         rollButton.onclick = (e) => {
             if (this._rolled) this.unroll();
-            else this.rollup();
+            else this._rollup();
             this.takeFocus();
 
             e.preventDefault();
@@ -129,12 +144,12 @@ class WidgetWindow {
 
         const titleEl = this._create("div", "wftTitle", this._drag);
         titleEl.innerHTML = _(this._title);
-        titleEl.id = key + "WidgetID";
+        titleEl.id = this._key + "WidgetID";
 
         const maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
         maxminButton.onclick = maxminButton.onmousedown = (e) => {
-            if (this._maximized) this.restore();
-            else this.maximize();
+            if (this._maximized) this._restore();
+            else this._maximize();
             this.takeFocus();
             this.onmaximize();
             e.preventDefault();
@@ -163,6 +178,10 @@ class WidgetWindow {
         this._widget.addEventListener("DOMMouseScroll", disableScroll, false);
     }
 
+    /**
+     * @private
+     * @returns {void}
+     */
     _setupLanguage() {
         let language = localStorage.languagePreference;
         if (language === undefined) {
@@ -181,12 +200,27 @@ class WidgetWindow {
         }
     }
 
+    /**
+     * @public
+     * @param {string} initial 
+     * @param {HTMLElement} parent 
+     * @returns {HTMLElement}
+     */
     addInputButton = (initial, parent) => {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<input value="' + initial + '" />';
         return el.querySelector("input");
     }
 
+    /**
+     * @public
+     * @param {number} initial 
+     * @param {HTMLElement} parent 
+     * @param {number} min 
+     * @param {number} max 
+     * @param {string} classNm 
+     * @returns {HTMLElement}
+     */
     addRangeSlider = (initial, parent, min, max, classNm) => {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.style.height = "250px";
@@ -205,6 +239,9 @@ class WidgetWindow {
         return slider;
     }
 
+    /**
+     * @deprecated
+     */
     addSelectorButton = (list, initial, parent) => {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<select value="' + initial + '" />';
@@ -216,11 +253,23 @@ class WidgetWindow {
         return selector;
     }
 
+    /**
+     * @public
+     * @returns {HTMLElement}
+     */
     addDivider = () => {
         const el = this._create("div", "wfbtHR", this._toolbar);
         return el;
     }
 
+    /**
+     * @public
+     * @param {number} index 
+     * @param {string} icon 
+     * @param {number} iconSize 
+     * @param {string} label 
+     * @returns {HTMLElement}
+     */
     modifyButton = (index, icon, iconSize, label) => {
         this._buttons[index].innerHTML =
             '<img src="header-icons/' +
@@ -237,16 +286,28 @@ class WidgetWindow {
         return this._buttons[index];
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     close = () => {
         this.onclose();
     }
 
-    // The title may change, as with the Help Widget.
+    /**
+     * The title may change, as with the Help Widget.
+     * @public
+     * @returns {void}
+     */
     updateTitle = (title) => {
         const wftTitle = docById(this._key + "WidgetID");
         wftTitle.innerHTML = title;
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     takeFocus = () => {
         const windows = docById("floatingWindows");
         const siblings = windows.children;
@@ -258,7 +319,20 @@ class WidgetWindow {
         this._frame.style.opacity = "1";
     }
 
+    /**
+     * @public
+     * @param {*} icon 
+     * @param {*} iconSize 
+     * @param {*} label 
+     * @param {HTMLElement} parent
+     * @returns {HTMLElement} 
+     */
     addButton = (icon, iconSize, label, parent) => {
+        console.log("From WidgetWindow addButton");
+        console.log(`type of icon = ${typeof(icon)}`);
+        console.log(`type of iconSize = ${typeof(iconSize)}`);
+        console.log(`type of label = ${typeof(label)}`);
+
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML =
             '<img src="header-icons/' +
@@ -276,6 +350,10 @@ class WidgetWindow {
         return el;
     }
 
+    /**
+     * @public
+     * @returns {WidgetWindow} this
+     */
     sendToCenter = () => {
         const canvas = docById("myCanvas");
         const fRect = this._frame.getBoundingClientRect();
@@ -296,7 +374,11 @@ class WidgetWindow {
         return this;
     }
 
-    restore = () => {
+    /**
+     * @private
+     * @returns {void}
+     */
+    _restore = () => {
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
         this._maximized = false;
 
@@ -309,7 +391,11 @@ class WidgetWindow {
         this._frame.style.height = "auto";
     }
 
-    maximize = () => {
+    /**
+     * @private
+     * @returns {void}
+     */
+    _maximize = () => {
         this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
         this._maximized = true;
         this.unroll();
@@ -322,56 +408,98 @@ class WidgetWindow {
         this._frame.style.top = "64px";
     }
 
+    /**
+     * @public
+     * @returns {HTMLElement}
+     */
     getWidgetBody = () => {
         return this._widget;
     }
 
+    /**
+     * @deprecated
+     */
     getDragElement = () => {
         return this._drag;
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     onclose = () => {
         this.destroy();
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     destroy = () => {
         this._frame.remove();
         window.widgetWindows.openWindows[this._key] = undefined;
     }
 
+    /**
+     * @public
+     * @returns {WidgetWindow} this
+     */
     onmaximize = () => {
         return this;
     }
 
+    /**
+     * @returns {void}
+     */
     show = () => {
         this._frame.style.display = "block";
     }
 
+    /**
+     * @public
+     * @param {number} x 
+     * @param {number} y 
+     * @returns {WidgetWindow} this
+     */
     setPosition = (x, y) => {
         this._frame.style.left = x + "px";
         this._frame.style.top = Math.max(y, 64) + "px";
         window.widgetWindows._posCache[this._key] = [x, Math.max(y, 64)];
-
         return this;
     }
 
+    /**
+     * @public
+     * @returns {boolean}
+     */
     isVisible = () => {
         return this._visible;
     }
 
+    /**
+     * @public
+     * @return {WidgetWindow} this
+     */
     clear = () => {
         this._widget.innerHTML = "";
         this._toolbar.innerHTML = "";
-
         return this;
     }
 
-    rollup = () => {
+    /**
+     * @private
+     * @return {WidgetWindow} this
+     */
+    _rollup = () => {
         this._rolled = true;
         this._body.style.display = "none";
         return this;
     }
 
+    /**
+     * @public
+     * @return {WidgetWindow} this
+     */
     unroll = () => {
         this._rolled = false;
         this._body.style.display = "flex";

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -9,6 +9,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+/*global _, docById*/
+
+/*
+     Globals location
+     - js/utils/utils.js
+         _, docById
+ */
+
 window.widgetWindows = { openWindows: {}, _posCache: {} };
 
 class WidgetWindow {
@@ -16,20 +24,20 @@ class WidgetWindow {
         // Keep a refernce to the object within handlers
         this._key = key;
 
-        let windows = docById("floatingWindows");
+        const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
 
         this._drag = this._create("div", "wfTopBar", this._frame);
         this._handle = this._create("div", "wfHandle", this._drag);
 
-        let closeButton = this._create("div", "wftButton close", this._drag);
-        let rollButton = this._create("div", "wftButton rollup", this._drag);
+        const closeButton = this._create("div", "wftButton close", this._drag);
+        const rollButton = this._create("div", "wftButton rollup", this._drag);
 
-        let titleEl = this._create("div", "wftTitle", this._drag);
+        const titleEl = this._create("div", "wftTitle", this._drag);
         titleEl.innerHTML = _(title);
         titleEl.id = key + "WidgetID";
 
-        let maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
+        const maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
         this._maxminIcon = this._create("img", undefined, maxminButton);
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
 
@@ -99,7 +107,7 @@ class WidgetWindow {
         document.addEventListener("mousemove", (e) => {
             if (!this._dragging) return;
 
-            let x = e.clientX - this._dx,
+            const x = e.clientX - this._dx,
                 y = e.clientY - this._dy;
 
             this.setPosition(x, y);
@@ -124,7 +132,7 @@ class WidgetWindow {
                 // restoring a window from maximized.
                 let bcr = this._drag.getBoundingClientRect();
                 let dx = (bcr.left - e.clientX) / (bcr.right - bcr.left);
-                let dy = bcr.top - e.clientY;
+                const dy = bcr.top - e.clientY;
 
                 this.restore();
                 this.onmaximize();
@@ -171,28 +179,28 @@ class WidgetWindow {
             e.stopImmediatePropagation();
         };
 
-        if (!!window.widgetWindows._posCache[this._key]) {
-            let _pos = window.widgetWindows._posCache[this._key];
+        if (window.widgetWindows._posCache[this._key]) {
+            const _pos = window.widgetWindows._posCache[this._key];
             this.setPosition(_pos[0], _pos[1]);
         }
         this.takeFocus();
     }
 
     _create = (base, className, parent) => {
-        let el = document.createElement(base);
+        const el = document.createElement(base);
         if (className) el.className = className;
         if (parent) parent.append(el);
         return el;
     };
 
     addInputButton = (initial, parent) => {
-        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<input value="' + initial + '" />';
         return el.querySelector("input");
     }
 
     addRangeSlider = (initial, parent, min, max, classNm) => {
-        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.style.height = "250px";
         el.innerHTML =
             '<input type="range" class="' +
@@ -204,24 +212,24 @@ class WidgetWindow {
             '" value="' +
             initial +
             '">';
-        let slider = el.querySelector("input");
+        const slider = el.querySelector("input");
         slider.style = " position:absolute;transform:rotate(270deg);height:10px;width:57%;";
         return slider;
     }
 
     addSelectorButton = (list, initial, parent) => {
-        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML = '<select value="' + initial + '" />';
-        let selector = el.querySelector("select");
-        for (let i of list) {
-            let newOption = new Option("turtle " + i, i);
+        const selector = el.querySelector("select");
+        for (const i of list) {
+            const newOption = new Option("turtle " + i, i);
             selector.add(newOption);
         }
         return selector;
     }
 
     addDivider = () => {
-        let el = this._create("div", "wfbtHR", this._toolbar);
+        const el = this._create("div", "wfbtHR", this._toolbar);
         return el;
     }
 
@@ -247,13 +255,13 @@ class WidgetWindow {
 
     // The title may change, as with the Help Widget.
     updateTitle = (title) => {
-        let wftTitle = docById(this._key + "WidgetID");
+        const wftTitle = docById(this._key + "WidgetID");
         wftTitle.innerHTML = title;
     }
 
     takeFocus = () => {
-        let windows = docById("floatingWindows");
-        let siblings = windows.children;
+        const windows = docById("floatingWindows");
+        const siblings = windows.children;
         for (let i = 0; i < siblings.length; i++) {
             siblings[i].style.zIndex = "0";
             siblings[i].style.opacity = ".7";
@@ -263,7 +271,7 @@ class WidgetWindow {
     }
 
     addButton = (icon, iconSize, label, parent) => {
-        let el = this._create("div", "wfbtItem", parent || this._toolbar);
+        const el = this._create("div", "wfbtItem", parent || this._toolbar);
         el.innerHTML =
             '<img src="header-icons/' +
             icon +
@@ -281,9 +289,9 @@ class WidgetWindow {
     }
 
     sendToCenter = () => {
-        let canvas = docById("myCanvas");
-        let fRect = this._frame.getBoundingClientRect();
-        let cRect = canvas.getBoundingClientRect();
+        const canvas = docById("myCanvas");
+        const fRect = this._frame.getBoundingClientRect();
+        const cRect = canvas.getBoundingClientRect();
 
         if (cRect.width === 0 || cRect.height === 0) {
             // The canvas isn't shown so we set some approximate numbers
@@ -391,7 +399,7 @@ window.widgetWindows.windowFor = (widget, title, saveAs) => {
     else key = saveAs || title;
 
     if (typeof window.widgetWindows.openWindows[key] === "undefined") {
-        let win = new WidgetWindow(key, title).sendToCenter();
+        const win = new WidgetWindow(key, title).sendToCenter();
         window.widgetWindows.openWindows[key] = win;
     }
 
@@ -399,7 +407,7 @@ window.widgetWindows.windowFor = (widget, title, saveAs) => {
 };
 
 window.widgetWindows.clear = (name) => {
-    let win = window.widgetWindows.openWindows[name];
+    const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     if (typeof win.onclose === "function") win.onclose();
 };
@@ -415,7 +423,7 @@ window.widgetWindows.hideAllWindows = () => {
 };
 
 window.widgetWindows.hideWindow = (name) => {
-    let win = window.widgetWindows.openWindows[name];
+    const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     win._frame.style.display = "none";
 };


### PR DESCRIPTION
Scrolling in any widget window leads to errors in the console.
The issue originated from `widgets/widgetWindow`, closer inspection revealed that this file's porting to ES6 done in #2722 had several other issues.
This PR aims to fix bugs, properly port to ES6 and add jsDoc style documentation for `widgetWindow` .

![scrolling console error in widget window](https://user-images.githubusercontent.com/39027928/104054519-4925c380-5213-11eb-960d-1eadd2ec1395.gif)

As always, please share feedback and suggestions. Thanks