### PR TITLE
BugFix: Phrase Maker - play stop button

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -267,10 +267,35 @@ class PhraseMaker {
             widgetWindow.destroy();
         };
 
-        widgetWindow.addButton("play-button.svg", PhraseMaker.ICONSIZE, _("Play")).onclick = () => {
+        this._playButton = widgetWindow.addButton("play-button.svg", PhraseMaker.ICONSIZE, _("Play"));
+        
+        this._playButton.onclick = () => {
             logo.turtleDelay = 0;
 
             logo.resetSynth(0);
+            if(this.playingNow) {
+                this._playButton.innerHTML =
+                    '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' +
+                    _("Play") +
+                    '" alt="' +
+                    _("Play") +
+                    '" height="' +
+                    PhraseMaker.ICONSIZE +
+                    '" width="' +
+                    PhraseMaker.ICONSIZE +
+                    '" vertical-align="middle">&nbsp;&nbsp;';
+            } else {
+                this._playButton.innerHTML =
+                    '&nbsp;&nbsp;<img src="header-icons/stop-button.svg" title="' +
+                    _("Stop") +
+                    '" alt="' +
+                    _("Stop") +
+                    '" height="' +
+                    PhraseMaker.ICONSIZE +
+                    '" width="' +
+                    PhraseMaker.ICONSIZE +
+                    '" vertical-align="middle">&nbsp;&nbsp;';
+            }
             this.playAll();
         };
 
@@ -3887,6 +3912,16 @@ class PhraseMaker {
                     _("Play")
                 );
                 this.playingNow = false;
+                this._playButton.innerHTML =
+                        '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' +
+                        _("Play") +
+                        '" alt="' +
+                        _("Play") +
+                        '" height="' +
+                        PhraseMaker.ICONSIZE +
+                        '" width="' +
+                        PhraseMaker.ICONSIZE +
+                        '" vertical-align="middle">&nbsp;&nbsp;';
             } else {
                 row = this._noteValueRow;
                 cell = row.cells[this._colIndex];


### PR DESCRIPTION
### Description
In the Phrase Maker upon clicking on the play button, ideally sound should start playing and it should turn into stop button. Either upon clicking on the stop button or when the sound has finished playing the stop button should turn into the play button again.

### Before
Upon clicking on play button, sound starts playing but it does not turn into stop button
![phrase_maker_button_before](https://user-images.githubusercontent.com/39027928/105126540-01514700-5b05-11eb-8002-4b153ebcb640.gif)

### After
- Upon clicking on play button sound starts playing and it turns into stop button
- Upon clicking on the stop button while the stop is playing, the sound stops playing and the stop button turns back into play button
- When the sound has finished playing, the stop button turns back into play button
![phrase_maker_button_after](https://user-images.githubusercontent.com/39027928/105126548-04e4ce00-5b05-11eb-8756-c4ae9084a8b3.gif)
