### PR TITLE
Oscilloscope: Error Fix and UI modification

### DIFF
--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -15,7 +15,18 @@
  */
 
 /* global _, SMALLERBUTTON, BIGGERBUTTON, Tone, instruments */
-
+/* 
+    Globals location
+     - js/artwork.js
+         SMALLERBUTTON,BIGGERBUTTON
+     - js/utils/utils.js
+         _
+     - js/activity.js
+         Tone
+     - js/utils/synthutils.js
+         instruments
+         
+*/
 /* exported Oscilloscope */
 
 /**
@@ -59,7 +70,7 @@ class Oscilloscope {
         const step = 10;
         this.zoomFactor = 40.0;
         this.verticalOffset = 0;
-        const zoomInButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("ZOOM IN"));
+        const zoomInButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("Zoom In"));
 
         zoomInButton.onclick = () => {
             this.zoomFactor += step;
@@ -68,7 +79,7 @@ class Oscilloscope {
             unescape(encodeURIComponent(BIGGERBUTTON))
         )}`;
 
-        const zoomOutButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("ZOOM OUT"));
+        const zoomOutButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("Zoom Out"));
 
         zoomOutButton.onclick = () => {
             this.zoomFactor -= step;

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -23,7 +23,7 @@
  * @classdesc pertains to setting up all features of the Oscilloscope Widget.
  */
 class Oscilloscope {
-    static ICONSIZE = 32;
+    static ICONSIZE = 40;
     static analyserSize = 8192;
     /**
      * @constructor
@@ -54,7 +54,8 @@ class Oscilloscope {
             this.pitchAnalysers = {};
             widgetWindow.destroy();
         };
-
+        document.getElementsByClassName("wfbToolbar")[0].style.backgroundColor = "#e8e8e8";
+        document.getElementsByClassName("wfbWidget")[0].style.backgroundColor = "#FFFFFF";
         const step = 10;
         this.zoomFactor = 40.0;
         this.verticalOffset = 0;
@@ -132,7 +133,7 @@ class Oscilloscope {
             this.drawVisualIDs[turtleIdx] = requestAnimationFrame(draw);
             if (!turtle.running) return;
 
-            canvasCtx.fillStyle = "rgb(200, 200, 200)";
+            canvasCtx.fillStyle = "#FFFFFF";
             const dataArray = this.pitchAnalysers[turtleIdx].getValue();
             const bufferLength = dataArray.length;
             canvasCtx.fillRect(0, 0, width, height);

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -64,7 +64,7 @@ class Oscilloscope {
             this.zoomFactor += step;
         };
         zoomInButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
-            unescape(encodeURIComponent(SMALLERBUTTON))
+            unescape(encodeURIComponent(BIGGERBUTTON))
         )}`;
 
         const zoomOutButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("ZOOM OUT"));
@@ -74,7 +74,7 @@ class Oscilloscope {
         };
 
         zoomOutButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
-            unescape(encodeURIComponent(BIGGERBUTTON))
+            unescape(encodeURIComponent(SMALLERBUTTON))
         )}`;
 
         widgetWindow.sendToCenter();


### PR DESCRIPTION
Issue Reference: #2767
In the Oscilloscope widget, the buttons of "Zoom In" and "Zoom Out" functionalities are cross-matched with their icons, i.e., the "Zoom Out" button executes the "Zoom In" process.

Before:
![image](https://user-images.githubusercontent.com/60084414/108812530-491c3000-75d5-11eb-82b7-070b70c4c713.png)

After:
![Screenshot from 2021-02-23 12-45-48](https://user-images.githubusercontent.com/60084414/108812565-5afdd300-75d5-11eb-9c0e-3ca64ad44a66.png)
