### PR TITLE
corrections in documentations

### DIFF
--- a/Debugging.md
+++ b/Debugging.md
@@ -85,7 +85,7 @@ e.g., x, y, heading, color, shade, grey, and pensize.
 ![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/guide/status3.svg "additional programming within the Status block")
 
 You can do additional programming within the status block. In the
-example above, `whole notes played` is divided by `4` (e.g. quarter notes)
+example above, `whole notes played` is multiplied by `4` (e.g. quarter notes)
 before being displayed.
 
 ## 4. Playback modes

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -216,7 +216,7 @@ loops. Whatever stack of blocks are placed inside its clamp will be
 repeated. It can be used to repeat individual notes, or entire phrases
 of music.
 
-![The Duplicate block(./duplicatenotes_block.svg "Duplicate block")
+![The Duplicate block](./duplicatenotes_block.svg "Duplicate block")
 
 The *Duplicate* block, found on the *Rhythms* palette, is used to
 repeat any contained notes. Similar to using a *Repeat* block, but


### PR DESCRIPTION
Correction in documentation/README.md file
path for duplicate notes image corrected from ![The Duplicate block(./duplicatenotes_block.svg "Duplicate block") to ![The Duplicate block](./duplicatenotes_block.svg "Duplicate block")

Correction in Debugging.md file in the status widget section
"whole notes played is divided by 4 (e.g. quarter notes) before being displayed." changed to 
"whole notes played is multipliced by 4 (e.g. quarter notes) before being displayed."
