### PR TITLE
Fixed scrollbar issue for smaller screen

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -407,6 +407,12 @@ body {
     overflow: hidden;
 }
 
+@media screen and (max-width: 798px) {
+    body {
+      overflow: overlay;
+    }
+  }
+
 body.noScroll {
     overflow: hidden;
 }


### PR DESCRIPTION
Closes https://github.com/sugarlabs/musicblocks/issues/3184

The fix/hack that I have added is to make the scrollbar appear for screens with a viewport less than 798px.