### PR TITLE
add popup message style: color, font, position

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1453,16 +1453,15 @@ input.timbreName {
  }
 
  .popupMsg {
-    width: 1000px;
-    height: 30px;
+    width: 50%;
+    height: 3%;
     position: absolute;
     top: 130px;
-    left: 50%;
-    margin-left: -500px;
-    padding-top: 2px;
+    left: 25%;
+    padding-top: 8px;
     border-radius: 8px;
-    background-color: white;
-    font-family: Arial, Helvetica, sans-serif;
+    background-color: #8CC6FF;
+    font-family: "Roboto", sans-serif;
     font-size: 19px;
     text-align: center;
     overflow: hidden;
@@ -1470,6 +1469,10 @@ input.timbreName {
     cursor: pointer;
     visibility: hidden;
 }
+
+ .popupMsg a {
+    color: #5c5c5c
+ }
 
 #palette td ,thead ,tr ,table {
     border-collapse: collapse;
@@ -1494,7 +1497,7 @@ input.timbreName {
 
  #printTextContent, #errorTextContent {
     display: inline-block;
-    width: 940px;
+    width: calc(100% - 60px);
     vertical-align: 7px;
   }
 

--- a/css/activities.css
+++ b/css/activities.css
@@ -1471,7 +1471,7 @@ input.timbreName {
 }
 
  .popupMsg a {
-    color: #5c5c5c
+    color: black;
  }
 
 #palette td ,thead ,tr ,table {


### PR DESCRIPTION
Fixes #3026 
Popup message from language select needed CSS styling.
Before
<img width="1255" alt="Screen Shot 2022-04-19 at 02 13 21" src="https://user-images.githubusercontent.com/90356606/163938275-e05a663e-2e65-4498-acb3-91111b41d8c6.png">
After
<img width="1256" alt="Screen Shot 2022-04-19 at 02 15 54" src="https://user-images.githubusercontent.com/90356606/163938280-677efb20-e609-4448-8be4-e8d54453c754.png">
I made the background color, text color, and font consistent with the theme of the rest of the program.  I also adjusted the positioning of the popup and its contents so that it scales properly with viewport resizing.  Note that all popup messages are now styled accordingly.
