### PR TITLE
fixes help img width

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -227,7 +227,7 @@ class HelpWidget {
 
                         // body = body + '<p><img src="' + path + "/" + name + '_block.svg"></p>';
                         const imageSrc = `${path}/${name}_block.svg` ;
-                        body += `<figure><img src=${imageSrc}></figure>`;
+                        body += `<figure style="width:100%;"><img style="max-width:100%;" src=${imageSrc}></figure>`;
                     }
 
                     body += `<p>${message[0]}</p>`;


### PR DESCRIPTION
I encountered a bug related to the help window image size. Image breaks on certain blocks like scaler block because they are to big .

Before:-

![image](https://github.com/sugarlabs/musicblocks/assets/89124765/92b4ed75-644a-41db-993b-0136680fcaf4)

After:-

![image](https://github.com/sugarlabs/musicblocks/assets/89124765/e53dd165-5671-4aa2-9e72-4607f65c5092)

