### PR TITLE
Bug Fix: Made ToolBar Icons Responsive

### DIFF
--- a/lib/materialize-iso.css
+++ b/lib/materialize-iso.css
@@ -3370,7 +3370,7 @@ i.left {
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 32px;  
+    font-size: 48px;  
     position: relative;
     margin: 0;
     padding: 0;
@@ -3382,14 +3382,12 @@ i.left {
     display: none;
   }
   .materialize-iso nav i.material-icons {
-    font-size: 28px;  
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 23px;  
     position: relative;
     margin: 0;
     padding: 0;
@@ -3401,14 +3399,14 @@ i.left {
     display: none;
   }
   .materialize-iso nav .main i.material-icons {
-    font-size: 26px;  
+    font-size: 5.3vw; 
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 23px;  
+    font-size: 5.3vw;  
     position: relative;
     margin: 0;
     padding: 0;
@@ -3421,14 +3419,12 @@ i.left {
   }
 
   .materialize-iso nav .main i.material-icons {
-    width: 20px;
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav  .aux i.material-icons{
-    width: 10px;
     position: relative;
     margin: 0;
     padding: 0;
@@ -3442,7 +3438,7 @@ i.left {
   }
 
   .materialize-iso nav .main i.material-icons {
-    font-size: 20px;
+    font-size: 7.5vw;
     position: relative;
     margin-left: -8px;
     margin-right: -8px;
@@ -3450,10 +3446,10 @@ i.left {
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 17px;
+    font-size: 7.5vw;
     position: relative;
-    margin-left: -7.5px;
-    margin-right: -7.5px;
+    margin-left: -8px;
+    margin-right: -8px;
     padding: 0px;
   }
 }


### PR DESCRIPTION
This PR fixes issue #4351 and includes several changes to the `lib/materialize-iso.css` file, primarily focusing on adjusting the font sizes and widths of icons within navigation elements.

Font size adjustments:

* Increased the font size of `.materialize-iso nav .aux i.material-icons` from `32px` to `48px`.
* Changed the font size of `.materialize-iso nav .main i.material-icons` and `.materialize-iso nav .aux i.material-icons` from fixed pixel values to viewport width units (`5.3vw`).
* Updated the font size of `.materialize-iso nav .main i.material-icons` and `.materialize-iso nav .aux i.material-icons` to `7.5vw` and adjusted the margin values accordingly.

Width adjustments:

* Removed the width properties from `.materialize-iso nav .main i.material-icons` and `.materialize-iso nav .aux i.material-icons`.

Before 

![image](https://github.com/user-attachments/assets/ebded286-3db0-4e01-ad10-4092dcb79f09)

After

https://github.com/user-attachments/assets/c2e7ada3-e639-487a-9ec0-5a48a80d3cd6

Note

* It now accomodates till the width of 525px or so, beyond this it is better to implement a hamburger menu of sorts for navbar. That is why I have not handled the media query of 400px in PR.