### PR TITLE
fixed undefined in silence block

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -140,7 +140,7 @@ const NSYMBOLS = { 1: "𝅝", 2: "𝅗𝅥", 4: "♩", 8: "♪", 16: "𝅘𝅥𝅯" };
  * @constant {Object.<number, string>}
  * @default
  */
-const RSYMBOLS = { 1: "𝄻", 2: "𝄼", 4: "𝄽" };
+const RSYMBOLS = { 1: "𝄻", 2: "𝄼", 4: "𝄽",8: "", 16: "" };
 
 /**
  * Maps from notes with flats to their corresponding notes with '♭' (flat) symbol.

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -140,7 +140,7 @@ const NSYMBOLS = { 1: "𝅝", 2: "𝅗𝅥", 4: "♩", 8: "♪", 16: "𝅘𝅥𝅯" };
  * @constant {Object.<number, string>}
  * @default
  */
-const RSYMBOLS = { 1: "𝄻", 2: "𝄼", 4: "𝄽",8: "", 16: "" };
+const RSYMBOLS = { 1: "𝄻", 2: "𝄼", 4: "𝄽",8: "𝄾", 16: "𝄿" };
 
 /**
  * Maps from notes with flats to their corresponding notes with '♭' (flat) symbol.


### PR DESCRIPTION
fixes #3859 

1) added "𝄾"  symbol for 1/8 and  "𝄿" for 1/16