### PR TITLE
removed clear confirmation during load project

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1082,7 +1082,7 @@ class Activity {
             document.body.appendChild(modal);
         };
         
-        this._allClear = (noErase) => {
+        this._allClear = (noErase, skipConfirmation = false) => {
             const clearCanvasAction = () => {
                 this.blocks.activeBlock = null;
                 hideDOMLabel();
@@ -1130,7 +1130,11 @@ class Activity {
                 }
             };
         
-            renderClearConfirmation(clearCanvasAction);
+            if (skipConfirmation) {
+                clearCanvasAction();
+            } else {
+                renderClearConfirmation(clearCanvasAction);
+            }
         };
         /**
          * Sets up play button functionality; runs Music Blocks.
@@ -3723,7 +3727,7 @@ class Activity {
             document.querySelector("#myOpenFile").click();
             window.scroll(0, 0);
             doHardStopButton(that);
-            that._allClear(true);
+            that._allClear(true, true);
         };
 
         window.prepareExport = this.prepareExport;


### PR DESCRIPTION
### Description 

Resolve #4152 

In Musicblocks when we try to load an existing project by clicking "Load project from file" from our system an unwanted clear confirmation happens because the doLoad() function internally called the _allClear() function so that due to _allClear() the unwanted confirmation happened. But now it is removed.

### Reason
![WhatsApp Image 2024-12-18 at 10 38 07_43ae9967](https://github.com/user-attachments/assets/07ff1417-cb31-45bc-a750-b1da1c6df50d)
![WhatsApp Image 2024-12-18 at 10 39 20_b11c8f87](https://github.com/user-attachments/assets/90c42003-a2ed-4922-b7ad-a0e9b62b4772)
here the doLoad() function called _allClear() function by passing true argument. So that internally canvas is going to clear. But we don't want that while loading an existing project because we are sure about to do it. 

So I pass an extra default argument which determine when the confirmation will skip. When the parameter is true the confirmation is skipped otherwise not.


But the other calling of _allClear() it has no such parameter so that it will not effect those calling because we don't pass anything by default as it is previously.

![Screenshot 2024-12-18 102054](https://github.com/user-attachments/assets/e772c973-98c9-4c69-9e87-34771b4285a1)

### Current Behaviour


https://github.com/user-attachments/assets/2fcc76a5-48bf-4422-a3e1-c933f25f239d

