### PR TITLE
fix bug: fullscreen button added to widget pitch slider

### DIFF
--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -51,7 +51,7 @@ class PitchSlider {
         }
 
         this._cellScale = 1.0;
-        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", false);
+        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", true);
         this.widgetWindow.onclose = () => {
             for (const osc of oscillators) osc.triggerRelease();
             this.widgetWindow.destroy();


### PR DESCRIPTION
Fixes #3535 
Changes made to pitch slider widget to allow fullscreen

![image](https://github.com/sugarlabs/musicblocks/assets/148698224/8dca6d1f-a1f1-4102-860c-b59c4e553a0f)
