### PR TITLE
Allowed rechoosing the same image for avatar in succession

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2097,10 +2097,12 @@ class Block {
                     if (that.name === "media") {
                         that.value = reader.result;
                         that.loadThumbnail(null);
+                        fileChooser.value = '';
                         return;
                     }
                     that.value = [fileChooser.files[0].name, reader.result];
                     that.blocks.updateBlockText(thisBlock);
+                    fileChooser.value = '';
                 }
             };
             if (that.name === "media") {


### PR DESCRIPTION
**Fixes #3883**

#### Issue Explanation:
In browsers like Chrome and Safari, when attempting to load the same image consecutively, the browser does not re-upload the exact same file. This occurs because the input field (with id `myOpenAll`) is reused for multiple media elements. Consequently, the browser considers re-uploading the already present image on the input field redundant and does not open it.

#### Fix:
To address this issue, after successfully attaching the file to the media/avatar element, the file is detached from the original input field. After detaching the file, there is no image currently on the input field. As a result, when the same image is chosen again, it is re-uploaded to the input field, thus resolving the issue.
