### PR TITLE
Rhythm Ruler Widget: fix rulers overflowing outside widetWindow and enhancements to fullscreen mode.

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -464,7 +464,7 @@ class RhythmRuler {
      * @returns {void}
      */
     _noteWidth(noteValue) {
-        return Math.floor(EIGHTHNOTEWIDTH * (8 / Math.abs(noteValue)) * 4);
+        return Math.floor(EIGHTHNOTEWIDTH * (8 / Math.abs(noteValue)) * 3);
     }
 
     /**

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -80,6 +80,7 @@ class RhythmRuler {
         this._dissectNumber = null;
         this._progressBar = null;
         this._rulers = [];
+        this._fullscreenScaleFactor = 3;
     }
 
     /**
@@ -162,6 +163,8 @@ class RhythmRuler {
 
             this.widgetWindow.destroy();
         };
+
+        this.widgetWindow.onmaximize = this._scale.bind(this);
 
         this._playAllCell = widgetWindow.addButton("play-button.svg", iconSize, _("Play all"));
         this._playAllCell.onclick = () => {
@@ -464,7 +467,36 @@ class RhythmRuler {
      * @returns {void}
      */
     _noteWidth(noteValue) {
-        return Math.floor(EIGHTHNOTEWIDTH * (8 / Math.abs(noteValue)) * 3);
+        const ans = Math.floor(EIGHTHNOTEWIDTH
+            * (8 / Math.abs(noteValue))
+            * (this.widgetWindow.isMaximized()? this._fullscreenScaleFactor: 3));
+        return ans;
+    }
+
+    _scale() {
+        if (this.widgetWindow.isMaximized()) {
+            const width = this.widgetWindow.getWidgetBody().getBoundingClientRect().width;
+            this._fullscreenScaleFactor =
+                Math.floor(width / (EIGHTHNOTEWIDTH * 8));
+        }
+        this._rulers.forEach((ruler) => {
+            if (this.widgetWindow.isMaximized()) {
+                Array.prototype.forEach.call(ruler.children, (child) => {
+                    child.style.width =
+                        Number(
+                            child.style.width.slice(0, child.style.width.indexOf("px")))
+                            * (this._fullscreenScaleFactor / 3) + "px";
+                    child.style.minWidth = child.style.width;
+                });
+            } else {
+                Array.prototype.forEach.call(ruler.children, (child) => {
+                    child.style.width =
+                        Math.floor(Number(child.style.width.slice(0, child.style.width.indexOf("px")))
+                        / Math.floor(this._fullscreenScaleFactor / 3)) + "px";
+                    child.style.minWidth = child.style.width;
+                });
+            }
+        });
     }
 
     /**
@@ -842,7 +874,7 @@ class RhythmRuler {
         };
 
         let obj;
-        if (cellWidth > 12 && noteValue > 0) {
+        if (cellWidth >= 18 && noteValue > 0) {
             obj = rationalToFraction(Math.abs(1 / noteValue));
             cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
         } else {


### PR DESCRIPTION
The rulers overflow outside the widget window due to this after dissections some notes may completely fall outside the widget window and could not be reached.

Here is a video demonstrating the overflowing rulers issue


https://user-images.githubusercontent.com/39027928/111056863-a3a7fe00-84a8-11eb-9d7d-904d46bd2543.mov

Ref #2808 
Currently, the fullscreen mode of the widget has no meaningful functionality. For smaller notes specially notes below (1/32) its difficult to see them in the ruler so it would be helpful if in the fullscreen mode the width of the notes is increased to better utilise the extra space and interact with the rulers.

Here is how the fullscreen mode looks now


https://user-images.githubusercontent.com/39027928/111056935-642de180-84a9-11eb-9fb0-2cbb3653cf90.mov


### After Changes

https://user-images.githubusercontent.com/39027928/111056965-bd961080-84a9-11eb-8dd4-848061ba9788.mov

Rulers overflowing issue fixed and enhancements made to the fullscreen mode to expand the rulers horizontally, increasing visibility of shorter notes.

Please share feedback and suggestions. Thanks


