### PR TITLE
Fixes #3526 Stop button turns red with play keyboard shortcut with modification

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2280,6 +2280,10 @@ class Activity {
                     case 82: // 'R'
                         this.textMsg("Alt-R " + _("Play"));
                         this._doFastButton();
+                        const stopButton = document.getElementById("stop");
+                        if (stopButton) {
+                            stopButton.style.color = "#ea174c";
+                        }
                         break;
                     case 83: // 'S'
                         this.textMsg("Alt-S " + _("Stop"));


### PR DESCRIPTION
This modification includes the addition of a check to ensure that the stopButton is not null or undefined before attempting to change its color. This is a precautionary measure in case the element with the id "stop" doesn't exist in the current context

