### PR TITLE
Updating #3551 Limits number of digits to 12 in number block

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2442,7 +2442,7 @@ class Block {
         // Some special cases
         if (SPECIALINPUTS.indexOf(this.name) !== -1) {
             this.text.textAlign = "center";
-            this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 0.5);
+            this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 10.0);
             if (EXTRAWIDENAMES.indexOf(this.name) !== -1) {
                 this.text.x *= 3.0;
             } else if (WIDENAMES.indexOf(this.name) !== -1) {

--- a/js/block.js
+++ b/js/block.js
@@ -4073,9 +4073,9 @@ class Block {
                 this.value = oldValue;
             }
 
-            if(String(this.value).length > 12) {
+            if(String(this.value).length > 10) {
                 const thisBlock = this.blocks.blockList.indexOf(this);
-                this.activity.errorMsg(_("Numbers can have at most 12 digits."), thisBlock);
+                this.activity.errorMsg(_("Numbers can have at most 10 digits."), thisBlock);
                 this.activity.refreshCanvas();
                 this.label.value = oldValue;
                 this.value = oldValue;


### PR DESCRIPTION
Updating fix #3551
Changing the limit to 10 in the number block and slightly shifting the text to the right to accommodate all 10 digits

Without shifting: 
![Captura de tela de 2024-01-16 17-31-53](https://github.com/sugarlabs/musicblocks/assets/132718029/2c1f55e9-03fa-4646-b70d-220a009008c4)

Shifting:
![Captura de tela de 2024-01-16 17-38-04](https://github.com/sugarlabs/musicblocks/assets/132718029/dbaf6f3a-1eb3-4ebe-8b5c-f8e0b9d51336)
