### PR TITLE
Fix search box hover behavior replacing input text

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2385,13 +2385,10 @@ class Activity {
                     that.doSearch();
                     if (event.keyCode === 13) this.searchWidget.style.visibility = "visible";
                 },
-                focus: (event, ui) => {
+                focus: (event) => {
                     event.preventDefault();
-                    that.searchWidget.value = ui.item.label;
                 }
             });
-
-            $j("#search").autocomplete("widget").addClass("scrollSearch");
 
             $j("#search").autocomplete("instance")._renderItem = (ul, item) => {
                 return $j("<li></li>")
@@ -2399,9 +2396,8 @@ class Activity {
                     .append(
                         '<img src="' +
                             item.artwork +
-                            '" height = "20px">' +
-                            "<a>" +
-                            " " +
+                            '" height="20px">' +
+                            "<a> " +
                             item.label +
                             "</a>"
                     )


### PR DESCRIPTION
Description:
This PR addresses an issue where hovering over options in the search box replaces the search query with the block's name, even if the option hasn’t been selected yet. This unintended behavior disrupts the user’s search input and creates a frustrating experience.
The fix ensures that the search query remains intact until an option is explicitly selected. It refines the search box functionality for smoother user interaction and prevents unwanted input replacement while browsing search results.

Changes:
Adjusted the focus event behavior in the search function to prevent the hover action from replacing the input field prematurely.

Screen Recording:

https://github.com/user-attachments/assets/56ddaf8f-b25d-47d0-b782-fc086eb34239

Fixes:
Closes #4024

Additional Notes:
Tested thoroughly to ensure that the search functionality behaves as expected. Please review and merge if it aligns with the expected behavior.