### PR TITLE
fixed issue #3373 | closing img on hardstop

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -861,7 +861,6 @@ class Activity {
         this._doFastButton = (env) => {
             this.blocks.activeBlock = null;
             hideDOMLabel();
-
             const currentDelay = this.logo.turtleDelay;
             this.logo.turtleDelay = 0;
             this.logo.synth.resume();
@@ -1101,7 +1100,8 @@ class Activity {
         this._doHardStopButton = (onblur) => {
             this.blocks.activeBlock = null;
             hideDOMLabel();
-
+            // Clear Canvas after hard stop audio
+            this._allClear();
             if (onblur === undefined) {
                 onblur = false;
             }
@@ -3205,7 +3205,7 @@ class Activity {
          */
         this.runProject = (env) => {
             document.removeEventListener("finishedLoading", this.runProject);
-
+            console.log("run project :", env)
             const that = this;
             setTimeout(() => {
                 that._changeBlockVisibility();

--- a/js/logo.js
+++ b/js/logo.js
@@ -1791,6 +1791,8 @@ class Logo {
                         logo.activity.showBlocksAfterRun = false;
                     }
                 }
+                // clearing canvas when audio is completed
+                this.activity._allClear();
                 document.getElementById("stop").style.color = "white";
             }
         }


### PR DESCRIPTION
### Description:
This PR addresses issue #3373 by resolving the bug where images populated by the song remain on the screen even after the music playback is completed. The fix involves ensuring that all images associated with the music are closed when the audio reaches its completion or when the hard stop button is pressed.

### Changes Made:
- Added activity._allClear() function when the hard stop button is triggered.
- Added activity._allClear() function when the music reaches completion.

### Steps Taken:
Implemented a check for music completion event.
Modified the functionality to close all images linked with the music upon completion.
Added handling to trigger the image closure when the hard stop button is pressed.

### Testing:
Manually tested the fix by:
- Loading various projects from the server (e.g., 'jingle bell').
- Initiating music playback.
- Ensuring that upon completion of music or pressing the hard stop button, all images associated with the music were - successfully removed from the screen.

### To Test:
- Pull this branch into your local environment.
- Run the application.
- Load any project that includes images associated with music.
- Play the music.
- Verify that upon completion of the music or pressing the hard stop button, the images are no longer displayed on the screen.

### Additional Notes:
This PR aims to enhance user experience by ensuring proper synchronization of image display with music playback.