### PR TITLE
fixes Warning issue in utils.js

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1302,11 +1302,12 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
         }
 
         // Add class type's instance to adding object
-        if (args === undefined || args === []) {
+        if (args === undefined || args.length === 0) {
             obj.added = new ctype();
         } else {
             obj.added = new ctype(...args);
         }
+        
 
         // Loop for all method names of class type
         for (const name of Object.getOwnPropertyNames(ctype.prototype)) {


### PR DESCRIPTION
This PR fixes the issue #3374 
The warning is because the condition args === [] will always return false as JavaScript compares objects by reference, not by value. An empty array is an object, and  using === to compare objects, it checks if they refer to the same object in memory.
To fix this, I used  its length is 0  to determine if it's an empty array instead of using args===[ ].
@walterbender 