### PR TITLE
 CI Tests for macOS Platform extended

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,3 +30,23 @@ jobs:
 
     - run: npm ci
     - run: npm run build --if-present
+  mac-build:
+      runs-on: macos-latest
+
+      strategy:
+        matrix:
+          node-version: [12.x, 14.x]
+
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+
+        - name: Use Node.js ${{ matrix.node-version }}
+          uses: actions/setup-node@v1
+          with:
+            node-version: ${{ matrix.node-version }}
+
+        - run: npm ci
+        - run: npm run build --if-present


### PR DESCRIPTION
fixes #3568 
## Description
The current Continuous Integration (CI) setup for our project primarily focuses on Ubuntu-based runners. However, in order to ensure comprehensive testing and compatibility across different environments, it's essential to extend our CI to include macOS runners.


## Proposed Solution
- **Incorporate macOS Runners**: Integrate macOS runners into our CI setup to run tests, builds, and any necessary tasks that ensure our project functions correctly on macOS.

@walterbender please review this