### PR TITLE
Added file type checking to the Sampler widget (fixes #3064)

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -138,6 +138,10 @@ function SampleWidget() {
         }
     };
 
+    this.showSampleTypeError = function () {
+            this.activity.errorMsg(_("Upload failed: Sample is not a .wav file."), this.timbreBlock);
+    };
+
     this.__save = function () {
         var that = this;
         setTimeout(function () {
@@ -262,10 +266,17 @@ function SampleWidget() {
 
                 // eslint-disable-next-line no-unused-vars
                 reader.onload = function (event) {
-                    that.sampleData = reader.result;
-                    that.sampleName = fileChooser.files[0].name;
-                    that._addSample();
-                    that.getSampleLength();
+                    // if the file is of .wav type, save it
+                    if (reader.result.substring(reader.result.indexOf(":")+1, reader.result.indexOf(";")) === 'audio/wav') {
+                        that.sampleData = reader.result;
+                        that.sampleName = fileChooser.files[0].name;
+                        that._addSample();
+                        that.getSampleLength();
+                    }
+                    // otherwise, output error message
+                    else {
+                        that.showSampleTypeError();
+                    }
                 };
 
                 reader.onloadend = function () {


### PR DESCRIPTION
Added file type checking to the Sampler widget in _sampler.js_ because it only accepts .wav files to fix issue #3064.

Also added an error message if the user uploads an incorrect file type.