### PR TITLE
Fix: Print simultaneous with the note

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -324,12 +324,14 @@ function setupExtrasBlocks() {
                             if (logo.blocks.blockList[cblk].name === "grid"){
                                 const temp = new DisplayGridBlock();
                                 temp.flow(args,logo,turtle,blk);
-                            } else if (args[0] === undefined) {
-                                logo.textMsg("undefined");
-                            } else if (args[0] === null) {
-                                logo.textMsg("null");
-                            } else {
-                                logo.textMsg(args[0].toString());
+                            } 
+                            else{
+                                const tur = logo.turtles.ithTurtle(turtle);
+                                if (tur.singer.inNoteBlock.length > 0) {
+                                    tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(
+                                        blk
+                                    );
+                                }
                             }
                         } else if (logo.runningLilypond) {
                             if (tur.singer.inNoteBlock.length > 0) {


### PR DESCRIPTION
Issue Reference: #2935 

- Print block is now simultaneous with the note like in the Show block.
- Arguments are firstly passed in the `parseArg` method(which is already done in the case of the Show block) in `logo.js` file and are printed using the `__print` function instead of directly printing with by the `textMsg` function.

### End Result:
https://user-images.githubusercontent.com/60084414/116988619-3ff2c200-acee-11eb-8f26-d011e275c85c.mp4

