### PR TITLE
fix: resolve docById undefined error 

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -31,4 +31,4 @@ requirejs.config({
     packages: []
 });
 
-requirejs(["activity/activity"]);
+requirejs(["utils/utils", "activity/activity"]);


### PR DESCRIPTION
### Description
fixes #4292 

fix: resolve docById undefined error by ensuring utils.js loads before activity.js

The error "ReferenceError: docById is not defined" was occurring in activity.js
because it was trying to use docById before utils.js was fully loaded. Fixed
this race condition by explicitly ordering module dependencies in RequireJS
to ensure utils.js loads before activity.js.

- Modified loader.js to load utils/utils before activity/activity
- Maintains existing folder structure and RequireJS paths configuration
- No changes to function definitions required