### PR TITLE
Update 'npm run serve' Script to Explicitly Call 'python3'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "lint": "eslint js/**/*.js",
-    "serve": "python -c \"import os, sys; os.system('python -m SimpleHTTPServer 3000 --bind 127.0.0.1') if sys.version_info.major==2 else os.system('python -m http.server 3000 --bind 127.0.0.1');\"",
+    "serve": "python3 -c \"import os, sys; os.system('python3 -m SimpleHTTPServer 3000 --bind 127.0.0.1') if sys.version_info.major==2 else os.system('python3 -m http.server 3000 --bind 127.0.0.1');\"",
     "winserve": "py -c \"import os, sys; os.system('py -m SimpleHTTPServer 3000') if sys.version_info.major==2 else os.system('py -m http.server 3000 --bind 127.0.0.1');\""
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #3593 

This pull request addresses the issue where running npm run serve in the musicblocks repository results in the system being unable to find the python command. The current behavior, which leads to a "sh: python: command not found" error, suggests an inconsistency in the system's expectation of the python command, particularly on some Linux distributions where python3 is the correct command for Python 3.

Changes Made:

Updated the 'npm run serve' script to explicitly call the 'python3' command, ensuring compatibility with systems that expect the use of Python 3.
This update ensures a smoother transition, allowing the python command to point to Python 3 as distributions phase out Python 2.