### PR TITLE
Z-Index of Palette is added 

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -113,7 +113,7 @@ class Palettes {
             element.setAttribute("class", "disable_highlighting");
             element.setAttribute(
                 "style",
-                "position: fixed; display: none ; left :0px; top:" + this.top + "px"
+                "position: fixed; z-index: 1000; display: none ; left :0px; top:" + this.top + "px"
             );
             element.innerHTML =
                 '<div style="float: left"><table width ="' +


### PR DESCRIPTION
closes: #3178
Grid, show/hide block, Expand/collapse blocks buttons is now under the Palette in small screen.

result:-
<img width="468" alt="Screenshot 2023-02-22 133633" src="https://user-images.githubusercontent.com/81948346/220636511-dfb536c0-c2b8-444a-9c95-ffabfb9636dd.png">
