### PR TITLE
Confirmation for changing theme

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -461,9 +461,19 @@ class Toolbar {
 
     renderDarkModeIcon(onclick) {
         const darkModeIcon = docById("darkModeIcon");
+        const MSGPrefix =
+        "<div id='theme-link' " +
+            "onMouseOver='this.style.opacity = 0.5'" +
+            "onMouseOut='this.style.opacity = 1'>";
+        const MSGSuffix = "</div>"; 
 
         darkModeIcon.onclick = () => {
-            onclick();
+            this.activity.textMsg(MSGPrefix + "Refresh your browser." + MSGSuffix);
+
+            const themeLink = docById("theme-link");
+            themeLink.addEventListener( "click", () => {
+                onclick();
+            })
         }
     }
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -468,7 +468,7 @@ class Toolbar {
         const MSGSuffix = "</div>"; 
 
         darkModeIcon.onclick = () => {
-            this.activity.textMsg(_(MSGPrefix + "Refresh your browser to change your theme." + MSGSuffix));
+            this.activity.textMsg(MSGPrefix + _("Refresh your browser to change your theme.") + MSGSuffix);
 
             const themeLink = docById("theme-link");
             themeLink.addEventListener( "click", () => {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -468,7 +468,7 @@ class Toolbar {
         const MSGSuffix = "</div>"; 
 
         darkModeIcon.onclick = () => {
-            this.activity.textMsg(MSGPrefix + "Refresh your browser to change your theme." + MSGSuffix);
+            this.activity.textMsg(_(MSGPrefix + "Refresh your browser to change your theme." + MSGSuffix));
 
             const themeLink = docById("theme-link");
             themeLink.addEventListener( "click", () => {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -468,7 +468,7 @@ class Toolbar {
         const MSGSuffix = "</div>"; 
 
         darkModeIcon.onclick = () => {
-            this.activity.textMsg(MSGPrefix + "Refresh your browser." + MSGSuffix);
+            this.activity.textMsg(MSGPrefix + "Refresh your browser to change your theme." + MSGSuffix);
 
             const themeLink = docById("theme-link");
             themeLink.addEventListener( "click", () => {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -461,15 +461,10 @@ class Toolbar {
 
     renderDarkModeIcon(onclick) {
         const darkModeIcon = docById("darkModeIcon");
-        const MSGPrefix =
-        "<div id='theme-link' " +
-            "onMouseOver='this.style.opacity = 0.5'" +
-            "onMouseOut='this.style.opacity = 1'>";
-        const MSGSuffix = "</div>"; 
 
         darkModeIcon.onclick = () => {
-            this.activity.textMsg(MSGPrefix + _("Refresh your browser to change your theme.") + MSGSuffix);
-
+            this.activity.textMsg(`<div id="theme-link" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=1"> ${_("Refresh your browser to change your theme.")} </div>`);
+              
             const themeLink = docById("theme-link");
             themeLink.addEventListener( "click", () => {
                 onclick();


### PR DESCRIPTION
Currently the theme changes without giving a confirmation and refresh the browser.

I have added a confirmation message for theme change,

vedio:

https://github.com/user-attachments/assets/837c8eeb-7cdf-4ba4-b6e7-c267442cc11e

on clicking the text message the browser refresh and new theme is applied.

@walterbender we have the same workflow for changing the language, so I thought we should also have that kind of workflow for changing the theme.
Please review.