### PR TITLE
fixed the bug issue #4221

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -329,7 +329,7 @@ class Toolbar {
     renderLogoIcon(onclick) {
         const logoIcon = docById("mb-logo");
         if (this.language === "ja") {
-            logoIcon.innerHTML = '<img style="width: 100%;" src="images/logo-ja.svg">';
+            logoIcon.innerHTML = '<img style="width: 100%;" src="">';
         }
 
         logoIcon.onmouseenter = () => {


### PR DESCRIPTION

### Description  

This pull request resolves an issue where an additional guide icon/help icon appeared on the left side of the screen when the application language was set to Japanese. In all other languages, only a single help icon was displayed on the right side. The fix ensures consistency across all languages by removing the unnecessary guide icon in the Japanese language interface.  

### Changes Made  

- Removed the additional guide icon that appeared on the left side of the screen in the Japanese language interface.  
- Verified that only one help icon is displayed on the right side across all supported languages.  

### Screenshots  

1. **Before Fix (Japanese):**  
   ![Screenshot 2025-01-02 175714](https://github.com/user-attachments/assets/0d83f383-a2e2-4938-b8da-123a3f2aea5a)
 

2. **After Fix (Japanese):**  
   ![image3](https://github.com/user-attachments/assets/bbe4c7a6-8411-4354-baf7-e18ff5111d59)
  

