### PR TITLE
check for undefined turtle

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4443,9 +4443,9 @@ class Activity {
                             // Find the turtle associated with this block.
                             // eslint-disable-next-line no-case-declarations
                             const turtle = this.turtles.turtleList[myBlock.value];
-                            if (turtle === null) {
+                            if (turtle === null || turtle === undefined) {
                                 args = {
-                                    id: Infinity,
+                                    id: this.turtles.turtleList.length,
                                     collapsed: false,
                                     xcor: 0,
                                     ycor: 0,


### PR DESCRIPTION
When prepping projects for loading, there is a check to see if a turtle is null, but not a check to see if the turtle is undefined. The latter case is triggering an error, which may or may not be causing the toolbar to disappear when loading a project from the Planet. In any case, it should be caught.

This patch checks for undefined as well as null. I assign a turtle ID of the length of the turtleList rather than Infinity in these situations.