### PR TITLE
Removed the deprecated returnValue property from the saveInterface class 

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -75,7 +75,7 @@ class SaveInterface {
 
         this.timeLastSaved = -100;
         const $j = jQuery.noConflict();
-        $j(window).bind("beforeunload", (event) => {
+        $j(window).on("beforeunload", (event) => {
             let saveButton = "#saveButtonAdvanced";
             if (this.activity.beginnerMode) {
                 saveButton = "#saveButton";
@@ -86,7 +86,6 @@ class SaveInterface {
                 this.PlanetInterface !== undefined
             ) {
                 event.preventDefault();
-                event.returnValue = "";
                 // Will trigger when exit/reload cancelled.
                 $j(saveButton).trigger("mouseenter");
                 return "";


### PR DESCRIPTION
This pr fixes the issue #3376  

1. I removed the `returnValue` property from the `saveInterface` class as it is deprecated and the `preventDefault` property is sufficient to prevent the default behavior during the `beforeunload` event.
2. changed the `.bind` method to `.on` since its deprecated in jQuery 3.0 version