### PR TITLE
piano metronome fix

### DIFF
--- a/dist/css/keyboard.css
+++ b/dist/css/keyboard.css
@@ -8,6 +8,30 @@
   cursor: pointer;
   position: relative;
 }
+
+#countdownContainer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 200;
+  background: rgba(53, 53, 53, 0.492);
+  pointer-events: all;
+}
+
+#countdownDisplay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: black;
+  color: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+}
+
 table {
   table-layout: fixed;
 }

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -320,16 +320,27 @@ function MusicKeyboard(activity) {
                 if (temp1[id] === "hertz") {
                     temp2[id] = parseInt(ele.getAttribute("alt").split("__")[1]);
                 } else if (temp1[id] in FIXEDSOLFEGE1) {
-                    temp2[id] = FIXEDSOLFEGE1[temp1[id]].replace(SHARP, "#").replace(FLAT, "b") + ele.getAttribute("alt").split("__")[1];
+                    temp2[id] =
+                        FIXEDSOLFEGE1[temp1[id]].replace(SHARP, "#").replace(FLAT, "b") +
+                        ele.getAttribute("alt").split("__")[1];
                 } else {
-                    temp2[id] = temp1[id].replace(SHARP, "#").replace(FLAT, "b") + ele.getAttribute("alt").split("__")[1];
+                    temp2[id] =
+                        temp1[id].replace(SHARP, "#").replace(FLAT, "b") +
+                        ele.getAttribute("alt").split("__")[1];
                 }
 
                 if (id == "rest") {
                     return;
                 }
 
-                this.activity.logo.synth.trigger(0, temp2[id], 1, this.instrumentMapper[id], null, null);
+                this.activity.logo.synth.trigger(
+                    0,
+                    temp2[id],
+                    1,
+                    this.instrumentMapper[id],
+                    null,
+                    null
+                );
 
                 if (this.tick && this.endTime !== undefined && this.firstNote) {
                     let restDuration = (startTime[id] - this.endTime) / 1000.0;

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -743,17 +743,62 @@ function MusicKeyboard(activity) {
                 this.firstNote = false;
                 this.loopTick.stop();
             } else {
-                this.tick = true;
-                this.activity.logo.synth.loadSynth(0, "cow bell");
-                this.loopTick = this.activity.logo.synth.loop(
-                    0,
-                    "cow bell",
-                    "C5",
-                    1 / 64,
-                    0,
-                    this.bpm || 90,
-                    0.07
-                );
+
+                const winBody = document.getElementsByClassName("wfbWidget")[0];
+
+                // Create a container for the countdown
+                const countdownContainer = document.createElement("div");
+                countdownContainer.id = "countdownContainer";
+
+                countdownContainer.style.position = "absolute";
+                countdownContainer.style.top = "0";
+                countdownContainer.style.left = "0";
+                countdownContainer.style.width = "100%";
+                countdownContainer.style.height = "100%";
+                countdownContainer.style.zIndex = "5";
+                countdownContainer.style.background = "rgba(0, 0, 0, 0.5)";
+                countdownContainer.style.pointerEvents = "all"; // Prevent interaction with other elements
+
+                // Centered inner countdown display
+                const countdownDisplay = document.createElement("div");
+                countdownDisplay.style.position = "absolute";
+                countdownDisplay.style.top = "50%";
+                countdownDisplay.style.left = "50%";
+                countdownDisplay.style.transform = "translate(-50%, -50%)";
+                countdownDisplay.style.background = "rgba(0, 0, 0, 0.8)";
+                countdownDisplay.style.color = "white";
+                countdownDisplay.style.padding = "20px";
+                countdownDisplay.style.borderRadius = "10px";
+                countdownDisplay.style.textAlign = "center";
+                countdownDisplay.innerText = "4";
+
+                // Append countdown display to container
+                countdownContainer.appendChild(countdownDisplay);
+                winBody.appendChild(countdownContainer);
+
+                let count = 4;
+                const interval = setInterval(() => {
+                    count--;
+                    if (count === 0) {
+                        clearInterval(interval);
+                        countdownContainer.remove(); // Removes countdown display
+                        this.tick = true;
+                        this.activity.logo.synth.loadSynth(0, "cow bell");
+                        this.loopTick = this.activity.logo.synth.loop(
+                            0,
+                            "cow bell",
+                            "C5",
+                            1 / 64,
+                            0,
+                            this.bpm || 90,
+                            0.07
+                        );
+                    } else {
+                        countdownDisplay.textContent = count;
+                    }
+                }, 1000);
+
+
                 setTimeout(() => {
                     this.activity.logo.synth.start();
                 }, 500);

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -675,6 +675,10 @@ function MusicKeyboard(activity) {
                 myNode.innerHTML = "";
             }
 
+            this.tick = false;
+            this.firstNote = false;
+            this.metronomeON = false;
+
             selectedNotes = [];
             if (this.loopTick) this.loopTick.stop();
             docById("wheelDivptm").style.display = "none";

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -323,6 +323,11 @@ function MusicKeyboard(activity) {
                 );
 
                 if (this.tick) {
+                    console.log(this.endTime);
+
+                    if (this.endTime === undefined) {
+                        return;
+                    }
                     let restDuration = (startTime[id] - this.endTime) / 1000.0;
 
                     restDuration /= 60; // time in minutes
@@ -330,6 +335,7 @@ function MusicKeyboard(activity) {
                     restDuration *= this.meterArgs[1];
 
                     restDuration = parseFloat((Math.round(restDuration * unit) / unit).toFixed(4));
+                    console.log(restDuration);
 
                     if (restDuration === 0) {
                         restDuration = 0;
@@ -763,6 +769,8 @@ function MusicKeyboard(activity) {
         this.tickButton.onclick = () => {
             if (this.tick) {
                 this.tick = false;
+                //if (this._notesPlayed.length === 0)
+                this.endTime = undefined;
                 this.loopTick.stop();
             } else {
                 this.tick = true;

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -832,11 +832,9 @@ function MusicKeyboard(activity) {
                 }, 1000);
 
                 // Start audio
-                setTimeout(() => {
-                    if (this.metronomeON) {
-                        this.activity.logo.synth.start();
-                    }
-                }, 500);
+                if (this.metronomeON) {
+                    this.activity.logo.synth.start();
+                }
             }
         };
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/e3acf978-88cb-44dd-9cd5-1ba18c3d738b

@pikurasa I found that while using the metronome, it records the last rest note also. So when you switch it ON again next time, it adds the previous rest duration. In this PR, a rest note is not added when you start playing the piano after switching the metronome ON. Please watch the video.
But imagine a case where a user wants to add rest before starting. The user can turn ON the metronome, he will wait for the right time, and then start playing the piano. Currently, there is no implementation for this. Do you think this would make sense?