### PR TITLE
fix all lint + Base64Encode errors

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -22,9 +22,8 @@
    DISABLEDFILLCOLOR, DISABLEDSTROKECOLOR, docById, DOUBLEFLAT,
    DOUBLESHARP, DRUMNAMES, EASTINDIANSOLFNOTES, EFFECTSNAMES,
    EXPANDBUTTON, FILTERTYPES, FLAT, getDrumName, getDrumSynthName,
-   getModeNumbers, getNoiseName, getNoiseSynthName, getTemperament,
-   getTemperamentKeys, getTemperamentsList, getTextWidth,
-   getVoiceSynthName, hideDOMLabel, HIGHLIGHTSTROKECOLORS,
+   getModeNumbers, getNoiseName, getTemperament,
+   getTemperamentKeys, getTemperamentsList, getTextWidth, hideDOMLabel, HIGHLIGHTSTROKECOLORS,
    i18nSolfege, INVERTMODES, isCustomTemperament, last, MEDIASAFEAREA,
    NATURAL, NOISENAMES, NSYMBOLS, NUMBERBLOCKDEFAULT, OSCTYPES,
    PALETTEFILLCOLORS, PALETTEHIGHLIGHTCOLORS, PALETTESTROKECOLORS,
@@ -225,7 +224,7 @@ const _blockMakeBitmap = (data, callback, args) => {
         callback(bitmap, args);
     };
 
-    img.src = "data:image/svg+xml;base64," + window.btoa(base64Encode(data));
+    img.src = "data:image/svg+xml;base64," + window.btoa(COLLAPSEBUTTON);
 };
 
 /**
@@ -963,8 +962,7 @@ class Block {
 
         if (this.image.search("xmlns") !== -1) {
             image.src =
-                "data:image/svg+xml;base64," +
-                window.btoa(base64Encode(this.image));
+                "data:image/svg+xml;base64," + window.btoa(this.image);
         } else {
             image.src = this.image;
         }
@@ -1516,7 +1514,7 @@ class Block {
 
             image.src =
                 "data:image/svg+xml;base64," +
-                window.btoa(base64Encode(COLLAPSEBUTTON));
+                window.btoa(COLLAPSEBUTTON);
         };
 
         /**
@@ -1549,7 +1547,7 @@ class Block {
 
             image.src =
                 "data:image/svg+xml;base64," +
-                window.btoa(base64Encode(EXPANDBUTTON));
+                window.btoa(EXPANDBUTTON);
         };
 
         /**
@@ -2939,9 +2937,9 @@ class Block {
             if (
                 that?.name === "vspace" &&
                 that.blocks.blockList[that.connections[1]]?.name === "rest2"
-              ) {
+            ) {
                 return;
-              }
+            }
 
             // Do not allow a stack of blocks to be dragged if the stack contains a silence block.
             let block = that.blocks.blockList[that.connections[1]];
@@ -3379,21 +3377,20 @@ class Block {
 
         const labelElem = docById("labelDiv");
 
-        var safetext = function(text){
+        const safetext = (text) => {
             // Best to avoid using these special characters in text strings
             // without first converting them to their "safe" form.
-            var table = {
-                '<': 'lt',
-                '>': 'gt',
-                '"': 'quot',
-                '\'': 'apos',
-                '&': 'amp',
-                '\r': '#10',
-                '\n': '#13'
+            const table = {
+                "<": "lt",
+                ">": "gt",
+                '"': "quot",
+                "'": "apos",
+                "&": "amp",
+                "\r": "#10",
+                "\n": "#13"
             };
-        
-            return text.toString().replace(/[<>"'\r\n&]/g, function(chr){
-                return '&' + table[chr] + ';';
+            return text.toString().replace(/[<>"'\r\n&]/g, (chr) => {
+                return "&" + table[chr] + ";";
             });
         };
 


### PR DESCRIPTION
The code was using an undefined `base64Encode` function, causing an error when opening the file on VS Code.
Removed the unnecessary `base64Encode` function call and directly used the built-in `window.btoa()` method for Base64 encoding.

Also fixed various EsLint errors. Most were solved by simply using double quotes.

I also removed unused variable names being declared.
