### PR TITLE
add percent symbol to pitch offsets in custom temperaments for user clarity

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3153,7 +3153,7 @@ function Blocks(activity) {
             const len = this.activity.logo.synth.startingPitch.length;
             postProcessArg = [
                 thisBlock,
-                this.activity.logo.synth.startingPitch.substring(0, len - 1) + "(+0)"
+                this.activity.logo.synth.startingPitch.substring(0, len - 1) + "(+0%)"
             ];
         } else if (name === "notename") {
             postProcessArg = [thisBlock, "G"];

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -1097,7 +1097,7 @@ function setupPitchBlocks(activity) {
             this.setPalette("pitch", activity);
             this.makeMacro((x, y) => [
                 [0, "pitch", x, y, [null, 1, 2, null]],
-                [1, ["customNote", { value: "C(+0)" }], 0, 0, [0]],
+                [1, ["customNote", { value: "C(+0%)" }], 0, 0, [0]],
                 [2, ["number", { value: 4 }], 0, 0, [0]]
             ]);
             this.hidden = true;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -365,7 +365,7 @@ function TemperamentWidget() {
                             this.ratiosNotesPair[index][1] +
                             "(- " +
                             centsDiff1[index].toFixed(2) +
-                            ")" +
+                            "%)" +
                             "</div>";
                     } else {
                         docById("noteInfo").innerHTML +=
@@ -375,7 +375,7 @@ function TemperamentWidget() {
                             this.ratiosNotesPair[index][1] +
                             "(+ " +
                             centsDiff1[index].toFixed(2) +
-                            ")" +
+                            "%)" +
                             "</div>";
                     }
                 }
@@ -1516,7 +1516,7 @@ function TemperamentWidget() {
                     if (this.ratios[i] == this.ratiosNotesPair[j][0]) {
                         notesMatch = true;
                         this.notes[i] =
-                            this.ratiosNotesPair[j][1][0] + "(+0)" + this.ratiosNotesPair[j][1][1];
+                            this.ratiosNotesPair[j][1][0] + "(+0%)" + this.ratiosNotesPair[j][1][1];
                         break;
                     }
                 }
@@ -1538,14 +1538,14 @@ function TemperamentWidget() {
                             this.ratiosNotesPair[index][1][0] +
                             "(-" +
                             centsDiff1[index].toFixed(0) +
-                            ")" +
+                            "%)" +
                             this.ratiosNotesPair[index][1][1];
                     } else {
                         this.notes[i] =
                             this.ratiosNotesPair[index][1][0] +
                             "(+" +
                             centsDiff1[index].toFixed(0) +
-                            ")" +
+                            "%)" +
                             this.ratiosNotesPair[index][1][1];
                     }
                 }
@@ -1634,7 +1634,7 @@ function TemperamentWidget() {
                         [
                             "text",
                             {
-                                value: this.notes[i].substring(0, this.notes[i].length - 1)
+                                value: (this.notes[i].substring(0, this.notes[i].length - 1))
                             }
                         ],
                         0,


### PR DESCRIPTION
Issue #2867 

There has been much discussion surrounding the labeling of the temperament widget.  It appears that the initial issue of mislabeling with an octave space other than 2:1 has been fixed, but the way the offsets were labeled remained confusing and a source of concern as the offsets had no units to tell how the frequency was augmented.  Upon hours of digging and testing, I uncovered that the offsets were actually in terms of percentage of a codified note.  To make this clearer and to alleviate any further concerns about labeling bugs, I have added the percentage unit in the custom temperament definition stack, the custom pitch block, and the temperament widget.  It is a simple change, but as we have been nagged about in our science classes, units are informative and essential for contextualization.

(note that there are two custom pitch blocks on the canvas and one is covered by the temperament widget to show all of the locations of the changes)

Before
<img width="1250" alt="Screen Shot 2022-04-20 at 21 28 28" src="https://user-images.githubusercontent.com/90356606/164353487-ac3e2626-a273-4e64-b090-7c284980733d.png">

After
<img width="1251" alt="Screen Shot 2022-04-20 at 21 24 44" src="https://user-images.githubusercontent.com/90356606/164353510-706200d4-6fa4-4e76-b79a-144a37372ae5.png">
