### PR TITLE
fixes incorrect use of label tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     </div>
     <div id="movable" tabindex="-1">
         <p>Solfege Pitch Preview</p>
-        <input class="radioBtn" type="radio" name="movable" value="true">
+        <input class="radioBtn" type="radio" name="movable" value="true" id="movabledo">
             <label for="movabledo">Movable Do</label>
         <input class="radioBtn" type="radio" name="movable" id="fixed" checked="checked" value="false">
             <label for="fixed">Fixed</label>

--- a/planet/index.html
+++ b/planet/index.html
@@ -100,7 +100,7 @@
                                 <div class="row">
                                     <div class="input-field">
                                         <div class="chips chips-autocomplete" id="tagsadd"></div>
-                                        <label for="publish-tags" id="publish-tags-label"></label>
+                                        <label for="publish-tags" id="tagsadd"></label>
                                     </div>
                                 </div>
                             </div>
@@ -160,7 +160,7 @@
                                     <option value="DOWNLOADED" id="option-downloaded"></option>
                                     <option value="ALPHABETICAL" id="option-alphabetical"></option>
                                 </select>
-                                <label id="option-sort-by"></label>
+                                <label for="sort-select" id="option-sort-by"></label>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
This PR fixes #3401 
There is incorrect use of label tag  as  the "for" attribute of <label> tag must be equal to the id attribute of the related element to bind them together.