### PR TITLE
highlights fix

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -994,6 +994,13 @@ class PhraseMaker {
                 lyricsInput.style.backgroundColor = "#FF6EA1";
 
                 inputCell.appendChild(lyricsInput);
+                inputCell.addEventListener("mouseover", (event) => {
+                    event.target.style.backgroundColor = platformColor.selectorSelected;
+                });
+
+                inputCell.addEventListener("mouseout", (event) => {
+                    event.target.style.backgroundColor = "#FF6EA1";
+                });
                 lyricsInput.addEventListener("focus", () => this.activity.isInputON = true);
                 lyricsInput.addEventListener("blur", () => this.activity.isInputON = false);
                 lyricsInput.addEventListener("input", (event) => {
@@ -3112,17 +3119,17 @@ class PhraseMaker {
                 // Using the alt attribute to store the note value
                 cell.setAttribute("alt", 1 / noteValue);
 
-                cell.onmouseover = (event) => {
+                cell.addEventListener("mouseover", (event) => {
                     if (event.target.style.backgroundColor !== "black") {
                         event.target.style.backgroundColor = platformColor.selectorSelected;
                     }
-                };
+                });
 
-                cell.onmouseout = (event) => {
+                cell.addEventListener("mouseout", (event) => {
                     if (event.target.style.backgroundColor !== "black") {
                         event.target.style.backgroundColor = event.target.getAttribute("cellColor");
                     }
-                };
+                });
             }
 
             // Add a note value.


### PR DESCRIPTION
While working on Phrase Maker I found this piece of code : 

![is](https://github.com/user-attachments/assets/0c3fec15-99bd-431d-8e4e-0123149abddf)

It was suppose to highlight cells on hovering but did not work. After using addEventListener it is working fine.
@walterbender  Please check this PR.

[fixed.webm](https://github.com/user-attachments/assets/776b82c8-3203-4724-9cca-5ccb55d3cfde)
