### PR TITLE
Fixes issue (#4053): maintain button visibility on window resize

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5660,7 +5660,7 @@ class Activity {
 
             const ButtonHolder = document.createElement("div");
             ButtonHolder.setAttribute("id", "buttoncontainerBOTTOM");
-            ButtonHolder.style.display = removeButtonContainer ? "none" : "block";
+            ButtonHolder.style.display = "block";
             document.body.appendChild(ButtonHolder);
 
             this.homeButtonContainer = createButton(GOHOMEFADEDBUTTON,


### PR DESCRIPTION
 #4053 

## Issue
When resizing the window, the five buttons at the bottom of the page disappear and don't reappear when maximizing the screen back to its original size.

## Root Cause
The button container's display property was being set to 'none' if a previous container existed, even though that container was immediately removed. This caused visibility issues during window resize operations.

## Solution
Modified the button container creation to always display the new container:

// Before
ButtonHolder.style.display = removeButtonContainer ? "none" : "block";

// After
ButtonHolder.style.display = "block";

##Testing Completed

Verified buttons remain visible during window resizing
Tested button functionality before and after resize

[Screencast from 14-11-24 10:40:48 AM IST.webm](https://github.com/user-attachments/assets/c2308fac-f5d4-4b62-9f2b-e2325c52e5cf)
