### PR TITLE
Show trash icon when dragging a block and hovering over another icon

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3111,7 +3111,9 @@ class Block {
         }
 
         // Always hide the trash when there is no block selected.
-        this.activity.trashcan.hide();
+        if (!moved) {
+            this.activity.trashcan.hide();
+        }
 
         if (this.blocks.longPressTimeout != null) {
             clearTimeout(this.blocks.longPressTimeout);


### PR DESCRIPTION
Resolve #3835 

Before while dragging the block, when hover another icon, the trash icon disappears.
Anyway if the block is dropped in the same place where the trash icon was there, the functionality of delete block works, hence the block gets deleted.

Before : 

https://github.com/user-attachments/assets/39b7fff6-adc0-43dd-899e-05e1405a6dcd

After : The trash icon remains visible even if hover other icon while dragging the block.


https://github.com/user-attachments/assets/b7971928-dcf7-4140-801e-de39d16d8dc2

