### PR TITLE
Fixes #3286 - TypeError while running the JavaScript code in the editor

### DIFF
--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -206,8 +206,10 @@ class MusicBlocks {
         // Remove any listeners that might be still active
         for (const mouse of Mouse.MouseList) {
             for (const listener in mouse.turtle.listeners) {
-                globalActivity.logo.stage.removeEventListener(
+                if (globalActivity.logo.stage && mouse.turtle.listeners.hasOwnProperty(listener)) {
+                    globalActivity.logo.stage.removeEventListener(
                     listener, mouse.turtle.listeners[listener], false);
+                }
             }
             mouse.turtle.listeners = {};
         }


### PR DESCRIPTION
Fixes #3286

This PR fixes the problem of undefined TypeError that occurs when the code in the JSeditor is ran twice as shown in the image below 

![image](https://github.com/sugarlabs/musicblocks/assets/52532308/ce445379-c092-4405-8667-7739f8b579a5)
 
Current Behavior :-

When the code in the JSeditor is ran the second time a TypeError is thrown in the console of `removeEventListener` being undefined.

Fix :-

This error occurs because there's no check in place to ensure that the `eventlistener` exists before removing it.
Hence I add a simple if block to ensure the `removeEventListener` runs only if `eventlistener` exists. 

@walterbender please review this PR and let me know if any changes are needed! 