### PR TITLE
Fix: Add Notification When Dragging Blocks to Trash (#4112)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3114,6 +3114,10 @@ class Block {
             ) {
                 if (this.activity.trashcan.isVisible) {
                     this.blocks.sendStackToTrash(this);
+                    this.activity.textMsg(
+                        _("You can restore deleted blocks from the trash with the Restore From Trash button."), 3000
+                    );
+
                 }
             } else {
                 // Otherwise, process move.

--- a/js/block.js
+++ b/js/block.js
@@ -3117,7 +3117,6 @@ class Block {
                     this.activity.textMsg(
                         _("You can restore deleted blocks from the trash with the Restore From Trash button."), 3000
                     );
-
                 }
             } else {
                 // Otherwise, process move.


### PR DESCRIPTION
## Description

 Closes #4112.

## Changes
* Introduced the txtMsg with a time out when blocks are deleted using drag and drop.

## Testing
* Manually tested message arrival and it's auto time out.
* No breaking changes introduced.