### PR TITLE
Fix/Resolve Console Warning - TypeError: Cannot read properties of null (reading 'innerHTML')

### DIFF
--- a/planet/js/StringHelper.js
+++ b/planet/js/StringHelper.js
@@ -79,10 +79,12 @@ class StringHelper {
             const obj = this.strings[i];
             const elem = document.getElementById(obj[0]);
 
-            if (this.strings[i].length==3)
-                elem.setAttribute(obj[2],obj[1]) ;
-                
-            else elem.innerHTML+=obj[1] ;
+            if(elem){
+                if (this.strings[i].length==3)
+                    elem.setAttribute(obj[2],obj[1]) ;
+                    
+                else elem.innerHTML+=obj[1] ;
+            }
         }
     };
 


### PR DESCRIPTION
Fixes #3546 

Changes:
Added check for "elem", if elem exists then only its property innerHTML or setAttribute will exist. 
