### PR TITLE
Fixed unwanted help window center on left and right clicks

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -464,7 +464,6 @@ class HelpWidget {
         this._helpDiv.insertAdjacentHTML("afterbegin", helpDivHTML) ;
 
         this.widgetWindow.getWidgetBody().append(this._helpDiv);
-        this.widgetWindow.sendToCenter();
         let cell = docById("right-arrow");
         let rightArrow = docById("right-arrow");
         let leftArrow = docById("left-arrow");


### PR DESCRIPTION
This pull request addresses the issue described in #3577 


Changes made:-

Right after the help block is finished , the beginner and advanced blocks are added. During that process the widget is centered using a function. I removed that function call.
