### PR TITLE
search overflowing fix

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -160,6 +160,7 @@ class Palettes {
         cover.style.background = platformColor.paletteLabelBackground;
         td.appendChild(cover);
         td.onmouseover = () => {
+            this.activity.hideSearchWidget();
             this.showSelection(i, tr);
             this.makePalettes(i);
         };

--- a/js/palette.js
+++ b/js/palette.js
@@ -484,6 +484,7 @@ class Palettes {
             } else {
                 document.body.style.cursor = "pointer";
                 clearTimeout(timeout);
+                this.activity.hideSearchWidget();
                 timeout = setTimeout(() => this.showPalette(name), 400);
             }
         };
@@ -496,6 +497,7 @@ class Palettes {
                 this._hideMenus();
                 this.activity.showSearchWidget();
             } else {
+                this.activity.hideSearchWidget();
                 this.showPalette(name);
             }
         };


### PR DESCRIPTION
When the search box was open, hovering over or clicking options in the palette caused the search box to overflow, hiding some block options.
This PR fixes the issue by ensuring that when the user hovers over or clicks on the palette section, the search box automatically minimizes.
 Before :-

https://github.com/user-attachments/assets/40b69618-d652-49fc-b36f-330480b0490d

After:-


https://github.com/user-attachments/assets/b743c565-1f3e-453d-80e4-69ccb18e92a1


