### PR TITLE
Fixing movable do - set key not working as expected

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3061,7 +3061,7 @@ const piemenuModes = function (block, selectedMode) {
 
     const __buildModeWheel = function () {
         const i = that._modeGroupWheel.selectedNavItemIndex;
-        const modeGroup = that._modeGroupWheel.navItems[i].title;
+        modeGroup = that._modeGroupWheel.navItems[i].title;
         __buildModeNameWheel(modeGroup);
     };
 

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -148,7 +148,7 @@ function setupIntervalsActions() {
                 logo.errorMsg(NOINPUTERRORMSG, blk);
                 modeName = "custom";
             } else {
-                modeName = args[0].toLowerCase();
+                modeName = name.toLowerCase();
             }
 
             const listenerName = "_definemode_" + turtle;


### PR DESCRIPTION
Set key and define mode blocks implement movable do in music blocks but there seems to be some issues specially when in custom mode.

Issues -
- When execution flows through the define mode block we get a console error.

  <img width="398" alt="Screenshot 2021-02-07 at 3 10 03 PM" src="https://user-images.githubusercontent.com/39027928/107147135-68c71d80-6972-11eb-8793-129f223fb0af.png">

- The output is not as expected when the selected mode is different from modes in the group 7 including custom mode. First set to major mode from group 7 and play, then select any another mode from any other group the output stays the same. The video below demonstrates this issue with custom mode.
  

  https://user-images.githubusercontent.com/39027928/107147460-4209e680-6974-11eb-9053-c49de17409b7.mov

  The expected output for the custom mode in the video above being
  
  <img width="225" alt="Screenshot 2021-02-07 at 6 18 26 PM" src="https://user-images.githubusercontent.com/39027928/107147510-85645500-6974-11eb-9f56-113a83ffe5cf.png">

  The video below demonstrates how only modes from group 7 give the correct output

  https://user-images.githubusercontent.com/39027928/107148287-6ff12a00-6978-11eb-80ad-5ce9effc3034.mov

This PR fixes these issues.

