### PR TITLE
fixed scroll issues with widget palette

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -878,8 +878,6 @@ class Palette {
         this.model.update();
         const paletteList = docById("PaletteBody_items");
 
-        this.setupGrabScroll(paletteList);
-
         const blocks = this.model.blocks;
         blocks.reverse();
         const protoListScope = [...this.protoList];


### PR DESCRIPTION
This pull request is in reference to the issue #3734 . 

Whenever scrollbar was used, the **setupGrabScroll()** function was being call which made the scroll bar go to the top and change the mouse pointer type to scroll.

This takes place in all widget palettes and makes it difficult to select something at the end.


Thanks,
Ritik