### PR TITLE
FIXES ISSUE #3921 Reexamine our default temperament list 

### DIFF
--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -849,7 +849,7 @@ function setupToneBlocks(activity) {
                 ""
             ]);
             this.makeMacro((x, y) => [
-                [0, "setdefaultvoice", x, y, [null, 1, null]],
+                [0, "setdefaultinstrument", x, y, [null, 1, null]],
                 [1, ["voicename", { value: DEFAULTVOICE }], 0, 0, [0]]
             ]);
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -2161,6 +2161,9 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
     if (block.name === "outputtools" || block.name === "grid") {
         // slightly larger menu
         size = 1000;
+    }else if ( block.name === "temperamentname"){
+        // slightly larger wheel size for the Temperament Menu
+        size = 1200;
     }
 
     // the selectedValueh selector

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1554,11 +1554,11 @@ const OSCTYPES = [
  * @constant {Array<Array<string>>}
  */
 const INITIALTEMPERAMENTS = [
-    [_("equal"), "equal", "equal"],
-    [_("just intonation"), "just intonation", "just intonation"],
-    [_("Pythagorean"), "Pythagorean", "Pythagorean"],
-    [_("meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
-    [_("meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"]
+    [_("Equal (12EDO)"), "equal", "equal"],
+    [_("5-limit Just Intonation"), "just intonation", "just intonation"],
+    [_("Pythagorean (3-limit JI)"), "Pythagorean", "Pythagorean"],
+    [_("Meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
+    [_("Meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"]
 ];
 
 /**
@@ -1566,12 +1566,12 @@ const INITIALTEMPERAMENTS = [
  * @type {Array<Array<string>>}
  */
 let TEMPERAMENTS = [
-    [_("equal"), "equal", "equal"],
-    [_("just intonation"), "just intonation", "just intonation"],
-    [_("Pythagorean"), "Pythagorean", "Pythagorean"],
-    [_("meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
-    [_("meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"],
-    [_("custom"), "custom", "custom"]
+    [_("Equal (12EDO)"), "equal", "equal"],
+    [_("5-limit Just Intonation"), "just intonation", "just intonation"],
+    [_("Pythagorean (3-limit JI)"), "Pythagorean", "Pythagorean"],
+    [_("Meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
+    [_("Meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"],
+    [_("Custom"), "custom", "custom"]
 ];
 
 /**


### PR DESCRIPTION
by the changes the names of the temperaments are updated and also the pie menu for the temperament selection opens well as mentioned in the issue #3921 by @pikurasa @walterbender 
Before : 
<img width="334" alt="Screenshot 2024-09-22 at 8 27 54 PM" src="https://github.com/user-attachments/assets/7e57b830-e377-4c42-b0e1-d05e650cf6bd">
After : 
<img width="290" alt="Screenshot 2024-09-22 at 4 01 31 PM" src="https://github.com/user-attachments/assets/c7cfce18-e4a0-4b7c-88b7-cdce7e9ac517">
