### PR TITLE
Bugfix: Fixing the redundant display of buttoncontainers (TOP&BOTTOM). 

### DIFF
--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -66,6 +66,7 @@ class PlanetInterface {
             const png = docById("overlayCanvas").toDataURL("image/png");
             this.planet.open(png);  // this.mainCanvas.toDataURL("image/png"));
             this.iframe.style.display = "block";
+            this.iframe.style.zIndex = "9999" ;
             try {
                 this.iframe.contentWindow.document.getElementById("local-tab").click();
             } catch (e) {


### PR DESCRIPTION
RATIONALE: 

- The 2 button containers TOP AND BOTTOM mustn't be visible when planet is displayed. The planet HTML page is loaded via Iframe. But after rendering, whenthe viewport was resized, the button containers would become visible on top of the planet page. 

- In order to fix this problem, a z-index was added.

BEFORE: 
<img width="499" alt="Screenshot 2023-04-14 204416" src="https://user-images.githubusercontent.com/102666605/232330490-b03ebb46-d9db-433b-9f91-7480ddfd5e93.png">
 