### PR TITLE
fix: prevent helpfulWheel from appearing on block right-click

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -510,23 +510,11 @@ class Activity {
                 (event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    if(this.beginnerMode) return;
-                    const x=event.clientX;
-                    const y=event.clientY;               
-                    const clickedOnBlock=this.blocks.blockList.some((block)=>{
-                        if (block.trash) return false;
-                        const blockX= block.container.x;
-                        const blockY= block.container.y;
-                        return x >= blockX && 
-                        x <= blockX + block.width &&
-                        y >= blockY && 
-                        y <= blockY + block.height;                            
-
-                    });
-                    if (!clickedOnBlock && event.target.id === "myCanvas") {
+                    if (this.beginnerMode) return;          
+                    if (!this.blocks.isCoordinateOnBlock(event.clientX, event.clientY) && 
+                        event.target.id === "myCanvas") {
                         this._displayHelpfulWheel(event);
-                    }
-                    
+                    }                 
                 },
                 false
             );

--- a/js/activity.js
+++ b/js/activity.js
@@ -510,11 +510,23 @@ class Activity {
                 (event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    if (!this.beginnerMode) {
-                        if (event.target.id === "myCanvas") {
-                            this._displayHelpfulWheel(event);
-                        }
+                    if(this.beginnerMode) return;
+                    const x=event.clientX;
+                    const y=event.clientY;               
+                    const clickedOnBlock=this.blocks.blockList.some((block)=>{
+                        if (block.trash) return false;
+                        const blockX= block.container.x;
+                        const blockY= block.container.y;
+                        return x >= blockX && 
+                        x <= blockX + block.width &&
+                        y >= blockY && 
+                        y <= blockY + block.height;                            
+
+                    });
+                    if (!clickedOnBlock && event.target.id === "myCanvas") {
+                        this._displayHelpfulWheel(event);
                     }
+                    
                 },
                 false
             );

--- a/js/activity.js
+++ b/js/activity.js
@@ -514,7 +514,7 @@ class Activity {
                     if (!this.blocks.isCoordinateOnBlock(event.clientX, event.clientY) && 
                         event.target.id === "myCanvas") {
                         this._displayHelpfulWheel(event);
-                    }                 
+                    }         
                 },
                 false
             );

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7036,5 +7036,25 @@ class Blocks {
         this.setSelectedBlocks = (blocks) => {
             this.selectedBlocks = blocks;
         };
+        
+        /**
+        * Checks if coordinates intersect with any block
+        * @public
+        * @param {number} x - The x coordinate to check
+        * @param {number} y - The y coordinate to check  
+        * @returns {boolean} True if coordinates intersect with a block
+        */
+        this.isCoordinateOnBlock = function(x, y) {
+            return this.blockList.some(block => {
+                if (block.trash) return false;
+                
+                const blockX = block.container.x;
+                const blockY = block.container.y;
+                return x >= blockX && 
+                    x <= blockX + block.width &&
+                    y >= blockY && 
+                    y <= blockY + block.height;
+            });
+        };
     }
 }


### PR DESCRIPTION
 #4217 

### Changes made
- Modified `doContextMenus` event handler to check if right-click intersects with block coordinates
- Added check to prevent helpfulWheel from appearing when blocks are clicked
- Improves menu behavior by ensuring only appropriate context menus appear

**Before fix:**
[Screencast from 02-01-25 12:03:14 AM IST.webm](https://github.com/user-attachments/assets/6e29de44-c207-462c-abbf-054d2d31870a)

**After fix:**
[Screencast from 02-01-25 12:40:36 AM IST.webm](https://github.com/user-attachments/assets/3dafba66-fb10-4732-82e8-f7f6eeec58c3)

