### PR TITLE
fixes warning issue in logo.js

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1810,9 +1810,10 @@ class Logo {
         // When turtle commands (forward, right, arc) are inside of notes,
         // they are run progressively over the course of the note duration.
 
+
         const tur = this.activity.turtles.ithTurtle(turtle);
 
-        if (tur.singer.embeddedGraphics === {}) return;
+        if (Object.keys(tur.singer.embeddedGraphics).length === 0) return;
 
         if (!(blk in tur.singer.embeddedGraphics)) return;
 


### PR DESCRIPTION
This PR fixes #3381 
I have used Object.keys method to get an array of the object's own enumerable property names.
After that make length of that array  zero,so that  the object is empty.

@walterbender 
