### PR TITLE
BugFix and Enhancement: widgets/meterWidget

### DIFF
--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -37,7 +37,7 @@ class MeterWidget {
     static ICONSIZE = 32;
 
     /**
-     * @param {number} widgetBlock 
+     * @param {number} widgetBlock
      */
     constructor(widgetBlock) {
         this._meterBlock = logo._meterBlock;
@@ -200,7 +200,7 @@ class MeterWidget {
 
     /**
      * @private
-     * @param {string} drum 
+     * @param {string} drum
      * @returns {void}
      */
     __playDrum(drum) {
@@ -225,8 +225,8 @@ class MeterWidget {
 
     /**
      * @private
-     * @param {number} i 
-     * @param {number} ms 
+     * @param {number} i
+     * @param {number} ms
      * @returns {void}
      */
     __playOneBeat(i, ms) {
@@ -331,111 +331,22 @@ class MeterWidget {
             if (i === 0) {
                 if (strongBeats.length === 1) {
                     newStack.push([0, "onbeatdo", 100, 100, [null, 1, 2, null]]);
-                    newStack.push([
-                        1,
-                        [
-                            "number",
-                            {
-                                value: strongBeats[i] + 1
-                            }
-                        ],
-                        0,
-                        0,
-                        [0]
-                    ]);
-                    newStack.push([
-                        2,
-                        [
-                            "text",
-                            {
-                                value: "action"
-                            }
-                        ],
-                        0,
-                        0,
-                        [0]
-                    ]);
+                    newStack.push([1, ["number", { value: strongBeats[i] + 1 }], 0, 0, [0]]);
+                    newStack.push([2, ["text", { value: "action" }], 0, 0, [0]]);
                 } else {
                     newStack.push([0, "onbeatdo", 100, 100, [null, 1, 2, 3]]);
-                    newStack.push([
-                        1,
-                        [
-                            "number",
-                            {
-                                value: strongBeats[i] + 1
-                            }
-                        ],
-                        0,
-                        0,
-                        [0]
-                    ]);
-                    newStack.push([
-                        2,
-                        [
-                            "text",
-                            {
-                                value: "action"
-                            }
-                        ],
-                        0,
-                        0,
-                        [0]
-                    ]);
+                    newStack.push([1, ["number", { value: strongBeats[i] + 1 }], 0, 0, [0]]);
+                    newStack.push([2, ["text", { value: "action" }], 0, 0, [0]]);
                 }
             } else if (i === strongBeats.length - 1) {
                 newStack.push([n, "onbeatdo", 0, 0, [n - 3, n + 1, n + 2, null]]);
-                newStack.push([
-                    n + 1,
-                    [
-                        "number",
-                        {
-                            value: strongBeats[i] + 1
-                        }
-                    ],
-                    0,
-                    0,
-                    [n]
-                ]);
-                newStack.push([
-                    n + 2,
-                    [
-                        "text",
-                        {
-                            value: "action"
-                        }
-                    ],
-                    0,
-                    0,
-                    [n]
-                ]);
+                newStack.push([n + 1, ["number", { value: strongBeats[i] + 1 }], 0, 0, [n]]);
+                newStack.push([n + 2, ["text", { value: "action" }], 0, 0, [n]]);
             } else {
                 newStack.push([n, "onbeatdo", 0, 0, [n - 3, n + 1, n + 2, n + 3]]);
-                newStack.push([
-                    n + 1,
-                    [
-                        "number",
-                        {
-                            value: strongBeats[i] + 1
-                        }
-                    ],
-                    0,
-                    0,
-                    [n]
-                ]);
-                newStack.push([
-                    n + 2,
-                    [
-                        "text",
-                        {
-                            value: "action"
-                        }
-                    ],
-                    0,
-                    0,
-                    [n]
-                ]);
+                newStack.push([n + 1, ["number", { value: strongBeats[i] + 1 }], 0, 0, [n]]);
+                newStack.push([n + 2, ["text", { value: "action" }], 0, 0, [n]]);
             }
-
             n += 3;
         }
 
@@ -445,8 +356,8 @@ class MeterWidget {
 
     /**
      * @private
-     * @param {number} numberOfBeats 
-     * @param {number} beatValue 
+     * @param {number} numberOfBeats
+     * @param {number} beatValue
      * @returns {void}
      */
     _piemenuMeter(numberOfBeats, beatValue) {
@@ -509,14 +420,6 @@ class MeterWidget {
             this._strongBeats.push(false);
         }
 
-        // Always make the meter a complete circle.
-        /*
-        let n = (1 - (numberOfBeats * beatValue)) / beatValue;
-        for (let i = 0; i < n; i++) {
-            beatList.push(null);
-        }
-        */
-
         this._meterWheel.createWheel(beatList);
 
         this._beatWheel.colors = platformColor.modeWheelcolors;
@@ -535,14 +438,6 @@ class MeterWidget {
             beatList.push("x");
         }
 
-        // Always make the meter a complete circle.
-        /*
-        let n = (1 - (numberOfBeats * beatValue)) / beatValue;
-        for (let i = 0; i < n; i++) {
-            beatList.push(null);
-        }
-        */
-
         this._beatWheel.createWheel(beatList);
 
         this._playWheel.colors = [platformColor.orange];
@@ -560,14 +455,6 @@ class MeterWidget {
         for (let i = 0; i < numberOfBeats; i++) {
             beatList.push(" ");
         }
-
-        // Always make the meter a complete circle.
-        /*
-        let n = (1 - (numberOfBeats * beatValue)) / beatValue;
-        for (let i = 0; i < n; i++) {
-            playList.push(null);
-        }
-        */
 
         this._playWheel.createWheel(beatList);
 
@@ -602,8 +489,8 @@ class MeterWidget {
 
     /**
      * @private
-     * @param {number} numberOfBeats 
-     * @param {number} beatValue 
+     * @param {number} numberOfBeats
+     * @param {number} beatValue
      * @returns {void}
      */
     _setupDefaultStrongWeakBeats(numberOfBeats, beatValue) {

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -9,6 +9,27 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+/*global logo, Singer, _, last, platformColor, docById, wheelnav, slicePath, PREVIEWVOLUME, TONEBPM*/
+
+/*
+     Globals location
+     - lib/wheelnav
+         slicePath, wheelnav
+     
+     - js/utils/utils.js
+         _, last, docById
+     
+     - js/turtle-singer.js
+         Singer
+     
+     - js/utils/platformstyle.js
+         platformColor
+     
+     - js/logo.js
+         PREVIEWVOLUME, TONEBPM
+*/
+
+// eslint-disable-next-line no-unused-vars
 class MeterWidget {
     // A pie menu is used to show the meter and strong beats
     static BUTTONDIVWIDTH = 535;
@@ -22,10 +43,10 @@ class MeterWidget {
         this._click_lock = false;
         this._beatValue = 1 / 4;
 
-        let w = window.innerWidth;
+        const w = window.innerWidth;
         this._cellScale = w / 1200;
 
-        let widgetWindow = window.widgetWindows.windowFor(this, "meter");
+        const widgetWindow = window.widgetWindows.windowFor(this, "meter");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
 
@@ -96,7 +117,7 @@ class MeterWidget {
         };
 
         // The pie menu goes here.
-        let meterTableDiv = this.meterDiv;
+        const meterTableDiv = this.meterDiv;
         meterTableDiv.style.display = "inline";
         meterTableDiv.style.visibility = "visible";
         meterTableDiv.style.border = "0px";
@@ -210,14 +231,14 @@ class MeterWidget {
     }
 
     _playBeat() {
-        let tur = logo.turtles.ithTurtle(0);
-        let bpmFactor =
+        const tur = logo.turtles.ithTurtle(0);
+        const bpmFactor =
             TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
         for (let i = 0; i < this._strongBeats.length; i++) {
             this._playWheel.navItems[i].navItem.hide();
         }
 
-        let noteBeatValue = bpmFactor * 1000 * this._beatValue;
+        const noteBeatValue = bpmFactor * 1000 * this._beatValue;
         this.__playOneBeat(0, noteBeatValue);
     }
 
@@ -225,7 +246,7 @@ class MeterWidget {
      * @deprecated
      */
     _addButton(row, icon, iconSize, label) {
-        let cell = row.insertCell(-1);
+        const cell = row.insertCell(-1);
         cell.innerHTML =
             '&nbsp;&nbsp;<img src="header-icons/' +
             icon +
@@ -259,10 +280,10 @@ class MeterWidget {
 
     _save() {
         // Export onbeatdo blocks for each strong beat
-        let strongBeats = [];
-        let newStack = [];
+        const strongBeats = [];
+        const newStack = [];
 
-        let numberOfBeats = this._strongBeats.length;
+        const numberOfBeats = this._strongBeats.length;
 
         for (let i = 0; i < numberOfBeats; i++) {
             if (this._strongBeats[i]) {
@@ -384,7 +405,7 @@ class MeterWidget {
             n += 3;
         }
 
-        console.debug(newStack);
+        // console.debug(newStack);
         logo.blocks.loadNewBlocks(newStack);
     }
 
@@ -423,7 +444,7 @@ class MeterWidget {
             numberOfBeats = 16;
         }
 
-        let labels = [
+        const labels = [
             "1",
             "2",
             "3",
@@ -516,15 +537,15 @@ class MeterWidget {
 
         // If a meterWheel sector is selected, show the corresponding
         // beat wheel sector.
-        let __setBeat = () => {
-            let i = this._meterWheel.selectedNavItemIndex;
+        const __setBeat = () => {
+            const i = this._meterWheel.selectedNavItemIndex;
             this._strongBeats[i] = true;
             this._beatWheel.navItems[i].navItem.show();
         };
 
         // If a beatWheel sector is selected, hide it.
-        let __clearBeat = () => {
-            let i = this._beatWheel.selectedNavItemIndex;
+        const __clearBeat = () => {
+            const i = this._beatWheel.selectedNavItemIndex;
             this._beatWheel.navItems[i].navItem.hide();
             this._strongBeats[i] = false;
         };

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -29,7 +29,7 @@
          PREVIEWVOLUME, TONEBPM
 */
 
-// eslint-disable-next-line no-unused-vars
+/*exported MeterWidget*/
 class MeterWidget {
     // A pie menu is used to show the meter and strong beats
     static BUTTONDIVWIDTH = 535;
@@ -68,6 +68,8 @@ class MeterWidget {
             logo.hideMsgs();
             widgetWindow.destroy();
         };
+
+        widgetWindow.onmaximize = this._scale;
 
         this._click_lock = false;
         const playBtn = widgetWindow.addButton("play-button.svg", MeterWidget.ICONSIZE, _("Play"));
@@ -188,6 +190,20 @@ class MeterWidget {
 
         logo.textMsg(_("Click in the circle to select strong beats for the meter."));
         widgetWindow.sendToCenter();
+        this._scale.call(this.widgetWindow);
+    }
+
+    _scale() {
+        const windowHeight =
+            this.getWidgetFrame().offsetHeight - this.getDragElement().offsetHeight;
+        const svg = this.getWidgetBody().getElementsByTagName("svg")[0];
+        const scale = this.isMaximized() ? windowHeight / 400 : 1;
+        svg.style.pointerEvents = "none";
+        svg.setAttribute("height", `${400 * scale}px`);
+        svg.setAttribute("width", `${400 * scale}px`);
+        setTimeout(() => {
+            svg.style.pointerEvents = "auto";
+        }, 100);
     }
 
     /**
@@ -363,7 +379,8 @@ class MeterWidget {
     _piemenuMeter(numberOfBeats, beatValue) {
         // pie menu for strong beat selection
 
-        docById("meterWheelDiv").style.display = "";
+        docById("meterWheelDiv").style.display = "flex";
+        docById("meterWheelDiv").style.justifyContent = "center";
 
         // Use advanced constructor for multiple wheelnavs in the same div.
         // The meterWheel is used to hold the strong beats.

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -36,6 +36,9 @@ class MeterWidget {
     static BUTTONSIZE = 53;
     static ICONSIZE = 32;
 
+    /**
+     * @param {number} widgetBlock 
+     */
     constructor(widgetBlock) {
         this._meterBlock = logo._meterBlock;
         this._strongBeats = [];
@@ -187,22 +190,45 @@ class MeterWidget {
         widgetWindow.sendToCenter();
     }
 
+    /**
+     * @private
+     * @returns {boolean}
+     */
     _get_click_lock() {
         return this._click_lock;
     }
 
+    /**
+     * @private
+     * @param {string} drum 
+     * @returns {void}
+     */
     __playDrum(drum) {
         logo.synth.trigger(0, "C4", Singer.defaultBPMFactor * this._beatValue, drum, null, null);
     }
 
+    /**
+     * @private
+     * @returns {boolean}
+     */
     __getPlayingStatus() {
         return this._playing;
     }
 
+    /**
+     * @private
+     * @returns {boolean}
+     */
     __getPauseStatus() {
         return !this._playing;
     }
 
+    /**
+     * @private
+     * @param {number} i 
+     * @param {number} ms 
+     * @returns {void}
+     */
     __playOneBeat(i, ms) {
         if (this.__getPauseStatus()) {
             for (let i = 0; i < this._strongBeats.length; i++) {
@@ -230,6 +256,10 @@ class MeterWidget {
         }, ms);
     }
 
+    /**
+     * @private
+     * @returns {void}
+     */
     _playBeat() {
         const tur = logo.turtles.ithTurtle(0);
         const bpmFactor =
@@ -278,6 +308,10 @@ class MeterWidget {
         return cell;
     }
 
+    /**
+     * @private
+     * @returns {void}
+     */
     _save() {
         // Export onbeatdo blocks for each strong beat
         const strongBeats = [];
@@ -409,6 +443,12 @@ class MeterWidget {
         logo.blocks.loadNewBlocks(newStack);
     }
 
+    /**
+     * @private
+     * @param {number} numberOfBeats 
+     * @param {number} beatValue 
+     * @returns {void}
+     */
     _piemenuMeter(numberOfBeats, beatValue) {
         // pie menu for strong beat selection
 
@@ -557,10 +597,16 @@ class MeterWidget {
             this._beatWheel.navItems[i].navItem.hide();
         }
 
-        this.setupDefaultStrongWeakBeats(numberOfBeats, beatValue);
+        this._setupDefaultStrongWeakBeats(numberOfBeats, beatValue);
     }
 
-    setupDefaultStrongWeakBeats(numberOfBeats, beatValue) {
+    /**
+     * @private
+     * @param {number} numberOfBeats 
+     * @param {number} beatValue 
+     * @returns {void}
+     */
+    _setupDefaultStrongWeakBeats(numberOfBeats, beatValue) {
         if (beatValue == 0.25 && numberOfBeats == 4) {
             this._strongBeats[0] = true;
             this._strongBeats[2] = true;

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -138,6 +138,7 @@ class MeterWidget {
         //TRANS.: Reset the widget layout
         widgetWindow.addButton("reload.svg", MeterWidget.ICONSIZE, _("Reset")).onclick = () => {
             //change Values of blocks in stack.
+            this._playing = false;
             const el = divInput.children[0];
             const el2 = divInput2.children[0];
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -62,7 +62,7 @@ class WidgetWindow {
             }
         });
 
-        document.addEventListener("mouseup", (e) => {
+        document.addEventListener("mouseup", () => {
             this._dragging = false;
         });
 
@@ -173,7 +173,7 @@ class WidgetWindow {
             window.onscroll = () => {
                 window.scrollTo(scrollLeft, scrollTop);
             };
-        }
+        };
 
         this._widget = this._create("div", "wfbWidget", this._body);
         this._widget.addEventListener("wheel", disableScroll, false);
@@ -190,7 +190,7 @@ class WidgetWindow {
             language = navigator.language;
         }
 
-        console.debug("language setting is " + language);
+        // console.debug("language setting is " + language);
         // For Japanese, put the toolbar on the top.
         if (language === "ja") {
             this._body.style.flexDirection = "column";
@@ -414,6 +414,14 @@ class WidgetWindow {
     }
 
     /**
+     * @public
+     * @returns {HTMLElement}
+     */
+    getWidgetFrame() {
+        return this._frame;
+    }
+
+    /**
      * @deprecated
      */
     getDragElement() {
@@ -443,6 +451,14 @@ class WidgetWindow {
      */
     onmaximize() {
         return this;
+    }
+
+    /**
+     * @public
+     * @returns {boolean}
+     */
+    isMaximized() {
+        return this._maximized;
     }
 
     /**


### PR DESCRIPTION
This PR does the following
- fixes sound playing indefinitely bug when reloaded while playing
- enhances fullscreen mode for this widget
- adds jsDoc style documentation
- fixes linting issues
- prettifies code

Related Issues #2767, #2630, #2609 

## Bug Details

When the sound is playing and the widget is reloaded with new settings then the widget reloads but the sound does not stop playing and it plays indefinitely. Even closing the widget does not stop it. The ideal behaviour should be that the sound should stop playing when the widget is reloaded.

Please keep audio on while playing the video below to notice the bug.

https://user-images.githubusercontent.com/39027928/105640365-9eb0d000-5ea3-11eb-8ad2-4a2653117f28.mov

## Enhancement Details

Fullscreen mode does nothing, the extra space in fullscreen mode is not utilised in a meaningful way.

![meter_fullscreen_before](https://user-images.githubusercontent.com/39027928/105640800-fbad8580-5ea5-11eb-9165-c7f8397a2943.gif)


## After Changes

- Sound playing indefinitely on reload while playing bug fixed. Upon reloading the sound stops if playing.

Please keep audio on while playing the video below to notice the changes.

https://user-images.githubusercontent.com/39027928/105640951-4aa7ea80-5ea7-11eb-9e11-de422e4c2406.mov



- Full screen mode enhanced
   
![meter_fullscreen_after](https://user-images.githubusercontent.com/39027928/105640810-0ec05580-5ea6-11eb-9011-58b23e9206c9.gif)
