### PR TITLE
Fixed : NaN appearing in Stats

### DIFF
--- a/js/rubrics.js
+++ b/js/rubrics.js
@@ -779,21 +779,33 @@ const getStatsFromNotation = (logo) => {
                     } else {
                         freq = logo.synth._getFrequency(note);
                     }
-                    projectStats["pitchNames"].add(note.slice(0, note.length - 1));
-                    projectStats["pitches"].push(freq);
-                    if (
-                        projectStats["lowestNote"] == undefined ||
-                        freq < projectStats["lowestNote"][2]
-                    ) {
-                        projectStats["lowestNote"] = [note, noteId, freq];
+                    if (note.slice(0, note.length - 1) === "") {
+                        projectStats["pitchNames"].add("R");
+                    } else {
+                        projectStats["pitchNames"].add(note.slice(0, note.length - 1));
                     }
-                    if (
-                        projectStats["highestNote"] == undefined ||
-                        freq > projectStats["highestNote"][2]
-                    ) {
-                        projectStats["highestNote"] = [note, noteId, freq];
+
+                    projectStats["pitches"].push(freq);
+                    if (projectStats["lowestNote"] == undefined) {
+                        if (!isNaN(freq)) {
+                            projectStats["lowestNote"] = [note, noteId, freq];
+                        }
+                    } else {
+                        if (freq < projectStats["lowestNote"][2]) {
+                            projectStats["lowestNote"] = [note, noteId, freq];
+                        }
+                    }
+                    if (projectStats["highestNote"] == undefined) {
+                        if (!isNaN(freq)) {
+                            projectStats["highestNote"] = [note, noteId, freq];
+                        }
+                    } else {
+                        if (freq > projectStats["highestNote"][2]) {
+                            projectStats["highestNote"] = [note, noteId, freq];
+                        }
                     }
                     projectStats["numberOfNotes"]++;
+
                     noteId++;
                 }
             }


### PR DESCRIPTION
Issue Reference : #2896

Fixed the issue with the R note, when R(silence) note is played before any note, NaN frequency is shown in stats.
Also R is also missing in the pitch names section.

## Before Change


https://user-images.githubusercontent.com/66181127/116986022-e9d04f80-acea-11eb-8c54-7fbe06d9da16.mov


## After Change


https://user-images.githubusercontent.com/66181127/116986031-edfc6d00-acea-11eb-8ffb-59c19e035a7b.mov


### If only R is placed then no information is printed in Stats


https://user-images.githubusercontent.com/66181127/116986323-45024200-aceb-11eb-8a3c-2cf858dd56c4.mov

Please share feedback and suggestions. Thanks
@walterbender
