### PR TITLE
FIXES ISSUE #4018 More default EDOs for temperament

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1774,7 +1774,7 @@ function TemperamentWidget() {
         for (let i = 0; i < this.pitchNumber; i++) {
             const idx = newStack.length;
             if (
-                this.inTemperament === "equal" ||
+                this.inTemperament.startsWith("equal") ||
                 this.inTemperament === "1/3 comma meantone" ||
                 (this.typeOfEdit === "equal" && this.divisions === this.pitchNumber)
             ) {


### PR DESCRIPTION
after the addition of some new temperament the define frequency block used in the define temperament block uses the division approach to calculate the frequency instead as per the requirement we have to use the exponential of 2 format for more understanding.

<img width="1164" alt="Screenshot 2024-10-05 at 10 25 25 AM" src="https://github.com/user-attachments/assets/653b8566-491c-4422-8137-74ed030f63dc">
