### PR TITLE
Fix: Enable Left Arrow Navigation in Widget Help Tour

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -380,6 +380,25 @@ class HelpWidget {
                 }
                 this._showPage(page);
             };
+            if (page === 0){
+                leftArrow.classList.add('disabled');
+            }
+            leftArrow.onclick = () => {
+                    if (page > 0){
+                        page = page - 1;
+                        leftArrow.classList.remove('disabled');
+                        if (page == 0) {
+                            this.widgetWindow.updateTitle("TAKE A TOUR");
+                        }
+                        else {
+                            this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
+                        }
+                        this._showPage(page);
+                    }
+                    if (page === 0){
+                        leftArrow.classList.add('disabled');
+                    }
+            };
         }
 
         helpBody.style.color = "#505050";


### PR DESCRIPTION
This PR resolves the issue #3549  with the disabled left arrow functionality in the widget help tour, preventing users from navigating back to the previous page.


https://github.com/sugarlabs/musicblocks/assets/88442916/0bf061b1-bc75-4aa5-80bb-58aead06a64d

