### PR TITLE
Adding Play-Only-Mode to MusicBlocks

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -12,6 +12,8 @@
 }
 */
 
+@import url("play-only-mode.css");
+
 *:focus {
   outline: none;
 }

--- a/css/play-only-mode.css
+++ b/css/play-only-mode.css
@@ -1,0 +1,36 @@
+.play-only #palette {
+    display: none !important; 
+    visibility: hidden !important; 
+    height: 0 !important; 
+    width: 0 !important; 
+    pointer-events: none !important; 
+    overflow: hidden !important;
+}   
+
+.play-only #Grid {
+    display: none !important; 
+    visibility: hidden !important; 
+    height: 0 !important; 
+    width: 0 !important; 
+    pointer-events: none !important; 
+    overflow: hidden !important; 
+}
+
+.play-only #Clear {
+    display: none !important; 
+    visibility: hidden !important; 
+    height: 0 !important; 
+    width: 0 !important; 
+    pointer-events: none !important; 
+    overflow: hidden !important; 
+}
+
+.play-only #Collapse {
+    display: none !important; 
+    visibility: hidden !important; 
+    height: 0 !important; 
+    width: 0 !important; 
+    pointer-events: none !important; 
+    overflow: hidden !important;
+}
+

--- a/index.html
+++ b/index.html
@@ -973,6 +973,21 @@
           </script>
         </div>
         </div>
+        <script>
+            function togglePlayOnlyMode() {
+                const isSmallScreen =
+                    window.innerWidth < 768 || window.innerHeight < 600;
+                const body = document.body;
+                if (isSmallScreen) {
+                    body.classList.add("play-only");
+                } else {
+                    body.classList.remove("play-only");
+                }
+            }
+            togglePlayOnlyMode();
+            window.addEventListener("resize", togglePlayOnlyMode);
+        </script>
+        
         <div id="searchBar" tabindex="-1">
             <input
                 type="text"


### PR DESCRIPTION
I have made some changes regarding the play-only-mode features, basically now the palette goes away whenever the play-only-mode is triggered. This mode is triggered automatically when the screen size goes below 768px in width or 600px in height. These are the basic changes i have made till now. I'll be adding more features to this to make this a better working feature in the upcoming days after taking inputs on what should be added. For now it looks something like this.


https://github.com/user-attachments/assets/9c5dafd3-a2a6-4437-b8a0-52fec02317eb


@walterbender @pikurasa I am still not sure on what features should be added to the dropdown menu. Please take a look at this till now and suggest if this looks good.
