### PR TITLE
Fix/'Display Statistics' window in Advance mode - Restore Hidden Blocks on Window Close

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -43,9 +43,9 @@ class HelpWidget {
         this.isOpen = true;
 
         const widgetWindow = window.widgetWindows.windowFor(this, "help", "help", false);
-        widgetWindow.getWidgetBody().style.overflowY = "auto";
+       //widgetWindow.getWidgetBody().style.overflowY = "auto";
         // const canvasHeight = docById("myCanvas").getBoundingClientRect().height;
-        widgetWindow.getWidgetBody().style.maxHeight = "500px";
+        widgetWindow.getWidgetBody().style.maxHeight = "450px";
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
@@ -185,7 +185,7 @@ class HelpWidget {
 
                 if (message) {
                     const helpBody = docById("helpBodyDiv");
-                    helpBody.style.height = "";
+                    helpBody.style.height = "450px";
 
                     let body = "";
                     if (message.length > 1) {
@@ -390,7 +390,7 @@ class HelpWidget {
         this._helpDiv = document.createElement("div");
 
         //this._helpDiv.style.width = "500px";
-        this._helpDiv.style.height = "500px";
+        this._helpDiv.style.height = "450px";
         this._helpDiv.style.backgroundColor = "#e8e8e8";
         
         const helpDivHTML =
@@ -457,7 +457,7 @@ class HelpWidget {
             const message = block.helpString;
 
             const helpBody = docById("helpBodyDiv");
-            helpBody.style.height = "500px";
+            helpBody.style.height = "450px";
             helpBody.style.backgroundColor = "#e8e8e8";
             if (message) {
                 let body = "";

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -123,8 +123,7 @@ class WidgetWindow {
 
         const closeButton = this._create("div", "wftButton close", this._drag);
         closeButton.onclick = (e) => {
-            this.destroy();
-
+            this.onclose() ; 
             e.preventDefault();
             e.stopPropagation();
         };


### PR DESCRIPTION
This pull request addresses issue   by implementing a fix that ensures the blocks hidden when "Display Statistics" is clicked in Advanced Mode will revert to their default visible state when the user closes the window 


https://github.com/sugarlabs/musicblocks/assets/88442916/9e883061-9ec7-4770-ad3b-5c9c92b48fce

