### PR TITLE
over lap issue resolved

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -410,6 +410,7 @@ class Palettes {
         // eslint-disable-next-line no-unused-vars
         row.onclick = (event) => {
             if (name == "search") {
+                this._hideMenus();
                 this.activity.showSearchWidget();
             } else {
                 this.showPalette(name);


### PR DESCRIPTION
issue : #3501 
before the search bar was overlapping with the palette body now it is resolved I have attached the screenshot in the issue 
after:
![Screenshot (884)](https://github.com/sugarlabs/musicblocks/assets/124120102/a3283469-05c5-476f-b8ab-38a08a452a46)
