### PR TITLE
fixes #2907: When new project button is pressed, the original project is first saved

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2920,19 +2920,12 @@ function Activity() {
      * Sets up a new "clean" MB i.e. new project instance
      */
     _afterDelete = function () {
-
-        planet.saveLocally();
-        planet.initialiseNewProject();
-        that._loadStart();
-        planet.saveLocally();
-
-        /*
-        toolbar.closeAuxToolbar(_showHideAuxMenu);
-        sendAllToTrash(true, false);
         if (planet !== undefined) {
-            planet.initialiseNewProject.bind(planet);
-        }
-        */
+            planet.saveLocally();
+            planet.initialiseNewProject();
+            that._loadStart();
+            planet.saveLocally();
+        }  
     };
 
     /**

--- a/js/activity.js
+++ b/js/activity.js
@@ -2920,11 +2920,19 @@ function Activity() {
      * Sets up a new "clean" MB i.e. new project instance
      */
     _afterDelete = function () {
+
+        planet.saveLocally();
+        planet.initialiseNewProject();
+        that._loadStart();
+        planet.saveLocally();
+
+        /*
         toolbar.closeAuxToolbar(_showHideAuxMenu);
         sendAllToTrash(true, false);
         if (planet !== undefined) {
             planet.initialiseNewProject.bind(planet);
         }
+        */
     };
 
     /**

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -313,11 +313,15 @@ class Toolbar {
      * @returns {void}
      */
     renderNewProjectIcon(onclick) {
+        
         const newProjectIcon = docById("new-project");
-
         newProjectIcon.onclick = () => {
+            //docById("toolbars").style.display = "none";
+            //docById("wheelDiv").style.display = "none";
+            //docById("contextWheelDiv").style.display = "none";
             onclick();
         };
+
     }
 
     /**

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -313,15 +313,11 @@ class Toolbar {
      * @returns {void}
      */
     renderNewProjectIcon(onclick) {
-        
         const newProjectIcon = docById("new-project");
+
         newProjectIcon.onclick = () => {
-            //docById("toolbars").style.display = "none";
-            //docById("wheelDiv").style.display = "none";
-            //docById("contextWheelDiv").style.display = "none";
             onclick();
         };
-
     }
 
     /**


### PR DESCRIPTION
Previously, the new project button on the main screen would overwrite the current project and replace it with a fresh one. This pull request saves the current project before creating a new one. 