### PR TITLE
Fix: LilyPond FileName issue

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -533,6 +533,7 @@ class SaveInterface {
     * @instance
     */
     afterSaveLilypond(filename) {
+        filename = docById("fileName").value;
         const ly = saveLilypondOutput(this.activity);
         switch (this.notationConvert) {
             case "pdf":
@@ -559,6 +560,7 @@ class SaveInterface {
      */
 
     afterSaveLilypondLY(lydata, filename) {
+        filename = docById("fileName").value;
         if (platform.FF) {
             // eslint-disable-next-line no-console
             console.debug('execCommand("copy") does not work on FireFox');

--- a/js/activity.js
+++ b/js/activity.js
@@ -1510,6 +1510,8 @@ class Activity {
                 activity.save.savePNG.bind(activity.save),
                 activity.save.saveWAV.bind(activity.save),
                 activity.save.saveLilypond.bind(activity.save),
+                activity.save.saveLilypond.bind(afterSaveLilypond),
+                activity.save.afterSaveLilypondLY.bind(activity.save),
                 activity.save.saveAbc.bind(activity.save),
                 activity.save.saveMxml.bind(activity.save),
                 activity.save.saveBlockArtwork.bind(activity.save)


### PR DESCRIPTION
fixes: #4286 

https://github.com/user-attachments/assets/6a8de70f-f6be-4d80-8c6d-f6233d754f92



now it only asks the user for the filename once, and that's the final one.
