### PR TITLE
Fix: Corrected MIDI pitch note addition bug

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1917,7 +1917,8 @@ function MusicKeyboard(activity) {
     this._createAddRowPieSubmenu = function () {
         docById("wheelDivptm").style.display = "";
         // docById("wheelDivptm").style.zIndex = "300";
-        const pitchLabels = ["do", "re", "mi", "fa", "sol", "la", "ti"];
+        const pitchLabels = [   "do", "do♯", "re", "re♯", "mi", "fa", "fa♯", "sol", "sol♯", "la", "la♯", "ti",
+        ];
         const hertzLabels = [262, 294, 327, 348, 392, 436, 490, 523];
         const VALUESLABEL = ["pitch", "hertz"];
         const VALUES = ["imgsrc: images/chime.svg", "imgsrc: images/synth.svg"];
@@ -2022,7 +2023,10 @@ function MusicKeyboard(activity) {
                     }
                 }
 
-                rLabel = pitchLabels[(i + 1) % pitchLabels.length];
+                do {
+                    rLabel = pitchLabels[(i + 1) % pitchLabels.length];
+                    i = (i + 1) % pitchLabels.length;
+                } while (this.layout.some(note => note.noteName === rLabel));
                 for (let j = this.layout.length; j > 0; j--) {
                     rArg = this.layout[j - 1].noteOctave;
                     if (isNaN(rArg)) {
@@ -2115,6 +2119,11 @@ function MusicKeyboard(activity) {
                     this.displayLayout = this.displayLayout.concat(sortedHertzList);
                     this._createKeyboard();
                     this._createTable();
+                    const n= this.layout.length;
+                    const key = this.layout[n-1];
+                    this.getElement[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
+                    this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
+                        key.objId; //convet solfege to alphabetic.
                 }, 500);
             } else {
                 // eslint-disable-next-line no-console

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1917,8 +1917,7 @@ function MusicKeyboard(activity) {
     this._createAddRowPieSubmenu = function () {
         docById("wheelDivptm").style.display = "";
         // docById("wheelDivptm").style.zIndex = "300";
-        const pitchLabels = [   "do", "do♯", "re", "re♯", "mi", "fa", "fa♯", "sol", "sol♯", "la", "la♯", "ti",
-        ];
+        const pitchLabels = ["do", "do♯", "re", "re♯", "mi", "fa", "fa♯", "sol", "sol♯", "la", "la♯", "ti"];
         const hertzLabels = [262, 294, 327, 348, 392, 436, 490, 523];
         const VALUESLABEL = ["pitch", "hertz"];
         const VALUES = ["imgsrc: images/chime.svg", "imgsrc: images/synth.svg"];
@@ -2119,8 +2118,8 @@ function MusicKeyboard(activity) {
                     this.displayLayout = this.displayLayout.concat(sortedHertzList);
                     this._createKeyboard();
                     this._createTable();
-                    const n= this.layout.length;
-                    const key = this.layout[n-1];
+                    const n = this.layout.length;
+                    const key = this.layout[n - 1];
                     this.getElement[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
                     this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
                         key.objId; //convet solfege to alphabetic.


### PR DESCRIPTION
### Description
This fix resolves an issue where newly added 'pitch' notes in the Music Keyboard Widget did not work with MIDI playback until the keyboard was restarted. While notes through virtual keyboard were clickable, they failed to  play with MIDI initially.
### Changes Made
1.Replaced the simpler pitchLabels array with a detailed version including sharps
2.Updated the logic to ensure new pitches don’t duplicate existing ones in the layout.
3.Ensured getElement mappings are updated immediately for new notes:
### Testing 
Verified that new pitches are functional immediately via MIDI without requiring a widget restart.






https://github.com/user-attachments/assets/55332aac-dd60-423b-891f-dbb68dd2082a

### Related Issue
Fixes #4149 - Bug in MIDI




