### PR TITLE
Issue #4094: Add Optional Timeout to Message Dismissal

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4907,7 +4907,7 @@ class Activity {
             }
         };
 
-        this.textMsg = (msg) => {
+        this.textMsg = (msg,duration = _MSGTIMEOUT_) => {
             if (this.msgTimeoutID !== null) {
                 clearTimeout(this.msgTimeoutID);
                 this.msgTimeoutID = null;
@@ -4925,7 +4925,7 @@ class Activity {
             this.msgTimeoutID = setTimeout(() => {
                 that.printText.classList.remove("show");
                 that.msgTimeoutID = null;
-            }, _MSGTIMEOUT_);
+            }, duration);
         };
 
         this.errorMsg = (msg, blk, text, timeout) => {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3507,7 +3507,7 @@ const piemenuBlockContext = (block) => {
         docById("contextWheelDiv").style.display = "none";
         // prompting a notification on deleting any block 
         activity.textMsg(
-            _("You can restore deleted blocks from the trash with the Restore From Trash button.")
+            _("You can restore deleted blocks from the trash with the Restore From Trash button."), 3000
         );       
     };
 


### PR DESCRIPTION
## Issue Reference
Closes #4094 

## Description
Adds an optional timeout parameter to the textMsg method to improve user experience when dismissing notifications.

## Changes
- Modified textMsg method to accept custom timeout duration
- Defaults to existing timeout if no duration specified
- Allows more flexible message display

## Testing
- Manually tested message dismissal
- No breaking changes introduced