### PR TITLE
Streamline Drumname for early return of drum post http match, use object lookup

### DIFF
--- a/js/turtleactions/DrumActions.js
+++ b/js/turtleactions/DrumActions.js
@@ -61,8 +61,10 @@ function setupDrumActions(activity) {
             if (drum.slice(0, 4) === "http") return drum;
             
             for (const [, value] of Object.entries(DRUMNAMES)) {
-                if (value.includes(drum)) {
+                if (value[0] === drum) {
                     return value[1];
+                } else if (value[1] === drum) {
+                    return drum;
                 }
             }
             

--- a/js/turtleactions/DrumActions.js
+++ b/js/turtleactions/DrumActions.js
@@ -58,21 +58,15 @@ function setupDrumActions(activity) {
          * @returns {String}
          */
         static GetDrumname(drum) {
-            let drumname = DEFAULTDRUM;
-            if (drum.slice(0, 4) === "http") {
-                drumname = drum;
-            } else {
-                for (const d in DRUMNAMES) {
-                    if (DRUMNAMES[d][0] === drum) {
-                        drumname = DRUMNAMES[d][1];
-                        break;
-                    } else if (DRUMNAMES[d][1] === drum) {
-                        drumname = drum;
-                        break;
-                    }
+            if (drum.slice(0, 4) === "http") return drum;
+            
+            for (const [, value] of Object.entries(DRUMNAMES)) {
+                if (value.includes(drum)) {
+                    return value[1];
                 }
             }
-            return drumname;
+            
+            return DEFAULTDRUM;
         }
 
         /**


### PR DESCRIPTION
- More efficient object iteration using `Object.entries()`
- Reduced comparisons per iteration
- Immediate return on match
