### PR TITLE
Fixes #3184: Enhance the Palette Body-Items Element(s)'

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -311,7 +311,7 @@ class Palettes {
 
         this.activity.hideSearchWidget(true);
         this.dict[name].showMenu(true);
-        this.activePalette = name;  // used to delete plugins
+        this.activePalette = name; // used to delete plugins
     }
 
     _showMenus() {}
@@ -377,13 +377,11 @@ class Palettes {
     _loadPaletteButtonHandler(name, row) {
         // eslint-disable-next-line no-unused-vars
         row.onmouseover = (event) => {
-            if(name == "search"){
+            if (name == "search") {
                 document.body.style.cursor = "text";
-            }
-            else{
+            } else {
                 document.body.style.cursor = "pointer";
             }
-
         };
 
         // eslint-disable-next-line no-unused-vars
@@ -782,10 +780,18 @@ class Palette {
         const palBody = document.createElement("table");
         palBody.id = "PaletteBody";
         const palBodyHeight = window.innerHeight - this.palettes.top - this.palettes.cellSize - 26;
-        palBody.innerHTML = `<thead></thead><tbody style = "display: block; height: ${palBodyHeight}px; overflow: auto; overflow-x: hidden;" id="PaletteBody_items" class="PalScrol"></tbody>`;
+
+        // palBody.innerHTML = `<thead></thead><tbody style = "display: block; height: ${palBodyHeight}px; overflow: auto; overflow-x: hidden;" id="PaletteBody_items" class="PalScrol"></tbody>`;
+
+        palBody.insertAdjacentHTML(
+            "afterbegin",
+            `<thead></thead><tbody style = "display: block;   width: 100% ; height:auto ; max-height: ${palBodyHeight}px;  overflow: auto; overflow-x: hidden;" id="PaletteBody_items" class="PalScrol"></tbody>`
+        );
+
         palBody.style.minWidth = "180px";
         palBody.style.background = platformColor.paletteBackground;
         palBody.style.float = "left";
+
         palBody.style.border = `1px solid ${platformColor.selectorSelected}`;
         [palBody.childNodes[0], palBody.childNodes[1]].forEach((item) => {
             item.style.boxSizing = "border-box";
@@ -1165,7 +1171,7 @@ class Palette {
             ["namedbox", "nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].indexOf(
                 protoblk.name
             ) === -1 &&
-                blockIsMacro(this.activity, blkname)
+            blockIsMacro(this.activity, blkname)
         ) {
             this._makeBlockFromProtoblock(protoblk, true, blkname, null, 100, 100);
             callback(lastBlock);


### PR DESCRIPTION
Make the Palette Body Item width and height (dimensions) responsive and flexible according to the immersing content size. 

NOTE: palBodyHeight is a fixed calculated value. 

- If the content is smaller, then resize the dimensions to fit the content. If larger than the calculated palBodyHeight value, then a scrollbar is added AND thus, the height never exceeds the palBodyHeight value. 
- In other terms, height: fit-content(palBodyHeight) 

BEFORE: 
![Screenshot (12)](https://user-images.githubusercontent.com/102666605/224466950-1474ad69-408d-4bf8-98f3-4497a5bdd3b5.png)

AFTER: 
![Screenshot (15)](https://user-images.githubusercontent.com/102666605/224467076-0d32dfc8-6222-4ed4-a7ba-fbd32274ece5.png)

PS: @walterbender  
Thanks in advance. 
