### PR TITLE
Fix - Placeholder Visibility in Search Bar on Planet Page

### DIFF
--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -157,6 +157,11 @@
 	box-shadow: 0 1px 0 0 #fff !important;
 }
 
+#searchcontainer
+{
+	width: 20vw ; ;
+}
+
 /* icon prefix focus color */
 #global-search .prefix.active {
 	color: #fff !important;

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -158,7 +158,7 @@
 }
 
 #searchcontainer {
-	width: 20vw ; ;
+	width: 20vw ; 
 }
 
 /* icon prefix focus color */

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -157,8 +157,7 @@
 	box-shadow: 0 1px 0 0 #fff !important;
 }
 
-#searchcontainer
-{
+#searchcontainer {
 	width: 20vw ; ;
 }
 


### PR DESCRIPTION
This PR addresses the issue #3640 of incomplete visibility of the placeholder text in the search bar on the planet page

![image](https://github.com/sugarlabs/musicblocks/assets/88442916/8fcb2be1-16d9-4635-9d69-f6251b613c86)

Current Search bar 
![image](https://github.com/sugarlabs/musicblocks/assets/88442916/eaf34994-cfab-4f63-9cb4-a2ad2085e0b1)

After changes
![image](https://github.com/sugarlabs/musicblocks/assets/88442916/fe253b9f-d294-4e35-a835-738927c8367d)



