### PR TITLE
fix: pitch octave limit to a valid range in pie menu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1871,10 +1871,10 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
     block._exitWheel.navItems[2].navigateFunction = () => {
         const cblk = that.connections[0];
         if (
-            that.value > 9 &&
+            that.value >= 8 &&
             (that.blocks.blockList[cblk].name === "pitch")
         ) {
-            that.value = 10;
+            that.value = 8;
         } else {
             that.value += 1;
         }


### PR DESCRIPTION
Before:
[before.webm](https://github.com/user-attachments/assets/88c0fe46-e0cd-436d-9f57-b51269b0d5e1)

After:
[after.webm](https://github.com/user-attachments/assets/8d9fe12f-5762-4fc5-9187-9da7a233b6d6)

@walterbender Can you please review this.
