### PR TITLE
[FIXED] Rendering Issue with Greater Than Equal To, Less Than Equal To, and Not Equal To Icons

### DIFF
--- a/documentation/greater_than_or_equal_to_block.svg
+++ b/documentation/greater_than_or_equal_to_block.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="76.5" height="63">
+  <g transform="translate(0, 0)">
+    <g transform="scale(1.5, 1.5)">
+      <g transform="matrix(1,0,0,1,0,-16)">
+        <path d="m0.5 41.5 A 7 7 90 0 1 7.5 34.5 L 8.5 34.5 L 8.5 24.5 A 8 8 90 0 1 16.5 16.5 L 50.5 16.5 L 50.5 24.5 L 46.5 24.5 L 46.5 21.5 L 42.5 21.5 L 42.5 31.5 L 46.5 31.5 L 46.5 28.5 L 50.5 28.5 L 50.5 45.5 L 46.5 45.5 L 46.5 42.5 L 42.5 42.5 L 42.5 52.5 L 46.5 52.5 L 46.5 49.5 L 50.5 49.5 L 50.5 57.5 L 20.5 57.5 L 8.5 57.5 L 8.5 49.5 L 8.5 48.5 L 7.5 48.5 A 7 7 90 0 1 0.5 41.5 z" style="fill:#D97DF5;fill-opacity:1;stroke:#B653D3;stroke-width:1;stroke-linecap:round;stroke-opacity:1;" />
+      </g>
+      <text style="font-size:14px;fill:#282828;font-family:sans-serif;text-anchor:end">
+        <tspan x="38" y="26" font-family="arial">≥</tspan>
+      </text>
+    </g>
+  </g>
+</svg>

--- a/documentation/less_than_or_equal_to_block.svg
+++ b/documentation/less_than_or_equal_to_block.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="76.5" height="63">
+  <g transform="translate(0, 0)">
+    <g transform="scale(1.5, 1.5)">
+      <g transform="matrix(1,0,0,1,0,-16)">
+        <path d="m0.5 41.5 A 7 7 90 0 1 7.5 34.5 L 8.5 34.5 L 8.5 24.5 A 8 8 90 0 1 16.5 16.5 L 50.5 16.5 L 50.5 24.5 L 46.5 24.5 L 46.5 21.5 L 42.5 21.5 L 42.5 31.5 L 46.5 31.5 L 46.5 28.5 L 50.5 28.5 L 50.5 45.5 L 46.5 45.5 L 46.5 42.5 L 42.5 42.5 L 42.5 52.5 L 46.5 52.5 L 46.5 49.5 L 50.5 49.5 L 50.5 57.5 L 20.5 57.5 L 8.5 57.5 L 8.5 49.5 L 8.5 48.5 L 7.5 48.5 A 7 7 90 0 1 0.5 41.5 z" style="fill:#D97DF5;fill-opacity:1;stroke:#B653D3;stroke-width:1;stroke-linecap:round;stroke-opacity:1;" />
+      </g>
+      <text style="font-size:14px;fill:#282828;font-family:sans-serif;text-anchor:end">
+        <tspan x="38" y="26" font-family="arial">≤</tspan>
+      </text>
+    </g>
+  </g>
+</svg>

--- a/documentation/not_equal_to_block.svg
+++ b/documentation/not_equal_to_block.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="76.5" height="63">
+  <g transform="translate(0, 0)">
+    <g transform="scale(1.5, 1.5)">
+      <g transform="matrix(1,0,0,1,0,-16)">
+        <path d="m0.5 41.5 A 7 7 90 0 1 7.5 34.5 L 8.5 34.5 L 8.5 24.5 A 8 8 90 0 1 16.5 16.5 L 50.5 16.5 L 50.5 24.5 L 46.5 24.5 L 46.5 21.5 L 42.5 21.5 L 42.5 31.5 L 46.5 31.5 L 46.5 28.5 L 50.5 28.5 L 50.5 45.5 L 46.5 45.5 L 46.5 42.5 L 42.5 42.5 L 42.5 52.5 L 46.5 52.5 L 46.5 49.5 L 50.5 49.5 L 50.5 57.5 L 20.5 57.5 L 8.5 57.5 L 8.5 49.5 L 8.5 48.5 L 7.5 48.5 A 7 7 90 0 1 0.5 41.5 z" style="fill:#D97DF5;fill-opacity:1;stroke:#B653D3;stroke-width:1;stroke-linecap:round;stroke-opacity:1;" />
+      </g>
+      <text style="font-size:14px;fill:#282828;font-family:sans-serif;text-anchor:end">
+        <tspan x="38" y="26" font-family="arial">≠</tspan>
+      </text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #3628 

### Description
This pull request addresses the rendering issue with the icons for greater than or equal to (≥), less than or equal to (≤), and not equal to (≠). The icons now render correctly without any distortion.

### Changes Made
Added the svg files in the correct path 

### Screenshots 
<img width="1439" alt="Screenshot 2024-01-19 at 9 21 10 PM" src="https://github.com/sugarlabs/musicblocks/assets/112820522/99e7d956-c650-489f-9a9d-d72e666b6ab2">
<img width="1440" alt="Screenshot 2024-01-19 at 9 21 33 PM" src="https://github.com/sugarlabs/musicblocks/assets/112820522/6d3e76f9-0cb9-4d5f-ab70-11c6465e6cf3">
<img width="1440" alt="Screenshot 2024-01-19 at 9 21 40 PM" src="https://github.com/sugarlabs/musicblocks/assets/112820522/ff97037b-e01b-4daa-b1b4-90b7b74442ff">


