### PR TITLE
fixes regression in Phrasemaker window size

### DIFF
--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -136,7 +136,7 @@
 #floatingWindows > .windowFrame > .wfWinBody > .wfbWidget {
     flex-grow: 1;
     overflow: hidden;
-    position: relative;
+    position: absolute;
 }
 #floatingWindows td {
     padding: 0;


### PR DESCRIPTION
fixes #3647 
I have set position absoulte which solves the issue of adding horizontal and vertical scrollbars

before: when it is set to relative

![image](https://github.com/sugarlabs/musicblocks/assets/97027791/cd9c41b8-ef69-4afb-b5e9-232258cc0d54)

after: when it is set to absoulte

![image](https://github.com/sugarlabs/musicblocks/assets/97027791/472908e0-1025-434b-94a4-6d0e6e7e7c88)

