### PR TITLE
Issue#4091 non root user added in dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,14 +3,20 @@ FROM python:latest AS build
 
 WORKDIR /app
 
+RUN useradd -m appuser
+
 COPY . .
 
 # Second stage: Final stage
 FROM python:latest
 
+RUN useradd -m appuser
+
 WORKDIR /app
 
 COPY --from=build /app /app
+
+USER appuser
 
 EXPOSE 3000
 


### PR DESCRIPTION
This PR addresses issue #4091 :- 

1. Introduce a non-root user named appuser in both stages of the Dockerfile.
2. Use USER appuser in the final stage to ensure the application runs securely.

The image is running smoothly and it is thoroughly checked.
![image](https://github.com/user-attachments/assets/e4597dc2-beaa-4d85-ba9e-cc78861d4a74)
![image](https://github.com/user-attachments/assets/f3003aca-0ac5-47ba-b3dc-436cf41633b3)
this closes #4091 