### PR TITLE
Removed not needed variable and condition

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3014,16 +3014,9 @@ class Activity {
         });
         window.addEventListener("orientationchange",  handleResize);
 
-        const that = this;
-        // removed "const screenWidth" as it isn't need anymore.
+        const that = this;        
         const  resizeCanvas_ = () => {            
             that._onResize(false);
-            /* 
-            Removed an extra if condition which was added for the resizing issue when the download toolbar used to appear
-            at the bottom of chrome.
-            Google Chrome has completely removed this feature and This feature can't be brought back even using chrome://flags/#download-bubble
-            as it was an experimental flag which google further removed.
-            */
             document.getElementById("hideContents").click();
         };
         

--- a/js/activity.js
+++ b/js/activity.js
@@ -3013,7 +3013,6 @@ class Activity {
             }, 100);
         });
         window.addEventListener("orientationchange",  handleResize);
-
         const that = this;        
         const  resizeCanvas_ = () => {            
             that._onResize(false);

--- a/js/activity.js
+++ b/js/activity.js
@@ -3014,13 +3014,18 @@ class Activity {
         });
         window.addEventListener("orientationchange",  handleResize);
         const that = this;        
-        const  resizeCanvas_ = () => {            
-            that._onResize(false);
-            document.getElementById("hideContents").click();
+        const resizeCanvas_ = () => {
+            try {
+                that._onResize(false);
+                document.getElementById("hideContents").click();
+            } catch (error) {
+                console.error("An error occurred in resizeCanvas_:", error);
+            }
         };
         
         resizeCanvas_();
-        window.addEventListener("orientationchange", resizeCanvas_ );
+        window.addEventListener("orientationchange", resizeCanvas_);
+        
         /*
          * Restore last stack pushed to trashStack back onto canvas.
          * Hides palettes before update

--- a/js/activity.js
+++ b/js/activity.js
@@ -3015,11 +3015,15 @@ class Activity {
         window.addEventListener("orientationchange",  handleResize);
 
         const that = this;
-        const screenWidth = window.innerWidth;
-        const  resizeCanvas_ = () => {
-            if (screenWidth !== window.innerWidth) {
-                that._onResize(false);
-            }
+        // removed "const screenWidth" as it isn't need anymore.
+        const  resizeCanvas_ = () => {            
+            that._onResize(false);
+            /* 
+            Removed an extra if condition which was added for the resizing issue when the download toolbar used to appear
+            at the bottom of chrome.
+            Google Chrome has completely removed this feature and This feature can't be brought back even using chrome://flags/#download-bubble
+            as it was an experimental flag which google further removed.
+            */
             document.getElementById("hideContents").click();
         };
         


### PR DESCRIPTION
Removed an extra if condition which was added for the resizing issue when the download toolbar used to appear
at the bottom of chrome.
Google Chrome has completely removed this feature and This feature can't be brought back even using chrome://flags/#download-bubble as it was an experimental flag which google further removed.