### PR TITLE
BugFix: custom mode block mode preview

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -281,8 +281,8 @@ const piemenuPitches = function (
         (block.name === "notename" &&
             (block.connections[0] != undefined
                 ? ["setkey", "setkey2"].indexOf(
-                      block.blocks.blockList[block.connections[0]].name
-                  ) === -1
+                    block.blocks.blockList[block.connections[0]].name
+                ) === -1
                 : true))
     ) {
         if (scale[6 - i][0] == FIXEDSOLFEGE[note] || scale[6 - i][0] == note) {
@@ -476,8 +476,8 @@ const piemenuPitches = function (
             (that.name == "notename" &&
                 (that.connections[0] != undefined
                     ? ["setkey", "setkey2"].indexOf(
-                          that.blocks.blockList[that.connections[0]].name
-                      ) === -1
+                        that.blocks.blockList[that.connections[0]].name
+                    ) === -1
                     : true))
         ) {
             let i = NOTENAMES.indexOf(FIXEDSOLFEGE[selection["note"]]);
@@ -2913,7 +2913,12 @@ const piemenuModes = function (block, selectedMode) {
         that._modeNameWheel.navigateWheel(i);
     };
 
+    let timeout;
+
     const __exitMenu = function () {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
         that._piemenuExitTime = new Date().getTime();
         docById("wheelDiv").style.display = "none";
         if (that._modeNameWheel !== null) {
@@ -2959,7 +2964,7 @@ const piemenuModes = function (block, selectedMode) {
                 that._modeWheel.navigateWheel(0);
             }
 
-            setTimeout(function () {
+            timeout = setTimeout(function () {
                 __playScale(activeTabs, idx + 1);
             }, 1000 / 10); // slight delay between notes
         }
@@ -2983,6 +2988,19 @@ const piemenuModes = function (block, selectedMode) {
         for (let k = mode.length - 1; k >= 0; k--) {
             activeTabs.push(last(activeTabs) - mode[k]);
         }
+
+        docById("wheelnav-_exitWheel-title-1").style.fill = "#ffffff";
+        docById("wheelnav-_exitWheel-title-1").style.pointerEvents = "none";
+        docById("wheelnav-_exitWheel-slice-1").style.pointerEvents = "none";
+        setTimeout(function() {
+            const playButtonTitle = docById("wheelnav-_exitWheel-title-1");
+            const playButtonSlice = docById("wheelnav-_exitWheel-slice-1");
+            if (playButtonTitle && playButtonSlice){
+                playButtonTitle.style.fill = "#000000";
+                playButtonTitle.style.pointerEvents = "auto";
+                playButtonSlice.style.pointerEvents = "auto";
+            }
+        }, 20 * 1000 / 10);
 
         __playScale(activeTabs, 0);
     };


### PR DESCRIPTION
In the mode pie menu of custom mode block we could play the preview of the currently selected option but there are some bugs associated with it.
- The play button could be clicked multiple times consecutively, this leads to some strange behaviour. Ideally the play button should disable for the period when sound is playing.
- On click the play button it turns from black to white but it does not go back to black even after the sound has finished playing, ideally it should be white for as long as the tune is playing and then it should go back to its original colour.
- On closing the piemenu when the tune is playing it results in an console error.

### Before

![Kapture 2021-02-02 at 16 58 17](https://user-images.githubusercontent.com/39027928/106594315-f0c6b500-6577-11eb-9ca6-11062c331ce3.gif)
<img width="383" alt="Screenshot 2021-02-02 at 4 58 43 PM" src="https://user-images.githubusercontent.com/39027928/106594325-f45a3c00-6577-11eb-95c2-f66337d7a7cb.png">


### After

![Kapture 2021-02-02 at 16 54 49](https://user-images.githubusercontent.com/39027928/106594003-8281f280-6577-11eb-989c-918f67c8de22.gif)
