### PR TITLE
Fixing Description for Interval Number Block in Music Blocks Tour - issue #3443

### DIFF
--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -172,9 +172,10 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             super("intervalnumber", _("interval number"));
             this.setPalette("intervals", activity);
-            this.setHelpString(_("The Interval number block returns the number of scalar steps in the current interval.") , 
-                               
-            );
+            this.setHelpString([_("The Interval number block returns the number of scalar steps in the current interval.") , 
+                                  "" ,
+                                  "" 
+                                ]);
             this.beginnerBlock(true);
             this.hidden = true;
             this.formBlock({ outType: "numberout" });

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -172,10 +172,9 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             super("intervalnumber", _("interval number"));
             this.setPalette("intervals", activity);
-            this.setHelpString([_("The Interval number block returns the number of scalar steps in the current interval.") , 
-                               "" , 
-                               ""
-            ]);
+            this.setHelpString(_("The Interval number block returns the number of scalar steps in the current interval.") , 
+                               
+            );
             this.beginnerBlock(true);
             this.hidden = true;
             this.formBlock({ outType: "numberout" });

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -173,7 +173,7 @@ function setupIntervalsBlocks(activity) {
             super("intervalnumber", _("interval number"));
             this.setPalette("intervals", activity);
             this.setHelpString([_("The Interval number block returns the number of scalar steps in the current interval.") , 
-                                  "" ,
+                                  "documentation" ,
                                   "" 
                                 ]);
             this.beginnerBlock(true);

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -172,7 +172,10 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             super("intervalnumber", _("interval number"));
             this.setPalette("intervals", activity);
-            this.setHelpString(_("The Interval number block returns the number of scalar steps in the current interval."));
+            this.setHelpString([_("The Interval number block returns the number of scalar steps in the current interval.") , 
+                               "" , 
+                               ""
+            ]);
             this.beginnerBlock(true);
             this.hidden = true;
             this.formBlock({ outType: "numberout" });


### PR DESCRIPTION
This pull request resolves issue #3443, which concerns the missing description for the Interval Number Block in the Music Blocks tour. The absence of a description hinders users' understanding of this important component in the music creation process.

![Screenshot (197)](https://github.com/sugarlabs/musicblocks/assets/88442916/c02661ce-86b0-4673-a42d-95a1ef4139c4)
