### PR TITLE
fix: display file name after upload in sampler

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -970,7 +970,7 @@ function SampleWidget() {
                 canvasCtx.fillRect(0, 0, width, height);
 
                 let oscText;
-                if (turtleIdx > 0) {
+                if (turtleIdx >= 0) {
                     //.TRANS: The sound sample that the user uploads.
                     oscText = this.sampleName != "" ? this.sampleName : _("sample");
                 }


### PR DESCRIPTION
Before: 
<img width="871" alt="Before" src="https://github.com/user-attachments/assets/58646917-3c01-4220-b2b2-d95b22d97017">
After:
<img width="871" alt="After" src="https://github.com/user-attachments/assets/a6b72bcc-a370-423e-a0bd-05db9e9fc8c6">
<img width="868" alt="After 1" src="https://github.com/user-attachments/assets/6cd621ad-0728-4256-ba7f-f00c404adbf4">
