### PR TITLE
dialogue box UI update

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -29,11 +29,27 @@
 }
 
 .modal-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400px;
+  padding: 24px;
   background-color: #fefefe;
-  margin: 15% auto;
-  padding: 20px;
-  border: 1px solid #888;
-  width: 50%;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 4px 8px;
+  border-radius: 8px;
+  z-index: 10000;
+  text-align: left;
+}
+
+#submitLilypond {
+  background-color: rgb(0, 102, 255);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-weight: bold;
+  cursor: pointer;
+  margin-right: 16px;
 }
 
 .close {

--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -54,4 +54,11 @@
     color: #fff;
 }
 
+.dark-mode .modal-content {
+    background-color: #1c1c1c;
+    color: #fff;
+}
 
+.dark-mode #submitLilypond {
+    background-color: rgb(0, 102, 255);
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b93d95ea-68d0-4d64-8c32-c8e07a317645)

![image](https://github.com/user-attachments/assets/a8339709-0ba4-41f2-a5e6-4c93ac557500)


@walterbender Sir, there might be more dialogue boxes whose style does not follow the usual theme of MB. I have added light and dark modes for the "Lilypond save box." Please review this PR. If there are any other such boxes I can update in this PR itself. 