### PR TITLE
Fixes collapsed state of note block

### DIFF
--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -133,7 +133,7 @@ class ProtoBlock {
         if (this.fontsize) {
             svg.setFontSize(this.fontsize);
         }
-        svg.setExpand(30 + this.extraWidth, 0, 0, 0);
+        svg.setExpand(10 + this.extraWidth, 0, 0, 0);
         return [
             svg.basicBlock(),
             svg.docks,


### PR DESCRIPTION
@walterbender @pikurasa 
Collapsed note block looks like...
![Screenshot 2024-07-27 015911](https://github.com/user-attachments/assets/00d91a08-93af-466e-8837-8368226fd811)
This PR fixes that issue...
![Screenshot 2024-07-27 234712](https://github.com/user-attachments/assets/5f72eb44-526f-4744-83eb-6826b4e2a0c4)
