### PR TITLE
Regression Fix: Add check to avoid name undefined errors

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4517,16 +4517,21 @@ function Blocks(activity) {
         }
 
         const myBlock = this.blockList[blk];
-
-        if (["pitch", "setpitchnumberoffset", "invert1", "tofrequency", "nthmodalpitch"].indexOf(
+        if (
+            myBlock.connections[0] !== null &&
+            ["pitch", "setpitchnumberoffset", "invert1", "tofrequency", "nthmodalpitch"].indexOf(
                 this.blockList[myBlock.connections[0]].name
             ) !== -1 &&
-            this.blockList[myBlock.connections[0]].connections[2] === blk) {
+            this.blockList[myBlock.connections[0]].connections[2] === blk
+        ) {
             return true;
         }
 
-        if (this.blockList[myBlock.connections[0]].name === "customsample" &&
-            this.blockList[myBlock.connections[0]].connections[3] === blk) {
+        if (
+            myBlock.connections[0] !== null &&
+            this.blockList[myBlock.connections[0]].name === "customsample" &&
+            this.blockList[myBlock.connections[0]].connections[3] === blk
+        ) {
             return true;
         }
 


### PR DESCRIPTION
An attempt to fix a part of #2928.

This PR fixes the regression in which the octave arg block would remain sticky with the mouse cursor upon clicking in its detached state from its parent block and would generate errors. To fix this, a condition/check is added to the `octaveNumber` method to check if the block has connections or not.

### Before:

https://user-images.githubusercontent.com/60084414/116188165-8a9b9980-a744-11eb-9396-e26615dab26b.mp4

### After:

https://user-images.githubusercontent.com/60084414/116188215-a99a2b80-a744-11eb-8d95-a93586dc624c.mp4

