### PR TITLE
fix: simultaneous opening of Pitch Pie Menu and Grey Menu on Right Click

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3139,7 +3139,7 @@ class Block {
                         this.blocks.mouseDownTime = new Date().getTime();
                         if (this.name === "media" || this.name === "loadFile") {
                             this._doOpenMedia(thisBlock);
-                        } else {
+                        } else if (!("ctrlKey" in event.nativeEvent && event.nativeEvent.ctrlKey)) {
                             this._changeLabel();
                         }
                     }


### PR DESCRIPTION
I found that this.container has both an on-click and a press-up event listener:
The on-click listener checks if the Ctrl key is pressed. If it is, it triggers the piemenuBlockContext function, which displays a grey menu. After this, the function returns, preventing any further code from executing.
The press-up listener calls the _mouseoutCallback function, but only if that.blocks.getLongPressStatus is false. This ultimately triggers the _changeLabels function without checking whether the Ctrl key is pressed or not.

@walterbender Can you please review it ?