### PR TITLE
Fixes regression in overlay of full-screen mode and disables full-screen in some widgets

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -42,7 +42,7 @@ class HelpWidget {
         this.index = 0;
         this.isOpen = true;
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "help", "help");
+        const widgetWindow = window.widgetWindows.windowFor(this, "help", "help", false);
         widgetWindow.getWidgetBody().style.overflowY = "auto";
         // const canvasHeight = docById("myCanvas").getBoundingClientRect().height;
         widgetWindow.getWidgetBody().style.maxHeight = "500px";

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -52,7 +52,7 @@ class PitchSlider {
         }
 
         this._cellScale = 1.0;
-        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider");
+        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", false);
         this.widgetWindow.onclose = () => {
             for (const osc of oscillators) osc.triggerRelease();
             this.widgetWindow.destroy();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -604,7 +604,7 @@ class PitchStaircase {
         const w = window.innerWidth;
         this._cellScale = w / 1200;
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "pitch staircase");
+        const widgetWindow = window.widgetWindows.windowFor(this, "pitch staircase", "pitch staircase", false);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -61,7 +61,7 @@ class Tempo {
             clearInterval(this._intervalID);
         }
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "tempo");
+        const widgetWindow = window.widgetWindows.windowFor(this, "tempo", "tempo", false);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -666,7 +666,7 @@ class TimbreWidget {
 
         this._playing = false;
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "timbre");
+        const widgetWindow = window.widgetWindows.windowFor(this, "timbre", "timbre", false);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -23,6 +23,7 @@ class WidgetWindow {
     /**
      * @param {string} key
      * @param {string} title
+     * @param {boolean} fullscreen
      */
     constructor(key, title) {
         // Keep a refernce to the object within handlers
@@ -183,24 +184,32 @@ class WidgetWindow {
         if (!this._dragging) return;
 
         if (this._frame.style.top === "64px") {
-            this._overlayframe.style.zIndex = "1";
-            this._overlayframe.style.width = "100vw";
-            this._overlayframe.style.height = "calc(100vh - 64px)";
-            this._overlayframe.style.left = "0";
-            this._overlayframe.style.top = "64px";
-            this._overlayframe.style.border = "0.25vw solid black";
-            this._frame.style.zIndex = "10";
-            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0.75)";
+            this._overlay(true);
         } else {
-            this._frame.style.zIndex = "1";
-            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0)";
-            this._overlayframe.style.border = "0px";
-            this._overlayframe.style.zIndex = "-1";
+            this._overlay(false);
         }
         const x = e.clientX - this._dx,
             y = e.clientY - this._dy;
 
         this.setPosition(x, y);
+    }
+
+    _overlay(add) {
+        if (add) {
+            this._frame.style.zIndex = "10";
+            this._overlayframe.style.left = "0";
+            this._overlayframe.style.zIndex = "1";
+            this._overlayframe.style.top = "64px";
+            this._overlayframe.style.width = "100vw";
+            this._overlayframe.style.height = "calc(100vh - 64px)";
+            this._overlayframe.style.border = "0.25vw solid black";
+            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0.75)";
+        } else {
+            this._frame.style.zIndex = "1";
+            this._overlayframe.style.border = "0px";
+            this._overlayframe.style.zIndex = "-1";
+            this._overlayframe.style.backgroundColor = "rgba(255,255,255,0)";
+        }
     }
 
     /**
@@ -225,7 +234,8 @@ class WidgetWindow {
      */
     _dragTopHandler(e) {
         this._dragging = false;
-        if (this._frame.style.top === "64px") {
+        if (this._frame.style.top === "64px"
+            && !this._maximized) {
             this._maximize();
             this.takeFocus();
             this.onmaximize();
@@ -439,6 +449,7 @@ class WidgetWindow {
             this._frame.style.top = this._savedPos[1];
             this._savedPos = null;
         }
+        this._overlay(false);
         this._frame.style.width = "auto";
         this._frame.style.height = "auto";
     }
@@ -583,7 +594,7 @@ class WidgetWindow {
  * @param {string} saveAs
  * @returns {WidgetWindow} this
  */
-window.widgetWindows.windowFor = (widget, title, saveAs) => {
+window.widgetWindows.windowFor = (widget, title, saveAs, fullscreen) => {
     let key = undefined;
     // Check for a blockNo attribute
     if (typeof widget.blockNo !== "undefined") key = widget.blockNo;
@@ -591,7 +602,7 @@ window.widgetWindows.windowFor = (widget, title, saveAs) => {
     else key = saveAs || title;
 
     if (typeof window.widgetWindows.openWindows[key] === "undefined") {
-        const win = new WidgetWindow(key, title).sendToCenter();
+        const win = new WidgetWindow(key, title, fullscreen).sendToCenter();
         window.widgetWindows.openWindows[key] = win;
     }
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -12,10 +12,10 @@
 /*global _, docById*/
 
 /*
-     Globals location
-     - js/utils/utils.js
-         _, docById
- */
+Globals location
+- js/utils/utils.js
+_, docById
+*/
 
 window.widgetWindows = { openWindows: {}, _posCache: {} };
 
@@ -25,7 +25,7 @@ class WidgetWindow {
      * @param {string} title
      * @param {boolean} fullscreen
      */
-    constructor(key, title) {
+    constructor(key, title, fullscreen = true) {
         // Keep a refernce to the object within handlers
         this._key = key;
         this._buttons = [];
@@ -35,6 +35,7 @@ class WidgetWindow {
         this._rolled = false;
         this._savedPos = null;
         this._maximized = false;
+        this._fullscreenEnabled = fullscreen;
 
         // Drag offset for correct positioning
         this._dx = this._dy = 0;
@@ -89,9 +90,11 @@ class WidgetWindow {
         // The handle needs the events bound as it's a sibling of the dragging div
         // not a relative in either direciton.
 
-        this._drag.ondblclick = () => {
-            this._maximize();
-        };
+        if (this._fullscreenEnabled) {
+            this._drag.ondblclick = () => {
+                this._maximize();
+            };
+        }
 
         this._drag.onmousedown = this._handle.onmousedown = (e) => {
             this._dragging = true;
@@ -139,22 +142,23 @@ class WidgetWindow {
         titleEl.innerHTML = _(this._title);
         titleEl.id = this._key + "WidgetID";
 
-        const maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
-        maxminButton.onclick = maxminButton.onmousedown = (e) => {
-            if (this._maximized) {
-                this._restore();
-                this.sendToCenter();
-            } else {
-                this._maximize();
-            }
-            this.takeFocus();
-            this.onmaximize();
-            e.preventDefault();
-            e.stopImmediatePropagation();
-        };
-
-        this._maxminIcon = this._create("img", undefined, maxminButton);
-        this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
+        if (this._fullscreenEnabled) {
+            const maxminButton = this._create("div", "wftButton wftMaxmin", this._drag);
+            maxminButton.onclick = maxminButton.onmousedown = (e) => {
+                if (this._maximized) {
+                    this._restore();
+                    this.sendToCenter();
+                } else {
+                    this._maximize();
+                }
+                this.takeFocus();
+                this.onmaximize();
+                e.preventDefault();
+                e.stopImmediatePropagation();
+            };
+            this._maxminIcon = this._create("img", undefined, maxminButton);
+            this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
+        }
 
         this._body = this._create("div", "wfWinBody", this._frame);
         this._toolbar = this._create("div", "wfbToolbar", this._body);
@@ -183,7 +187,8 @@ class WidgetWindow {
     _docMouseMoveHandler(e) {
         if (!this._dragging) return;
 
-        if (this._frame.style.top === "64px") {
+        if (this._fullscreenEnabled
+            && this._frame.style.top === "64px") {
             this._overlay(true);
         } else {
             this._overlay(false);
@@ -234,7 +239,8 @@ class WidgetWindow {
      */
     _dragTopHandler(e) {
         this._dragging = false;
-        if (this._frame.style.top === "64px"
+        if (this._fullscreenEnabled
+            && this._frame.style.top === "64px"
             && !this._maximized) {
             this._maximize();
             this.takeFocus();


### PR DESCRIPTION
This PR does the following
- Fixing issue with overlay, steps to reproduce - maximise a widget window by dragging it to the top then minimise it using the minimise icon, the overlay sticks around and could not be removed unless the widgetWindow is closed. Ideal behaviour should be that the overlay should appear only on dragging the window to the top to indicate the window could be maximised and should not stick around in after the window is minimised.
  ![Kapture 2021-03-11 at 07 03 05](https://user-images.githubusercontent.com/39027928/110722508-63424900-8238-11eb-987a-8dfa5e3fae7c.gif)

- Maximise functionality in all forms (double click, drag to top and maximise button) disabled for the help, tempo, pitch slider, pitch staircase and timbre widgets.

Please share feedback and suggestions. Thanks
@meganindya 