### PR TITLE
same msg timeout for horizontal scroll

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -827,18 +827,12 @@ class Toolbar {
                     enableHorizScrollIcon.style.display = "block";
                     enableHorizScrollIcon.onclick = () => {
                         setScroller(this.activity);
-                        this.activity.textMsg(
-                            _("Horizontal scrolling enabled.")
-                        );
                     };
                 }
                 
                 if (disableHorizScrollIcon) {
                     disableHorizScrollIcon.onclick = () => {
                         setScroller(this.activity);
-                        this.activity.textMsg(
-                            _("Horizontal scrolling disabled.")
-                        );
                     };
                 }
                 


### PR DESCRIPTION
if we enable horizontal scrolling by helpfulwheel the notification timeout is 3 seconds but if we enable it through button in navbar it has no such timeout.

https://github.com/user-attachments/assets/aea08fcf-9ec5-40b7-8cc5-11ddde992064


I think both should be same. 
removing this part from toolbar.js because notification is already handled by this function and it is same for both cases (helpfulwheel and buttons ). 
![Screenshot 2024-12-21 005211](https://github.com/user-attachments/assets/648e0afe-2833-42ac-ad4c-4a034ef8f16b)
So, we don't need those extra lines.
