### PR TITLE
FIXES ISSUE #3921 Reexamine our default temperament list

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -2161,6 +2161,9 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
     if (block.name === "outputtools" || block.name === "grid") {
         // slightly larger menu
         size = 1000;
+    }else if ( block.name === "temperamentname"){
+        // slightly larger wheel size for the Temperament Menu
+        size = 1200;
     }
 
     // the selectedValueh selector

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1554,11 +1554,11 @@ const OSCTYPES = [
  * @constant {Array<Array<string>>}
  */
 const INITIALTEMPERAMENTS = [
-    [_("equal"), "equal", "equal"],
-    [_("just intonation"), "just intonation", "just intonation"],
-    [_("Pythagorean"), "Pythagorean", "Pythagorean"],
-    [_("meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
-    [_("meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"]
+    [_("Equal (12EDO)"), "equal", "equal"],
+    [_("5-limit Just Intonation"), "just intonation", "just intonation"],
+    [_("Pythagorean (3-limit JI)"), "Pythagorean", "Pythagorean"],
+    [_("Meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
+    [_("Meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"]
 ];
 
 /**
@@ -1566,12 +1566,12 @@ const INITIALTEMPERAMENTS = [
  * @type {Array<Array<string>>}
  */
 let TEMPERAMENTS = [
-    [_("equal"), "equal", "equal"],
-    [_("just intonation"), "just intonation", "just intonation"],
-    [_("Pythagorean"), "Pythagorean", "Pythagorean"],
-    [_("meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
-    [_("meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"],
-    [_("custom"), "custom", "custom"]
+    [_("Equal (12EDO)"), "equal", "equal"],
+    [_("5-limit Just Intonation"), "just intonation", "just intonation"],
+    [_("Pythagorean (3-limit JI)"), "Pythagorean", "Pythagorean"],
+    [_("Meantone") + " (1/3)", "1/3 comma meantone", "meantone (1/3)"],
+    [_("Meantone") + " (1/4)", "1/4 comma meantone", "meantone (1/4)"],
+    [_("Custom"), "custom", "custom"]
 ];
 
 /**


### PR DESCRIPTION
by the changes the names of the temperaments are updated and also the pie menu for the temperament selection opens well as mentioned in the issue https://github.com/sugarlabs/musicblocks/issues/3921 by @pikurasa @walterbender
Before : 
![image](https://github.com/user-attachments/assets/48785f32-dd4e-4e1e-ae71-7be177083530)
After : 
![image](https://github.com/user-attachments/assets/4dcbebd0-7db2-4dd7-8d47-ba6a4d150743)
