### PR TITLE
Fix  project remove after saving as png  [Chrome] #3034

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2571,8 +2571,11 @@ class Activity {
         };
 
         const that = this;
+        const screenWidth = window.innerWidth
         window.onresize = () => {
-            that._onResize(false);
+            if(screenWidth !== window.innerWidth ){
+                that._onResize(false);
+            }
         };
 
         /*

--- a/js/activity.js
+++ b/js/activity.js
@@ -2573,7 +2573,7 @@ class Activity {
         const that = this;
         const screenWidth = window.innerWidth
         window.onresize = () => {
-            if(screenWidth !== window.innerWidth ){
+            if (screenWidth !== window.innerWidth) {
                 that._onResize(false);
             }
         };


### PR DESCRIPTION
I fixed the frame resizing issue that clears project after  saving as PNG on chrome

issue  --  #3034
https://github.com/sugarlabs/musicblocks/issues/3034
@walterbender 
I will also love to know if you will suggest the restriction of this changes to chrome browser alone or it's okay like this.