### PR TITLE
Blocks generated from the palette now does not generate behind the palette

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3098,6 +3098,13 @@ class Blocks {
             myBlock.container.snapToPixelEnabled = true;
             myBlock.container.x = 0;
             myBlock.container.y = 0;
+            
+            // All the new generated block graphics have this default position when clicked.
+            requestAnimationFrame(function() {
+             myBlock.container.x = 550;
+             myBlock.container.y = 250;
+             },0);
+        
 
             /** and we need to load the images into the container. */
             myBlock.imageLoad();


### PR DESCRIPTION

The new blocks now generated by using the palette now does not generate behind the palette. Gets generated at an other location on the canvas after clicked.

"Fixes #3175" 
[https://github.com/sugarlabs/musicblocks/issues/3175](url)