### PR TITLE
#4154 issue: Fixed palette dropdown to prevent accidental switching

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -446,15 +446,20 @@ class Palettes {
     // Palette Button event handlers
     _loadPaletteButtonHandler(name, row) {
         // eslint-disable-next-line no-unused-vars
-        row.onmouseover = (event) => {
-            if (name == "search") {
+        let timeout;
+
+        row.onmouseover = () => {
+            if (name === "search") {
                 document.body.style.cursor = "text";
             } else {
                 document.body.style.cursor = "pointer";
-                this.showPalette(name);
+                clearTimeout(timeout);
+                timeout = setTimeout(() => this.showPalette(name), 400);
             }
         };
-
+        
+        row.onmouseout = () => clearTimeout(timeout);
+        
         // eslint-disable-next-line no-unused-vars
         row.onclick = (event) => {
             if (name == "search") {


### PR DESCRIPTION
* Fixed issue where the palette dropdown switched unintentionally when hovering over
  other tabs.
* Dropdown now locks to the selected palette upon click and remains active until the
* user explicitly changes it or closes the dropdown.


https://github.com/user-attachments/assets/df4f1880-ac6f-432f-a30b-ed49239d9be4

