### PR TITLE
removed_fa#5

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2269,6 +2269,7 @@ class PhraseMaker {
                 this.stylePhraseMaker();
             }
 
+            if(obj[1]!=='fa♯')
             this.rowLabels.push(obj[1]);
             this.rowArgs.push(Number(obj[2]));
         }


### PR DESCRIPTION
issue: #3291 

I have removed the duplicate pitch in phrase maker 
![Screenshot (843)](https://github.com/sugarlabs/musicblocks/assets/124120102/6ab58a33-2a4e-4bc9-89b4-2f01663787e3)
I think removing that one case is better than removing the fa#5 from the obj itself 

once review my PR @pikurasa and tell me any changes are required