### PR TITLE
[FIXED] Popup window bug 

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -139,7 +139,11 @@ class WidgetWindow {
 
         const rollButton = this._create("div", "wftButton rollup", this._drag);
         rollButton.onclick = (e) => {
-            if (this._rolled) {
+            if (this._maximized) {             
+                this._toggleClass(rollButton, "plus");
+                this._maximized = false;
+            }
+            else if (this._rolled) {
                 this.unroll();
                 this._toggleClass(rollButton, "plus");
             }


### PR DESCRIPTION
fixes #3637 

### Changes made

Updated the conditional block for the maximized state to toggle the class of the rollButton
Reset the _maximized property to false to reflect the change in state.

### Video

https://github.com/sugarlabs/musicblocks/assets/112820522/32f521db-9978-4c92-a384-757ebb496bd8

### Testing
Verified seamless functionality across all combinations of maximizing and rolling up scenarios demonstrated in the video.