### PR TITLE
timbre erratic svgs update

### DIFF
--- a/guide/timbre4.svg
+++ b/guide/timbre4.svg
@@ -5,36 +5,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="160.86668mm"
    height="176.20143mm"
    viewBox="0 0 160.86669 176.20143"
    version="1.1"
-   id="svg8"
-   sodipodi:docname="timbre4.svg"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     id="namedview161"
-     showgrid="false"
-     inkscape:snap-text-baseline="false"
-     inkscape:zoom="1.2838644"
-     inkscape:cx="304.00003"
-     inkscape:cy="58.806832"
-     inkscape:window-x="-9"
-     inkscape:window-y="-9"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8" />
+   id="svg8">
   <defs
      id="defs2">
     <marker
@@ -79,7 +54,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -757,7 +732,6 @@ S</tspan></text>
        x="92.387871"
        y="12.416073"
        id="text1287-6"><tspan
-         sodipodi:role="line"
          x="0"
          y="0"
          id="tspan192"><tspan
@@ -776,7 +750,6 @@ S</tspan></text>
      x="83.051666"
      y="25.142193"
      id="text200"><tspan
-       sodipodi:role="line"
        id="tspan198"
        x="83.051666"
        y="25.142193"

--- a/guide/timbre4.svg
+++ b/guide/timbre4.svg
@@ -5,11 +5,36 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="160.86668mm"
    height="176.20143mm"
    viewBox="0 0 160.86669 176.20143"
    version="1.1"
-   id="svg8">
+   id="svg8"
+   sodipodi:docname="timbre4.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
+     id="namedview161"
+     showgrid="false"
+     inkscape:snap-text-baseline="false"
+     inkscape:zoom="1.2838644"
+     inkscape:cx="304.00003"
+     inkscape:cy="58.806832"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
   <defs
      id="defs2">
     <marker
@@ -54,7 +79,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -707,42 +732,55 @@ S</tspan></text>
 6</tspan></text>
     </g>
   </g>
-  <g
-     id="g6265"
-     transform="translate(0,1.4956309)">
-    <text
-       xml:space="preserve"
-       style="font-size:6.35px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
+  <text
+     xml:space="preserve"
+     style="font-size:6.35px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
+     x="39.66787"
+     y="21.720165"
+     id="text3828"><tspan
+       id="tspan3826"
        x="39.66787"
-       y="20.224535"
-       id="text3828"><tspan
-         id="tspan3826"
-         x="39.66787"
-         y="20.224535"
-         style="font-size:6.35px;stroke-width:0.264583">type</tspan></text>
-    <g
-       id="g6236">
-      <rect
-         style="fill:#19ff2e;fill-opacity:1;stroke:none;stroke-width:0.794282;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-         id="rect2146"
-         width="34.395832"
-         height="9.260417"
-         x="80.251839"
-         y="14.02543" />
-      <text
-         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:6.61458px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="92.387871"
-         y="12.416073"
-         id="text1287-6"><tspan
+       y="21.720165"
+       style="font-size:6.35px;stroke-width:0.264583">type</tspan></text>
+  <g
+     id="g6236"
+     transform="translate(0,1.4956309)">
+    <rect
+       style="fill:#19ff2e;fill-opacity:1;stroke:none;stroke-width:0.794282;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2146"
+       width="34.395832"
+       height="9.260417"
+       x="80.251839"
+       y="14.02543" />
+    <text
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:6.61458px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="92.387871"
+       y="12.416073"
+       id="text1287-6"><tspan
+         sodipodi:role="line"
+         x="0"
+         y="0"
+         id="tspan192"><tspan
            id="tspan1285-7"
            x="92.387871"
            y="12.416073"
-           style="font-size:4.9389px;stroke-width:0.264583px">
-sine</tspan></text>
-      <path
-         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.0939358px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 111.26755,19.326798 -1.19745,-1.366621 h 2.39488 z"
-         id="path2180" />
-    </g>
+           style="font-size:4.9389px;stroke-width:0.264583px" /></tspan></text>
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.0939358px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 111.26755,19.326798 -1.19745,-1.366621 h 2.39488 z"
+       id="path2180" />
   </g>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+     x="83.051666"
+     y="25.142193"
+     id="text200"><tspan
+       sodipodi:role="line"
+       id="tspan198"
+       x="83.051666"
+       y="25.142193"
+       style="font-size:8.46667px;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
+       dy="-1.86"
+       dx="4">sine</tspan></text>
 </svg>

--- a/guide/timbre5.svg
+++ b/guide/timbre5.svg
@@ -5,35 +5,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="160.86668mm"
    height="176.20143mm"
    viewBox="0 0 160.86669 176.20143"
    version="1.1"
-   id="svg8"
-   sodipodi:docname="timbre5.svg"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     id="namedview702"
-     showgrid="false"
-     inkscape:zoom="1.3214043"
-     inkscape:cx="304.00003"
-     inkscape:cy="272.43743"
-     inkscape:window-x="-9"
-     inkscape:window-y="-9"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8" />
+   id="svg8">
   <defs
      id="defs2">
     <marker
@@ -78,7 +54,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -723,8 +699,7 @@ S</tspan></text>
        id="tspan2176-5"
        x="137.34099"
        y="44.534233"
-       style="font-size:5.61671px;stroke-width:0.468061px">
-</tspan></text>
+       style="font-size:5.61671px;stroke-width:0.468061px" /></text>
   <rect
      style="fill:#90c100;fill-opacity:1;stroke:none;stroke-width:1.56542;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="rect2157-1"
@@ -755,8 +730,7 @@ S</tspan></text>
        id="tspan2176-3"
        x="139.08798"
        y="8.652359"
-       style="font-size:5.61671px;stroke-width:1.00013;stroke-miterlimit:4;stroke-dasharray:none">
-</tspan></text>
+       style="font-size:5.61671px;stroke-width:1.00013;stroke-miterlimit:4;stroke-dasharray:none" /></text>
   <rect
      style="fill:#90c100;fill-opacity:1;stroke:none;stroke-width:1.56542;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="rect2157-0"
@@ -811,8 +785,7 @@ S</tspan></text>
        id="tspan2176-37"
        x="139.08798"
        y="62.479294"
-       style="font-size:5.61671px;stroke-width:0.468061px">
-</tspan></text>
+       style="font-size:5.61671px;stroke-width:0.468061px" /></text>
   <ellipse
      style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28159;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="path3905"
@@ -887,7 +860,6 @@ S</tspan></text>
      x="148.36961"
      y="71.882172"
      id="text1559"><tspan
-       sodipodi:role="line"
        id="tspan1557"
        x="148.36961"
        y="71.882172"
@@ -900,7 +872,6 @@ S</tspan></text>
      x="145.76663"
      y="55.663631"
      id="text1563"><tspan
-       sodipodi:role="line"
        id="tspan1561"
        x="145.76663"
        y="55.663631"
@@ -913,7 +884,6 @@ S</tspan></text>
      x="146.96802"
      y="39.645321"
      id="text1567"><tspan
-       sodipodi:role="line"
        id="tspan1565"
        x="146.96802"
        y="39.645321"
@@ -926,7 +896,6 @@ S</tspan></text>
      x="145.96686"
      y="23.426781"
      id="text1571"><tspan
-       sodipodi:role="line"
        id="tspan1569"
        x="145.96686"
        y="23.426781"

--- a/guide/timbre5.svg
+++ b/guide/timbre5.svg
@@ -5,11 +5,35 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="160.86668mm"
    height="176.20143mm"
    viewBox="0 0 160.86669 176.20143"
    version="1.1"
-   id="svg8">
+   id="svg8"
+   sodipodi:docname="timbre5.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
+     id="namedview702"
+     showgrid="false"
+     inkscape:zoom="1.3214043"
+     inkscape:cx="304.00003"
+     inkscape:cy="272.43743"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
   <defs
      id="defs2">
     <marker
@@ -54,7 +78,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -700,7 +724,7 @@ S</tspan></text>
        x="137.34099"
        y="44.534233"
        style="font-size:5.61671px;stroke-width:0.468061px">
-60</tspan></text>
+</tspan></text>
   <rect
      style="fill:#90c100;fill-opacity:1;stroke:none;stroke-width:1.56542;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="rect2157-1"
@@ -715,27 +739,24 @@ S</tspan></text>
      cy="20.612551"
      rx="5.176527"
      ry="4.6659894" />
-  <g
-     id="g7649">
-    <ellipse
-       style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:1.41067;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path2159-2-0"
-       cx="148.43376"
-       cy="20.612551"
-       rx="5.176527"
-       ry="4.6659894" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.468061px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+  <ellipse
+     style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:1.00013;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path2159-2-0"
+     cx="148.43376"
+     cy="20.612551"
+     rx="5.176527"
+     ry="4.6659894" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.00013;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     x="139.08798"
+     y="8.652359"
+     id="text2178-9"
+     transform="scale(1.0532886,0.9494074)"><tspan
+       id="tspan2176-3"
        x="139.08798"
        y="8.652359"
-       id="text2178-9"
-       transform="scale(1.0532886,0.9494074)"><tspan
-         id="tspan2176-3"
-         x="139.08798"
-         y="8.652359"
-         style="font-size:5.61671px;stroke-width:0.468061px">
-1</tspan></text>
-  </g>
+       style="font-size:5.61671px;stroke-width:1.00013;stroke-miterlimit:4;stroke-dasharray:none">
+</tspan></text>
   <rect
      style="fill:#90c100;fill-opacity:1;stroke:none;stroke-width:1.56542;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="rect2157-0"
@@ -750,27 +771,23 @@ S</tspan></text>
      cy="37.647102"
      rx="5.176527"
      ry="4.6659894" />
-  <g
-     id="g7654">
-    <ellipse
-       style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:1.41067;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path2159-2-2"
-       cx="148.43376"
-       cy="37.647102"
-       rx="5.176527"
-       ry="4.6659894" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.468061px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+  <ellipse
+     style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:1.41067;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+     id="path2159-2-2"
+     cx="148.43376"
+     cy="37.647102"
+     rx="5.176527"
+     ry="4.6659894" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.468061px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="137.32042"
+     y="26.591915"
+     id="text2178-6"
+     transform="scale(1.0532886,0.9494074)"><tspan
+       id="tspan2176-1"
        x="137.32042"
        y="26.591915"
-       id="text2178-6"
-       transform="scale(1.0532886,0.9494074)"><tspan
-         id="tspan2176-1"
-         x="137.32042"
-         y="26.591915"
-         style="font-size:5.61671px;stroke-width:0.468061px">
-50</tspan></text>
-  </g>
+       style="font-size:5.61671px;stroke-width:0.468061px" /></text>
   <rect
      style="fill:#90c100;fill-opacity:1;stroke:none;stroke-width:1.56542;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
      id="rect2157-7"
@@ -795,81 +812,125 @@ S</tspan></text>
        x="139.08798"
        y="62.479294"
        style="font-size:5.61671px;stroke-width:0.468061px">
-1</tspan></text>
-  <g
-     transform="matrix(0.49300263,0,0,0.44437991,5.5291156,-10.705132)"
-     id="g3914">
-    <circle
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73808;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path3905"
-       cx="49.901596"
-       cy="70.475006"
-       r="10.5" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="43.521389"
-       y="77.279045"
-       id="text3909"><tspan
-         id="tspan3907"
-         x="43.521389"
-         y="77.279045"
-         style="font-size:18.6667px;fill:#ffffff">A</tspan></text>
-  </g>
-  <g
-     id="g3914-1"
-     transform="matrix(0.49300263,0,0,0.44437991,5.5291156,23.363963)">
-    <circle
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73808;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path3905-2"
-       cx="49.901596"
-       cy="70.475006"
-       r="10.5" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="43.521389"
-       y="77.279045"
-       id="text3909-9"><tspan
-         id="tspan3907-3"
-         x="43.521389"
-         y="77.279045"
-         style="font-size:18.6667px;fill:#ffffff">S</tspan></text>
-  </g>
-  <g
-     id="g3914-19"
-     transform="matrix(0.49300263,0,0,0.44437991,5.5291156,6.3294157)">
-    <circle
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73808;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path3905-4"
-       cx="49.901596"
-       cy="70.475006"
-       r="10.5" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="43.521389"
-       y="77.279045"
-       id="text3909-7"><tspan
-         id="tspan3907-8"
-         x="43.521389"
-         y="77.279045"
-         style="font-size:18.6667px;fill:#ffffff">D</tspan></text>
-  </g>
-  <g
-     id="g3914-4"
-     transform="matrix(0.49300263,0,0,0.44437991,5.5291156,40.39851)">
-    <circle
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73808;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
-       id="path3905-5"
-       cx="49.901596"
-       cy="70.475006"
-       r="10.5" />
-    <text
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="43.521389"
-       y="77.279045"
-       id="text3909-0"><tspan
-         id="tspan3907-36"
-         x="43.521389"
-         y="77.279045"
-         style="font-size:18.6667px;fill:#ffffff">R</tspan></text>
-  </g>
+</tspan></text>
+  <ellipse
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28159;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+     id="path3905"
+     cx="30.130733"
+     cy="20.612545"
+     rx="5.1765275"
+     ry="4.6659889" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46806px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="25.620018"
+     y="24.89566"
+     id="text3909"
+     transform="scale(1.0532887,0.94940735)"><tspan
+       id="tspan3907"
+       x="25.620018"
+       y="24.89566"
+       style="font-size:8.73714px;fill:#ffffff;stroke-width:0.46806px">A</tspan></text>
+  <ellipse
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28159;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+     id="path3905-2"
+     cx="30.130733"
+     cy="54.681641"
+     rx="5.1765275"
+     ry="4.6659889" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46806px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="25.620018"
+     y="60.780251"
+     id="text3909-9"
+     transform="scale(1.0532887,0.94940735)"><tspan
+       id="tspan3907-3"
+       x="25.620018"
+       y="60.780251"
+       style="font-size:8.73714px;fill:#ffffff;stroke-width:0.46806px">S</tspan></text>
+  <ellipse
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28159;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+     id="path3905-4"
+     cx="30.130733"
+     cy="37.647091"
+     rx="5.1765275"
+     ry="4.6659889" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46806px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="25.620018"
+     y="42.837955"
+     id="text3909-7"
+     transform="scale(1.0532887,0.94940735)"><tspan
+       id="tspan3907-8"
+       x="25.620018"
+       y="42.837955"
+       style="font-size:8.73714px;fill:#ffffff;stroke-width:0.46806px">D</tspan></text>
+  <ellipse
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28159;stroke-linecap:round;stroke-miterlimit:1.41421;stroke-dasharray:none;stroke-opacity:1"
+     id="path3905-5"
+     cx="30.130733"
+     cy="71.716187"
+     rx="5.1765275"
+     ry="4.6659889" />
+  <text
+     style="font-style:normal;font-weight:normal;font-size:18.7224px;line-height:11.7015px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46806px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="25.620018"
+     y="78.722549"
+     id="text3909-0"
+     transform="scale(1.0532887,0.94940735)"><tspan
+       id="tspan3907-36"
+       x="25.620018"
+       y="78.722549"
+       style="font-size:8.73714px;fill:#ffffff;stroke-width:0.46806px">R</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+     x="148.36961"
+     y="71.882172"
+     id="text1559"><tspan
+       sodipodi:role="line"
+       id="tspan1557"
+       x="148.36961"
+       y="71.882172"
+       style="font-size:7.05556px;stroke-width:0.264583"
+       dx="-1.55"
+       dy="1.55">1</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+     x="145.76663"
+     y="55.663631"
+     id="text1563"><tspan
+       sodipodi:role="line"
+       id="tspan1561"
+       x="145.76663"
+       y="55.663631"
+       style="font-size:7.05556px;stroke-width:0.264583"
+       dx="-1.42"
+       dy="1.42">60</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+     x="146.96802"
+     y="39.645321"
+     id="text1567"><tspan
+       sodipodi:role="line"
+       id="tspan1565"
+       x="146.96802"
+       y="39.645321"
+       style="font-size:7.05556px;stroke-width:0.264583"
+       dx="-2.5999999"
+       dy="-0.0099999998">50</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:7.05556px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+     x="145.96686"
+     y="23.426781"
+     id="text1571"><tspan
+       sodipodi:role="line"
+       id="tspan1569"
+       x="145.96686"
+       y="23.426781"
+       style="font-size:7.05556px;stroke-width:0.264583"
+       dy="-0.31"
+       dx="0.11">1</tspan></text>
 </svg>


### PR DESCRIPTION
While solving #2591 unknowingly, certain erroneous svgs were generated. Couple of svgs in the guide pertaining to timbre widget were erratic. SVGs were namely, `timbre4.svg` and `timbre5.svg`

Behavior before :- 
![image](https://user-images.githubusercontent.com/50985033/106563766-4720fd00-6552-11eb-99b6-0aea8eae5c58.png)
and 
![image](https://user-images.githubusercontent.com/50985033/106563797-5142fb80-6552-11eb-808f-300d0f01373d.png)

they've been fixed in this PR.