### PR TITLE
No wrapping in middle of fill

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -720,7 +720,7 @@ class Painter {
                 h
             );
 
-        if (!WRAP || !out) {
+        if (!WRAP || !out || this._fillState) {
             this._move(ox, oy, nx, ny, true);
             turtles.refreshCanvas();
         } else {


### PR DESCRIPTION
Implements no wrapping in graphics in middle of `fill` block or between `begin Fill` and `end Fill` blocks.

### Before
<img width="1405" alt="before_scaled" src="https://user-images.githubusercontent.com/39027928/105119596-ab75a280-5af6-11eb-86c8-75ec0b6d9ff3.png">

### After
![after_scaled](https://user-images.githubusercontent.com/39027928/105119599-add7fc80-5af6-11eb-94af-c9d4c5e4db40.jpg)

