### PR TITLE
Fix: Play piano after adding a new note

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2751,7 +2751,7 @@ function MusicKeyboard(activity) {
                               ")</small><br/>"
                             : "";
                 }
-                if (p >= 0 && p < this.layout.length) {
+                if (p < this.layout.length) {
                     this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
                     this.layout[p].objId = "blackRow" + myrow2Id.toString();
                 }

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2644,8 +2644,10 @@ function MusicKeyboard(activity) {
                     this.displayLayout[p].blockNumber
                 ]);
 
-                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
-                this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                if (p < this.layout.length) {
+                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                    this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                }
 
                 myrow2Id++;
                 newel2.innerHTML = "";
@@ -2749,9 +2751,10 @@ function MusicKeyboard(activity) {
                               ")</small><br/>"
                             : "";
                 }
-
-                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
-                this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                if (p >= 0 && p < this.layout.length) {
+                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                    this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                }
 
                 myrow2Id++;
                 newel2.style.position = "relative";
@@ -2814,9 +2817,10 @@ function MusicKeyboard(activity) {
                             this.displayLayout[p].noteOctave;
                     }
                 }
-
-                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
-                this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                if (p < this.layout.length) {
+                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                    this.layout[p].objId = "blackRow" + myrow2Id.toString();
+                }
 
                 myrow2Id++;
                 newel2.style.position = "relative";
@@ -2863,9 +2867,10 @@ function MusicKeyboard(activity) {
                             this.displayLayout[p].noteOctave;
                     }
                 }
-
-                this.displayLayout[p].objId = "whiteRow" + myrowId.toString();
-                this.layout[p].objId = "whiteRow" + myrowId.toString();
+                if (p < this.layout.length) {
+                    this.displayLayout[p].objId = "whiteRow" + myrowId.toString();
+                    this.layout[p].objId = "whiteRow" + myrowId.toString();
+                }
 
                 myrowId++;
                 newel.style.position = "relative";


### PR DESCRIPTION
Issue #4061 

Previously adding a new 'Pitch' Note to the piano roll disabled the keyboard. Their were some issues with assigning values to undefined objects (this.layout). This fix resolve this issue by checking proper boundary values. 

Although there is another issue related to it. On clicking the 'Add Pitch' button, intead of adding a last Note (matching Octave and pitch) it is adding many notes together. These notes are in proper order but still it is not the intended behavior. I tried solving this problem but I need assist on doing so. 

@walterbender Sir, please check this PR, Thank You.