### PR TITLE
Solving rendering problems during the trash events

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1243,6 +1243,8 @@ class Activity {
 
                 this.setSmallerLargerStatus();
             }
+            this.activity.refreshCanvas();
+            document.getElementById('hideContents').click();
         };
 
         /*
@@ -1269,6 +1271,8 @@ class Activity {
             }
 
             this.setSmallerLargerStatus();
+            this.activity.refreshCanvas();
+            document.getElementById('hideContents').click();
         };
 
         /*

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6771,7 +6771,7 @@ class Blocks {
                     } else {
                         this.turtles.turtleList[turtle].inTrash = true;
                         this.turtles.turtleList[turtle].container.visible = false;
-                    }
+                    } 
                 }
             } else if (myBlock.name === "action") {
                 if (!myBlock.trash) {
@@ -6823,6 +6823,9 @@ class Blocks {
                 this._cleanupStacks();
                 this.activity.refreshCanvas();
             }
+            this.activity.refreshCanvas();
+            this.activity.trashcan.stopHighlightAnimation();
+            document.getElementById('hideContents').click();
         };
 
         /***

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6771,7 +6771,7 @@ class Blocks {
                     } else {
                         this.turtles.turtleList[turtle].inTrash = true;
                         this.turtles.turtleList[turtle].container.visible = false;
-                    } 
+                    }
                 }
             } else if (myBlock.name === "action") {
                 if (!myBlock.trash) {


### PR DESCRIPTION
For issue #3317:

This also worked on touch device 

Now, blocks are deleted instantly after coming into the trash area, and the red color of the trash boundary is set to be in its original color after the event.