### PR TITLE
fixes warning issue in export.js

### DIFF
--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -245,7 +245,8 @@ class MusicBlocks {
                 cname = cname === "Painter" ? this.turtle.painter : eval(cname);
 
                 returnVal =
-                    args === undefined || args === [] ? cname[command]() : cname[command](...args);
+                 args === undefined || (Array.isArray(args) && args.length === 0) ? cname[command]() : cname[command](...args);
+
             }
 
             const delay = this.turtle.waitTime;


### PR DESCRIPTION
This PR fixes #3435 
I have use Array.isArray(args) to ensure that args is an array and args.length === 0 to check wheather it is empty or not .
so
(Array.isArray(args) && args.length === 0) checks both aspects: whether args is an array and whether it is an empty array.