### PR TITLE
pitchdrum-mapper: Implement Stop Functionality and enhance UI

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -688,14 +688,12 @@ table {
     left: 0px;
     top: 0px;
     right: 5em;
-    overflow-y: auto;
-    overflow-x: none;
     background: rgba(255, 255, 255, 0.85);
 }
 
 #pdmInnerDiv {
     overflow-x:auto;
-    margin-left: 53px;
+    overflow-y: auto;
 }
 
 #mkbDiv {

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -111,8 +111,8 @@ class PitchDrumMatrix {
 
         this.pitchDrumDiv = document.createElement("div");
         widgetWindow.getWidgetBody().append(this.pitchDrumDiv);
-        widgetWindow.getWidgetBody().style.height = "300px";
-        widgetWindow.getWidgetBody().style.width = "300px";
+        widgetWindow.getWidgetBody().style.height = "400px";
+        widgetWindow.getWidgetBody().style.width = "400px";
 
         // The pdm table
         const pdmTableDiv = this.pitchDrumDiv;
@@ -200,10 +200,10 @@ class PitchDrumMatrix {
         const outerDiv = docById("pdmOuterDiv");
         let ow;
         if (pdmTable.rows.length + 2 > n) {
-            outerDiv.style.height = window.innerHeight / 2 + "px";
+            outerDiv.style.height = widgetWindow.getWidgetBody().style.height;
             ow = Math.max(
                 Math.min(
-                    window.innerWidth / 2,
+                    widgetWindow.getWidgetBody().style.width,
                     this._cellScale *
                         (this.drums.length * (PitchDrumMatrix.DRUMNAMEWIDTH + 2) +
                             MATRIXSOLFEWIDTH +
@@ -227,12 +227,9 @@ class PitchDrumMatrix {
         outerDiv.style.width = ow + "px";
 
         const innerDiv = docById("pdmInnerDiv");
-        const iw = Math.min(
-            ow - 100,
-            this._cellScale * this.drums.length * (PitchDrumMatrix.DRUMNAMEWIDTH + 2)
-        );
-        innerDiv.style.width = iw + "px";
-        innerDiv.style.marginLeft = PitchDrumMatrix.BUTTONSIZE * this._cellScale + "px";
+        innerDiv.style.height = widgetWindow.getWidgetBody().style.height;
+        innerDiv.style.width = widgetWindow.getWidgetBody().style.width;
+        innerDiv.style.marginLeft = "0px";
 
         pdmCell = pdmTableRow.insertCell();
         // Create table to store drum names.
@@ -257,8 +254,11 @@ class PitchDrumMatrix {
             } else {
                 widgetWindow.getWidgetBody().style.position = "relative";
                 widgetWindow.getWidgetBody().style.left = "0px";
-                widgetWindow.getWidgetBody().style.height = "300px";
-                widgetWindow.getWidgetBody().style.width = "300px";
+                widgetWindow.getWidgetBody().style.height = "400px";
+                widgetWindow.getWidgetBody().style.width = "400px";
+                const innerDiv = docById("pdmInnerDiv");
+                innerDiv.style.height = widgetWindow.getWidgetBody().style.height;
+                innerDiv.style.width = widgetWindow.getWidgetBody().style.width;
             }
         };
 

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -250,6 +250,7 @@ class PitchDrumMatrix {
                 docById("pdmOuterDiv").style.height = "calc(100vh - 80px)";
                 docById("pdmOuterDiv").style.width = "calc(200vh - 64px)";
                 docById("pdmInnerDiv").style.width = "calc(200vh - 64px)";
+                docById("pdmInnerDiv").style.height= "calc(100vh - 80px)";
                 widgetWindow.getWidgetBody().style.left = "70px";
             } else {
                 widgetWindow.getWidgetBody().style.position = "relative";
@@ -604,7 +605,9 @@ class PitchDrumMatrix {
             },pairs.length*1000);
         }
         else{
-            logo.textMsg(_("Click in the grid to map notes to drums."));
+            if(!this.widgetWindow._maximized){
+                logo.textMsg(_("Click in the grid to map notes to drums."));
+            }
             icon.innerHTML =
                 '&nbsp;&nbsp;<img src="header-icons/' +
                 "play-button.svg" +

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -15,8 +15,7 @@
 /*
    global logo, blocks, turtles, platformColor, _, docById, getNote, getDrumName, getDrumIcon,
    getDrumSynthName, Singer, MATRIXSOLFEHEIGHT, MATRIXSOLFEWIDTH, SOLFEGECONVERSIONTABLE
- */
-
+*/
 /*
    Global locations
     js/activity.js
@@ -29,7 +28,6 @@
     js/utils/platformstyle.js
         platformColor
 */
-
 /*exported PitchDrumMatrix */
 
 class PitchDrumMatrix {
@@ -45,7 +43,7 @@ class PitchDrumMatrix {
         this.rowArgs = [];
         this.drums = [];
         this._rests = 0;
-
+        this._playing = false;
         // The pitch-block number associated with a row; a drum block is
         // associated with a column. We need to keep track of which
         // intersections in the grid are populated.  The blockMap is a
@@ -75,11 +73,14 @@ class PitchDrumMatrix {
         widgetWindow.clear();
         widgetWindow.show();
 
-        widgetWindow.addButton(
+        this.playButton = widgetWindow.addButton(
             "play-button.svg",
             PitchDrumMatrix.ICONSIZE,
             _("Play")
-        ).onclick = () => {
+        );
+
+        this.playButton.onclick = () => {
+            this._playing = !(this._playing);
             logo.turtleDelay = 0;
             this._playAll();
         };
@@ -521,6 +522,35 @@ class PitchDrumMatrix {
      */
     _playAll() {
         // Play all of the pitch/drum combinations in the matrix.
+        const icon = this.playButton;
+        if(this._playing){
+            icon.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' +
+            "stop-button.svg" +
+            '" title="' +
+            _("Stop") +
+            '" alt="' +
+            _("Stop") +
+            '" height="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" width="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+        }
+        else{
+            icon.innerHTML =
+            '&nbsp;&nbsp;<img src="header-icons/' +
+            "play-button.svg" +
+            '" title="' +
+            _("Play") +
+            '" alt="' +
+            _("Play") +
+            '" height="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" width="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+            return;
+        }
         logo.synth.stop();
 
         const pairs = [];
@@ -546,11 +576,49 @@ class PitchDrumMatrix {
                 pairs.push([i, -1]);
             }
         }
-
-        const ii = 0;
-        if (ii < pairs.length) {
-            this._playPitchDrum(ii, pairs);
+        let isEmpty = true;
+        for(let i = 0;i < pairs.length;i++){
+            if(pairs[i][1]!=-1){
+                isEmpty = false;
+                break;
+            }
         }
+        if(!isEmpty){
+            const ii = 0;
+            if (ii < pairs.length) {
+                this._playPitchDrum(ii, pairs);
+            }
+            setTimeout(() => {
+                icon.innerHTML =
+                '&nbsp;&nbsp;<img src="header-icons/' +
+                "play-button.svg" +
+                '" title="' +
+                _("Play") +
+                '" alt="' +
+                _("Play") +
+                '" height="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" width="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+            },pairs.length*1000);
+        }
+        else{
+            logo.textMsg(_("Click in the grid to map notes to drums."));
+            icon.innerHTML =
+                '&nbsp;&nbsp;<img src="header-icons/' +
+                "play-button.svg" +
+                '" title="' +
+                _("Play") +
+                '" alt="' +
+                _("Play") +
+                '" height="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" width="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+        }
+        
     }
 
     /**
@@ -561,11 +629,29 @@ class PitchDrumMatrix {
      */
     _playPitchDrum(i, pairs) {
         // Find the drum cell
+        let pdmTable = docById("pdmTable");
+        if(!this._playing){
+            for (let j = 0; j < i; j++) {
+                pdmTable.rows[j].cells[0].style.backgroundColor = platformColor.labelColor;
+            }
+            const icon = this.playButton;
+            icon.innerHTML =
+            '&nbsp;&nbsp;<img src="header-icons/' +
+            "play-button.svg" +
+            '" title="' +
+            _("Play") +
+            '" alt="' +
+            _("Play") +
+            '" height="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" width="' +
+            PitchDrumMatrix.ICONSIZE +
+            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+            return;
+        }
         const drumTable = docById("pdmDrumTable");
         let row = drumTable.rows[0];
         // const drumCell = row.cells[i];
-
-        let pdmTable = docById("pdmTable");
         const table = docById("pdmCellTable" + i);
         row = table.rows[0];
         const cell = row.cells[i];

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -80,7 +80,7 @@ class PitchDrumMatrix {
         );
 
         this.playButton.onclick = () => {
-            this._playing = !(this._playing);
+            this._playing = !this._playing;
             logo.turtleDelay = 0;
             this._playAll();
         };
@@ -250,7 +250,7 @@ class PitchDrumMatrix {
                 docById("pdmOuterDiv").style.height = "calc(100vh - 80px)";
                 docById("pdmOuterDiv").style.width = "calc(200vh - 64px)";
                 docById("pdmInnerDiv").style.width = "calc(200vh - 64px)";
-                docById("pdmInnerDiv").style.height= "calc(100vh - 80px)";
+                docById("pdmInnerDiv").style.height = "calc(100vh - 80px)";
                 widgetWindow.getWidgetBody().style.left = "70px";
             } else {
                 widgetWindow.getWidgetBody().style.position = "relative";
@@ -524,32 +524,32 @@ class PitchDrumMatrix {
     _playAll() {
         // Play all of the pitch/drum combinations in the matrix.
         const icon = this.playButton;
-        if(this._playing){
-            icon.innerHTML = '&nbsp;&nbsp;<img src="header-icons/' +
-            "stop-button.svg" +
-            '" title="' +
-            _("Stop") +
-            '" alt="' +
-            _("Stop") +
-            '" height="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" width="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-        }
-        else{
+        if (this._playing) {
             icon.innerHTML =
-            '&nbsp;&nbsp;<img src="header-icons/' +
-            "play-button.svg" +
-            '" title="' +
-            _("Play") +
-            '" alt="' +
-            _("Play") +
-            '" height="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" width="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+                '&nbsp;&nbsp;<img src="header-icons/' +
+                "stop-button.svg" +
+                '" title="' +
+                _("Stop") +
+                '" alt="' +
+                _("Stop") +
+                '" height="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" width="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+        } else {
+            icon.innerHTML =
+                '&nbsp;&nbsp;<img src="header-icons/' +
+                "play-button.svg" +
+                '" title="' +
+                _("Play") +
+                '" alt="' +
+                _("Play") +
+                '" height="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" width="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
             return;
         }
         logo.synth.stop();
@@ -578,34 +578,33 @@ class PitchDrumMatrix {
             }
         }
         let isEmpty = true;
-        for(let i = 0;i < pairs.length;i++){
-            if(pairs[i][1]!=-1){
+        for (let i = 0; i < pairs.length; i++) {
+            if (pairs[i][1] != -1) {
                 isEmpty = false;
                 break;
             }
         }
-        if(!isEmpty){
+        if (!isEmpty) {
             const ii = 0;
             if (ii < pairs.length) {
                 this._playPitchDrum(ii, pairs);
             }
             setTimeout(() => {
                 icon.innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/' +
-                "play-button.svg" +
-                '" title="' +
-                _("Play") +
-                '" alt="' +
-                _("Play") +
-                '" height="' +
-                PitchDrumMatrix.ICONSIZE +
-                '" width="' +
-                PitchDrumMatrix.ICONSIZE +
-                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
-            },pairs.length*1000);
-        }
-        else{
-            if(!this.widgetWindow._maximized){
+                    '&nbsp;&nbsp;<img src="header-icons/' +
+                    "play-button.svg" +
+                    '" title="' +
+                    _("Play") +
+                    '" alt="' +
+                    _("Play") +
+                    '" height="' +
+                    PitchDrumMatrix.ICONSIZE +
+                    '" width="' +
+                    PitchDrumMatrix.ICONSIZE +
+                    '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+            }, pairs.length * 1000);
+        } else {
+            if (!this.widgetWindow._maximized) {
                 logo.textMsg(_("Click in the grid to map notes to drums."));
             }
             icon.innerHTML =
@@ -621,7 +620,6 @@ class PitchDrumMatrix {
                 PitchDrumMatrix.ICONSIZE +
                 '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
         }
-        
     }
 
     /**
@@ -633,23 +631,23 @@ class PitchDrumMatrix {
     _playPitchDrum(i, pairs) {
         // Find the drum cell
         let pdmTable = docById("pdmTable");
-        if(!this._playing){
+        if (!this._playing) {
             for (let j = 0; j < i; j++) {
                 pdmTable.rows[j].cells[0].style.backgroundColor = platformColor.labelColor;
             }
             const icon = this.playButton;
             icon.innerHTML =
-            '&nbsp;&nbsp;<img src="header-icons/' +
-            "play-button.svg" +
-            '" title="' +
-            _("Play") +
-            '" alt="' +
-            _("Play") +
-            '" height="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" width="' +
-            PitchDrumMatrix.ICONSIZE +
-            '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+                '&nbsp;&nbsp;<img src="header-icons/' +
+                "play-button.svg" +
+                '" title="' +
+                _("Play") +
+                '" alt="' +
+                _("Play") +
+                '" height="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" width="' +
+                PitchDrumMatrix.ICONSIZE +
+                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
             return;
         }
         const drumTable = docById("pdmDrumTable");


### PR DESCRIPTION
The pitchdrum-mapper widget did not have a STOP functionality which meant that whenever a user clicked the PLAY button, the sound started playing irrespective of whether it was already playing or not. Thus, if once the PLAY button is clicked, if it is clicked again, the sound would start playing from the first note again in addition to the already playing sounds. Additionally, one could not stop the sound in any way. It also started playing even when no cells were selected to be played. Also, some rows of cells along with the drum row could not be accessed without maximizing the widget in case of a larger grid, and there existed a wide gap between the control buttons and the grid. This patch solves all these issues.

## Before:
The PLAY button is clicked twice in the video below, and one can notice multiple sounds at once.

https://user-images.githubusercontent.com/60084414/111583325-3b2b8a80-87e2-11eb-85d0-302f28b71b79.mp4

## After:

https://user-images.githubusercontent.com/60084414/111584139-7ed2c400-87e3-11eb-8d1a-3ffc403cd4d4.mp4


Please share your feedback @walterbender @meganindya.
Thanks.
