### PR TITLE
fix the vanishing content after resize 

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3160,6 +3160,7 @@ class Activity {
                 canvasHolder.height = canvas.height;
             }
             document.getElementById("hideContents").click();
+            that.refreshCanvas();
         }
 
         let resizeTimeout;


### PR DESCRIPTION
Fixed the resize bug which vanishes the blocks until we touch the screen .

Before : -

https://github.com/sugarlabs/musicblocks/assets/89124765/e12bb4bb-ef62-43db-bf51-aa542976b373

After :- 


https://github.com/sugarlabs/musicblocks/assets/89124765/ca626abe-3547-41fd-89b0-06334b017659



