### PR TITLE
Updated "help window carousel" with title of blocks

### DIFF
--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -336,6 +336,9 @@ function setupBooleanBlocks(activity) {
                 "documentation",
                 ""
             ]);
+            this.formBlock({
+                name: "boolean"
+            });
         }
 
         arg(logo, turtle, blk) {

--- a/js/blocks/DrumBlocks.js
+++ b/js/blocks/DrumBlocks.js
@@ -21,7 +21,7 @@
 function setupDrumBlocks(activity) {
     class NoiseNameBlock extends ValueBlock {
         constructor() {
-            super("noisename");
+            super("noisename", _("noise name"));
             this.setPalette("drum", activity);
             this.formBlock({ outType: "textout" });
             this.extraWidth = 50;
@@ -37,7 +37,7 @@ function setupDrumBlocks(activity) {
 
     class DrumNameBlock extends ValueBlock {
         constructor() {
-            super("drumname");
+            super("drumname", _("drum name"));
             this.setPalette("drum", activity);
             this.formBlock({ outType: "textout" });
             this.extraWidth = 50;
@@ -52,7 +52,7 @@ function setupDrumBlocks(activity) {
 
     class EffectsNameBlock extends ValueBlock {
         constructor() {
-            super("effectsname");
+            super("effectsname", _("effects name"));
             this.setPalette("drum", activity);
             this.formBlock({ outType: "textout" });
             this.extraWidth = 50;

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -64,7 +64,7 @@ function setupIntervalsBlocks(activity) {
 
     class TemperamentNameBlock extends ValueBlock {
         constructor() {
-            super("temperamentname");
+            super("temperamentname", _("temperament name"));
             this.setPalette("tone", activity);
             this.setHelpString([
                 _("The Temperament name block is used to select a tuning method."),

--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -299,7 +299,7 @@ function setupMediaBlocks(activity) {
 
     class CameraBlock extends ValueBlock {
         constructor() {
-            super("camera");
+            super("camera", _("camera"));
             this.setPalette("media", activity);
             this.setHelpString([
                 _("The Camera block connects a webcam to the Show block."),
@@ -314,7 +314,7 @@ function setupMediaBlocks(activity) {
 
     class VideoBlock extends ValueBlock {
         constructor() {
-            super("video");
+            super("video", _("video"));
             this.setPalette("media", activity);
             this.setHelpString([
                 _("The Video block selects video for use with the Show block."),
@@ -329,7 +329,7 @@ function setupMediaBlocks(activity) {
 
     class LoadFileBlock extends ValueBlock {
         constructor() {
-            super("loadFile", "");
+            super("loadFile", _("open file"));
             this.setPalette("media", activity);
             this.setHelpString([
                 _(
@@ -534,7 +534,7 @@ function setupMediaBlocks(activity) {
 
     class MediaBlock extends ValueBlock {
         constructor() {
-            super("media");
+            super("media", _("media"));
             this.setPalette("media", activity);
             this.beginnerBlock(true);
 
@@ -564,7 +564,7 @@ function setupMediaBlocks(activity) {
 
     class TextBlock extends ValueBlock {
         constructor() {
-            super("text");
+            super("text", _("text"));
             this.extraWidth = 30;
             this.setPalette("media", activity);
             this.beginnerBlock(true);

--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -904,7 +904,7 @@ function setupNumberBlocks(activity) {
 
     class NumberBlock extends ValueBlock {
         constructor() {
-            super("number");
+            super("number", _("number"));
             this.setPalette("number", activity);
             this.beginnerBlock(true);
 

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -413,7 +413,7 @@ function setupPitchBlocks(activity) {
 
     class OutputToolsBlocks extends LeftBlock {
         constructor() {
-            super("outputtools");
+            super("outputtools", _("pitch converter"));
             this.setPalette("pitch", activity);
             this.beginnerBlock(true);
             this.extraWidth = 50;
@@ -825,7 +825,7 @@ function setupPitchBlocks(activity) {
 
     class AccidentalNameBlock extends ValueBlock {
         constructor() {
-            super("accidentalname");
+            super("accidentalname", _("accidental selector"));
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _(
@@ -841,7 +841,7 @@ function setupPitchBlocks(activity) {
 
     class EastIndianSolfegeBlock extends ValueBlock {
         constructor() {
-            super("eastindiansolfege");
+            super("eastindiansolfege", _("east indian solfege"));
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of ni dha pa ma ga re sa."),
@@ -855,7 +855,7 @@ function setupPitchBlocks(activity) {
 
     class NoteNameBlock extends ValueBlock {
         constructor() {
-            super("notename");
+            super("notename", _("note name"));
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of C D E F G A B."),
@@ -869,7 +869,7 @@ function setupPitchBlocks(activity) {
 
     class SolfegeBlock extends ValueBlock {
         constructor() {
-            super("solfege");
+            super("solfege", _("solfede"));
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of do re mi fa sol la ti."),
@@ -1707,7 +1707,7 @@ function setupPitchBlocks(activity) {
     class ScaleDegree2Block extends ValueBlock {
         constructor() {
             //.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-            super("scaledegree2");
+            super("scaledegree2", _("scale degree"));
             this.setPalette("pitch", activity);
             this.extraWidth = 10;
             this.setHelpString([

--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -596,7 +596,7 @@ function setupToneBlocks(activity) {
 
     class VoiceNameBlock extends ValueBlock {
         constructor() {
-            super("voicename");
+            super("voicename", _("set instrument"));
             this.setPalette("tone", activity);
             this.setHelpString([
                 _(
@@ -758,7 +758,7 @@ function setupToneBlocks(activity) {
 
     class AudioFileBlock extends ValueBlock {
         constructor() {
-            super("audiofile");
+            super("audiofile", _("audio file"));
             this.parameter = true;
             this.extraWidth = 20;
             this.setPalette("tone", activity);


### PR DESCRIPTION
Fixes: #3014 
Enhanced the "help window carousel" with titles similar to other blocks, like shown below-
![imgonline-com-ua-twotoone-rG0saedFJeAY9vJo](https://user-images.githubusercontent.com/86892991/147856448-d8d18e1f-12cf-44cc-85c9-8fd9bed8bd97.jpg)