### PR TITLE
refactor: replaced deprecated method

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1548,7 +1548,7 @@ class Activity {
                 that.msgText = text;
             };
 
-            img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(svgData)));
+            img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(svgData)));
         };
 
         /*
@@ -4096,7 +4096,7 @@ class Activity {
             };
 
             const img = new Image();
-            img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(name)));
+            img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(name)));
 
             container.appendChild(img);
             container.setAttribute(
@@ -4238,7 +4238,7 @@ class Activity {
                 }
             };
 
-            img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(svgData)));
+            img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(svgData)));
         };
 
         /*
@@ -4669,28 +4669,28 @@ class Activity {
             this.stage.enableMouseOver(10); // default is 20
 
             this.cartesianBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(CARTESIAN)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(CARTESIAN)))
             );
             this.polarBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(POLAR)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(POLAR)))
             );
             this.trebleBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE)))
             );
             this.grandBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(GRAND)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(GRAND)))
             );
             this.sopranoBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(SOPRANO)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(SOPRANO)))
             );
             this.altoBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(ALTO)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(ALTO)))
             );
             this.tenorBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TENOR)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TENOR)))
             );
             this.bassBitmap = this._createGrid(
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(BASS)))
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(BASS)))
             );
 
             // We use G (one sharp) and F (one flat) as prototypes for all
@@ -4699,40 +4699,40 @@ class Activity {
             // horizonally so as not to overlap.
             for (let i = 0; i < 7; i++) {
                 this.grandSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(GRAND_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(GRAND_G)))
                 );
                 this.grandFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(GRAND_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(GRAND_F)))
                 );
                 this.trebleSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_G)))
                 );
                 this.trebleFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_F)))
                 );
                 this.sopranoSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_G)))
                 );
                 this.sopranoFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_F)))
                 );
                 this.altoSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_G)))
                 );
                 this.altoFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_F)))
                 );
                 this.tenorSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_G)))
                 );
                 this.tenorFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_F)))
                 );
                 this.bassSharpBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_G)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_G)))
                 );
                 this.bassFlatBitmap[i] = this._createGrid(
-                    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(TREBLE_F)))
+                    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(TREBLE_F)))
                 );
             }
 

--- a/js/block.js
+++ b/js/block.js
@@ -172,7 +172,7 @@ const _blockMakeBitmap = (data, callback, args) => {
         callback(bitmap, args);
     };
 
-    img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(data)));
+    img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(data)));
 };
 
 // Define block instance objects and any methods that are intra-block.
@@ -856,7 +856,7 @@ class Block {
         if (this.image.search("xmlns") !== -1) {
             image.src =
                 "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(this.image)));
+                window.btoa(decodeURIComponent(encodeURIComponent(this.image)));
         } else {
             image.src = this.image;
         }
@@ -1392,7 +1392,7 @@ class Block {
 
             image.src =
                 "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(COLLAPSEBUTTON)));
+                window.btoa(decodeURIComponent(encodeURIComponent(COLLAPSEBUTTON)));
         };
 
         /**
@@ -1425,7 +1425,7 @@ class Block {
 
             image.src =
                 "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(EXPANDBUTTON)));
+                window.btoa(decodeURIComponent(encodeURIComponent(EXPANDBUTTON)));
         };
 
         /**

--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -1064,7 +1064,7 @@ function setupEnsembleBlocks(activity) {
                 .replace(/fill_color/g, fillColor)
                 .replace(/stroke_color/g, strokeColor);
 
-            tur.doTurtleShell(55, "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(artwork))));
+            tur.doTurtleShell(55, "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(artwork))));
 
             // Restore the heading.
             if (heading != 0) {

--- a/js/boundary.js
+++ b/js/boundary.js
@@ -91,7 +91,7 @@ class Boundary {
             img.src =
                 "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(
+                    decodeURIComponent(
                         encodeURIComponent(
                             BOUNDARY.replace("HEIGHT", this.h)
                                 .replace("WIDTH", this.w)

--- a/js/palette.js
+++ b/js/palette.js
@@ -47,7 +47,7 @@ const paletteBlockButtonPush = (blocks, name, arg) => {
 
 const makePaletteIcons = (data, width, height) => {
     const img = new Image();
-    img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(data)));
+    img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(data)));
     if (width) img.width = width;
     if (height) img.height = height;
     return img;
@@ -724,7 +724,7 @@ class PaletteModel {
             label,
             artwork,
             artwork64:
-                "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(artwork))),
+                "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(artwork))),
             docks,
             image: block.image,
             scale: block.scale,

--- a/js/pastebox.js
+++ b/js/pastebox.js
@@ -146,6 +146,6 @@ class PasteBox {
             callback(this, name, bitmap, extras);
         };
 
-        img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(data)));
+        img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(data)));
     }
 }

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -178,7 +178,7 @@ class PlanetInterface {
                     };
                     img.src =
                         "data:image/svg+xml;base64," +
-                        window.btoa(unescape(encodeURIComponent(svgData)));
+                        window.btoa(decodeURIComponent(encodeURIComponent(svgData)));
                 }
             } catch (e) {
                 if (

--- a/js/trash.js
+++ b/js/trash.js
@@ -84,7 +84,7 @@ class Trashcan {
         img.src =
             "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(encodeURIComponent(BORDER.replace("stroke_color", highlightString)))
+                decodeURIComponent(encodeURIComponent(BORDER.replace("stroke_color", highlightString)))
             );
     }
 
@@ -106,7 +106,7 @@ class Trashcan {
         img.src =
             "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(
+                decodeURIComponent(
                     encodeURIComponent(BORDER.replace("stroke_color", platformColor.trashBorder))
                 )
             );
@@ -133,7 +133,7 @@ class Trashcan {
         img.src =
             "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(
+                decodeURIComponent(
                     encodeURIComponent(TRASHICON.replace(/fill_color/g, platformColor.trashBorder))
                 )
             );

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -1179,7 +1179,7 @@ class Painter {
                 this.turtle.doTurtleShell(
                     55,
                     "data:image/svg+xml;base64," +
-                        window.btoa(unescape(encodeURIComponent(artwork)))
+                        window.btoa(decodeURIComponent(encodeURIComponent(artwork)))
                 );
                 this.turtle.skinChanged = false;
             }

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -920,6 +920,6 @@ Turtle.TurtleView = class {
             activity.refreshCanvas();
         };
 
-        img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(data)));
+        img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(data)));
     }
 };

--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -440,13 +440,13 @@ const createHelpContent = (activity) => {
                     " " +
                     VERSION,
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(LOGO)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(LOGO)))
             ],
             [
                 _("Play"),
                 _("Click the run button to run the project in fast mode."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(RUNBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(RUNBUTTON)))
             ],
             [
                 _("Stop"),
@@ -454,7 +454,7 @@ const createHelpContent = (activity) => {
                     " " +
                     _("You can also type Alt-S to stop."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(STOPTURTLEBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(STOPTURTLEBUTTON)))
             ]
         ];
     } else {
@@ -467,7 +467,7 @@ const createHelpContent = (activity) => {
                     " " +
                     VERSION,
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(LOGO)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(LOGO)))
             ],
             [
                 _("Meet Mr. Mouse!"),
@@ -477,13 +477,13 @@ const createHelpContent = (activity) => {
                     " " +
                     _("Let us start our tour!"),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(MOUSEPALETTEICON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(MOUSEPALETTEICON)))
             ],
             [
                 _("Play"),
                 _("Click the run button to run the project in fast mode."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(RUNBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(RUNBUTTON)))
             ],
             [
                 _("Stop"),
@@ -491,7 +491,7 @@ const createHelpContent = (activity) => {
                     " " +
                     _("You can also type Alt-S to stop."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(STOPTURTLEBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(STOPTURTLEBUTTON)))
             ]
         ];
     }
@@ -500,20 +500,20 @@ const createHelpContent = (activity) => {
         _("New project"),
         _("Initialize a new project."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(NEWBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(NEWBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Load project from file"),
         _("You can also load projects from the file system."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(LOADBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(LOADBUTTON)))
     ]);
     if (activity.beginnerMode) {
         HELPCONTENT.push([
             _("Save project"),
             _("Save your project to a file."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(SAVEBUTTON)))
+                window.btoa(decodeURIComponent(encodeURIComponent(SAVEBUTTON)))
         ]);
     } else {
         if (_THIS_IS_TURTLE_BLOCKS_) {
@@ -535,7 +535,7 @@ const createHelpContent = (activity) => {
                     ": " +
                     _("Save block artwork as an SVG file."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(SAVEBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(SAVEBUTTON)))
             ]);
         } else {
             HELPCONTENT.push([
@@ -568,7 +568,7 @@ const createHelpContent = (activity) => {
                     ": " +
                     _("Save block artwork as an SVG file."),
                 "data:image/svg+xml;base64," +
-                    window.btoa(unescape(encodeURIComponent(SAVEBUTTON)))
+                    window.btoa(decodeURIComponent(encodeURIComponent(SAVEBUTTON)))
             ]);
         }
     }
@@ -576,7 +576,7 @@ const createHelpContent = (activity) => {
         _("Load samples from server"),
         _("This button opens a viewer for loading example projects."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(PLANETBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(PLANETBUTTON)))
     ]);
     if (_THIS_IS_MUSIC_BLOCKS_) {
         HELPCONTENT.push([
@@ -585,83 +585,83 @@ const createHelpContent = (activity) => {
                 " " +
                 _("Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(RHYTHMPALETTEICON)))
+                window.btoa(decodeURIComponent(encodeURIComponent(RHYTHMPALETTEICON)))
         ]);
     }
     HELPCONTENT.push([
         _("Cartesian/Polar"),
         _("Show or hide a coordinate grid."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(CARTESIANBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(CARTESIANBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Clean"),
         _("Clear the screen and return the mice to their initial positions."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(CLEARBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(CLEARBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Collapse"),
         _("Collapse the graphics window."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(COLLAPSEBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(COLLAPSEBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Home"),
         _("Return all blocks to the center of the screen."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(GOHOMEBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(GOHOMEBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Show/hide blocks"),
         _("Hide or show the blocks and the palettes."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(HIDEBLOCKSBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(HIDEBLOCKSBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Expand/collapse collapsable blocks"),
         _("Expand or collapse start and action stacks."),
         "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(encodeURIComponent(COLLAPSEBLOCKSBUTTON))
+                decodeURIComponent(encodeURIComponent(COLLAPSEBLOCKSBUTTON))
             )
     ]);
     HELPCONTENT.push([
         _("Decrease block size"),
         _("Decrease the size of the blocks."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(SMALLERBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(SMALLERBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Increase block size"),
         _("Increase the size of the blocks."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(BIGGERBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(BIGGERBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Expand/collapse option toolbar"),
         _("Click this button to expand or collapse the auxillary toolbar."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(MENUBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(MENUBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Run slow"),
         _("Click to run the project in slow mode."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(SLOWBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(SLOWBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Run step by step"),
         _("Click to run the project step by step."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(STEPBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(STEPBUTTON)))
     ]);
     if (!activity.beginnerMode) {
         HELPCONTENT.push([
             _("Display statistics"),
             _("Display statistics about your Music project."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(STATSBUTTON)))
+                window.btoa(decodeURIComponent(encodeURIComponent(STATSBUTTON)))
         ]);
         // TODO: add plugin
         HELPCONTENT.push([
@@ -669,7 +669,7 @@ const createHelpContent = (activity) => {
             _("Delete a selected plugin."),
             "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(encodeURIComponent(PLUGINSDELETEBUTTON))
+                    decodeURIComponent(encodeURIComponent(PLUGINSDELETEBUTTON))
                 )
         ]);
         HELPCONTENT.push([
@@ -677,7 +677,7 @@ const createHelpContent = (activity) => {
             _("You can scroll the blocks on the canvas."),
             "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(encodeURIComponent(SCROLLUNLOCKBUTTON))
+                    decodeURIComponent(encodeURIComponent(SCROLLUNLOCKBUTTON))
                 )
         ]);
     }
@@ -687,7 +687,7 @@ const createHelpContent = (activity) => {
         _("Turn Turtle wrapping On or Off."),
         "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(encodeURIComponent(WRAPTURTLEBUTTON))
+                decodeURIComponent(encodeURIComponent(WRAPTURTLEBUTTON))
             )
     ]);
     // TODO: Music Blocks: set pitch preview
@@ -697,41 +697,41 @@ const createHelpContent = (activity) => {
         _("Restore blocks from the trash."),
         "data:image/svg+xml;base64," +
             window.btoa(
-                unescape(encodeURIComponent(RESTORETRASHBUTTON))
+                decodeURIComponent(encodeURIComponent(RESTORETRASHBUTTON))
             )
     ]);
     HELPCONTENT.push([
         _("Switch mode"),
         _("Switch between beginner and advance modes."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(ADVANCEDBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(ADVANCEDBUTTON)))
     ]);
     HELPCONTENT.push([
         _("Select language"),
         _("Select your language preference."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(LANGUAGEBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(LANGUAGEBUTTON)))
     ]);
     if (_THIS_IS_MUSIC_BLOCKS_) {
         HELPCONTENT.push([
             _("Keyboard shortcuts"),
             _("You can type d to create a do block and r to create a re block etc."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(SHORTCUTSBUTTON)))
+                window.btoa(decodeURIComponent(encodeURIComponent(SHORTCUTSBUTTON)))
         ]);
     }
     HELPCONTENT.push([
         _("Help"),
         _("Show these messages."),
         "data:image/svg+xml;base64," +
-            window.btoa(unescape(encodeURIComponent(HELPBUTTON)))
+            window.btoa(decodeURIComponent(encodeURIComponent(HELPBUTTON)))
     ]);
     if (_THIS_IS_TURTLE_BLOCKS_) {
         HELPCONTENT.push([
             _("Guide"),
             _("A detailed guide to Turtle Blocks is available."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO))),
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO))),
             GUIDEURL,
             _("Turtle Blocks Guide")
         ]);
@@ -747,7 +747,7 @@ const createHelpContent = (activity) => {
                 " " +
                 VERSION,
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO))),
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO))),
             "https://github.com/sugarlabs/turtleblocksjs",
             _("Turtle Blocks GitHub repository")
         ]);
@@ -755,14 +755,14 @@ const createHelpContent = (activity) => {
             _("Congratulations."),
             _("You have finished the tour. Please enjoy Turtle Blocks!"),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO)))
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO)))
         ]);
     } else {
         HELPCONTENT.push([
             _("Guide"),
             _("A detailed guide to Music Blocks is available."),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO))),
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO))),
             GUIDEURL,
             _("Music Blocks Guide")
         ]);
@@ -778,7 +778,7 @@ const createHelpContent = (activity) => {
                 " " +
                 VERSION,
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO))),
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO))),
             "https://github.com/sugarlabs/musicblocks",
             _("Music Blocks GitHub repository")
         ]);
@@ -786,7 +786,7 @@ const createHelpContent = (activity) => {
             _("Congratulations."),
             _("You have finished the tour. Please enjoy Music Blocks!"),
             "data:image/svg+xml;base64," +
-                window.btoa(unescape(encodeURIComponent(LOGO)))
+                window.btoa(decodeURIComponent(encodeURIComponent(LOGO)))
         ]);
     }
 };

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -772,7 +772,7 @@ Turtles.TurtlesView = class {
                 }
             };
             const img = new Image();
-            img.src = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(svg)));
+            img.src = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(svg)));
 
             container.appendChild(img);
             container.setAttribute(
@@ -1021,7 +1021,7 @@ Turtles.TurtlesView = class {
             img.src =
                 "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(
+                    decodeURIComponent(
                         encodeURIComponent(
                             MBOUNDARY.replace("HEIGHT", this._h)
                                 .replace("WIDTH", this._w)
@@ -1062,7 +1062,7 @@ Turtles.TurtlesView = class {
             img.src =
                 "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(
+                    decodeURIComponent(
                         encodeURIComponent(
                             MBOUNDARY.replace("HEIGHT", this._h)
                                 .replace("WIDTH", this._w)

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -598,19 +598,19 @@ const MATRIXBUTTONHEIGHT2 = 66;
 const MATRIXSOLFEHEIGHT = 30;
 
 const wholeNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(WHOLENOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(WHOLENOTE)));
 const halfNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(HALFNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(HALFNOTE)));
 const quarterNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(QUARTERNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(QUARTERNOTE)));
 const eighthNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(EIGHTHNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(EIGHTHNOTE)));
 const sixteenthNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(SIXTEENTHNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(SIXTEENTHNOTE)));
 const thirtysecondNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(THIRTYSECONDNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(THIRTYSECONDNOTE)));
 const sixtyfourthNoteImg =
-    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(SIXTYFOURTHNOTE)));
+    "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(SIXTYFOURTHNOTE)));
 
 const NOTESYMBOLS = {
     1: wholeNoteImg,

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -42,8 +42,8 @@
 */
 
 const changeImage = (imgElement, from, to) => {
-    const oldSrc = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(from)));
-    const newSrc = "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(to)));
+    const oldSrc = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(from)));
+    const newSrc = "data:image/svg+xml;base64," + window.btoa(decodeURIComponent(encodeURIComponent(to)));
     if (imgElement.src === oldSrc) {
         imgElement.src = newSrc;
     }

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -82,7 +82,7 @@ class Oscilloscope {
             this.zoomFactor *= step;
         };
         zoomInButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
-            unescape(encodeURIComponent(BIGGERBUTTON))
+            decodeURIComponent(encodeURIComponent(BIGGERBUTTON))
         )}`;
 
         const zoomOutButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("Zoom Out"));
@@ -95,7 +95,7 @@ class Oscilloscope {
         };
 
         zoomOutButton.children[0].src = `data:image/svg+xml;base64,${window.btoa(
-            unescape(encodeURIComponent(SMALLERBUTTON))
+            decodeURIComponent(encodeURIComponent(SMALLERBUTTON))
         )}`;
 
         widgetWindow.sendToCenter();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -145,7 +145,7 @@ class PitchStaircase {
             const svgData =
                 "data:image/svg+xml;base64," +
                 window.btoa(
-                    unescape(
+                    decodeURIComponent(
                         encodeURIComponent(
                             SYNTHSVG.replace(/SVGWIDTH/g, svgWidth)
                                 .replace(/XSCALE/g, svgScale)


### PR DESCRIPTION
`unescape()` is deprecated so it should be avoided to use
 According to [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape) we can use `decodeURIComponent()`  to decode a URI component previously created by `encodeURIComponent()`.