### PR TITLE
Update translator web interface URL in README.md - FIX for issue #4184

### DIFF
--- a/po/README.md
+++ b/po/README.md
@@ -1,9 +1,9 @@
 Internationalization
 ====================
 
-We are using PO files as the basic mechanism for managing translation
+We use PO files as the basic mechanism for managing translation
 of Music Blocks. We'd prefer that translators work with the Sugar
-Labs [Pootle server](http://translate.sugarlabs.org/projects/MusicBlocks/) and
+Labs [Weblate Server](https://weblate.sugarlabs.org) and
 we will work with you to set up a PO file for your language if one is
 not presently on the server. Also feel free to make Pull Requests
 directly to this repository with updates to existing (or new) PO


### PR DESCRIPTION
This PR updates the outdated translator web interface URL in the README.md file.

Previous URL: http://translate.sugarlabs.org/projects/MusicBlocks/
New URL: https://weblate.sugarlabs.org
This ensures that contributors are directed to the correct translation platform for Music Blocks.

Closes #4184 