### PR TITLE
add how-to-reproduce section in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,10 @@ assignees: ""
 
 <!-- Add screenshots, if applicable, to help explain your problem. -->
 
+### How to Reproduce
+
+<!-- Add specific steps to reproduce that issue -->
+
 ### Console log Errors:
 
 <!-- Upload console log screenshots to help explain your problem in much better fashion -->


### PR DESCRIPTION
Fixes: #3557

This PR adds a section 'How to Reproduce' in the Issue Template for better tackling of it.

kindly review this @walterbender sir.