### PR TITLE
Update UI of Temperament Widget

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -365,8 +365,10 @@ class TemperamentWidget {
             const angleDiff = [];
             for (let i = 0; i < this.notesCircle.navItemCount; i++) {
                 this.notesCircle.navItems[i].fillAttr = "#c8C8C8";
-                this.notesCircle.navItems[i].titleAttr.font = "20 20px Impact, Charcoal, sans-serif";
-                this.notesCircle.navItems[i].titleSelectedAttr.font = "20 20px Impact, Charcoal, sans-serif";
+                this.notesCircle.navItems[i].titleAttr.font =
+                    "20 20px Impact, Charcoal, sans-serif";
+                this.notesCircle.navItems[i].titleSelectedAttr.font =
+                    "20 20px Impact, Charcoal, sans-serif";
                 angle[i] = 270 + 360 * (Math.log10(ratios[i]) / Math.log10(this.powerBase));
                 if (i !== 0) {
                     if (i == pitchNumber - 1) {
@@ -575,7 +577,7 @@ class TemperamentWidget {
                 docById("noteInfo").style.zIndex = 10;
 
                 docById("close").style.cursor = "pointer";
-                
+
                 docById("close").onclick = () => {
                     docById("noteInfo").remove();
                 };
@@ -862,43 +864,41 @@ class TemperamentWidget {
         menuItems[0].style.background = "#FFFFFF";
         this.equalEdit();
 
-        for(let i = 0;i<4;i++){
+        for (let i = 0; i < 4; i++) {
             menuItems[i].onmouseover = () => {
                 menuItems[i].style.backgroundColor = "#7bb5ee";
             };
         }
 
-        for(let i = 0;i<4;i++){
+        for (let i = 0; i < 4; i++) {
             menuItems[i].onmouseout = () => {
-                if((i==0 && this.editMode!="equal")
-                || (i==1 && this.editMode!="ratio")
-                || (i==2 && this.editMode!="arbitrary")
-                || (i==3 && this.editMode!="octave")){
+                if (
+                    (i == 0 && this.editMode != "equal") ||
+                    (i == 1 && this.editMode != "ratio") ||
+                    (i == 2 && this.editMode != "arbitrary") ||
+                    (i == 3 && this.editMode != "octave")
+                ) {
                     menuItems[i].style.backgroundColor = "#8cc6ff";
                 }
             };
         }
 
-        for(let i = 0;i<4;i++){
+        for (let i = 0; i < 4; i++) {
             menuItems[i].onclick = () => {
-                for(let j = 0;j<4;j++){
-                    if(i!=j){
-                        menuItems[j].style.background = platformColor.selectorBackground;      
-                    }
-                    else{
+                for (let j = 0; j < 4; j++) {
+                    if (i != j) {
+                        menuItems[j].style.background = platformColor.selectorBackground;
+                    } else {
                         menuItems[i].style.background = "#FFFFFF";
                     }
                 }
-                if(i==0){
+                if (i == 0) {
                     this.equalEdit();
-                }
-                else if(i==1){
+                } else if (i == 1) {
                     this.ratioEdit();
-                }
-                else if(i==2){
+                } else if (i == 2) {
                     this.arbitraryEdit();
-                }
-                else{
+                } else {
                     this.octaveSpaceEdit();
                 }
             };

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -928,6 +928,7 @@ class TemperamentWidget {
             divAppend.style.marginTop = "40px";
             divAppend.style.overflow = "auto";
             divAppend.style.cursor = "32px";
+            divAppend.style.cursor = "pointer";
             equalEdit.append(divAppend);
 
             const divAppend1 = docById("preview");
@@ -948,10 +949,6 @@ class TemperamentWidget {
         }
 
         addDivision(false);
-
-        divAppend.onmouseover = (event) => {
-            event.target.style.cursor = "pointer";
-        };
 
         let pitchNumber = this.pitchNumber;
         let pitchNumber1 = Number(docById("octaveIn").value);
@@ -1116,6 +1113,7 @@ class TemperamentWidget {
             divAppend.style.marginTop = "40px";
             divAppend.style.overflow = "auto";
             divAppend.style.lineHeight = "32px";
+            divAppend.style.cursor = "pointer";
             ratioEdit.append(divAppend);
 
             const divAppend1 = docById("preview");
@@ -1136,10 +1134,6 @@ class TemperamentWidget {
         };
 
         addButtons(false);
-
-        divAppend.onmouseover = (event) => {
-            event.target.style.cursor = "pointer";
-        };
 
         divAppend.onclick = (event) => {
             const input1 = docById("ratioIn").value;
@@ -1467,11 +1461,8 @@ class TemperamentWidget {
         divAppend.style.height = "25px";
         divAppend.style.marginTop = "40px";
         divAppend.style.overflow = "auto";
+        divAppend.style.cursor = "pointer";
         arbitraryEdit.append(divAppend);
-
-        divAppend.onmouseover = (event) => {
-            event.target.style.cursor = "pointer";
-        };
 
         divAppend.onclick = () => {
             this.ratios = this.tempRatios1.slice();

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -697,6 +697,7 @@ class TemperamentWidget {
             menuItems[i].style.background = platformColor.labelColor;
             menuItems[i].style.height = 30 + "px";
             menuItems[i].style.textAlign = "center";
+            menuItems[i].style.fontSize = "0.9rem";
             menuItems[i].style.fontWeight = "bold";
             if (isCustom(this.inTemperament)) {
                 menuItems[0].style.width = 40 + "px";
@@ -725,45 +726,52 @@ class TemperamentWidget {
         const notesRow = [];
         const notesCell = [];
         const ratios = [];
-        let playImage;
 
         for (let i = 0; i <= this.pitchNumber; i++) {
             notesRow[i] = docById("notes_" + i);
+            notesRow[i].style.background = platformColor.selectorBackground;
+            notesRow[i].style.transition = "background 0.25s ease";
+            notesRow[i].onmouseover = () => {
+                notesRow[i].style.background = platformColor.paletteBackground;
+            };
+            notesRow[i].onmouseout = () => {
+                notesRow[i].style.background = platformColor.selectorBackground;
+            };
 
             notesCell[(i, 0)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 0)].innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="Play" alt="play" height="20px" width="20px" style="margin-top:20px;" id="play_' +
-                i +
-                '" data-id="' +
-                i +
-                '">&nbsp;&nbsp;';
             notesCell[(i, 0)].style.width = 40 + "px";
-            notesCell[(i, 0)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 0)].style.textAlign = "center";
 
-            notesCell[(i, 0)].onmouseover = (event) => {
-                event.target.style.backgroundColor = platformColor.selectorBackgroundHOVER;
-            };
+            const img_wrap = document.createElement("div");
+            img_wrap.style.height = "2.5rem";
+            img_wrap.style.display = "grid";
+            img_wrap.style.alignItems = "center";
+            img_wrap.style.justifyContent = "center";
 
-            notesCell[(i, 0)].onmouseout = (event) => {
-                event.target.style.backgroundColor = platformColor.selectorBackground;
-            };
-
-            playImage = docById("play_" + i);
-
-            playImage.onmouseover = (event) => {
+            const play_btn = document.createElement("img");
+            play_btn.src = "header-icons/play-button.svg";
+            play_btn.id = `play_${i}`;
+            play_btn.style.height = "1.25rem";
+            play_btn.style.width = "1.25rem";
+            play_btn.style.transition = "all 0.25s ease";
+            play_btn.onmouseover = (event) => {
                 event.target.style.cursor = "pointer";
+                event.target.style.transform = "scale(1.1)";
+            };
+            play_btn.onmouseout = (event) => {
+                event.target.style.transform = "scale(1)";
+            };
+            play_btn.onclick = (event) => {
+                this.playNote(event.target.id.split("_")[1]);
             };
 
-            playImage.onclick = (event) => {
-                this.playNote(event.target.dataset.id);
-            };
+            img_wrap.appendChild(play_btn);
+            notesCell[(i, 0)].appendChild(img_wrap);
 
             //Pitch Number
             notesCell[(i, 1)] = notesRow[i].insertCell(-1);
             notesCell[(i, 1)].id = "pitchNumber_" + i;
             notesCell[(i, 1)].innerHTML = i;
-            notesCell[(i, 1)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 1)].style.textAlign = "center";
 
             ratios[i] = this.ratios[i];
@@ -772,7 +780,6 @@ class TemperamentWidget {
             //Ratio
             notesCell[(i, 2)] = notesRow[i].insertCell(-1);
             notesCell[(i, 2)].innerHTML = ratios[i];
-            notesCell[(i, 2)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 2)].style.textAlign = "center";
 
             if (!isCustom(this.inTemperament)) {
@@ -780,14 +787,12 @@ class TemperamentWidget {
                 notesCell[(i, 3)] = notesRow[i].insertCell(-1);
                 notesCell[(i, 3)].innerHTML = this.intervals[i];
                 notesCell[(i, 3)].style.width = 120 + "px";
-                notesCell[(i, 3)].style.backgroundColor = platformColor.selectorBackground;
                 notesCell[(i, 3)].style.textAlign = "center";
 
                 //Notes
                 notesCell[(i, 4)] = notesRow[i].insertCell(-1);
-                notesCell[(i, 4)].innerHTML = this.notes[i];
+                notesCell[(i, 4)].innerHTML = `${this.notes[i][0]}, ${this.notes[i][1]}`;
                 notesCell[(i, 4)].style.width = 50 + "px";
-                notesCell[(i, 4)].style.backgroundColor = platformColor.selectorBackground;
                 notesCell[(i, 4)].style.textAlign = "center";
 
                 //Mode
@@ -802,14 +807,12 @@ class TemperamentWidget {
                     notesCell[(i, 5)].innerHTML = "Non Scalar";
                 }
                 notesCell[(i, 5)].style.width = 100 + "px";
-                notesCell[(i, 5)].style.backgroundColor = platformColor.selectorBackground;
                 notesCell[(i, 5)].style.textAlign = "center";
             }
 
             //Frequency
             notesCell[(i, 6)] = notesRow[i].insertCell(-1);
             notesCell[(i, 6)].innerHTML = this.frequencies[i];
-            notesCell[(i, 6)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 6)].style.textAlign = "center";
 
             if (isCustom(this.inTemperament)) {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -859,40 +859,50 @@ class TemperamentWidget {
             menuItems[i].style.paddingRight = "5px";
         }
 
-        menuItems[0].style.background = "#c8C8C8";
+        menuItems[0].style.background = "#FFFFFF";
         this.equalEdit();
 
-        menuItems[0].onclick = () => {
-            menuItems[1].style.background = platformColor.selectorBackground;
-            menuItems[2].style.background = platformColor.selectorBackground;
-            menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[0].style.background = "#FFFFFF";
-            this.equalEdit();
-        };
+        for(let i = 0;i<4;i++){
+            menuItems[i].onmouseover = () => {
+                menuItems[i].style.backgroundColor = "#7bb5ee";
+            }
+        }
 
-        menuItems[1].onclick = () => {
-            menuItems[0].style.background = platformColor.selectorBackground;
-            menuItems[2].style.background = platformColor.selectorBackground;
-            menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[1].style.background = "#FFFFFF";
-            this.ratioEdit();
-        };
+        for(let i = 0;i<4;i++){
+            menuItems[i].onmouseout = () => {
+                if((i==0 && this.editMode!="equal") 
+                || (i==1 && this.editMode!="ratio")
+                || (i==2 && this.editMode!="arbitrary") 
+                || (i==3 && this.editMode!="octave")){
+                    menuItems[i].style.backgroundColor = "#8cc6ff";
+                }
+            }
+        }
 
-        menuItems[2].onclick = () => {
-            menuItems[0].style.background = platformColor.selectorBackground;
-            menuItems[1].style.background = platformColor.selectorBackground;
-            menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[2].style.background = "#FFFFFF";
-            this.arbitraryEdit();
-        };
-
-        menuItems[3].onclick = () => {
-            menuItems[0].style.background = platformColor.selectorBackground;
-            menuItems[1].style.background = platformColor.selectorBackground;
-            menuItems[2].style.background = platformColor.selectorBackground;
-            menuItems[3].style.background = "#FFFFFF";
-            this.octaveSpaceEdit();
-        };
+        for(let i = 0;i<4;i++){
+            menuItems[i].onclick = () => {
+                for(let j = 0;j<4;j++){
+                    if(i!=j){
+                        menuItems[j].style.background = platformColor.selectorBackground;        
+                    }
+                    else{
+                        menuItems[i].style.background = "#FFFFFF";
+                    }
+                }
+                if(i==0){
+                    this.equalEdit();
+                }
+                else if(i==1){
+                    this.ratioEdit();
+                }
+                else if(i==2){
+                    this.arbitraryEdit();
+                }
+                else{
+                    this.octaveSpaceEdit();
+                }
+            }
+        }
     }
 
     /**
@@ -1531,7 +1541,6 @@ class TemperamentWidget {
                 docById("noteInfo1").style.left = "90px";
 
                 docById("close").style.cursor = "pointer";
-                
                 docById("frequencySlider").oninput = () => {
                     this._refreshInnerWheel();
                 };

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -214,11 +214,11 @@ class TemperamentWidget {
         this.toggleNotesButton = () => {
             if (this.circleIsVisible) {
                 noteCell.getElementsByTagName("img")[0].src = "header-icons/circle.svg";
-                noteCell.getElementsByTagName("img")[0].title = "circle";
+                noteCell.getElementsByTagName("img")[0].title = "Circle";
                 noteCell.getElementsByTagName("img")[0].alt = "circle";
             } else {
                 noteCell.getElementsByTagName("img")[0].src = "header-icons/table.svg";
-                noteCell.getElementsByTagName("img")[0].title = "table";
+                noteCell.getElementsByTagName("img")[0].title = "Table";
                 noteCell.getElementsByTagName("img")[0].alt = "table";
             }
         };
@@ -522,12 +522,12 @@ class TemperamentWidget {
                     'px;"><span class="popuptext" id="myPopup"></span></div>';
                 if (i !== 0) {
                     docById("noteInfo").innerHTML +=
-                        '<img src="header-icons/edit.svg" id="edit" title="edit" alt="edit" height=20px width=20px data-message="' +
+                        '<img src="header-icons/edit.svg" id="edit" title="Edit" alt="edit" height=20px width=20px data-message="' +
                         i +
                         '">';
                 }
                 docById("noteInfo").innerHTML +=
-                    '<img src="header-icons/close-button.svg" id="close" title="close" alt="close" height=20px width=20px align="right"><br>';
+                    '<img src="header-icons/close-button.svg" id="close" title="Close" alt="close" height=20px width=20px align="right"><br>';
                 noteDefined = false;
                 for (let j = 0; j < this.ratiosNotesPair.length; j++) {
                     if (this.ratios[i] == this.ratiosNotesPair[j][0]) {
@@ -729,7 +729,7 @@ class TemperamentWidget {
 
             notesCell[(i, 0)] = notesRow[i].insertCell(-1);
             notesCell[(i, 0)].innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="play" alt="play" height="20px" width="20px" id="play_' +
+                '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="Play" alt="play" height="20px" width="20px" id="play_' +
                 i +
                 '" data-id="' +
                 i +
@@ -1507,7 +1507,7 @@ class TemperamentWidget {
                 docById("wheelDiv3").innerHTML +=
                     '<div class="popup" id="noteInfo1" style="width:180px; height:135px;"><span class="popuptext" id="myPopup"></span></div>';
                 docById("noteInfo1").innerHTML +=
-                    '<img src="header-icons/close-button.svg" id="close" title="close" alt="close" height=20px width=20px align="right">';
+                    '<img src="header-icons/close-button.svg" id="close" title="Close" alt="close" height=20px width=20px align="right">';
                 docById("noteInfo1").innerHTML +=
                     '<br><center><input type="range" class="sliders" id = "frequencySlider" style="width:170px; background:white; border:0;" min="' +
                     frequencies[i] +

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -926,6 +926,7 @@ class TemperamentWidget {
             divAppend.style.height = "32px";
             divAppend.style.marginTop = "40px";
             divAppend.style.overflow = "auto";
+            divAppend.style.cursor = "pointer";
             equalEdit.append(divAppend);
 
             const divAppend1 = docById("preview");
@@ -933,13 +934,15 @@ class TemperamentWidget {
             divAppend1.style.marginLeft = "3px";
             divAppend1.style.backgroundColor = platformColor.selectorBackground;
             divAppend1.style.width = "215px";
+            divAppend1.style.cursor = "pointer";
 
             const divAppend2 = docById("done_");
             divAppend2.style.height = "30px";
             divAppend2.style.marginRight = "3px";
             divAppend2.style.backgroundColor = platformColor.selectorBackground;
             divAppend2.style.width = "205px";
-        };
+            divAppend2.style.cursor = "pointer";
+        }
 
         addDivision(false);
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -365,10 +365,8 @@ class TemperamentWidget {
             const angleDiff = [];
             for (let i = 0; i < this.notesCircle.navItemCount; i++) {
                 this.notesCircle.navItems[i].fillAttr = "#c8C8C8";
-                this.notesCircle.navItems[i].titleAttr.font =
-                    "20 20px Impact, Charcoal, sans-serif";
-                this.notesCircle.navItems[i].titleSelectedAttr.font =
-                    "20 20px Impact, Charcoal, sans-serif";
+                this.notesCircle.navItems[i].titleAttr.font = "20 20px Impact, Charcoal, sans-serif";
+                this.notesCircle.navItems[i].titleSelectedAttr.font = "20 20px Impact, Charcoal, sans-serif";
                 angle[i] = 270 + 360 * (Math.log10(ratios[i]) / Math.log10(this.powerBase));
                 if (i !== 0) {
                     if (i == pitchNumber - 1) {
@@ -729,7 +727,7 @@ class TemperamentWidget {
 
             notesCell[(i, 0)] = notesRow[i].insertCell(-1);
             notesCell[(i, 0)].innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="Play" alt="play" height="20px" width="20px" id="play_' +
+                '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="Play" alt="play" height="20px" width="20px" style="margin-top:20px;" id="play_' +
                 i +
                 '" data-id="' +
                 i +
@@ -853,6 +851,7 @@ class TemperamentWidget {
             menuItems[i].style.background = platformColor.selectorBackground;
             menuItems[i].style.height = 40 + "px";
             menuItems[i].style.textAlign = "center";
+            menuItems[i].style.cursor = "pointer";
             menuItems[i].style.fontWeight = "bold";
             menuItems[i].style.paddingRight = "5px";
         }

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -573,6 +573,9 @@ class TemperamentWidget {
                 docById("noteInfo").style.left = "132px";
                 docById("noteInfo").style.position = "absolute";
                 docById("noteInfo").style.zIndex = 10;
+
+                docById("close").style.cursor = "pointer";
+                
                 docById("close").onclick = () => {
                     docById("noteInfo").remove();
                 };
@@ -1527,6 +1530,8 @@ class TemperamentWidget {
                 docById("noteInfo1").style.top = "100px";
                 docById("noteInfo1").style.left = "90px";
 
+                docById("close").style.cursor = "pointer";
+                
                 docById("frequencySlider").oninput = () => {
                     this._refreshInnerWheel();
                 };

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1521,7 +1521,7 @@ class TemperamentWidget {
                     docById("noteInfo1").remove();
                 }
                 docById("wheelDiv3").innerHTML +=
-                    '<div class="popup" id="noteInfo1" style="width:180px; height:135px;"><span class="popuptext" id="myPopup"></span></div>';
+                    '<div class="popup" id="noteInfo1" style="width:180px; height:146px;"><span class="popuptext" id="myPopup"></span></div>';
                 docById("noteInfo1").innerHTML +=
                     '<img src="header-icons/close-button.svg" id="close" title="Close" alt="close" height=20px width=20px align="right">';
                 docById("noteInfo1").innerHTML +=
@@ -1535,10 +1535,12 @@ class TemperamentWidget {
                     frequencies[i] +
                     "</span>";
                 docById("noteInfo1").innerHTML +=
-                    '<br><br><div id="done" style="background:rgb(196, 196, 196);"><center>Done</center><div>';
+                    '<br><br><div id="done" style="background:#8cc6ff; cursor: pointer"><center>Done</center><div>';
 
                 docById("noteInfo1").style.top = "100px";
                 docById("noteInfo1").style.left = "90px";
+                docById("done").style.height = "30px";
+                docById("done").style.lineHeight = "30px";
 
                 docById("close").style.cursor = "pointer";
                 docById("frequencySlider").oninput = () => {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -863,7 +863,7 @@ class TemperamentWidget {
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[0].style.background = "#c8C8C8";
+            menuItems[0].style.background = "#FFFFFF";
             this.equalEdit();
         };
 
@@ -871,7 +871,7 @@ class TemperamentWidget {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[1].style.background = "#c8C8C8";
+            menuItems[1].style.background = "#FFFFFF";
             this.ratioEdit();
         };
 
@@ -879,7 +879,7 @@ class TemperamentWidget {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
-            menuItems[2].style.background = "#c8C8C8";
+            menuItems[2].style.background = "#FFFFFF";
             this.arbitraryEdit();
         };
 
@@ -887,7 +887,7 @@ class TemperamentWidget {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
-            menuItems[3].style.background = "#c8C8C8";
+            menuItems[3].style.background = "#FFFFFF";
             this.octaveSpaceEdit();
         };
     }
@@ -900,7 +900,7 @@ class TemperamentWidget {
         this.editMode = "equal";
         docById("userEdit").innerHTML = "";
         const equalEdit = docById("userEdit");
-        equalEdit.style.backgroundColor = "#c8C8C8";
+        equalEdit.style.backgroundColor = "#FFFFFF";
         equalEdit.innerHTML =
             '<br>Pitch Number &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="octaveIn" value="0"></input> &nbsp;&nbsp; To &nbsp;&nbsp; <input type="text" id="octaveOut" value="0"></input><br><br>';
         equalEdit.innerHTML +=
@@ -1088,7 +1088,7 @@ class TemperamentWidget {
         this.editMode = "ratio";
         docById("userEdit").innerHTML = "";
         const ratioEdit = docById("userEdit");
-        ratioEdit.style.backgroundColor = "#c8C8C8";
+        ratioEdit.style.backgroundColor = "#FFFFFF";
         ratioEdit.innerHTML =
             '<br>Ratio &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="ratioIn" value="1"></input> &nbsp;&nbsp; : &nbsp;&nbsp; <input type="text" id="ratioOut" value="1"></input><br><br>';
         ratioEdit.innerHTML +=
@@ -1272,6 +1272,7 @@ class TemperamentWidget {
         const arbitraryEdit = docById("userEdit");
         arbitraryEdit.innerHTML = '<br><div id="wheelDiv3" class="wheelNav"></div>';
         arbitraryEdit.style.paddingLeft = "0px";
+        arbitraryEdit.style.backgroundColor = "#FFFFFF";
 
         const radius = 128;
         const height = 2 * radius;
@@ -1299,6 +1300,8 @@ class TemperamentWidget {
             docById("wheelDiv4").style.background = "none";
             docById("wheelDiv4").style.position = "relative";
             docById("wheelDiv4").style.zIndex = 5;
+            docById("wheelDiv4").style.marginTop = "13.5px";
+            docById("wheelDiv4").style.marginLeft = "37.5px";
             this.wheel1 = new wheelnav("wheelDiv4");
             this.wheel1.wheelRadius = 200;
             this.wheel1.navItemsEnabled = false;
@@ -1368,7 +1371,8 @@ class TemperamentWidget {
         const canvas = docById("circ1");
         canvas.style.position = "absolute";
         canvas.style.zIndex = 1;
-        canvas.style.marginTop = "-305px";
+        canvas.style.marginTop = "-310px";
+        canvas.style.marginLeft = "-5px";
         const ctx = canvas.getContext("2d");
         const centerX = canvas.width / 2;
         const centerY = canvas.height / 2;
@@ -1591,7 +1595,7 @@ class TemperamentWidget {
         const len = this.ratios.length;
         const octaveRatio = this.ratios[len - 1];
         const octaveSpaceEdit = docById("userEdit");
-        octaveSpaceEdit.style.backgroundColor = "#c8C8C8";
+        octaveSpaceEdit.style.backgroundColor = "#FFFFFF";
         octaveSpaceEdit.innerHTML =
             '<br><br>Octave Space &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="startNote" value="' +
             octaveRatio +

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -439,13 +439,13 @@ class TemperamentWidget {
             divAppend1.style.textAlign = "center";
             divAppend1.style.position = "absolute";
             divAppend1.style.zIndex = 2;
-            divAppend1.style.paddingTop = "5px";
             divAppend1.style.backgroundColor = platformColor.selectorBackground;
-            divAppend1.style.height = "25px";
+            divAppend1.style.height = "30px";
             divAppend1.style.width = docById("wheelDiv2").style.width;
             divAppend1.style.marginTop = docById("wheelDiv2").style.height;
             divAppend1.style.overflow = "auto";
             divAppend1.style.cursor = "pointer";
+            divAppend1.style.lineHeight = divAppend1.style.height; 
             docById("temperamentTable").append(divAppend1);
         }
 
@@ -1462,12 +1462,12 @@ class TemperamentWidget {
         divAppend.id = "divAppend";
         divAppend.innerHTML = "Done";
         divAppend.style.textAlign = "center";
-        divAppend.style.paddingTop = "5px";
         divAppend.style.backgroundColor = platformColor.selectorBackground;
-        divAppend.style.height = "25px";
+        divAppend.style.height = "30px";
         divAppend.style.marginTop = "40px";
         divAppend.style.overflow = "auto";
         divAppend.style.cursor = "pointer";
+        divAppend.style.lineHeight = "30px";
         arbitraryEdit.append(divAppend);
 
         divAppend.onclick = () => {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -851,9 +851,10 @@ class TemperamentWidget {
         const menuItems = document.querySelectorAll("#editMenus");
         for (let i = 0; i < editMenus.length; i++) {
             menuItems[i].style.background = platformColor.selectorBackground;
-            menuItems[i].style.height = 30 + "px";
+            menuItems[i].style.height = 40 + "px";
             menuItems[i].style.textAlign = "center";
             menuItems[i].style.fontWeight = "bold";
+            menuItems[i].style.paddingRight = "5px";
         }
 
         menuItems[0].style.background = "#c8C8C8";
@@ -1611,17 +1612,13 @@ class TemperamentWidget {
         divAppend.id = "divAppend";
         divAppend.innerHTML = "Done";
         divAppend.style.textAlign = "center";
-        divAppend.style.paddingTop = "5px";
         divAppend.style.marginLeft = "-70px";
         divAppend.style.backgroundColor = platformColor.selectorBackground;
-        divAppend.style.height = "25px";
+        divAppend.style.height = "30px";
         divAppend.style.marginTop = "40px";
-        divAppend.style.overflow = "auto";
+        divAppend.style.lineHeight = divAppend.style.height;
+        divAppend.style.cursor = "pointer";
         octaveSpaceEdit.append(divAppend);
-
-        divAppend.onmouseover = (event) => {
-            event.target.style.cursor = "pointer";
-        };
 
         divAppend.onclick = () => {
             const startRatio = docById("startNote").value;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -447,6 +447,7 @@ class TemperamentWidget {
             divAppend1.style.width = docById("wheelDiv2").style.width;
             divAppend1.style.marginTop = docById("wheelDiv2").style.height;
             divAppend1.style.overflow = "auto";
+            divAppend1.style.cursor = "pointer";
             docById("temperamentTable").append(divAppend1);
         }
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -865,25 +865,25 @@ class TemperamentWidget {
         for(let i = 0;i<4;i++){
             menuItems[i].onmouseover = () => {
                 menuItems[i].style.backgroundColor = "#7bb5ee";
-            }
+            };
         }
 
         for(let i = 0;i<4;i++){
             menuItems[i].onmouseout = () => {
-                if((i==0 && this.editMode!="equal") 
+                if((i==0 && this.editMode!="equal")
                 || (i==1 && this.editMode!="ratio")
-                || (i==2 && this.editMode!="arbitrary") 
+                || (i==2 && this.editMode!="arbitrary")
                 || (i==3 && this.editMode!="octave")){
                     menuItems[i].style.backgroundColor = "#8cc6ff";
                 }
-            }
+            };
         }
 
         for(let i = 0;i<4;i++){
             menuItems[i].onclick = () => {
                 for(let j = 0;j<4;j++){
                     if(i!=j){
-                        menuItems[j].style.background = platformColor.selectorBackground;        
+                        menuItems[j].style.background = platformColor.selectorBackground;      
                     }
                     else{
                         menuItems[i].style.background = "#FFFFFF";
@@ -901,7 +901,7 @@ class TemperamentWidget {
                 else{
                     this.octaveSpaceEdit();
                 }
-            }
+            };
         }
     }
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -445,7 +445,7 @@ class TemperamentWidget {
             divAppend1.style.marginTop = docById("wheelDiv2").style.height;
             divAppend1.style.overflow = "auto";
             divAppend1.style.cursor = "pointer";
-            divAppend1.style.lineHeight = divAppend1.style.height; 
+            divAppend1.style.lineHeight = divAppend1.style.height;
             docById("temperamentTable").append(divAppend1);
         }
 
@@ -948,7 +948,7 @@ class TemperamentWidget {
             divAppend2.style.width = "205px";
             divAppend2.style.lineHeight = "30px";
             divAppend2.style.cursor = "pointer";
-        }
+        };
 
         addDivision(false);
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -926,7 +926,7 @@ class TemperamentWidget {
             divAppend.style.height = "32px";
             divAppend.style.marginTop = "40px";
             divAppend.style.overflow = "auto";
-            divAppend.style.cursor = "pointer";
+            divAppend.style.cursor = "32px";
             equalEdit.append(divAppend);
 
             const divAppend1 = docById("preview");
@@ -934,6 +934,7 @@ class TemperamentWidget {
             divAppend1.style.marginLeft = "3px";
             divAppend1.style.backgroundColor = platformColor.selectorBackground;
             divAppend1.style.width = "215px";
+            divAppend1.style.lineHeight = "30px";
             divAppend1.style.cursor = "pointer";
 
             const divAppend2 = docById("done_");
@@ -941,6 +942,7 @@ class TemperamentWidget {
             divAppend2.style.marginRight = "3px";
             divAppend2.style.backgroundColor = platformColor.selectorBackground;
             divAppend2.style.width = "205px";
+            divAppend2.style.lineHeight = "30px";
             divAppend2.style.cursor = "pointer";
         }
 
@@ -1112,18 +1114,23 @@ class TemperamentWidget {
             divAppend.style.height = "32px";
             divAppend.style.marginTop = "40px";
             divAppend.style.overflow = "auto";
+            divAppend.style.lineHeight = "32px";
             ratioEdit.append(divAppend);
 
             const divAppend1 = docById("preview");
             divAppend1.style.height = "30px";
             divAppend1.style.marginLeft = "3px";
             divAppend1.style.backgroundColor = platformColor.selectorBackground;
+            divAppend1.style.cursor = "pointer";
+            divAppend1.style.lineHeight = "30px";
             divAppend1.style.width = "215px";
 
             const divAppend2 = docById("done_");
             divAppend2.style.height = "30px";
             divAppend2.style.marginRight = "3px";
             divAppend2.style.backgroundColor = platformColor.selectorBackground;
+            divAppend2.style.cursor = "pointer";
+            divAppend2.style.lineHeight = "30px";
             divAppend2.style.width = "205px";
         };
 


### PR DESCRIPTION
Minor UI Improvement: Related to #2767 

This PR resolves a UI inconsistency in the temperament widget in which several buttons would have the cursor as "pointer" on mouseover while others did not. Also, the text in various buttons was not vertically central-aligned. Specifically, once clicked on the "Preview" button in the "Equal" and "Ratios" tab, the appearing "Back" and "Done" buttons had this issue:

![image](https://user-images.githubusercontent.com/60084414/105949479-bef2b180-6092-11eb-955c-ad58f8c6705e.png)

Also, the "Clear" button in this widget did not have a pointer cursor. Finally, all button-texts were vertically central-aligned.
After resolving these, final result looks like this:

![image](https://user-images.githubusercontent.com/60084414/105949610-f3ff0400-6092-11eb-9a25-9d8c2612352b.png)
![image](https://user-images.githubusercontent.com/60084414/105949736-36284580-6093-11eb-99a9-ec0c457d2250.png)
