### PR TITLE
≤,≥,≠ Boolean blocks available only in Advanced mode

### DIFF
--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -592,12 +592,6 @@ function setupBooleanBlocks(activity) {
             this.setPalette("boolean", activity);
 
             /**
-             * Sets the beginner status for the block.
-             * @param {boolean} true - The beginner status.
-             */
-            this.beginnerBlock(true);
-
-            /**
              * Sets the help string for the block.
              * @type {string[]}
              */
@@ -697,12 +691,6 @@ function setupBooleanBlocks(activity) {
              * @param {Activity} activity - The activity associated with the block.
              */
             this.setPalette("boolean", activity);
-
-            /**
-             * Sets the beginner status for the block.
-             * @param {boolean} true - The beginner status.
-             */
-            this.beginnerBlock(true);
 
             /**
              * Sets the help string for the block.
@@ -912,12 +900,6 @@ function setupBooleanBlocks(activity) {
              * @param {Activity} activity - The activity associated with the block.
              */
             this.setPalette("boolean", activity);
-
-            /**
-             * Sets the beginner status for the block.
-             * @param {boolean} true - The beginner status.
-             */
-            this.beginnerBlock(true);
 
             /**
              * Sets the help string for the block.


### PR DESCRIPTION
fixes #3633 

### Description
This pull request addresses the issue #3633 where the boolean blocks for less than or equal to (≤), greater than or equal to (≥), and not equal to (≠) were available in both beginner and advanced modes. The proposed solution restricts these blocks to the advanced mode only, enhancing the user experience and simplifying the interface for users in the beginner mode.

### Changes Made

Updates relevant code sections to enforce the restriction.
### Screenshots 

<img width="1440" alt="Screenshot 2024-01-20 at 11 44 00 AM" src="https://github.com/sugarlabs/musicblocks/assets/112820522/dd4e8ae9-c764-4185-b9ae-e990611e6256">

<img width="1440" alt="Screenshot 2024-01-20 at 11 43 21 AM" src="https://github.com/sugarlabs/musicblocks/assets/112820522/3cde79b9-14cd-499b-84f3-43f5719ed60b">


### Testing

Verified that boolean blocks for ≤, ≥, and ≠ are visible only in the advanced mode.
Checked that users in beginner mode do not have access to these blocks.