### PR TITLE
Removing the toggle dark mode button from the Planet page

### DIFF
--- a/planet/index.html
+++ b/planet/index.html
@@ -69,7 +69,6 @@
                 <a id="logo-container" class="brand-logo inactiveLink"><i class="material-icons" id="planeticon">public</i></a>
                 <ul class="right"><li><a id="close-planet" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">close</i></a></li></ul>
                 <ul class="right"><li><a id="planet-open-file" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">folder_open</i></a></li></ul>
-                <ul class="right"><li><a id="toggle-dark-mode" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip="Toggle Dark Mode"><i class="material-icons">brightness_6</i></a></li></ul>
                 <ul class="right"><li><a id="planet-new-project" class="tooltipped" data-position="bottom" data-delay="50" data-tooltip=""><i class="material-icons">note_add</i></a></li></ul>
                 <ul class="right tabs tabs-transparent" id="localglobal">
                     <li class="tab"><a class="active" id="local-tab" href="#local"></a></li>

--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -153,19 +153,8 @@ class Planet {
 
 // trigger and sync the dark mode of the planet with the main page
 document.addEventListener("DOMContentLoaded", function () {
-    const toggleButton = document.getElementById("toggle-dark-mode");
-
     if (localStorage.getItem("darkMode") === "enabled") {
         document.body.classList.add("dark-mode");
-    }
-    if (toggleButton) {
-        toggleButton.addEventListener("click", function () {
-            document.body.classList.toggle("dark-mode");
-            const newMode = document.body.classList.contains("dark-mode") ? "enabled" : "disabled";
-
-            localStorage.setItem("darkMode", newMode);
-            localStorage.setItem("darkModeTrigger", Date.now());
-        });
     }
     window.addEventListener("storage", function (event) {
         if (event.key === "darkMode" || event.key === "darkModeTrigger") {


### PR DESCRIPTION
@walterbender @pikurasa as we discussed not the toggle button is not there in the planet page and now there is only one way for the user to switch between the themes that is the main page dark mode tooge button
After: 
<img width="1440" alt="Screenshot 2025-02-01 at 12 46 37 AM" src="https://github.com/user-attachments/assets/0c880fa5-9f37-4171-bf8c-4c57048bbf0e" />
