### PR TITLE
enhancement: utils.JS Translation Method

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -167,7 +167,7 @@ let format = (str, data) => {
             if (x === undefined) {
                 // eslint-disable-next-line no-console
                 console.debug("Undefined value in template string", str, name, x, v);
-            }  
+            }
 
             x = x[v];
         });
@@ -179,7 +179,6 @@ let format = (str, data) => {
         return _(item);
     });
 };
-
 
 /**
  * Detects the current browser name.

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -58,58 +58,95 @@ const changeImage = (imgElement, from, to) => {
 };
 
 /**
- * A simple localization function for translating strings.
+ * Enhanced _() method to handle case variations for translations
+ * prioritize exact matches and preserve the case of the input text.
  * @function
  * @param {string} text - The input text to be translated.
  * @returns {string} The translated text.
  */
 function _(text) {
-    if (text === null) {
+    if (text === null || text === undefined) {
         // console.debug("null string passed to _");
         return "";
     }
 
-    let replaced = text;
-    const replace = [
-        ",",
-        "(",
-        ")",
-        "?",
-        "¿",
-        "<",
-        ">",
-        ".",
-        "\n",
-        '"',
-        ":",
-        "%s",
-        "%d",
-        "/",
-        "'",
-        ";",
-        "×",
-        "!",
-        "¡"
-    ];
-    for (let p = 0; p < replace.length; p++) {
-        replaced = replaced.replace(replace[p], "");
-    }
-
-    replaced = replaced.replace(/ /g, "-");
-
-    if (localStorage.kanaPreference === "kana") {
-        const lang = document.webL10n.getLanguage();
-        if (lang === "ja") {
-            replaced = "kana-" + replaced;
-        }
-    }
-
     try {
-        let translation = document.webL10n.get(replaced);
-        if (translation === "") {
-            translation = text;
+        // Replace certain characters from the input text
+        const replace = [
+            ",",
+            "(",
+            ")",
+            "?",
+            "¿",
+            "<",
+            ">",
+            ".",
+            "\n",
+            '"',
+            ":",
+            "%s",
+            "%d",
+            "/",
+            "'",
+            ";",
+            "×",
+            "!",
+            "¡"
+        ];
+
+        let replaced = text;
+
+        // to remove unwanted characters
+        for (let p = 0; p < replace.length; p++) {
+            replaced = replaced.split(replace[p]).join(""); // Efficient replacement
         }
-        return translation;
+        
+        //the replaced version is the version WITHOUT the unwanted characters.
+        replaced = replaced.replace(/ /g, "-");
+
+        if (localStorage.kanaPreference === "kana") {
+            const lang = document.webL10n.getLanguage();
+            if (lang === "ja") {
+                replaced = "kana-" + replaced;
+            }
+        }
+
+        // first, we actually tried to find out if there was an existing translation with SAME case
+        let translated = document.webL10n.get(text);
+
+        // Takes, for example
+        if ((!translated || translated === text) && replaced !== text) {
+            translated = document.webL10n.get(replaced);
+        }
+
+        // If still no translation is found, try the lowercase version
+        if (!translated || translated === text) {
+            translated = document.webL10n.get(text.toLowerCase());
+        }
+
+        //if still no translation is found, try the initial caps translation too
+        if (!translated || translated === text) {
+            const initialCaps = text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();
+            translated = document.webL10n.get(initialCaps);
+        }
+
+        //function returns the ORIGINAL case without any translation if no translation exists
+        translated = translated || text;
+
+        // this if ensures Correct LETTER CASING, for example, "Search" -> "Buscar" and "SEARCH" -> "BUSCAR" and "search" -> "buscar"
+        if (text === text.toUpperCase()) {
+            //if the input is all uppercase, then we will return the translation in uppercase
+            return translated.toUpperCase();
+        } else if (text === text.toLowerCase()) {
+            //if the input is all lowercase,then return the translation in lowercase
+            return translated.toLowerCase();
+        } else if (text.charAt(0).toUpperCase() + text.slice(1).toLowerCase() === text) {
+            //if the input is in title case, then return the translation in title case
+            return translated.charAt(0).toUpperCase() + translated.slice(1).toLowerCase();
+        }
+
+        // return the translation as is if any of the case does not match
+        return translated;
     } catch (e) {
         // console.debug("i18n error: " + text);
         return text;
@@ -130,7 +167,7 @@ let format = (str, data) => {
             if (x === undefined) {
                 // eslint-disable-next-line no-console
                 console.debug("Undefined value in template string", str, name, x, v);
-            }
+            }  
 
             x = x[v];
         });
@@ -142,6 +179,7 @@ let format = (str, data) => {
         return _(item);
     });
 };
+
 
 /**
  * Detects the current browser name.


### PR DESCRIPTION
@walterbender as you told, I have enhanced the _() method for better translations.
It's a pretty big change in the functionality.

## Issue:
Earlier, _() method didn't recogonize "Search" as "search" and wouldn't give translated text since translation for "Search" was not given but "search" was.

## Translation with enhanced _() method:
![127 0 0 1_3000 - Google Chrome 13-01-2025 09_32_06](https://github.com/user-attachments/assets/bdde5e5c-ad2c-47c0-a2b7-e1d68c226f31)
![127 0 0 1_3000 - Google Chrome 13-01-2025 09_34_04](https://github.com/user-attachments/assets/b78bf3c2-985b-4429-9a01-e352835ec30f)
