### PR TITLE
Fix Palette Sticky Positioning After Dragging Large Block 

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1732,6 +1732,10 @@ table {
 .disable_highlighting {
   user-select: none;
 }
+#palette.flex-palette {
+  display: flex !important;
+  flex-direction: row !important;
+}
 
 @media (max-width: 390px) {
   #right-arrow,

--- a/js/palette.js
+++ b/js/palette.js
@@ -111,12 +111,13 @@ class Palettes {
             const element = document.createElement("div");
             element.id = "palette";
             element.setAttribute("class", "disable_highlighting");
+            element.classList.add('flex-palette')
             element.setAttribute(
                 "style",
-                "position: absolute; z-index: 1000; display: none ; left :0px; top:" + this.top + "px"
+                "position: absolute; z-index: 1000; left :0px; top:" + this.top + "px"
             );
             element.innerHTML =
-                '<div style="float: left"><table width ="' +
+                '<div style="height:fit-content"><table width ="' +
                 1.5 * this.cellSize +
                 'px"bgcolor="white"><thead><tr></tr></thead></table><table width ="' +
                 4.5 * this.cellSize +


### PR DESCRIPTION
Issue: When dragging a large block out of the palette (especially in advanced mode with longer palettes), the palette would become "sticky," retaining its position on the last pulled block. This behavior was caused by the use of float: left, which created inconsistencies in the layout, especially when the palette body height was affected by larger blocks.

Fixes : #3863 

Solution: Replaced float: left with display: flex and flex-direction: row for both tables in the palette component. This adjustment maintains consistent positioning and layout for both standard and advanced blocks, ensuring the palette body does not shift unexpectedly, even with larger elements.

Testing: Verified that the palette behaves consistently across different block sizes and that closing the palette fully resets its state.


Before : 
![image](https://github.com/user-attachments/assets/dd986482-222d-4275-a487-f9327db38a5d)

After :

https://github.com/user-attachments/assets/28c31e6c-5b90-4d45-811d-aae1cbe91543

