### PR TITLE
Reposition guide within help widget

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -476,6 +476,14 @@ const createHelpContent = (activity) => {
                     _("Let us start our tour!"),
                 "data:image/svg+xml;base64," +
                     window.btoa(base64Encode(MOUSEPALETTEICON))
+            ],            
+            [
+                _("Guide"),
+                _("A detailed guide to Music Blocks is available."),
+                "data:image/svg+xml;base64," +
+                    window.btoa(base64Encode(LOGO)),
+                GUIDEURL,
+                _("Music Blocks Guide")
             ],
             [
                 _("Play"),
@@ -697,7 +705,7 @@ const createHelpContent = (activity) => {
             "data:image/svg+xml;base64," +
                 window.btoa(
                     base64Encode(PLUGINSDELETEBUTTON))
-                
+
         ]);
         HELPCONTENT.push([
             _("Enable scrolling"),
@@ -705,8 +713,8 @@ const createHelpContent = (activity) => {
             "data:image/svg+xml;base64," +
                 window.btoa(
                     base64Encode(SCROLLUNLOCKBUTTON))
-                
-        ]);
+
+        ]);        
     }
     // TODO: Add merge
     HELPCONTENT.push([
@@ -715,7 +723,7 @@ const createHelpContent = (activity) => {
         "data:image/svg+xml;base64," +
             window.btoa(
                 base64Encode(WRAPTURTLEBUTTON))
-            
+
     ]);
     // TODO: Music Blocks: set pitch preview
     // TODO: toggle JS editor
@@ -725,7 +733,7 @@ const createHelpContent = (activity) => {
         "data:image/svg+xml;base64," +
             window.btoa(
                 base64Encode(RESTORETRASHBUTTON))
-            
+                            
     ]);
     HELPCONTENT.push([
         _("Switch mode"),
@@ -785,14 +793,6 @@ const createHelpContent = (activity) => {
                 window.btoa(base64Encode(LOGO))
         ]);
     } else {
-        HELPCONTENT.push([
-            _("Guide"),
-            _("A detailed guide to Music Blocks is available."),
-            "data:image/svg+xml;base64," +
-                window.btoa(base64Encode(LOGO)),
-            GUIDEURL,
-            _("Music Blocks Guide")
-        ]);
         HELPCONTENT.push([
             _("About"),
             _("Music Blocks is an open source collection of tools for exploring musical concepts.") +


### PR DESCRIPTION
## Summary

This pull request repositions the guide link within the help widget to enhance usability for students by directing them to the [guide.html](https://musicblocks.sugarlabs.org/guide/guide.html) file for study purposes.

## Changes introduced

- Moved the guide link in the help widget to the 3rd position (immediately after the 'Meet Mr. Mouse' section). Previously, it was located at the end of the menu.
- Improved code readability by rearranging certain sections.

## Screenshots/video

https://github.com/user-attachments/assets/4fa76192-5dae-415b-8e6c-a4576416deb2

## Checklist

- [x] The changes adhere to the project's contribution guidelines.
- [x] Code changes have been implemented and tested.