### PR TITLE
 fix: remove redundant code to improve codebase clarity

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -333,17 +333,6 @@ function SampleWidget() {
         this.playBtn.onclick = () => {
             if (this.isMoving) {
                 this.pause();
-                this.playBtn.innerHTML =
-                    '<img src="header-icons/play-button.svg" title="' +
-                    _("Play") +
-                    '" alt="' +
-                    _("Play") +
-                    '" height="' +
-                    ICONSIZE +
-                    '" width="' +
-                    ICONSIZE +
-                    '" vertical-align="middle">';
-                this.isMoving = false;
             } else {
                 if (!(this.sampleName == "")) {
                     this.resume();


### PR DESCRIPTION
@walterbender I was going through sampler.js code and found this redundant code. I think we should remove this.