### PR TITLE
Image format detection functionality improved

### DIFF
--- a/plugins/pluginify.py
+++ b/plugins/pluginify.py
@@ -16,6 +16,7 @@
 import re
 import sys
 import json
+import imghdr
 
 HELP = '''Usage:
     python pluginify.py (file)
@@ -170,9 +171,9 @@ def pluginify(data):
             outp[type_][name] = value
 
         if type_ == 'image':
-            # TODO: Detect if its png
-            # Assume for now it is SVG.
-            IMAGES[name] = value  # 'data:image/svg+xml;utf8,' + value
+             image_format = imghdr.what(None, h=value)
+        if image_format:
+                IMAGES[name] = f'data:image/{image_format};base64,{value}'  
 
     if IMAGES:
         outp['IMAGES'] = IMAGES


### PR DESCRIPTION
Fixes #3533 
The current code within the pluginify function at [line 173](https://github.com/sugarlabs/musicblocks/blob/175ea9aa096e8d2420c7d56cc89584844e813ef4/plugins/pluginify.py#L173) changed for detecting image formats, specifically to distinguish between different formats such as SVG and PNG. 

Now  accurate image format detection occurs, particularly for detecting PNG format