### PR TITLE
allow for solfege when setting key

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -494,11 +494,18 @@ const piemenuPitches = (
                     ) === -1
                     : true))
         ) {
-            let i = NOTENAMES.indexOf(FIXEDSOLFEGE[selection["note"]]);
+            let i = scale.indexOf(selection["note"]);
+            if (i === -1) {
+                i = scale.indexOf(that.value);
+            }
+            if (i === -1) {
+                i = NOTENAMES.indexOf(FIXEDSOLFEGE[selection["note"]]);
+            }
             if (i === -1) {
                 i = NOTENAMES.indexOf(FIXEDSOLFEGE[that.value]);
             }
             if (
+                NOTENAMES.indexOf(selection["note"]) !== -1 ||
                 scale[i][0] === FIXEDSOLFEGE[selection["note"]] ||
                 scale[i][0] === FIXEDSOLFEGE[that.value] ||
                 scale[i][0] === selection["note"]

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -65,7 +65,7 @@ function setupIntervalsActions(activity) {
             return modename;
         }
 
- /**
+        /**
          * @static
          * @param {number} turtle
          * @returns {String}
@@ -91,26 +91,19 @@ function setupIntervalsActions(activity) {
          */
         static setKey(key, mode, turtle) {
             const modename = Singer.IntervalsActions.GetModename(mode);
-
             const tur = activity.turtles.ithTurtle(turtle);
-            // Check to see if there are any transpositions on the key
-            if (tur.singer.transposition !== 0) {
-                const noteObj = getNote(
-                    key,
-                    4,
-                    tur.singer.transposition,
-                    tur.singer.keySignature,
-                    false,
-                    null,
-                    activity.errorMsg,
-                    activity.logo.synth.inTemperament
-                );
-                tur.singer.keySignature = noteObj[0] + " " + modename;
-                activity.logo.notation.notationKey(turtle, noteObj[0], modename);
-            } else {
-                tur.singer.keySignature = key + " " + modename;
-                activity.logo.notation.notationKey(turtle, key, modename);
-            }
+            const noteObj = getNote(
+                key,
+                4,
+                tur.singer.transposition,
+                tur.singer.keySignature,
+                false,
+                null,
+                activity.errorMsg,
+                activity.logo.synth.inTemperament
+            );
+            tur.singer.keySignature = noteObj[0] + " " + modename;
+            activity.logo.notation.notationKey(turtle, noteObj[0], modename);
         }
 
         /**

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1877,6 +1877,10 @@ const keySignatureToMode = (keySignature) => {
     } else if (key == "F" + FLAT) {
         parts = keySignature.split(" ");
         key = "F" + FLAT;
+    } else if (SOLFEGENAMES1.indexOf(key) !== -1) {
+        // This conversion will be a bit iffy depending upon the current mode.
+        // eslint-disable-next-line no-use-before-define
+        key = getNote(key, 4, 0, "C Major", false)[0];
     } else if (NOTESSHARP.indexOf(key) === -1 && NOTESFLAT.indexOf(key) === -1) {
         // eslint-disable-next-line no-console
         console.debug("Invalid key or missing name; reverting to C.");


### PR DESCRIPTION
It is a bit anomalous, but we should be more flexible with the arguments to setkey. This patch allows solfege (with a built-in assumption of C Major, movable=false) to be used as an argument to setkey. (Fixes #3168)