### PR TITLE
Update Hyperscore example link in guide.html

### DIFF
--- a/guide/guide.html
+++ b/guide/guide.html
@@ -215,6 +215,7 @@
           <a href="#3-programming-with-music">Next Section (3. Programming with Music)</a>
         </p>
         <p>
+          
           Music Blocks incorporates many common elements of music, such as
           <a href="#22-pitch-blocks">pitch</a>, <a href="#21-note-value-blocks">rhythm</a>,
           <a href="#341-set-volume-and-crescendo">volume</a>, and, to some degree,
@@ -2406,7 +2407,7 @@
         </p>
         <p>
           <a
-            href="https://walterbender.github.io/musicblocks/index.html?id=1523896294964170&amp;run=True&amp;run=True"
+            href="https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&run=True&run=True"
             >RUN LIVE</a
           >
         </p>


### PR DESCRIPTION
Issue #3939

Updated the old "Hyperscore" link to the new link in guide.html.