### PR TITLE
FIXES ISSUE #4025 Issue with refreshing Search Bar in the pallete menu

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -330,8 +330,8 @@ class Palettes {
         if (this.mobile) {
             return;
         }
-
-        this.activity.hideSearchWidget(true);
+        // In order to open the search widget and palette menu simulataneously
+        // this.activity.hideSearchWidget(true);
         this.dict[name].showMenu(true);
         this.activePalette = name; // used to delete plugins
     }


### PR DESCRIPTION
By these changes now the search widget and the palette menu opens simultaneously providing better experience without vanishing the search widget.
After changes: 
[Screen Recording 2024-10-13 at 3.17.10 AM.zip](https://github.com/user-attachments/files/17351633/Screen.Recording.2024-10-13.at.3.17.10.AM.zip)
