### PR TITLE
Made the Auxillary menu responsive

### DIFF
--- a/lib/materialize-iso.css
+++ b/lib/materialize-iso.css
@@ -3363,7 +3363,7 @@ i.left {
   
 }
 
-@media only screen and (max-width: 1004px) {
+@media only screen and (max-width: 1090px) {
 
   .materialize-iso .filler {
     display: none;
@@ -3377,7 +3377,7 @@ i.left {
   }
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 805px) {
   .materialize-iso .filler {
     display: none;
   }
@@ -3415,7 +3415,7 @@ i.left {
   }
 }
 
-@media only screen and (max-width: 550px) {
+@media only screen and (max-width: 690px) {
   .materialize-iso .filler, .materialize-iso .logo {
     display: none;
   }
@@ -3436,7 +3436,7 @@ i.left {
 }
 
 
-@media only screen and (max-width: 450px) {
+@media only screen and (max-width: 525px) {
   .materialize-iso .filler, .materialize-iso .logo {
     display: none;
   }
@@ -3461,33 +3461,23 @@ i.left {
 
 @media only screen and (max-width: 400px) {
   .materialize-iso .filler, .materialize-iso .logo {
-    display: block;
+    display: none;
   }
+
   .materialize-iso nav .main i.material-icons {
-    font-size: 18px;  
+    font-size: 15px;
     position: relative;
-    margin-left: -5px;
-    margin-right: -5px;
+    margin-left: -8px;
+    margin-right: -8px;
     padding: 0px;
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 16px;  
+    font-size: 12px;
     position: relative;
     margin-left: -7.5px;
     margin-right: -7.5px;
     padding: 0px;
-  }
-}
-
-@media only screen and (min-width: 360px) and (max-width: 400px) {
-  .materialize-iso nav .main i.material-icons,
-  .materialize-iso nav .aux i.material-icons {
-    font-size: 19px; 
-    position: relative;
-    margin-left: -4px; 
-    margin-right: -4px;
-    padding: 0; 
   }
 }
 

--- a/lib/materialize-iso.css
+++ b/lib/materialize-iso.css
@@ -3363,7 +3363,7 @@ i.left {
   
 }
 
-@media only screen and (max-width: 1090px) {
+@media only screen and (max-width:1100px) {
 
   .materialize-iso .filler {
     display: none;
@@ -3377,7 +3377,7 @@ i.left {
   }
 }
 
-@media only screen and (max-width: 805px) {
+@media only screen and (max-width: 820px) {
   .materialize-iso .filler {
     display: none;
   }
@@ -3444,8 +3444,8 @@ i.left {
   .materialize-iso nav .main i.material-icons {
     font-size: 20px;
     position: relative;
-    margin-left: -5px;
-    margin-right: -5px;
+    margin-left: -8px;
+    margin-right: -8px;
     padding: 0px;
   }
 
@@ -3457,7 +3457,6 @@ i.left {
     padding: 0px;
   }
 }
-
 
 @media only screen and (max-width: 400px) {
   .materialize-iso .filler, .materialize-iso .logo {


### PR DESCRIPTION
This PR closes #4121 

In advance mode the auxiliary menu items was breaking into next line.
![Screenshot 2025-01-07 205113](https://github.com/user-attachments/assets/7b259109-f3d0-413c-ac29-9069aa014673)

After changes:
https://github.com/user-attachments/assets/4d439837-09c9-4d77-8f59-359f2defb97b

