### PR TITLE
Link of images in documentations

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -117,7 +117,8 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt tag](./note1.svg)
+![alt tag](./note1.svg "A single Note value block (top) and two consecutive Note value
+ blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,7 +117,8 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt tag](./note1.svg "A single Note value block (top) and two consecutive Note value
+![alt 
+tag](./note1.svg "A single Note value block (top) and two consecutive Note value
  blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*
@@ -128,10 +129,7 @@ At the bottom, two notes that are played consecutively are shown. They
 are both `1/8` notes, making the duration of the entire sequence
 `1/4`.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note2.svg
- "A quarter note, a sixteenth note, and a half note Note value
- blocks")
+![alt tag](./note2.svg "A quarter note, a sixteenth note, and a half note Note value blocks")
 
 In this example, different note values are shown. From top to bottom,
 they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
@@ -140,15 +138,11 @@ they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
 Note that any mathematical operations can be used as input to the
 *Note value*.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/piemenu1.svg
- "A pie menu for selecting note values.")
+![alt tag](./piemenu1.svg "A pie menu for selecting note values.")
 
 As a convenience, a pie menu is used for selecting common note values.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/charts/NotationRestChart.svg
- "A chart of note values and their corresponding note value blocks")
+![alt tag](./NotationRestChart.svg "A chart of note values and their corresponding note value blocks")
 
 Please refer to the above picture for a visual representation of note
 values.
@@ -160,8 +154,7 @@ As we have seen, *Pitch* blocks are used inside the
 pitch name and pitch octave of a note that in combination determines
 the frequency (and therefore pitch) at which the note is played.
 
-![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note3.svg
- "Specifying a pitch block's name and octave")
+![alt tag](./note3.svg "Specifying a pitch block's name and octave")
 
 There are many systems you can use to specify a *pitch* block's name
 and octave. Some examples are shown above.
@@ -209,29 +202,21 @@ The octave of the last block is specified using a *next* text block
 
 Note that the pitch name can also be specified using a *Text* block. 
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/piemenu2.svg
- "A pie menu for selecting pitch.")
+![alt tag](./piemenu2.svg "A pie menu for selecting pitch.")
 
 As a convenience, a pie menu is used for selecting pitch, accidental,
 and octave.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/charts/KeyboardChart.svg
- "Note layout chart for keyboard")
+![alt tag](./KeyboardChart.svg "Note layout chart for keyboard")
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/charts/MalletChart.svg
- "Note layout chart for mallet")
+![alt tag](./MalletChart.svg "Note layout chart for mallet")
 
 Please refer to the above charts for a visual representation of where
 notes are located on a keyboard or staff.
 
 ### <a name="CHORDS"></a>2.3 Chords
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note4.svg
- "Forming a chord")
+![alt tag](./note4.svg "Forming a chord")
 
 A chord (multiple, simultaneous pitches) can be specified by adding
 multiple *Pitch* blocks into a single *Note value* block, like the
@@ -239,27 +224,21 @@ above example.
 
 ### <a name="RESTS"></a>2.4 Rests
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/silence.svg
- "Silence blocks create rests")
+![alt tag](./silence.svg "Silence blocks create rests")
 
 A rest of the specified note value duration can be constructed using a
 *Silence* block in place of a *Pitch* block.
 
 ### <a name="DRUMS"></a>2.5 Drums
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum1.svg
- "Using Drum Sample block")
+![alt tag](./drum1.svg "Using Drum Sample block")
 
 Anywhere a *Pitch* block can be used&mdash;e.g., inside of the matrix
 or a *Note value* block&mdash;a *Drum Sample* block can also be used
 instead. Currently there about two dozen different samples from which
 to choose. The default drum is a kick drum.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note5.svg
- "Multiple Drum Sample blocks in combinations")
+![alt tag](./note5.svg "Multiple Drum Sample blocks in combinations")
 
 Just as in the [chord](#CHORD) example above, you can use multiple
 *Drum* blocks within a single *Note value* blocks, and combine them
@@ -277,9 +256,7 @@ get started.
 
 ### <a name="CHUNKS"></a>3.1 Chunks
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-2.svg
- "working of action stack")
+![alt tag](./chunk-2.svg "working of action stack")
 
 ![alt
  tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-1.svg

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,8 +117,7 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt 
-tag](./note1.svg "A single Note value block (top) and two consecutive Note value
+![alt tag](./note1.svg "A single Note value block (top) and two consecutive Note value
  blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,9 +117,10 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-[![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)]
- (https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)
+![alt
+ tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
+ "A single Note value block (top) and two consecutive Note value
+ blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this

--- a/guide/README.md
+++ b/guide/README.md
@@ -598,7 +598,6 @@ flats, so they are skipped. D major has two sharps, `F#` and `C#`. The
 
 Scale Degree with *Set Key* is a very powerful tool for expression. It
 is also very common in music pedagogy. However, because the number
-
 values 1-7 are hard wired into this system, it is a tool that works
 best to express seven-pitch tonal frameworks (e.g. major, minor, and
 other common seven pitch scales). For musical ideas where a more

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,10 +117,9 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
- "A single Note value block (top) and two consecutive Note value
- blocks (bottom)")
+[![alt
+ tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)]
+ (https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this
@@ -598,6 +597,7 @@ flats, so they are skipped. D major has two sharps, `F#` and `C#`. The
 
 Scale Degree with *Set Key* is a very powerful tool for expression. It
 is also very common in music pedagogy. However, because the number
+
 values 1-7 are hard wired into this system, it is a tool that works
 best to express seven-pitch tonal frameworks (e.g. major, minor, and
 other common seven pitch scales). For musical ideas where a more

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,10 +117,7 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
- "A single Note value block (top) and two consecutive Note value
- blocks (bottom)")
+![alt tag](./note1.svg)
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this

--- a/guide/README.md
+++ b/guide/README.md
@@ -118,7 +118,9 @@ value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)
+ tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
+ "A single Note value block (top) and two consecutive Note value
+ blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this

--- a/guide/README.md
+++ b/guide/README.md
@@ -118,9 +118,7 @@ value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
- "A single Note value block (top) and two consecutive Note value
- blocks (bottom)")
+ tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg)
 
 At the top of the example above, a single (detached) *Note value*
 block is shown. The `1/8` is value of the note, which is, in this

--- a/guide/README.md
+++ b/guide/README.md
@@ -118,7 +118,7 @@ value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
 ![alt 
-tag](./note1.svg "A single Note value block (top) and two consecutive Note value
+ tag](./note1.svg "A single Note value block (top) and two consecutive Note value
  blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*
@@ -129,7 +129,8 @@ At the bottom, two notes that are played consecutively are shown. They
 are both `1/8` notes, making the duration of the entire sequence
 `1/4`.
 
-![alt tag](./note2.svg "A quarter note, a sixteenth note, and a half note Note value blocks")
+![alt 
+ tag](./note2.svg "A quarter note, a sixteenth note, and a half note Note value blocks")
 
 In this example, different note values are shown. From top to bottom,
 they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
@@ -138,11 +139,13 @@ they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
 Note that any mathematical operations can be used as input to the
 *Note value*.
 
-![alt tag](./piemenu1.svg "A pie menu for selecting note values.")
+![alt 
+ tag](./piemenu1.svg "A pie menu for selecting note values.")
 
 As a convenience, a pie menu is used for selecting common note values.
 
-![alt tag](./NotationRestChart.svg "A chart of note values and their corresponding note value blocks")
+![alt 
+ tag](./NotationRestChart.svg "A chart of note values and their corresponding note value blocks")
 
 Please refer to the above picture for a visual representation of note
 values.
@@ -154,7 +157,8 @@ As we have seen, *Pitch* blocks are used inside the
 pitch name and pitch octave of a note that in combination determines
 the frequency (and therefore pitch) at which the note is played.
 
-![alt tag](./note3.svg "Specifying a pitch block's name and octave")
+![alt 
+ tag](./note3.svg "Specifying a pitch block's name and octave")
 
 There are many systems you can use to specify a *pitch* block's name
 and octave. Some examples are shown above.
@@ -202,21 +206,25 @@ The octave of the last block is specified using a *next* text block
 
 Note that the pitch name can also be specified using a *Text* block. 
 
-![alt tag](./piemenu2.svg "A pie menu for selecting pitch.")
+![alt 
+ tag](./piemenu2.svg "A pie menu for selecting pitch.")
 
 As a convenience, a pie menu is used for selecting pitch, accidental,
 and octave.
 
-![alt tag](./KeyboardChart.svg "Note layout chart for keyboard")
+![alt 
+tag](./KeyboardChart.svg "Note layout chart for keyboard")
 
-![alt tag](./MalletChart.svg "Note layout chart for mallet")
+![alt 
+ tag](./MalletChart.svg "Note layout chart for mallet")
 
 Please refer to the above charts for a visual representation of where
 notes are located on a keyboard or staff.
 
 ### <a name="CHORDS"></a>2.3 Chords
 
-![alt tag](./note4.svg "Forming a chord")
+![alt 
+ tag](./note4.svg "Forming a chord")
 
 A chord (multiple, simultaneous pitches) can be specified by adding
 multiple *Pitch* blocks into a single *Note value* block, like the
@@ -224,21 +232,24 @@ above example.
 
 ### <a name="RESTS"></a>2.4 Rests
 
-![alt tag](./silence.svg "Silence blocks create rests")
+![alt 
+ tag](./silence.svg "Silence blocks create rests")
 
 A rest of the specified note value duration can be constructed using a
 *Silence* block in place of a *Pitch* block.
 
 ### <a name="DRUMS"></a>2.5 Drums
 
-![alt tag](./drum1.svg "Using Drum Sample block")
+![alt 
+ tag](./drum1.svg "Using Drum Sample block")
 
 Anywhere a *Pitch* block can be used&mdash;e.g., inside of the matrix
 or a *Note value* block&mdash;a *Drum Sample* block can also be used
 instead. Currently there about two dozen different samples from which
 to choose. The default drum is a kick drum.
 
-![alt tag](./note5.svg "Multiple Drum Sample blocks in combinations")
+![alt 
+ tag](./note5.svg "Multiple Drum Sample blocks in combinations")
 
 Just as in the [chord](#CHORD) example above, you can use multiple
 *Drum* blocks within a single *Note value* blocks, and combine them
@@ -256,10 +267,11 @@ get started.
 
 ### <a name="CHUNKS"></a>3.1 Chunks
 
-![alt tag](./chunk-2.svg "working of action stack")
+![alt 
+ tag](./chunk-2.svg "working of action stack")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-1.svg
+ tag](./chunk-1.svg
  "using chunk inside Start block")
 
 Every time you create a new *Action* stack, Music Blocks creates a new
@@ -293,33 +305,33 @@ add more chunks after this one inside the *Start* block to execute
 them sequentially.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-3.svg
+ tag](./chunk-3.svg
  "usage of multiple Chunk blocks")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-4.svg
+ tag](./chunk-4.svg
  "usage of Repeat block")
 
 You can [repeat](#REPETITION) chunks either by using multiple *Chunk*
 blocks or using a *Repeat* block.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-6.svg
+ tag](./chunk-6.svg
  "multiple action stacks")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-5.svg
+ tag](./chunk-5.svg
  "mixing and matching chunks")
 
 You can also mix and match chunks. Here we play the action block with
 name `chunk0`, followed by `chunk1` twice, and then `chunk0` again.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-8.svg
+ tag](./chunk-8.svg
  "creating a song using chunks")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/chunk-7.svg
+ tag](./chunk-7.svg
  "usage of Repeat block in a song")
 
 A few more chunks and we can make a song. (Can you read the block
@@ -333,7 +345,7 @@ There are many ways to transform pitch, rhythm, and other sonic qualities.
 #### <a name="STEP-PITCH"></a>3.2.1 Step Pitch Block
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform0.svg
+ tag](./transform0.svg
  "Using the Step Pitch block")
 
 The *Step Pitch* block will move up or down notes in a scale from the
@@ -362,7 +374,7 @@ modes).
 #### <a name="SHARPS-AND-FLATS"></a>3.2.2 Sharps And Flats
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform1.svg
+ tag](./transform1.svg
  "Using Sharp and Flat blocks")
 
 The *Accidental* block can be wrapped around *Pitch* blocks, *Note
@@ -375,7 +387,7 @@ also use a double-sharp or double-flat accidental.)
 #### <a name="ADJUST-TRANSPOSITION"></a>3.2.3 Adjusting Transposition
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform2.svg
+ tag](./transform2.svg
  "Adjusting transpositions")
 
 There are several ways to transpose a pitch: by semi-tone or scalar
@@ -398,14 +410,14 @@ provided: *Unison*, *Second*, *Third*, ..., *Seventh*, *Down third*,
 and *Down sixth*, as well as a transposition for *Octave*.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform3.svg
+ tag](./transform3.svg
  "raising an octave using semi-tone-transposition")
 
 In the example above, we take the song we programmed previously and
 raise it by one octave.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform18.svg
+ tag](./transform18.svg
  "The Register block")
 
 The *Register* block provides an easy way to modify the register
@@ -424,12 +436,12 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks Code for Scalar Step |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement1.svg "scalar") |
+| ![alt tag](./pitchmovement1.svg "scalar") |
 | The example above demonstrates traveling up and down the major scale by moving an octave up from the starting note, do, one note at a time and then back down the same way. |
 
 | Standard Notation with Scalar Step |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement1.png "scalar step up and down") |
+| ![alt tag](./pitchmovement1.png "scalar step up and down") |
 
 | Representation | Pitch Movement | Properties |
 | --- | --- | --- |
@@ -441,11 +453,11 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks Code with Scalar Transpose |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement2.svg "semi-tone transposition") |
+| ![alt tag](./pitchmovement2.svg "semi-tone transposition") |
 
 | Standard Notation for Scalar Transpose |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement2.png "semi-tone transposition") |
+| ![alt tag](./pitchmovement2.png "semi-tone transposition") |
 
 | Representation | Pitch Movement | Properties |
 | --- | --- | --- |
@@ -457,11 +469,11 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks for Set Key and Movable Do | 
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement3.svg "scalar transposition") |
+| ![alt tag](./pitchmovement3.svg "scalar transposition") |
 
 | Standard Notation for Set Key and Movable Do |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement3.png "scalar transposition") |
+| ![alt tag](./pitchmovement3.png "scalar transposition") |
 
 | Representation | Pitch Movement | Properties |
 | --- | --- | --- |
@@ -470,11 +482,11 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks Code with Scale Degrees 1-5 |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement4.svg "scale degree") |
+| ![alt tag](./pitchmovement4.svg "scale degree") |
 
 | Standard Notation for Scale Degrees 1-5 |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement4.png "scale degree") |
+| ![alt tag](./pitchmovement4.png "scale degree") |
 
 | Representation | Pitch Movement | Properties |
 | --- | --- | --- |
@@ -485,11 +497,11 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks Code with Set Key and Movable Do |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement5.svg "moveable do") |
+| ![alt tag](./pitchmovement5.svg "moveable do") |
 
 | Standard Notation Code for Set Key and Movable Do |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement5.png "moveable do") |
+| ![alt tag](./pitchmovement5.png "moveable do") |
 
 | Representation | Pitch Movement | Properties |
 | --- | --- | --- |
@@ -497,11 +509,11 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 | Music Blocks for Set Key and Scalar Step |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement6.svg "moveable do") |
+| ![alt tag](./pitchmovement6.svg "moveable do") |
 
 | Standard Notation with Set Key and Scalar Step |
 | --- |
-| ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchmovement6.png "moveable do") |
+| ![alt tag](./pitchmovement6.png "moveable do") |
 
 #### <a name="FIXED-AND-MOVABLE-PITCH-SYSTEMS"></a>3.2.5 Pitch Systems: Fixed and Movable and Subsystems
 
@@ -523,7 +535,7 @@ same. In Alphabet Notation, pitches are the same ("fixed") regardless
 of the context.
 
 ![Alphabet Fixed
- System](https://rawgit.com/sugarlabs/musicblocks/master/guide/systems-alphabet.svg
+ System](./systems-alphabet.svg
  "Alphabet (Fixed) System")
 
 An example of a movable system is Scale Degree. Pitches are expressed
@@ -534,7 +546,7 @@ dorian, these pitches are `D`, `E`, `F`, `G`, `A`, `B`, and `C`. In
 all three examples, the pitches are determined by the tonal context.
 
 ![Scale Degree Movable
- System](https://rawgit.com/sugarlabs/musicblocks/master/guide/systems-scale-degree.svg
+ System](./systems-scale-degree.svg
  "Scale Degree (Movable) System")
 
 Solfege is an example of a system that can be either fixed or movable;
@@ -549,7 +561,7 @@ major, `Do` is 1st scale degree, `Re` is 2nd, `Mi` is 3rd, `Fa` is
 `Do` is `G`, `Re` is `A`, et al.
 
 ![Movable Solfege
- System](https://rawgit.com/sugarlabs/musicblocks/master/guide/systems-movable-solfege.svg
+ System](./systems-movable-solfege.svg
  "Movable Solfege System")
 
 Music Blocks users can create and preview code in both Fixed Solfege
@@ -629,7 +641,7 @@ Because some users may want to explicitly spell out all of the pitches
 regardless of the chosen key, we allow them to use Scale Degree with
 the *Movable Do* block (remember, Scale Degree works like Movable=La
 by default). Please see [this
-code](https://rawgithub.com/sugarlabs/musicblocks/master/examples/2-spelling-systems-for-Scale-Degree.html)
+code](./2-spelling-systems-for-Scale-Degree.html)
 as an example.
 
 The following chart describes the behavior of different blocks
@@ -656,14 +668,14 @@ combines math and musical modifiers. When combining numbers and
 accidentals, it recreates the same functionality as the *Scale Degree*
 block.
 
-![Scale Degree Improv Example](https://rawgit.com/sugarlabs/musicblocks/master/guide/scale-degree-improv.svg "Scale Degree Improv")
+![Scale Degree Improv Example](./scale-degree-improv.svg "Scale Degree Improv")
 
-[Scale Degree Improv](https://rawgit.com/sugarlabs/musicblocks/master/examples/Scale-Degree-Improv.html)
+[Scale Degree Improv](./Scale-Degree-Improv.html)
 
 #### <a name="DOTTED"></a>3.2.6 Dotted Notes
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform4.svg
+ tag](./transform4.svg
  "Creating dotted notes using the Dot block")
 
 You can "dot" notes using the *Dot* block. A dotted note extends the
@@ -685,11 +697,11 @@ The chart below shows two common examples, dotted quarter and dotted
 eighth, and how to achieve them with either the dot block or by direct
 calculation into a note's note value.
 
-![alt tag](https://rawgit.com/sugarlabs/musicblocks/master/charts/DotsChart.svg "using dotted notes")
+![alt tag](./DotsChart.svg "using dotted notes")
 
 #### <a name="MULTIPLY-AND-DIVIDE"></a>3.2.7 Changing Note(s) duration via Mathematical Operations
 
-![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform5.svg "Changing note duration for a note or notes")
+![alt tag](./transform5.svg "Changing note duration for a note or notes")
 
 You can also multiply (or divide) the note value, which will change
 the duration of the notes by changing their note values. Multiplying
@@ -699,7 +711,7 @@ of an `1/8` note by `2/1` (which has the effect of dividing by `1/2`)
 will result in the equivalent of a `1/4` note.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum4.svg
+ tag](./drum4.svg
  "increasing sequence of drum beats over time")
 
 In the above example, the sequence of [drum](#DRUMS) note values is
@@ -710,7 +722,7 @@ decreased over time, at each repetition.
 #### <a name="REPETITION"></a>3.2.8 Repeating Notes
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform6.svg
+ tag](./transform6.svg
  "repeating notes")
 
 There are several ways to repeat notes. The *Repeat* block will play a
@@ -724,7 +736,7 @@ Re, Sol, Sol, Re, Sol, Sol, Re, Sol`; on the right the result would be
 #### <a name="SWINGING"></a>3.2.9 Swinging Notes and Tied Notes
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform7.svg
+ tag](./transform7.svg
  "swinging notes and tied notes")
 
 The *Swing* block works on pairs of notes (specified by note value),
@@ -741,13 +753,13 @@ Tie also works on pairs of notes, combining them into one note. (The
 notes must be identical in pitch, but can vary in rhythm.)
 
 ![alt
- tag](https://rawgit.com/sugarlabs/musicblocks/master/charts/TiesChart.svg
+ tag](./TiesChart.svg
  "using notes with ties")
 
 #### <a name="MORE-TRANSFORMATIONS"></a>3.2.10 Set Volume, Crescendo, Staccato, and Slur
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform8.svg
+ tag](./transform8.svg
  "Set master volume, set synth volume, set relative volume,
  crescendo")
 
@@ -779,7 +791,7 @@ NOTE: The *Crescendo* block does not alter the volume of a note as it
 is being played. Music Blocks does not yet have this functionality.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform17.svg
+ tag](./transform17.svg
  "Staccato, and Slur blocks")
 
 The *Staccato* block shortens the length of the actual
@@ -793,7 +805,7 @@ maintaining the specified rhythmic value of the notes.
 #### <a name="INTERVALS"></a>3.2.11 Intervals
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform9.svg
+ tag](./transform9.svg
  "Scalar interval block")
 
 The *Scalar interval* block calculates a relative interval based on
@@ -813,7 +825,7 @@ of scalar steps between two pitched.
 Absolute (or semi-tone) intervals are based on half-steps.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform14.svg
+ tag](./transform14.svg
  "Using absolute intervals")
 
 The *Augmented* block calculates an absolute interval (in half-steps),
@@ -846,7 +858,7 @@ notes), and even five-, six-, and seven-note chords.
 The *Chord* block builds a chord from a base note.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/chordinterval_block.svg
+ tag](./chordinterval_block.svg
  "Chord Block")
 
 We support many basic chords:
@@ -871,7 +883,7 @@ a `1/4` step, enabling rotation around a point between two notes. In
 rotation.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform13.svg
+ tag](./transform13.svg
  "inversion")
 
 NOTE: The initial `C5` pitch (as a half note) remains unchanged (in
@@ -892,14 +904,14 @@ This operation can also be visualized on a pitch clock. The arrows on
 the following diagram point from the starting pitch, around the axis
 of the reference pitch, to its destination ending pitch.
 
-![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/even-invert-chart.svg "even invert chart")
+![alt tag](./even-invert-chart.svg "even invert chart")
 
 In standard notation the result of this *even* inversion operation is
 depicted in the second measure of the following example. The first
 measure is the original reference.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/invert-even.png
+ tag](./invert-even.png
  "even invert example")
 
 Underneath the *even* inversion in the example code is an *odd*
@@ -918,7 +930,7 @@ inversion except offset in-between `C5` and `C♯5` (i.e. quarter step
 *above* `C5`).
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/odd-invert-chart.svg
+ tag](./odd-invert-chart.svg
  "odd invert chart")
 
 In standard notation the result of this *odd* inversion operation is
@@ -931,7 +943,7 @@ inversion around `C5` and `odd` would be 0.5 half steps *above* the
 axis of rotation).
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/invert-odd.png
+ tag](./invert-odd.png
  "odd invert example")
 
 Scalar inversion
@@ -951,7 +963,7 @@ chosen key) are skipped. NOTE: The scalar pitches are shown in bold in
 the following pitch clock diagram.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/scalar-invert-chart.svg
+ tag](./scalar-invert-chart.svg
  "scalar invert chart")
 
 In standard notation the result of *scalar* inversion operation is
@@ -959,7 +971,7 @@ depicted in the second measure of the following example. The first
 measure is the original reference.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/invert-scalar.png
+ tag](./invert-scalar.png
  "scalar invert example")
 
 In the *invert (even)* example above, notes are inverted around `C5`.
@@ -971,7 +983,7 @@ half-steps.
 #### <a name="BACKWARDS"></a>3.2.13 Backwards
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform11.svg
+ tag](./transform11.svg
  "Backward block")
 
 The *Backward* block will play the contained notes in reverse order
@@ -991,14 +1003,14 @@ notes.
 #### <a name= "SETTING"></a>3.2.14 Setting Voice and Keys
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform12.svg
+ tag](./transform12.svg
  "setting voice and keys using Set Voice block")
 
 The *Set Voice* block selects a [voice](#VOICES) for the synthesizer for any
 contained blocks, e.g., violin or cello.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform10.svg
+ tag](./transform10.svg
  "Set Key block")
 
 The *Set Key* block will change the key and mode of the mapping
@@ -1010,7 +1022,7 @@ where the mapping of solfege to particular pitch changes depending on
 the user's specified tonality.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform19.svg
+ tag](./transform19.svg
  "Define mode block")
 
 The *Define mode* block can be used to define a custom mode by
@@ -1020,7 +1032,7 @@ use your custom mode with the *Set key* block.
 #### <a name="VIBRATO"></a>3.2.15 Vibrato, Tremelo, et al.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/transform15.svg
+ tag](./transform15.svg
  "Vibrato, tremelo, chorus, distortion, neighbor, and phaser blocks")
 
 The *Vibrato* Block adds a rapid variation in pitch to any contained
@@ -1037,25 +1049,25 @@ you click on the Run button, all of the *Start* blocks are run
 concurrently.)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/voices1.svg
+ tag](./voices1.svg
  "use of voices")
 
 If we put our song into an action...
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/voices2.svg
+ tag](./voices2.svg
  "running the song using multiple Start blocks")
 
 ...we can run it from multiple *Start* blocks.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/voices3.svg
+ tag](./voices3.svg
  "shifting the octaves up and down")
 
 It gets more interesting if we shift up and down octaves.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/voices4.svg
+ tag](./voices4.svg
  "playing the various voices offset in time")
 
 And even more interesting if we bring the various voices offset in time.
@@ -1064,7 +1076,7 @@ And even more interesting if we bring the various voices offset in time.
 LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523026536194324&run=True)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/voices5.svg
+ tag](./voices5.svg
  "queuing the various voices using events")
 
 An alternative to use a preprogrammed delay is to use the *Broadcast*
@@ -1074,7 +1086,7 @@ a new voice. Note the use of the *Mouse Sync* block. This ensures that
 the multiple voices are synced to the same master clock.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum3.svg
+ tag](./drum3.svg
  "usage of kick drum")
 
 A special *Start drum* version of the *Start* block is available for
@@ -1086,11 +1098,11 @@ kick drum.
 ### <a name="GRAPHICS"></a>3.4 Adding graphics
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics1.svg
+ tag](./graphics1.svg
  "adding graphics")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics2.svg
+ tag](./graphics2.svg
  "color range")
 
 Turtle graphics can be combined with the music blocks. By placing
@@ -1105,7 +1117,7 @@ the inner repeat loop.
 LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523494709674021&run=True)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics3.svg
+ tag](./graphics3.svg
  "synchronizing graphics and music")
 
 Another example of graphics synchronized to the music by placing the
@@ -1115,7 +1127,7 @@ graphics commands inside of *Note value* blocks
 LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523106271018484&run=True)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/drift_block.svg
+ tag](./drift_block.svg
  "No-clock block")
 
 Music Blocks has an internal "conductor" maintaining the beat.  When
@@ -1145,7 +1157,7 @@ might be consumed by trying to catch up with the conductor. The
 about the conductor.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/fibonacci3.svg
+ tag](./fibonacci3.svg
  "usage of No-clock block")
 
 In this example, because the computation and graphics are more
@@ -1154,18 +1166,18 @@ master clock. The "No-clock* block prioritizes the sequence of
 actions over the specified rhythm.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics4.png
+ tag](./graphics4.png
  "rhythm sequence")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/tree-example.svg
+ tag](./tree-example.svg
  "another example of the No-clock block")
 
 Another example of embedding graphics into notes: in case, a recursive
 tree drawing, where the pitch goes up as the branches assend.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/tree.svg
+ tag](./tree.svg
  "tree graphic")
 
 [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523029986215035&run=True)
@@ -1179,20 +1191,20 @@ The *Pickup* block can be used to accommodate any notes that come in
 before the beat.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/beat1.svg
+ tag](./beat1.svg
  "meter and pickup")
 
 The Beat count block is the number of the current beat, eg 1, 2, 3, or 4. 
 In the figure, it is used to take an action on the first beat of each measure.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/beatvalue_block.svg
+ tag](./beatvalue_block.svg
  "beat count")
 
 The Measure count block returns the current measure.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/measurevalue_block.svg
+ tag](./measurevalue_block.svg
  "measure count")
 
 Specifying beat is useful in that you can have the character of a note
@@ -1201,7 +1213,7 @@ notes on Beat `1` and Beat `3` are increased, while the volume of off
 beats is decreased.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/beat2.svg
+ tag](./beat2.svg
  "on-beat-do")
 
 The *On-Beat-Do* and *Off-Beat-Do* blocks let you specify actions to
@@ -1209,7 +1221,7 @@ take on specific beats. (Note that the action is run before any blocks
 inside the note block associated with the beat are run.)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics5.svg
+ tag](./graphics5.svg
  "using beat to synchronize graphics")
 
 Another approach to graphics is to use modulate them based on the
@@ -1221,7 +1233,7 @@ to `25` and the volume to `50`. On off beats, the pen size is set to `5` and
 the volumne to `5`. The resultant graphic is shown below.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/graphics6.svg
+ tag](./graphics6.svg
  "graphics modulated by beat")
 
 ### <a name="INTERACTIONS"></a>3.6 Interactions
@@ -1230,7 +1242,7 @@ There are many ways to interactive with Music Blocks, including
 tracking the mouse position to impact some aspect of the music.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/interactive.svg
+ tag](./interactive.svg
  "interactions")
 
 For example, we can launch the phrases (chunks) interactively. We use
@@ -1242,7 +1254,7 @@ upper-left quadrant, `chunk2`; and upper-right quadrant, `chunk3`.
 [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523028011868930&run=True)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/interactive2.svg
+ tag](./interactive2.svg
  "creation of a two-key piano")
 
 In the example above, a simple two-key piano is created by associating
@@ -1252,7 +1264,7 @@ make an 8-key piano?
 [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523107390715125&run=True)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/interactive3.svg
+ tag](./interactive3.svg
  "adding randomness to your music")
 
 You can also add a bit of randomness to your music. In the top example
@@ -1270,7 +1282,7 @@ la Vidsizer) and playback your painting as a composition (a la
 Hyperscore), but also generate *Note* blocks from your composition.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/hyperscore.svg
+ tag](./hyperscore.svg
  "musical paint")
 
 The program works by first creating an array from the heap that
@@ -1317,27 +1329,27 @@ To use the ensemble blocks, you must assign a name to each mouse, as
 we will reference each mouse by its name.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/turtlenameonly_block.svg
+ tag](./turtlenameonly_block.svg
  "mouse name")
 
 Use the *Mouse count* block in combination with the *Nth mouse name*
 block to iterate through all of the mice.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/turtleiteration.svg
+ tag](./turtleiteration.svg
  "mouse iteration")
 
 The *Mouse sync* block aligns the beat count between mice.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/turtlesync_block.svg
+ tag](./turtlesync_block.svg
  "mouse sync")
 
 The *Mouse index heap* block returns a value in the heap at a specified
 location for a specified mouse.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/turtleheap_block.svg
+ tag](./turtleheap_block.svg
  "mouse heap index")
 
 You can use the dictionary entries to data between mice. The *Get
@@ -1346,7 +1358,7 @@ access. For example, you can access a mouse's pen attributes, such as
 color, shade, and grey values.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/dictionary-pen.svg
+ tag](./dictionary-pen.svg
  "mouse pen attributes")
 
 You can also access the mouse's graphics attributes, such as x, y, and
@@ -1354,7 +1366,7 @@ heading. You can also set attributes of a mouse using the *Set value*
 block. In the example, a mouse's heading is set to 90.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/dictionary-graphics.svg
+ tag](./dictionary-graphics.svg
  "mouse graphics attributes")
 
 Some music status is also available through the dictionary. You can
@@ -1362,14 +1374,14 @@ access a mouse's "current pitch", "pitch number", "note value", the
 number of "notes played".
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/dictionary-music.svg
+ tag](./dictionary-music.svg
  "mouse music attributes")
 
 The dictionary can be used to share other things too. Just set a
 *key/value* pair with one mouse and access it from another.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/dictionary-key.svg
+ tag](./dictionary-key.svg
  "sharing key/value pairs")
 
 Other Ensemble blocks include:
@@ -1377,13 +1389,13 @@ Other Ensemble blocks include:
 The *Found mouse* block will return true if the specified mouse can be found.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/foundturtle_block.svg
+ tag](./foundturtle_block.svg
  "found mouse")
 
 The *Set mouse* block sends a stack of blocks to be run by the specified mouse.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/setturtle_block.svg
+ tag](./setturtle_block.svg
  "set mouse")
 
 ## <a name="CONVERTERS"></a>3.8 Converters
@@ -1393,7 +1405,7 @@ Converters are used to transform one form of inputs into other, more usable form
 Generalized shape of a converter is:
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/number2pitch_block.svg
+ tag](./number2pitch_block.svg
  "Generalized converter")
 
 where the right argument is converted accordingly, and output is received on the left side.
@@ -1407,7 +1419,7 @@ where the right argument is converted accordingly, and output is received on the
 ### <a name="y-to-pitch"></a>4.1 Y to Pitch
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/ytopitch_block.svg
+ tag](./ytopitch_block.svg
  "Y to Pitch converter")
 
 This converter takes input in the form of a number that represents Staff Y position in pixels, and processes the value such that it can be used with certain pitch blocks (pitch number, nth modal pitch, pitch) to produce notes corresponding to given Staff Y position as an argument.  
@@ -1416,7 +1428,7 @@ Additionally, the block can be plugged into a print block to view the converted 
 ### <a name="pitch-converter"></a>4.2 Pitch converter
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/outputtools_block.svg
+ tag](./outputtools_block.svg
  "Pitch converter block")
 
 Pitch converter offers a range of options through a pie-menu based interface and it can potentially convert or extract info out of the current playing pitch using the current pitch block as an input. 
@@ -1425,7 +1437,7 @@ It can also take custom input in form or solfege, hertz, pitch number etc.
 All these options are provided in the form of a pie-menu which can be accessed simply by clicking on the converter.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchconverter.svg
+ tag](./pitchconverter.svg
  "Pitch converter block")
 
 Below explained is the utility of every conversion option:
@@ -1461,7 +1473,7 @@ Returns the Y staff position of the note being played according to staff dimensi
 ### <a name="number-2-octave"></a>4.3  Number to Octave  
   
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/number2octave_block.svg
+ tag](./number2octave_block.svg
  "Y to Pitch converter")
 
 This converter takes a numeric value which denotes pitch number and returns the octave corresponding to that pitch number.
@@ -1469,7 +1481,7 @@ This converter takes a numeric value which denotes pitch number and returns the 
 ### <a name="number-2-pitch"></a>4.3  Number to Pitch
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/number2pitch_block.svg
+ tag](./number2pitch_block.svg
  "Y to Pitch converter")
 
 This converter takes a numeric value which denotes pitch number and returns the pitch name corresponding to that pitch number. No octave is inferred.
@@ -1485,13 +1497,13 @@ be used within Music Blocks to enhance your experience.
 Every widget has a menu with at least two buttons.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/close-button.svg
+ tag](./close-button.svg
  "close button")
 
 You can hide the widget by clicking on the *Close* button.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/grab-handle.svg
+ tag](./grab-handle.svg
  "drag handle")
 
 You can move the widget by dragging it by the *Drag* handle.
@@ -1499,11 +1511,11 @@ You can move the widget by dragging it by the *Drag* handle.
 ### <a name="status"></a>4.1 Status
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/status1.svg
+ tag](./status1.svg
  "given Music block")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/status2.svg
+ tag](./status2.svg
  "status in tabular form")
 
 The *Status widget* is a tool for inspecting the status of Music
@@ -1518,7 +1530,7 @@ skip, [staccato](#MORE-TRANSFORMATIONS),
 e.g., x, y, heading, color, shade, grey, and pensize.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/status3.svg
+ tag](./status3.svg
  "additional programming within the Status block")
 
 You can do additional programming within the status block. In the
@@ -1533,7 +1545,7 @@ notes at a much faster speed.
 #### <a name="pitch-time"></a>4.2.1 The Phrase Maker
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix1.svg
+ tag](./matrix1.svg
  "phrase maker")
 
 Music Blocks provides a widget, the *Phrase maker*, as a scaffold
@@ -1545,7 +1557,7 @@ screen. (For the moment, ignore the *Start* block.) You'll see a grid
 organized vertically by pitch and horizontally by rhythm.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix2.svg
+ tag](./matrix2.svg
  "Pitch and Rhythm block matrix")
 
 The matrix in the figure above has three *Pitch* blocks and one
@@ -1560,7 +1572,7 @@ note.) Also by default, there are two *Rhythm* blocks, which specifies
 six quarter `(1/4)` notes followed by one half `(1/2)` note.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix3.svg
+ tag](./matrix3.svg
  "matrix")
 
 By clicking on individual cells in the grid, you should hear
@@ -1569,7 +1581,7 @@ column). In the figure, three quarter notes are selected (black
 cells). First `Re 4`, followed by `Mi 4`, followed by `Sol 4`.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/play-button.svg
+ tag](./play-button.svg
  "play button")
 
 If you click on the *Play* button (found in the top row of the grid),
@@ -1577,7 +1589,7 @@ you will hear a sequence of notes played (from left to right): `Re 4`,
 `Mi 4`, `Sol 4`.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/export-chunk.svg
+ tag](./export-chunk.svg
  "save button")
 
 Once you have a group of notes (a "chunk") that you like, click on the
@@ -1589,14 +1601,14 @@ You can rearrange the selected notes in the grid and save other chunks
 as well.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/sort.svg
+ tag](./sort.svg
  "sort button")
 
 The *Sort* button will reorder the pitches in the matrix from highest
 to lowest and eliminate any duplicate *Pitch* blocks.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/header-icons/erase-button.svg
+ tag](./erase-button.svg
  "erase button")
 
 There is also an Erase button that will clear the grid.
@@ -1609,7 +1621,7 @@ Tip: You can put a chunk inside a *Phrase maker* block to generate
 the matrix to corresponds to that chunk.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix4.svg
+ tag](./matrix4.svg
  "usage of octave for a pitch")
 
 The chunk created when you click on the matrix is a stack of
@@ -1631,7 +1643,7 @@ action). You should hear the notes play, ordered from top to bottom.
 #### <a name="THE-RHYTHM-BLOCK"></a>4.2.2 The Rhythm Block
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix6.svg
+ tag](./matrix6.svg
  "the Rhythm block")
 
 *Rhythm* blocks are used to generate rhythm patterns in the
@@ -1643,11 +1655,11 @@ for an eighth note would be generated. In the bottom example, seven
 columns for 16th notes would be generated.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix7.svg
+ tag](./matrix7.svg
  "usage of Rhythm block")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix8.svg
+ tag](./matrix8.svg
  "resulting notes in tabular format")
 
 You can use as many *Rhythm* blocks as you'd like inside the
@@ -1658,11 +1670,11 @@ notes.
 #### <a name="CREATING-TUPLETS"></a>4.2.3 Creating Tuplets
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix9.svg
+ tag](./matrix9.svg
  "simple tuplet")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix10.svg
+ tag](./matrix10.svg
  "tuplet and rhythmic note values")
 
 Tuplets are a collection of notes that get scaled to a specific
@@ -1676,7 +1688,7 @@ common in music, is called a *triplet*. Other common tuplets include a
 *quintuplet* and a *septuplet*.)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix11.svg
+ tag](./matrix11.svg
  "usage of tuplet")
 
 In the example above, the three quarter notes are defined in the
@@ -1686,11 +1698,11 @@ note. The result is three twelfth notes. This more complex form allows
 for intermixing multiple rhythms within single tuplet.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix12.svg
+ tag](./matrix12.svg
  "embedding rhythm and Tuplet block")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix13.svg
+ tag](./matrix13.svg
  "tuplet and rhythmic note values")
 
 In the example above, the two *Rhythm* blocks are embedded in the
@@ -1702,17 +1714,17 @@ defining your matrix.
 #### <a name="WHAT-IS-TUPLET"></a>4.2.4 What is a Tuplet?
 
 ![alt
- tag](https://rawgit.com/sugarlabs/musicblocks/master/charts/TupletChart.svg
+ tag](./TupletChart.svg
  "tuplet chart")
 
 ![alt
- tag](https://rawgit.com/sugarlabs/musicblocks/master/charts/TripletChart.svg
+ tag](./TripletChart.svg
  "triplet chart")
 
 #### <a name="INDIVIDUAL-NOTES"></a>4.2.5 Using Individual Notes in the Phrase Maker
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix14.svg)
+ tag](./matrix14.svg)
 
 You can also use individual notes when defining the grid. These blocks
 will expand into *Rhythm* blocks with the corresponding values.
@@ -1720,7 +1732,7 @@ will expand into *Rhythm* blocks with the corresponding values.
 #### <a name="USING-A-SCALE"></a>4.2.6 Using a Scale of Pitches in the Phrase Maker
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/matrix15.svg)
+ tag](./matrix15.svg)
 
 You can use the *Scalar step* block to generate a scale of pitches in
 the matrix. In the example above, the pitches comprising the G major
@@ -1737,7 +1749,7 @@ The *Rhythm Maker* block is used to launch a widget similar to the
 patterns.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm1.svg
+ tag](./rhythm1.svg
  "generating rhythms")
 
 The argument to the *Rhythm Maker* block specifies the duration that
@@ -1750,7 +1762,7 @@ default, two rhythm "rulers" are defined. The embedded *Rhythm* blocks define
 the initial subdivision of each rhythm ruler.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm2.svg
+ tag](./rhythm2.svg
  "rhythm maker")
 
 When the *Rhythm Maker* block is clicked, the *Rhythm Maker* widget is
@@ -1760,7 +1772,7 @@ created within a cell when it is clicked. By default, 2 subdivisions
 are created.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm3.svg
+ tag](./rhythm3.svg
  "usage of rhythm maker")
 
 As shown in the above figure, the top rhythm ruler has been divided
@@ -1771,7 +1783,7 @@ button on the upper-left of the widget will play back all rhythms
 simultaneously.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm4.svg
+ tag](./rhythm4.svg
  "divide cells in rhythm maker")
 
 The rhythm can be further subdivided by clicking in individual
@@ -1779,27 +1791,27 @@ cells. In the example above, two quarter-notes have been created by
 clicking on one of the half-notes.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm8.svg
+ tag](./rhythm8.svg
  "tie cells in Rhythm Maker")
 
 By dragging across multiple cells, they become tied. In the example
 above, two third-notes have been tied into one two-thirds-note.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm5.svg
+ tag](./rhythm5.svg
  "save stack button")
 
 The *Save stack* button will export rhythm stacks.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm6.svg
+ tag](./rhythm6.svg
  "stacks of rhythms" )
 
 These stacks of rhythms can be used to define rhythmic patterns used
 with the *Phrase maker* block.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/rhythm7.svg
+ tag](./rhythm7.svg
  "save drum machine button")
 
 The *Save drum machine* button will export *Start* stacks that will
@@ -1837,7 +1849,7 @@ The *Mode length* block will return the number of intervals (scalar
 steps) in the current mode.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode1.svg
+ tag](./mode1.svg
  "mode widget")
 
 The *Mode* widget lets you explore modes and generate custom
@@ -1846,7 +1858,7 @@ specified in the *Set key* block will be the default mode when the
 widget launches.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode2.svg
+ tag](./mode2.svg
  "launching widget with Major mode")
 
 In the above example, the widget has been launched with *Major* mode
@@ -1884,21 +1896,21 @@ Note that the mode inside the *Custom mode* block is updated whenever
 the mode is changed inside the widget.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode3.svg
+ tag](./mode3.svg
  "creating Dorian mode")
 
 In the above example, the *Major* mode has been rotated counter-clockwise,
 transforming it into *Dorian*.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode4.svg
+ tag](./mode4.svg
  "creating Locrian mode")
 
 In the above example, the *Major* mode has been rotated
 clockwise, transforming it into *Locrian*.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode5.svg
+ tag](./mode5.svg
  "creating Phrygian mode")
 
 In the above example, the *Major* mode has been inverted, transforming
@@ -1907,7 +1919,7 @@ it into *Phrygian*.
 Note: The build-in modes in Music Blocks can be found in [musicutils.js](https://github.com/sugarlabs/musicblocks/blob/master/js/musicutils.js#L68).
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/mode6.svg
+ tag](./mode6.svg
  "phrase maker block")
 
 The *Save* button exports a stack of blocks representing the mode that
@@ -1916,7 +1928,7 @@ can be used inside the *Phrase maker* block.
 ### <a name="meters"></a>4.5 Meters
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/meter1.svg
+ tag](./meter1.svg
  "meter widget block")
 
 The *Meter Widget* block is used to explore strong and weak
@@ -1925,7 +1937,7 @@ example, the meter is 4 beats per measure, where each beat is one
 quarter note.)
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/meter2.svg
+ tag](./meter2.svg
  "Meter Widget")
 
 Inside the widget, you can click on a sector to indicate a strong
@@ -1936,7 +1948,7 @@ The *Play* button will play the beat, using a snare drum for strong
 beats and a kick drum for weak beats.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/meter3.svg
+ tag](./meter3.svg
  "on strong beat do blocks")
 
 The *Save* button will export *On strong beat do* blocks for each strong beat.
@@ -1965,13 +1977,13 @@ catch up with the conductor. The No-clock block essentially says, do
 your own thing and don't worry about the conductor.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/f057d42544ff53dc3d71ee241b53bf6bff0ddf24/documentation/no-clock.svg
+ tag](./no-clock.svg
  "no clock")
 
 ### <a name="pitch-drum"></a>4.6 The Pitch-Drum Matrix
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum2.svg
+ tag](./drum2.svg
  "Pitch-drum matrix")
 
 The *Set Drum* block is used to map the enclosed pitches into drum
@@ -1980,19 +1992,19 @@ sample. In the example above, a `kick drum` will be substitued for
 each occurance of a `Re` `4`.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum5a.svg
+ tag](./drum5a.svg
  "pitch-drum matrix 1")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum5.svg
+ tag](./drum5.svg
  "table for pitch-drum matrix")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum6.svg
+ tag](./drum6.svg
  "table for pitch-drum matrix")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/drum7.svg
+ tag](./drum7.svg
  "pitch-drum matrix 1")
 
 As an experience for creating mapping with the *Set Drum* block, we
@@ -2010,7 +2022,7 @@ block define the pitches to be initialized simultaneously. By default,
 one pitch is defined and it have default note "la" and octave "3".
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase0.svg
+ tag](./pitchstaircase0.svg
  "generating arbitrary pitches")
 
 When *Pitch Staircase* block is clicked, the *Pitch Staircase* widget is
@@ -2022,15 +2034,15 @@ denominator in the proportion resectively. By default the proportion
 is 3:2.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase1.svg
+ tag](./pitchstaircase1.svg
  "notes associated with the step in the stairs")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase2.svg
+ tag](./pitchstaircase2.svg
  "notes associated with the step in the stairs")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase3.svg
+ tag](./pitchstaircase3.svg
  "notes associated with the step in the stairs")
 
 Clicking on the *Play* button to the left of each row will playback
@@ -2045,14 +2057,14 @@ above configuration, the output from pressing the *Save stack* button
 is shown below:
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase4.svg
+ tag](./pitchstaircase4.svg
  "Pitch Stair block")
 
 These stacks can be used with the *Phrase maker* block to define
 the rows in the matrix.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchstaircase5.svg
+ tag](./pitchstaircase5.svg
  "Pitch Stair block")
 
 ### <a name="slider"></a>4.8 Generating Arbritary Pitches
@@ -2066,11 +2078,11 @@ Each *Sine* block contained within the clamp of the *Pitch Slider* block defines
 for an ocatve.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider0.svg
+ tag](./pitchslider0.svg
  "Pitch Slider")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider1.svg
+ tag](./pitchslider1.svg
  "Pitch Slider-One Column")
 
 When the *Pitch Slider* block is clicked, the *Pitch Slider* widget is
@@ -2082,25 +2094,25 @@ down continuously. Buttons are used for intervals. Arrow keys can also
 be used to move up and down, or between columns.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider0a.svg
+ tag](./pitchslider0a.svg
  "Pitch Slider Block")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider2.svg
+ tag](./pitchslider2.svg
  "Pitch Slider-Two Column")
 
 Clicking in a column will extact the corresponding *Note* blocks, for example:
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider3.svg
+ tag](./pitchslider3.svg
  "Pitch Slider-Two Columns Adjusting")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider4.svg
+ tag](./pitchslider4.svg
  " Pitch Slider block")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/pitchslider5.svg
+ tag](./pitchslider5.svg
  " Pitch Slider block")
 
 ### <a name="tempo"></a>4.9 Changing Tempo
@@ -2116,7 +2128,7 @@ forth. If BPM is `60`, then it will take one second for the ball to move
 across the widget. A round-trip would take two seconds.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/tempo0.svg
+ tag](./tempo0.svg
  "changing tempo")
 
 The top row of the widget holds the *Play/pause* button, the *Speed
@@ -2124,7 +2136,7 @@ up* and *Slow down* buttons, and an input field for updating the
 Tempo.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/tempo1.svg
+ tag](./tempo1.svg
  "changing tempo")
 
 You can also update the tempo by clicking twice in spaced succession
@@ -2138,7 +2150,7 @@ While Music Blocks comes with many built-in instruments, it is also
 possible to create custom timbres with unique sound qualities.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre1.svg
+ tag](./timbre1.svg
  "the Timbre widget")
 
 The *Timbre* block can be used to launch the *Timbre* widget, which
@@ -2150,7 +2162,7 @@ block (by default, `custom`). This name is passed to the *Set timbre*
 block in order to use your custom timbre.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre2.svg
+ tag](./timbre2.svg
  "the Timbre widget toolbar")
 
 The *Timbre* widget has a number of different panels, each of which is
@@ -2162,7 +2174,7 @@ custom timbre. By default, it will play `Sol`, `Mi`, `Sol` using the
 combination of filters you define.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre1a.svg
+ tag](./timbre1a.svg
  "the notes inside Timbre block")
 
 You can also put notes in the *Timbre* block to use for testing your
@@ -2172,14 +2184,14 @@ sound. In the example above, a scale will be used for the test.
 your program.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre3.svg
+ tag](./timbre3.svg
  "select synth")
 
 * The *Synth* button, which lets you choose between an AM synth, a PM
 synth, or a Duo synth.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre4.svg
+ tag](./timbre4.svg
  "select osc")
 
 * The *Oscillator* button, which lets you choose between a sine wave,
@@ -2187,17 +2199,17 @@ square wave, triangle wave, or sawtooth wave. You can also change
 the number of partials.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre5.svg
+ tag](./timbre5.svg
  "set envelope")
 
 * The *Envelope* button, which lets you change the shape of the sound
 envelope, with controls for attack, decay, sustain, and release.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre6.svg
+ tag](./timbre6.svg
  "select effect")
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre6a.svg
+ tag](./timbre6a.svg
  "tremolo")
 
 * The *Effects* button, which lets you add effects to your custom
@@ -2205,7 +2217,7 @@ timbre: tremelo, vibrato, chorus, phaser, and distortion. When an
 effect is selected, additional controls will appear in the widget.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/timbre7.svg
+ tag](./timbre7.svg
  "select filter")
 
 * The *Filter* button, which lets you choose between a number of
@@ -2229,11 +2241,11 @@ When there are no *Pitch* blocks inside the widget clamp, a keyboard with
 all keys between C4 and G5 is created.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/keyboard1.svg
+ tag](./keyboard1.svg
  "keyboard block without clamp")
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/keyboard2.svg
+ tag](./keyboard2.svg
  "keyboard widget without clamp")
 
 When there are *Pitch* blocks inside the widget clamp, a keyboard with
@@ -2255,7 +2267,7 @@ making it narrower or wider than pure. It is also possible to change
 and create different tuning systems.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament1.svg
+ tag](./temperament1.svg
  "the Temperament block")
 
 The *Temperament* block is used to launch a widget that enables the
@@ -2268,7 +2280,7 @@ system. *Starting Pitch* is the argument of pitch block inside
 temperament block. In the above example, starting pitch is `C4`.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament2.svg
+ tag](./temperament2.svg
  "the Temperament widget")
 
 In the above example, selected temperament is *Just Intonation*. Notes
@@ -2283,7 +2295,7 @@ respective circle. In the above example, circle (pitch number) `2` is
 hand side corner of note information popup).
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament3.svg
+ tag](./temperament3.svg
  "the Temperament widget")
 
 Information regarding notes can also be viewed in the form of a
@@ -2313,9 +2325,9 @@ representation of notes.
 The *Add* button is used to edit notes through different tools:
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament4.svg
+ tag](./temperament4.svg
  "Equal Edit tool") ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament4a.svg
+ tag](./temperament4a.svg
  "Temperament widget with new element")
 
 The `Equal` edit tool is used to make *equal divisions* between two
@@ -2324,9 +2336,9 @@ between pitch numbers `0` and `1` and the resultant number of notes
 within an octave are changed from 12 to 13.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament5.svg
+ tag](./temperament5.svg
  "Ratio Edit tool") ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament5a.svg
+ tag](./temperament5a.svg
  "Temperament widget with new element")
 
 The `Ratio` tool is used to add notes of specified ratios in such a
@@ -2338,7 +2350,7 @@ of first pitch is (Starting Pitch Frequency) * (16/13) and second
 pitch is (Starting Pitch Frequency) * (16/13)².
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament6.svg
+ tag](./temperament6.svg
  "Arbitrary Edit tool")
 
 The `Arbitrary` edit tool is used to add a note in an arbitrary
@@ -2349,7 +2361,7 @@ will be added somewhere between pitch numbers `2` and `3` by adjusting
 the frequency slider.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/temperament7.svg
+ tag](./temperament7.svg
  "Octave Space Edit tool")
 
 The `Octave Space` tool is used to edit the octave ratio. The standard
@@ -2365,10 +2377,10 @@ The *Close* button will close the widget.
 Music Blocks has an Oscillosope Widget to visualize the music as it plays.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/oscilloscope1.svg
+ tag](./oscilloscope1.svg
  "Oscilloscope")
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/oscilloscope2.svg
+ tag](./oscilloscope2.svg
  "Oscilloscope")
 
 A separate wave will be displayed for each mouse.
@@ -2376,20 +2388,20 @@ A separate wave will be displayed for each mouse.
 ###  <a name="sampler"></a>4.14 Sampler
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/sampler_block.svg
+ tag](./sampler_block.svg
  "Sampler")
 
 You can import sound samples (.WAV files) and use them with the *Set Instrument" block. The *Sampler* widget lets you set the center pitch of your sample so that it can be tuned.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/sampler1.svg
+ tag](./sampler1.svg
  "Sampler Widget")
 
 You can then use the *Sample* block as you would any input to the *Set
 Instrument* block.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/sampler2.svg
+ tag](./sampler2.svg
  "Sampler Widget")
 
 
@@ -2405,7 +2417,7 @@ point the learner towards other powerful tools.
 One such tool is [Lilypond](http://lilypond.org), a music engraving program.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/lilypond1.svg
+ tag](./lilypond1.svg
  "adding Save as Lilypond block")
 
 The *Save as Lilypond* option from the Save menu will transcribe your
@@ -2416,7 +2428,7 @@ create a "markup" or annotation for that note. It is a simple way to
 add lyrics to your score.
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/lilypond2.svg
+ tag](./lilypond2.svg
  "Save as Lilypond icon")
 
 ```
@@ -2440,7 +2452,7 @@ e'4 e'4 d'8 d'8 d'8 d'8 d'4 d'4 c'8 c'8 c'8 c'8 c'4 c'4
 ```
 
 ![alt
- tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/hotdog.png
+ tag](./hotdog.png
  "sheet music")
 
 [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1523043053377623&run=True)

--- a/guide/README.md
+++ b/guide/README.md
@@ -117,7 +117,8 @@ At the heart of Music Blocks is the *Note value* block. The *Note
 value* block is a container for a [*Pitch* block](#PITCH) that
 specifies the duration (note value) of the pitch.
 
-![alt tag](./note1.svg "A single Note value block (top) and two consecutive Note value
+![alt 
+tag](./note1.svg "A single Note value block (top) and two consecutive Note value
  blocks (bottom)")
 
 At the top of the example above, a single (detached) *Note value*


### PR DESCRIPTION
**URL now points directly to the linked object.**

**Before :-** 

**[note1.svg]**

![image](https://user-images.githubusercontent.com/75945709/184936602-6b19cdc1-2678-460a-b699-18d626180e7f.png)


**After :-**

**[note1.svg]**

<img width="958" alt="image" src="https://user-images.githubusercontent.com/75945709/184937737-70242636-bd99-4364-8f8e-1f9e5150af3a.png">


**Closed #3056**