### PR TITLE
Increasing the size of chord pie menu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -2395,7 +2395,7 @@ const piemenuChords = (block, selectedChord) => {
     docById("wheelDiv").style.display = "";
 
     // the chord selector
-    block._chordWheel = new wheelnav("wheelDiv", null, 800, 800);
+    block._chordWheel = new wheelnav("wheelDiv", null, 1000, 1000);
     block._exitWheel = new wheelnav("_exitWheel", block._chordWheel.raphael);
 
     const chordLabels = [];
@@ -2468,7 +2468,7 @@ const piemenuChords = (block, selectedChord) => {
     const canvasTop = block.activity.canvas.offsetTop + 6 * block.blocks.blockScale;
 
     docById("wheelDiv").style.position = "absolute";
-    setWheelSize(300);
+    setWheelSize(400);
     docById("wheelDiv").style.left =
         Math.min(
             block.blocks.turtles._canvas.width - 300,


### PR DESCRIPTION
to enchance the viewer's experience and to view all the chord name properly 
Before:
<img width="301" alt="Screenshot 2024-11-16 at 6 29 42 PM" src="https://github.com/user-attachments/assets/1a78dbcd-f21e-4220-9c3b-47e3ebba1751">
After:
<img width="440" alt="Screenshot 2024-11-16 at 6 28 20 PM" src="https://github.com/user-attachments/assets/15b5da4a-c1a4-4ec1-be33-a982ec76d534">
