### PR TITLE
Issue #4110 Newer node version 18x and 20x added in smoke test to give best compatibility

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This PR :- The updated GitHub Actions workflow installs Node.js dependencies, builds the source code, and runs tests across the newer LTS versions of Node.js (18.x and 20.x), replacing the outdated 12.x and 14.x versions. The workflow includes steps for checking out the code, setting up the appropriate Node.js version, running npm ci to install dependencies, and building the project.

closes #4110