### PR TITLE
Issue #4108 post Build clean up in CI added

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,3 +30,8 @@ jobs:
 
     - run: npm ci
     - run: npm run build --if-present
+
+    # Post-run cleanup to remove the build directory after the job finishes
+    - name: Post-run cleanup
+      if: always()
+      run: rm -rf ./build


### PR DESCRIPTION
This PR:- a Post-run cleanup step is added, which removes the ./build directory to ensure a clean environment, especially useful for self-hosted runners. This cleanup step is executed with if: always(), ensuring it runs regardless of whether the previous steps succeed or fail, preventing the accumulation of unnecessary files.

closes #4108 