### PR TITLE
Bug Fix: Pitch Staircase Widget

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -25,7 +25,6 @@
     - js/logo.js
         logo
 */
-
 /*exported PitchStaircase */
 
 class PitchStaircase {
@@ -648,7 +647,8 @@ class PitchStaircase {
                 }, 1000);
             }
         };
-
+        document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 10*(PitchStaircase.BUTTONSIZE) + "px";
+        document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
         this._musicRatio1 = widgetWindow.addInputButton("3");
         widgetWindow.addDivider();
         this._musicRatio2 = widgetWindow.addInputButton("2");

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -691,6 +691,17 @@ class PitchStaircase {
         this._refresh();
 
         logo.textMsg(_("Click on a note to create a new step."));
+
+        widgetWindow.onmaximize = () => {
+            if((widgetWindow._maximized)){
+                document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 16*(PitchStaircase.BUTTONSIZE) + "px";
+                document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
+            }
+            else{
+                document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 10*(PitchStaircase.BUTTONSIZE) + "px";
+                document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
+            }
+        };
     }
 
     /**

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -647,7 +647,8 @@ class PitchStaircase {
                 }, 1000);
             }
         };
-        document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 10*(PitchStaircase.BUTTONSIZE) + "px";
+        document.getElementsByClassName("wfbWidget")[0].style.maxHeight =
+            10 * PitchStaircase.BUTTONSIZE + "px";
         document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
         this._musicRatio1 = widgetWindow.addInputButton("3");
         widgetWindow.addDivider();
@@ -693,12 +694,13 @@ class PitchStaircase {
         logo.textMsg(_("Click on a note to create a new step."));
 
         widgetWindow.onmaximize = () => {
-            if((widgetWindow._maximized)){
-                document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 16*(PitchStaircase.BUTTONSIZE) + "px";
+            if (widgetWindow._maximized) {
+                document.getElementsByClassName("wfbWidget")[0].style.maxHeight =
+                    16 * PitchStaircase.BUTTONSIZE + "px";
                 document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
-            }
-            else{
-                document.getElementsByClassName("wfbWidget")[0].style.maxHeight = 10*(PitchStaircase.BUTTONSIZE) + "px";
+            } else {
+                document.getElementsByClassName("wfbWidget")[0].style.maxHeight =
+                    10 * PitchStaircase.BUTTONSIZE + "px";
                 document.getElementsByClassName("wfbWidget")[0].style.overflowY = "scroll";
             }
         };


### PR DESCRIPTION
Issue Reference: #2808, #2767 
This PR enables scrolling in the pitch staircase widget as earlier, on the addition of more items, the widget would ultimately reach its maximum height and the earlier items became inaccessible. Also, this enables scrolling in case maximized widget due to same issues earlier.

Before:

https://user-images.githubusercontent.com/60084414/108665153-44cf1480-74fa-11eb-932a-6b40914d622b.mp4

After:

https://user-images.githubusercontent.com/60084414/108665181-544e5d80-74fa-11eb-8570-7557f3784afe.mp4

