### PR TITLE
Add click event listener to close helpful wheel when clicking outside

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -570,6 +570,15 @@ class Activity {
                 wheel.navItems[i].setTooltip(_(ele.label));
                 wheel.navItems[i].navigateFunction = () => ele.fn(this);
             })
+            const closeHelpfulWheel = (e) => {
+                const isClickInside = helpfulWheelDiv.contains(e.target);
+                if (!isClickInside) {
+                    helpfulWheelDiv.style.display = "none"; 
+                    document.removeEventListener("click", closeHelpfulWheel);
+                }
+            };
+        
+            document.addEventListener("click", closeHelpfulWheel);
         }
 
         /**


### PR DESCRIPTION
This is a fix to issue #4050 

The piemenu now closes whenever you click anywhere in the canvas as well as on the cross icon.