### PR TITLE
Fixed regression in lillypond- corrected the wrongly generated syntax

### DIFF
--- a/js/lilypond.js
+++ b/js/lilypond.js
@@ -85,6 +85,8 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
 
     let noteCounter = 0;
     let queueSlur = false;
+    let queueCrescendo = false
+    let queueDecrescendo = false
     let articulation = false;
     let targetDuration = 0;
     let tupletDuration = 0;
@@ -209,10 +211,12 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
                     articulation = false;
                     break;
                 case "begin crescendo":
-                    logo.notationNotes[turtle] += "\\< ";
+                    logo.notationNotes[turtle] += "  ";
+                    queueCrescendo = true
                     break;
                 case "begin decrescendo":
-                    logo.notationNotes[turtle] += "\\> ";
+                    logo.notationNotes[turtle] += "  ";
+                    queueDecrescendo = true
                     break;
                 case "end crescendo":
                     logo.notationNotes[turtle] += "\\! ";
@@ -588,6 +592,15 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
             if (queueSlur) {
                 queueSlur = false;
                 logo.notationNotes[turtle] += "(  ";
+            }
+            if (queueCrescendo) {
+                queueCrescendo = false;
+                logo.notationNotes[turtle] += "\\< ";
+            }
+            if (queueDecrescendo) {
+                queueDecrescendo = false;
+                logo.notationNotes[turtle] += "\\> ";
+
             }
         }
     }


### PR DESCRIPTION
Here is a potential fix for issue https://github.com/sugarlabs/musicblocks/pull/2843

I fixed a regression in the lillypond code by correcting the wrongly generated syntax \< \> [ Crescendo start syntax and the Decrescendo start syntax ].

here is a sample MB project to test this
[dynamicstest.zip](https://github.com/sugarlabs/musicblocks/files/11175239/dynamicstest.zip)

Now using decrescendo and crescendo in any MB project wont be an issue as one can generate the lillypond code without error

@walterbender I will love to know your view about this