### PR TITLE
Fixes #3485 Bigger values overflow from the block

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -75,7 +75,7 @@
 /* exported Block, $ */
 
 // Length of a long touch
-const TEXTWIDTH = 240; // 90
+const TEXTWIDTH = 90; // 90
 const STRINGLEN = 9;
 const LONGPRESSTIME = 1500;
 const INLINECOLLAPSIBLES = ["newnote", "interval", "osctime", "definemode"];


### PR DESCRIPTION
Fixes https://github.com/sugarlabs/musicblocks/issues/3485
Changes: The TEXTWIDTH constant represents the maximum allowed width for the text within the block in pixels. I have TEXTWIDTH to a lower value.  Reducing the value of TEXTWIDTH will reduce the allowed width for the text within the block, potentially displaying fewer characters. 

![Screenshot 2024-01-09 140600](https://github.com/sugarlabs/musicblocks/assets/148698224/c001e2c8-c5ec-479f-b151-5935e48cd3ad)
