### PR TITLE
No need to extract the block again which is already extracted

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -260,6 +260,14 @@ class Blocks {
             /** Remove a single block from within a stack. */
             const blkObj = this.blockList[blk];
 
+            // Exit if already disconnected from parent
+            if (blkObj.connections[0] === null) {
+                this.activity.textMsg(
+                    _("The block is already extracted"), 3000
+                );
+                return;
+            }
+
             const firstConnection = blkObj.connections[0];
             let connectionIdx;
 


### PR DESCRIPTION
Resolve #4214 

No need to extract the block again which is already extracted. It indicates that the block is already extracted from its parent block.


https://github.com/user-attachments/assets/38220ccd-4b88-4b29-90e1-4f0a3e9bfd39

