### PR TITLE
Fixed Reference error, doSearch() is not defined 🛠️

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 
         <script type="text/javascript">
             $(document).ready(function() {
-                doSearch();
+                // ?????
             });
         </script>
     </head>


### PR DESCRIPTION
## I resolved a reference error issue identified in this issue:
* [https://github.com/sugarlabs/musicblocks/issues/3320](https://github.com/sugarlabs/musicblocks/issues/3320)

After seeing the console in the dev tools, it became evident that one last missed function were not defined.

To solve this issue, I removed the last missed function `doSearch()` from the `./index.html` file and replaced it with a comment;
This change effectively mitigates the reference error, for further proposed solutions...