### PR TITLE
Fixes bugs in PhraseMaker with custom pitch and custom temperament

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -14,7 +14,7 @@
 SOLFEGECONVERSIONTABLE, slicePath, wheelnav, delayExecution, DEFAULTVOICE, getDrumName,
 MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege, getNote, DEFAULTDRUM,
 last, DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency, getDrumIndex, LCD,
-calcNoteValueToDisplay, NOTESYMBOLS, EIGHTHNOTEWIDTH, saveLocally, docBySelector*/
+calcNoteValueToDisplay, NOTESYMBOLS, EIGHTHNOTEWIDTH, saveLocally, docBySelector, TEMPERAMENT*/
 
 /*
 Globals location
@@ -25,7 +25,7 @@ Globals location
     EIGHTHNOTEWIDTH, NOTESYMBOLS, calcNoteValueToDisplay, getDrumIndex, noteToFrequency,
     FLAT, SHARP, DRUMS, MATRIXSOLFEHEIGHT, toFraction, SOLFEGECONVERSIONTABLE, DEFAULTVOICE,
     getDrumName, MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege,
-    getNote, DEFAULTDRUM
+    getNote, DEFAULTDRUM, TEMPERAMENT
 
 - js/utils/utils.js
     _, delayExecution, last, LCD, docById, docBySelector
@@ -43,7 +43,9 @@ Globals location
     saveLocally(window, planet)
 */
 
-    const MATRIXGRAPHICS = [
+/*exported PhraseMaker*/
+
+const MATRIXGRAPHICS = [
     "forward",
     "back",
     "right",
@@ -199,7 +201,7 @@ class PhraseMaker {
         for (let i = 0; i < this._blockMap[blk].length; i++) {
             obj = this._blockMap[blk][i];
             if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
-                console.debug("node is already in the list");
+                // console.debug("node is already in the list");
                 j += 1;
             }
         }
@@ -232,7 +234,6 @@ class PhraseMaker {
         this._noteStored = [];
         this._noteBlocks = false;
         this._rests = 0;
-        logo = logo;
 
         this.playingNow = false;
 
@@ -245,6 +246,7 @@ class PhraseMaker {
         widgetWindow.clear();
         widgetWindow.show();
 
+        //eslint-disable-next-line no-console
         console.debug("notes " + this.rowLabels + " octave " + this.rowArgs);
 
         this._notesToPlay = [];
@@ -267,13 +269,17 @@ class PhraseMaker {
             widgetWindow.destroy();
         };
 
-        this._playButton = widgetWindow.addButton("play-button.svg", PhraseMaker.ICONSIZE, _("Play"));
-        
+        this._playButton = widgetWindow.addButton(
+            "play-button.svg",
+            PhraseMaker.ICONSIZE,
+            _("Play")
+        );
+
         this._playButton.onclick = () => {
             logo.turtleDelay = 0;
 
             logo.resetSynth(0);
-            if(this.playingNow) {
+            if (this.playingNow) {
                 this._playButton.innerHTML =
                     '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' +
                     _("Play") +
@@ -576,7 +582,7 @@ class PhraseMaker {
                         eCell = eCell.parentNode;
                     }
                     const index = eCell.getAttribute("alt").split("__")[0];
-                    const condition = eCell.getAttribute("alt").split("__")[1];
+                    // const condition = eCell.getAttribute("alt").split("__")[1];
                     this._createMatrixGraphics2PieSubmenu(index, null);
                 };
 
@@ -584,8 +590,7 @@ class PhraseMaker {
                     this.rowLabels[i] + ": " + this.rowArgs[i][0] + ": " + this.rowArgs[i][1]
                 );
             } else {
-                if (noteIsSolfege(this.rowLabels[i])
-                    && !isCustom(logo.synth.inTemperament)) {
+                if (noteIsSolfege(this.rowLabels[i]) && !isCustom(logo.synth.inTemperament)) {
                     cell.innerHTML =
                         i18nSolfege(this.rowLabels[i]) + this.rowArgs[i].toString().sub();
                     noteObj = getNote(
@@ -611,15 +616,13 @@ class PhraseMaker {
                             logo.synth.inTemperament
                         );
                         const label = this.rowLabels[i];
-                        let note = TEMPERAMENT[logo.synth.inTemperament].filter(
-                            (ele) => {
-                                return ele[3] === label || ele[1] === label;
-                            }
-                        );
+                        let note = TEMPERAMENT[logo.synth.inTemperament].filter((ele) => {
+                            return ele[3] === label || ele[1] === label;
+                        });
                         if (note.length > 0) {
                             note = note[0];
                         }
-                        if (note[3] && note[3] !==  note[1]) {
+                        if (note[3] && note[3] !== note[1]) {
                             cell.innerHTML = note[1];
                         } else {
                             cell.innerHTML = label + this.rowArgs[i].toString().sub();
@@ -701,7 +704,7 @@ class PhraseMaker {
         // Sort them if there are note blocks.
         if (!this.sorted) {
             setTimeout(() => {
-                console.debug("sorting");
+                //console.debug("sorting");
                 this._sort();
             }, 1000);
         } else {
@@ -803,20 +806,16 @@ class PhraseMaker {
             this._exitWheel.removeWheel();
         };
 
-        const __subMenuChanged = () => {
-            __selectionChanged();
-        };
-
-        let __selectionChanged = () => {
+        const __selectionChanged = () => {
             label = VALUESLABEL[this._menuWheel.selectedNavItemIndex];
-            console.debug(label);
+            //console.debug(label);
             let rLabel = null;
             let rArg = null;
             const blockLabel = "";
             const newBlock = logo.blocks.blockList.length;
             switch (label) {
                 case "pitch":
-                    console.debug("loading new pitch block");
+                    //console.debug("loading new pitch block");
                     logo.blocks.loadNewBlocks([
                         [0, ["pitch", {}], 0, 0, [null, 1, 2, null]],
                         [1, ["solfege", { value: "sol" }], 0, 0, [0]],
@@ -826,7 +825,7 @@ class PhraseMaker {
                     rArg = 4;
                     break;
                 case "hertz":
-                    console.debug("loading new Hertz block");
+                    //console.debug("loading new Hertz block");
                     logo.blocks.loadNewBlocks([
                         [0, ["hertz", {}], 0, 0, [null, 1, null]],
                         [1, ["number", { value: 392 }], 0, 0, [0]]
@@ -835,7 +834,7 @@ class PhraseMaker {
                     rArg = 392;
                     break;
                 case "drum":
-                    console.debug("loading new playdrum block");
+                    //console.debug("loading new playdrum block");
                     logo.blocks.loadNewBlocks([
                         [0, ["playdrum", {}], 0, 0, [null, 1, null]],
                         [1, ["drumname", { value: DEFAULTDRUM }], 0, 0, [0]]
@@ -844,7 +843,7 @@ class PhraseMaker {
                     rArg = -1;
                     break;
                 case "graphics":
-                    console.debug("loading new forward block");
+                    //console.debug("loading new forward block");
                     logo.blocks.loadNewBlocks([
                         [0, ["forward", {}], 0, 0, [null, 1, null]],
                         [1, ["number", { value: 100 }], 0, 0, [0]]
@@ -853,7 +852,7 @@ class PhraseMaker {
                     rArg = 100;
                     break;
                 case "pen":
-                    console.debug("loading new setcolor block");
+                    //console.debug("loading new setcolor block");
                     logo.blocks.loadNewBlocks([
                         [0, ["setcolor", {}], 0, 0, [null, 1, null]],
                         [1, ["number", { value: 0 }], 0, 0, [0]]
@@ -862,6 +861,7 @@ class PhraseMaker {
                     rArg = 0;
                     break;
                 default:
+                    //eslint-disable-next-line no-console
                     console.debug(label + " not found");
                     break;
             }
@@ -876,7 +876,7 @@ class PhraseMaker {
                         blocksNo = this._mapNotesBlocks(graphicLabels[i]);
                         if (blocksNo.length >= 1) {
                             aboveBlock = last(blocksNo);
-                            console.debug(aboveBlock);
+                            //console.debug(aboveBlock);
                             break;
                         }
                     }
@@ -902,6 +902,7 @@ class PhraseMaker {
             }
 
             if (aboveBlock === null) {
+                //eslint-disable-next-line no-console
                 console.debug("WARNING: aboveBlock is null");
                 // Look for a pitch block.
                 blocksNo = this._mapNotesBlocks("pitch");
@@ -961,6 +962,10 @@ class PhraseMaker {
                     this.pitchBlockAdded(newBlock);
                 }, 200);
             }
+        };
+
+        const __subMenuChanged = () => {
+            __selectionChanged();
         };
 
         for (let i = 0; i < valueLabel.length; i++) {
@@ -1078,7 +1083,7 @@ class PhraseMaker {
             this._pitchWheel.createWheel(setxyValueLabel);
         }
 
-        console.debug(_blockNames.indexOf(blockLabel));
+        //console.debug(_blockNames.indexOf(blockLabel));
         this._blockLabelsWheel.navigateWheel(_blockNames.indexOf(blockLabel));
 
         this.xblockValue = [xblockLabelValue.toString(), "x"];
@@ -1097,6 +1102,7 @@ class PhraseMaker {
             this.xblockValue[0] = this._blockLabelsWheel2.navItems[
                 this._blockLabelsWheel2.selectedNavItemIndex
             ].title;
+            // eslint-disable-next-line no-use-before-define
             __selectionChanged(true);
         };
 
@@ -1104,6 +1110,7 @@ class PhraseMaker {
             this.yblockValue[0] = this._pitchWheel.navItems[
                 this._pitchWheel.selectedNavItemIndex
             ].title;
+            // eslint-disable-next-line no-use-before-define
             __selectionChanged(true);
         };
 
@@ -1369,6 +1376,7 @@ class PhraseMaker {
                 this._pitchWheel.selectedNavItemIndex
             ].title;
             docById("wheelnav-_exitWheel-title-1").children[0].textContent = this.blockValue;
+            // eslint-disable-next-line no-use-before-define
             __selectionChanged(true);
         };
 
@@ -1487,7 +1495,8 @@ class PhraseMaker {
             } else if (condition === "synthsblocks") {
                 noteStored = this.rowArgs[blockIndex];
             }
-
+            //eslint-disable-next-line no-console
+            console.debug(noteStored);
             this._noteStored[blockIndex] =
                 this.rowLabels[blockIndex] + ": " + this.rowArgs[blockIndex];
         };
@@ -2040,6 +2049,7 @@ class PhraseMaker {
 
     _sort() {
         if (this.sorted) {
+            //eslint-disable-next-line no-console
             console.debug("already sorted");
             return;
         }
@@ -2173,6 +2183,7 @@ class PhraseMaker {
             if (i === 0) {
                 this._sortedRowMap.push(0);
             } else if (i > 0 && obj[1] !== "hertz" && obj[1] === last(this.rowLabels)) {
+                //eslint-disable-next-line no-console
                 console.debug("skipping " + obj[1] + " " + last(this.rowLabels));
                 this._sortedRowMap.push(last(this._sortedRowMap));
                 if (oldColumnBlockMap[sortedList[lastObj][3]] != undefined) {
@@ -2193,6 +2204,7 @@ class PhraseMaker {
                 this._rowMap[i] = this._rowMap[i - 1];
                 continue;
             } else {
+                //eslint-disable-next-line no-console
                 console.debug("pushing " + obj[1] + " " + last(this.rowLabels));
                 this._sortedRowMap.push(last(this._sortedRowMap) + 1);
                 lastObj = i;
@@ -2231,9 +2243,10 @@ class PhraseMaker {
 
     _export() {
         const exportWindow = window.open("");
-        console.debug(exportWindow);
+        //console.debug(exportWindow);
         const exportDocument = exportWindow.document;
         if (exportDocument === undefined) {
+            //eslint-disable-next-line no-console
             console.debug("Could not create export window");
             return;
         }
@@ -2412,7 +2425,7 @@ class PhraseMaker {
         const tupletTimeFactor = param[0][0] / param[0][1];
         const numberOfNotes = param[1].length;
         let totalNoteInterval = 0;
-        const ptmTable = docById("ptmTable");
+        // const ptmTable = docById("ptmTable");
         let lcd;
         for (let i = 0; i < numberOfNotes; i++) {
             if (i === 0) {
@@ -2449,7 +2462,7 @@ class PhraseMaker {
         }
 
         // First, ensure that the matrix is set up for tuplets.
-        let firstRow, labelCell, noteRow, valueRow, noteValueRow, cell;
+        let firstRow, labelCell, noteRow, valueRow, cell;
         if (!this._matrixHasTuplets) {
             firstRow = this._rows[0];
 
@@ -2594,7 +2607,7 @@ class PhraseMaker {
         cell.style.backgroundColor = platformColor.tupletBackground;
 
         // And a span in the note value column too.
-        noteValueRow = this._noteValueRow;
+        const noteValueRow = this._noteValueRow;
         cell = noteValueRow.insertCell();
         cell.colSpan = numberOfNotes;
         cell.style.fontSize = Math.floor(this._cellScale * 75) + "%";
@@ -2724,6 +2737,7 @@ class PhraseMaker {
             }
 
             if (logo.blocks.blockList[blk] === undefined) {
+                //eslint-disable-next-line no-console
                 console.debug("block " + blk + " is undefined");
                 continue;
             }
@@ -2732,6 +2746,7 @@ class PhraseMaker {
                 logo.blocks.blockList[blk].name === "newnote" ||
                 logo.blocks.blockList[blk].name === "repeat"
             ) {
+                //eslint-disable-next-line no-console
                 console.debug("FOUND A NOTE OR REPEAT BLOCK.");
                 this._noteBlocks = true;
                 break;
@@ -2898,6 +2913,7 @@ class PhraseMaker {
             bottomBlockLoop += 1;
             if (bottomBlockLoop > 2 * logo.blocks.blockList) {
                 // Could happen if the block data is malformed.
+                //eslint-disable-next-line no-console
                 console.debug("infinite loop finding bottomBlock?");
                 break;
             }
@@ -3094,7 +3110,8 @@ class PhraseMaker {
         }
 
         this._blockMapHelper = [];
-        for (let i = 0; i < downCellId; i++) {
+        let i;
+        for (i = 0; i < downCellId; i++) {
             this._blockMapHelper.push([this._colBlocks[i], [i]]);
         }
         let j = i;
@@ -3655,8 +3672,9 @@ class PhraseMaker {
                     }
 
                     if (rIdx === null) {
+                        //eslint-disable-next-line no-console
                         console.debug("Could not find a row match.");
-                        console.debug(obj[0]);
+                        //console.debug(obj[0]);
                         continue;
                     }
 
@@ -3690,6 +3708,7 @@ class PhraseMaker {
                     // If we found a match, mark this cell
                     row = this._rows[r];
                     if (row === null || typeof row === "undefined") {
+                        //eslint-disable-next-line no-console
                         console.debug("COULD NOT FIND ROW " + r);
                     } else {
                         cell = row.cells[c];
@@ -3902,13 +3921,13 @@ class PhraseMaker {
                                     this.rowArgs[j]
                             );
                         } else {
-                            if (isCustom(logo.synth.inTemperament)
-                                && TEMPERAMENT[logo.synth.inTemperament].filter(
-                                    (ele) => {
-                                        const label = this.rowLabels[j];
-                                        return ele[3] === label || ele[1] === label;
-                                    }
-                                ).length !== 0) {
+                            if (
+                                isCustom(logo.synth.inTemperament) &&
+                                TEMPERAMENT[logo.synth.inTemperament].filter((ele) => {
+                                    const label = this.rowLabels[j];
+                                    return ele[3] === label || ele[1] === label;
+                                }).length !== 0
+                            ) {
                                 // custom pitch in custom temperament
                                 note.push(this.rowLabels[j] + this.rowArgs[j]);
                             } else {
@@ -3966,15 +3985,15 @@ class PhraseMaker {
                 );
                 this.playingNow = false;
                 this._playButton.innerHTML =
-                        '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' +
-                        _("Play") +
-                        '" alt="' +
-                        _("Play") +
-                        '" height="' +
-                        PhraseMaker.ICONSIZE +
-                        '" width="' +
-                        PhraseMaker.ICONSIZE +
-                        '" vertical-align="middle">&nbsp;&nbsp;';
+                    '&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="' +
+                    _("Play") +
+                    '" alt="' +
+                    _("Play") +
+                    '" height="' +
+                    PhraseMaker.ICONSIZE +
+                    '" width="' +
+                    PhraseMaker.ICONSIZE +
+                    '" vertical-align="middle">&nbsp;&nbsp;';
             } else {
                 row = this._noteValueRow;
                 cell = row.cells[this._colIndex];
@@ -4157,6 +4176,7 @@ class PhraseMaker {
                 turtles.turtleList[0].painter.doSetXY(obj[1], obj[2]);
                 break;
             default:
+                //eslint-disable-next-line no-console
                 console.debug("unknown graphics command " + obj[0]);
                 break;
         }
@@ -4240,6 +4260,7 @@ class PhraseMaker {
                         logo.synth.trigger(0, note, noteValue, this._instrumentName, null, null);
                     }
                 } else {
+                    //eslint-disable-next-line no-console
                     console.debug("Cannot parse note object: " + obj);
                 }
             }
@@ -4266,7 +4287,7 @@ class PhraseMaker {
 
     _save() {
         /* Saves the current matrix as an action stack consisting of
-            * note and pitch blocks (saving as chunks is deprecated). */
+         * note and pitch blocks (saving as chunks is deprecated). */
 
         // First, hide the palettes as they will need updating.
         for (const name in logo.blocks.palettes.dict) {
@@ -4362,7 +4383,7 @@ class PhraseMaker {
             newStack[idx][4][1] = idx + 2; // divide block
             newStack[idx][4][2] = idx + 1; // vspace block
 
-            const x = idx + delta;
+            // const x = idx + delta;
             let lastConnection, previousBlock, thisBlock;
 
             if (note[0][0] === "R" || note[0][0] == undefined) {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -11,39 +11,39 @@
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
 /*global logo, turtles, _, platformColor, docById, MATRIXSOLFEHEIGHT, toFraction, Singer,
-   SOLFEGECONVERSIONTABLE, slicePath, wheelnav, delayExecution, DEFAULTVOICE, getDrumName,
-   MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege, getNote, DEFAULTDRUM,
-   last, DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency, getDrumIndex, LCD,
-   calcNoteValueToDisplay, NOTESYMBOLS, EIGHTHNOTEWIDTH, saveLocally, docBySelector*/
+SOLFEGECONVERSIONTABLE, slicePath, wheelnav, delayExecution, DEFAULTVOICE, getDrumName,
+MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege, getNote, DEFAULTDRUM,
+last, DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency, getDrumIndex, LCD,
+calcNoteValueToDisplay, NOTESYMBOLS, EIGHTHNOTEWIDTH, saveLocally, docBySelector*/
 
 /*
-     Globals location
-     - lib/wheelnav
-         slicePath, wheelnav
-     
-     - js/utils/musicutils.js
-         EIGHTHNOTEWIDTH, NOTESYMBOLS, calcNoteValueToDisplay, getDrumIndex, noteToFrequency,
-         FLAT, SHARP, DRUMS, MATRIXSOLFEHEIGHT, toFraction, SOLFEGECONVERSIONTABLE, DEFAULTVOICE,
-         getDrumName, MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege,
-         getNote, DEFAULTDRUM
-     
-     - js/utils/utils.js
-         _, delayExecution, last, LCD, docById, docBySelector
-     
-     - js/turtle-singer.js
-         Singer
-     
-     - js/utils/platformstyle.js
-         platformColorcl
-     
-     - js/logo.js
-         PREVIEWVOLUME, DEFAULTVOLUME
-     
-     - js/activity.js
-         saveLocally(window, planet)
- */
+Globals location
+- lib/wheelnav
+    slicePath, wheelnav
 
-const MATRIXGRAPHICS = [
+- js/utils/musicutils.js
+    EIGHTHNOTEWIDTH, NOTESYMBOLS, calcNoteValueToDisplay, getDrumIndex, noteToFrequency,
+    FLAT, SHARP, DRUMS, MATRIXSOLFEHEIGHT, toFraction, SOLFEGECONVERSIONTABLE, DEFAULTVOICE,
+    getDrumName, MATRIXSOLFEWIDTH, getDrumIcon, noteIsSolfege, isCustom, i18nSolfege,
+    getNote, DEFAULTDRUM
+
+- js/utils/utils.js
+    _, delayExecution, last, LCD, docById, docBySelector
+
+- js/turtle-singer.js
+    Singer
+
+- js/utils/platformstyle.js
+    platformColorcl
+
+- js/logo.js
+    PREVIEWVOLUME, DEFAULTVOLUME
+
+- js/activity.js
+    saveLocally(window, planet)
+*/
+
+    const MATRIXGRAPHICS = [
     "forward",
     "back",
     "right",
@@ -584,7 +584,8 @@ class PhraseMaker {
                     this.rowLabels[i] + ": " + this.rowArgs[i][0] + ": " + this.rowArgs[i][1]
                 );
             } else {
-                if (noteIsSolfege(this.rowLabels[i]) && !isCustom(logo.synth.inTemperament)) {
+                if (noteIsSolfege(this.rowLabels[i])
+                    && !isCustom(logo.synth.inTemperament)) {
                     cell.innerHTML =
                         i18nSolfege(this.rowLabels[i]) + this.rowArgs[i].toString().sub();
                     noteObj = getNote(
@@ -598,8 +599,35 @@ class PhraseMaker {
                         logo.synth.inTemperament
                     );
                 } else {
-                    cell.innerHTML = this.rowLabels[i] + this.rowArgs[i].toString().sub();
-                    noteObj = [this.rowLabels[i], this.rowArgs[i]];
+                    if (isCustom(logo.synth.inTemperament)) {
+                        noteObj = getNote(
+                            this.rowLabels[i],
+                            this.rowArgs[i],
+                            0,
+                            turtles.ithTurtle(0).singer.keySignature,
+                            false,
+                            null,
+                            logo.errorMsg,
+                            logo.synth.inTemperament
+                        );
+                        const label = this.rowLabels[i];
+                        let note = TEMPERAMENT[logo.synth.inTemperament].filter(
+                            (ele) => {
+                                return ele[3] === label || ele[1] === label;
+                            }
+                        );
+                        if (note.length > 0) {
+                            note = note[0];
+                        }
+                        if (note[3] && note[3] !==  note[1]) {
+                            cell.innerHTML = note[1];
+                        } else {
+                            cell.innerHTML = label + this.rowArgs[i].toString().sub();
+                        }
+                    } else {
+                        cell.innerHTML = this.rowLabels[i] + this.rowArgs[i].toString().sub();
+                        noteObj = [this.rowLabels[i], this.rowArgs[i]];
+                    }
                 }
                 cell.setAttribute("alt", i + "__" + "pitchblocks");
 
@@ -1814,8 +1842,22 @@ class PhraseMaker {
                     logo.synth.inTemperament
                 );
             } else {
-                cell.innerHTML = this.rowLabels[index] + this.rowArgs[index].toString().sub();
-                noteObj = [this.rowLabels[index], this.rowArgs[index]];
+                if (isCustom(logo.synth.inTemperament)) {
+                    noteObj = getNote(
+                        this.rowLabels[i],
+                        this.rowArgs[i],
+                        0,
+                        turtles.ithTurtle(0).singer.keySignature,
+                        false,
+                        null,
+                        logo.errorMsg,
+                        logo.synth.inTemperament
+                    );
+                    cell.innerHTML = this.rowLabels[i] + this.rowArgs[i].toString().sub();
+                } else {
+                    cell.innerHTML = this.rowLabels[i] + this.rowArgs[i].toString().sub();
+                    noteObj = [this.rowLabels[i], this.rowArgs[i]];
+                }
             }
 
             let noteStored = null;
@@ -3598,8 +3640,8 @@ class PhraseMaker {
                     // Look in the rowBlocks for the nth match
                     for (let j = 0; j < this._rowBlocks.length; j++) {
                         /* for note blocks within repeat block
-                           their ids are added with a larger number
-                           e.g. 11 becomes 1000011 or 2000011 */
+                            their ids are added with a larger number
+                            e.g. 11 becomes 1000011 or 2000011 */
 
                         // Slice length of comparing id from end
                         // of augmented id and compare
@@ -3860,8 +3902,19 @@ class PhraseMaker {
                                     this.rowArgs[j]
                             );
                         } else {
-                            // if drum push drum name
-                            note.push(this.rowLabels[j]);
+                            if (isCustom(logo.synth.inTemperament)
+                                && TEMPERAMENT[logo.synth.inTemperament].filter(
+                                    (ele) => {
+                                        const label = this.rowLabels[j];
+                                        return ele[3] === label || ele[1] === label;
+                                    }
+                                ).length !== 0) {
+                                // custom pitch in custom temperament
+                                note.push(this.rowLabels[j] + this.rowArgs[j]);
+                            } else {
+                                // if drum push drum name
+                                note.push(this.rowLabels[j]);
+                            }
                         }
                     }
                 }
@@ -4213,7 +4266,7 @@ class PhraseMaker {
 
     _save() {
         /* Saves the current matrix as an action stack consisting of
-         * note and pitch blocks (saving as chunks is deprecated). */
+            * note and pitch blocks (saving as chunks is deprecated). */
 
         // First, hide the palettes as they will need updating.
         for (const name in logo.blocks.palettes.dict) {


### PR DESCRIPTION
### Details
Here is a a short video on how the issue might be reproduced.

https://user-images.githubusercontent.com/39027928/111003945-17b1ab80-83ae-11eb-93c1-9278f94faf8b.mov

When any of the cells of the row of the custom pitch is selected in the PhraseMaker widget window then leads to an error rendering the widget unusable. Even if we manage to select the cell without any errors then more errors are encountered upon either playing or saving the selections, as demonstrated in the video below


https://user-images.githubusercontent.com/39027928/111004218-9ad30180-83ae-11eb-8fdc-7bac458b94a7.mov

## After Changes

This PR fixes all the issues when either selecting cells of custom pitch, playing or saving the selections.

https://user-images.githubusercontent.com/39027928/111004584-52681380-83af-11eb-974a-49a862c4b46a.mov

Also compatibility with #2871 is ensured. So the phrase maker works as expected with custom pitch names as well, as demonstrated in the video below


https://user-images.githubusercontent.com/39027928/111004843-b7236e00-83af-11eb-8e63-4bfa64e39396.mov

