### PR TITLE
fix:disable save button when the project is playing (#4239)

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -361,12 +361,20 @@ class Toolbar {
         function handleClick() {
             if (!isPlayIconRunning) {
                 playIcon.onclick = null;
+                saveButton.disabled = true;
+                saveButtonAdvanced.disabled = true;
+                saveButton.className = "grey-text inactiveLink";
+                saveButtonAdvanced.className = "grey-text inactiveLink";
                 // eslint-disable-next-line no-console
                 console.log("Wait for next 2 seconds to play the music");
             } else {
                 // eslint-disable-next-line no-use-before-define
                 playIcon.onclick = tempClick;
                 isPlayIconRunning = false;
+                saveButton.disabled = false;
+                saveButtonAdvanced.disabled = false;
+                saveButton.className = "";
+                saveButtonAdvanced.className = "";
             }
         }
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -357,6 +357,7 @@ class Toolbar {
         const stopIcon = docById("stop");
 
         let isPlayIconRunning = false;
+        const recordButton = docById("record");
 
         function handleClick() {
             if (!isPlayIconRunning) {
@@ -365,6 +366,9 @@ class Toolbar {
                 saveButtonAdvanced.disabled = true;
                 saveButton.className = "grey-text inactiveLink";
                 saveButtonAdvanced.className = "grey-text inactiveLink";
+                recordButton._tempOnClick = recordButton.onclick;
+                recordButton.onclick = null;
+                recordButton.style.opacity = "0.4";
                 // eslint-disable-next-line no-console
                 console.log("Wait for next 2 seconds to play the music");
             } else {
@@ -375,6 +379,8 @@ class Toolbar {
                 saveButtonAdvanced.disabled = false;
                 saveButton.className = "";
                 saveButtonAdvanced.className = "";
+                recordButton.onclick = recordButton._tempOnClick;
+                recordButton.style.opacity = "1";
             }
         }
 


### PR DESCRIPTION
### Description
This PR addresses issue (#4239) by disabling the save and record buttons while a project is playing to prevent buggy behavior.

### Changes made
- Added functionality to disable save and record buttons when play is clicked
- Re-enable save buttons and record buttons when playback stops

### Screenshot
[Screencast from 08-01-25 02:33:14 AM IST.webm](https://github.com/user-attachments/assets/8de1abe1-4fb3-44f8-aee8-33ce07d98eaf)

