### PR TITLE
Fix search box hover behavior replacing input text

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -61,6 +61,7 @@
   transition: width 0.4s ease-in-out;
   font-size: 24px;
   color: black;
+  max-width: 100%;
 }
 
 #search:focus {
@@ -75,6 +76,8 @@
   position: relative;
   background-color: rgba(255, 255, 255, 1);
   max-width: 396px;
+  max-height: 200px;
+  overflow-y: auto;
   font-size: 18px;
   border: 2px solid #87cefa;
   list-style-type: none;

--- a/js/activity.js
+++ b/js/activity.js
@@ -2385,13 +2385,10 @@ class Activity {
                     that.doSearch();
                     if (event.keyCode === 13) this.searchWidget.style.visibility = "visible";
                 },
-                focus: (event, ui) => {
+                focus: (event) => {
                     event.preventDefault();
-                    that.searchWidget.value = ui.item.label;
                 }
             });
-
-            $j("#search").autocomplete("widget").addClass("scrollSearch");
 
             $j("#search").autocomplete("instance")._renderItem = (ul, item) => {
                 return $j("<li></li>")
@@ -2399,9 +2396,8 @@ class Activity {
                     .append(
                         '<img src="' +
                             item.artwork +
-                            '" height = "20px">' +
-                            "<a>" +
-                            " " +
+                            '" height="20px">' +
+                            "<a> " +
                             item.label +
                             "</a>"
                     )

--- a/js/activity.js
+++ b/js/activity.js
@@ -2401,7 +2401,11 @@ class Activity {
                             item.label +
                             "</a>"
                     )
-                    .appendTo(ul.css("z-index", 9999));
+                    .appendTo(ul.css({
+                        "z-index": 9999,
+                        "max-height": "200px",
+                        "overflow-y": "auto"
+                    }));
             };
             const searchInput = this.searchWidget.idInput_custom;
             if (!searchInput || searchInput.length <= 0) return;


### PR DESCRIPTION
Description:
This PR addresses an issue where hovering over options in the search box replaces the search query with the block's name, even if the option hasn’t been selected yet. This unintended behavior disrupts the user’s search input and creates a frustrating experience.
The fix ensures that the search query remains intact until an option is explicitly selected. It refines the search box functionality for smoother user interaction and prevents unwanted input replacement while browsing search results.

Changes:
Adjusted the focus event behavior in the search function to prevent the hover action from replacing the input field prematurely.

Screen Recording:
https://github.com/user-attachments/assets/56e77cfb-9cb3-4d2d-a415-46bc249ae9ed

Fixes:
Closes #4024 

Additional Notes:
Tested thoroughly to ensure that the search functionality behaves as expected. Please review and merge if it aligns with the expected behavior.

