### PR TITLE
Added Meta Description for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@
             concepts.
         </title>
 
+	<meta name="description" content="Learn coding through music with Music Blocks. Arrange colorful blocks to create everything from simple melodies to games.">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height"/>
-
+	
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
         <link href="https://fonts.googleapis.com/css2?family=PT+Mono&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="css/activities.css" />


### PR DESCRIPTION
What problem is this PR trying to fix?

If you search for "Music Blocks" in a search engine (e.g. Google), you get several relevant options. One of the options, thankfully, is musicblocks.sugarlabs.org

However, the description that is displayed in a query is a mess and could be offputting to someone who stumbles upon Music Blocks in a search. Plus, without any other descriptive words, it limits which search words would point to Music Blocks.

![Screen Shot 2021-12-27 at 8 51 20 PM](https://user-images.githubusercontent.com/13454579/147520137-3fb6b29a-9edf-47fa-9651-36d2f48990e6.png)

I don't really know if this fixes it, and cannot really test, but found the info on https://ahrefs.com/blog/seo-meta-tags/

I noticed we did not have a Meta Description Parameter as in `<meta name="description" content="Place the meta description text here.">`

This adds one.