### PR TITLE
Addition of lyrics through phase maker

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3749,7 +3749,6 @@ class Activity {
             document.querySelector("#myOpenFile").click();
             window.scroll(0, 0);
             doHardStopButton(that);
-            that._allClear(true, true);
         };
 
         window.prepareExport = this.prepareExport;

--- a/js/activity.js
+++ b/js/activity.js
@@ -3749,6 +3749,7 @@ class Activity {
             document.querySelector("#myOpenFile").click();
             window.scroll(0, 0);
             doHardStopButton(that);
+            that._allClear(true, true);
         };
 
         window.prepareExport = this.prepareExport;

--- a/js/activity.js
+++ b/js/activity.js
@@ -269,6 +269,9 @@ class Activity {
         // Flag to check if the helpful search widget is active or not (for "click" event handler purpose)
         this.isHelpfulSearchWidgetOn = false;
 
+        //Flag to check if any other input box is active or not
+        this.isInputON = false;
+
         this.beginnerMode = true;
         try {
             if (this.storage.beginnerMode === undefined) {
@@ -2681,6 +2684,7 @@ class Activity {
                 docById("lilypondModal").style.display === "block" ||
                 this.searchWidget.style.visibility === "visible" ||
                 this.helpfulSearchWidget.style.visibility === "visible" ||
+                this.isInputON ||
                 docById("planet-iframe").style.display === "" ||
                 docById("paste").style.visibility === "visible" ||
                 docById("wheelDiv").style.display === "" ||

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -508,7 +508,9 @@ function setupExtrasBlocks(activity) {
                     logo.oscilloscopeTurtles.indexOf(activity.turtles.turtleList[turtleIndex]) < 0
                 )
                     logo.oscilloscopeTurtles.push(activity.turtles.turtleList[turtleIndex]);
-            } else if (!logo.inStatusMatrix && !logo.inMatrix)  {
+            } else if (logo.inMatrix) {
+                logo.phraseMaker._lyricsON = true;
+            } else if (!logo.inStatusMatrix) {
                 if (args.length === 1) {
                     if (args[0] !== null) {
                         const tur = activity.turtles.ithTurtle(turtle);
@@ -534,8 +536,6 @@ function setupExtrasBlocks(activity) {
                         }
                     }
                 }
-            } else if (logo.inMatrix) {
-                logo.phraseMaker._lyricsON = true;
             }
         }
     }

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -509,7 +509,7 @@ function setupExtrasBlocks(activity) {
                 )
                     logo.oscilloscopeTurtles.push(activity.turtles.turtleList[turtleIndex]);
             } else if (logo.inMatrix) {
-                logo.phraseMaker._lyricsON = true;
+                logo.phraseMaker.lyricsON = true;
             } else if (!logo.inStatusMatrix) {
                 if (args.length === 1) {
                     if (args[0] !== null) {

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -535,12 +535,7 @@ function setupExtrasBlocks(activity) {
                     }
                 }
             } else if (logo.inMatrix) {
-                logo.phraseMaker.addRowBlock(blk);
-                if (!logo.pitchBlocks.includes(blk)) {
-                    logo.pitchBlocks.push(blk);
-                }
-                logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
-                logo.phraseMaker.rowArgs.push(args[0]);
+                logo.phraseMaker._lyricsON = true;
             }
         }
     }

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -508,7 +508,7 @@ function setupExtrasBlocks(activity) {
                     logo.oscilloscopeTurtles.indexOf(activity.turtles.turtleList[turtleIndex]) < 0
                 )
                     logo.oscilloscopeTurtles.push(activity.turtles.turtleList[turtleIndex]);
-            } else if (!logo.inStatusMatrix) {
+            } else if (!logo.inStatusMatrix && !logo.inMatrix)  {
                 if (args.length === 1) {
                     if (args[0] !== null) {
                         const tur = activity.turtles.ithTurtle(turtle);
@@ -534,6 +534,13 @@ function setupExtrasBlocks(activity) {
                         }
                     }
                 }
+            } else if (logo.inMatrix) {
+                logo.phraseMaker.addRowBlock(blk);
+                if (!logo.pitchBlocks.includes(blk)) {
+                    logo.pitchBlocks.push(blk);
+                }
+                logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                logo.phraseMaker.rowArgs.push(args[0]);
             }
         }
     }

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -1430,6 +1430,7 @@ function setupWidgetBlocks(activity) {
             logo.phraseMaker.rowArgs = [];
             logo.phraseMaker.graphicsBlocks = [];
             logo.phraseMaker.clearBlocks();
+            logo.phraseMaker._lyricsON = false;
 
             logo.tupletRhythms = [];
             logo.tupletParams = [];

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -1430,7 +1430,7 @@ function setupWidgetBlocks(activity) {
             logo.phraseMaker.rowArgs = [];
             logo.phraseMaker.graphicsBlocks = [];
             logo.phraseMaker.clearBlocks();
-            logo.phraseMaker._lyricsON = false;
+            logo.phraseMaker.lyricsON = false;
 
             logo.tupletRhythms = [];
             logo.tupletParams = [];

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -135,6 +135,7 @@ class PlanetInterface {
             this.activity.loading = true;
             document.body.style.cursor = "wait";
             this.activity.doLoadAnimation();
+            this.activity._allClear(false);
 
             // First, hide the palettes as they will need updating.
             this.activity.blocks.palettes._hideMenus(true);

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -135,7 +135,6 @@ class PlanetInterface {
             this.activity.loading = true;
             document.body.style.cursor = "wait";
             this.activity.doLoadAnimation();
-            this.activity._allClear(false);
 
             // First, hide the palettes as they will need updating.
             this.activity.blocks.palettes._hideMenus(true);

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -210,7 +210,7 @@ class PhraseMaker {
 
         // This array keeps track of the position of the rows after sorting.
         /**
-         * Map of row positions after sorting.
+         * Map of row positions after sorting. 
          * @type {Array<number>}
          * @private
          */
@@ -250,6 +250,18 @@ class PhraseMaker {
         this.notesBlockMap = [];
         this._blockMapHelper = [];
         this.columnBlocksMap = [];
+
+        /**
+         * Stores lyrics for each column.
+         * @type {Array<string>}
+         * @private
+         */
+        this._lyrics = [];
+
+        this._lyricsON = true;
+
+        this._durationArray = [];
+
     }
 
     /**
@@ -911,7 +923,78 @@ class PhraseMaker {
             this._rows[j] = ptmRow;
 
             j += 1;
-        }
+        }       
+
+
+        // Add a row for lyrics
+        const lyricsRow = ptmTable.insertRow();
+        lyricsRow.setAttribute("id", "lyricRow");
+        lyricsRow.style.position = "sticky";
+
+        // Label Cell (Fixed like "note value")
+        cell = lyricsRow.insertCell();
+        cell.setAttribute("colspan", "2");
+        cell.className = "headcol";
+        cell.style.position = "sticky";
+        cell.style.left = "1.2px";
+        cell.style.zIndex = "1";
+        cell.style.backgroundColor = platformColor.lyricsLabelBackground || "#FF2B77";
+        cell.style.textAlign = "center";
+        cell.innerHTML = "Lyrics";
+
+        // Nested Table for Input Fields
+        tempTable = document.createElement("table");
+        tempTable.setAttribute("cellpadding", "0px");
+        const inputRow = tempTable.insertRow();
+
+        // Add input cells for lyrics
+        
+        this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+        for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
+            const inputCell = inputRow.insertCell();
+            inputCell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + 1 + "px";
+            inputCell.style.width = Math.floor(MATRIXSOLFEWIDTH * 0.93 * this._cellScale) + "px";
+            inputCell.style.minWidth = inputCell.style.width;
+            inputCell.style.maxWidth = inputCell.style.width;
+            inputCell.style.backgroundColor = "#FF6EA1"; 
+            inputCell.style.fontFamily = "sans-serif"; 
+            inputCell.style.cursor = "default"; 
+            inputCell.style.borderSpacing = "1px 1px"; 
+            inputCell.style.borderCollapse = "collapse"; 
+            inputCell.style.boxSizing = "border-box"; 
+            inputCell.style.padding = "0"; 
+            inputCell.style.borderRadius = "6px"; 
+            inputCell.style.border = "none"; 
+            inputCell.setAttribute("alt", i + "__" + "graphicsblocks2");
+            
+            const lyricsInput = document.createElement("input");
+            lyricsInput.type = "text";
+            
+           
+            lyricsInput.style.height = inputCell.style.height; 
+            lyricsInput.style.width = "100%";
+            lyricsInput.style.minWidth = inputCell.style.minWidth; 
+            lyricsInput.style.maxWidth = inputCell.style.maxWidth; 
+            lyricsInput.style.fontSize = "inherit"; 
+            lyricsInput.style.fontFamily = "sans-serif"; 
+            lyricsInput.style.cursor = "default"; 
+            lyricsInput.style.boxSizing = "border-box";
+            lyricsInput.style.padding = "0"; 
+            lyricsInput.style.border = "none"; 
+            lyricsInput.style.borderRadius = "6px"; 
+            lyricsInput.style.backgroundColor = "#FF6EA1"; 
+            
+            inputCell.appendChild(lyricsInput);
+            
+
+            // Optional: Add input listener
+            lyricsInput.addEventListener("input", (event) => {
+                this._lyrics[i] = event.target.value;
+            });
+        };
+
+        // Append Nested Table to Row
+        lyricsRow.insertCell().appendChild(tempTable);
 
         // An extra row for the note and tuplet values
         ptmTableRow = ptmTable.insertRow();
@@ -953,9 +1036,16 @@ class PhraseMaker {
         tempTable = document.createElement("table");
         tempTable.setAttribute("cellpadding", "0px");
         this._tupletNoteValueRow = tempTable.insertRow();
+        const tempTable2 = tempTable;
         this._tupletValueRow = tempTable.insertRow();
-        this._noteValueRow = tempTable.insertRow();
+        this._noteValueRow = tempTable.insertRow(); 
         ptmTableRow.insertCell().append(tempTable);
+
+        console.log(tempTable2.outerHTML);
+
+        
+
+        
 
         if (this._blockMap[this.blockNo] === undefined) {
             this._blockMap[this.blockNo] = [];
@@ -2763,6 +2853,7 @@ class PhraseMaker {
 
         const tupletTimeFactor = param[0][0] / param[0][1];
         const numberOfNotes = param[1].length;
+        console.log("num", numberOfNotes);
         let totalNoteInterval = 0;
         // const ptmTable = docById("ptmTable");
         let lcd;
@@ -5036,7 +5127,7 @@ class PhraseMaker {
                     if (obj === null) {
                         // add a hertz block
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5061,7 +5152,7 @@ class PhraseMaker {
                     } else if (drumName != null) {
                         // add a playdrum block
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5086,7 +5177,7 @@ class PhraseMaker {
                     } else if (note[0][j].slice(0, 4) === "http") {
                         // add a playdrum block with URL
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5111,7 +5202,7 @@ class PhraseMaker {
                     } else if (obj.length > 2) {
                         // add a 2-arg graphics block
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 3;
@@ -5143,7 +5234,7 @@ class PhraseMaker {
                     } else if (obj.length > 1) {
                         // add a 1-arg graphics block
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5168,10 +5259,10 @@ class PhraseMaker {
                     } else {
                         // add a pitch block
                         // The last connection in last pitch block is null.
-                        if (note[0].length === 1 || j === note[0].length - 1) {
+                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
-                            lastConnection = thisBlock + 3;
+                            lastConnection = thisBlock + 3; 
                         }
 
                         if (note[0][j][1] === "♯") {
@@ -5345,7 +5436,35 @@ class PhraseMaker {
                             }
                             previousBlock = thisBlock;
                             thisBlock += 3;
-                        }
+                        }                    
+                    }
+                }
+                if (this._lyricsON) {
+                    newStack.push([
+                        thisBlock,
+                        "print",
+                        0,
+                        0,
+                        [previousBlock, thisBlock + 1, null] // c is set to null for now
+                    ]);
+                    previousBlock = thisBlock;
+                    thisBlock += 1;
+                    if (this._lyrics[i] && this._lyrics !== "") {
+                        newStack.push([
+                            thisBlock,
+                            ["text", { value: this._lyrics[i] }], 
+                            0, 
+                            0, 
+                            [previousBlock]
+                        ]);
+                    } else {
+                        newStack.push([
+                            thisBlock,
+                            ["text", { value: "..." }], 
+                            0, 
+                            0, 
+                            [previousBlock]
+                        ]); 
                     }
                 }
             }

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -256,7 +256,7 @@ class PhraseMaker {
          * @type {Array<string>}
          * @private
          */
-        this._lyrics = [];
+        this.lyrics = [];
 
         /**
          * Marks the presence of print block
@@ -952,7 +952,7 @@ class PhraseMaker {
             const inputRow = tempTable.insertRow();
 
             // Add input cells for lyrics
-            this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+            this.lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
             for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
                 const noteValue = this.activity.logo.tupletRhythms[i][2];
                 const inputCell = inputRow.insertCell();
@@ -991,7 +991,7 @@ class PhraseMaker {
                 lyricsInput.addEventListener("focus", () => this.activity.isInputON = true);
                 lyricsInput.addEventListener("blur", () => this.activity.isInputON = false);
                 lyricsInput.addEventListener("input", (event) => {
-                    this._lyrics[i] = event.target.value;
+                    this.lyrics[i] = event.target.value;
                 });
 
             };
@@ -5431,7 +5431,7 @@ class PhraseMaker {
                             }
                             previousBlock = thisBlock;
                             thisBlock += 3;
-                        }                    
+                        }
                     }
                 }
                 if (this._lyricsON) {
@@ -5444,22 +5444,22 @@ class PhraseMaker {
                     ]);
                     previousBlock = thisBlock;
                     thisBlock += 1;
-                    if (this._lyrics[i] && this._lyrics !== "") {
+                    if (this.lyrics[i] && this.lyrics !== "") {
                         newStack.push([
                             thisBlock,
-                            ["text", { value: this._lyrics[i] }], 
-                            0, 
-                            0, 
+                            ["text", { value: this.lyrics[i] }],
+                            0,
+                            0,
                             [previousBlock]
                         ]);
                     } else {
                         newStack.push([
                             thisBlock,
-                            ["text", { value: "..." }], 
-                            0, 
-                            0, 
+                            ["text", { value: "..." }],
+                            0,
+                            0,
                             [previousBlock]
-                        ]); 
+                        ]);
                     }
                 }
             }

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -256,7 +256,7 @@ class PhraseMaker {
          * @type {Array<string>}
          * @private
          */
-        this.lyrics = [];
+        this._lyrics = [];
 
         /**
          * Marks the presence of print block
@@ -929,7 +929,7 @@ class PhraseMaker {
         }
 
         // Add a row for lyrics if they are enabled in the ExtraBlocks.js
-        if (this._lyricsON) {
+        if (this.lyricsON) {
 
             const lyricsRow = ptmTable.insertRow();
             lyricsRow.setAttribute("id", "lyricRow");
@@ -952,7 +952,7 @@ class PhraseMaker {
             const inputRow = tempTable.insertRow();
 
             // Add input cells for lyrics
-            this.lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+            this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
             for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
                 const noteValue = this.activity.logo.tupletRhythms[i][2];
                 const inputCell = inputRow.insertCell();
@@ -991,7 +991,7 @@ class PhraseMaker {
                 lyricsInput.addEventListener("focus", () => this.activity.isInputON = true);
                 lyricsInput.addEventListener("blur", () => this.activity.isInputON = false);
                 lyricsInput.addEventListener("input", (event) => {
-                    this.lyrics[i] = event.target.value;
+                    this._lyrics[i] = event.target.value;
                 });
 
             };
@@ -5122,7 +5122,7 @@ class PhraseMaker {
                     if (obj === null) {
                         // add a hertz block
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5147,7 +5147,7 @@ class PhraseMaker {
                     } else if (drumName != null) {
                         // add a playdrum block
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5172,7 +5172,7 @@ class PhraseMaker {
                     } else if (note[0][j].slice(0, 4) === "http") {
                         // add a playdrum block with URL
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5197,7 +5197,7 @@ class PhraseMaker {
                     } else if (obj.length > 2) {
                         // add a 2-arg graphics block
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 3;
@@ -5229,7 +5229,7 @@ class PhraseMaker {
                     } else if (obj.length > 1) {
                         // add a 1-arg graphics block
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 2;
@@ -5254,7 +5254,7 @@ class PhraseMaker {
                     } else {
                         // add a pitch block
                         // The last connection in last pitch block is null.
-                        if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
                             lastConnection = thisBlock + 3;
@@ -5434,7 +5434,7 @@ class PhraseMaker {
                         }
                     }
                 }
-                if (this._lyricsON) {
+                if (this.lyricsON) {
                     newStack.push([
                         thisBlock,
                         "print",
@@ -5444,10 +5444,10 @@ class PhraseMaker {
                     ]);
                     previousBlock = thisBlock;
                     thisBlock += 1;
-                    if (this.lyrics[i] && this.lyrics !== "") {
+                    if (this._lyrics[i] && this._lyrics !== "") {
                         newStack.push([
                             thisBlock,
-                            ["text", { value: this.lyrics[i] }],
+                            ["text", { value: this._lyrics[i] }],
                             0,
                             0,
                             [previousBlock]

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -928,7 +928,6 @@ class PhraseMaker {
             j += 1;
         }       
 
-
         // Add a row for lyrics if they are enabled in the ExtraBlocks.js
         if (this._lyricsON) { 
 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2461,8 +2461,6 @@ class PhraseMaker {
 
         // Keep track of marked cells.
         this._markedColsInRow = [];
-        console.log("in sort ->",this._lyricsON);
-        //let lyricsSwitch = this._lyricsON;
         let thisRow, row, n, cell;
         for (let r = 0; r < this.rowLabels.length; r++) {
             thisRow = [];
@@ -2646,7 +2644,6 @@ class PhraseMaker {
         }
 
         this.makeClickable();
-        //this._lyricsON = false;
 
     }
 
@@ -2853,7 +2850,6 @@ class PhraseMaker {
 
         const tupletTimeFactor = param[0][0] / param[0][1];
         const numberOfNotes = param[1].length;
-        console.log("num", numberOfNotes);
         let totalNoteInterval = 0;
         // const ptmTable = docById("ptmTable");
         let lcd;

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -293,7 +293,7 @@ class PhraseMaker {
           * @type {NodeListOf<Element>}
           */
         var windowFrameElements = floatingWindowsDiv.querySelectorAll(".windowFrame");
-    
+
         for (var i = 0; i < windowFrameElements.length; i++) {
 
             /**
@@ -337,7 +337,7 @@ class PhraseMaker {
              * @type {number}
              */
             var maxHeight = screenHeight * 0.8;
-    
+
             if (totalWidth > screenWidth || totalHeight > screenHeight) {
                 windowFrame.style.height = Math.min(totalHeight, maxHeight) + "px";
                 windowFrame.style.width = Math.min(totalWidth, maxWidth) + "px";
@@ -356,7 +356,7 @@ class PhraseMaker {
             }
         }
     }
- 
+
     /**
      * Clears block references within the PhraseMaker.
      * Resets arrays used to track row and column blocks.
@@ -926,15 +926,15 @@ class PhraseMaker {
             this._rows[j] = ptmRow;
 
             j += 1;
-        }       
+        }
 
         // Add a row for lyrics if they are enabled in the ExtraBlocks.js
-        if (this._lyricsON) { 
+        if (this._lyricsON) {
 
             const lyricsRow = ptmTable.insertRow();
             lyricsRow.setAttribute("id", "lyricRow");
             lyricsRow.style.position = "sticky";
-    
+
             // Label Cell (Fixed like "note value")
             cell = lyricsRow.insertCell();
             cell.setAttribute("colspan", "2");
@@ -945,13 +945,13 @@ class PhraseMaker {
             cell.style.backgroundColor = platformColor.lyricsLabelBackground || "#FF2B77";
             cell.style.textAlign = "center";
             cell.innerHTML = "Lyrics";
-    
+
             // Nested Table for Input Fields
             tempTable = document.createElement("table");
             tempTable.setAttribute("cellpadding", "0px");
             const inputRow = tempTable.insertRow();
-    
-            // Add input cells for lyrics       
+
+            // Add input cells for lyrics
             this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
             for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
                 const noteValue = this.activity.logo.tupletRhythms[i][2];
@@ -960,44 +960,44 @@ class PhraseMaker {
                 inputCell.style.width = this._noteWidth(noteValue) + "px";
                 inputCell.style.minWidth = inputCell.style.width;
                 inputCell.style.maxWidth = inputCell.style.width;
-                inputCell.style.backgroundColor = "#FF6EA1"; 
-                inputCell.style.fontFamily = "sans-serif"; 
-                inputCell.style.cursor = "default"; 
-                inputCell.style.borderSpacing = "1px 1px"; 
-                inputCell.style.borderCollapse = "collapse"; 
-                inputCell.style.boxSizing = "border-box"; 
-                inputCell.style.padding = "0"; 
-                inputCell.style.borderRadius = "6px"; 
-                inputCell.style.border = "none"; 
+                inputCell.style.backgroundColor = "#FF6EA1";
+                inputCell.style.fontFamily = "sans-serif";
+                inputCell.style.cursor = "default";
+                inputCell.style.borderSpacing = "1px 1px";
+                inputCell.style.borderCollapse = "collapse";
+                inputCell.style.boxSizing = "border-box";
+                inputCell.style.padding = "0";
+                inputCell.style.borderRadius = "6px";
+                inputCell.style.border = "none";
                 inputCell.setAttribute("alt", i + "__" + "graphicsblocks2");
-                
+
                 const lyricsInput = document.createElement("input");
                 lyricsInput.type = "text";
-                
-               
-                lyricsInput.style.height = inputCell.style.height; 
+
+                lyricsInput.style.height = inputCell.style.height;
                 lyricsInput.style.width = "100%";
-                lyricsInput.style.minWidth = inputCell.style.minWidth; 
-                lyricsInput.style.maxWidth = inputCell.style.maxWidth; 
-                lyricsInput.style.fontSize = "inherit"; 
-                lyricsInput.style.fontFamily = "sans-serif"; 
-                lyricsInput.style.cursor = "default"; 
+                lyricsInput.style.minWidth = inputCell.style.minWidth;
+                lyricsInput.style.maxWidth = inputCell.style.maxWidth;
+                lyricsInput.style.fontSize = "inherit";
+                lyricsInput.style.fontFamily = "sans-serif";
+                lyricsInput.style.cursor = "default";
                 lyricsInput.style.boxSizing = "border-box";
-                lyricsInput.style.padding = "0"; 
-                lyricsInput.style.border = "none"; 
-                lyricsInput.style.borderRadius = "6px"; 
-                lyricsInput.style.backgroundColor = "#FF6EA1"; 
-                
+                lyricsInput.style.padding = "0";
+                lyricsInput.style.border = "none";
+                lyricsInput.style.borderRadius = "6px";
+                lyricsInput.style.backgroundColor = "#FF6EA1";
+
                 inputCell.appendChild(lyricsInput);
+                lyricsInput.addEventListener("focus", () => this.activity.isInputON = true);
+                lyricsInput.addEventListener("blur", () => this.activity.isInputON = false);
                 lyricsInput.addEventListener("input", (event) => {
                     this._lyrics[i] = event.target.value;
-                    //Disable keyboard shortcuts when typing lyrics
-                    lyricsInput.focus();
                 });
+
             };
             lyricsRow.insertCell().appendChild(tempTable);
         }
-        
+
         // An extra row for the note and tuplet values
         ptmTableRow = ptmTable.insertRow();
         ptmCell = ptmTableRow.insertCell();

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -258,7 +258,7 @@ class PhraseMaker {
          */
         this._lyrics = [];
 
-        this._lyricsON = true;
+        this._lyricsON = false;
 
         this._durationArray = [];
 
@@ -516,6 +516,7 @@ class PhraseMaker {
             this.activity.hideMsgs();
             docById("wheelDivptm").style.display = "none";
 
+            document.onkeydown = activity.__keyPressed; 
             widgetWindow.destroy();
         };
 
@@ -930,9 +931,8 @@ class PhraseMaker {
 
 
         // Add a row for lyrics
-        if (this.rowLabels.includes("print")) { 
+        if (this._lyricsON) { 
 
-            this._lyricsON = true;
             const lyricsRow = ptmTable.insertRow();
             lyricsRow.setAttribute("id", "lyricRow");
             lyricsRow.style.position = "sticky";
@@ -993,6 +993,7 @@ class PhraseMaker {
                 inputCell.appendChild(lyricsInput);
                 lyricsInput.addEventListener("input", (event) => {
                     this._lyrics[i] = event.target.value;
+                    lyricsInput.focus();
                 });
             };
             lyricsRow.insertCell().appendChild(tempTable);
@@ -2466,6 +2467,8 @@ class PhraseMaker {
 
         // Keep track of marked cells.
         this._markedColsInRow = [];
+        console.log("in sort ->",this._lyricsON);
+        //let lyricsSwitch = this._lyricsON;
         let thisRow, row, n, cell;
         for (let r = 0; r < this.rowLabels.length; r++) {
             thisRow = [];
@@ -2649,6 +2652,7 @@ class PhraseMaker {
         }
 
         this.makeClickable();
+        //this._lyricsON = false;
 
     }
 
@@ -3085,8 +3089,7 @@ class PhraseMaker {
         for (let j = 0; j < numBeats; j++) {
             for (let i = 0; i < rowCount; i++) {
                 // Depending on the row, we choose a different background color.
-                if (this.rowLabels[i] === "print") break; 
-                else if (
+                if (
                     MATRIXGRAPHICS.indexOf(this.rowLabels[i]) != -1 ||
                     MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) != -1
                 ) {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -210,7 +210,7 @@ class PhraseMaker {
 
         // This array keeps track of the position of the rows after sorting.
         /**
-         * Map of row positions after sorting. 
+         * Map of row positions after sorting.
          * @type {Array<number>}
          * @private
          */
@@ -258,10 +258,11 @@ class PhraseMaker {
          */
         this._lyrics = [];
 
-        this._lyricsON = false;
-
-        this._durationArray = [];
-
+        /**
+         * Marks the presence of print block
+         * @type {boolean}
+         */
+        this.lyricsON = false;
     }
 
     /**
@@ -515,8 +516,6 @@ class PhraseMaker {
             this._stopOrCloseClicked = true;
             this.activity.hideMsgs();
             docById("wheelDivptm").style.display = "none";
-
-            document.onkeydown = activity.__keyPressed; 
             widgetWindow.destroy();
         };
 
@@ -930,7 +929,7 @@ class PhraseMaker {
         }       
 
 
-        // Add a row for lyrics
+        // Add a row for lyrics if they are enabled in the ExtraBlocks.js
         if (this._lyricsON) { 
 
             const lyricsRow = ptmTable.insertRow();
@@ -993,6 +992,7 @@ class PhraseMaker {
                 inputCell.appendChild(lyricsInput);
                 lyricsInput.addEventListener("input", (event) => {
                     this._lyrics[i] = event.target.value;
+                    //Disable keyboard shortcuts when typing lyrics
                     lyricsInput.focus();
                 });
             };
@@ -1041,14 +1041,8 @@ class PhraseMaker {
         this._tupletNoteValueRow = tempTable.insertRow();
         const tempTable2 = tempTable;
         this._tupletValueRow = tempTable.insertRow();
-        this._noteValueRow = tempTable.insertRow(); 
+        this._noteValueRow = tempTable.insertRow();
         ptmTableRow.insertCell().append(tempTable);
-
-        console.log(tempTable2.outerHTML);
-
-        
-
-        
 
         if (this._blockMap[this.blockNo] === undefined) {
             this._blockMap[this.blockNo] = [];
@@ -5268,7 +5262,7 @@ class PhraseMaker {
                         if (!this._lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
                             lastConnection = null;
                         } else {
-                            lastConnection = thisBlock + 3; 
+                            lastConnection = thisBlock + 3;
                         }
 
                         if (note[0][j][1] === "♯") {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -664,7 +664,9 @@ class PhraseMaker {
             cell.innerHTML = "";
             this._headcols[i] = cell;
 
-            if (drumName != null) {
+            if (this.rowLabels[i].toLowerCase() === "print") {
+                cell.innerHTML = "Lyrics";
+            } else if (drumName != null) {
                 cell.innerHTML =
                     '&nbsp;&nbsp;<img src="' +
                     getDrumIcon(drumName) +
@@ -769,7 +771,12 @@ class PhraseMaker {
             cell.setAttribute("alt", i);
             this._labelcols[i] = cell;
 
-            if (drumName != null) {
+            if (this.rowLabels[i].toLowerCase() === "print") {
+                cell.innerHTML = "Lyrics";
+                cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
+                cell.style.textAlign = "center";
+                cell.style.verticalAlign = "middle";
+            } else if (drumName != null) {
                 cell.innerHTML = _(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 cell.setAttribute("alt", i + "__" + "drumblocks");

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -637,7 +637,8 @@ class PhraseMaker {
             drumName = getDrumName(this.rowLabels[i]);
 
             // Depending on the row, we choose a different background color.
-            if (
+            if (this.rowLabels[i] === "print") break;
+            else if (
                 MATRIXGRAPHICS.indexOf(this.rowLabels[i]) != -1 ||
                 MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) != -1
             ) {
@@ -664,9 +665,8 @@ class PhraseMaker {
             cell.innerHTML = "";
             this._headcols[i] = cell;
 
-            if (this.rowLabels[i].toLowerCase() === "print") {
-                cell.innerHTML = "Lyrics";
-            } else if (drumName != null) {
+            if (this.rowLabels[i] === "print") break;
+            else if (drumName != null) {
                 cell.innerHTML =
                     '&nbsp;&nbsp;<img src="' +
                     getDrumIcon(drumName) +
@@ -771,12 +771,8 @@ class PhraseMaker {
             cell.setAttribute("alt", i);
             this._labelcols[i] = cell;
 
-            if (this.rowLabels[i].toLowerCase() === "print") {
-                cell.innerHTML = "Lyrics";
-                cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
-                cell.style.textAlign = "center";
-                cell.style.verticalAlign = "middle";
-            } else if (drumName != null) {
+            if (this.rowLabels[i] === "print") break;
+            else if (drumName != null) {
                 cell.innerHTML = _(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 cell.setAttribute("alt", i + "__" + "drumblocks");
@@ -934,75 +930,74 @@ class PhraseMaker {
 
 
         // Add a row for lyrics
-        const lyricsRow = ptmTable.insertRow();
-        lyricsRow.setAttribute("id", "lyricRow");
-        lyricsRow.style.position = "sticky";
+        if (this.rowLabels.includes("print")) { 
 
-        // Label Cell (Fixed like "note value")
-        cell = lyricsRow.insertCell();
-        cell.setAttribute("colspan", "2");
-        cell.className = "headcol";
-        cell.style.position = "sticky";
-        cell.style.left = "1.2px";
-        cell.style.zIndex = "1";
-        cell.style.backgroundColor = platformColor.lyricsLabelBackground || "#FF2B77";
-        cell.style.textAlign = "center";
-        cell.innerHTML = "Lyrics";
-
-        // Nested Table for Input Fields
-        tempTable = document.createElement("table");
-        tempTable.setAttribute("cellpadding", "0px");
-        const inputRow = tempTable.insertRow();
-
-        // Add input cells for lyrics
+            this._lyricsON = true;
+            const lyricsRow = ptmTable.insertRow();
+            lyricsRow.setAttribute("id", "lyricRow");
+            lyricsRow.style.position = "sticky";
+    
+            // Label Cell (Fixed like "note value")
+            cell = lyricsRow.insertCell();
+            cell.setAttribute("colspan", "2");
+            cell.className = "headcol";
+            cell.style.position = "sticky";
+            cell.style.left = "1.2px";
+            cell.style.zIndex = "1";
+            cell.style.backgroundColor = platformColor.lyricsLabelBackground || "#FF2B77";
+            cell.style.textAlign = "center";
+            cell.innerHTML = "Lyrics";
+    
+            // Nested Table for Input Fields
+            tempTable = document.createElement("table");
+            tempTable.setAttribute("cellpadding", "0px");
+            const inputRow = tempTable.insertRow();
+    
+            // Add input cells for lyrics       
+            this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+            for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
+                const noteValue = this.activity.logo.tupletRhythms[i][2];
+                const inputCell = inputRow.insertCell();
+                inputCell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + 1 + "px";
+                inputCell.style.width = this._noteWidth(noteValue) + "px";
+                inputCell.style.minWidth = inputCell.style.width;
+                inputCell.style.maxWidth = inputCell.style.width;
+                inputCell.style.backgroundColor = "#FF6EA1"; 
+                inputCell.style.fontFamily = "sans-serif"; 
+                inputCell.style.cursor = "default"; 
+                inputCell.style.borderSpacing = "1px 1px"; 
+                inputCell.style.borderCollapse = "collapse"; 
+                inputCell.style.boxSizing = "border-box"; 
+                inputCell.style.padding = "0"; 
+                inputCell.style.borderRadius = "6px"; 
+                inputCell.style.border = "none"; 
+                inputCell.setAttribute("alt", i + "__" + "graphicsblocks2");
+                
+                const lyricsInput = document.createElement("input");
+                lyricsInput.type = "text";
+                
+               
+                lyricsInput.style.height = inputCell.style.height; 
+                lyricsInput.style.width = "100%";
+                lyricsInput.style.minWidth = inputCell.style.minWidth; 
+                lyricsInput.style.maxWidth = inputCell.style.maxWidth; 
+                lyricsInput.style.fontSize = "inherit"; 
+                lyricsInput.style.fontFamily = "sans-serif"; 
+                lyricsInput.style.cursor = "default"; 
+                lyricsInput.style.boxSizing = "border-box";
+                lyricsInput.style.padding = "0"; 
+                lyricsInput.style.border = "none"; 
+                lyricsInput.style.borderRadius = "6px"; 
+                lyricsInput.style.backgroundColor = "#FF6EA1"; 
+                
+                inputCell.appendChild(lyricsInput);
+                lyricsInput.addEventListener("input", (event) => {
+                    this._lyrics[i] = event.target.value;
+                });
+            };
+            lyricsRow.insertCell().appendChild(tempTable);
+        }
         
-        this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
-        for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
-            const inputCell = inputRow.insertCell();
-            inputCell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + 1 + "px";
-            inputCell.style.width = Math.floor(MATRIXSOLFEWIDTH * 0.93 * this._cellScale) + "px";
-            inputCell.style.minWidth = inputCell.style.width;
-            inputCell.style.maxWidth = inputCell.style.width;
-            inputCell.style.backgroundColor = "#FF6EA1"; 
-            inputCell.style.fontFamily = "sans-serif"; 
-            inputCell.style.cursor = "default"; 
-            inputCell.style.borderSpacing = "1px 1px"; 
-            inputCell.style.borderCollapse = "collapse"; 
-            inputCell.style.boxSizing = "border-box"; 
-            inputCell.style.padding = "0"; 
-            inputCell.style.borderRadius = "6px"; 
-            inputCell.style.border = "none"; 
-            inputCell.setAttribute("alt", i + "__" + "graphicsblocks2");
-            
-            const lyricsInput = document.createElement("input");
-            lyricsInput.type = "text";
-            
-           
-            lyricsInput.style.height = inputCell.style.height; 
-            lyricsInput.style.width = "100%";
-            lyricsInput.style.minWidth = inputCell.style.minWidth; 
-            lyricsInput.style.maxWidth = inputCell.style.maxWidth; 
-            lyricsInput.style.fontSize = "inherit"; 
-            lyricsInput.style.fontFamily = "sans-serif"; 
-            lyricsInput.style.cursor = "default"; 
-            lyricsInput.style.boxSizing = "border-box";
-            lyricsInput.style.padding = "0"; 
-            lyricsInput.style.border = "none"; 
-            lyricsInput.style.borderRadius = "6px"; 
-            lyricsInput.style.backgroundColor = "#FF6EA1"; 
-            
-            inputCell.appendChild(lyricsInput);
-            
-
-            // Optional: Add input listener
-            lyricsInput.addEventListener("input", (event) => {
-                this._lyrics[i] = event.target.value;
-            });
-        };
-
-        // Append Nested Table to Row
-        lyricsRow.insertCell().appendChild(tempTable);
-
         // An extra row for the note and tuplet values
         ptmTableRow = ptmTable.insertRow();
         ptmCell = ptmTableRow.insertCell();
@@ -3090,7 +3085,8 @@ class PhraseMaker {
         for (let j = 0; j < numBeats; j++) {
             for (let i = 0; i < rowCount; i++) {
                 // Depending on the row, we choose a different background color.
-                if (
+                if (this.rowLabels[i] === "print") break; 
+                else if (
                     MATRIXGRAPHICS.indexOf(this.rowLabels[i]) != -1 ||
                     MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) != -1
                 ) {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -952,7 +952,12 @@ class PhraseMaker {
             const inputRow = tempTable.insertRow();
 
             // Add input cells for lyrics
-            this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+            if (!this._lyrics || this._lyrics.length === 0) {
+                this._lyrics = Array(this.activity.logo.tupletRhythms.length).fill("");
+            } else if (this.activity.logo.tupletRhythms.length > this._lyrics.length) {
+                const additionalLength = this.activity.logo.tupletRhythms.length - this._lyrics.length;
+                this._lyrics = this._lyrics.concat(Array(additionalLength).fill(""));
+            }
             for (let i = 0; i < this.activity.logo.tupletRhythms.length; i++) {
                 const noteValue = this.activity.logo.tupletRhythms[i][2];
                 const inputCell = inputRow.insertCell();
@@ -973,6 +978,7 @@ class PhraseMaker {
 
                 const lyricsInput = document.createElement("input");
                 lyricsInput.type = "text";
+                lyricsInput.value = this._lyrics[i];
 
                 lyricsInput.style.height = inputCell.style.height;
                 lyricsInput.style.width = "100%";
@@ -3550,7 +3556,7 @@ class PhraseMaker {
         this._restartGrid.call(this);
     }
 
-    
+
     /**
      * Deletes a note from the grid and readjusts the notes accordingly.
      * @param {number} noteToDivide - The index of the note to delete.
@@ -4593,6 +4599,10 @@ class PhraseMaker {
      * @param {number} noteCounter - The current note index in the playback sequence.
      */
     __playNote(time, noteCounter) {
+        // Show lyrics while playing notes.
+        if (this.lyricsON) {
+            this.activity.textMsg(this._lyrics[noteCounter]);
+        }
         // If the widget is closed, stop playing.
         if (!this.widgetWindow.isVisible()) {
             return;
@@ -4965,7 +4975,16 @@ class PhraseMaker {
      * @private
      */
     _clear() {
-        // 'Unclick' every entry in the matrix.
+        // Reset the `_lyrics` array
+        this._lyrics = Array(this._lyrics.length).fill("");
+        const lyricsRow = document.getElementById("lyricRow");
+        if (lyricsRow) {
+            const inputFields = lyricsRow.querySelectorAll("input[type='text']");
+            inputFields.forEach((inputField, index) => {
+                inputField.value = this._lyrics[index] || "";
+            });
+        }
+        // 'Unclick' every entry in the matrix
         let row, cell;
         for (let i = 0; i < this.rowLabels.length; i++) {
             row = this._rows[i];
@@ -4979,6 +4998,7 @@ class PhraseMaker {
             }
         }
     }
+
 
     /**
      * Saves the current matrix state as an action stack consisting of note and pitch blocks.
@@ -5440,7 +5460,7 @@ class PhraseMaker {
                         "print",
                         0,
                         0,
-                        [previousBlock, thisBlock + 1, null] // c is set to null for now
+                        [previousBlock, thisBlock + 1, null]
                     ]);
                     previousBlock = thisBlock;
                     thisBlock += 1;


### PR DESCRIPTION
https://github.com/sugarlabs/musicblocks/issues/3842

I was able to figure out how we can add print blocks to the block stack. But addition of a "true" print block in the phase maker widget and detecting it in the matrix is challenging. I spent almost 2 days on this problem but no results were produced. 
Hence I am making it a draft PR for the interested one. They can  continue my work and also I am ready to collab. 

Things we can focus on :-
1. Modifying print block code. Orginally the phase maker only identifies notes and instruments like drum. No such implementation 
 for other blocks.
2. Removal of keyboard shorcuts while typing in the cell. 
3. Here I have used an array to store lyrics. Is there any better option ? 

@walterbender @pikurasa Sir please check this PR. 


https://github.com/user-attachments/assets/68c4b05e-bc26-4664-9e7e-32779535c1eb

