### PR TITLE
FIXES ISSUE #3895 Add alphabet "G" as a block found in easy mode 

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -875,6 +875,7 @@ function setupPitchBlocks(activity) {
                 "note2"
             ]);
             this.formBlock({ outType: "noteout" });
+            this.beginnerBlock(true);
         }
     }
 
@@ -1841,6 +1842,7 @@ function setupPitchBlocks(activity) {
                 [1, ["notename", { value: "G" }], 0, 0, [0]],
                 [2, ["number", { value: 4 }], 0, 0, [0]]
             ]);
+            this.beginnerBlock(true);
         }
     }
 


### PR DESCRIPTION
The requirement of this issue is to add the Pitch-G4 and Alphabet-G block in pitch menu of the beginner mode.
So you can observe that the user is in beginner mode and can also use Pitch-G4 and Alphabet-G blocks.
Before :
<img width="1440" alt="Screenshot 2024-08-21 at 11 58 57 PM" src="https://github.com/user-attachments/assets/99370e4e-89c7-4457-abfd-fde25f5d25a6">
After :
<img width="1429" alt="Screenshot 2024-08-21 at 7 28 35 PM" src="https://github.com/user-attachments/assets/e2c2d1f3-b16a-4437-8a4b-ccdb06505c9d">
