### PR TITLE
giving bpm a default value of 1 so that bpmFactor is not null 

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -231,7 +231,7 @@ class Turtle {
         this.singer.whichNoteToCount = 1;
         this.singer.movable = false;
 
-        this.singer.bpm = [];
+        this.singer.bpm = [1];
         this.singer.previousTurtleTime = 0;
         this.singer.turtleTime = 0;
         this.singer.pushedNote = false;


### PR DESCRIPTION
This pull request addresses issue #3931,

Changes Made
BPM Default Value: Added a default value of 1 to TONEBPM to handle cases where tur.singer.bpm might be empty, ensuring bpmFactor is never null.
Error Handling: Updated js/turtle.js 
How to Test
Run the Application: Navigate to the BPM handling section and check that default values are correctly applied when tur.singer.bpm is empty.
Additional Information
Now issue look fixed now we can hear the beats properly