### PR TITLE
warning box disappear when stop button is clicked, issue#3248 fixed

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -367,6 +367,9 @@ class Toolbar {
         }
 
         var tempClick = playIcon.onclick = () => {
+            const hideMsgs = () => {
+                this.activity.hideMsgs();
+            };
             isPlayIconRunning = false;
             onclick(this.activity);
             handleClick();
@@ -377,6 +380,7 @@ class Toolbar {
             stopIcon.addEventListener("click", function(){
                 clearTimeout(play_button_debounce_timeout);
                 isPlayIconRunning = true;
+                hideMsgs();
                 handleClick();
             });
         };


### PR DESCRIPTION
when play button is clicked and if there is no start block then a message box popup, previously it did not hide when stop button is clicked , which is misleading cause confusion and potentially impede the user's ability to interact with the menu. 
Now this issue#3248 is fixed. message box hide when stop button clicked