### PR TITLE
FIXES ISSUE #4012 Scalar Step doesn't work for default temperaments (other than 12EDO) 

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3824,7 +3824,7 @@ function getNote(
     let note;
     let articulation;
 
-    if (temperament = "equal") {
+    if (temperament in PreDefinedTemperaments) {
         // Check for double flat or double sharp. Since bb and x behave
         // funny with string operations, we jump through some hoops.
         articulation = getArticulation(noteArg);

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3824,7 +3824,7 @@ function getNote(
     let note;
     let articulation;
 
-    if (temperament === "equal") {
+    if (temperament = "equal") {
         // Check for double flat or double sharp. Since bb and x behave
         // funny with string operations, we jump through some hoops.
         articulation = getArticulation(noteArg);


### PR DESCRIPTION
after these changes the scalar step (+/-) block stepping up and down pitch perfectly for the temperaments other than Equal 12EDO and Custom
before :
[temperament-test-2024-09-23_10.51.50 (2).zip](https://github.com/user-attachments/files/17299964/temperament-test-2024-09-23_10.51.50.2.zip)
after : 
https://github.com/user-attachments/assets/a6b7241b-fbcc-4bb4-8e27-acbb4da92e3f

