### PR TITLE
Fixes #3210: error message is hidden behind

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -72,7 +72,7 @@ class Palettes {
         this.scale = 1.0;
         this.mobile = false;
         // Top of the palette
-        this.top = 55 + 20 + LEADING;
+        this.top = 105 + 20 + LEADING;
         this.current = DEFAULTPALETTE;
         this.x = []; // We track x and y for each of the multipalettes
         this.y = [];


### PR DESCRIPTION
make fixes in the `palette.js` file so that error message can be displayed properly.
Change `this.top = 55 + 20 + LEADING;` to `this.top = 105 + 20 + LEADING;` So that error message could be shown properly 
Before Fix:
![Screenshot (101)](https://user-images.githubusercontent.com/62383314/225892438-fd6efb2e-274a-4421-add9-ec072a005bf2.png)


After Fix:
![Screenshot (99)](https://user-images.githubusercontent.com/62383314/225892504-c670a1d1-11f8-446c-b2f2-5d4138562c25.png)

![Screenshot (100)](https://user-images.githubusercontent.com/62383314/225892523-6b7cd61c-b4c2-4c42-b856-e4cc30de051d.png)
