### PR TITLE
FIXES ISSUE #4000 Regression: 'Set Default Instrument' Block Converts to 'Unknown' Block 

### DIFF
--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -849,7 +849,7 @@ function setupToneBlocks(activity) {
                 ""
             ]);
             this.makeMacro((x, y) => [
-                [0, "setdefaultvoice", x, y, [null, 1, null]],
+                [0, "setdefaultinstrument", x, y, [null, 1, null]],
                 [1, ["voicename", { value: DEFAULTVOICE }], 0, 0, [0]]
             ]);
 


### PR DESCRIPTION
Now by this commit the "set default block" is working fine and poping out on canvas instead of that unknown block.
@walterbender @pikurasa 

https://github.com/user-attachments/assets/f442dbc8-cce3-48f8-bb93-39fa2c36099e

