### PR TITLE
Fixes #3485 Bigger values overflow from the block

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2442,7 +2442,7 @@ class Block {
         // Some special cases
         if (SPECIALINPUTS.indexOf(this.name) !== -1) {
             this.text.textAlign = "center";
-            this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 0.5);
+            this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 10.0);
             if (EXTRAWIDENAMES.indexOf(this.name) !== -1) {
                 this.text.x *= 3.0;
             } else if (WIDENAMES.indexOf(this.name) !== -1) {

--- a/js/block.js
+++ b/js/block.js
@@ -4096,11 +4096,11 @@ class Block {
 
         if (
             WIDENAMES.indexOf(this.name) === -1 &&
-            getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH
+            label.length > 10
         ) {
             let slen = label.length - 5;
             let nlabel = "" + label.substr(0, slen) + "...";
-            while (getTextWidth(nlabel, "bold 20pt Sans") > TEXTWIDTH) {
+            while (nlabel.length > 10) {
                 slen -= 1;
                 nlabel = "" + label.substr(0, slen) + "...";
                 // const foo = getTextWidth(nlabel, "bold 20pt Sans");


### PR DESCRIPTION
Fixes #3485 
Changes:
Limit in the number of digits displayed that was typed inside the blocks to avoid overflow from the block
A slight rightward shift of the numbers typed inside the blocks, to improve aesthetics and to make the numbers occupy all the space inside the block