### PR TITLE
Up down notation at al.

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -1588,16 +1588,7 @@ function setupPitchBlocks(activity) {
             } else if (logo.inPitchSlider) {
                 logo.pitchSlider.frequencies.push(args[0]);
             } else {
-                try {
-                    return Singer.PitchActions.playHertz(arg, turtle, blk);
-                } catch (e) {
-                    if (e === "NoNoteError") {
-                        activity.errorMsg(_("Hertz Block: Did you mean to use a Note block?"), blk);
-                    } else {
-                        // eslint-disable-next-line no-console
-                        console.error(e);
-                    }
-                }
+                return Singer.PitchActions.playHertz(arg, turtle, blk);
             }
         }
     }

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -699,6 +699,7 @@ const piemenuCustomNotes = function (
 
     //Disable rotation, set navAngle and create the menus
     block._cusNoteWheel.clickModeRotate = false;
+    block._cusNoteWheel.titleRotateAngle = 0;
     block._cusNoteWheel.animatetime = 0; // 300;
     const labels = [];
     let blockCustom = 0;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -699,7 +699,7 @@ const piemenuCustomNotes = function (
 
     //Disable rotation, set navAngle and create the menus
     block._cusNoteWheel.clickModeRotate = false;
-    block._cusNoteWheel.titleRotateAngle = 0;
+    block._cusNoteWheel.titleRotateAngle = 180;
     block._cusNoteWheel.animatetime = 0; // 300;
     const labels = [];
     let blockCustom = 0;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -83,6 +83,7 @@ class Singer {
         this.transpositionRatios = [];
 
         // Parameters used by notes
+        this.defaultNoteValue = 4;
         this.register = 0;
         this.beatFactor = 1;
         this.dotCount = 0;
@@ -1195,7 +1196,7 @@ class Singer {
 
             tur.singer.pushedNote = true;
 
-            Singer.processNote(activity, 4, false, blk, turtle, () => {
+            Singer.processNote(activity, tur.singer.defaultNoteValue, false, blk, turtle, () => {
                 tur.singer.inNoteBlock.splice(tur.singer.inNoteBlock.indexOf(blk), 1);
             });
         }

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -558,7 +558,9 @@ function setupPitchActions(activity) {
                     );
                 }
             } else {
+                tur.singer.defaultNoteValue = 32;
                 Singer.processPitch(activity, note, octave, cents, turtle, blk);
+                tur.singer.defaultNoteValue = 4;
             }
         }
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -356,7 +356,6 @@ function TemperamentWidget() {
                         return Math.min(a, b);
                     });
                     const index = centsDiff1.indexOf(min);
-
                     if (centsDiff[index] < 0) {
                         docById("noteInfo").innerHTML +=
                             '<div id="note">&nbsp;' +
@@ -1533,16 +1532,29 @@ function TemperamentWidget() {
                         return Math.min(a, b);
                     });
                     index = centsDiff1.indexOf(min);
+                    let updown = "";
                     if (centsDiff[index] < 0) {
+                        if (centsDiff[index] < -30) {
+                            updown = "vv";
+                        } else if (centsDiff[index] < -15) {
+                            updown = "v";
+                        }
                         this.notes[i] =
                             this.ratiosNotesPair[index][1][0] +
+                            updown +
                             "(-" +
                             centsDiff1[index].toFixed(0) +
                             "%)" +
                             this.ratiosNotesPair[index][1][1];
                     } else {
+                        if (centsDiff[index] > 30) {
+                            updown = "^^";
+                        } else if (centsDiff[index] > 15) {
+                            updown = "^";
+                        }
                         this.notes[i] =
                             this.ratiosNotesPair[index][1][0] +
+                            updown +
                             "(+" +
                             centsDiff1[index].toFixed(0) +
                             "%)" +


### PR DESCRIPTION
* Add up-down notation to custom notes (See #2859)
* Fix orientation of custom note pie menu
* Use note value of 32 for standalone Hertz block (See #2410)