### PR TITLE
FIXES #4171 pen args mismatched inside note blocks

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1844,7 +1844,7 @@ class Logo {
         const suppressOutput = tur.singer.suppressOutput;
 
         const __pen = (turtle, name, b, timeout) => {
-            let arg; // Declaring `arg` within the function to avoid sharing 
+            let arg;
             switch (name) {
                 case "penup":
                 case "pendown":

--- a/js/logo.js
+++ b/js/logo.js
@@ -1843,8 +1843,8 @@ class Logo {
 
         const suppressOutput = tur.singer.suppressOutput;
 
-        let arg;
         const __pen = (turtle, name, b, timeout) => {
+            let arg; // Declaring `arg` within the function to avoid sharing 
             switch (name) {
                 case "penup":
                 case "pendown":


### PR DESCRIPTION
this resolves the issue #4171 now the pen block takes its individual arg and do not depends on last pen arg. when placed in side the note block.
pen block inside the note block :
<img width="663" alt="Screenshot 2024-12-23 at 10 25 48 AM" src="https://github.com/user-attachments/assets/ee05eeb1-0f02-41d7-925f-8f1cccee307a" />
pen block outside the note block : 
<img width="555" alt="Screenshot 2024-12-23 at 10 24 56 AM" src="https://github.com/user-attachments/assets/dd0f8347-69cd-4462-ac56-736cc7149550" />
