### PR TITLE
Syncing dark mode between planet page and main page

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6677,10 +6677,18 @@ class Activity {
             // Function to toggle theme mode
             this.toggleThemeMode = () => {
                 if (this.storage.myThemeName === "darkMode") {
-                    // If currently in dark mode, remove the theme
                     delete this.storage.myThemeName;
+                    localStorage.setItem("darkMode", "disabled");
                 } else {
                     this.storage.myThemeName = "darkMode";
+                    localStorage.setItem("darkMode", "enabled");
+                }
+                const planetIframe = document.getElementById("planet-iframe");
+                if (planetIframe) {
+                    planetIframe.contentWindow.postMessage(
+                        { darkMode: localStorage.getItem("darkMode") },
+                        "*"
+                    );
                 }
                 try {
                     window.location.reload();

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -307,7 +307,6 @@ class PlanetInterface {
          */
         this.init = async () => {
             this.iframe = document.getElementById("planet-iframe");
-            this.iframe.style.backgroundColor = platformColor.background;
             try {
                 await this.iframe.contentWindow.makePlanet(
                     _THIS_IS_MUSIC_BLOCKS_,

--- a/planet/index.html
+++ b/planet/index.html
@@ -338,11 +338,5 @@
                 </div>
             </div>
         </div>
-        <script>
-            // Dark Mode Toggle Functionality
-            document.getElementById('toggle-dark-mode').addEventListener('click', function () {
-                document.body.classList.toggle('dark-mode');
-            });
-        </script>
     </body>
 </html>

--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -150,3 +150,30 @@ class Planet {
     };
 
 }
+
+// trigger and sync the dark mode of the planet with the main page
+document.addEventListener("DOMContentLoaded", function () {
+    const toggleButton = document.getElementById("toggle-dark-mode");
+
+    if (localStorage.getItem("darkMode") === "enabled") {
+        document.body.classList.add("dark-mode");
+    }
+    if (toggleButton) {
+        toggleButton.addEventListener("click", function () {
+            document.body.classList.toggle("dark-mode");
+            const newMode = document.body.classList.contains("dark-mode") ? "enabled" : "disabled";
+
+            localStorage.setItem("darkMode", newMode);
+            localStorage.setItem("darkModeTrigger", Date.now());
+        });
+    }
+    window.addEventListener("storage", function (event) {
+        if (event.key === "darkMode" || event.key === "darkModeTrigger") {
+            if (localStorage.getItem("darkMode") === "enabled") {
+                document.body.classList.add("dark-mode");
+            } else {
+                document.body.classList.remove("dark-mode");
+            }
+        }
+    });
+});


### PR DESCRIPTION
Earlier the Dark mode of the main page is not synced with the planet page dark mode after these changes 
the dark mode of the planet is automatically tiggered when there is change in the theme of the main page therfore creating a sync of theme between two different pages. 

before:

https://github.com/user-attachments/assets/d10c618b-4418-430b-9160-b8e83695776d

after :

https://github.com/user-attachments/assets/cd6f5f80-456f-4b2f-9263-ae4bd35c5561

