### PR TITLE
fix renderLanguageSelectIcon logic

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -51,7 +51,7 @@ class Toolbar {
                 ["record",_("Record")],
                 ["Full Screen", _("Full screen")],
                 ["FullScreen", _("Full screen")],
-		["Toggle Fullscreen", _("Toggle Fullscreen")],
+                ["Toggle Fullscreen", _("Toggle Fullscreen")],
                 ["newFile", _("New project")],
                 ["load", _("Load project from file")],
                 ["saveButton", _("Save project")],
@@ -177,7 +177,7 @@ class Toolbar {
                 ["record", _("Record")],
                 ["Full Screen", _("Full Screen")],
                 ["FullScreen", _("Full Screen")],
-		["Toggle Fullscreen", _("Toggle Fullscreen")],
+                ["Toggle Fullscreen", _("Toggle Fullscreen")],
                 ["newFile", _("New project")],
                 ["load", _("Load project from file")],
                 ["saveButton", _("Save project")],
@@ -461,7 +461,7 @@ class Toolbar {
                     } else if (ele.label === "Turtle Wrap On") {
                         ele.display = false;
                     }
-                })
+                });
             } else {
                 wrapButtonTooltipData = _("Turtle Wrap On");
                 this.activity.helpfulWheelItems.forEach(ele => {
@@ -470,7 +470,7 @@ class Toolbar {
                     } else if (ele.label === "Turtle Wrap On") {
                         ele.display = true;
                     }
-                })
+                });
             }
 
             wrapIcon.setAttribute("data-tooltip", wrapButtonTooltipData);
@@ -501,7 +501,7 @@ class Toolbar {
                 } else if (ele.label === "Turtle Wrap On") {
                     ele.display = false;
                 }
-            })
+            });
         } else {
             wrapButtonTooltipData = _("Turtle Wrap On");
             activity.helpfulWheelItems.forEach(ele => {
@@ -510,7 +510,7 @@ class Toolbar {
                 } else if (ele.label === "Turtle Wrap On") {
                     ele.display = true;
                 }
-            })
+            });
         }
 
         wrapIcon.setAttribute("data-tooltip", wrapButtonTooltipData);
@@ -929,108 +929,15 @@ class Toolbar {
      */
     renderLanguageSelectIcon(languageBox) {
         const languageSelectIcon = docById("languageSelectIcon");
+        const languages = [
+            "enUS", "enUK", "es", "pt", "ko", "ja", "kana", "zhCN", "th",
+            "ayc", "quz", "gug", "hi", "ibo", "ar", "te", "he"
+        ];
+    
         languageSelectIcon.onclick = () => {
-            const enUS = docById("enUS");
-
-            enUS.onclick = () => {
-                languageBox.enUS_onclick(this.activity);
-            };
-
-            const enUK = docById("enUK");
-
-            enUK.onclick = () => {
-                languageBox.enUK_onclick(this.activity);
-            };
-
-            const es = docById("es");
-
-            es.onclick = () => {
-                languageBox.es_onclick(this.activity);
-            };
-
-            const pt = docById("pt");
-
-            pt.onclick = () => {
-                languageBox.pt_onclick(this.activity);
-            };
-
-            const ko = docById("ko");
-
-            ko.onclick = () => {
-                languageBox.ko_onclick(this.activity);
-            };
-
-            const ja = docById("ja");
-
-            ja.onclick = () => {
-                languageBox.ja_onclick(this.activity);
-            };
-
-            const kana = docById("kana");
-
-            kana.onclick = () => {
-                languageBox.kana_onclick(this.activity);
-            };
-
-            const zhCN = docById("zhCN");
-
-            zhCN.onclick = () => {
-                languageBox.zhCN_onclick(this.activity);
-            };
-
-            const th = docById("th");
-
-            th.onclick = () => {
-                languageBox.th_onclick(this.activity);
-            };
-
-            const ayc = docById("ayc");
-
-            ayc.onclick = () => {
-                languageBox.ayc_onclick(this.activity);
-            };
-
-            const quz = docById("quz");
-
-            quz.onclick = () => {
-                languageBox.quz_onclick(this.activity);
-            };
-
-            const gug = docById("gug");
-
-            gug.onclick = () => {
-                languageBox.gug_onclick(this.activity);
-            };
-
-            const hi = docById("hi");
-
-            hi.onclick = () => {
-                languageBox.hi_onclick(this.activity);
-            };
-
-            const ibo = docById("ibo");
-
-            ibo.onclick = () => {
-                languageBox.ibo_onclick(this.activity);
-            };
-
-            const ar = docById("ar");
-
-            ar.onclick = () => {
-                languageBox.ar_onclick(this.activity);
-            };
-
-            const te = docById("te");
-
-            te.onclick = () => {
-                languageBox.te_onclick(this.activity);
-            };
-
-            const he = docById("he");
-
-            he.onclick = () => {
-                languageBox.he_onclick(this.activity);
-            };
+            languages.forEach(lang => {
+                docById(lang).onclick = () => languageBox[`${lang}_onclick`](this.activity);
+            });
         };
     }
 


### PR DESCRIPTION
This PR simplifies the `renderLanguageSelectIcon` method in the Toolbar class to make it more concise and maintainabl e

- The current implementation has repetitive code for each language, making it harder to maintain and add new languages
- Also fixed some of the ESLint warnings in the file
- It works