### PR TITLE
Added the less-than-or-equal-to and greater-than-or-equal-to boolean blocks

### DIFF
--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -576,6 +576,222 @@ function setupBooleanBlocks(activity) {
      * Represents a block for the equality comparison.
      * @extends {BooleanBlock}
      */
+
+    class LessThanOrEqualToBlock extends BooleanBlock {
+        /**
+         * Constructs a LessBlock.
+         */
+        constructor() {
+            super("less_than_or_equal_to");
+
+            /**
+             * Sets the palette for the block.
+             * @param {string} "boolean" - The palette category.
+             * @param {Activity} activity - The activity associated with the block.
+             */
+            this.setPalette("boolean", activity);
+
+            /**
+             * Sets the beginner status for the block.
+             * @param {boolean} true - The beginner status.
+             */
+            this.beginnerBlock(true);
+
+            /**
+             * Sets the help string for the block.
+             * @type {string[]}
+             */
+            this.setHelpString([
+                _(
+                    "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
+                ),
+                "documentation",
+                ""
+            ]);
+
+            /**
+             * Sets the font size for the block.
+             * @type {number}
+             */
+            this.fontsize = 14;
+
+            /**
+             * Specifies the parameter of the block.
+             */
+            this.parameter = true;
+
+            /**
+             * Forms the block with specified configuration.
+             * @param {Object} config - The configuration object.
+             * @param {string} config.name - The name of the block.
+             * @param {number} config.args - The number of arguments.
+             * @param {string[]} config.argTypes - The allowed argument types.
+             */
+            this.formBlock({
+                name: "≤",
+                args: 2,
+                argTypes: ["numberin", "numberin"]
+            });
+        }
+
+        /**
+         * Updates the parameter of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @returns {string} - The updated parameter value.
+         */
+        updateParameter(logo, turtle, blk) {
+            if (activity.blocks.blockList[blk].value) {
+                return _("true");
+            } else {
+                return _("false");
+            }
+        }
+
+        /**
+         * Handles the argument of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @param {number} receivedArg - The received argument.
+         * @returns {boolean} - The result of the argument handling.
+         */
+        arg(logo, turtle, blk, receivedArg) {
+            const cblk1 = activity.blocks.blockList[blk].connections[1];
+            const cblk2 = activity.blocks.blockList[blk].connections[2];
+
+            if (cblk1 === null || cblk2 === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+
+            const a = logo.parseArg(logo, turtle, cblk1, blk, receivedArg);
+            const b = logo.parseArg(logo, turtle, cblk2, blk, receivedArg);
+
+            try {
+                return Number(a) <= Number(b);
+            } catch (e) {
+                // eslint-disable-next-line no-console
+                console.debug(e);
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+        }
+    }
+    /**
+     * Represents a block for the equality comparison.
+     * @extends {BooleanBlock}
+     */
+
+    class GreaterThanOrEqualToBlock extends BooleanBlock {
+        /**
+         * Constructs a LessBlock.
+         */
+        constructor() {
+            super("greater_than_or_equal_to");
+
+            /**
+             * Sets the palette for the block.
+             * @param {string} "boolean" - The palette category.
+             * @param {Activity} activity - The activity associated with the block.
+             */
+            this.setPalette("boolean", activity);
+
+            /**
+             * Sets the beginner status for the block.
+             * @param {boolean} true - The beginner status.
+             */
+            this.beginnerBlock(true);
+
+            /**
+             * Sets the help string for the block.
+             * @type {string[]}
+             */
+            this.setHelpString([
+                _(
+                    "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
+                ),
+                "documentation",
+                ""
+            ]);
+
+            /**
+             * Sets the font size for the block.
+             * @type {number}
+             */
+            this.fontsize = 14;
+
+            /**
+             * Specifies the parameter of the block.
+             */
+            this.parameter = true;
+
+            /**
+             * Forms the block with specified configuration.
+             * @param {Object} config - The configuration object.
+             * @param {string} config.name - The name of the block.
+             * @param {number} config.args - The number of arguments.
+             * @param {string[]} config.argTypes - The allowed argument types.
+             */
+            this.formBlock({
+                name: "≥",
+                args: 2,
+                argTypes: ["numberin", "numberin"]
+            });
+        }
+
+        /**
+         * Updates the parameter of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @returns {string} - The updated parameter value.
+         */
+        updateParameter(logo, turtle, blk) {
+            if (activity.blocks.blockList[blk].value) {
+                return _("true");
+            } else {
+                return _("false");
+            }
+        }
+
+        /**
+         * Handles the argument of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @param {number} receivedArg - The received argument.
+         * @returns {boolean} - The result of the argument handling.
+         */
+        arg(logo, turtle, blk, receivedArg) {
+            const cblk1 = activity.blocks.blockList[blk].connections[1];
+            const cblk2 = activity.blocks.blockList[blk].connections[2];
+
+            if (cblk1 === null || cblk2 === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+
+            const a = logo.parseArg(logo, turtle, cblk1, blk, receivedArg);
+            const b = logo.parseArg(logo, turtle, cblk2, blk, receivedArg);
+
+            try {
+                return Number(a) >= Number(b);
+            } catch (e) {
+                // eslint-disable-next-line no-console
+                console.debug(e);
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+        }
+    }
+    /**
+     * Represents a block for the equality comparison.
+     * @extends {BooleanBlock}
+     */
+
+
     class EqualBlock extends BooleanBlock {
         /**
          * Constructs an EqualBlock.
@@ -736,6 +952,8 @@ function setupBooleanBlocks(activity) {
     new XorBlock().setup(activity);
     new AndBlock().setup(activity);
     new OrBlock().setup(activity);
+    new GreaterThanOrEqualToBlock().setup(activity);
+    new LessThanOrEqualToBlock().setup(activity);
     new GreaterBlock().setup(activity);
     new LessBlock().setup(activity);
     new EqualBlock().setup(activity);

--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -892,6 +892,114 @@ function setupBooleanBlocks(activity) {
             }
         }
     }
+
+    /**
+     * Represents a block for the equality comparison.
+     * @extends {BooleanBlock}
+     */
+
+
+    class NotEqualToBlock extends BooleanBlock {
+        /**
+         * Constructs an EqualBlock.
+         */
+        constructor() {
+            super("not_equal_to");
+
+            /**
+             * Sets the palette for the block.
+             * @param {string} "boolean" - The palette category.
+             * @param {Activity} activity - The activity associated with the block.
+             */
+            this.setPalette("boolean", activity);
+
+            /**
+             * Sets the beginner status for the block.
+             * @param {boolean} true - The beginner status.
+             */
+            this.beginnerBlock(true);
+
+            /**
+             * Sets the help string for the block.
+             * @type {string[]}
+             */
+            this.setHelpString([
+                _("The Not-equal-to block returns True if the two numbers are not equal to each other."),
+                "documentation",
+                ""
+            ]);
+
+            /**
+             * Sets the font size for the block.
+             * @type {number}
+             */
+            this.fontsize = 14;
+
+            /**
+             * Specifies the parameter of the block.
+             */
+            this.parameter = true;
+
+            /**
+             * Forms the block with specified configuration.
+             * @param {Object} config - The configuration object.
+             * @param {string} config.name - The name of the block.
+             * @param {number} config.args - The number of arguments.
+             * @param {string[]} config.argTypes - The allowed argument types.
+             */
+            this.formBlock({
+                name: "!=",
+                args: 2,
+                argTypes: ["anyin", "anyin"]
+            });
+        }
+
+        /**
+         * Updates the parameter of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @returns {string} - The updated parameter value.
+         */
+        updateParameter(logo, turtle, blk) {
+            if (activity.blocks.blockList[blk].value) {
+                return _("true");
+            } else {
+                return _("false");
+            }
+        }
+
+        /**
+         * Handles the argument of the block.
+         * @param {Logo} logo - The logo instance.
+         * @param {string} turtle - The turtle identifier.
+         * @param {string} blk - The block identifier.
+         * @param {number} receivedArg - The received argument.
+         * @returns {boolean} - The result of the argument handling.
+         */
+        arg(logo, turtle, blk, receivedArg) {
+            const cblk1 = activity.blocks.blockList[blk].connections[1];
+            const cblk2 = activity.blocks.blockList[blk].connections[2];
+
+            if (cblk1 === null || cblk2 === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+
+            const a = logo.parseArg(logo, turtle, cblk1, blk, receivedArg);
+            const b = logo.parseArg(logo, turtle, cblk2, blk, receivedArg);
+
+            try {
+                return a !== b;
+            } catch (e) {
+                // eslint-disable-next-line no-console
+                console.debug(e);
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return false;
+            }
+        }
+    }
+
     /**
      * Represents a static boolean block.
      * @extends {BooleanBlock}
@@ -956,6 +1064,7 @@ function setupBooleanBlocks(activity) {
     new LessThanOrEqualToBlock().setup(activity);
     new GreaterBlock().setup(activity);
     new LessBlock().setup(activity);
+    new NotEqualToBlock().setup(activity);
     new EqualBlock().setup(activity);
     new StaticBooleanBlock().setup(activity);
 }

--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -579,7 +579,7 @@ function setupBooleanBlocks(activity) {
 
     class LessThanOrEqualToBlock extends BooleanBlock {
         /**
-         * Constructs a LessBlock.
+         * Constructs a LessThanOrEqualToBlock.
          */
         constructor() {
             super("less_than_or_equal_to");
@@ -686,7 +686,7 @@ function setupBooleanBlocks(activity) {
 
     class GreaterThanOrEqualToBlock extends BooleanBlock {
         /**
-         * Constructs a LessBlock.
+         * Constructs a GreaterThanOrEqualToBlock.
          */
         constructor() {
             super("greater_than_or_equal_to");
@@ -901,7 +901,7 @@ function setupBooleanBlocks(activity) {
 
     class NotEqualToBlock extends BooleanBlock {
         /**
-         * Constructs an EqualBlock.
+         * Constructs an NotEqualToBlock.
          */
         constructor() {
             super("not_equal_to");


### PR DESCRIPTION
Fixes #3601 

This PR adds the less-than-or-equal-to and greater-than-or-equal-to Boolean blocks.


![image](https://github.com/sugarlabs/musicblocks/assets/52532308/1c21d5d6-4fcc-4a70-9242-8802b7dbee74)


Less-than-or-equal-to :- 

![image](https://github.com/sugarlabs/musicblocks/assets/52532308/8902824d-ca14-4c11-8230-4f8be7e10e59)


![image](https://github.com/sugarlabs/musicblocks/assets/52532308/7ec94777-0690-4edb-8c55-62cfb9eb9819)


![image](https://github.com/sugarlabs/musicblocks/assets/52532308/b8d1b31b-9944-4270-a818-6793be323029)

Greater-than-or-equal-to :- 

![image](https://github.com/sugarlabs/musicblocks/assets/52532308/3ee26957-6282-4823-ae7d-8a1da2192d13)

![image](https://github.com/sugarlabs/musicblocks/assets/52532308/d40cf33e-73e4-4b09-b098-f1832a84159e)

![image](https://github.com/sugarlabs/musicblocks/assets/52532308/4cd9cb9c-d3f2-4c02-b448-ebded497b948)
