### PR TITLE
Handles silence block corner cases

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2710,6 +2710,24 @@ class Block {
                 return;
             }
 
+            // Do not allow a vspace block attached to a silence block to be dragged out of a note.
+            if (
+                that?.name === "vspace" &&
+                that.blocks.blockList[that.connections[1]]?.name === "rest2"
+              ) {
+                return;
+              }
+
+            // Do not allow a stack of blocks to be dragged if the stack contains a silence block.
+            let block = that.blocks.blockList[that.connections[1]];
+            while (block != undefined) {
+                if (block?.name === "rest2") {
+                    this.activity.errorMsg(_("Silence block cannot be dragged out of a note clamp"), block);
+                    return;
+                }
+                block = block?.blocks.blockList[block.connections[1]];
+            }
+
             if (window.hasMouse) {
                 moved = true;
             } else {

--- a/js/block.js
+++ b/js/block.js
@@ -2722,7 +2722,7 @@ class Block {
             let block = that.blocks.blockList[that.connections[1]];
             while (block != undefined) {
                 if (block?.name === "rest2") {
-                    this.activity.errorMsg(_("Silence block cannot be dragged out of a note clamp"), block);
+                    this.activity.errorMsg(_("Silence block cannot be removed."), block);
                     return;
                 }
                 block = block?.blocks.blockList[block.connections[1]];

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1331,7 +1331,7 @@ class Blocks {
                   this.blockList[thisBlockobj.connections[0]].name === "vspace")
               ) {
                 return;
-              }              
+            }       
 
             thisBlockobj = this.blockList[thisBlock];
             if (thisBlockobj.name === "rest2") {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1323,12 +1323,15 @@ class Blocks {
 
             // Do not remove the silence block if only a vspace block is added before the silence block.
             if (
-                thisBlockobj.name === "vspace" &&
-                this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
-                this.blockList[thisBlockobj.connections[0]].name === "newnote"
+                (thisBlockobj.name === "vspace" &&
+                  this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
+                  this.blockList[thisBlockobj.connections[0]].name === "newnote") ||
+                (thisBlockobj.name === "vspace" &&
+                  this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
+                  this.blockList[thisBlockobj.connections[0]].name === "vspace")
               ) {
                 return;
-              }
+              }              
 
             thisBlockobj = this.blockList[thisBlock];
             if (thisBlockobj.name === "rest2") {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1331,7 +1331,7 @@ class Blocks {
                   this.blockList[thisBlockobj.connections[0]].name === "vspace")
               ) {
                 return;
-            }       
+            }
 
             thisBlockobj = this.blockList[thisBlock];
             if (thisBlockobj.name === "rest2") {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1320,9 +1320,15 @@ class Blocks {
             }
 
             let thisBlockobj = this.blockList[thisBlock];
-            if (thisBlockobj.name === "vspace") {
+
+            // Do not remove the silence block if only a vspace block is added before the silence block.
+            if (
+                thisBlockobj.name === "vspace" &&
+                this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
+                this.blockList[thisBlockobj.connections[0]].name === "newnote"
+              ) {
                 return;
-            }
+              }
 
             thisBlockobj = this.blockList[thisBlock];
             if (thisBlockobj.name === "rest2") {
@@ -1364,6 +1370,12 @@ class Blocks {
          */
         this.deletePreviousDefault = (thisBlock) => {
             let thisBlockobj = this.blockList[thisBlock];
+
+            // Do not remove the silence block if only a vspace block is inserted after the silence block.
+            if (this.blockList[thisBlockobj.connections[0]]?.name === "rest2" && this.blockList[thisBlock]?.name === "vspace") {
+                return thisBlockobj.connections[0];
+            }
+
             if (this._blockInStack(thisBlock, ["rest2"])) {
                 this._deletePitchBlocks(thisBlock);
                 return this.blockList[thisBlock].connections[0];

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1330,6 +1330,10 @@ class Blocks {
                   this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
                   this.blockList[thisBlockobj.connections[0]].name === "vspace")
               ) {
+                console.log("getting returned");
+                console.log(this.blockList[thisBlockobj.connections[1]].name);
+                console.log(this.blockList[thisBlockobj.connections[0]].name);
+                console.log(thisBlockobj.name);
                 return;
               }              
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1330,10 +1330,6 @@ class Blocks {
                   this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
                   this.blockList[thisBlockobj.connections[0]].name === "vspace")
               ) {
-                console.log("getting returned");
-                console.log(this.blockList[thisBlockobj.connections[1]].name);
-                console.log(this.blockList[thisBlockobj.connections[0]].name);
-                console.log(thisBlockobj.name);
                 return;
               }              
 


### PR DESCRIPTION
Fixes #3669 
I've implemented a restriction preventing users from dislodging the vspace block connected to the silence block within the note block, which solves the first corner case @pikurasa mentions in the ticket.
The other corner cases have been handled by 
1. A while loop that checks if a stack within the note block contains the silence block, if yes then it cant be dragged out.
2. By removing the piece of code that was returning the function that removed the silence block if the block inserted was a vspace block. This is as even if a user inserted a pitch block connected to a vspace block to the clamp even then the silence block would not be removed as the function would return.