### PR TITLE
fixes the size of theme button in js editor

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -156,7 +156,7 @@ class JSEditor {
         styleBtn.style.borderRadius = "50%";
         styleBtn.style.padding = ".25rem";
         styleBtn.style.marginRight = ".75rem";
-        styleBtn.style.fontSize = "1.5rem";
+        styleBtn.style.fontSize = "2rem";
         styleBtn.style.background = "#2196f3";
         styleBtn.style.cursor = "pointer";
         styleBtn.innerHTML = "invert_colors";


### PR DESCRIPTION
Fixes: #3454

This PR fixes the size of theme button in javascript editor. making it sync with the size of other buttons 

![btn](https://github.com/sugarlabs/musicblocks/assets/109718740/d03a67f2-1482-4c3d-a6a2-a3dd505e88d6)

kindly review this @walterbender sir