### PR TITLE
hide option for advance mode search bar

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -479,11 +479,13 @@ class Activity {
                 if (docById("helpfulWheelDiv").style.display !== "none") {
                     docById("helpfulWheelDiv").style.display = "none";
                 }
-                if (docById("helpfulSearchDiv").style.display !== "none" && e.target.id !== "helpfulSearch") {
+                if (docById("helpfulSearchDiv").style.display !== "none" && !docById("helpfulSearchDiv").contains(e.target) && e.target.id !== "helpfulSearch") {
                     docById("helpfulSearchDiv").style.display = "none";
                 }
                 that.__tick();
         }
+
+        document.addEventListener("click", this._hideHelpfulSearchWidget);
 
         /*
          * Sets up right click functionality opening the context menus


### PR DESCRIPTION

Resolves issue #4122 

The search bar of advance mode now closes like master branch search bar if no blocks selected. The advance mode search bar automatically closes if block selected after search. Now it can be closes by click outside of it like master branch search option if no block selected in search bar.

### Screen record


https://github.com/user-attachments/assets/230dc025-4b59-4ad1-b5cc-e27fbf1c597c

