### PR TITLE
Feat: added_colour_on_hovering_of_msgcloseIcon

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1622,6 +1622,12 @@ input.timbreName {
     width: 28px;
     height: 28px;
     filter: invert(100%);
+    transition: background-color 0.3s, filter 0.3s;
+  }
+
+  .msgCloseIcon:hover {
+    background-color: #fd0707;
+    filter: invert(0%);
   }
 
   .disable_highlighting {

--- a/css/activities.css
+++ b/css/activities.css
@@ -1626,7 +1626,6 @@ input.timbreName {
   }
 
   .msgCloseIcon:hover {
-    background-color: #fd0707;
     filter: invert(0%);
   }
 


### PR DESCRIPTION
Added the colour of msg close icon on hovering and transition 

Fixes:#3631
[screen-capture (1).webm](https://github.com/sugarlabs/musicblocks/assets/103755591/bb81ce31-4457-4cc3-9b3c-b6f5229a53ca)
