### PR TITLE
popup msg for restore items

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3222,7 +3222,19 @@ class Activity {
          * Repositions blocks about trash area
          */
         const restoreTrash = (activity) => {
+            if (!activity.blocks || !activity.blocks.trashStacks || activity.blocks.trashStacks.length === 0) {
+                activity.textMsg(
+                    _("Nothing in the trash to restore."),
+                    3000 
+                );
+                return;
+            }
             activity._restoreTrash();
+            activity.textMsg(
+                _("Item restored from the trash."),
+                3000 
+            );
+        
             if (docById("helpfulWheelDiv").style.display !== "none") {
                 docById("helpfulWheelDiv").style.display = "none";
                 activity.__tick();


### PR DESCRIPTION
resolve issue #4115 

### Current behaviour 

now if user restore item from trash it shows popup message that items restored...if there are nothing in trash still user want to restore it show popup that nothing in trash to restore

### screen record


https://github.com/user-attachments/assets/bee25d21-fde0-4f58-8459-5572ea937357

