### PR TITLE
fix: duplicate icon removed for japanese

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -328,9 +328,6 @@ class Toolbar {
      */
     renderLogoIcon(onclick) {
         const logoIcon = docById("mb-logo");
-        if (this.language === "ja") {
-            logoIcon.innerHTML = '<img style="width: 100%;" src="images/logo-ja.svg">';
-        }
 
         logoIcon.onmouseenter = () => {
             document.body.style.cursor = "pointer";


### PR DESCRIPTION
Fixes #4221

Only one help icon displayed on the right side of the screen, regardless of the selected language, maintaining consistency across all languages.

![musicblocks](https://github.com/user-attachments/assets/331a35c7-358f-4005-9429-f7c5579e8654)

Ran tests locally on windows resolving the issue.