### PR TITLE
BugFix: strage behaviour for mouse events in some widgets

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -210,7 +210,6 @@ class WidgetWindow {
             this.takeFocus();
             this.onmaximize();
             e.preventDefault();
-            e.stopImmediatePropagation();
         }
     }
 


### PR DESCRIPTION
### Bug Description
In some widgets which has interactive elements in the widgetBody show some strange behaviour for mouse events in full screen mode. This PR fixes these issues.

In Mode widget, unable to select items in fullscreen mode

![fullscreen_strange_behaviour_1](https://user-images.githubusercontent.com/39027928/106113349-65fb4a00-6174-11eb-8fb8-abefed72e1b5.gif)


In Phrase maker, pie menus don't appear upon clicking on note values

![fullscreen_strange_behaviour](https://user-images.githubusercontent.com/39027928/106114818-04d47600-6176-11eb-80db-588cd102baa9.gif)

