### PR TITLE
Enhanced the UI of search-bar and its suggestions

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -68,11 +68,14 @@
 }
 
 .ui-menu {
-  position: relative;
-  background-color: rgba(255,255,255,1.0);
-  max-width: 350px;
-  font-size: 24px;
+    position: relative;
+    background-color: rgba(255,255,255,1.0);
+    max-width: 396px;
+    font-size: 18px;
+    border: 2px solid #87CEFA;
+    list-style-type: none;
 }
+  
 
 #ui-id-1 {
 	margin: 0;
@@ -85,8 +88,15 @@
 	list-style-type: none;
 }
 
+#ui-id-1 li{
+    padding-top: 5px;
+}
+
+#ui-id-1 li img{
+    margin-left: 10px;
+}
+
 #ui-id-1 li:before {
-	content:"• ";
     margin-right: 5px;
     font-size: 20px;
     font-weight: bold;
@@ -102,7 +112,7 @@
 }
 
 .scrollSearch {
-    max-height: 200px;
+    max-height: 215px;
     margin-bottom: 10px;
     overflow-x: auto;
     overflow-y: auto;

--- a/js/activity.js
+++ b/js/activity.js
@@ -2025,8 +2025,8 @@ function Activity() {
             searchWidget.value = null;
             //docById("searchResults").style.visibility = "visible";
             searchWidget.style.visibility = "visible";
-            searchWidget.style.left = palettes.getSearchPos()[0] * turtleBlocksScale + "px";
-            searchWidget.style.top = palettes.getSearchPos()[1] * turtleBlocksScale + "px";
+            searchWidget.style.left = palettes.getSearchPos()[0] * turtleBlocksScale * 1.5 + "px";
+            searchWidget.style.top = palettes.getSearchPos()[1] * turtleBlocksScale * 0.95 + "px";
 
             searchBlockPosition = [100, 100];
             prepSearchWidget();

--- a/js/activity.js
+++ b/js/activity.js
@@ -361,7 +361,7 @@ function Activity() {
 
         searchWidget = docById("search");
         searchWidget.style.visibility = "hidden";
-        searchWidget.placeholder = _("search for blocks");
+        searchWidget.placeholder = _("Search for blocks");
 
         progressBar = docById("myProgress");
         progressBar.style.visibility = "hidden";

--- a/js/palette.js
+++ b/js/palette.js
@@ -371,7 +371,13 @@ class Palettes {
     // Palette Button event handlers
     _loadPaletteButtonHandler(name, row) {
         row.onmouseover = (evt) => {
-            document.body.style.cursor = "pointer";
+            if(name == "search"){
+                document.body.style.cursor = "text";
+            }
+            else{
+                document.body.style.cursor = "pointer";
+            }
+
         };
         row.onclick = (evt) => {
             if (name == "search") {


### PR DESCRIPTION
The current version of the search-bar and its suggestion had few inconsistencies.
- Search Bar blocked some of the search icon (magnifying glass icon) and the subsequent palette icons. Also, its alignment was slightly off.
- Bullets in the list feel unnecessary.
- The search input suggestions had a different width than the search bar, which also compromised the alignment.
- The suggestions of this search bar were too cramped in the list, which lead to the addition of a new line in the case of the block names, which were comparatively longer. So some negative space was added between them.
- This list of suggestions had the same white background color as the palette beneath it. Thus, there was no differentiating between them.

These are fixed in this patch, as shown below.

Before:
![before](https://user-images.githubusercontent.com/60084414/110658909-19ca0d80-81e8-11eb-93c4-95643b5176d4.png)

After:
![after](https://user-images.githubusercontent.com/60084414/110658850-0dde4b80-81e8-11eb-8d67-bd222f599009.png)

