### PR TITLE
Add close button to extended-menu pie menu (fixes #3933)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4761,6 +4761,9 @@ class Activity {
         
             if (!this.helpfulWheelItems.find(ele => ele.label === "Paste previous stack")) 
                 this.helpfulWheelItems.push({label: "Paste previous stack", icon: "imgsrc:header-icons/copy-button.svg", display: false, fn: this.turtles.expand});
+            if(!this.helpfulWheelItems.find(ele => ele.label=== "Close"))
+                this.helpfulWheelItems.push({label: "Close", icon: "imgsrc:header-icons/cancel-button.svg",
+                display: true, fn: this._hideHelpfulSearchWidget});
         
         };
 


### PR DESCRIPTION
Description
Related Issue
This PR fixes #3933 

Changes Made
Change 1-Added the close icon functionality to the pie menu which appears on right click
...
Testing Performed
Tested feature close button on clicking the close icon .
Tested on browsers Chrome and Firefox.
...
Checklist
[x] I have tested these changes locally and they work as expected.
[x] I have followed the project's coding style guidelines.
[Screencast from 03-07-24 10:17:59 PM IST.webm](https://github.com/sugarlabs/musicblocks/assets/154296996/b9f27d08-0d6d-4369-8847-444b5a28918f)
