### PR TITLE
Enhancement: Enrich the Help-Block UI for smaller Viewports

### DIFF
--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -157,7 +157,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        z-index: 1000;
+        z-index: 10000;
     }
     #floatingWindows > .windowFrame {
         border-radius: 0;

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -214,7 +214,7 @@ class WidgetWindow {
             this._overlayframe.style.border = "0.25vw solid black";
             this._overlayframe.style.backgroundColor = "rgba(255,255,255,0.75)";
         } else {
-            this._frame.style.zIndex = "1";
+            this._frame.style.zIndex = "10000";
             this._overlayframe.style.border = "0px";
             this._overlayframe.style.zIndex = "-1";
             this._overlayframe.style.backgroundColor = "rgba(255,255,255,0)";
@@ -229,7 +229,7 @@ class WidgetWindow {
     _docMouseDownHandler(e) {
         if (e.target === this._frame || this._frame.contains(e.target)) {
             this._frame.style.opacity = "1";
-            this._frame.style.zIndex = "1";
+            this._frame.style.zIndex = "10000";
         } else {
             this._frame.style.opacity = ".7";
             this._frame.style.zIndex = "0";
@@ -392,7 +392,10 @@ class WidgetWindow {
             siblings[i].style.zIndex = "0";
             siblings[i].style.opacity = ".7";
         }
-        this._frame.style.zIndex = "1";
+
+        // this._frame.style.zIndex = "1";
+        // When in focus, the zIndex of the help must be the highest. Even greater than the input search display block
+        this._frame.style.zIndex = "10000" ;
         this._frame.style.opacity = "1";
     }
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -392,8 +392,7 @@ class WidgetWindow {
             siblings[i].style.zIndex = "0";
             siblings[i].style.opacity = ".7";
         }
-
-        // this._frame.style.zIndex = "1";
+        
         // When in focus, the zIndex of the help must be the highest. Even greater than the input search display block
         this._frame.style.zIndex = "10000" ;
         this._frame.style.opacity = "1";


### PR DESCRIPTION
RATIONALE : 
- In Smaller Screens (<= 600px) the Help Block took the entire width and height of the device. But immediately after the animation was completed, you'd have a palette on top of the Help section which isn't well reasoned/rational. 

-  In my humble opinion, the user should/would want to first take a tour and learn about the project if (s)he's a first-time user. An extra palette on top of the help section would discombobulate the user. After the user completes the intro to the project or skips it, then along with all other blocks, the palette must be visible. That was the intent behind these changes. 

- Now in all viewports, the help block when focused, has the highest z-index. 

BEFORE: 

![Screenshot (24)](https://user-images.githubusercontent.com/102666605/225869628-d3315c67-6a02-46b3-915b-f4b0d5982458.png)


AFTER: 

![Screenshot (25)](https://user-images.githubusercontent.com/102666605/225870757-2aa429df-fdc5-48d6-8694-057f3d7217aa.png)

![Screenshot (26)](https://user-images.githubusercontent.com/102666605/225979302-f51f43ee-45a2-47b5-8749-caa41689d24f.png)

@walterbender  I appreciate it. 
