### PR TITLE
Stop_button_red_on_keyboard_shortcut

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2234,6 +2234,7 @@ class Activity {
             const KEYCODE_DOWN = 40;
             const DEL = 46;
             const V = 86;
+            const ENTER = 13;
 
             // Shortcuts for creating new notes
             const KEYCODE_D = 68; // do
@@ -2260,7 +2261,7 @@ class Activity {
                 }
             }
 
-            if (event.altKey && !disableKeys) {
+            if ((event.altKey && !disableKeys) || (event.keyCode == 13) ) {
                 switch (event.keyCode) {
                     case 66: // 'B'
                         this.textMsg("Alt-B " + _("Saving block artwork"));
@@ -2277,8 +2278,20 @@ class Activity {
                         this.textMsg("Alt-E " + _("Erase"));
                         this._allClear(false);
                         break;
-                    case 82: // 'R'
+                    case 82: // 'R or ENTER'
                         this.textMsg("Alt-R " + _("Play"));
+                        let stopbtn = document.getElementById("stop");
+                        if (stopbtn) {
+                            stopbtn.style.color = platformColor.stopIconcolor;
+                        }
+                        this._doFastButton();
+                        break;
+                    case 13: // 'R or ENTER'
+                        this.textMsg("ENter " + _("Play"));
+                        let stopbt = document.getElementById("stop");
+                        if (stopbt) {
+                            stopbt.style.color = platformColor.stopIconcolor;
+                        }
                         this._doFastButton();
                         break;
                     case 83: // 'S'

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -11,7 +11,7 @@
 
 /*
   global _, jQuery, _THIS_IS_MUSIC_BLOCKS_, docById, doSVG, fnBrowserDetect,
-  RECORDBUTTON
+  RECORDBUTTON, platformColor
  */
 
 /* exported Toolbar */
@@ -24,7 +24,7 @@ class Toolbar {
      * @constructor
      */
     constructor() {
-        this.stopIconColorWhenPlaying = "#ea174c";
+        this.stopIconColorWhenPlaying = window.platformColor.stopIconcolor;
         this.language = localStorage.languagePreference;
         if (this.language === undefined) {
             this.language = navigator.language;

--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -89,6 +89,7 @@ window.platformColor = {
     pitchLabelBackground: "#77C428",
     graphicsLabelBackground: "#728FF9",
     rhythmcellcolor: "#c8c8c8",
+    stopIconcolor : "#ea174c",
     hitAreaGraphicsBeginFill: "#FFF",
     orange: "#e37a00", // 5YR
     piemenuBasic: ["#3ea4a3", "#60bfbc", "#1d8989", "#60bfbc", "#1d8989"],

--- a/planet/index.html
+++ b/planet/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-            <title>Music Blocks is a collection of tools for exploring musical concepts.</title>
+            <title>Music Blocks</title>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <!--Import Google Icon Font-->
         <link type="text/css" href="fonts/material-icons.css" rel="stylesheet">


### PR DESCRIPTION
Fixes #3526
In #3526 I have created a constant in utils/platform.js and used in toolbar.js and activity.js.
ALSO same functionality for ENTER is also defined stop button turns red even on clicking ENTER...

https://github.com/sugarlabs/musicblocks/assets/127110636/df42f398-8b00-45b0-8c67-a9ffcf167429

