### PR TITLE
Bug Fix, Temperament Widget: Play and Stop not working properly

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2234,6 +2234,22 @@ class TemperamentWidget {
                     }
                 }, Singer.defaultBPMFactor * 1000 * duration);
             }
+            else{
+                this._playing = false;
+                cell.innerHTML =
+                            '&nbsp;&nbsp;<img src="header-icons/' +
+                            "play-button.svg" +
+                            '" title="' +
+                            _("Play") +
+                            '" alt="' +
+                            _("Play") +
+                            '" height="' +
+                            TemperamentWidget.ICONSIZE +
+                            '" width="' +
+                            TemperamentWidget.ICONSIZE +
+                            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+                console.log("completed");
+            }
         };
         if (this._playing) {
             __playLoop(0);

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -16,7 +16,7 @@
 
 /*
    global platformColor, docById, wheelnav, slicePath, logo, Singer, isCustom,
-   TEMPERAMENT, rationalToFraction, _, getNoteFromInterval,
+   TEMPERAMENT, OCTAVERATIO: true, rationalToFraction, _, getNoteFromInterval,
    FLAT, SHARP, pitchToFrequency, updateTemperaments, _buildScale
  */
 
@@ -1768,7 +1768,8 @@ class TemperamentWidget {
             }
         }
 
-        const OctaveRatio = this.powerBase;
+        // Global value
+        OCTAVERATIO = this.powerBase;
 
         const value = logo.blocks.findUniqueTemperamentName(this.inTemperament);
         this.inTemperament = value; // change from temporary "custom" to "custom1" or "custom2" ..
@@ -1780,8 +1781,8 @@ class TemperamentWidget {
             [4, ["number", { value: this.frequencies[0] }], 0, 0, [2]],
             [5, ["octavespace"], 0, 0, [2, 6, 9]],
             [6, ["divide"], 0, 0, [5, 7, 8]],
-            [7, ["number", { value: rationalToFraction(OctaveRatio)[0] }], 0, 0, [6]],
-            [8, ["number", { value: rationalToFraction(OctaveRatio)[1] }], 0, 0, [6]],
+            [7, ["number", { value: rationalToFraction(OCTAVERATIO)[0] }], 0, 0, [6]],
+            [8, ["number", { value: rationalToFraction(OCTAVERATIO)[1] }], 0, 0, [6]],
             [9, "vspace", 0, 0, [5, 10]]
         ];
         let previousBlock = 9;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2009,7 +2009,6 @@ class TemperamentWidget {
         this.playbackForward = true;
         this._playing = !this._playing;
         if (!this._playing) {
-            logo.synth.setMasterVolume(0);
             return;
         }
         logo.resetSynth(0);

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -16,7 +16,7 @@
 
 /*
    global platformColor, docById, wheelnav, slicePath, logo, Singer, isCustom,
-   TEMPERAMENT, OCTAVERATIO: true, rationalToFraction, _, getNoteFromInterval,
+   TEMPERAMENT, rationalToFraction, _, getNoteFromInterval,
    FLAT, SHARP, pitchToFrequency, updateTemperaments, _buildScale
  */
 
@@ -1763,8 +1763,7 @@ class TemperamentWidget {
             }
         }
 
-        // Global value
-        OCTAVERATIO = this.powerBase;
+        const OctaveRatio = this.powerBase;
 
         const value = logo.blocks.findUniqueTemperamentName(this.inTemperament);
         this.inTemperament = value; // change from temporary "custom" to "custom1" or "custom2" ..
@@ -1776,8 +1775,8 @@ class TemperamentWidget {
             [4, ["number", { value: this.frequencies[0] }], 0, 0, [2]],
             [5, ["octavespace"], 0, 0, [2, 6, 9]],
             [6, ["divide"], 0, 0, [5, 7, 8]],
-            [7, ["number", { value: rationalToFraction(OCTAVERATIO)[0] }], 0, 0, [6]],
-            [8, ["number", { value: rationalToFraction(OCTAVERATIO)[1] }], 0, 0, [6]],
+            [7, ["number", { value: rationalToFraction(OctaveRatio)[0] }], 0, 0, [6]],
+            [8, ["number", { value: rationalToFraction(OctaveRatio)[1] }], 0, 0, [6]],
             [9, "vspace", 0, 0, [5, 10]]
         ];
         let previousBlock = 9;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -37,6 +37,9 @@ class TemperamentWidget {
     static INNERWINDOWWIDTH = 600;
     static BUTTONSIZE = 53;
     static ICONSIZE = 32;
+    static LIGHTGREY = "#e0e0e0";
+    static GREY = "#c8c8c8";
+    static DARKGREY = "#808080";
 
     /**
      * @constructor
@@ -367,7 +370,7 @@ class TemperamentWidget {
             const sliceAngle = [];
             const angleDiff = [];
             for (let i = 0; i < this.notesCircle.navItemCount; i++) {
-                this.notesCircle.navItems[i].fillAttr = "#c8C8C8";
+                this.notesCircle.navItems[i].fillAttr = TemperamentWidget.GREY;
                 this.notesCircle.navItems[i].titleAttr.font =
                     "20 20px Impact, Charcoal, sans-serif";
                 this.notesCircle.navItems[i].titleSelectedAttr.font =
@@ -1051,10 +1054,11 @@ class TemperamentWidget {
                 docById("userEdit").innerHTML = '<div id="wheelDiv2" class="wheelNav"></div>';
                 this.createMainWheel(this.tempRatios, pitchNumber);
                 for (let i = 0; i < pitchNumber; i++) {
-                    this.notesCircle.navItems[i].fillAttr = "#e0e0e0";
-                    this.notesCircle.navItems[i].sliceHoverAttr.fill = "#e0e0e0";
-                    this.notesCircle.navItems[i].slicePathAttr.fill = "#e0e0e0";
-                    this.notesCircle.navItems[i].sliceSelectedAttr.fill = "#e0e0e0";
+                    this.notesCircle.navItems[i].fillAttr = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].sliceHoverAttr.fill = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].slicePathAttr.fill = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].sliceSelectedAttr.fill =
+                        TemperamentWidget.LIGHTGREY;
                 }
                 this.notesCircle.refreshWheel();
                 docById("userEdit").style.paddingLeft = "0px";
@@ -1222,10 +1226,11 @@ class TemperamentWidget {
                 docById("userEdit").innerHTML = '<div id="wheelDiv2" class="wheelNav"></div>';
                 this.createMainWheel(this.tempRatios, pitchNumber);
                 for (let i = 0; i < pitchNumber; i++) {
-                    this.notesCircle.navItems[i].fillAttr = "#e0e0e0";
-                    this.notesCircle.navItems[i].sliceHoverAttr.fill = "#e0e0e0";
-                    this.notesCircle.navItems[i].slicePathAttr.fill = "#e0e0e0";
-                    this.notesCircle.navItems[i].sliceSelectedAttr.fill = "#e0e0e0";
+                    this.notesCircle.navItems[i].fillAttr = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].sliceHoverAttr.fill = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].slicePathAttr.fill = TemperamentWidget.LIGHTGREY;
+                    this.notesCircle.navItems[i].sliceSelectedAttr.fill =
+                        TemperamentWidget.LIGHTGREY;
                 }
                 this.notesCircle.refreshWheel();
                 docById("userEdit").style.paddingLeft = "0px";
@@ -1338,7 +1343,7 @@ class TemperamentWidget {
             const angle = [];
             const angleDiff = [];
             for (let i = 0; i < this.wheel1.navItemCount; i++) {
-                this.wheel1.navItems[i].fillAttr = "#e0e0e0";
+                this.wheel1.navItems[i].fillAttr = TemperamentWidget.LIGHTGREY;
                 this.wheel1.navItems[i].titleAttr.font = "20 20px Impact, Charcoal, sans-serif";
                 this.wheel1.navItems[i].titleSelectedAttr.font =
                     "20 20px Impact, Charcoal, sans-serif";
@@ -1425,7 +1430,7 @@ class TemperamentWidget {
             this.wheel.slicePathCustom.maxRadiusPercent = 1.0;
             this.wheel.sliceSelectedPathCustom = this.wheel.slicePathCustom;
             this.wheel.sliceInitPathCustom = this.wheel.slicePathCustom;
-            this.wheel.colors = ["#c0c0c0", "#e0e0e0"];
+            this.wheel.colors = ["#c0c0c0", TemperamentWidget.LIGHTGREY];
             this.wheel.titleRotateAngle = 90;
             this.wheel.navItemsEnabled = false;
 
@@ -2069,35 +2074,44 @@ class TemperamentWidget {
             }
             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
                 if (i === pitchNumber) {
-                    this.notesCircle.navItems[0].fillAttr = "#808080";
-                    this.notesCircle.navItems[0].sliceHoverAttr.fill = "#808080";
-                    this.notesCircle.navItems[0].slicePathAttr.fill = "#808080";
-                    this.notesCircle.navItems[0].sliceSelectedAttr.fill = "#808080";
+                    this.notesCircle.navItems[0].fillAttr = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[0].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[0].slicePathAttr.fill = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[0].sliceSelectedAttr.fill =
+                        TemperamentWidget.DARKGREY;
                 } else {
-                    this.notesCircle.navItems[i].fillAttr = "#808080";
-                    this.notesCircle.navItems[i].sliceHoverAttr.fill = "#808080";
-                    this.notesCircle.navItems[i].slicePathAttr.fill = "#808080";
-                    this.notesCircle.navItems[i].sliceSelectedAttr.fill = "#808080";
+                    this.notesCircle.navItems[i].fillAttr = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[i].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[i].slicePathAttr.fill = TemperamentWidget.DARKGREY;
+                    this.notesCircle.navItems[i].sliceSelectedAttr.fill =
+                        TemperamentWidget.DARKGREY;
                 }
 
                 if (this.playbackForward == false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
-                        this.notesCircle.navItems[0].fillAttr = "#c8C8C8";
-                        this.notesCircle.navItems[0].sliceHoverAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[0].slicePathAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[0].sliceSelectedAttr.fill = "#c8C8C8";
+                        this.notesCircle.navItems[0].fillAttr = TemperamentWidget.GREY;
+                        this.notesCircle.navItems[0].sliceHoverAttr.fill = TemperamentWidget.GREY;
+                        this.notesCircle.navItems[0].slicePathAttr.fill = TemperamentWidget.GREY;
+                        this.notesCircle.navItems[0].sliceSelectedAttr.fill =
+                            TemperamentWidget.GREY;
                     } else {
-                        this.notesCircle.navItems[i + 1].fillAttr = "#c8C8C8";
-                        this.notesCircle.navItems[i + 1].sliceHoverAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[i + 1].slicePathAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill = "#c8C8C8";
+                        this.notesCircle.navItems[i + 1].fillAttr = TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
+                            TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i + 1].slicePathAttr.fill =
+                            TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
+                            TemperamentWidget.GREY;
                     }
                 } else {
                     if (i !== 0) {
-                        this.notesCircle.navItems[i - 1].fillAttr = "#c8C8C8";
-                        this.notesCircle.navItems[i - 1].sliceHoverAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
-                        this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill = "#c8C8C8";
+                        this.notesCircle.navItems[i - 1].fillAttr = TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
+                            TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i - 1].slicePathAttr.fill =
+                            TemperamentWidget.GREY;
+                        this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
+                            TemperamentWidget.GREY;
                     }
                 }
 
@@ -2116,35 +2130,42 @@ class TemperamentWidget {
                 }
             } else if (docById("wheelDiv4") !== null) {
                 if (i === pitchNumber) {
-                    this.wheel1.navItems[0].fillAttr = "#808080";
-                    this.wheel1.navItems[0].sliceHoverAttr.fill = "#808080";
-                    this.wheel1.navItems[0].slicePathAttr.fill = "#808080";
-                    this.wheel1.navItems[0].sliceSelectedAttr.fill = "#808080";
+                    this.wheel1.navItems[0].fillAttr = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[0].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[0].slicePathAttr.fill = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[0].sliceSelectedAttr.fill = TemperamentWidget.DARKGREY;
                 } else {
-                    this.wheel1.navItems[i].fillAttr = "#808080";
-                    this.wheel1.navItems[i].sliceHoverAttr.fill = "#808080";
-                    this.wheel1.navItems[i].slicePathAttr.fill = "#808080";
-                    this.wheel1.navItems[i].sliceSelectedAttr.fill = "#808080";
+                    this.wheel1.navItems[i].fillAttr = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[i].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[i].slicePathAttr.fill = TemperamentWidget.DARKGREY;
+                    this.wheel1.navItems[i].sliceSelectedAttr.fill = TemperamentWidget.DARKGREY;
                 }
 
                 if (this.playbackForward == false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
-                        this.wheel1.navItems[0].fillAttr = "#e0e0e0";
-                        this.wheel1.navItems[0].sliceHoverAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[0].slicePathAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[0].sliceSelectedAttr.fill = "#e0e0e0";
+                        this.wheel1.navItems[0].fillAttr = TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[0].sliceHoverAttr.fill = TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[0].slicePathAttr.fill = TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[0].sliceSelectedAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
                     } else {
-                        this.wheel1.navItems[i + 1].fillAttr = "#e0e0e0";
-                        this.wheel1.navItems[i + 1].sliceHoverAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[i + 1].slicePathAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[i + 1].sliceSelectedAttr.fill = "#e0e0e0";
+                        this.wheel1.navItems[i + 1].fillAttr = TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i + 1].sliceHoverAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i + 1].slicePathAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i + 1].sliceSelectedAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
                     }
                 } else {
                     if (i !== 0) {
-                        this.wheel1.navItems[i - 1].fillAttr = "#e0e0e0";
-                        this.wheel1.navItems[i - 1].sliceHoverAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[i - 1].slicePathAttr.fill = "#e0e0e0";
-                        this.wheel1.navItems[i - 1].sliceSelectedAttr.fill = "#e0e0e0";
+                        this.wheel1.navItems[i - 1].fillAttr = TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i - 1].sliceHoverAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i - 1].slicePathAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
+                        this.wheel1.navItems[i - 1].sliceSelectedAttr.fill =
+                            TemperamentWidget.LIGHTGREY;
                     }
                 }
 
@@ -2177,24 +2198,32 @@ class TemperamentWidget {
                             '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
                         if (i !== -1) {
                             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
-                                this.notesCircle.navItems[i - 1].fillAttr = "#c8C8C8";
-                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill = "#c8C8C8";
-                                this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
-                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill = "#c8C8C8";
+                                this.notesCircle.navItems[i - 1].fillAttr = TemperamentWidget.GREY;
+                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
+                                    TemperamentWidget.GREY;
+                                this.notesCircle.navItems[i - 1].slicePathAttr.fill =
+                                    TemperamentWidget.GREY;
+                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
+                                    TemperamentWidget.GREY;
                                 if (i == 11) {
                                     //on completion of a full circle and on hitting '0' note in clockwise direction
-                                    this.notesCircle.navItems[0].fillAttr = "#c8C8C8";
-                                    this.notesCircle.navItems[0].sliceHoverAttr.fill = "#c8C8C8";
-                                    this.notesCircle.navItems[0].slicePathAttr.fill = "#c8C8C8";
-                                    this.notesCircle.navItems[0].sliceSelectedAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[0].fillAttr = TemperamentWidget.GREY;
+                                    this.notesCircle.navItems[0].sliceHoverAttr.fill =
+                                        TemperamentWidget.GREY;
+                                    this.notesCircle.navItems[0].slicePathAttr.fill =
+                                        TemperamentWidget.GREY;
+                                    this.notesCircle.navItems[0].sliceSelectedAttr.fill =
+                                        TemperamentWidget.GREY;
                                 } else if (i < 11) {
                                     //in case of counter-clockwise direction, i.e., when this.playbackForward = false
-                                    this.notesCircle.navItems[i + 1].fillAttr = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].fillAttr =
+                                        TemperamentWidget.GREY;
                                     this.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
-                                        "#c8C8C8";
-                                    this.notesCircle.navItems[i + 1].slicePathAttr.fill = "#c8C8C8";
+                                        TemperamentWidget.GREY;
+                                    this.notesCircle.navItems[i + 1].slicePathAttr.fill =
+                                        TemperamentWidget.GREY;
                                     this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
-                                        "#c8C8C8";
+                                        TemperamentWidget.GREY;
                                 }
                                 this.notesCircle.refreshWheel();
                             } else if (
@@ -2205,10 +2234,13 @@ class TemperamentWidget {
                                 docById("pitchNumber_" + j).style.background =
                                     platformColor.selectorBackground;
                             } else if (docById("wheelDiv4") !== null) {
-                                this.wheel1.navItems[i - 1].fillAttr = "#e0e0e0";
-                                this.wheel1.navItems[i - 1].sliceHoverAttr.fill = "#e0e0e0";
-                                this.wheel1.navItems[i - 1].slicePathAttr.fill = "#e0e0e0";
-                                this.wheel1.navItems[i - 1].sliceSelectedAttr.fill = "#e0e0e0";
+                                this.wheel1.navItems[i - 1].fillAttr = TemperamentWidget.LIGHTGREY;
+                                this.wheel1.navItems[i - 1].sliceHoverAttr.fill =
+                                    TemperamentWidget.LIGHTGREY;
+                                this.wheel1.navItems[i - 1].slicePathAttr.fill =
+                                    TemperamentWidget.LIGHTGREY;
+                                this.wheel1.navItems[i - 1].sliceSelectedAttr.fill =
+                                    TemperamentWidget.LIGHTGREY;
                                 this.wheel1.refreshWheel();
                             }
                         }

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -75,7 +75,9 @@ class TemperamentWidget {
         widgetWindow.getWidgetBody().style.width = "500px";
 
         widgetWindow.onclose = () => {
-            this.closed = true;
+            if (this._playing) {
+                this.closed = true;
+            }
             logo.synth.setMasterVolume(0);
             if (docById("wheelDiv2") != null) {
                 docById("wheelDiv2").style.display = "none";
@@ -2174,11 +2176,10 @@ class TemperamentWidget {
 
             if (i <= pitchNumber && i >= 0 && p < 2) {
                 setTimeout(() => {
-                    if(this.closed){
-                        this.closed = !(this.closed);
+                    if (this.closed) {
+                        this.closed = !this.closed;
                         return;
-                    }
-                    else if ((!this._playing)) {
+                    } else if (!this._playing) {
                         cell.innerHTML =
                             '&nbsp;&nbsp;<img src="header-icons/' +
                             "play-button.svg" +
@@ -2194,24 +2195,23 @@ class TemperamentWidget {
                         if (i !== -1) {
                             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
                                 this.notesCircle.navItems[i - 1].fillAttr = "#c8C8C8";
-                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
-                                    "#c8C8C8";
+                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill = "#c8C8C8";
                                 this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
-                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
-                                    "#c8C8C8";
-                                if(i==11){
+                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill = "#c8C8C8";
+                                if (i == 11) {
                                     //on completion of a full circle and on hitting '0' note in clockwise direction
                                     this.notesCircle.navItems[0].fillAttr = "#c8C8C8";
                                     this.notesCircle.navItems[0].sliceHoverAttr.fill = "#c8C8C8";
                                     this.notesCircle.navItems[0].slicePathAttr.fill = "#c8C8C8";
                                     this.notesCircle.navItems[0].sliceSelectedAttr.fill = "#c8C8C8";
-                                }
-                                else if(i<11){
+                                } else if (i < 11) {
                                     //in case of counter-clockwise direction, i.e., when this.playbackForward = false
                                     this.notesCircle.navItems[i + 1].fillAttr = "#c8C8C8";
-                                    this.notesCircle.navItems[i + 1].sliceHoverAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
+                                        "#c8C8C8";
                                     this.notesCircle.navItems[i + 1].slicePathAttr.fill = "#c8C8C8";
-                                    this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
+                                        "#c8C8C8";
                                 }
                                 this.notesCircle.refreshWheel();
                             } else if (
@@ -2230,8 +2230,7 @@ class TemperamentWidget {
                             }
                         }
                         this._playing = false;
-                    }
-                    else{
+                    } else {
                         __playLoop(i);
                     }
                 }, Singer.defaultBPMFactor * 1000 * duration);

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2199,6 +2199,20 @@ class TemperamentWidget {
                                 this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
                                 this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
                                     "#c8C8C8";
+                                if(i==11){
+                                    //on completion of a full circle and on hitting '0' note in clockwise direction
+                                    this.notesCircle.navItems[0].fillAttr = "#c8C8C8";
+                                    this.notesCircle.navItems[0].sliceHoverAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[0].slicePathAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[0].sliceSelectedAttr.fill = "#c8C8C8";
+                                }
+                                else if(i<11){
+                                    //in case of counter-clockwise direction, i.e., when this.playbackForward = false
+                                    this.notesCircle.navItems[i + 1].fillAttr = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].sliceHoverAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].slicePathAttr.fill = "#c8C8C8";
+                                    this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill = "#c8C8C8";
+                                }
                                 this.notesCircle.refreshWheel();
                             } else if (
                                 this.circleIsVisible == true &&

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2234,6 +2234,8 @@ class TemperamentWidget {
                     '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
             }
         };
-        
+        if (this._playing) {
+            __playLoop(0);
+        }
     }
 }

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1468,7 +1468,7 @@ class TemperamentWidget {
                 docById("wheelDiv3").addEventListener("mouseover", (e) => {
                     this.arbitraryEditSlider(e, angle1, ratios, pitchNumber);
                 });
-            },1500);
+            }, 1500);
         };
 
         this._createOuterWheel();
@@ -2005,7 +2005,10 @@ class TemperamentWidget {
         let p = 0;
         this.playbackForward = true;
         this._playing = !this._playing;
-
+        if (!this._playing) {
+            logo.synth.setMasterVolume(0);
+            return;
+        }
         logo.resetSynth(0);
 
         const cell = this.playButton;
@@ -2060,6 +2063,7 @@ class TemperamentWidget {
         }
 
         const __playLoop = (i) => {
+            console.log("Play Loop Called for " + i);
             let j;
             if (i === pitchNumber) {
                 this.playbackForward = false;
@@ -2078,7 +2082,6 @@ class TemperamentWidget {
                 );
                 this.playNote(i);
             }
-
             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
                 if (i === pitchNumber) {
                     this.notesCircle.navItems[0].fillAttr = "#808080";
@@ -2169,46 +2172,52 @@ class TemperamentWidget {
                 i -= 1;
             }
 
-            if (i <= pitchNumber && i >= 0 && this._playing && p < 2) {
+            if (i <= pitchNumber && i >= 0 && p < 2) {
                 setTimeout(() => {
-                    __playLoop(i);
-                }, Singer.defaultBPMFactor * 1000 * duration);
-            } else {
-                cell.innerHTML =
-                    '&nbsp;&nbsp;<img src="header-icons/' +
-                    "play-button.svg" +
-                    '" title="' +
-                    _("Play") +
-                    '" alt="' +
-                    _("Play") +
-                    '" height="' +
-                    TemperamentWidget.ICONSIZE +
-                    '" width="' +
-                    TemperamentWidget.ICONSIZE +
-                    '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-                if (i !== -1) {
-                    setTimeout(() => {
-                        if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
-                            this.notesCircle.navItems[i - 1].fillAttr = "#c8C8C8";
-                            this.notesCircle.navItems[i - 1].sliceHoverAttr.fill = "#c8C8C8";
-                            this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
-                            this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill = "#c8C8C8";
-                            this.notesCircle.refreshWheel();
-                        } else if (this.circleIsVisible == true && docById("wheelDiv4") == null) {
-                            j = i - 1;
-                            docById("pitchNumber_" + j).style.background =
-                                platformColor.selectorBackground;
-                        } else if (docById("wheelDiv4") !== null) {
-                            this.wheel1.navItems[i - 1].fillAttr = "#e0e0e0";
-                            this.wheel1.navItems[i - 1].sliceHoverAttr.fill = "#e0e0e0";
-                            this.wheel1.navItems[i - 1].slicePathAttr.fill = "#e0e0e0";
-                            this.wheel1.navItems[i - 1].sliceSelectedAttr.fill = "#e0e0e0";
+                    if (!this._playing) {
+                        cell.innerHTML =
+                            '&nbsp;&nbsp;<img src="header-icons/' +
+                            "play-button.svg" +
+                            '" title="' +
+                            _("Play") +
+                            '" alt="' +
+                            _("Play") +
+                            '" height="' +
+                            TemperamentWidget.ICONSIZE +
+                            '" width="' +
+                            TemperamentWidget.ICONSIZE +
+                            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+                        if (i !== -1) {
+                            if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
+                                this.notesCircle.navItems[i - 1].fillAttr = "#c8C8C8";
+                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
+                                    "#c8C8C8";
+                                this.notesCircle.navItems[i - 1].slicePathAttr.fill = "#c8C8C8";
+                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
+                                    "#c8C8C8";
+                                this.notesCircle.refreshWheel();
+                            } else if (
+                                this.circleIsVisible == true &&
+                                docById("wheelDiv4") == null
+                            ) {
+                                j = i - 1;
+                                docById("pitchNumber_" + j).style.background =
+                                    platformColor.selectorBackground;
+                            } else if (docById("wheelDiv4") !== null) {
+                                this.wheel1.navItems[i - 1].fillAttr = "#e0e0e0";
+                                this.wheel1.navItems[i - 1].sliceHoverAttr.fill = "#e0e0e0";
+                                this.wheel1.navItems[i - 1].slicePathAttr.fill = "#e0e0e0";
+                                this.wheel1.navItems[i - 1].sliceSelectedAttr.fill = "#e0e0e0";
 
-                            this.wheel1.refreshWheel();
+                                this.wheel1.refreshWheel();
+                            }
                         }
-                    }, Singer.defaultBPMFactor * 1000 * duration);
-                }
-                this._playing = false;
+                        this._playing = false;
+                    }
+                    else{
+                        __playLoop(i);
+                    }
+                }, Singer.defaultBPMFactor * 1000 * duration);
             }
         };
         if (this._playing) {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2053,6 +2053,13 @@ class TemperamentWidget {
             pitchNumber = this.tempRatios1.length - 1;
         }
 
+        const updateNotesCircle = (index,color) => {
+            this.notesCircle.navItems[index].fillAttr = color;
+            this.notesCircle.navItems[index].sliceHoverAttr.fill = color;
+            this.notesCircle.navItems[index].slicePathAttr.fill = color;
+            this.notesCircle.navItems[index].sliceSelectedAttr.fill = color;
+        };
+
         const __playLoop = (i) => {
             let j;
             if (i === pitchNumber) {
@@ -2074,44 +2081,20 @@ class TemperamentWidget {
             }
             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
                 if (i === pitchNumber) {
-                    this.notesCircle.navItems[0].fillAttr = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[0].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[0].slicePathAttr.fill = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                        TemperamentWidget.DARKGREY;
+                    updateNotesCircle(0,TemperamentWidget.DARKGREY);
                 } else {
-                    this.notesCircle.navItems[i].fillAttr = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[i].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[i].slicePathAttr.fill = TemperamentWidget.DARKGREY;
-                    this.notesCircle.navItems[i].sliceSelectedAttr.fill =
-                        TemperamentWidget.DARKGREY;
+                    updateNotesCircle(i,TemperamentWidget.DARKGREY);
                 }
 
                 if (this.playbackForward == false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
-                        this.notesCircle.navItems[0].fillAttr = TemperamentWidget.GREY;
-                        this.notesCircle.navItems[0].sliceHoverAttr.fill = TemperamentWidget.GREY;
-                        this.notesCircle.navItems[0].slicePathAttr.fill = TemperamentWidget.GREY;
-                        this.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                            TemperamentWidget.GREY;
+                        updateNotesCircle(0,TemperamentWidget.GREY);
                     } else {
-                        this.notesCircle.navItems[i + 1].fillAttr = TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
-                            TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i + 1].slicePathAttr.fill =
-                            TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
-                            TemperamentWidget.GREY;
+                        updateNotesCircle(i + 1,TemperamentWidget.GREY);
                     }
                 } else {
                     if (i !== 0) {
-                        this.notesCircle.navItems[i - 1].fillAttr = TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
-                            TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i - 1].slicePathAttr.fill =
-                            TemperamentWidget.GREY;
-                        this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
-                            TemperamentWidget.GREY;
+                        updateNotesCircle(i - 1,TemperamentWidget.GREY);
                     }
                 }
 
@@ -2130,42 +2113,20 @@ class TemperamentWidget {
                 }
             } else if (docById("wheelDiv4") !== null) {
                 if (i === pitchNumber) {
-                    this.wheel1.navItems[0].fillAttr = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[0].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[0].slicePathAttr.fill = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[0].sliceSelectedAttr.fill = TemperamentWidget.DARKGREY;
+                    updateNotesCircle(0,TemperamentWidget.DARKGREY);
                 } else {
-                    this.wheel1.navItems[i].fillAttr = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[i].sliceHoverAttr.fill = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[i].slicePathAttr.fill = TemperamentWidget.DARKGREY;
-                    this.wheel1.navItems[i].sliceSelectedAttr.fill = TemperamentWidget.DARKGREY;
+                    updateNotesCircle(i,TemperamentWidget.DARKGREY);
                 }
 
                 if (this.playbackForward == false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
-                        this.wheel1.navItems[0].fillAttr = TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[0].sliceHoverAttr.fill = TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[0].slicePathAttr.fill = TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[0].sliceSelectedAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
+                        updateNotesCircle(0,TemperamentWidget.LIGHTGREY);
                     } else {
-                        this.wheel1.navItems[i + 1].fillAttr = TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i + 1].sliceHoverAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i + 1].slicePathAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i + 1].sliceSelectedAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
+                        updateNotesCircle(i + 1,TemperamentWidget.LIGHTGREY);
                     }
                 } else {
                     if (i !== 0) {
-                        this.wheel1.navItems[i - 1].fillAttr = TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i - 1].sliceHoverAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i - 1].slicePathAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
-                        this.wheel1.navItems[i - 1].sliceSelectedAttr.fill =
-                            TemperamentWidget.LIGHTGREY;
+                        updateNotesCircle(i - 1,TemperamentWidget.LIGHTGREY);
                     }
                 }
 
@@ -2198,40 +2159,20 @@ class TemperamentWidget {
                             '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
                         if (i !== -1) {
                             if (this.circleIsVisible == false && docById("wheelDiv4") == null) {
-                                this.notesCircle.navItems[i - 1].fillAttr = TemperamentWidget.GREY;
-                                this.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
-                                    TemperamentWidget.GREY;
-                                this.notesCircle.navItems[i - 1].slicePathAttr.fill =
-                                    TemperamentWidget.GREY;
-                                this.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
-                                    TemperamentWidget.GREY;
+                                updateNotesCircle(i - 1,TemperamentWidget.GREY);
                                 if (i == 11) {
                                     //on completion of a full circle and on hitting '0' note in clockwise direction
-                                    this.notesCircle.navItems[0].fillAttr = TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[0].sliceHoverAttr.fill =
-                                        TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[0].slicePathAttr.fill =
-                                        TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                                        TemperamentWidget.GREY;
+                                    updateNotesCircle(0,TemperamentWidget.GREY);
                                 } else if (i < 11) {
                                     //in case of counter-clockwise direction, i.e., when this.playbackForward = false
-                                    this.notesCircle.navItems[i + 1].fillAttr =
-                                        TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
-                                        TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[i + 1].slicePathAttr.fill =
-                                        TemperamentWidget.GREY;
-                                    this.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
-                                        TemperamentWidget.GREY;
+                                    updateNotesCircle(i + 1,TemperamentWidget.GREY);
                                 }
                                 this.notesCircle.refreshWheel();
                             } else if (
                                 this.circleIsVisible == true &&
                                 docById("wheelDiv4") == null
                             ) {
-                                j = i - 1;
-                                docById("pitchNumber_" + j).style.background =
+                                docById("pitchNumber_" + (i - 1)).style.background =
                                     platformColor.selectorBackground;
                             } else if (docById("wheelDiv4") !== null) {
                                 this.wheel1.navItems[i - 1].fillAttr = TemperamentWidget.LIGHTGREY;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2233,22 +2233,20 @@ class TemperamentWidget {
                         __playLoop(i);
                     }
                 }, Singer.defaultBPMFactor * 1000 * duration);
-            }
-            else{
+            } else {
                 this._playing = false;
                 cell.innerHTML =
-                            '&nbsp;&nbsp;<img src="header-icons/' +
-                            "play-button.svg" +
-                            '" title="' +
-                            _("Play") +
-                            '" alt="' +
-                            _("Play") +
-                            '" height="' +
-                            TemperamentWidget.ICONSIZE +
-                            '" width="' +
-                            TemperamentWidget.ICONSIZE +
-                            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-                console.log("completed");
+                    '&nbsp;&nbsp;<img src="header-icons/' +
+                    "play-button.svg" +
+                    '" title="' +
+                    _("Play") +
+                    '" alt="' +
+                    _("Play") +
+                    '" height="' +
+                    TemperamentWidget.ICONSIZE +
+                    '" width="' +
+                    TemperamentWidget.ICONSIZE +
+                    '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
             }
         };
         if (this._playing) {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2027,21 +2027,6 @@ class TemperamentWidget {
                 '" width="' +
                 TemperamentWidget.ICONSIZE +
                 '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-        } else {
-            logo.synth.setMasterVolume(0);
-            logo.synth.stop();
-            cell.innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/' +
-                "play-button.svg" +
-                '" title="' +
-                _("Play") +
-                '" alt="' +
-                _("Play") +
-                '" height="' +
-                TemperamentWidget.ICONSIZE +
-                '" width="' +
-                TemperamentWidget.ICONSIZE +
-                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
         }
 
         const duration = 1 / 2;
@@ -2249,8 +2234,6 @@ class TemperamentWidget {
                     '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
             }
         };
-        if (this._playing) {
-            __playLoop(0);
-        }
+        
     }
 }

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -54,6 +54,7 @@ class TemperamentWidget {
         this.pitchNumber = 0;
         this.circleIsVisible = true;
         this.playbackForward = true;
+        this.closed = false;
     }
 
     /**
@@ -74,8 +75,8 @@ class TemperamentWidget {
         widgetWindow.getWidgetBody().style.width = "500px";
 
         widgetWindow.onclose = () => {
+            this.closed = true;
             logo.synth.setMasterVolume(0);
-            logo.synth.stop();
             if (docById("wheelDiv2") != null) {
                 docById("wheelDiv2").style.display = "none";
                 this.notesCircle.removeWheel();
@@ -2063,7 +2064,6 @@ class TemperamentWidget {
         }
 
         const __playLoop = (i) => {
-            console.log("Play Loop Called for " + i);
             let j;
             if (i === pitchNumber) {
                 this.playbackForward = false;
@@ -2174,7 +2174,11 @@ class TemperamentWidget {
 
             if (i <= pitchNumber && i >= 0 && p < 2) {
                 setTimeout(() => {
-                    if (!this._playing) {
+                    if(this.closed){
+                        this.closed = !(this.closed);
+                        return;
+                    }
+                    else if ((!this._playing)) {
                         cell.innerHTML =
                             '&nbsp;&nbsp;<img src="header-icons/' +
                             "play-button.svg" +
@@ -2208,7 +2212,6 @@ class TemperamentWidget {
                                 this.wheel1.navItems[i - 1].sliceHoverAttr.fill = "#e0e0e0";
                                 this.wheel1.navItems[i - 1].slicePathAttr.fill = "#e0e0e0";
                                 this.wheel1.navItems[i - 1].sliceSelectedAttr.fill = "#e0e0e0";
-
                                 this.wheel1.refreshWheel();
                             }
                         }


### PR DESCRIPTION
Issue Reference: #2767 
There were some bugs in this widget, all connected to the Play and Stop functionality.

- Firstly, if the STOP button was clicked on a certain note (let's say 3), it would not reflect that as the same in the UI. Instead, it would appear to be stopping on the next note (i.e., in this case, 4):


https://user-images.githubusercontent.com/60084414/107975089-91d45780-6fdd-11eb-87d4-1bd0b44d6ed4.mp4

- Secondly, if the widget was closed while it was still playing, the sound of the same note would still be heard (once again), even after closing:


https://user-images.githubusercontent.com/60084414/107975431-1b842500-6fde-11eb-8302-3b882ed91bbe.mp4

- Lastly, if the process was Stopped in the counter-clockwise cycle, i.e., when `this.playbackForward = false`, the stopping functionality would not be reflected in the UI and thus would result in a regression:

https://user-images.githubusercontent.com/60084414/107975820-b0871e00-6fde-11eb-879a-2c73c41f3969.mp4

This PR solves these bugs as shown below (all solved bugs are shown in the sequence as they are mentioned above) :

https://user-images.githubusercontent.com/60084414/107976365-6f433e00-6fdf-11eb-9563-f35f6bd1295d.mp4


