### PR TITLE
Add Keyboard Navigation to Tour Window

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -122,7 +122,6 @@ class HelpWidget {
                     if (page === 0){
                         leftArrow.classList.add('disabled');
                     }
-
             };
 
             cell = docById("right-arrow");
@@ -432,7 +431,6 @@ class HelpWidget {
             this._blockHelp(
                 this.activity.blocks.protoBlockDict[this.appendedBlockList[this.index]]
             );
-
         };
 
         cell = docById("left-arrow");

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -49,9 +49,10 @@ class HelpWidget {
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
-        widgetWindow.onClose = () => {
+        widgetWindow.onclose = () => {
             this.isOpen = false;
-            this.destroy();
+            document.onkeydown = activity.__keyPressed ; 
+            widgetWindow.destroy();
         };
         // Position the widget and make it visible.
         this._helpDiv = document.createElement("div");
@@ -99,6 +100,14 @@ class HelpWidget {
             leftArrow = document.getElementById("left-arrow");
             leftArrow.style.display = "block";
             leftArrow.classList.add("hover");
+            
+            document.onkeydown = function handleArrowKeys(event) {
+                if (event.key === 'ArrowLeft') {
+                    leftArrow.click(); 
+                } else if (event.key === 'ArrowRight') {
+                    rightArrow.click(); 
+                }
+            } ;
 
             let cell = docById("left-arrow");
             if (page === 0){
@@ -113,6 +122,7 @@ class HelpWidget {
                     if (page === 0){
                         leftArrow.classList.add('disabled');
                     }
+
             };
 
             cell = docById("right-arrow");
@@ -401,6 +411,16 @@ class HelpWidget {
         this.widgetWindow.sendToCenter();
         let cell = docById("right-arrow");
         let rightArrow = docById("right-arrow");
+        let leftArrow = docById("left-arrow");
+
+        document.onkeydown = function handleArrowKeys(event) {
+            if (event.key === 'ArrowLeft') {
+                leftArrow.click(); 
+            } else if (event.key === 'ArrowRight') {
+                rightArrow.click(); 
+            }
+        } ; 
+
         if(this.index == this.appendedBlockList.length - 1)
         {
            rightArrow.classList.add("disabled") ;       
@@ -412,6 +432,7 @@ class HelpWidget {
             this._blockHelp(
                 this.activity.blocks.protoBlockDict[this.appendedBlockList[this.index]]
             );
+
         };
 
         cell = docById("left-arrow");


### PR DESCRIPTION
This pull request addresses issue #3492  by implementing keyboard navigation functionality in the tour window of Music Blocks. Users can now navigate between tour widgets using their keyboard's left and right arrow keys, enhancing accessibility and improving the user experience.

https://github.com/sugarlabs/musicblocks/assets/88442916/b1a71f09-72cb-4772-a7fd-ae4e33ea72d7


Note: Changes are made in such a way that it does not impact any existing functionalities 

