### PR TITLE
fix/disabling-right-arrow-of-last-slide-of-blocks-tour 

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -833,6 +833,11 @@ table {
     cursor: not-allowed;
 }
 
+#right-arrow.disabled{
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 #right-arrow, #left-arrow {
     position: absolute;
     background-size: 40px;

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -400,6 +400,11 @@ class HelpWidget {
         this.widgetWindow.getWidgetBody().append(this._helpDiv);
         this.widgetWindow.sendToCenter();
         let cell = docById("right-arrow");
+        let rightArrow = docById("right-arrow");
+        if(this.index == this.appendedBlockList.length - 1)
+        {
+           rightArrow.classList.add("disabled") ;       
+        }
         cell.onclick = () => {
             if (this.index !== this.appendedBlockList.length - 1) {
                 this.index += 1;


### PR DESCRIPTION
This pull request addresses issue #3476, which involves disabling the right arrow on the last slide of the blocks tour. This action is taken because allowing navigation to the next slide is unnecessary as there are no further slides for the user to access.


https://github.com/sugarlabs/musicblocks/assets/88442916/943f1766-e043-4601-94b4-b1b4cf3075f3

