### PR TITLE
Fixes #3808

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -173,7 +173,7 @@ class WidgetWindow {
 
         if (this._fullscreenEnabled) {
             const maxminButton = this._create("div", "wftButton wftMaxmin", this._nonclosebuttons);
-            maxminButton.onclick = maxminButton.onmousedown = (e) => {
+            maxminButton.onclick = (e) => {
                 if (this._maximized) {
                     this._restore();
                     this.sendToCenter();


### PR DESCRIPTION
This PR fixes issue #3808 . There were two Event Listeners being assigned to the maxmin button , "onclick" and "onmousedown". Only "onclick" listener is required and the presence of two Event Listeners caused this erratic behaviour.