### PR TITLE
Fix Broken Links in README.md

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -104,27 +104,27 @@ Context menus are an important part of user interfaces that provide users with q
 # The Block context menu:
 This context menu appears when you right-click on a block in the workspace. It provides options such as "Duplicate," "Delete," "Help," and "Copy to Palette." The "Duplicate" option creates a copy of the selected block, while the "Delete" option removes the selected block from the workspace. The "Help" option opens a help dialog for the selected block, and the "Copy to Palette" option adds the selected block to the user's custom block palette.
 
-![Right-click context menu](./block_context.png "Right-click context menu")
+![Right-click context menu](./block_context.PNG "Right-click context menu")
 
 # Extract
 The "Extract" option in Music Blocks allows you to separate a nested block into its individual components or sub-blocks. This can be useful if you want to modify or reuse specific parts of a block without affecting the rest of the block.
 
-![Extract the selected block](./extract.png "Extract the selected block")
+![Extract the selected block](./extract.PNG "Extract the selected block")
 
 # Duplicate
 This option creates a duplicate of the selected block and places it next to the original block.
 
-![Duplicate](./duplicate.png "Duplicate")
+![Duplicate](./duplicate.PNG "Duplicate")
 
 # Delete
 This option removes the selected block from your program
 
-![Delete](./delete.png "Delete")
+![Delete](./delete.PNG "Delete")
 
 # Help
 This option shows a help screen with information about the selected block. You can use this option to learn more about the block's functionality and how to use it in your projects.
 
-![Help](./help.png "Help")
+![Help](./help.PNG "Help")
 
 By using the right-click context menu in Music Blocks, you can quickly perform common tasks and manipulate blocks on the workspace. This can help you to work more efficiently and effectively in your projects.
 


### PR DESCRIPTION
In the documentation README there were some images that didn't show up. Examination of the code showed that they were referencing files that were named correctly except for the case of the suffix. "block.png" was referenced in the file, but the file is named "block.PNG". With this change, the images now display correctly.