### PR TITLE
Add More Frequent "RUN LIVE" Links to Music Blocks Programming Guide

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -142,7 +142,7 @@ case, an eighth note.
 At the bottom, two notes that are played consecutively are shown. They
 are both `1/8` notes, making the duration of the entire sequence
 `1/4`.
-[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793425037300&run=True)
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726138873526815&run=True)
 
 
 ![notes](./note2.svg "A quarter note, a sixteenth note, and a half note Note value blocks")
@@ -150,7 +150,7 @@ are both `1/8` notes, making the duration of the entire sequence
 In this example, different note values are shown. From top to bottom,
 they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
 `1/2` for a half note.
-[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793536240960&run=True)
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726139143565736&run=True)
 
 Note that any mathematical operations can be used as input to the
 *Note value*.
@@ -173,6 +173,8 @@ pitch name and pitch octave of a note that in combination determines
 the frequency (and therefore pitch) at which the note is played.
 
 ![pitch block](./note3.svg "Specifying a pitch block's name and octave")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726139416021937&run=True)
 
 There are many systems you can use to specify a *pitch* block's name
 and octave. Some examples are shown above.
@@ -787,6 +789,8 @@ block.
 
 ![interval](./transform9.svg "Scalar interval block")
 
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726142617030713&run=True)
+
 The *Scalar interval* block calculates a relative interval based on
 the current mode, skipping all notes outside of the mode. For example,
 a *fifth*, and adds the additional pitches to a note's playback. In
@@ -804,6 +808,8 @@ of scalar steps between two pitched.
 Absolute (or semitone) intervals are based on half-steps.
 
 ![intervals](./transform14.svg "Using absolute intervals")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726143428513328&run=True)
 
 The *Augmented* block calculates an absolute interval (in half-steps),
 e.g., an augmented fifth, and adds the additional pitches to a
@@ -833,6 +839,8 @@ example, a ratio of 2:1 would be an octave shift up; 1:2 would be an
 octave shift down; 3/2 would be a fifth.
 
 ![ratio interval](../documentation/ratiointerval_block.svg "Ratio Interval example")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726144197873608&run=True)
 
 The *Ratio Interval* block lets you generate an interval based on a
 ratio.
@@ -878,6 +886,8 @@ a `1/4` step, enabling rotation around a point between two notes. In
 rotation.
 
 ![inversion](./transform13.svg "inversion")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726144415115588&run=True)
 
 NOTE: The initial `C5` pitch (as a half note) remains unchanged (in
 all of the examples) as it is outside of the invert block.
@@ -1254,7 +1264,7 @@ block. In the example above, the default instrument is set to piano,
 so any note that is not inside of a *Set instrument* block will be
 played using the piano synthesizer. The first note in this example is
 piano; the second note is guitar; and the third is piano.
-[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725869737763127&run=True)
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1726145948711407&run=True)
 
 #### <a name= "SETTINGKEY"></a>3.4.3 Setting Key and Mode
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -1114,9 +1114,13 @@ In the example, on the left, the result would be `Sol, Re, Sol, Sol,
 Re, Sol, Sol, Re, Sol, Sol, Re, Sol`; on the right the result would be
 `Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol`.
 
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725794018017026&run=True)
+
 #### <a name="SWINGING">3.3.4 Swinging Notes and Tied Notes</a>
 
 ![swing](./transform7.svg "swinging notes and tied notes")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725867425283695&run=True)
 
 The *Swing* block works on pairs of notes (specified by note value),
 adding some duration (specified by swing value) to the first note and
@@ -1178,6 +1182,8 @@ The *Slur* block lengthens the sustain of notes&mdash;running longer than
 the noted duration and blending it into the next note&mdash;while
 maintaining the specified rhythmic value of the notes.
 
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725868210212676&run=True)
+
 #### <a name="BACKWARDS">3.3.7 Backwards</a>
 
 ![backwards](./transform11.svg "Backward block")
@@ -1226,6 +1232,8 @@ example, if you have 3 notes in sequence contained in a *Crescendo*
 block with a value of `5`, the final note will be at 15% more 
 than the original value for volume.
 
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725868641106995&run=True)
+
 NOTE: The *Crescendo* block does not alter the volume of a note as it
 is being played. Music Blocks does not yet have this functionality.
 
@@ -1237,7 +1245,7 @@ The default instrument is an electronic synthesizer, so by default,
 that is the instrument used when playing notes. You can override this
 default for a group of notes by using the *Set Instrument* block. It
 will select an [instrument](#342-setting-instrument) for the
-synthesizer for any contained blocks, e.g., violin.
+synthesizer for any contained blocks, e.g., violin. [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725869548034418&run=True)
 
 ![default voice](../documentation/setdefaultinstrument_block.svg "Set Default Instrument")
 
@@ -1246,6 +1254,7 @@ block. In the example above, the default instrument is set to piano,
 so any note that is not inside of a *Set instrument* block will be
 played using the piano synthesizer. The first note in this example is
 piano; the second note is guitar; and the third is piano.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725869737763127&run=True)
 
 #### <a name= "SETTINGKEY"></a>3.4.3 Setting Key and Mode
 
@@ -1258,6 +1267,7 @@ and a number of more exotic modes, such as Bebop, Geez, Maqam, etc.
 This block allows users to access "movable Do" within Music Blocks,
 where the mapping of solfege to particular pitch changes depending on
 the user's specified tonality.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725870361330836&run=True)
 
 ![mode](./transform19.svg "Define mode block")
 
@@ -1275,6 +1285,7 @@ e.g. plus or minus up to one half step. The rate argument determines
 the rate of the variation.
 
 The other effects blocks also modulate pitch over time. Give them a try.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725870963978517&run=True)
 
 ### <a name="VOICES">3.5 Voices</a>
 
@@ -1699,6 +1710,7 @@ You can use as many *Rhythm* blocks as you'd like inside the
 *Phrase maker* block. In the above example, two *Rhythm*
 blocks are used, resulting in three quarter notes and six eighth
 notes.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725873372253840&run=True)
 
 #### <a name="CREATING-TUPLETS">4.2.3 Creating Tuplets</a>
 
@@ -1708,7 +1720,7 @@ notes.
 
 Tuplets are a collection of notes that get scaled to a specific
 duration. Using tuplets makes it easy to create groups of notes that
-are not based on a power of 2.
+are not based on a power of 2 [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725874435939635&run=True).
 
 In the example above, three quarter notes&mdash;defined in the *Simple
 Tuplet* block&mdash;are played in the time of a single quarter
@@ -1730,6 +1742,7 @@ for intermixing multiple rhythms within single tuplet.
 
 In the example above, the two *Rhythm* blocks are embedded in the
 *Tuplet* block, resulting in a more complex rhythm.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725874743559698&run=True)
 
 Note: You can mix and match *Rhythm* blocks and *Tuplet* blocks when
 defining your matrix.
@@ -1826,6 +1839,7 @@ sub-cells. Once the fourth tone has sounded, a progress bar will run
 from left to right across the screen. Each click of the mouse will
 define another beat within the cell. If you don't like your rhythm,
 use the *Undo* button and try again.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725875683911786&run=True)
 
 ### <a name="modes">4.4 Musical Modes</a>
 
@@ -1914,6 +1928,7 @@ Note: The build-in modes in Music Blocks can be found in [musicutils.js](https:/
 
 The *Save* button exports a stack of blocks representing the mode that
 can be used inside the *Phrase maker* block.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725877046734200&run=True)
 
 ### <a name="meters">4.5 Meters</a>
 
@@ -2258,6 +2273,8 @@ The *Drag* button will drag the widget.
 
 The *Close* button will close the widget.
 
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725879922065766&run=True)
+
 ###  <a name="oscilloscope">4.13 The Oscilloscope</a>
 
 Music Blocks has an Oscilloscope Widget to visualize the music as it plays.
@@ -2267,6 +2284,7 @@ Music Blocks has an Oscilloscope Widget to visualize the music as it plays.
 ![widget](./oscilloscope2.svg "Oscilloscope")
 
 A separate wave will be displayed for each mouse.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725883406989554&run=True)
 
 ###  <a name="sampler">4.14 The Sampler</a>
 
@@ -2282,6 +2300,8 @@ You can then use the *Sample* block as you would any input to the *Set
 Instrument* block.
 
 ![widget](./sampler2.svg "Sampler Widget")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725883527894966&run=True)
 
 ###  <a name="arpeggio">4.15 Arpeggio</a>
 
@@ -2307,6 +2327,8 @@ The sequence in the pattern above is ```do mi sol do do mi do sol mi
 do do sol```.
 
 ![widget](../documentation/custom_arpeggio.svg "Custom Arpeggio")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725883915389933&run=True)
 
 ## <a name="BEYOND-MUSIC-BLOCKS">5. Beyond Music Blocks</a>
 
@@ -2413,6 +2435,8 @@ Editor*" (`<>`) button in the auxilliary menu.
 For the block stacks (and mouse art generated after running),
 
 ![Example Project](../js/js-export/samples/mode-up-down.png)
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725884337271676&run=True)
 
 the following code is generated:
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -142,12 +142,15 @@ case, an eighth note.
 At the bottom, two notes that are played consecutively are shown. They
 are both `1/8` notes, making the duration of the entire sequence
 `1/4`.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793425037300&run=True)
+
 
 ![notes](./note2.svg "A quarter note, a sixteenth note, and a half note Note value blocks")
 
 In this example, different note values are shown. From top to bottom,
 they are: `1/4` for an quarter note, `1/16` for a sixteenth note, and
 `1/2` for a half note.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793536240960&run=True)
 
 Note that any mathematical operations can be used as input to the
 *Note value*.
@@ -236,6 +239,7 @@ notes are located on a keyboard or staff.
 Multiple, simultaneous pitches can be specified by adding multiple
 *Pitch* blocks into a single *Note value* block, like the above
 example.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793652385126&run=True)
 
 ### <a name="RESTS">2.4 Rests</a>
 
@@ -243,6 +247,7 @@ example.
 
 A rest of the specified note value duration can be constructed using a
 *Silence* block in place of a *Pitch* block.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793737126028&run=True)
 
 ### <a name="DRUMS">2.5 Drums</a>
 
@@ -252,12 +257,14 @@ Anywhere a *Pitch* block can be used&mdash;e.g., inside of the matrix
 or a *Note value* block&mdash;a *Drum Sample* block can also be used
 instead. Currently there about two dozen different samples from which
 to choose. The default drum is a kick drum.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793852737369&run=True)
 
 ![drums](./note5.svg "Multiple Drum Sample blocks in combinations")
 
 Just as in the [multi-pitch](#23-multiple-pitches) example above, you
 can use multiple *Drum* blocks within a single *Note value* blocks,
 and combine them with *Pitch* blocks as well.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725793935277059&run=True)
 
 ## <a name="PROGRAMMING-WITH-MUSIC">3. Programming with Music</a>
 
@@ -274,6 +281,8 @@ widget to help you get started.
 ![action](./chunk-2.svg "working of action stack")
 
 ![action](./chunk-1.svg "using action inside Start block")
+
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725788353457649&run=True)
 
 Every time you create a new *Action* stack, Music Blocks creates a new
 block specific to, and linked with, that stack. (The new block is
@@ -311,6 +320,7 @@ block to execute them sequentially.
 
 You can [repeat](#333-repeating-notes) actions either by using
 multiple *Action* blocks or using a *Repeat* block.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725788849659637&run=True)
 
 ![multiple actions](./chunk-6.svg "multiple action stacks")
 
@@ -318,6 +328,7 @@ multiple *Action* blocks or using a *Repeat* block.
 
 You can also mix and match actions. Here we play the *Action* block with
 name `chunk0`, followed by `chunk1` twice, and then `chunk0` again.
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725789807251793&run=True)
 
 ![actions](./chunk-8.svg "creating a song using actions")
 
@@ -326,6 +337,8 @@ name `chunk0`, followed by `chunk1` twice, and then `chunk0` again.
 A few more chunks and we can make a song. (Can you read the block
 notation well enough to guess the outcome? Are you familiar with the
 song we created?)
+[RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1725791527821787&run=True)
+
 
 ### <a name="PITCH-TRANSFORMATION">3.2 Pitch Transformations</a>
 


### PR DESCRIPTION
This pull request improves the Music Blocks Programming Guide by adding more "RUN LIVE" links throughout the document, particularly in sections with step-by-step screenshots. These additions aim to:

* Increase Interactivity: Provide new users with more opportunities to experiment with Palette buttons and other features 
  directly from the guide, similar to the Turtle Blocks guide's approach.
* Enhance User Experience: Enable users to follow along more easily and tinker with examples as they read, thereby improving 
  their learning experience.

Key Changes:
* Added "RUN LIVE" links in sections where screenshots and descriptions are provided.
* Ensured that all new links are functional and point to the correct interactive examples.

Commit Messages and Contribution Guidelines:
* Each commit is clearly labeled and focused on a specific addition or improvement to maintain a clean and organized commit 
   history.
* The PR name directly reflects the content of the changes made.
* Extensive testing has been conducted to ensure that all links and changes function correctly.
* The PR description provides a concise summary of what has been addressed and how it improves the guide.
* This PR is ready for review and merging.

Closes #3843.