### PR TITLE
Fix/'Display Statistics' window in Advance mode - Restore Hidden Blocks on Window Close - #3456

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -123,8 +123,7 @@ class WidgetWindow {
 
         const closeButton = this._create("div", "wftButton close", this._drag);
         closeButton.onclick = (e) => {
-            this.destroy();
-
+            this.onclose();
             e.preventDefault();
             e.stopPropagation();
         };


### PR DESCRIPTION
This pull request addresses issue #3456  by implementing a fix that ensures the blocks hidden when "Display Statistics" is clicked in Advanced Mode will revert to their default visible state when the user closes the window




https://github.com/sugarlabs/musicblocks/assets/88442916/78dff7d4-5bd6-475f-bb70-25e00ea5ccf6

