### PR TITLE
Hide trash icon when collapsing or expanding a block

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2895,8 +2895,7 @@ class Block {
             }, LONGPRESSTIME);
 
             //hide the trash when block is being collapse or expand
-            const hasColExpBtns =
-                this.collapseButtonBitmap && this.expandButtonBitmap;
+            const hasColExpBtns = this.collapseButtonBitmap && this.expandButtonBitmap;
 
             if (hasColExpBtns) {
                 const localPoint = this.container.globalToLocal(event.stageX, event.stageY);

--- a/js/block.js
+++ b/js/block.js
@@ -2894,6 +2894,22 @@ class Block {
                 that.blocks.triggerLongPress();
             }, LONGPRESSTIME);
 
+            //hide the trash when block is being collapse or expand
+            const hasColExpBtns =
+                this.collapseButtonBitmap && this.expandButtonBitmap;
+
+            if (hasColExpBtns) {
+                const localPoint = this.container.globalToLocal(event.stageX, event.stageY);
+                const isColExpClick =
+                    this.collapseButtonBitmap.getBounds().contains(localPoint.x, localPoint.y) ||
+                    this.expandButtonBitmap.getBounds().contains(localPoint.x, localPoint.y);
+
+                if (isColExpClick) {
+                    that.activity.trashcan.hide();
+                    return;
+                }
+            }
+            
             // Always show the trash when there is a block selected,
             that.activity.trashcan.show();
 


### PR DESCRIPTION
resolves #3849 

In this issue mentioned that the delete icon pop-up when we collapse or expand a block but the collapse and expand works properly. Only issue that the trash icon pop-up when expanding or collapsing a block. 

In this PR, the trash icon not appears when the block is collapsed or expanded and only pop-up when we perform other interaction with block.


https://github.com/user-attachments/assets/7d6a2d1b-531e-4ea7-97a9-4460751afd6d


