### PR TITLE
Fix: JavaScript Editor Help Button Color and Click Functionality Issues

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -377,6 +377,10 @@ class JSEditor {
         this._code = JSGenerate.code;
         this._jar.updateCode(this._code);
         this._setLinesCount(this._code);
+        const helpBtn = docById("js_editor_help_btn");
+        if(helpBtn)
+        helpBtn.style.color = "white"; 
+        this._showingHelp = !this._showingHelp;
     }
 
     /**

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -378,9 +378,11 @@ class JSEditor {
         this._jar.updateCode(this._code);
         this._setLinesCount(this._code);
         const helpBtn = docById("js_editor_help_btn");
-        if(helpBtn)
-        helpBtn.style.color = "white"; 
+        if(helpBtn) {
+            helpBtn.style.color = "white"; 
+        }
         this._showingHelp = false;
+        
     }
 
     /**

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -380,7 +380,7 @@ class JSEditor {
         const helpBtn = docById("js_editor_help_btn");
         if(helpBtn)
         helpBtn.style.color = "white"; 
-        this._showingHelp = !this._showingHelp;
+        this._showingHelp = false;
     }
 
     /**

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -378,7 +378,7 @@ class JSEditor {
         this._jar.updateCode(this._code);
         this._setLinesCount(this._code);
         const helpBtn = docById("js_editor_help_btn");
-        if(helpBtn) {
+        if (helpBtn) {
             helpBtn.style.color = "white"; 
         }
         this._showingHelp = false;


### PR DESCRIPTION
This pull request addresses the issue #3573  malfunctioning behavior of the help button in the JavaScript editor. The current issue causes the button to remain in a gold-colored state after clicking on reset code button, contrary to the expected behavior. Additionally, the functionality requires users to click twice to return to the help mode, which is not the intended behavior


https://github.com/sugarlabs/musicblocks/assets/88442916/d93935be-2812-4076-ba76-c3308433d39e





