### PR TITLE
Fix/Japanese Loader, Header and Icon update

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,13 +154,10 @@
                         console.debug("Reverting to " + lang);
                     }
 
-
                     document.getElementById("loading-image-container").innerHTML =
                         '<video loop autoplay muted playsinline style="width: 100%; height:500px; margin-top:30px; overflow: hidden;"><source src="loading-animation.webm" type="video/webm"><source src="loading-animation.mp4" type="video/mp4"></video>';
                     
                 };
-
-
 
                 loadL10nSplashScreen();
             </script>

--- a/index.html
+++ b/index.html
@@ -137,39 +137,30 @@
             style="position: absolute; width: 100%; height: 100%;cursor: wait; text-align: center; background-color: #FFFFFF;"
         >
             <script>
-                let loadL10nSplashScreen = function() {
-                    console.debug(
-                        "The browser is set to " + navigator.language
-                    );
+                let loadL10nSplashScreen = function () {
+                    console.debug("The browser is set to " + navigator.language);
+
                     let lang = navigator.language;
                     if (localStorage.languagePreference) {
                         console.debug(
-                            "Music Blocks is set to " +
-                                localStorage.languagePreference
+                            "Music Blocks is set to " + localStorage.languagePreference
                         );
                         lang = localStorage.languagePreference;
                     }
 
                     console.debug("Using " + lang);
-		    if (lang === undefined) {
-			lang = "enUS";
-			console.debug("Reverting to " + lang);
-		    }
-                    
-                    // Intentional placement of SVG image per user request by Japanese Schools.
-                    
-                    if (lang === "ja") {
-                        document.getElementById(
-                            "loading-image-container"
-                        ).innerHTML =
-                            '<img src="loading-animation-ja.svg" style="width: 100%; margin: auto; display: block; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);" />';
-                    } else {
-                        document.getElementById(
-                            "loading-image-container"
-                        ).innerHTML =
-                            '<video loop autoplay muted playsinline style="width: 100%; height:500px; margin-top:30px; overflow: hidden;"><source src="loading-animation.webm" type="video/webm"><source src="loading-animation.mp4" type="video/mp4"></video>';
+                    if (lang === undefined) {
+                        lang = "enUS";
+                        console.debug("Reverting to " + lang);
                     }
+
+
+                    document.getElementById("loading-image-container").innerHTML =
+                        '<video loop autoplay muted playsinline style="width: 100%; height:500px; margin-top:30px; overflow: hidden;"><source src="loading-animation.webm" type="video/webm"><source src="loading-animation.mp4" type="video/mp4"></video>';
+                    
                 };
+
+
 
                 loadL10nSplashScreen();
             </script>

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -328,9 +328,6 @@ class Toolbar {
      */
     renderLogoIcon(onclick) {
         const logoIcon = docById("mb-logo");
-        if (this.language === "ja") {
-            logoIcon.innerHTML = '<img style="width: 100%;" src="images/logo-ja.svg">';
-        }
 
         logoIcon.onmouseenter = () => {
             document.body.style.cursor = "pointer";

--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -425,9 +425,6 @@ const createHelpContent = (activity) => {
     }
 
     let LOGO = LOGODEFAULT;
-    if (language === "ja") {
-        LOGO = LOGOJA;
-    }
 
     if (_THIS_IS_TURTLE_BLOCKS_) {
         HELPCONTENT = [


### PR DESCRIPTION
fixes both : #4221 AND #4220 

# Issues:
## 1) Inconsistent loading screen both Japanese and Kana-japanese language:

![ミュージック・ブロックス - Google Chrome 12-01-2025 16_50_33](https://github.com/user-attachments/assets/6ff350a1-907f-499a-a8e4-617248c8ad1d)

## 2) Incorrect logo for both Japanese and Kana-Japanese language.

### Japanese:
![ミュージック・ブロックス - Google Chrome 12-01-2025 16_53_55](https://github.com/user-attachments/assets/6602b2de-d69f-42ea-80c0-d1c95ce77c13)

## Kana- Japanese
![ミュージック・ブロックス - Google Chrome 12-01-2025 16_51_54](https://github.com/user-attachments/assets/78206357-8373-48c4-9be2-6865e246d14d)



# After fixing:
## Loading screen:
![Music Blocks - Google Chrome 13-01-2025 11_26_20](https://github.com/user-attachments/assets/71ca597a-e32d-41fb-8ef2-48cf2360a234)


## Logos:
### Japanese:
![Music Blocks - Google Chrome 13-01-2025 11_29_21](https://github.com/user-attachments/assets/3cfc115f-3e55-4c76-a61e-79a1d57f136b)

### Kana-Japanese:
![Music Blocks - Google Chrome 13-01-2025 11_31_08](https://github.com/user-attachments/assets/a9be9ab0-e117-4c91-915c-d62de0d004ae)
