### PR TITLE
make top-right corner buttons responsive to aux menu

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3154,6 +3154,18 @@ class Activity {
         this._showHideAuxMenu = (resize) => {
             const cellsize = 55;
             let dy;
+
+            // function to increase or decrease the "top" property of the top-right corner buttons
+
+            const topRightButtons = document.querySelectorAll("#buttoncontainerTOP .tooltipped");
+            const btnY = document.getElementById("Grid").getBoundingClientRect().top;
+
+            this.changeTopButtonsPosition = (value) => {
+                topRightButtons.forEach((child) => {
+                    child.style.top = `${btnY + value}px`;
+                });
+            };
+            
             if (!resize && this.toolbarHeight === 0) {
                 dy = cellsize + LEADING + 5;
                 this.toolbarHeight = dy;
@@ -3162,6 +3174,7 @@ class Activity {
                 this.turtles.deltaY(dy);
 
                 this.blocksContainer.y += dy;
+                this.changeTopButtonsPosition(dy);
                 this.blocks.checkBounds();
             } else {
                 dy = this.toolbarHeight;
@@ -3171,6 +3184,7 @@ class Activity {
                 this.turtles.deltaY(-dy);
 
                 this.blocksContainer.y -= dy;
+                this.changeTopButtonsPosition(-dy);
             }
 
             this.refreshCanvas();


### PR DESCRIPTION
Fixes: #3727

This PR makes the top-right buttons responsive to the height of aux menu


https://github.com/sugarlabs/musicblocks/assets/109718740/90ecf3e7-f4d4-44b6-8958-d92eac625c34


kindly review @walterbender sir.