### PR TITLE
Added a tooltip element to display the fullscreen mode text

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
                         </ul>
                         <ul class="main right">
                             <li>
-                                <a id="FullScreen" class="FullScreen" onclick="setIcon()">
+                                <a id="FullScreen" class="FullScreen tooltipped" data-position="bottom"  data-tooltip="FullScreen Mode" onclick="setIcon()">
                                     <i class="material-icons">&#xe5d0;</i>
             
                                 </a>


### PR DESCRIPTION
Added hover functionality to display fullscreen mode as text.
By implementing this feature, we aim to make the fullscreen mode more intuitive and user-friendly. This enhancement will help users easily identify and understand the purpose of the fullscreen option, ultimately improving their interaction with the application.
Before :-
<img width="244" alt="image" src="https://github.com/sugarlabs/musicblocks/assets/111771508/7e7e4f64-8af1-4e97-a4c3-61e624fd1071">
After:-
<img width="265" alt="image" src="https://github.com/sugarlabs/musicblocks/assets/111771508/da4bb7e9-78f0-4fca-9d35-274037137afe">
