### PR TITLE
Bugfix: Fix the redundant display of Offline/No project message 

### DIFF
--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -333,7 +333,26 @@ function GlobalPlanet(Planet) {
         }
     };
 
+    this.cleanContainer = () => {
+        const element = document.getElementById("global-projects").firstElementChild ;
+        const list = element?.classList ?? "empty" ;
+
+        if (list === "empty")
+            return ;
+
+        list.forEach(name => {
+            if (name === "container" || name === "center-align") {
+                element.remove() ;
+                return ;
+            }
+        });
+    } ;
+
     this.render = data => {
+        
+        // Make sure the container doesn't display the offlineHTML or noProjectsHTML even when cards are being rendered.
+        this.cleanContainer() ;
+
         for (let i = 0; i < data.length; i++) {
             // eslint-disable-next-line no-prototype-builtins
             if (this.cache.hasOwnProperty(data[i][0])) {


### PR DESCRIPTION
- RATIONALE: 

- If in the global project container, for some reason, data couldn't be fetched then according to the error handling process, a container was rendered which had an error message with a request to reload the page. 

- Same was true if there were no cards that matched the selected tags/queries. 

But in some cases like a slow internet connection, the message was delivered and it persisted despite the rendering of all the projects after a while. So the container displayed both the error message and the projects that matched the query/tags AT THE SAME TIME, which is irrational. 

- To solve the problem a new method was added which, before rendering the projects, checks if the error message is still displayed on the screen. If it is, then it is removed from the DOM before the project cards are rendered. 


BEFORE: 
![Screenshot (40)](https://user-images.githubusercontent.com/102666605/227590356-1bb8175b-c9dc-48b0-9660-5dbcf52fd5f7.png)

![Screenshot (48)](https://user-images.githubusercontent.com/102666605/227590374-489e0ec8-b0e3-4741-8e07-6fa724401b6e.png)

AFTER: 
Different situations beget different responses. So, only the project(s) or the error message is rendered in appropriate situations. NEVER BOTH. 

@walterbender  Thanks in advance. 