### PR TITLE
fixes #3497

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -807,6 +807,7 @@ table {
     top: 20%;
     left: 20%;
     background: rgba(255, 255, 255, 0.85) !important;
+    user-select: none;
     -webkit-user-select: none;
 }
 
@@ -1273,6 +1274,7 @@ input.timbreName {
     border-style: solid;
     border: 0 !important;
     background: rgba(255, 255, 255, 0.85);
+    user-select: none;
     -webkit-user-select: none;
     overflow-y: scroll !important;
 }
@@ -1285,6 +1287,7 @@ input.timbreName {
     border-style: solid;
     border: 0 !important;
     background: rgba(255, 255, 255, 0.85);
+    user-select: none;
     -webkit-user-select: none;
     overflow-y: scroll !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 input[type=range] {
   height: 4px;
+  appearance: none;
   -webkit-appearance: none;
   width: 250px;
 }


### PR DESCRIPTION
fixes #3497 
This modification ensures compatibility across different browsers. The user-select: none; property prevents the user from selecting the text within the specified element.
for the standard property 'user-select' for compatibility, I included the non-prefixed version along with the prefixed version for older browsers.