### PR TITLE
Fixes issue: #4047 - circle closing when click on anywhere on the page

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1958,8 +1958,8 @@ class Activity {
 
                 that.stage.removeAllEventListeners("stagemousemove");
                 that.stage.on("stagemousemove", (event) => {
-                    that.stageX = moveEvent.stageX;
-                    that.stageY = moveEvent.stageY;
+                    that.stageX = event.stageX;
+                    that.stageY = event.stageY;
     
                     if (!that.moving) return;
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3495,6 +3495,14 @@ const piemenuBlockContext = (block) => {
         docById("contextWheelDiv").style.display = "none";
     };
 
+    document.body.addEventListener("click", (event) => {
+        const wheelElement = document.getElementById("contextWheelDiv");
+        const displayStyle = window.getComputedStyle(wheelElement).display;
+        if (displayStyle === "block") {
+            wheelElement.style.display = "none";
+        }
+    });
+
     if (
         ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
             block.name


### PR DESCRIPTION
Fix: Close Circular Menu (Wheel) on Click Outside

Issue Addressed: #4047 

Changes Made:

1. Added an event listener to detect clicks outside the circular menu (wheel).
2.  When a click outside the menu is detected, the menu is now closed, improving the user experience and consistency with standard UI behavior.

How to test:

1. Right-click on any block to open the circular menu (wheel).
2. Click anywhere outside the menu (on the page).
3. The menu should close automatically as expected.

Screenshots :

Right click on any block: 

![image](https://github.com/user-attachments/assets/fa0e9a13-3413-42e2-b323-a2f3f6e4e9c9)


When we click anywhere on the page: 

![image](https://github.com/user-attachments/assets/0c5586ac-3599-497c-8e80-0bb58984777c)


it will be closed

 
