### PR TITLE
Fixes issue #2053 Updates the UI on switching mode without page refresh

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1389,26 +1389,25 @@ class Activity {
          * Switches between beginner/advanced mode
          */
         const doSwitchMode = (activity) => {
-            // Toggle beginner mode
-            activity.beginnerMode = !activity.beginnerMode;
-        
-            this.saveLocally();
-        
-            // Update toolbar display
+            // Update toolbar
             activity.toolbar.renderSaveIcons(
-                this.save.saveHTML.bind(save),
+                activity.save.saveHTML.bind(activity.save),
                 doSVG,
-                this.save.saveSVG.bind(save),
-                this.save.savePNG.bind(save),
-                this.save.saveWAV.bind(save),
-                this.save.saveLilypond.bind(save),
-                this.save.saveAbc.bind(save),
-                this.save.saveMxml.bind(save),
-                this.save.saveBlockArtwork.bind(save)
+                activity.save.saveSVG.bind(activity.save),
+                activity.save.savePNG.bind(activity.save),
+                activity.save.saveWAV.bind(activity.save),
+                activity.save.saveLilypond.bind(activity.save),
+                activity.save.saveAbc.bind(activity.save),
+                activity.save.saveMxml.bind(activity.save),
+                activity.save.saveBlockArtwork.bind(activity.save)
             );
-            activity.toolbar.renderModeSelectIcon(() => {});
-            
-            // Force canvas refresh
+        
+            // Regenerate palettes
+            if (activity.regeneratePalettes) {
+                activity.regeneratePalettes();
+            }
+        
+            // Force immediate canvas refresh
             activity.refreshCanvas();
         };
 
@@ -6375,7 +6374,7 @@ class Activity {
             this.toolbar.renderPlanetIcon(this.planet, doOpenSamples);
             this.toolbar.renderMenuIcon(showHideAuxMenu);
             this.toolbar.renderHelpIcon(showHelp);
-            this.toolbar.renderModeSelectIcon(doSwitchMode);
+            this.toolbar.renderModeSelectIcon(doSwitchMode, doRecordButton);
             this.toolbar.renderRunSlowlyIcon(doSlowButton);
             this.toolbar.renderRunStepIcon(doStepButton);
             // this.toolbar.renderAdvancedIcons(

--- a/js/activity.js
+++ b/js/activity.js
@@ -1395,7 +1395,17 @@ class Activity {
             this.saveLocally();
         
             // Update toolbar display
-            activity.toolbar.renderSaveIcons(this.save.saveHTML.bind(save), doSVG, this.save.saveSVG.bind(save), this.save.savePNG.bind(save), this.save.saveWAV.bind(save), this.save.saveLilypond.bind(save), this.save.saveAbc.bind(save), this.save.saveMxml.bind(save), this.save.saveBlockArtwork.bind(save));
+            activity.toolbar.renderSaveIcons(
+                this.save.saveHTML.bind(save),
+                doSVG,
+                this.save.saveSVG.bind(save),
+                this.save.savePNG.bind(save),
+                this.save.saveWAV.bind(save),
+                this.save.saveLilypond.bind(save),
+                this.save.saveAbc.bind(save),
+                this.save.saveMxml.bind(save),
+                this.save.saveBlockArtwork.bind(save)
+            );
             activity.toolbar.renderModeSelectIcon(() => {});
             
             // Force canvas refresh

--- a/js/activity.js
+++ b/js/activity.js
@@ -6378,9 +6378,9 @@ class Activity {
             this.toolbar.renderModeSelectIcon(doSwitchMode);
             this.toolbar.renderRunSlowlyIcon(doSlowButton);
             this.toolbar.renderRunStepIcon(doStepButton);
-            this.toolbar.renderAdvancedIcons(
-                doRecordButton, doAnalytics, doOpenPlugin, deletePlugin, setScroller
-            );
+            // this.toolbar.renderAdvancedIcons(
+            //     doRecordButton, doAnalytics, doOpenPlugin, deletePlugin, setScroller
+            // );
             this.toolbar.renderMergeIcon(_doMergeLoad);
             this.toolbar.renderRestoreIcon(restoreTrash);
             if (_THIS_IS_MUSIC_BLOCKS_) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1392,13 +1392,10 @@ class Activity {
             // Toggle beginner mode
             activity.beginnerMode = !activity.beginnerMode;
         
-            try {
-                localStorage.setItem('beginnerMode', activity.beginnerMode.toString());
-            } catch (e) {
-                console.error(e);
-            }
+            this.saveLocally();
         
             // Update toolbar display
+            activity.toolbar.renderSaveIcons(this.save.saveHTML.bind(save), doSVG, this.save.saveSVG.bind(save), this.save.savePNG.bind(save), this.save.saveWAV.bind(save), this.save.saveLilypond.bind(save), this.save.saveAbc.bind(save), this.save.saveMxml.bind(save), this.save.saveBlockArtwork.bind(save));
             activity.toolbar.renderModeSelectIcon(() => {});
             
             // Force canvas refresh

--- a/js/activity.js
+++ b/js/activity.js
@@ -1389,38 +1389,20 @@ class Activity {
          * Switches between beginner/advanced mode
          */
         const doSwitchMode = (activity) => {
-            activity._doSwitchMode();
-        };
-
-        /**
-         * Switches between beginner and advanced modes.
-         * Displays a message prompting browser refresh to apply mode change.
-         * @private
-         */
-        this._doSwitchMode = () => {
-            this.blocks.activeBlock = null;
-            const mode = this.storage.beginnerMode;
-
-            const MSGPrefix =
-                "<a href='#' " +
-                "onClick='window.location.reload()'" +
-                "onMouseOver='this.style.opacity = 0.5'" +
-                "onMouseOut='this.style.opacity = 1'>";
-            const MSGSuffix = "</a>";
-
-            if (mode === null || mode === undefined || mode === "true") {
-                this.textMsg(
-                    _(MSGPrefix + _("Refresh your browser to change to advanced mode.") + MSGSuffix)
-                );
-                this.storage.setItem("beginnerMode", false);
-            } else {
-                this.textMsg(
-                    _(MSGPrefix + _("Refresh your browser to change to beginner mode.") + MSGSuffix)
-                );
-                this.storage.setItem("beginnerMode", true);
+            // Toggle beginner mode
+            activity.beginnerMode = !activity.beginnerMode;
+        
+            try {
+                localStorage.setItem('beginnerMode', activity.beginnerMode.toString());
+            } catch (e) {
+                console.error(e);
             }
-
-            this.refreshCanvas();
+        
+            // Update toolbar display
+            activity.toolbar.renderModeSelectIcon(() => {});
+            
+            // Force canvas refresh
+            activity.refreshCanvas();
         };
 
         /*
@@ -6946,6 +6928,105 @@ class Activity {
                 this.planet.planet.setAnalyzeProject(doAnalyzeProject);
             }
         };
+    }
+
+    /**
+     * Saves the current state locally
+     * @returns {void}
+     */
+    saveLocally() {
+        try {
+            localStorage.setItem('beginnerMode', this.beginnerMode.toString());
+        } catch (e) {
+            console.error('Error saving to localStorage:', e);
+        }
+    }
+
+    /**
+     * Regenerates all palettes based on current mode
+     * @returns {void}
+     */
+    regeneratePalettes() {
+        try {
+            // Store current palette positions
+            const palettePositions = {};
+            if (this.palettes && this.palettes.dict) {
+                for (const name in this.palettes.dict) {
+                    const palette = this.palettes.dict[name];
+                    if (palette && palette.container && typeof palette.container.x !== 'undefined') {
+                        palettePositions[name] = {
+                            x: palette.container.x,
+                            y: palette.container.y,
+                            visible: !!palette.visible
+                        };
+                    }
+                }
+            }
+    
+            // Safely hide and clear existing palettes
+            if (!this.palettes) {
+                console.warn('Palettes object not initialized');
+                return;
+            }
+    
+            if (typeof this.palettes.hide !== 'function') {
+                console.warn('Palettes hide method not available');
+            } else {
+                this.palettes.hide();
+            }
+    
+            if (typeof this.palettes.clear !== 'function') {
+                console.warn('Palettes clear method not available');
+                // Fallback clear implementation
+                this.palettes.dict = {};
+                this.palettes.visible = false;
+                this.palettes.activePalette = null;
+                this.palettes.paletteObject = null;
+            } else {
+                this.palettes.clear();
+            }
+    
+            // Reinitialize palettes
+            initPalettes(this.palettes);
+            
+            // Reinitialize blocks
+            if (this.blocks) {
+                initBasicProtoBlocks(this);
+            }
+    
+            // Restore palette positions
+            if (this.palettes && this.palettes.dict) {
+                for (const name in palettePositions) {
+                    const palette = this.palettes.dict[name];
+                    const pos = palettePositions[name];
+                    
+                    if (palette && palette.container && pos) {
+                        palette.container.x = pos.x;
+                        palette.container.y = pos.y;
+                        
+                        if (pos.visible) {
+                            palette.showMenu(true);
+                        }
+                    }
+                }
+            }
+    
+            // Update the palette display
+            if (this.palettes && typeof this.palettes.updatePalettes === 'function') {
+                this.palettes.updatePalettes();
+            }
+            
+            // Update blocks
+            if (this.blocks && typeof this.blocks.updateBlockPositions === 'function') {
+                this.blocks.updateBlockPositions();
+            }
+            
+            this.refreshCanvas();
+    
+        } catch (e) {
+            console.error('Error regenerating palettes:', e);
+            this.errorMsg(_('Error regenerating palettes. Please refresh the page.'));
+        }
     }
 }
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -6374,12 +6374,9 @@ class Activity {
             this.toolbar.renderPlanetIcon(this.planet, doOpenSamples);
             this.toolbar.renderMenuIcon(showHideAuxMenu);
             this.toolbar.renderHelpIcon(showHelp);
-            this.toolbar.renderModeSelectIcon(doSwitchMode, doRecordButton);
+            this.toolbar.renderModeSelectIcon(doSwitchMode, doRecordButton, doAnalytics, doOpenPlugin, deletePlugin, setScroller);
             this.toolbar.renderRunSlowlyIcon(doSlowButton);
             this.toolbar.renderRunStepIcon(doStepButton);
-            // this.toolbar.renderAdvancedIcons(
-            //     doRecordButton, doAnalytics, doOpenPlugin, deletePlugin, setScroller
-            // );
             this.toolbar.renderMergeIcon(_doMergeLoad);
             this.toolbar.renderRestoreIcon(restoreTrash);
             if (_THIS_IS_MUSIC_BLOCKS_) {

--- a/js/palette.js
+++ b/js/palette.js
@@ -385,6 +385,59 @@ class Palettes {
         docById("palette").style.visibility = "visible";
     }
 
+    clear() {
+        try {
+            // First hide all palettes
+            for (const name in this.dict) {
+                if (this.dict.hasOwnProperty(name)) {
+                    const palette = this.dict[name];
+                    if (palette && typeof palette.hideMenu === 'function') {
+                        palette.hideMenu();
+                    }
+                }
+            }
+    
+            // Store the original top position
+            const originalTop = 60 + this.top;
+    
+            // Remove the palette DOM element if it exists
+            const paletteElement = docById("palette");
+            if (paletteElement) {
+                paletteElement.parentNode.removeChild(paletteElement);
+            }
+    
+            // Clear the dictionary and reset state
+            this.dict = {};
+            this.visible = false;
+            this.activePalette = null;
+            this.paletteObject = null;
+    
+            // Calculate the available height for the palette
+            const maxHeight = window.innerHeight - originalTop - 10;
+    
+            // Recreate the palette using the original initialization code
+            const element = document.createElement("div");
+            element.id = "palette";
+            element.setAttribute("class", "disable_highlighting");
+            element.classList.add('flex-palette');
+            element.setAttribute(
+                "style",
+                `position: fixed; z-index: 1000; left: 0px; top: ${originalTop}px; max-height: ${maxHeight}px; overflow-y: auto;`
+            );
+            element.innerHTML =
+                '<div style="height:fit-content"><table width ="' +
+                1.5 * this.cellSize +
+                'px"bgcolor="white"><thead><tr></tr></thead></table><table width ="' +
+                4.5 * this.cellSize +
+                'px"bgcolor="white"><thead><tr><td style= "width:28px"></tr></thead><tbody></tbody></table></div>';
+            element.childNodes[0].style.border = `1px solid ${platformColor.selectorSelected}`;
+            document.body.appendChild(element);
+    
+        } catch (e) {
+            console.error('Error clearing palettes:', e);
+        }
+    }
+
     setBlocks(blocks) {
         this.blocks = blocks;
         return this;

--- a/js/palette.js
+++ b/js/palette.js
@@ -397,9 +397,6 @@ class Palettes {
                 }
             }
     
-            // Store the original top position
-            const originalTop = 60 + this.top;
-    
             // Remove the palette DOM element if it exists
             const paletteElement = docById("palette");
             if (paletteElement) {
@@ -411,10 +408,7 @@ class Palettes {
             this.visible = false;
             this.activePalette = null;
             this.paletteObject = null;
-    
-            // Calculate the available height for the palette
-            const maxHeight = window.innerHeight - originalTop - 10;
-    
+
             // Recreate the palette using the original initialization code
             const element = document.createElement("div");
             element.id = "palette";
@@ -422,7 +416,7 @@ class Palettes {
             element.classList.add('flex-palette');
             element.setAttribute(
                 "style",
-                `position: fixed; z-index: 1000; left: 0px; top: ${originalTop}px; max-height: ${maxHeight}px; overflow-y: auto;`
+                `position: fixed; z-index: 1000; left: 0px; top: ${60+this.top}px; overflow-y: auto;`
             );
             element.innerHTML =
                 '<div style="height:fit-content"><table width ="' +

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -835,6 +835,15 @@ class Toolbar {
                 if (toggleJavaScriptIcon) {
                     toggleJavaScriptIcon.style.display = "block";
                 }
+
+                // Update helpful wheel items visibility for advanced mode
+                if (this.activity.helpfulWheelItems) {
+                    this.activity.helpfulWheelItems.forEach(item => {
+                        if (item.label === "Enable horizontal scrolling") {
+                            item.display = true;
+                        }
+                    });
+                }
             } else {
                 // Hide all advanced icons in beginner mode
                 const advancedIcons = [
@@ -852,6 +861,15 @@ class Toolbar {
                         icon.style.display = "none";
                     }
                 });
+
+                // Update helpful wheel items visibility for beginner mode
+                if (this.activity.helpfulWheelItems) {
+                    this.activity.helpfulWheelItems.forEach(item => {
+                        if (item.label === "Enable horizontal scrolling") {
+                            item.display = false;
+                        }
+                    });
+                }
             }
 
             // Update save buttons
@@ -872,6 +890,21 @@ class Toolbar {
             }
 
             updateUIForMode();
+
+            // Reinitialize tooltips after mode switch
+            if (!this.tooltipsDisabled) {
+                $j(".tooltipped").tooltip({
+                    html: true,
+                    delay: 100
+                });
+            }
+
+            // Reinitialize dropdowns
+            $j(".materialize-iso, .dropdown-trigger").dropdown({
+                constrainWidth: false,
+                hover: false,
+                belowOrigin: true
+            });
 
             if (onclick) {
                 onclick(this.activity);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -766,14 +766,17 @@ class Toolbar {
     }
 
     /**
-     * Renders the mode select icon with the provided onclick handler.
+     * Renders the mode changes with the provided onclick handler.
      * 
      * @public
-     * @param {Function} onclick - The onclick handler for the mode select icon.
-     * @param {Function} rec_onclick - The onclick handler for the record button
+     * @param  {Function} rec_onclick - The onclick handler for the record icon.
+     * @param  {Function} analytics_onclick - The onclick handler for the analytics icon.
+     * @param  {Function} openPlugin_onclick - The onclick handler for the open plugin icon.
+     * @param  {Function} delPlugin_onclick - The onclick handler for the delete plugin icon.
+     * @param  {Function} setScroller - The function to set the scroller.
      * @returns {void}
      */
-    renderModeSelectIcon(onclick, rec_onclick) {
+    renderModeSelectIcon(onclick, rec_onclick, analytics_onclick, openPlugin_onclick, delPlugin_onclick, setScroller) {
         const begIcon = docById("beginnerMode");
         const advIcon = docById("advancedMode");
 
@@ -784,30 +787,72 @@ class Toolbar {
 
             // Update record button
             const recordButton = docById("record");
-            if (recordButton) {    
+            if (recordButton) {
                 if (!this.activity.beginnerMode) {
                     recordButton.style.display = "block";
-                    this.updateRecordButton(rec_onclick);
+                    this.updateRecordButton();
+                    recordButton.onclick = () => rec_onclick(this.activity);
                 } else {
                     recordButton.style.display = "none";
                 }
             }
 
-            // Update advanced icons
-            const advancedIcons = [
-                "displayStatsIcon",
-                "loadPluginIcon", 
-                "delPluginIcon",
-                "enableHorizScrollIcon",
-                "toggleJavaScriptIcon"
-            ];
-
-            advancedIcons.forEach(iconId => {
-                const icon = docById(iconId);
-                if (icon) {
-                    icon.style.display = this.activity.beginnerMode ? "none" : "block";
+            if (!this.activity.beginnerMode) {
+                // Display Stats
+                const displayStatsIcon = docById("displayStatsIcon");
+                if (displayStatsIcon) {
+                    displayStatsIcon.style.display = "block";
+                    displayStatsIcon.onclick = () => analytics_onclick(this.activity);
                 }
-            });
+
+                // Load Plugin
+                const loadPluginIcon = docById("loadPluginIcon");
+                if (loadPluginIcon) {
+                    loadPluginIcon.style.display = "block";
+                    loadPluginIcon.onclick = () => openPlugin_onclick(this.activity);
+                }
+
+                // Delete Plugin
+                const delPluginIcon = docById("delPluginIcon");
+                if (delPluginIcon) {
+                    delPluginIcon.style.display = "block";
+                    delPluginIcon.onclick = () => delPlugin_onclick(this.activity);
+                }
+
+                // Horizontal Scroll
+                const enableHorizScrollIcon = docById("enableHorizScrollIcon");
+                const disableHorizScrollIcon = docById("disableHorizScrollIcon");
+                if (enableHorizScrollIcon) {
+                    enableHorizScrollIcon.style.display = "block";
+                    enableHorizScrollIcon.onclick = () => setScroller(this.activity);
+                }
+                if (disableHorizScrollIcon) {
+                    disableHorizScrollIcon.onclick = () => setScroller(this.activity);
+                }
+
+                // JavaScript Toggle
+                const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
+                if (toggleJavaScriptIcon) {
+                    toggleJavaScriptIcon.style.display = "block";
+                }
+            } else {
+                // Hide all advanced icons in beginner mode
+                const advancedIcons = [
+                    "displayStatsIcon",
+                    "loadPluginIcon", 
+                    "delPluginIcon",
+                    "enableHorizScrollIcon",
+                    "disableHorizScrollIcon",
+                    "toggleJavaScriptIcon"
+                ];
+
+                advancedIcons.forEach(iconId => {
+                    const icon = docById(iconId);
+                    if (icon) {
+                        icon.style.display = "none";
+                    }
+                });
+            }
 
             // Update save buttons
             const saveButton = docById('saveButton');
@@ -832,12 +877,10 @@ class Toolbar {
                 onclick(this.activity);
             }
 
-            // Update palettes
             if (this.activity.palettes?.updatePalettes) {
                 this.activity.palettes.updatePalettes();
             }
 
-            // Refresh canvas
             if (this.activity.refreshCanvas) {
                 this.activity.refreshCanvas();
             }

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -569,7 +569,14 @@ class Toolbar {
                     };
                     const savePNG = docById('save-png-beg');
                     console.debug(savePNG);
-                    const svgData = doSVG_onclick(canvas, logo, turtles, canvas.width, canvas.height, 1.0);
+                    const svgData = doSVG_onclick(
+                        this.activity.canvas, 
+                        this.activity.logo, 
+                        this.activity.turtles, 
+                        this.activity.canvas.width, 
+                        this.activity.canvas.height, 
+                        1.0
+                    );
                     if (svgData == '') {
                         savePNG.disabled = true;
                         savePNG.className = 'grey-text inactiveLink';
@@ -595,7 +602,14 @@ class Toolbar {
                 const saveSVG = docById('save-svg');
                 const savePNG = docById('save-png');
                 console.debug(savePNG);
-                const svgData = doSVG_onclick(canvas, logo, turtles, canvas.width, canvas.height, 1.0);
+                const svgData = doSVG_onclick(
+                    this.activity.canvas, 
+                    this.activity.logo, 
+                    this.activity.turtles, 
+                    this.activity.canvas.width, 
+                    this.activity.canvas.height, 
+                    1.0
+                );
                 // if there is no mouse artwork to save then grey out
                 if (svgData == '') {
                     saveSVG.disabled = true;
@@ -810,19 +824,73 @@ class Toolbar {
                 // Update the Record button logic dynamically
                 if (docById("record")) {
                     if (this.activity.beginnerMode) {
-                        docById("record").style.display = "none"; // Hide in beginner mode
+                        docById("record").style.display = "none";
                     } else {
                         // Reinitialize the Record button for advanced mode
                         this.updateRecordButton(rec_onclick);
                     }
                 }
         
-                // Update save menu visibility
+                // Update save menu visibility and reinitialize handlers
+                const saveButton = docById('saveButton');
+                const saveButtonAdvanced = docById('saveButtonAdvanced');
+
                 if (saveButton) {
                     saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
+                    saveButton.onclick = null;
                 }
                 if (saveButtonAdvanced) {
                     saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
+                    saveButtonAdvanced.onclick = null;
+                }
+
+                // Re-render save icons to attach new handlers
+                if (this.activity.toolbar) {
+                    // Generate SVG data
+                    const svgData = doSVG(
+                        this.activity.canvas, 
+                        this.activity.logo, 
+                        this.activity.turtles, 
+                        this.activity.canvas.width, 
+                        this.activity.canvas.height, 
+                        1.0
+                    );
+                
+                    this.activity.toolbar.renderSaveIcons(
+                        this.activity.save.saveHTML.bind(this.activity.save),
+                        doSVG,
+                        this.activity.save.saveSVG.bind(this.activity.save),
+                        this.activity.save.savePNG.bind(this.activity.save),
+                        this.activity.save.saveWAV.bind(this.activity.save),
+                        this.activity.save.saveLilypond.bind(this.activity.save),
+                        this.activity.save.saveAbc.bind(this.activity.save),
+                        this.activity.save.saveMxml.bind(this.activity.save),
+                        this.activity.save.saveBlockArtwork.bind(this.activity.save)
+                    );
+                
+                    // After rendering, check SVG data and update button states
+                    const saveSVG = docById('save-svg');
+                    const savePNG = docById('save-png');
+                
+                    if (svgData === '') {
+                        if (saveSVG) {
+                            saveSVG.disabled = true;
+                            saveSVG.className = "grey-text inactiveLink";
+                        }
+                        if (savePNG) {
+                            savePNG.disabled = true;
+                            savePNG.className = "grey-text inactiveLink";
+                        }
+                    } else {
+                        if (saveSVG) {
+                            saveSVG.disabled = false;
+                            saveSVG.className = "";
+                        }
+                        if (savePNG) {
+                            savePNG.disabled = false;
+                            savePNG.className = "";
+                        }
+                    }
                 }
         
                 // Hide all palettes

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -561,12 +561,13 @@ class Toolbar {
             else {
                 saveButton.style.display = 'block';
                 saveButtonAdvanced.style.display = 'none';
-                saveButton.onclick = () => {  // Changed to arrow function to preserve this
+                saveButton.onclick = () => {
                     const saveHTML = docById('save-html-beg');
                     console.debug(saveHTML);
                     saveHTML.onclick = () => {
                         html_onclick(this.activity);
                     };
+
                     const savePNG = docById('save-png-beg');
                     console.debug(savePNG);
                     const svgData = doSVG_onclick(
@@ -577,6 +578,7 @@ class Toolbar {
                         this.activity.canvas.height, 
                         1.0
                     );
+                    
                     if (svgData == '') {
                         savePNG.disabled = true;
                         savePNG.className = 'grey-text inactiveLink';
@@ -595,7 +597,8 @@ class Toolbar {
             saveButtonAdvanced.style.display = 'block';
             saveButtonAdvanced.onclick = () => {
                 const saveHTML = docById('save-html');
-                console.debug(saveHTML);
+                //console.debug(saveHTML);
+
                 saveHTML.onclick = () => {
                     html_onclick(this.activity);
                 };
@@ -610,6 +613,7 @@ class Toolbar {
                     this.activity.canvas.height, 
                     1.0
                 );
+
                 // if there is no mouse artwork to save then grey out
                 if (svgData == '') {
                     saveSVG.disabled = true;
@@ -633,15 +637,10 @@ class Toolbar {
 
                 if (_THIS_IS_MUSIC_BLOCKS_) {
                     const saveWAV = docById('save-wav');
-                    // Until we fix #1744, disable recorder on FF
-                    // if (platform.FF) {
-                        saveWAV.disabled = true;
-                        saveWAV.className = 'grey-text inactiveLink';
-                    // } else {
-                    //    saveWAV.onclick = function () {
-                    //        wave_onclick();
-                    //    };
-                    // }
+                     saveWAV.onclick = () => {
+                        wave_onclick(this.activity);
+                    };
+
                     const saveLY = docById('save-ly');
                     saveLY.onclick = () => {
                         ly_onclick(this.activity);
@@ -680,8 +679,9 @@ class Toolbar {
             return;
         }
     
-        Record.style.display = "block"; // Ensure visibility
+        Record.style.display = "block";
         Record.innerHTML = `<i class="material-icons main">${RECORDBUTTON}</i>`;
+        Record.onclick = () => rec_onclick(this.activity);
     }
 
     /**
@@ -771,208 +771,85 @@ class Toolbar {
      * @public
      * @param {Function} onclick - The onclick handler for the mode select icon.
      * @param {Function} rec_onclick - The onclick handler for the record button
-     * @param {Function} analytics_onclick - The onclick handler for analytics
-     * @param {Function} openPlugin_onclick - The onclick handler for plugins
-     * @param {Function} delPlugin_onclick - The onclick handler for deleting plugins
-     * @param {Function} setScroller - The scroller handler
      * @returns {void}
      */
-    renderModeSelectIcon(onclick, rec_onclick, analytics_onclick, openPlugin_onclick, delPlugin_onclick, setScroller) {
+    renderModeSelectIcon(onclick, rec_onclick) {
         const begIcon = docById("beginnerMode");
         const advIcon = docById("advancedMode");
-        const displayStatsIcon = docById("displayStatsIcon");
-        const loadPluginIcon = docById("loadPluginIcon");
-        const delPluginIcon = docById("delPluginIcon");
-        const enableHorizScrollIcon = docById("enableHorizScrollIcon");
-        const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
-        // Add save menu elements
-        const saveButton = docById('saveButton');
-        const saveButtonAdvanced = docById('saveButtonAdvanced');
 
-        const advancedIcons = [
-            displayStatsIcon,
-            loadPluginIcon,
-            delPluginIcon,
-            enableHorizScrollIcon,
-            toggleJavaScriptIcon
-        ];
+        // Update UI based on current mode
+        const updateUIForMode = () => {
+            begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
+            advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
 
-        // Function to update all advanced icons handlers and visibility
-        const updateAdvancedIcons = () => {
+            // Update record button
             const recordButton = docById("record");
-            if (recordButton) {
+            if (recordButton) {    
                 if (!this.activity.beginnerMode) {
                     recordButton.style.display = "block";
                     this.updateRecordButton(rec_onclick);
-                    recordButton.onclick = () => rec_onclick(this.activity);
                 } else {
                     recordButton.style.display = "none";
                 }
             }
 
-            // Set up click handlers for advanced icons when in advanced mode
-            if (!this.activity.beginnerMode) {
-                if (displayStatsIcon) {
-                    displayStatsIcon.style.display = "block";
-                    displayStatsIcon.onclick = () => analytics_onclick(this.activity);
+            // Update advanced icons
+            const advancedIcons = [
+                "displayStatsIcon",
+                "loadPluginIcon", 
+                "delPluginIcon",
+                "enableHorizScrollIcon",
+                "toggleJavaScriptIcon"
+            ];
+
+            advancedIcons.forEach(iconId => {
+                const icon = docById(iconId);
+                if (icon) {
+                    icon.style.display = this.activity.beginnerMode ? "none" : "block";
                 }
-                if (loadPluginIcon) {
-                    loadPluginIcon.style.display = "block";
-                    loadPluginIcon.onclick = () => openPlugin_onclick(this.activity);
-                }
-                if (delPluginIcon) {
-                    delPluginIcon.style.display = "block";
-                    delPluginIcon.onclick = () => delPlugin_onclick(this.activity);
-                }
-                if (enableHorizScrollIcon) {
-                    enableHorizScrollIcon.style.display = "block";
-                    enableHorizScrollIcon.onclick = () => setScroller(this.activity);
-                }
-                if (toggleJavaScriptIcon) {
-                    toggleJavaScriptIcon.style.display = "block";
-                }
-            } else {
-                // Hide advanced icons in beginner mode
-                advancedIcons.forEach(icon => {
-                    if (icon) icon.style.display = "none";
-                });
-            }
+            });
+
+            // Update save buttons
+            const saveButton = docById('saveButton');
+            const saveButtonAdvanced = docById('saveButtonAdvanced');
+            if (saveButton) saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
+            if (saveButtonAdvanced) saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
         };
 
-        const switchMode = () => {
-            if (!this.activity) {
-                console.error("Activity not initialized");
-                return;
-            }
-
+        // Handle mode switching
+        const handleModeSwitch = (event) => {
+            this.activity.beginnerMode = !this.activity.beginnerMode;
+            
             try {
-                // Toggle beginnerMode state
-                this.activity.beginnerMode = !this.activity.beginnerMode;
+                localStorage.setItem("beginnerMode", this.activity.beginnerMode.toString());
+            } catch (e) {
+                console.error(e);
+            }
 
-                // Save the current mode to localStorage
-                try {
-                    localStorage.setItem("beginnerMode", this.activity.beginnerMode.toString());
-                } catch (error) {
-                    console.error("Error saving to localStorage:", error);
-                }
+            updateUIForMode();
 
-                // Update beginner/advanced mode toggle icons
-                if (begIcon) begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
-                if (advIcon) advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
+            if (onclick) {
+                onclick(this.activity);
+            }
 
-                // Update all advanced icons and their handlers
-                updateAdvancedIcons();
+            // Update palettes
+            if (this.activity.palettes?.updatePalettes) {
+                this.activity.palettes.updatePalettes();
+            }
 
-                // Update save menu visibility
-                if (saveButton) {
-                    saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
-                }
-                if (saveButtonAdvanced) {
-                    saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
-                }
-
-                // Re-render save icons to attach new handlers
-                if (this.activity.toolbar) {
-                    // Generate SVG data
-                    const svgData = doSVG(
-                        this.activity.canvas, 
-                        this.activity.logo, 
-                        this.activity.turtles, 
-                        this.activity.canvas.width, 
-                        this.activity.canvas.height, 
-                        1.0
-                    );
-                
-                    this.activity.toolbar.renderSaveIcons(
-                        this.activity.save.saveHTML.bind(this.activity.save),
-                        doSVG,
-                        this.activity.save.saveSVG.bind(this.activity.save),
-                        this.activity.save.savePNG.bind(this.activity.save),
-                        this.activity.save.saveWAV.bind(this.activity.save),
-                        this.activity.save.saveLilypond.bind(this.activity.save),
-                        this.activity.save.saveAbc.bind(this.activity.save),
-                        this.activity.save.saveMxml.bind(this.activity.save),
-                        this.activity.save.saveBlockArtwork.bind(this.activity.save)
-                    );
-                
-                    // After rendering, check SVG data and update button states
-                    const saveSVG = docById('save-svg');
-                    const savePNG = docById('save-png');
-                
-                    if (svgData === '') {
-                        if (saveSVG) {
-                            saveSVG.disabled = true;
-                            saveSVG.className = "grey-text inactiveLink";
-                        }
-                        if (savePNG) {
-                            savePNG.disabled = true;
-                            savePNG.className = "grey-text inactiveLink";
-                        }
-                    } else {
-                        if (saveSVG) {
-                            saveSVG.disabled = false;
-                            saveSVG.className = "";
-                        }
-                        if (savePNG) {
-                            savePNG.disabled = false;
-                            savePNG.className = "";
-                        }
-                    }
-                }
-        
-                // Hide all palettes
-                if (this.activity.palettes?.dict) {
-                    for (const name in this.activity.palettes.dict) {
-                        const palette = this.activity.palettes.dict[name];
-                        if (palette?.hideMenu) {
-                            palette.hideMenu(true);
-                        }
-                    }
-                }
-        
-                // Update palettes for the new mode
-                if (this.activity.palettes?.updatePalettes) {
-                    this.activity.palettes.updatePalettes();
-                }
-        
-                // Regenerate palettes for the new mode
-                if (this.activity.regeneratePalettes) {
-                    this.activity.regeneratePalettes();
-                }
-        
-                // Trigger the provided onclick handler
-                if (onclick) {
-                    onclick(this.activity);
-                }
-
-                // Refresh the canvas
-                if (this.activity.refreshCanvas) {
-                    this.activity.refreshCanvas();
-                }
-            } catch (error) {
-                console.error("Error switching modes:", error);
-                if (this.activity?.errorMsg) {
-                    this.activity.errorMsg("Error switching modes. Please refresh the page.");
-                }
+            // Refresh canvas
+            if (this.activity.refreshCanvas) {
+                this.activity.refreshCanvas();
             }
         };
 
-        // Attach click handlers
-        if (begIcon) begIcon.onclick = switchMode;
-        if (advIcon) advIcon.onclick = switchMode;
+        begIcon.onclick = null;
+        advIcon.onclick = null;
 
-        // Initial setup of icons and handlers
-        begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
-        advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
-        updateAdvancedIcons();
+        begIcon.onclick = handleModeSwitch;
+        advIcon.onclick = handleModeSwitch;
 
-        // Initial render of save menu
-        if (saveButton) {
-            saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
-        }
-        if (saveButtonAdvanced) {
-            saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
-        }
+        updateUIForMode();
     }
 
     /**

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -767,15 +767,104 @@ class Toolbar {
     renderModeSelectIcon(onclick) {
         const begIcon = docById("beginnerMode");
         const advIcon = docById("advancedMode");
-        if (begIcon.style.display === "none") {
-            advIcon.onclick = () => {
-                onclick(this.activity);
-            };
-        } else {
-            begIcon.onclick = () => {
-                onclick(this.activity);
-            };
+        const displayStatsIcon = docById("displayStatsIcon");
+        const loadPluginIcon = docById("loadPluginIcon");
+        const delPluginIcon = docById("delPluginIcon");
+        const enableHorizScrollIcon = docById("enableHorizScrollIcon");
+        const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
+    
+        const advancedIcons = [
+            displayStatsIcon,
+            loadPluginIcon,
+            delPluginIcon,
+            enableHorizScrollIcon,
+            toggleJavaScriptIcon
+        ];
+    
+        const switchMode = () => {
+            if (!this.activity) {
+                console.error('Activity not initialized');
+                return;
+            }
+        
+            try {
+                // Toggle mode in activity
+                this.activity.beginnerMode = !this.activity.beginnerMode;
+                
+                // Save to localStorage
+                try {
+                    localStorage.setItem('beginnerMode', this.activity.beginnerMode.toString());
+                } catch (e) {
+                    console.error('Error saving to localStorage:', e);
+                }
+        
+                // Update icon visibility
+                if (begIcon) begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
+                if (advIcon) advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
+        
+                // Toggle visibility of advanced features
+                advancedIcons.forEach(icon => {
+                    if (icon) {
+                        icon.style.display = this.activity.beginnerMode ? "none" : "block";
+                    }
+                });
+        
+                // Hide all palettes first
+                if (this.activity.palettes && this.activity.palettes.dict) {
+                    for (const name in this.activity.palettes.dict) {
+                        const palette = this.activity.palettes.dict[name];
+                        if (palette && typeof palette.hideMenu === 'function') {
+                            palette.hideMenu(true);
+                        }
+                    }
+                }
+        
+                // Update palettes for new mode
+                if (this.activity.palettes && typeof this.activity.palettes.updatePalettes === 'function') {
+                    this.activity.palettes.updatePalettes();
+                }
+                
+                // Regenerate all palettes with new mode
+                if (typeof this.activity.regeneratePalettes === 'function') {
+                    this.activity.regeneratePalettes();
+                }
+        
+                // Call the provided onclick handler
+                if (onclick) {
+                    onclick(this.activity);
+                }
+        
+                // Force canvas refresh
+                if (typeof this.activity.refreshCanvas === 'function') {
+                    this.activity.refreshCanvas();
+                }
+        
+            } catch (e) {
+                console.error('Error switching modes:', e);
+                // Error message to user
+                if (this.activity && typeof this.activity.errorMsg === 'function') {
+                    this.activity.errorMsg(_('Error switching modes. Please refresh the page.'));
+                }
+            }
+        };
+    
+        // Attach click handlers
+        if (begIcon) {
+            begIcon.onclick = switchMode;
         }
+        if (advIcon) {
+            advIcon.onclick = switchMode;
+        }
+    
+        // Initial render of icons based on current mode
+        begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
+        advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
+        
+        advancedIcons.forEach(icon => {
+            if (icon) {
+                icon.style.display = this.activity.beginnerMode ? "none" : "block";
+            }
+        });
     }
 
     /**

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -550,78 +550,54 @@ class Toolbar {
         mxml_onclick,
         blockartworksvg_onclick
     ) {
-        const saveButton = docById("saveButton");
-        const saveButtonAdvanced = docById("saveButtonAdvanced");
-        let saveHTML;
-        let savePNG;
-        let saveWAV;
-        let saveSVG;
-        let saveLY;
-        let saveABC;
-        let saveMXML;
-        let svgData;
-
+        const saveButton = docById('saveButton');
+        const saveButtonAdvanced = docById('saveButtonAdvanced');
         if (this.activity.beginnerMode) {
             if (this.language === "ja") {
                 saveButton.onclick = () => {
                     html_onclick(this.activity);
-                };
-            } else {
-                saveButton.style.display = "block";
-                saveButtonAdvanced.style.display = "none";
-
-                saveButton.onclick = () => {
-                    saveHTML = docById("save-html-beg");
+                }
+            }
+            else {
+                saveButton.style.display = 'block';
+                saveButtonAdvanced.style.display = 'none';
+                saveButton.onclick = () => {  // Changed to arrow function to preserve this
+                    const saveHTML = docById('save-html-beg');
+                    console.debug(saveHTML);
                     saveHTML.onclick = () => {
                         html_onclick(this.activity);
                     };
-
-                    savePNG = docById("save-png-beg");
-                    svgData = doSVG(
-                        this.activity.canvas,
-                        this.activity.logo,
-                        this.activity.turtles,
-                        this.activity.canvas.width,
-                        this.activity.canvas.height,
-                        1.0
-                    );
-
-                    if (svgData == "") {
+                    const savePNG = docById('save-png-beg');
+                    console.debug(savePNG);
+                    const svgData = doSVG_onclick(canvas, logo, turtles, canvas.width, canvas.height, 1.0);
+                    if (svgData == '') {
                         savePNG.disabled = true;
-                        savePNG.className = "grey-text inactiveLink";
+                        savePNG.className = 'grey-text inactiveLink';
                     } else {
                         savePNG.disabled = false;
-                        savePNG.className = "";
+                        savePNG.className = '';
                         savePNG.onclick = () => {
                             png_onclick(this.activity);
                         };
-                    }
+                    }  
                 };
             }
         } else {
-            // console.debug("ADVANCED MODE BUTTONS");
-            saveButton.style.display = "none";
-            saveButtonAdvanced.style.display = "block";
+            console.debug('ADVANCED MODE BUTTONS')
+            saveButton.style.display = 'none';
+            saveButtonAdvanced.style.display = 'block';
             saveButtonAdvanced.onclick = () => {
-                saveHTML = docById("save-html");
-                // console.debug(saveHTML);
-
+                const saveHTML = docById('save-html');
+                console.debug(saveHTML);
                 saveHTML.onclick = () => {
                     html_onclick(this.activity);
                 };
-
-                saveSVG = docById("save-svg");
-                savePNG = docById("save-png");
-                svgData = doSVG(
-                    this.activity.canvas,
-                    this.activity.logo,
-                    this.activity.turtles,
-                    this.activity.canvas.width,
-                    this.activity.canvas.height,
-                    1.0);
-
-                // If there is no mouse artwork to save then grey out.
-                if (svgData == "") {
+                const saveSVG = docById('save-svg');
+                const savePNG = docById('save-png');
+                console.debug(savePNG);
+                const svgData = doSVG_onclick(canvas, logo, turtles, canvas.width, canvas.height, 1.0);
+                // if there is no mouse artwork to save then grey out
+                if (svgData == '') {
                     saveSVG.disabled = true;
                     savePNG.disabled = true;
                     saveSVG.className = "grey-text inactiveLink";
@@ -631,7 +607,7 @@ class Toolbar {
                     savePNG.disabled = false;
                     saveSVG.className = "";
                     savePNG.className = "";
-
+                    
                     saveSVG.onclick = () => {
                         svg_onclick(this.activity);
                     };
@@ -642,38 +618,59 @@ class Toolbar {
                 }
 
                 if (_THIS_IS_MUSIC_BLOCKS_) {
-                    saveWAV = docById("save-wav");
-
-                    saveWAV.onclick = () => {
-                        wave_onclick(this.activity);
-                    };
-
-                    saveLY = docById("save-ly");
-
+                    const saveWAV = docById('save-wav');
+                    // Until we fix #1744, disable recorder on FF
+                    // if (platform.FF) {
+                        saveWAV.disabled = true;
+                        saveWAV.className = 'grey-text inactiveLink';
+                    // } else {
+                    //    saveWAV.onclick = function () {
+                    //        wave_onclick();
+                    //    };
+                    // }
+                    const saveLY = docById('save-ly');
                     saveLY.onclick = () => {
                         ly_onclick(this.activity);
                     };
-
-                    saveABC = docById("save-abc");
-
+                    const saveABC = docById('save-abc');
                     saveABC.onclick = () => {
                         abc_onclick(this.activity);
                     };
-
-                    saveMXML = docById("save-mxml");
-
+                    const saveMXML = docById('save-mxml');
                     saveMXML.onclick = () => {
                         mxml_onclick(this.activity);
                     };
                 }
-
-                const saveArtworkSVG = docById("save-blockartwork-svg");
-
+                const saveArtworkSVG = docById('save-blockartwork-svg');
                 saveArtworkSVG.onclick = () => {
                     blockartworksvg_onclick(this.activity);
                 };
-            };
+            }
         }
+    }
+
+    /**
+     * Renders Record button style
+     * 
+     * @public 
+     * @param {Function} rec_onclick
+     * @returns {void}
+     */  
+    updateRecordButton(rec_onclick) {
+        const Record = docById("record");
+        const browser = fnBrowserDetect();
+        const hideIn = ["firefox", "safari"];
+    
+        if (hideIn.includes(browser)) {
+            Record.classList.add("hide");
+            return;
+        }
+    
+        Record.style.display = "block"; // Ensure visibility
+        Record.innerHTML = `<i class="material-icons main">${RECORDBUTTON}</i>`;
+        Record.onclick = () => {
+            rec_onclick(this.activity);
+        };
     }
 
     /**
@@ -762,9 +759,10 @@ class Toolbar {
      * 
      * @public
      * @param {Function} onclick - The onclick handler for the mode select icon.
+     * @param {Function} rec_onclick
      * @returns {void}
      */
-    renderModeSelectIcon(onclick) {
+    renderModeSelectIcon(onclick, rec_onclick) {
         const begIcon = docById("beginnerMode");
         const advIcon = docById("advancedMode");
         const displayStatsIcon = docById("displayStatsIcon");
@@ -772,6 +770,9 @@ class Toolbar {
         const delPluginIcon = docById("delPluginIcon");
         const enableHorizScrollIcon = docById("enableHorizScrollIcon");
         const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
+        // Add save menu elements
+        const saveButton = docById('saveButton');
+        const saveButtonAdvanced = docById('saveButtonAdvanced');
     
         const advancedIcons = [
             displayStatsIcon,
@@ -783,67 +784,83 @@ class Toolbar {
     
         const switchMode = () => {
             if (!this.activity) {
-                console.error('Activity not initialized');
+                console.error("Activity not initialized");
                 return;
             }
         
             try {
-                // Toggle mode in activity
+                // Toggle beginnerMode state
                 this.activity.beginnerMode = !this.activity.beginnerMode;
-                
-                // Save to localStorage
+        
+                // Save the current mode to localStorage
                 try {
-                    localStorage.setItem('beginnerMode', this.activity.beginnerMode.toString());
-                } catch (e) {
-                    console.error('Error saving to localStorage:', e);
+                    localStorage.setItem("beginnerMode", this.activity.beginnerMode.toString());
+                } catch (error) {
+                    console.error("Error saving to localStorage:", error);
                 }
         
-                // Update icon visibility
+                // Update beginner and advanced mode icons visibility
                 if (begIcon) begIcon.style.display = this.activity.beginnerMode ? "none" : "block";
                 if (advIcon) advIcon.style.display = this.activity.beginnerMode ? "block" : "none";
         
-                // Toggle visibility of advanced features
+                // Toggle visibility of advanced icons
                 advancedIcons.forEach(icon => {
                     if (icon) {
                         icon.style.display = this.activity.beginnerMode ? "none" : "block";
                     }
                 });
         
-                // Hide all palettes first
-                if (this.activity.palettes && this.activity.palettes.dict) {
+                // Update the Record button logic dynamically
+                if (docById("record")) {
+                    if (this.activity.beginnerMode) {
+                        docById("record").style.display = "none"; // Hide in beginner mode
+                    } else {
+                        // Reinitialize the Record button for advanced mode
+                        this.updateRecordButton(rec_onclick);
+                    }
+                }
+        
+                // Update save menu visibility
+                if (saveButton) {
+                    saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
+                }
+                if (saveButtonAdvanced) {
+                    saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
+                }
+        
+                // Hide all palettes
+                if (this.activity.palettes?.dict) {
                     for (const name in this.activity.palettes.dict) {
                         const palette = this.activity.palettes.dict[name];
-                        if (palette && typeof palette.hideMenu === 'function') {
+                        if (palette?.hideMenu) {
                             palette.hideMenu(true);
                         }
                     }
                 }
         
-                // Update palettes for new mode
-                if (this.activity.palettes && typeof this.activity.palettes.updatePalettes === 'function') {
+                // Update palettes for the new mode
+                if (this.activity.palettes?.updatePalettes) {
                     this.activity.palettes.updatePalettes();
                 }
-                
-                // Regenerate all palettes with new mode
-                if (typeof this.activity.regeneratePalettes === 'function') {
+        
+                // Regenerate palettes for the new mode
+                if (this.activity.regeneratePalettes) {
                     this.activity.regeneratePalettes();
                 }
         
-                // Call the provided onclick handler
+                // Trigger the provided onclick handler
                 if (onclick) {
                     onclick(this.activity);
                 }
         
-                // Force canvas refresh
-                if (typeof this.activity.refreshCanvas === 'function') {
+                // Refresh the canvas
+                if (this.activity.refreshCanvas) {
                     this.activity.refreshCanvas();
                 }
-        
-            } catch (e) {
-                console.error('Error switching modes:', e);
-                // Error message to user
-                if (this.activity && typeof this.activity.errorMsg === 'function') {
-                    this.activity.errorMsg(_('Error switching modes. Please refresh the page.'));
+            } catch (error) {
+                console.error("Error switching modes:", error);
+                if (this.activity?.errorMsg) {
+                    this.activity.errorMsg("Error switching modes. Please refresh the page.");
                 }
             }
         };
@@ -865,6 +882,14 @@ class Toolbar {
                 icon.style.display = this.activity.beginnerMode ? "none" : "block";
             }
         });
+
+        // Initial render of save menu
+        if (saveButton) {
+            saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
+        }
+        if (saveButtonAdvanced) {
+            saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
+        }
     }
 
     /**
@@ -885,6 +910,7 @@ class Toolbar {
             docById("stop").style.color = this.stopIconColorWhenPlaying;
         };
     }
+
     /**
      * Renders the advanced icons with the provided onclick handlers.
      * 
@@ -903,25 +929,16 @@ class Toolbar {
         delPlugin_onclick,
         setScroller
     ) {
-        const RecIcon = docById("record");
         const displayStatsIcon = docById("displayStatsIcon");
         const loadPluginIcon = docById("loadPluginIcon");
         const delPluginIcon = docById("delPluginIcon");
         const enableHorizScrollIcon = docById("enableHorizScrollIcon");
         const disableHorizScrollIcon = docById("disableHorizScrollIcon");
         const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
-        const browser = fnBrowserDetect();
-        const btn = document.getElementById("record");
-        const hideIn = ["firefox", "safari"];
-        if (hideIn.includes(browser)) {
-            btn.classList.add("hide");
-        }
-
+        
         if (!this.activity.beginnerMode) {
-            RecIcon.innerHTML= `<i class=""material-icons main">${RECORDBUTTON}</i>`;
-            RecIcon.onclick = () => {
-                rec_onclick(this.activity);
-            };
+
+            this.updateRecordButton(rec_onclick);
 
             displayStatsIcon.onclick = () => {
                 analytics_onclick(this.activity);
@@ -943,6 +960,7 @@ class Toolbar {
                 setScroller(this.activity);
             };
         } else {
+            docById("record").style.display = "none";
             displayStatsIcon.style.display = "none";
             loadPluginIcon.style.display = "none";
             delPluginIcon.style.display = "none";

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -668,9 +668,6 @@ class Toolbar {
     
         Record.style.display = "block"; // Ensure visibility
         Record.innerHTML = `<i class="material-icons main">${RECORDBUTTON}</i>`;
-        Record.onclick = () => {
-            rec_onclick(this.activity);
-        };
     }
 
     /**
@@ -939,6 +936,9 @@ class Toolbar {
         if (!this.activity.beginnerMode) {
 
             this.updateRecordButton(rec_onclick);
+            docById("record").onclick = () => {
+                rec_onclick(this.activity);
+            };
 
             displayStatsIcon.onclick = () => {
                 analytics_onclick(this.activity);


### PR DESCRIPTION
This PR improves the user experience when switching between beginner and advanced modes without requiring a page refresh. Previously, changing modes required reloading the page.

Key Changes:
- Updated the star toggle icon to dynamically reflect the current mode.
- Adjusted advanced icons to update based on mode without a page reload.
- The palette regenerates after switching the mode.
- Save menu and record button also update according to the mode.