### PR TITLE
musicKeyboard: fix extra octave generated with hertz blocks

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -758,7 +758,10 @@ function MusicKeyboard() {
             removeBlock(i);
         }
 
-        const newList = fillChromaticGaps(sortedList);
+        const sortedHertzList = sortedList.filter(note => note.noteName === "hertz");
+        const sortedNotesList = sortedList.filter(note => note.noteName !== "hertz");
+        let newList = fillChromaticGaps(sortedNotesList);
+        newList = newList.concat(sortedHertzList);
 
         for (let i = 0; i < newList.length; i++) {
             this.layout.push({


### PR DESCRIPTION
This PR fixes the issue of generation of extra octave in music keyboard when there is a hertz block in the widgetBlock.

https://github.com/sugarlabs/musicblocks/commit/d449b0f454d1d73d943101795600d27667643d23 fixes this issue for standard auto generated values but the issue still persists for custom values as demonstrated in the video below.

https://user-images.githubusercontent.com/39027928/107997911-f4dbe380-7009-11eb-8ce5-1f96ab414e1c.mov

Please share feedback and suggestions. Thanks
@walterbender 