### PR TITLE
Fixes: Left arrow on first slide of the blocks tour

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -424,7 +424,7 @@ class HelpWidget {
         {
            rightArrow.classList.add("disabled") ;       
         }
-        if(this.index == 0)
+        if(this.index === 0)
         {
            leftArrow.classList.add("disabled") ;       
         }

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -424,6 +424,11 @@ class HelpWidget {
         {
            rightArrow.classList.add("disabled") ;       
         }
+        if(this.index == 0)
+        {
+           leftArrow.classList.add("disabled") ;       
+        }
+        
         cell.onclick = () => {
             if (this.index !== this.appendedBlockList.length - 1) {
                 this.index += 1;


### PR DESCRIPTION
Fixes #3481 

Now the leftArrow is disable in RHYTHM modal

![Screenshot 2024-01-02 at 3 09 55 PM (2)](https://github.com/sugarlabs/musicblocks/assets/72220579/627cbb99-187e-4002-9b69-0895d0b216c8)
