### PR TITLE
[Enhancement] Add Notification for toggling Horizontal Scroll

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -822,14 +822,26 @@ class Toolbar {
                 // Horizontal Scroll
                 const enableHorizScrollIcon = docById("enableHorizScrollIcon");
                 const disableHorizScrollIcon = docById("disableHorizScrollIcon");
+                
                 if (enableHorizScrollIcon) {
                     enableHorizScrollIcon.style.display = "block";
-                    enableHorizScrollIcon.onclick = () => setScroller(this.activity);
+                    enableHorizScrollIcon.onclick = () => {
+                        setScroller(this.activity);
+                        this.activity.textMsg(
+                            _("Horizontal scrolling enabled.")
+                        );
+                    };
                 }
+                
                 if (disableHorizScrollIcon) {
-                    disableHorizScrollIcon.onclick = () => setScroller(this.activity);
+                    disableHorizScrollIcon.onclick = () => {
+                        setScroller(this.activity);
+                        this.activity.textMsg(
+                            _("Horizontal scrolling disabled.")
+                        );
+                    };
                 }
-
+                
                 // JavaScript Toggle
                 const toggleJavaScriptIcon = docById("toggleJavaScriptIcon");
                 if (toggleJavaScriptIcon) {


### PR DESCRIPTION
### Description
This PR addresses issue #4135 by adding a notification feature that triggers when horizontal scrolling is enabled or disabled. The notification will appear on the page when the user toggles horizontal scrolling and will remain visible until manually closed.

### Changes Made
#### Notification for Horizontal Scrolling Toggle:
A notification is triggered when horizontal scrolling is enabled or disabled.
The notification provides feedback to the user, with distinct messages for enabling and disabling horizontal scrolling.
The notification appears at the bottom of the page and remains visible until the user interacts with it.

### Screenshots

![Screenshot 2024-12-13 180318](https://github.com/user-attachments/assets/4eeaeff3-af75-498d-bf46-8af6bfd2e614)

### Checklist:
- [x] My changes adhere to the project's contribution guidelines.
- [x] Code changes are implemented.
- [x] Notification functionality works as expected.