### PR TITLE
Fixes #4038 Issue with Note Block collapsing

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -327,7 +327,7 @@ const piemenuPitches = (
         } else {
             accidental = EQUIVALENTACCIDENTALS[scale[6 - i]].substr(1);
         }
-        block.value = block.value.replace(SHARP, "").replace(FLAT, "");
+        block.value = block.value.replace(SHARP, "").replace(FLAT, "").replace(DOUBLESHARP, "").replace(DOUBLEFLAT, "");
         block.value += accidental;
         block.text.text = block.value;
     }


### PR DESCRIPTION
fixes #4038 By this commit collapsing DOUBLE SHARP and DOUBLE FLAT notes no longer shows 'undefined'.

Video before fix:
https://github.com/user-attachments/assets/7e140174-634e-4018-bd6d-509e7e7ca015

Video after fix:
https://github.com/user-attachments/assets/212314d0-31ec-42c0-8ba8-541e5354e27d



