### PR TITLE
Fixed phrasemaker dimension resize issue

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2262,7 +2262,6 @@ class PhraseMaker {
                 console.debug("pushing " + obj[1] + " " + last(this.rowLabels));
                 this._sortedRowMap.push(last(this._sortedRowMap) + 1);
                 lastObj = i;
-                this.stylePhraseMaker();
             }
 
             this.rowLabels.push(obj[1]);


### PR DESCRIPTION
Hey @walterbender ,

I have raised this pull request to address the #3647 issue. 

The **stylePhraseMaker** function gets invoked after a split second and changes the dimensions of the widget. I noticed this also hampers the roll up and down feature of the widget. The "+" "-" does not seem to work correctly.

For me it seems to fix the dimension change after a split second issue. The widget opens in the required size and does not change after that.

Thanks,
Ritik