### PR TITLE
Fixes #3973 Right click menu only opens in the advanced mode

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -491,12 +491,12 @@ class Activity {
                 (event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    if(this.beginnerMode == false){
-                    if (event.target.id === "myCanvas") {
-                        this._displayHelpfulWheel(event);
+                    if (!this.beginnerMode) {
+                        if (event.target.id === "myCanvas") {
+                            this._displayHelpfulWheel(event);
+                        }
                     }
-                }
-            },
+                },
                 false
             );
         };

--- a/js/activity.js
+++ b/js/activity.js
@@ -491,10 +491,12 @@ class Activity {
                 (event) => {
                     event.preventDefault();
                     event.stopPropagation();
+                    if(this.beginnerMode == false){
                     if (event.target.id === "myCanvas") {
                         this._displayHelpfulWheel(event);
                     }
-                },
+                }
+            },
                 false
             );
         };


### PR DESCRIPTION
- Context menu only opens up in the advanced mode.  
- Nothing happens when screen is right clicked in the begineer mode.
<img width="1080" alt="musicblocks" src="https://github.com/user-attachments/assets/b794b42b-f65d-45a4-b2b4-c13a86a83f53">



