### PR TITLE
Enhancement: Fix overlapping dropdown list

### DIFF
--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -243,6 +243,14 @@
 	cursor: pointer;
 }
 
+div.select-wrapper * {  
+	cursor: pointer ;
+}
+
+.select-wrapper ul.dropdown-content { 
+	top: 100% !important ;
+}
+
 .centre-button {
 	left: 50%;
 	-webkit-transform: translateX(-50%);


### PR DESCRIPTION
RATIONALE: 

- Multiple elements were listening to the click event and handling it. Consequentially,  the dropdown list had to be clicked twice in order for it to be active and display the options. 

- By adding distance between the input and the dropdown list, we only have to click it once  to open it. 

![dropdown](https://user-images.githubusercontent.com/102666605/227965527-bd2d2e93-9cac-4815-af28-bd88048506e3.png)
