### PR TITLE
Statistics Widget: Enhancements to fullscreen mode

### DIFF
--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -35,6 +35,17 @@ class StatsWindow {
         };
         this.doAnalytics();
 
+        this.widgetWindow.onmaximize = () => {
+            this.widgetWindow.getWidgetBody().innerHTML = "";
+            if (this.widgetWindow.isMaximized()) {
+                this.widgetWindow.getWidgetBody().style.display = "flex";
+                this.widgetWindow.getWidgetBody().style.justifyContent = "space-between";
+                this.widgetWindow.getWidgetBody().style.padding = "0 2vw";
+            } else {
+                this.widgetWindow.getWidgetBody().style.padding = "0 0";
+            }
+            this.doAnalytics();
+        };
         this.widgetWindow.sendToCenter();
     }
 
@@ -60,7 +71,11 @@ class StatsWindow {
             const imageData = myRadarChart.toBase64Image();
             const img = new Image();
             img.src = imageData;
-            img.width = 200;
+            if (this.widgetWindow.isMaximized()) {
+                img.width = this.widgetWindow.getWidgetFrame().getBoundingClientRect().height - 80;
+            } else {
+                img.width = 200;
+            }
             this.widgetWindow.getWidgetBody().appendChild(img);
             blocks.hideBlocks();
             logo.showBlocksAfterRun = false;


### PR DESCRIPTION
Ref #2808 
The Statistics widget takes only a very small portion of the screen in the fullscreen mode. When not it fullscreen mode the radar chart is barely visible and it would be nice to be able to utilise the extra space of the fullscreen mode to show the graph in greater detail.

Here is how it looks,

### Before Changes

![statistics not utilising fullscreen](https://user-images.githubusercontent.com/39027928/111056233-7a38a380-84a3-11eb-834c-24a0952f2fd3.gif)

### After Changes

![solved statistics not utilising fullscreen](https://user-images.githubusercontent.com/39027928/111056241-83c20b80-84a3-11eb-8046-d67d8c7e506a.gif)

Please share feedback and suggestions. Thanks
@meganindya 