### PR TITLE
Add Contributor Metrics Widget to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Conduct](https://github.com/sugarlabs/sugar-docs/blob/master/src/CODE_OF_CONDUCT
 
 ## <a name="CONTRIBUTING"></a>Contributing
 
+<a href="https://github.com/monoclehq">
+<img src="https://open-source-assets.middlewarehq.com/svgs/sugarlabs-musicblocks-contributor-metrics-dark-widget.svg"></img>
+</a>
+
 Please consider contributing to the project, with your ideas, your
 music, your lesson plans, your artwork, and your code.
 


### PR DESCRIPTION
## Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
- A widget showcasing recent contributions can be motivating for new contributors.
- This widget is already present in some selected opensource repositories- [RocketChat/Apps.GitHub22](https://github.com/RocketChat/Apps.Github22), [RocketChat/EmbeddedChat](https://github.com/RocketChat/EmbeddedChat), [RocketChat/RC4Community](https://github.com/RocketChat/RC4Community) etc. and has helped in community building around those projects. 
- A number of  students had mentioned their rank on this widget in their GSoC 2023 proposal for RocketChat. Hence, this can be great motivator for student contributors. 

## Proposed Changes
- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics regularly and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 2 months.

![image](https://github.com/sugarlabs/musicblocks/assets/70485812/e0fb87d9-4460-4478-9875-df301ce41d24)
