### PR TITLE
Fix: Ensure helpfulSearchDiv hides consistently on context menu

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -513,7 +513,10 @@ class Activity {
                 (event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    if (this.beginnerMode) return;          
+                    if (this.beginnerMode) return;
+                    if (this.isHelpfulSearchWidgetOn) {
+                        this._hideHelpfulSearchWidget();
+                    }
                     if (!this.blocks.isCoordinateOnBlock(event.clientX, event.clientY) && 
                         event.target.id === "myCanvas") {
                         this._displayHelpfulWheel(event);


### PR DESCRIPTION
### Description
 Fixes #4275 

### What does this PR do?
This pull request fixes an issue where the helpfulSearchDiv widget does not hide consistently when the context menu is triggered on the canvas. This ensures a cleaner UI and a better user experience.

### Key changes
Added a check while opening do context menu to ensure if the helpfulSearchWidget is on, it closes before opening the menu, the method being already defined as _hideHelpfulSearchDiv

###Screenshots
[Screencast from 15-01-25 03:05:23 PM IST.webm](https://github.com/user-attachments/assets/7e78f6b0-7448-4fc8-bbe8-dc91236bbcd4)

special thanks @haroon10725 and @walterbender for pointing out the bug
