### PR TITLE
FIXES ISSUE #4018 More default EDOs for temperament

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1774,9 +1774,11 @@ function TemperamentWidget() {
         for (let i = 0; i < this.pitchNumber; i++) {
             const idx = newStack.length;
             if (
-                this.inTemperament === "equal" ||
+               (this.inTemperament === "equal" || this.inTemperament === "equal5" ||
+                this.inTemperament === "equal7" || this.inTemperament === "equal19" ||
+                this.inTemperament === "equal31" ) ||
                 this.inTemperament === "1/3 comma meantone" ||
-                (this.typeOfEdit === "equal" && this.divisions === this.pitchNumber)
+               (this.typeOfEdit === "equal" && this.divisions === this.pitchNumber)
             ) {
                 newStack.push([
                     idx,


### PR DESCRIPTION
after the addition of some new temperament the define frequency block used in the define temperament block uses the division approach to calculate the frequency instead as per the requirement we have to use the exponential of 2 format for more understanding.
[temperament-test-2-2024-10-01_14.04.51.zip](https://github.com/user-attachments/files/17226825/temperament-test-2-2024-10-01_14.04.51.zip)
