### PR TITLE
Corrected a wrong link in the music blocks guide

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -752,7 +752,7 @@ block.
 
 ![Scale Degree Improv Example](./scale-degree-improv.svg "Scale Degree Improv")
 
-[Scale Degree Improv](https://rawgit.com/sugarlabs/musicblocks/master/examples/Scale-Degree-Improv.html)
+[Scale Degree Improv](https://musicblocks.sugarlabs.org/index.html?id=1675577999425474&run=True)
 
 #### <a name="INTERVALS">3.2.7 Intervals</a>
 


### PR DESCRIPTION
I corrected the link-(scale degree improv) after the illustrative example that demonstrates how  Scale Degree functionality combines math and musical modifiers. 

#  3.2.6 Fixed an movable pitch system

![w](https://user-images.githubusercontent.com/100171190/216807609-6f29683f-60ae-42e3-b7e3-83770573f6fd.PNG)