### PR TITLE
Fix Bug in Arbitrary Edit Tab and improvements in Tempo Widget.

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1464,9 +1464,11 @@ class TemperamentWidget {
             docById("wheelDiv3").style.zIndex = 10;
             docById("wheelDiv3").style.marginTop = 15 + "px";
             docById("wheelDiv3").style.marginLeft = 37 + "px";
-            docById("wheelDiv3").addEventListener("mouseover", (e) => {
-                this.arbitraryEditSlider(e, angle1, ratios, pitchNumber);
-            });
+            setTimeout(() => {
+                docById("wheelDiv3").addEventListener("mouseover", (e) => {
+                    this.arbitraryEditSlider(e, angle1, ratios, pitchNumber);
+                });
+            },1500);
         };
 
         this._createOuterWheel();

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -275,6 +275,7 @@ class Tempo {
         this.BPMs[i] = parseFloat(this.BPMs[i]) + Math.round(0.1 * this.BPMs[i]);
 
         if (this.BPMs[i] > 1000) {
+            logo.errorMsg(_("The beats per minute must be below 1000."));
             this.BPMs[i] = 1000;
         }
 
@@ -290,6 +291,7 @@ class Tempo {
     slowDown(i) {
         this.BPMs[i] = parseFloat(this.BPMs[i]) - Math.round(0.1 * this.BPMs[i]);
         if (this.BPMs[i] < 30) {
+            logo.errorMsg(_("The beats per minute must be above 30"));
             this.BPMs[i] = 30;
         }
 

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -79,9 +79,9 @@ class Tempo {
                 this.pause();
                 pauseBtn.innerHTML =
                     '<img src="header-icons/play-button.svg" title="' +
-                    _("Pause") +
+                    _("Play") +
                     '" alt="' +
-                    _("Pause") +
+                    _("Play") +
                     '" height="' +
                     Tempo.ICONSIZE +
                     '" width="' +
@@ -92,9 +92,9 @@ class Tempo {
                 this.resume();
                 pauseBtn.innerHTML =
                     '<img src="header-icons/pause-button.svg" title="' +
-                    _("Play") +
+                    _("Pause") +
                     '" alt="' +
-                    _("Play") +
+                    _("Pause") +
                     '" height="' +
                     Tempo.ICONSIZE +
                     '" width="' +


### PR DESCRIPTION
Issue Reference: #2767 
In the Arbitrary Tab of the Add Pitches section in the Temperament Widget, I noticed that once if you hover on the outer circle before the animation is completed, it remains incomplete forever.

Before:

https://user-images.githubusercontent.com/60084414/106860648-afa2e200-66ea-11eb-9dfb-63355fde9680.mp4

So, I just added a Timeout on the event listener of mouseover event so that it activates only after the animation is completed.

After:


https://user-images.githubusercontent.com/60084414/106860850-f7296e00-66ea-11eb-8960-1cf0f49db968.mp4


Also, in the Tempo widget, it showed "Play" on the Pause button and vice-versa.

![image](https://user-images.githubusercontent.com/60084414/106989238-bb98ad80-6797-11eb-9ec6-5529649ac8e1.png)

![image](https://user-images.githubusercontent.com/60084414/106989272-ceab7d80-6797-11eb-9dd4-2e0b976b9fb6.png)

This was fixed in this PR.
Finally, there was no error shown on clicking the down button when the BPM is 30 or clicking the speed up button when the BPM is 1000.
Thus, I added an error message showing the subsequent errors:
For BPM=30 and clicking the down button:

![image](https://user-images.githubusercontent.com/60084414/106989662-9eb0aa00-6798-11eb-9dbd-04331b244a12.png)

For BPM=1000 and clicking the speed up button:

![Screenshot from 2021-02-05 09-56-39](https://user-images.githubusercontent.com/60084414/106989730-c3a51d00-6798-11eb-9685-218e82d6ae25.png)


