### PR TITLE
Fix regressions in MusicKeyboard widget

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -950,12 +950,12 @@ function MusicKeyboard() {
         let newList = fillChromaticGaps(sortedNotesList);
         newList = newList.concat(sortedHertzList);
 
-        for (let i = 0; i < sortedList.length; i++) {
+        for (let i = 0; i < newList.length; i++) {
             this.layout.push({
-                noteName: sortedList[i].noteName,
-                noteOctave: sortedList[i].noteOctave,
-                blockNumber: sortedList[i].blockNumber,
-                voice: sortedList[i].voice
+                noteName: newList[i].noteName,
+                noteOctave: newList[i].noteOctave,
+                blockNumber: newList[i].blockNumber,
+                voice: newList[i].voice
             });
         }
         return newList;

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1016,8 +1016,8 @@ function MusicKeyboard() {
             noteOctave: temp2,
             blockNumber: this.layout[n - j - 1].blockNumber,
             duration: parseFloat(ele.getAttribute("alt")),
-            objId: this.layout[n - j - 1].objId,
-            voice: this.layout[n - j - 1].voice
+            objId: this.displayLayout[n - j - 1].objId,
+            voice: this.displayLayout[n - j - 1].voice
         });
 
         this._notesPlayed.sort(function (a, b) {


### PR DESCRIPTION
After #2849, the Music Keyboard widget has two regressions:
- The lower 8 notes from G4 to C4) in the column of the grid were unclickable.
  This is happening as the `for` loop (starting from line 1057 in the `makeClickable` function), the parameter `this.layout.length` is getting set to 5, after #2849, instead of 12.  Now, the error arises in the `_keysLayout` function where the notes are pushed in the layout array. So, `sortedList` is replaced by `newList` . Here,
`newList = fillChromaticGaps(sortedNotesList)` 
Thus, `newList` contains all the 12 notes whereas `sortedList` contains only the first 5 notes.

- In case when multiple notes were selected in a column, the music would stop playing and not move any further.
  This regression arises as when multiple notes are selected, the `playOne` could not fetch the `objId` of the notes from `selectedNotes` . Now, this happens when the `setNoteCell` method is called in the `setNotes` function. In this `setNoteCell` method, when the note is being pushed in the `selectedNotes` array, `objId` should be assigned to that in the `displayLayout` (introduced in #2849) array and not of the `layout` array.  

Below is the video showing both these regressions:

https://user-images.githubusercontent.com/60084414/109455958-d0f2b600-7a7d-11eb-966b-e07b7c69636e.mp4

This patch fixes these regressions and the widget functions as expected.

https://user-images.githubusercontent.com/60084414/109455983-df40d200-7a7d-11eb-91cb-a439a555544b.mp4

Please have a look at this @walterbender  @meganindya and let me know if it has any issues.
Thanks.