### PR TITLE
Last selected Grid is re-applied after expanding from collapse state

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3582,12 +3582,15 @@ const piemenuGrid = (activity) => {
     activity.turtles.gridWheel.clockwise = false;
     activity.turtles.gridWheel.initWheel(grids);
     activity.turtles.gridWheel.createWheel();
-    activity.turtles.gridWheel.navigateWheel(
-        activity.turtles.currentGrid ? activity.turtles.currentGrid : 0
-    );
-
+    const storedGrid = activity.turtles.currentGrid ?? 0;
+    activity.turtles.gridWheel.navigateWheel(storedGrid);
+      
     for (let i = 0; i < gridLabels.length; i++) {
-        activity.turtles.gridWheel.navItems[i].navigateFunction = activity.turtles.doGrid;
+        activity.turtles.gridWheel.navItems[i].navigateFunction = function () {
+            activity.hideGrids();
+            activity.turtles.currentGrid = i;
+            activity.turtles.doGrid(i);
+        };
         activity.turtles.gridWheel.navItems[i].setTooltip(gridLabels[i]);
     }
 

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -960,6 +960,10 @@ Turtles.TurtlesView = class {
                 menuIcon.innerHTML = "menu";
                 docById("toggleAuxBtn").className -= "blue darken-1";
             }
+            // Store the currently selected grid
+            if (this.activity.turtles.currentGrid !== undefined) {
+                this.selectedGrid = this.activity.turtles.currentGrid;
+            }
             this._expandButton.style.visibility = "visible";
             this._collapseButton.style.visibility = "hidden";
             this.gridButton.style.visibility = "hidden";
@@ -1047,6 +1051,15 @@ Turtles.TurtlesView = class {
                     this.gridButton.scale = 1;
                     this.gridButton.x = this._w - 10 - 3 * 55;
                     this.gridButton.visible = true;
+                }
+
+                // Restore the previously selected grid
+                if (this.selectedGrid !== undefined) {
+                    this.activity.turtles.currentGrid = this.selectedGrid;
+                    this.activity.turtles.doGrid(this.selectedGrid);
+                } else {
+                    this.activity.turtles.currentGrid = 0;
+                    this.activity.turtles.doGrid(0);
                 }
 
                 // remove the stage and add it back in position 0


### PR DESCRIPTION
Resolves #4346 

Now the last selected grid is re-applied again when expanding after collapse. The grid which is selected before collapse is re-applied after expanded it can be changed by selected other grid option from piemenu.


https://github.com/user-attachments/assets/519fe95b-bb0d-4bd6-aa16-e75dd46c95e6



