### PR TITLE
Fix Hide Block bug

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -283,7 +283,7 @@ function setupExtrasBlocks(activity) {
          */
         flow(args, logo) {
             activity.blocks.hideBlocks();
-            logo.showBlocksAfterRun = false;
+            logo.activity.showBlocksAfterRun = false;
             logo.turtleDelay = 0;
         }
     }


### PR DESCRIPTION
The hide block was hiding blocks, but not keeping them hidden. This was because it was referencing showBlocksAfterRun in logo.js instead of activity.js

Now the blocks stay hidden after execution stops. This is really useful for many games and interactive projects.