### PR TITLE
documentation correction: 'second' -> 'minutes' in  documentation-es/…

### DIFF
--- a/documentation-es/README.md
+++ b/documentation-es/README.md
@@ -148,7 +148,7 @@ use musical notation, referring to whole notes (`1`), half notes
 the note duration. (There are some practical limitations, which you
 can discover through experimentation.) The relative length of a
 quarter note is half as long as a half note. By default, Music Blocks
-will play 90 quarter notes per second, so each quarter note is `2/3`
+will play 90 quarter notes per minute, so each quarter note is `2/3`
 seconds (`666` microseconds) in duration.
 
 The *Pitch* block (found on the Pitch Palette) is used to specify the


### PR DESCRIPTION
Fix duration error in  documentation-es/README.md

There was an error in the README.md file where the term "second" was incorrectly used, causing confusion about the actual duration. The corrected version now uses the term "minute," ensuring accurate information.

Before correction:
![Before](https://github.com/sugarlabs/musicblocks/assets/106376368/30ed5503-0b91-4392-b25d-07d2400974ae)

After correction:
![After](https://github.com/sugarlabs/musicblocks/assets/106376368/2b1065b7-775f-488e-8b80-91e74d5822c6)

This change is necessary to reflect the correct duration of `2/3` seconds as mentioned in the code. The corrected terminology provides a more accurate representation in the README.md file.