### PR TITLE
Fixes #3210: Shift error container(one with graphics) to center, to prevent overlapping by palette

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1501,7 +1501,7 @@ class Activity {
         this._createMsgContainer = (fillColor, strokeColor, callback, y) => {
             const container = new createjs.Container();
             this.stage.addChild(container);
-            container.x = (this.canvas.width - 1000) / 2;
+            container.x = (this.canvas.width) / 2;
             container.y = y;
             container.visible = false;
 
@@ -1568,7 +1568,7 @@ class Activity {
         this._makeErrorArtwork = (name) => {
             const container = new createjs.Container();
             this.stage.addChild(container);
-            container.x = (this.canvas.width - 1000) / 2;
+            container.x = (this.canvas.width) / 2;
             container.y = 80;
             this.errorArtwork[name] = container;
             this.errorArtwork[name].name = name;
@@ -3262,7 +3262,7 @@ class Activity {
                 blk in this.blocks.blockList &&
                 !this.blocks.blockList[blk].collapsed
             ) {
-                const fromX = (this.canvas.width - 1000) / 2;
+                const fromX = (this.canvas.width) / 2;
                 const fromY = 128;
                 const toX = this.blocks.blockList[blk].container.x + this.blocksContainer.x;
                 const toY = this.blocks.blockList[blk].container.y + this.blocksContainer.y;


### PR DESCRIPTION
Make fixes in `activity.js` file so that error message can be displayed properly.
Change `(this.canvas.width - 1000) / 2;` to `(this.canvas.width) / 2;` So that error message could be shown properly at the center of screen. This change has been made at 3 places in file, to shift the containers & arrows.
## Before Fix:
![Screenshot (118)](https://user-images.githubusercontent.com/62383314/227164025-a49a40cf-849f-48de-9437-7b7c518fb208.png)
## After Fix:
![Screenshot (117)](https://user-images.githubusercontent.com/62383314/227164080-a3dfa183-7cdd-4361-bfcc-5653a5ab1c8b.png)