### PR TITLE
Closing of popup message for quick action

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,6 @@
                         let printText = document.getElementById("printText");
                         printText.classList.remove("show");
                     }
-                
                     function hideErrorText() {
                         let errorText = document.getElementById("errorText");
                         errorText.classList.remove("show");

--- a/index.html
+++ b/index.html
@@ -324,12 +324,24 @@
                         let printText = document.getElementById("printText");
                         printText.classList.remove("show");
                     }
-
+                
                     function hideErrorText() {
                         let errorText = document.getElementById("errorText");
                         errorText.classList.remove("show");
                         hideArrows(); // This function is declared in js/activity.js
                     }
+                
+                    document.addEventListener("click", function (event) {
+                        let printText = document.getElementById("printText");
+                        let errorText = document.getElementById("errorText");
+                
+                        if (printText && printText.classList.contains("show") && !printText.contains(event.target)) {
+                            hidePrintText();
+                        }
+                        if (errorText && errorText.classList.contains("show") && !errorText.contains(event.target)) {
+                            hideErrorText();
+                        }
+                    });
                 </script>
 
                 <div id ="canvasContainer">


### PR DESCRIPTION
### Current Behavior

As per the issue #4094   now user can close the popup message that appears after moving a block in trash not only the cross button as well as anywhere in the canvas. So user can take next action very quickly. It improves the user experience.

### Screen Record


https://github.com/user-attachments/assets/a7f216a3-3403-4d6d-8f7e-8dfdea47e240



