### PR TITLE
add onResize refresh to play-button (Fixes #3900)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1160,6 +1160,7 @@ class Activity {
         };
 
         this._doFastButton = (env) => {
+            this._onResize();
             this.blocks.activeBlock = null;
             hideDOMLabel();
 


### PR DESCRIPTION
# Description of #3900 
- **Root cause**: The issue is that when we use the blocks set x, y = (0,0) then the mouse/turtle is supposed to be at the origin on the graph. but when we resize the window then we hit play the mouse or turtle is on the center of the screen but it is supposed to be on the center of the graph in the background.

- **Solution**: We should also update the graph's position to match 0,0 on the resized screen. As suggested, we are doing this now when the play-button is pressed.

# How this PR fixes #3900

I simply add `this._onResize();` to the `play-button` functionality. As described it refreshes the grid too.

**NOTE**: I tested and confirmed that this issue isn't just on the cartesian grid but also other forms of grid. 


# Test plan

Here is a video showing in various scenarios how the issue is now fixed. The video contains both the current version of the site and the fixed version (the tab that contains the html file).

https://github.com/user-attachments/assets/7d55aa8d-9bf8-47b1-877b-2d9c53a1c08b


## How to test it locally

Simply run the `index.html` file from my branch.


---
Please look into this and suggest any changes if needed. 

---
## Acknowledgments
Thank you @walterbender for your quick responses and clear answers.
This was an important issue to fix. As it greatly impacted the User-Experience.



