### PR TITLE
fixes issue with extra line number in JavaScript Editor

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -409,7 +409,7 @@ class JSEditor {
     _setLinesCount(code) {
         if (!docById("editorLines")) return;
 
-        const linesCount = code.replace(/\n+$/, "\n").split("\n").length + 1;
+        const linesCount = code.replace(/\n+$/, "\n").split("\n").length;
         let text = "";
         for (let i = 1; i < linesCount; i++) {
             text += `${i}\n`;


### PR DESCRIPTION
Fixed Issue with extra line number in Javascript Editor.

Before:

https://github.com/user-attachments/assets/401a94f9-150d-44ba-b8a8-8d4c945ef6d8

After: 

https://github.com/user-attachments/assets/83db3777-b320-4630-a2c0-0b9bf68df275

