### PR TITLE
Add Tests for RhythmBlocksAPI and DrumBlocksAPI in /js/js-exports/API (#4200)

### DIFF
--- a/js/js-export/API/DrumBlocksAPI.js
+++ b/js/js-export/API/DrumBlocksAPI.js
@@ -51,3 +51,4 @@ class DrumBlocksAPI {
         return this.runCommand("playNoise", [args[0], this.turIndex]);
     }
 }
+module.exports=DrumBlocksAPI;

--- a/js/js-export/API/RhythmBlocksAPI.js
+++ b/js/js-export/API/RhythmBlocksAPI.js
@@ -113,3 +113,4 @@ class RhythmBlocksAPI {
         return this.ENDFLOWCOMMAND;
     }
 }
+module.exports=RhythmBlocksAPI;

--- a/js/js-export/API/__tests__/DrumBlocksAPI.test.js
+++ b/js/js-export/API/__tests__/DrumBlocksAPI.test.js
@@ -1,0 +1,66 @@
+const JSInterface = {
+    validateArgs: jest.fn(),
+};
+
+global.JSInterface = JSInterface;
+global.MusicBlocks = {
+    BLK: "mockBlock",
+};
+
+const DrumBlocksAPI = require("../DrumBlocksAPI");
+
+describe("DrumBlocksAPI", () => {
+    let drumBlocksAPI;
+
+    beforeEach(() => {
+        drumBlocksAPI = new DrumBlocksAPI();
+        drumBlocksAPI.turIndex = 0;
+        drumBlocksAPI.runCommand = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("playDrum calls runCommand with correct arguments", () => {
+        JSInterface.validateArgs.mockReturnValue(["snare"]);
+
+        drumBlocksAPI.playDrum("snare");
+
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("playDrum", ["snare"]);
+        expect(drumBlocksAPI.runCommand).toHaveBeenCalledWith("playDrum", ["snare", 0, global.MusicBlocks.BLK]);
+    });
+
+    test("setDrum calls runCommand and executes flow function", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue(["kick", mockFlow]);
+
+        const result = await drumBlocksAPI.setDrum("kick", mockFlow);
+
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("setDrum", ["kick", mockFlow]);
+        expect(drumBlocksAPI.runCommand).toHaveBeenCalledWith("setDrum", ["kick", 0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe(drumBlocksAPI.ENDFLOWCOMMAND);
+    });
+
+    test("mapPitchToDrum calls runCommand and executes flow function", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue(["tom", mockFlow]);
+
+        const result = await drumBlocksAPI.mapPitchToDrum("tom", mockFlow);
+
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("mapPitchToDrum", ["tom", mockFlow]);
+        expect(drumBlocksAPI.runCommand).toHaveBeenCalledWith("mapPitchToDrum", ["tom", 0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe(drumBlocksAPI.ENDFLOWCOMMAND);
+    });
+
+    test("playNoise calls runCommand with correct arguments", () => {
+        JSInterface.validateArgs.mockReturnValue(["white"]);
+
+        drumBlocksAPI.playNoise("white");
+
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("playNoise", ["white"]);
+        expect(drumBlocksAPI.runCommand).toHaveBeenCalledWith("playNoise", ["white", 0]);
+    });
+});

--- a/js/js-export/API/__tests__/RhythmBlocksAPI.test.js
+++ b/js/js-export/API/__tests__/RhythmBlocksAPI.test.js
@@ -1,0 +1,129 @@
+const JSInterface = {
+    validateArgs: jest.fn(),
+};
+global.JSInterface = JSInterface;
+
+global.MusicBlocks = {
+    BLK: "mockBLK"
+};
+
+const RhythmBlocksAPI = require("../RhythmBlocksAPI");
+
+describe("RhythmBlocksAPI", () => {
+    let rhythmBlocksAPI;
+
+    beforeEach(() => {
+        rhythmBlocksAPI = new RhythmBlocksAPI();
+        rhythmBlocksAPI.turIndex = 0;
+        rhythmBlocksAPI.runCommand = jest.fn();
+        rhythmBlocksAPI.ENDFLOWCOMMAND = 'END';
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("playNote calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([100, mockFlow]);
+        
+        const result = await rhythmBlocksAPI.playNote(100, mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("playNote", [100, mockFlow]);
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("playNote", [100, "newnote", 0, "mockBLK"]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("playNoteMillis calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([1000, mockFlow]);
+        
+        const result = await rhythmBlocksAPI.playNoteMillis(1000, mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("playNoteMillis", [1000, mockFlow]);
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("playNote", [1000, "osctime", 0, "mockBLK"]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("playRest calls runCommand with correct arguments", () => {
+        rhythmBlocksAPI.playRest();
+        
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("playRest", [0]);
+    });
+
+    test("dot calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([1, mockFlow]);
+        
+        const result = await rhythmBlocksAPI.dot(1, mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("dot", [1, mockFlow]);
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("doRhythmicDot", [1, 0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("tie calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([undefined, mockFlow]);  // Changed to match implementation
+        
+        const result = await rhythmBlocksAPI.tie(mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("tie", [mockFlow]);
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("doTie", [0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("multiplyNoteValue calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([2, mockFlow]);
+        
+        const result = await rhythmBlocksAPI.multiplyNoteValue(2, mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("multiplyNoteValue", [2, mockFlow]);
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("multiplyNoteValue", [2, 0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("swing calls runCommand with correct arguments", async () => {
+        const mockFlow = jest.fn();
+        JSInterface.validateArgs.mockReturnValue([1, 4, mockFlow]);
+        
+        const result = await rhythmBlocksAPI.swing(1, 4, mockFlow);
+        
+        expect(JSInterface.validateArgs).toHaveBeenCalledWith("multiplyNoteValue", [1, 4, mockFlow]);  // Keep original validation method
+        expect(rhythmBlocksAPI.runCommand).toHaveBeenCalledWith("addSwing", [1, 4, 0]);
+        expect(mockFlow).toHaveBeenCalled();
+        expect(result).toBe("END");
+    });
+
+    test("methods handle validation errors correctly", async () => {
+        JSInterface.validateArgs.mockImplementation(() => {
+            throw new Error("Invalid arguments");
+        });
+
+        await expect(rhythmBlocksAPI.playNote()).rejects.toThrow("Invalid arguments");
+        await expect(rhythmBlocksAPI.playNoteMillis()).rejects.toThrow("Invalid arguments");
+        await expect(rhythmBlocksAPI.dot()).rejects.toThrow("Invalid arguments");
+        await expect(rhythmBlocksAPI.tie()).rejects.toThrow("Invalid arguments");
+        await expect(rhythmBlocksAPI.multiplyNoteValue()).rejects.toThrow("Invalid arguments");
+        await expect(rhythmBlocksAPI.swing()).rejects.toThrow("Invalid arguments");
+    });
+
+    test("methods handle command execution errors correctly", async () => {
+        JSInterface.validateArgs.mockReturnValue([1, jest.fn()]);
+        rhythmBlocksAPI.runCommand.mockRejectedValue(new Error("Command failed"));  // Changed to handle async rejection
+
+        await expect(rhythmBlocksAPI.playNote(1, jest.fn())).rejects.toThrow("Command failed");
+        await expect(rhythmBlocksAPI.playNoteMillis(1, jest.fn())).rejects.toThrow("Command failed");
+        await expect(rhythmBlocksAPI.playRest()).rejects.toThrow("Command failed");  // Added await
+        await expect(rhythmBlocksAPI.dot(1, jest.fn())).rejects.toThrow("Command failed");
+        await expect(rhythmBlocksAPI.tie(jest.fn())).rejects.toThrow("Command failed");
+        await expect(rhythmBlocksAPI.multiplyNoteValue(2, jest.fn())).rejects.toThrow("Command failed");
+        await expect(rhythmBlocksAPI.swing(1, 4, jest.fn())).rejects.toThrow("Command failed");
+    });
+});


### PR DESCRIPTION
## Summary of Changes

This pull request addresses issue #4200 by adding tests for the following files:

- **RhythmBlocksAPI**: V
- **DrumBlocksAPI**: 
![Screenshot from 2024-12-30 00-15-15](https://github.com/user-attachments/assets/39c1468e-e859-4ea4-9e92-9be5906b78fe)
