### PR TITLE
Limit the pitch numbers and division

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -712,12 +712,12 @@ function TemperamentWidget() {
         equalEdit.innerHTML =
             "<br>" +
             _("pitch number") +
-            '&nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="octaveIn" value="0"></input> &nbsp;&nbsp; ' +
+            '&nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="octaveIn" maxlength="3" value="0"></input> &nbsp;&nbsp; ' +
             _("to") +
-            ' &nbsp;&nbsp; <input type="text" id="octaveOut" value="0"></input><br><br>';
+            ' &nbsp;&nbsp; <input type="text" id="octaveOut" maxlength="3" value="0"></input><br><br>';
         equalEdit.innerHTML +=
             _("number of divisions") +
-            ' &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="divisions" value="' +
+            ' &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="divisions" maxlength="2" value="' +
             this.pitchNumber +
             '"></input>';
         equalEdit.style.paddingLeft = "80px";


### PR DESCRIPTION
Fixes: #3622

As per the conversation in ticket number #3622, This PR limits the pitch number to < 1000, and for division, I have tested for all the two-digit numbers. It's working fine without any page crashes or too much overlapping.

kindly review this PR @walterbender sir, and please provide your considerations on this.