### PR TITLE
fixes issue #3066 - to remove arrows on dismissing error message

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -331,8 +331,8 @@ class Activity {
             // Error message containers
             this.errorText = docById("errorText");
             this.errorTextContent = docById("errorTextContent");
-            //hideArrow on hiding error message
-            this.errorText.addEventListener("click", this._hideArrows );
+            // Hide Arrow on hiding error message
+            this.errorText.addEventListener("click", this._hideArrows);
             // Show and populate the printText div.
             this.printText = docById("printText");
             this.printTextContent = docById("printTextContent");

--- a/js/activity.js
+++ b/js/activity.js
@@ -331,6 +331,8 @@ class Activity {
             // Error message containers
             this.errorText = docById("errorText");
             this.errorTextContent = docById("errorTextContent");
+            //hideArrow on hiding error message
+            this.errorText.addEventListener("click", this._hideArrows );
             // Show and populate the printText div.
             this.printText = docById("printText");
             this.printTextContent = docById("printTextContent");


### PR DESCRIPTION
The following pull request fixes issue #3066 dismissing an error message removeArrow() is not found