### PR TITLE
Pitch Drum Matrix: enhancements to fullscreen mode

### DIFF
--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -31,56 +31,12 @@
 */
 /* exported PitchDrumMatrix */
 
-/**
- * Represents a PitchDrumMatrix widget for making a mapping between pitch and drum sounds.
- * 
- * @class
- * @memberof global
- * @requires Singer
- * @requires _ 
- * @requires docById
- * @requires platformColor
- * @exports PitchDrumMatrix
- */
 class PitchDrumMatrix {
-     /**
-     * Width of the button division.
-     * 
-     * @type {number}
-     */
     static BUTTONDIVWIDTH = 295; // 5 buttons
-
-    /**
-     * Width of the drum name column.
-     * 
-     * @type {number}
-     */
     static DRUMNAMEWIDTH = 50;
-
-    /**
-     * Width of the outer window.
-     * 
-     * @type {number}
-     */
     static OUTERWINDOWWIDTH = 128;
-
-    /**
-     * Width of the inner window.
-     * 
-     * @type {number}
-     */
     static INNERWINDOWWIDTH = 50;
-    /**
-     * Size of the buttons.
-     * 
-     * @type {number}
-     */
     static BUTTONSIZE = 53;
-     /**
-     * Size of the icons.
-     * 
-     * @type {number}
-     */
     static ICONSIZE = 32;
 
     constructor() {
@@ -106,41 +62,19 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Initializes the pitch/drum matrix. 
-     * 
-     * @param {Activity} activity - The activity instance.
+     * Initializes the pitch/drum matrix. First removes the previous matrix and them make another
+     * one in DOM (Document Object Model).
      */
     init(activity) {
-        /**
-         * The activity associated with the PitchDrumMatrix.
-         * 
-         * @type {Activity}
-         */
         this.activity = activity;
         const w = window.innerWidth;
-        /**
-         * The scale factor for cell sizes.
-         * 
-         * @type {number}
-         * @private
-         */
         this._cellScale = w / 1200;
-        
-        /**
-         * The widget window for the PitchDrumMatrix.
-         * 
-         * @type {WidgetWindow}
-         */
+
         const widgetWindow = window.widgetWindows.windowFor(this, "pitch drum");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
-        
-        /**
-         * The button to play all sounds associated with the matrix.
-         * 
-         * @type {HTMLButtonElement}
-         */
+
         this.playButton = widgetWindow.addButton(
             "play-button.svg",
             PitchDrumMatrix.ICONSIZE,
@@ -152,13 +86,7 @@ class PitchDrumMatrix {
             this.activity.logo.turtleDelay = 0;
             this._playAll();
         };
-        
-        /**
-         * Flag indicating whether saving operation is locked.
-         * 
-         * @type {boolean}
-         * @private
-         */
+
         this._save_lock = false;
         widgetWindow.addButton(
             "export-chunk.svg",
@@ -182,21 +110,16 @@ class PitchDrumMatrix {
         ).onclick = () => {
             this._clear();
         };
-        
-        /**
-         * The container for the pitch/drum matrix.
-         * 
-         * @type {HTMLDivElement}
-         */
+
         this.pitchDrumDiv = document.createElement("div");
         widgetWindow.getWidgetBody().append(this.pitchDrumDiv);
         widgetWindow.getWidgetBody().style.height = "400px";
-        widgetWindow.getWidgetBody().style.width = "400px";
+        widgetWindow.getWidgetBody().style.width = "500px";
 
         // The pdm table
         const pdmTableDiv = this.pitchDrumDiv;
-        pdmTableDiv.style.display = "inline";
-        pdmTableDiv.style.visibility = "visible";
+        pdmTableDiv.style.position = "relative";
+        pdmTableDiv.style.visibility = "invisible";
         pdmTableDiv.style.border = "0px";
         pdmTableDiv.innerHTML = "";
 
@@ -252,6 +175,12 @@ class PitchDrumMatrix {
             labelCell.className = "headcol";
             labelCell.innerHTML = this.rowLabels[j] + this.rowArgs[j].toString().sub();
 
+            labelCell.className = "headcol";
+            labelCell.style.position = "sticky";
+            labelCell.style.left = "0"; // This will keep it fixed horizontally
+            labelCell.style.top = "0"; // Change if you have a header row you want it to go below
+            labelCell.style.zIndex = "5";
+
             pdmCell = pdmTableRow.insertCell();
             // Create tables to store individual notes.
             pdmCell.innerHTML =
@@ -277,11 +206,18 @@ class PitchDrumMatrix {
         labelCell.className = "headcol";
         labelCell.innerHTML = "";
 
+        labelCell.style.position = "sticky";
+        labelCell.style.left = "0"; // This will keep it fixed horizontally
+        labelCell.style.top = "0"; // Change if you have a header row you want it to go below
+        labelCell.style.bottom = "0";
+        labelCell.style.zIndex = "20";
+
         const n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 8);
         const outerDiv = docById("pdmOuterDiv");
+        outerDiv.style.height = widgetWindow.getWidgetBody().style.height;
+        outerDiv.style.width = widgetWindow.getWidgetBody().style.width;
         let ow;
         if (pdmTable.rows.length + 2 > n) {
-            outerDiv.style.height = widgetWindow.getWidgetBody().style.height;
             ow = Math.max(
                 Math.min(
                     widgetWindow.getWidgetBody().style.width,
@@ -293,8 +229,6 @@ class PitchDrumMatrix {
                 PitchDrumMatrix.BUTTONDIVWIDTH
             ); // Add room for the vertical slider.
         } else {
-            outerDiv.style.height =
-                this._cellScale * MATRIXSOLFEHEIGHT * (pdmTable.rows.length + 3) + "px";
             ow = Math.max(
                 Math.min(
                     window.innerWidth / 2,
@@ -305,8 +239,6 @@ class PitchDrumMatrix {
             );
         }
 
-        outerDiv.style.width = ow + "px";
-
         const innerDiv = docById("pdmInnerDiv");
         innerDiv.style.height = widgetWindow.getWidgetBody().style.height;
         innerDiv.style.width = widgetWindow.getWidgetBody().style.width;
@@ -315,6 +247,9 @@ class PitchDrumMatrix {
         pdmCell = pdmTableRow.insertCell();
         // Create table to store drum names.
         pdmCell.innerHTML = '<table cellpadding="0px" id="pdmDrumTable"><tr></tr></table>';
+        pdmCell.style.position = "sticky";
+        pdmCell.style.bottom = "0";
+        pdmCell.style.zIndex = "10";
 
         // Add any drum blocks here.
         for (let i = 0; i < this.drums.length; i++) {
@@ -326,18 +261,18 @@ class PitchDrumMatrix {
         widgetWindow.onmaximize = () => {
             if (widgetWindow._maximized) {
                 widgetWindow.getWidgetBody().style.position = "absolute";
-                widgetWindow.getWidgetBody().style.height = "calc(100vh - 80px)";
-                widgetWindow.getWidgetBody().style.width = "200vh";
-                docById("pdmOuterDiv").style.height = "calc(100vh - 80px)";
-                docById("pdmOuterDiv").style.width = "calc(200vh - 64px)";
-                docById("pdmInnerDiv").style.width = "calc(200vh - 64px)";
-                docById("pdmInnerDiv").style.height = "calc(100vh - 80px)";
-                widgetWindow.getWidgetBody().style.left = "70px";
+                widgetWindow.getWidgetBody().style.height = "calc(-95px + 100vh)";
+                widgetWindow.getWidgetBody().style.width = "calc(-55px + 100vw)";
+                widgetWindow.getWidgetBody().style.left = "55px";
+                outerDiv.style.height = widgetWindow.getWidgetBody().style.height;
+                outerDiv.style.width = widgetWindow.getWidgetBody().style.width;
+                innerDiv.style.height = widgetWindow.getWidgetBody().style.height;
+                innerDiv.style.width = widgetWindow.getWidgetBody().style.width;
             } else {
                 widgetWindow.getWidgetBody().style.position = "relative";
                 widgetWindow.getWidgetBody().style.left = "0px";
                 widgetWindow.getWidgetBody().style.height = "400px";
-                widgetWindow.getWidgetBody().style.width = "400px";
+                widgetWindow.getWidgetBody().style.width = "500px";
                 const innerDiv = docById("pdmInnerDiv");
                 innerDiv.style.height = widgetWindow.getWidgetBody().style.height;
                 innerDiv.style.width = widgetWindow.getWidgetBody().style.width;
@@ -348,8 +283,6 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Clears the row and column block arrays.
-     * 
      * @public
      * @returns {void}
      */
@@ -359,35 +292,29 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Adds a pitch block to the row block array.
-     * 
      * @public
-     * @param {number} pitchBlock - The pitch block to add.
-     * @returns {void}
+     * @param {number} pitchBlock
+     * @return {void}
      */
     addRowBlock(pitchBlock) {
         this._rowBlocks.push(pitchBlock);
     }
 
     /**
-     * Adds a drum block to the column block array.
-     * 
      * @public
-     * @param {number} drumBlock - The drum block to add.
-     * @returns {void}
+     * @param {number} drumBlock
+     * @return {void}
      */
     addColBlock(drumBlock) {
         this._colBlocks.push(drumBlock);
     }
 
     /**
-     * Adds a node (intersection) to the block map.
-     * 
      * @public
-     * @param {number} pitchBlock - The pitch block index.
-     * @param {number} drumBlock - The drum block index.
+     * @param {number} pitchBlock
+     * @param {number} drumBlock
      * @returns {void}
-     */    
+     */
     addNode(pitchBlock, drumBlock) {
         let obj;
         for (let i = 0; i < this._blockMap.length; i++) {
@@ -400,13 +327,11 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Removes a node (intersection) from the block map.
-     * 
      * @public
-     * @param {number} pitchBlock - The pitch block index.
-     * @param {number} drumBlock - The drum block index.
+     * @param {number} pitchBlock
+     * @param {number} drumBlock
      * @returns {void}
-     */    
+     */
     removeNode(pitchBlock, drumBlock) {
         let obj;
         for (let i = 0; i < this._blockMap.length; i++) {
@@ -418,25 +343,15 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Returns the save lock element.
-     * 
      * @private
-     * @returns {HTMLElement} - The save lock element.
-     */    
+     * @returns {HTMLElement}
+     */
     _get_save_lock() {
         return this._save_lock;
     }
 
     /**
-     * [DEPRECATED] Adds a button to the matrix.
-     * 
-     * @private
-     * @deprecated This method is deprecated.
-     * @param {HTMLTableRowElement} row - The table row to which the button will be added.
-     * @param {string} icon - The icon image source.
-     * @param {number} iconSize - The size of the icon.
-     * @param {string} label - The label text for the button.
-     * @returns {HTMLTableCellElement} - The cell element containing the button.
+     * @deprecated
      */
     _addButton(row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
@@ -472,10 +387,8 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Adds a drum to the matrix.
-     * 
      * @private
-     * @param {number} drumIdx - The index of the drum to add.
+     * @param {number} drumIdx
      * @returns {void}
      */
     _addDrum(drumIdx) {
@@ -546,8 +459,7 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Makes the matrix clickable, enabling user interaction.
-     * 
+     * Once the entire matrix is generated, this function makes it clickable.
      * @public
      * @returns {void}
      */
@@ -622,8 +534,6 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Handles the scaling of the widget.
-     * 
      * @private
      * @returns {void}
      */
@@ -649,8 +559,6 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Handles playing all pitch/drum combinations in the matrix.
-     * 
      * @private
      * @returns {void}
      */
@@ -758,11 +666,9 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Plays the pitch and drum combination at the given index in the pairs array recursively.
-     * 
      * @private
-     * @param {number} i - The index indicating which pair of pitch and drum to play.
-     * @param {Array<Array<number>>} pairs - An array containing pairs of pitch and drum indices.
+     * @param {number} i
+     * @param {number} pairs
      * @returns {void}
      */
     _playPitchDrum(i, pairs) {
@@ -818,12 +724,10 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Sets the pitch and drum combination for a specific cell in the matrix and plays the combination if specified.
-     * 
      * @private
-     * @param {number} colIndex - The column index of the cell.
-     * @param {number} rowIndex - The row index of the cell.
-     * @param {number} playNote - A flag indicating whether to play the note or not.
+     * @param {number} colIndex
+     * @param {number} rowIndex
+     * @param {number} playNote
      * @returns {void}
      */
     _setCellPitchDrum(colIndex, rowIndex, playNote) {
@@ -880,17 +784,7 @@ class PitchDrumMatrix {
             }
         }
     }
-    
-    /**
-     * Sets the pair of pitch and drum for a specific cell in the matrix and plays the combination if specified.
-     * 
-     * @private
-     * @param {number} rowIndex - The row index of the cell.
-     * @param {number} colIndex - The column index of the cell.
-     * @param {HTMLElement} cell - The HTML element representing the matrix cell.
-     * @param {boolean} playNote - A flag indicating whether to play the note or not.
-     * @returns {void}
-     */
+
     _setPairCell(rowIndex, colIndex, cell, playNote) {
         const pdmTable = docById("pdmTable");
         let row = pdmTable.rows[rowIndex];
@@ -930,12 +824,6 @@ class PitchDrumMatrix {
         }
     }
 
-    /**
-     * Clears all the selections in the matrix.
-     * 
-     * @private
-     * @returns {void}
-     */
     _clear() {
         // "Unclick" every entry in the matrix.
         const pdmTable = docById("pdmTable");
@@ -956,8 +844,6 @@ class PitchDrumMatrix {
     }
 
     /**
-     * Saves the current matrix as an action stack consisting of a set drum and pitch blocks.
-     * 
      * @private
      * @returns {void}
      */


### PR DESCRIPTION
Ref https://github.com/sugarlabs/musicblocks/issues/2808
The Pitch Drum Matrix widget's white background doesn't match the window size before it is maximized, and it will change after the window is maximized and then minimized. 

**Before the change, the widget looks like this:**

https://github.com/sugarlabs/musicblocks/assets/76172789/bb1065c8-5f7a-4cd1-9775-add58adb8177

**After the change, it appears as follows:**

https://github.com/sugarlabs/musicblocks/assets/76172789/ec2b54b2-c91c-4417-b011-29258f8f4292

Furthermore, as more pitches and drums are added, creating music becomes challenging when the images of pitches and drums do not appear together.

**Here is how it looks with a large matrix before the change:**

https://github.com/sugarlabs/musicblocks/assets/76172789/67a64dd8-672a-47d5-bf0f-ac3a97102f94

**And this is how the large matrix looks with the sticky pitch bar and drum table implemented:**

https://github.com/sugarlabs/musicblocks/assets/76172789/aed38410-f53b-43c1-ad98-ba86da947e9d

Please share your feedback and suggestions. Thanks
