### PR TITLE
Fix the palette-search-display block visibility issue

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1828,7 +1828,7 @@ class Activity {
                             item.label +
                             "</a>"
                     )
-                    .appendTo(ul);
+                    .appendTo(ul.css("z-index", 9999));
             };
             const searchInput = this.searchWidget.idInput_custom;
             if (!searchInput || searchInput.length <= 0) return;


### PR DESCRIPTION
- Due to the dearth of z-index property on the input block, the z-index value of the palette body items was the only dominating value and thus, the undesirable order of elements. 

- After adding a  z-index value that is greater than that of the z-index value of palette body items, the input display block will take precedence and will be displayed on top. 

NOTE: Display Block was GIVEN A YELLOW BACKGROUND to highlight the issue. 

BEFORE: 
![Screenshot (17)](https://user-images.githubusercontent.com/102666605/224491275-7af5ccc7-3f1b-482d-9555-acbcb6e44a28.png)

AFTER: 
![Screenshot (18)](https://user-images.githubusercontent.com/102666605/224491284-10136b92-f11a-4c79-9681-78018c08433b.png)

@walterbender  Would you mind sharing some tips regarding how to quickly and efficiently navigate to the target file which has the code that contains the breaking changes/needs enhancement? Is it strange that it takes me hours to find the exact point of code that needs to be changed and a minute to make the changes?  
Thanks in Advance 