### PR TITLE
Bug Fix: Force stop runnning project on New Project

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2921,7 +2921,15 @@ function Activity() {
      */
     _afterDelete = function () {
         toolbar.closeAuxToolbar(_showHideAuxMenu);
-        sendAllToTrash(true, false);
+
+        if(turtles.running()){
+            that.doHardStopButton();
+        }
+
+        setTimeout(() => {
+            sendAllToTrash(true, false);
+        },1000);
+        
         if (planet !== undefined) {
             planet.initialiseNewProject.bind(planet);
         }


### PR DESCRIPTION
Issue Reference: #2925

- Force stops the already running project.
- Displays the stopped project and then opens the new project.
- End Result:

https://user-images.githubusercontent.com/60084414/115680349-1e4e1e00-a371-11eb-91b3-1ba8ec16c86f.mp4
