### PR TITLE
Improve Documentation By Removing Google Play link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ like:
 Visit the Music Blocks website for a hands on experience:
 [https://musicblocks.sugarlabs.org](https://musicblocks.sugarlabs.org).
 
-Or download Music Blocks from the [Google Play Store](https://play.google.com/store/apps/details?id=my.musicblock.sugarlab)
-
 Additional background on why we combine music and programming can be found
 [here](./WhyMusicBlocks.md).
 


### PR DESCRIPTION
This pull request addresses issue by improving documentation by removing Google play link.
There is no need to add google play link which is not working.

Changes include:
- Removes google play link of music blocks app.

 Please add working link to this improves user experience of music block app also.