### PR TITLE
"Duplicate" now only duplicates the selected block

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4859,7 +4859,7 @@ function Blocks(activity) {
             return;
         }
 
-        this.selectedStack = this.findTopBlock(this.activeBlock);
+        this.selectedStack = this.activeBlock;
 
         // Copy the selectedStack.
         this.selectedBlocksObj = JSON.parse(JSON.stringify(this._copyBlocksToObj(false)));


### PR DESCRIPTION
Currently, when you bring up the pie menu on a block and press duplicate, it duplicates the entire chunk that the block is part of. This is inconsistent with the behavior of "extract", which only extracts that block. The modified code changes the `this.selectedstack`  assignment in `prepareStackForCopy()` from getting the top level block to the active block.