### PR TITLE
fix(js/blocks.js): fixing the dragloopcounter

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3626,7 +3626,7 @@ class Blocks {
          */
         this._calculateDragGroup = (blk) => {
             this.dragLoopCounter += 1;
-            if (this.dragLoopCount > this.blockList.length) {
+            if (this.dragLoopCounter > this.blockList.length) {
                 // eslint-disable-next-line no-console
                 console.debug(
                     "Maximum loop counter exceeded in calculateDragGroup... this is bad. " + blk


### PR DESCRIPTION
fixes #3799

Errors were being displayed in the console due to a typo in the `blocks.js` file.