### PR TITLE
Regression Resolved

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3331,30 +3331,27 @@ function _getStepSize(keySignature, pitch, direction, transposition, temperament
         thisPitch = STOSHARP[thisPitch];
     } 
 
-        function logicalEquals(s1,s2) {
+    function logicalEquals(s1,s2) {
             // console.debug(s1,s2);
-        if(s1==s2)
-        {
+        if(s1==s2) {
+            return true;
+        } else if(s1=="E♯"&&s2=="F") {
+            return true;
+        } else if(s1=="E"&&s2=="F♭") {
+            return true;
+        } else if(s1=="F"&&s2=="E♯") {
+            return true;
+        } else if(s1=="F♭"&&s2=="E") {
+            return true;
+        } else if(s1=="B♯"&&s2=="C") {
+            return true;
+        } else if(s1=="B"&&s2=="C♭") {
+            return true;
+        } else if(s1=="C"&&s2=="B♯") {
+            return true;
+        } else if(s1=="C♭"&&s2=="B") {
             return true;
         }
-        else if(s1=="E♯"&&s2=="F")
-        {
-            return true;
-        }
-        else if(s1=="E"&&s2=="F♭")
-        {
-            return true;
-        }
-        
-        else if(s1=="F"&&s2=="E♯")
-        {
-            return true;
-        }
-        else if(s1=="F♭"&&s2=="E")
-        {
-            return true;
-        }
-        
         return false;
       }
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3329,9 +3329,37 @@ function _getStepSize(keySignature, pitch, direction, transposition, temperament
         thisPitch = BTOFLAT[thisPitch];
     } else if (thisPitch in STOSHARP) {
         thisPitch = STOSHARP[thisPitch];
-    }
+    } 
 
-    let ii = scale.indexOf(thisPitch);
+        function logicalEquals(s1,s2) {
+            // console.debug(s1,s2);
+        if(s1==s2)
+        {
+            return true;
+        }
+        else if(s1=="E♯"&&s2=="F")
+        {
+            return true;
+        }
+        else if(s1=="E"&&s2=="F♭")
+        {
+            return true;
+        }
+        
+        else if(s1=="F"&&s2=="E♯")
+        {
+            return true;
+        }
+        else if(s1=="F♭"&&s2=="E")
+        {
+            return true;
+        }
+        
+        return false;
+      }
+
+    let ii = scale.findIndex(scale => logicalEquals(scale, pitch)); //indexOf() replaced by findIndex()
+    // let ii = scale.indexOf(thisPitch);
     if (ii !== -1) {
         if (direction === "up") {
             return halfSteps[ii];

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3228,8 +3228,7 @@ function _calculate_pitch_number(activity, np, tur) {
                 // Hertz
                 obj = frequencyToPitch(np);
             }
-
-        } catch(e) {
+        } catch (e) {
             activity.errorMsg(INVALIDPITCH);
             obj = ["G", 4];
         }
@@ -3329,33 +3328,33 @@ function _getStepSize(keySignature, pitch, direction, transposition, temperament
         thisPitch = BTOFLAT[thisPitch];
     } else if (thisPitch in STOSHARP) {
         thisPitch = STOSHARP[thisPitch];
-    } 
+    }
 
-    function logicalEquals(s1,s2) {
-            // console.debug(s1,s2);
-        if(s1==s2) {
+    function logicalEquals(s1, s2) {
+        // console.debug(s1,s2);
+        if (s1 == s2) {
             return true;
-        } else if(s1=="E♯"&&s2=="F") {
+        } else if (s1 == "E♯" && s2 == "F") {
             return true;
-        } else if(s1=="E"&&s2=="F♭") {
+        } else if (s1 == "E" && s2 == "F♭") {
             return true;
-        } else if(s1=="F"&&s2=="E♯") {
+        } else if (s1 == "F" && s2 == "E♯") {
             return true;
-        } else if(s1=="F♭"&&s2=="E") {
+        } else if (s1 == "F♭" && s2 == "E") {
             return true;
-        } else if(s1=="B♯"&&s2=="C") {
+        } else if (s1 == "B♯" && s2 == "C") {
             return true;
-        } else if(s1=="B"&&s2=="C♭") {
+        } else if (s1 == "B" && s2 == "C♭") {
             return true;
-        } else if(s1=="C"&&s2=="B♯") {
+        } else if (s1 == "C" && s2 == "B♯") {
             return true;
-        } else if(s1=="C♭"&&s2=="B") {
+        } else if (s1 == "C♭" && s2 == "B") {
             return true;
         }
         return false;
-      }
+    }
 
-    let ii = scale.findIndex(scale => logicalEquals(scale, pitch)); //indexOf() replaced by findIndex()
+    let ii = scale.findIndex((scale) => logicalEquals(scale, pitch)); //indexOf() replaced by findIndex()
     // let ii = scale.indexOf(thisPitch);
     if (ii !== -1) {
         if (direction === "up") {


### PR DESCRIPTION
### Regression

For:- 

<img width="202" alt="image" src="https://user-images.githubusercontent.com/75945709/182606602-cb6eba73-f79f-4fc9-bdba-daeaee2957ad.png">

**Before:-** 

**F♯4, G♯4, A♯4, B4, C♯5, D♯5, E♯5 F♯5, G♯5, A♯5, B5, C♯6, D♯6, E♯6 is what one would expect to see**
So the transition from D#5 to F5 is where things begin to break down.
The F# through A# are skipped for some reason.
Maybe it gets confused when it does the conversion from D# to F (which it really should not be doing in F# Major)

<img width="472" alt="image" src="https://user-images.githubusercontent.com/75945709/182606481-5263fcb1-c46a-4820-8231-40b3356a87c7.png">

**REASON**

F# major is broken due to a nomenclature anomaly
        F# major (full, full, half, full, full, full, half) is:
        F# -> G# -> A# -> B -> C# -> D# -> E# -> (+1)F#
        this is the internal representation used
        F#, G#, A#, B, C#, D#, E#, F#
        the thing is ... E# is same as F
        so the code is trying to find F in the scale (list) but the list instead has E#
        improve on the "find in list". Instead of string equality if you can find logical equality it should fix it.
        Say something like
        obj.findIndex(item => logicalEquals(item, thisPitch))
        the new logicalEquals function should return true for E# and F, E and Fb, etc but false for say E# and F#
        whenever there are two white keys in a row. E==Fb and E#==F; B==Cb and B#==C

**After:-**

<img width="466" alt="image" src="https://user-images.githubusercontent.com/75945709/182606290-e525337d-6eb8-41b6-9cee-9fa7d780f4c5.png">

**Regression removed from musicutils.js**
closes #3055 