### PR TITLE
Removed warning

### DIFF
--- a/guide-zhCN/README.md
+++ b/guide-zhCN/README.md
@@ -71,7 +71,7 @@
 ### <a name="NOTE-VALUE"></a>
 2.1 《音乐拼块》最有用的拼块是《音符长度》。《音符长度》里面有一个[音调拼块](#PITCH)和音符的长度。
 
-![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
+![alt tag](./note1.svg
 "一个《音符长度拼块》(在上面) 和两个连接的拼块(在下面)")
 
 上面的例子有一个“音符拼块”。“1/8”是价值或长度，在这种情况下是一个八分音符

--- a/guide-zhCN/README.md
+++ b/guide-zhCN/README.md
@@ -71,7 +71,7 @@
 ### <a name="NOTE-VALUE"></a>
 2.1 《音乐拼块》最有用的拼块是《音符长度》。《音符长度》里面有一个[音调拼块](#PITCH)和音符的长度。
 
-![alt tag](./note1.svg
+![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/note1.svg
 "一个《音符长度拼块》(在上面) 和两个连接的拼块(在下面)")
 
 上面的例子有一个“音符拼块”。“1/8”是价值或长度，在这种情况下是一个八分音符

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1838,16 +1838,9 @@ class Singer {
                     // const notesInfo = "";
 
                     const obj = rationalToFraction(1 / noteBeatValue);
-                    
-                    // if (obj[0] > 0) {
-                    //     if (obj[0] / obj[1] > 2) {
-                    //         // activity.errorMsg(_("Warning: Note value greater than 2."), blk);
 
                     //         //-> Removed the WARNING to play a note longer than 2 whole 
                     //         //   notes since some samples are very long.
-
-                    //     }
-                    // }
 
                     if (!tur.singer.suppressOutput) {
                         tur.blink(duration, last(Singer.masterVolume));

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1838,11 +1838,16 @@ class Singer {
                     // const notesInfo = "";
 
                     const obj = rationalToFraction(1 / noteBeatValue);
-                    if (obj[0] > 0) {
-                        if (obj[0] / obj[1] > 2) {
-                            activity.errorMsg(_("Warning: Note value greater than 2."), blk);
-                        }
-                    }
+                    
+                    // if (obj[0] > 0) {
+                    //     if (obj[0] / obj[1] > 2) {
+                    //         // activity.errorMsg(_("Warning: Note value greater than 2."), blk);
+
+                    //         //-> Removed the WARNING to play a note longer than 2 whole 
+                    //         //   notes since some samples are very long.
+
+                    //     }
+                    // }
 
                     if (!tur.singer.suppressOutput) {
                         tur.blink(duration, last(Singer.masterVolume));


### PR DESCRIPTION
Removed the WARNING when you try to play a note longer than 2 whole notes since some samples are very long.
closes #3065 