### PR TITLE
fix console error - #4074

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,11 +108,7 @@
                 }
             }
         </script>
-        <script type="text/javascript">
-            $(document).ready(function() {
-                doSearch();
-            });
-        </script>
+       
     </head>
 
     <!-- #96D3F3-->


### PR DESCRIPTION
### doSearch() is not defined in index.html

While inspecting in index.html it's shows that doSearch function is not defined. I noticed that there is no global declaration of doSearch function. So I think it's a redundancy.