### PR TITLE
Remove extra blank option from grid piemenu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3597,8 +3597,7 @@ const piemenuGrid = (activity) => {
             "imgsrc: images/grid/Mezzo-soprano.svg",
             "imgsrc: images/grid/Alto.svg",
             "imgsrc: images/grid/Tenor.svg",
-            "imgsrc: images/grid/Bass.svg",
-            ""
+            "imgsrc: images/grid/Bass.svg"
         ];
 
         gridLabels = [
@@ -3611,8 +3610,7 @@ const piemenuGrid = (activity) => {
             "Mezzo Soprano",
             "Alto",
             "Tenor",
-            "Bass",
-            "Blank"
+            "Bass"
         ];
     }
 


### PR DESCRIPTION
In the piemenu(for grid) there are different svg for different grid. But the last option is set to "Blank" and don't have corresponding svg. The first option is also set to "Blank" and have its corresponding svg.

![Screenshot 2024-12-22 002837](https://github.com/user-attachments/assets/1d067e69-1ab6-4e0c-8746-ea34e8b04c12)
I think it should be removed so that it looks nice.
Before
![Screenshot 2024-12-22 003338](https://github.com/user-attachments/assets/ca86e313-0277-46f3-bc8f-560668c4e87c) 
After 
![Screenshot 2024-12-22 002528](https://github.com/user-attachments/assets/1df59161-78ee-48dc-afb9-5807792b200b)

