### PR TITLE
Add page count in Take A Tour section 

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -982,6 +982,7 @@ table {
 #helpBodyDiv .message {
   text-align: center;
   line-height: 1.2;
+  margin: auto;
 }
 
 #helpBodyDiv .icon-container {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -325,6 +325,8 @@ class HelpWidget {
     _showPage(page) {
         const helpBody = docById("helpBodyDiv");
         helpBody.innerHTML = "" ;
+        const totalPages = HELPCONTENT.length;
+        const pageCount = `Page ${page + 1} of ${totalPages}`;
 
         // Previous HTML content is removed, and new one is generated. 
         let body = "";
@@ -345,8 +347,8 @@ class HelpWidget {
         
         const helpContentHTML =
         `<h1 class="heading">${HELPCONTENT[page][0]}</h1> 
-         <p class ="description">${HELPCONTENT[page][1]}</p>
-        ` ;
+         <p class="description">${HELPCONTENT[page][1]}</p>
+         <p>${pageCount}</p>`;
         
         body += helpContentHTML ;
 

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -326,7 +326,7 @@ class HelpWidget {
         const helpBody = docById("helpBodyDiv");
         helpBody.innerHTML = "" ;
         const totalPages = HELPCONTENT.length;
-        const pageCount = `Page ${page + 1} of ${totalPages}`;
+        const pageCount = `${page + 1}/${totalPages}`;
 
         // Previous HTML content is removed, and new one is generated. 
         let body = "";


### PR DESCRIPTION
Adding page count in Take A Tour section for better user experience. Previously there was no idea about how long the basic tutorial of MB will take place. But if we add a page count so that user can get a idea about the tutorial. 

![Screenshot 2025-01-18 131907](https://github.com/user-attachments/assets/1d426c00-5326-43fe-a6b9-2af6710d96c5)
![Screenshot 2025-01-18 131927](https://github.com/user-attachments/assets/5061a565-4013-47fb-9cc8-7d1acd0c792a)
