### PR TITLE
WidgetWindows: UX Enhancement

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -82,14 +82,13 @@ class WidgetWindow {
     _createUIelements() {
         const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
-
+        this._overlayframe = this._create("div", "windowFrame", windows);
         this._drag = this._create("div", "wfTopBar", this._frame);
         this._handle = this._create("div", "wfHandle", this._drag);
         // The handle needs the events bound as it's a sibling of the dragging div
         // not a relative in either direciton.
 
         this._drag.ondblclick = () => {
-            console.log("Double Clicked");
             this._maximize();
         };
 
@@ -183,6 +182,21 @@ class WidgetWindow {
     _docMouseMoveHandler(e) {
         if (!this._dragging) return;
 
+        if (this._frame.style.top === "64px") {
+            this._overlayframe.style.zIndex = "1";
+            this._overlayframe.style.width = "100vw";
+            this._overlayframe.style.height = "calc(100vh - 64px)";
+            this._overlayframe.style.left = "0";
+            this._overlayframe.style.top = "64px";
+            this._overlayframe.style.border = "0.25vw solid black";
+            this._frame.style.zIndex = "10";
+            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0.75)";
+        } else {
+            this._frame.style.zIndex = "1";
+            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0)";
+            this._overlayframe.style.border = "0px";
+            this._overlayframe.style.zIndex = "-1";
+        }
         const x = e.clientX - this._dx,
             y = e.clientY - this._dy;
 
@@ -229,7 +243,6 @@ class WidgetWindow {
             language = navigator.language;
         }
 
-        // console.debug("language setting is " + language);
         // For Japanese, put the toolbar on the top.
         if (language === "ja") {
             this._body.style.flexDirection = "column";
@@ -484,6 +497,7 @@ class WidgetWindow {
      */
     destroy() {
         this._frame.remove();
+        this._overlayframe.remove();
         window.widgetWindows.openWindows[this._key] = undefined;
     }
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -87,6 +87,12 @@ class WidgetWindow {
         this._handle = this._create("div", "wfHandle", this._drag);
         // The handle needs the events bound as it's a sibling of the dragging div
         // not a relative in either direciton.
+
+        this._drag.ondblclick = () => {
+            console.log("Double Clicked");
+            this._maximize();
+        };
+
         this._drag.onmousedown = this._handle.onmousedown = (e) => {
             this._dragging = true;
             if (this._maximized) {


### PR DESCRIPTION
Issue Reference: #2808 
This PR introduces a feature to maximize the widget window by double-clicking the top-bar of the widget window. This is necessary as every Operating system has this feature and thus, people are used to this.

https://user-images.githubusercontent.com/60084414/107497055-0f503000-6bb8-11eb-92f2-cddb29be2051.mp4

Also, while the feature of dragging the widget to the top and maximizing was very useful, there was no indication for a new user that this feature was present. Thus, I added a white overlay on the event of the widget window reaching the top so as to indicate to a user that this event will maximize the widget window. This will enhance the experience of dragging and maximizing the widget window.



https://user-images.githubusercontent.com/60084414/107497308-6a822280-6bb8-11eb-95db-525c6a7db68c.mp4
