### PR TITLE
Fixes new silence block corner cases 

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1321,19 +1321,30 @@ class Blocks {
 
             let thisBlockobj = this.blockList[thisBlock];
 
-            // Do not remove the silence block if only a vspace block is added before the silence block.
+            // Do not remove the silence block if the user places a block just over it.
             if (
-                (thisBlockobj.name === "vspace" &&
-                  this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
-                  this.blockList[thisBlockobj.connections[0]].name === "newnote") ||
-                (thisBlockobj.name === "vspace" &&
-                  this.blockList[thisBlockobj.connections[1]].name === "vspace" &&
-                  this.blockList[thisBlockobj.connections[0]].name === "vspace")
+                thisBlockobj?.name === "vspace" &&
+                this.blockList[thisBlockobj.connections[1]]?.name === "rest2" &&
+                this.blockList[thisBlockobj.connections[0]]?.name === "vspace"
               ) {
                 return;
             }
 
             thisBlockobj = this.blockList[thisBlock];
+
+            // Do not remove the silence block if only vspace blocks are added before the silence block.
+
+            let block = thisBlockobj;
+            while (block?.name == "vspace") {
+                if (block?.name != "vspace") {
+                    break;
+                }
+                block = this.blockList[block.connections[0]];
+                if (block?.name == "newnote") {
+                    return;
+                }
+            }
+            
             if (thisBlockobj.name === "rest2") {
                 this._deletePitchBlocks(thisBlock);
             } else {


### PR DESCRIPTION
A few corner cases will arise once vspace blocks that connecting to each other -

1. If a vspace block was connected to the vspace block connected to the silence block then the silence block would disappear.
2. If a pitch block with 2 or more vspace blocks attached below it would be placed inside the note clamp, the silence block would not disappear and could be dragged out of the note clamp.

Thus I have placed restrictions on both these corner cases. I am adding on to the fixes I made in #3718 .


