### PR TITLE
fix: Add stage initialization check in _onResize

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3142,6 +3142,9 @@ class Activity {
                     this.saveLocally();
                 }
             }
+            if (!this.stage) {
+                return;
+            }
 
             const $j = jQuery.noConflict();
             let w = 0,


### PR DESCRIPTION
### Description
fixes #4300
This PR adds a defensive check in the `_onResize` method to ensure `this.stage` is properly initialized before executing resize operations. This prevents potential errors during the application's initialization phase.

### Changes Made
- Added initialization check at the start of `_onResize` method
- Added early return if stage is not initialized
- Maintains existing resize functionality when stage is ready

### Before
The `_onResize` method would attempt to access `this.stage` properties before initialization was complete.

### After
Method is only called when the stage is available

### Testing Done
- Verified application loads without errors
- Confirmed resize functionality works as expected after initialization
- Tested resize behavior across different browsers