### PR TITLE
Closing of piemenu for Grid button added outside click option

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3652,7 +3652,7 @@ const piemenuGrid = (activity) => {
     activity.turtles._exitWheel.slicePathCustom.minRadiusPercent = 0.0;
     activity.turtles._exitWheel.slicePathCustom.maxRadiusPercent = 0.3;
     activity.turtles._exitWheel.sliceSelectedPathCustom =
-        activity.turtles._exitWheel.slicePathCustom;
+    activity.turtles._exitWheel.slicePathCustom;
     activity.turtles._exitWheel.sliceInitPathCustom = activity.turtles._exitWheel.slicePathCustom;
     activity.turtles._exitWheel.clickModeRotate = false;
     activity.turtles._exitWheel.createWheel(["×", " "]);
@@ -3670,7 +3670,8 @@ const piemenuGrid = (activity) => {
         activity.turtles.gridWheel.removeWheel();
         activity.turtles._exitWheel.removeWheel();
     };
-     const clickOutsideHandler = (event) => {
+
+    const clickOutsideHandler = (event) => {
         const piemenu = docById("wheelDivptm");
         if (!piemenu.contains(event.target)) {
             hidePiemenu(activity);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3658,14 +3658,27 @@ const piemenuGrid = (activity) => {
     activity.turtles._exitWheel.createWheel(["×", " "]);
 
     activity.turtles._exitWheel.navItems[0].navigateFunction = () => {
-        docById("wheelDivptm").style.display = "none";
-        activity.turtles.gridWheel.removeWheel();
-        activity.turtles._exitWheel.removeWheel();
+        hidePiemenu(activity);
     };
 
     if (docById("helpfulWheelDiv").style.display !== "none") {
         docById("helpfulWheelDiv").style.display = "none";
     }
+
+    const hidePiemenu = (activity) => {
+        docById("wheelDivptm").style.display = "none";
+        activity.turtles.gridWheel.removeWheel();
+        activity.turtles._exitWheel.removeWheel();
+    };
+     const clickOutsideHandler = (event) => {
+        const piemenu = docById("wheelDivptm");
+        if (!piemenu.contains(event.target)) {
+            hidePiemenu(activity);
+            document.removeEventListener("mousedown", clickOutsideHandler);
+        }
+    };
+
+    document.addEventListener("mousedown", clickOutsideHandler);
 };
 
 const piemenuKey = (activity) => {


### PR DESCRIPTION
As per the issue #4085 i changes it like that


### Current Behaviour

As like other options  - **New project, clean button** user can click the cancel button as well as outside of the piemenu.
User selects the grid from piemenu. After that they can click either the cross "x" button Or outside of the piemenu to close the piemenu.  It enhance the experiences of using Grid menu.

### Screen Record


https://github.com/user-attachments/assets/8ad72a22-44e0-441f-84bb-5d8417aef779

