### PR TITLE
Created a prompt notification for deleted blocks 

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3505,6 +3505,10 @@ const piemenuBlockContext = (block) => {
             that.blocks.sendStackToTrash(that.blocks.blockList[blockBlock]);
         }
         docById("contextWheelDiv").style.display = "none";
+        // prompting a notification on deleting any block 
+        activity.textMsg(
+            _("You can restore deleted blocks from the trash with the Restore From Trash button.")
+        );       
     };
 
     wheel.navItems[3].navigateFunction = () => {


### PR DESCRIPTION
while deleting any block from the stack now the user will get a prompt notification informing more about how to restore the deleted block as before there is no such message.
<img width="883" alt="Screenshot 2024-11-26 at 10 38 56 PM" src="https://github.com/user-attachments/assets/7e46ccbf-5bfc-4acd-9bf6-dbf9408f6e52">
