### PR TITLE
Made jest file for munsell.js

### DIFF
--- a/js/utils/__tests__/munsell.test.js
+++ b/js/utils/__tests__/munsell.test.js
@@ -1,0 +1,95 @@
+const { interpColor, getMunsellColor, getcolor, searchColors } = require('../munsell');
+
+global.createjs = {
+    Graphics: {
+        getRGB: (r, g, b, a) => {
+            return `rgba(${r}, ${g}, ${b}, ${a})`;
+        },
+    },
+};
+
+describe('munsell', () => {
+
+    describe('interpColor', () => {
+        it('should interpolate between two colors', () => {
+            expect(
+                interpColor('#ff0000', '#0000ff', 0.5) // red and blue
+            ).toBe('rgba(127, 0, 127, 1)'); // purple
+            expect(
+                interpColor('#00ff00', '#000000', 0.75)
+            ).toBe('rgba(0, 191, 0, 1)'); 
+        });
+
+        it('should return the first color if p = 1', () => {
+            expect(
+                interpColor('#123456', '#abcdef', 1)
+            ).toBe('#123456');
+        });
+
+        it('should return the second color if p = 0', () => {
+            expect(
+                interpColor('#123456', '#abcdef', 0)
+            ).toBe('#abcdef');
+        });
+
+        it('should handle undefined colors gracefully', () => {
+            expect(
+                interpColor(undefined, '#123456', 0.5)
+            ).toBe('rgba(18, 52, 86, 1)');
+            expect(
+                interpColor('#123456', undefined, 0.5)
+            ).toBe('rgba(18, 52, 86, 1)');
+        });
+    });
+
+    describe('getMunsellColor', () => {
+        it('should return the correct Munsell color', () => {
+            const color = getMunsellColor(50, 50, 50);
+            expect(color).toMatch(/^#[0-9a-fA-F]{6}$/); // Ensure valid hex color format
+        });
+
+        it('should handle edge cases for hue, value, and chroma', () => {
+            expect(getMunsellColor(0, 0, 0)).toBeDefined();
+            expect(getMunsellColor(100, 100, 100)).toBeDefined();
+            expect(getMunsellColor(-10, -10, -10)).toBeDefined();
+            expect(getMunsellColor(110, 110, 110)).toBeDefined();
+        });
+    });
+
+    describe('getcolor', () => {
+        it('should return a valid array for a given color value', () => {
+            const color = getcolor(50);
+            expect(Array.isArray(color)).toBe(true);
+            expect(color.length).toBe(3);
+            expect(typeof color[0]).toBe('number'); 
+            expect(typeof color[1]).toBe('number');
+            expect(color[2]).toMatch(/^#[0-9a-fA-F]{6}$/); // Ensure RGB component is a valid hex color
+        });
+
+        it('should handle edge cases for color value', () => {
+            expect(getcolor(0)).toBeDefined();
+            expect(getcolor(-10)).toBeDefined();
+            expect(getcolor(110)).toBeDefined();
+        });
+    });
+
+    describe('searchColors', () => {
+        it('should return a color value between 0 and 100', () => {
+            const color = searchColors(128, 128, 128);
+            expect(color).toBeGreaterThanOrEqual(0);
+            expect(color).toBeLessThanOrEqual(100);
+        });
+
+        it('should find the nearest color for black', () => {
+            const color = searchColors(0, 0, 0);
+            const nearestColor = getcolor(color);
+            expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
+        });
+
+        it('should identify a close match for a RGB value', () => {
+            const color = searchColors(100, 150, 200);
+            const nearestColor = getcolor(color);
+            expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
+        });
+    });
+});

--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -6858,7 +6858,7 @@ let searchColors = (r, g, b) => {
 
     return nearestColor;
 };
-
+module.exports = {interpColor, getMunsellColor, getcolor, searchColors};
 // /**
 //  * @deprecated
 //  * @param {number} r - intensity of red


### PR DESCRIPTION
Issue https://github.com/sugarlabs/musicblocks/issues/4124

I am creating a new PR. The package-lock-json file somehow got changed, i dont know how. But this should work. @walterbender 
This PR addresses the need of a jest testing file for munsell.js
It validates the functionality of four core functions from the Munsell module: interpColor, getMunsellColor, getcolor, and searchColors.


![image](https://github.com/user-attachments/assets/89e561b7-37da-4685-8d16-b09a12d6a37c)
