### PR TITLE
added fullscreen mode in widget window

### DIFF
--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -51,7 +51,7 @@ class PitchSlider {
         }
 
         this._cellScale = 1.0;
-        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", false);
+        this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", true);
         this.widgetWindow.onclose = () => {
             for (const osc of oscillators) osc.triggerRelease();
             this.widgetWindow.destroy();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -608,7 +608,7 @@ class PitchStaircase {
         const w = window.innerWidth;
         this._cellScale = w / 1200;
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "pitch staircase", "pitch staircase", false);
+        const widgetWindow = window.widgetWindows.windowFor(this, "pitch staircase", "pitch staircase", true);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -722,7 +722,7 @@ class TimbreWidget {
 
         this._playing = false;
 
-        const widgetWindow = window.widgetWindows.windowFor(this, "timbre", "timbre", false);
+        const widgetWindow = window.widgetWindows.windowFor(this, "timbre", "timbre", true);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();


### PR DESCRIPTION
fixes issue #3528 
All the widget window have implemtation of full screen expansion and contraction but missing in pitchstaircase , pitchslider and timber... I have set fullscreen to true ..This modification ensures expansion and contraction of widget windows .
