### PR TITLE
Fixed minimize sizing issues(Phrasemaker minimize)

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -34,6 +34,7 @@ class WidgetWindow {
         this._visible = true;
         this._rolled = false;
         this._savedPos = null;
+        this._savedDimensions = null;
         this._maximized = false;
         this._fullscreenEnabled = fullscreen;
 
@@ -478,11 +479,22 @@ class WidgetWindow {
             this._frame.style.top = this._savedPos[1];
             this._savedPos = null;
         }
-        this._overlay(false);
-        this._frame.style.width = "auto";
-        this._frame.style.height = "auto";
-        this._frame.style.minHeight = "420px";
-        this._frame.style.minWidth = "470px";
+
+        this._overlay(false)
+
+        if(this._savedDimensions)
+        {
+            this._frame.style.height = this._savedDimensions[0];
+            this._frame.style.width = this._savedDimensions[1];
+        }else
+        {
+            this._frame.style.width = "auto";
+            this._frame.style.height = "auto";
+            this._frame.style.minHeight = "420px";
+            this._frame.style.minWidth = "470px";
+        }
+        ;
+        
     }
 
     /**
@@ -496,6 +508,7 @@ class WidgetWindow {
         this.takeFocus();
 
         this._savedPos = [this._frame.style.left, this._frame.style.top];
+        this._savedDimensions = [this._frame.style.height , this._frame.style.width];
         this._frame.style.width = "100vw";
         this._frame.style.height = "calc(100vh - 64px)";
         this._frame.style.left = "0";


### PR DESCRIPTION
Hey @walterbender ,

I'm raising the pull request to address the resize issue #3647  for not only Phrasemaker but all widgets. 

Similar to as we use **savedPos** array which store the position of the widgetWindow to be used when minimized from full screen.
I have added a **savedDimensions** array which stores the width and height of the widget before the maximize.

This is checked and restored back on minimize . It should work for all widgets.

Thanks,
Ritik 