### PR TITLE
Improve piemenu, grid and help window in dark mode

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -54,4 +54,46 @@
     color: #fff;
 }
 
+body.dark-mode #floatingWindows > .windowFrame {
+    background-color: #1C1C1C !important;  
+    border: 2px solid #444 !important;     
+    color: #FFFFFF !important;             
+}
 
+body.dark-mode #helpBodyDiv {
+    background: #1C1C1C !important; 
+    color: #FFFFFF !important;      
+    border: 1px solid #444 !important; /
+}
+
+body.dark-mode #helpDiv {
+    background: #2A2A2A !important;  
+    color: #FFFFFF !important;       
+    box-shadow: 0 1px 10px #0000008f !important;  
+    border-radius: 5px !important;   
+} 
+
+body.dark-mode #helpButtonsDiv {
+    background: #1C1C1C !important;  
+    color: #FFFFFF !important;       
+    border: 1px solid #444 !important; 
+    transition: background-color 0.3s ease-in-out !important; 
+}
+
+body.dark-mode #floatingWindows > .windowFrame {
+    background-color: #1A1A1A !important; 
+    border: 2px solid #555 !important;
+}
+
+body.dark-mode #helpBodyDiv,
+body.dark-mode #helpDiv {
+    background: #1E1E1E !important;
+    color: #FFFFFF !important;
+} 
+
+body.dark-mode #floatingWindows > .windowFrame, 
+body.dark-mode #helpDiv, 
+body.dark-mode #helpBodyDiv, 
+body.dark-mode #helpButtonsDiv {
+    transition: background-color 0.3s ease-in-out !important;
+} 

--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -107,10 +107,10 @@ if (themeName === "darkMode") {
         exitWheelcolors2: ["#757575", "#7986CB", "#4CAF50"],
         pitchWheelcolors: ["#388E3C", "#4CAF50", "#388E3C", "#008BA3", "#388E3C", "#4CAF50", "#66BB6A"],
         gridWheelcolors: {
-            wheel: ["#1C1C1C"],
+            wheel: ["#D6D6D6"], 
             selected: {
-                fill: "#303030",
-                stroke: "#757575"
+                fill: "#858585",  
+                stroke: "#777"    
             }
         },
         drumWheelcolors: ["#008BA3", "#00ACC1"],


### PR DESCRIPTION
This PR is concerning improving the piemenu of gris and the help window in dark mode as highlighted in the PR #4244
I'll be adding more features to this to make this a better working feature.