### PR TITLE
Fixes typos in docs

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -178,7 +178,7 @@ loops. Whatever stack of blocks are placed inside its clamp will be
 repeated. It can be used to repeat individual notes, or entire phrases
 of music.</p>
 <p><img src="duplicatenotes_block.svg" alt="duplicatenotes_block.svg" title="Duplicate block"></p>
-<p>The <em>Duplicate</em> block, found on the <em>Rhythms</em> palette, is used to
+<p>The <em>Duplicate</em> block, found on the <em>Rhythm</em> palette, is used to
 repeat any contained notes. Similar to using a <em>Repeat</em> block, but
 rather than repeating a sequence of notes multiple times, each note is
 repeated in turn, e.g. duplicate x2 of <code>4 4 8</code> would result in <code>4 4 4
@@ -236,11 +236,11 @@ shade 0</code> is black. <code>set shade 100</code> is white.</p>
 the color of the &quot;ink&quot; used in the mouse pen. <code>set color 0</code> is
 red. <code>set color 70</code> is blue.</p>
 <p><img src="random_block.svg" alt="random_block.svg" title="random"></p>
-<p>The <em>Random</em> block, found on the <em>Numbers</em> palette, is used to
+<p>The <em>Random</em> block, found on the <em>Number</em> palette, is used to
 generate a random number, because sometimes being unpredictable is
 nice.</p>
 <p><img src="oneOf_block.svg" alt="oneOf_block.svg" title="on of this or that"></p>
-<p>The <em>One of</em> block, also found on the <em>Numbers</em> palette, is used to
+<p>The <em>One of</em> block, also found on the <em>Number</em> palette, is used to
 generate a binary choice, one of &quot;this&quot; or &quot;that&quot;, because sometimes
 being unpredictable is nice.</p>
 <p><img src="show_block.svg" alt="show_block.svg" title="show media"></p>


### PR DESCRIPTION
Fixes: #3409

This PR Fixes the words 'Rhythms' and 'Numbers' in docs to 'Rhythm' and 'Number' 