### PR TITLE
Useful comment in index.html for develepors 

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,9 @@
 			lang = "enUS";
 			console.debug("Reverting to " + lang);
 		    }
-
+                    
+                    // Intentional placement of SVG image per user request by Japanese Schools.
+                    // Do not consider this as an issue; it's by design.  
                     if (lang === "ja") {
                         document.getElementById(
                             "loading-image-container"

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 		    }
                     
                     // Intentional placement of SVG image per user request by Japanese Schools.
-                    // Do not consider this as an issue; it's by design.  
+                    
                     if (lang === "ja") {
                         document.getElementById(
                             "loading-image-container"


### PR DESCRIPTION
# Description:
This pull request addresses the need for clear communication regarding the intentional placement of the SVG image in the Japanese part of the preloader code in [Index.html](https://github.com/sugarlabs/musicblocks/blob/master/index.html) page line: _107_

This comment provides context for developers and ensures they understand the design choice behind this placement.
So that people don't raise unnecessary issues like #3645 

# Screenshot

![Screenshot 2024-01-24 013317](https://github.com/sugarlabs/musicblocks/assets/117789470/9ab7f369-4b5d-4135-9765-5a4e788dae99)

![Screenshot 2024-01-24 012429](https://github.com/sugarlabs/musicblocks/assets/117789470/5ad80006-7c8a-4e9a-a9e9-909aa0e97a3b)
