### PR TITLE
Enhancement: Enrich the User Interface of the helpBlock's topBar

### DIFF
--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -23,6 +23,7 @@
     position: relative;
 }
 #floatingWindows > .windowFrame > .wfTopBar > .wfHandle {
+    display: none ;
     height: 2px;
     width: 50px;
     position: absolute;
@@ -38,9 +39,10 @@
     position: absolute;
     top: -4px;
     height: 2px;
-    width: 120%;
+    width: 120% ; 
     left: -10%;
     background-color: #666;
+    display: none ;
 }
 #floatingWindows > .windowFrame > .wfTopBar > .wfHandle::after {
     top: 4px;
@@ -64,6 +66,9 @@
 }
 #floatingWindows > .windowFrame > .wfTopBar .wftButton:last-child {
     margin: 0;
+}
+#floatingWindows > .windowFrame > .wfTopBar .wftButton.rollup {
+    order: 2 ; 
 }
 #floatingWindows > .windowFrame > .wfTopBar .wftButton.rollup::before {
     content: "";
@@ -96,6 +101,9 @@
     flex-grow: 1;
     color: #666;
     user-select: none;
+    text-align: center ;
+    text-transform: uppercase ;
+    letter-spacing: 1.2px ;
 }
 #floatingWindows > .windowFrame > .wfWinBody {
     min-height: 50px;
@@ -214,8 +222,12 @@
     #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
         flex-grow: 1;
         color: #fff;
-        font-size: 1.4em;
+        font-size: 1.5em;
         padding: 0 15px;
+        text-align: center ; 
+        text-transform: uppercase ; 
+        font-weight: 500;
+        letter-spacing: 1.5px ;
     }
     #floatingWindows > .windowFrame > .wfWinBody {
         flex-direction: column;
@@ -236,4 +248,3 @@
     #floatingWindows > .windowFrame > .wfWinBody > .wfbWidget {
         padding: 10px;
     }
-}


### PR DESCRIPTION
RATIONALE: 

- In the Help Section's Top-Bar, the Handle(div) was positioned absolutely in the center of the bar, which caused the HEADING/TITLE to appear cluttered and messy, which didn't make the UI so appealing. 

- The title must be the priority and that's why I'd argue that it should either be uppercase or capitalized and should be designed in such a way that it's eye-catchy.  (The User ideally must not search for the title) 

- All of which, the previous design failed to offer. Moreover, the code for the handle bloats the CSS file and offers too little in exchange. (as it's also styled using pseudo-elements). 

BEFORE: 

![Screenshot (25)](https://user-images.githubusercontent.com/102666605/226091828-6a2d2d54-658a-44be-aeac-8c3234ead1ea.png)

![Screenshot (26)](https://user-images.githubusercontent.com/102666605/226091832-668724e6-9b25-4c5c-b0f0-8676478bc0bb.png)

AFTER: 

![Screenshot (27)](https://user-images.githubusercontent.com/102666605/226091840-1867654d-214a-4831-b445-8f6a73e3d864.png)

![Screenshot (28)](https://user-images.githubusercontent.com/102666605/226091850-80dcbe21-b2d9-47cc-bc7f-ab3882b57082.png)

![Screenshot (29)](https://user-images.githubusercontent.com/102666605/226091857-5135db28-288a-46e9-b150-60001a15fea1.png)


CHANGES: 
- In small viewports, the heading is now in uppercase and in the center. 
- In larger viewports, the rollup button is ordered to be in the end and also the above changes are made. 

@walterbender 
If everything is up to the mark, I'll remove the HANDLE(div) code entirely from the file. Right now I've just set the display to none. Thanks :) 

