### PR TITLE
Refactor: Moved inline styles to external CSS classes-01 Fixes #4374

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1884,3 +1884,37 @@ table {
   stroke : #78E600;
   stroke-width: 3;
 }
+.palette-container {
+  position: absolute;
+  z-index: 1000;
+  left: 0;
+}
+.palette-border {
+  border-bottom: 1px solid #0CAFFF;
+}
+.palette-body {
+  min-width: 180px; 
+  background: var(--palette-background);
+  float: left;
+  border: 1px solid var(--selector-selected);
+}
+
+.palette-item-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 126px;
+  background-color: var(--palette-background, white);
+  transition: background-color 0.2s ease-in-out; 
+}
+
+
+.palette-item-row:hover {
+  background-color: var(--palette-hover, lightgray);
+}
+
+@media (max-width: 768px) {
+  .palette-container {
+    width: 100%;
+  }
+}

--- a/css/activities.css
+++ b/css/activities.css
@@ -1884,6 +1884,16 @@ table {
   stroke : #78E600;
   stroke-width: 3;
 }
+
+:root {
+  --palette-top: 75px;
+  --palette-cell-size: 55px;
+  --palette-background: #f0f0f0;
+  --palette-label-background: #e8e8e8;
+  --selector-selected: #4a90e2;
+  --text-color: #333333;
+  --palette-body-height: calc(100vh - var(--palette-top) - var(--palette-cell-size) - 26px);
+}
 .palette-container {
   position: absolute;
   z-index: 1000;
@@ -1911,6 +1921,93 @@ table {
 
 .palette-item-row:hover {
   background-color: var(--palette-hover, lightgray);
+}
+
+.palette-fixed-container {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: calc(60px + var(--palette-top));
+  overflow-y: auto;
+}
+
+.palette-header {
+  background-color: var(--palette-label-background);
+  padding: 8px;
+}
+
+.palette-header-cell {
+  width: 100%;
+  height: 42px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.palette-icon {
+  border-radius: 4px;
+  padding: 2px;
+  background-color: var(--palette-background);
+}
+
+.palette-close-button {
+  height: var(--palette-cell-size);
+}
+
+.palette-body-container {
+  min-width: 180px;
+  background: var(--palette-background);
+  float: left;
+  border: 1px solid var(--selector-selected);
+}
+
+.palette-items-container {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: var(--palette-body-height);
+  overflow: auto;
+  overflow-x: hidden;
+}
+
+.palette-label {
+  font-weight: bold;
+  color: var(--text-color);
+}
+
+.palette-menu-border {
+  border: 1px solid var(--selected-border-color);
+}
+
+.palette-body-cell {
+  box-sizing: border-box;
+  padding: 8px;
+}
+
+.palette-image {
+  padding: 4px;
+  box-sizing: content-box;
+}
+
+.palette-label {
+  padding: 4px;
+}
+
+.kana-text {
+  font-size: 12px;
+}
+
+.regular-text {
+  font-size: 16px;
+}
+
+.palette-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 126px;
 }
 
 @media (max-width: 768px) {

--- a/js/palette.js
+++ b/js/palette.js
@@ -112,18 +112,16 @@ class Palettes {
             element.id = "palette";
             element.setAttribute("class", "disable_highlighting");
             element.classList.add('flex-palette')
-            element.setAttribute(
-                "style",
-                "position: absolute; z-index: 1000; left :0px; top:" + this.top + "px"
-            );
+            element.classList.add("palette-container");
+            element.style.top = this.top + "px";
             element.innerHTML =
                 `<div style="height:fit-content">
-                    <table width="${1.5 * this.cellSize}" bgcolor="white">
+                    <table class="palette-body">
                         <thead>
                             <tr></tr>
                         </thead>
                     </table>
-                    <table width ="${4.5 * this.cellSize}" bgcolor="white">
+                    <table class="palette-body">
                         <thead>
                             <tr>
                                 <td style= "width:28px"></td>
@@ -306,7 +304,7 @@ class Palettes {
         img.style.height = `${this.cellSize}px`;
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        row.style.borderBottom = "1px solid #0CAFFF";
+        row.classList.add('palette-border');
         label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
@@ -336,12 +334,10 @@ class Palettes {
         row.style.alignItems = "center";
         row.style.width = "126px";
         row.style.backgroundColor = platformColor.paletteBackground;
-        row.addEventListener('mouseover', () => {
-            row.style.backgroundColor = platformColor.hoverColor;
-        });
-        row.addEventListener('mouseout', () => {
-            row.style.backgroundColor = platformColor.paletteBackground;
-        });
+        row.classList.add('palette-item-row');
+        row.style.setProperty('--palette-background', platformColor.paletteBackground);
+        row.style.setProperty('--palette-hover', platformColor.hoverColor);
+
 
         this._loadPaletteButtonHandler(name, row);
     }

--- a/js/palette.js
+++ b/js/palette.js
@@ -298,20 +298,19 @@ class Palettes {
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
         img.appendChild(icon);
-        img.style.padding = "4px";
-        img.style.boxSizing = "content-box";
+        img.classList.add('palette-image');
         img.style.width = `${this.cellSize}px`;
         img.style.height = `${this.cellSize}px`;
+
+        label.classList.add('palette-label');
         label.textContent = toTitleCase(_(name));
-        label.style.color = platformColor.paletteText;
-        row.classList.add('palette-border');
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
-        label.style.padding = "4px";
-        row.style.display = "flex";
-        row.style.flexDirection = "row";
-        row.style.alignItems = "center";
-        row.style.width = "126px";
-        row.style.backgroundColor = platformColor.paletteBackground;
+        label.classList.add('palette-label', localStorage.kanaPreference === "kana" ? 'kana-text' : 'regular-text');
+        label.style.color = platformColor.paletteText; 
+
+
+row.classList.add('palette-border', 'palette-row');
+row.style.backgroundColor = platformColor.paletteBackground;
+
 
         this._loadPaletteButtonHandler(name, row);
     }
@@ -320,27 +319,32 @@ class Palettes {
         const row = listBody.insertRow(-1);
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
+    
         img.appendChild(icon);
-        img.style.padding = "4px";
-        img.style.boxSizing = "content-box";
+    
+        img.classList.add('palette-image');
         img.style.width = `${this.cellSize}px`;
         img.style.height = `${this.cellSize}px`;
+    
+        label.classList.add('palette-label', localStorage.kanaPreference === "kana" ? 'kana-text' : 'regular-text');
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
-        label.style.padding = "4px";
-        row.style.display = "flex";
-        row.style.flexDirection = "row";
-        row.style.alignItems = "center";
-        row.style.width = "126px";
+    
+        row.classList.add('palette-row');
         row.style.backgroundColor = platformColor.paletteBackground;
-        row.classList.add('palette-item-row');
-        row.style.setProperty('--palette-background', platformColor.paletteBackground);
-        row.style.setProperty('--palette-hover', platformColor.hoverColor);
-
-
+    
+        
+        row.addEventListener("mouseenter", () => {
+            row.style.backgroundColor = platformColor.hoverColor;
+        });
+    
+        row.addEventListener("mouseleave", () => {
+            row.style.backgroundColor = platformColor.paletteBackground;
+        });
+    
         this._loadPaletteButtonHandler(name, row);
     }
+    
 
     showPalette(name) {
         if (this.mobile) {
@@ -429,10 +433,7 @@ class Palettes {
             element.id = "palette";
             element.setAttribute("class", "disable_highlighting");
             element.classList.add('flex-palette');
-            element.setAttribute(
-                "style",
-                `position: fixed; z-index: 1000; left: 0px; top: ${60+this.top}px; overflow-y: auto;`
-            );
+            element.classList.add('palette-fixed-container');
             element.innerHTML =
                 `<div style="height:fit-content">
                     <table width="${1.5 * this.cellSize}" bgcolor="white">
@@ -450,7 +451,9 @@ class Palettes {
                         </tbody>
                     </table>
                 </div>`;
-            element.childNodes[0].style.border = `1px solid ${platformColor.selectorSelected}`;
+                element.childNodes[0].classList.add('palette-menu-border');
+element.childNodes[0].style.setProperty('--selected-border-color', platformColor.selectorSelected);
+
             document.body.appendChild(element);
 
         } catch (e) {
@@ -888,17 +891,12 @@ class Palette {
 
         palBody.insertAdjacentHTML(
             "afterbegin",
-            `<thead></thead><tbody style = "display: block;   width: 100% ; height:auto ; max-height: ${palBodyHeight}px;  overflow: auto; overflow-x: hidden;" id="PaletteBody_items" class="PalScrol"></tbody>`
+            `<thead></thead><tbody class="palette-items-container" id="PaletteBody_items"></tbody>`
         );
 
-        palBody.style.minWidth = "180px";
-        palBody.style.background = platformColor.paletteBackground;
-        palBody.style.float = "left";
-
-        palBody.style.border = `1px solid ${platformColor.selectorSelected}`;
+        palBody.classList.add('palette-body-container');
         [palBody.childNodes[0], palBody.childNodes[1]].forEach((item) => {
-            item.style.boxSizing = "border-box";
-            item.style.padding = "8px";
+            item.classList.add('palette-body-cell')
         });
         palDiv.appendChild(palBody);
 
@@ -907,30 +905,25 @@ class Palette {
         if (createHeader) {
             let header = this.menuContainer.children[0];
             header = header.insertRow();
-            header.style.backgroundColor = platformColor.paletteLabelBackground;
-            header.innerHTML =
-                '<td style ="width: 100%; height: 42px; box-sizing: border-box; display: flex; flex-direction: row; align-items: center; justify-content: space-between;"></td>';
-            header = header.children[0];
-            header.style.padding = "8px";
+            header.classList.add('palette-header');
+            header.innerHTML = '<td class="palette-header-cell"></td>';  
 
             const labelImg = makePaletteIcons(
                 PALETTEICONS[this.name],
                 this.palettes.cellSize,
                 this.palettes.cellSize
             );
-            labelImg.style.borderRadius = "4px";
-            labelImg.style.padding = "2px";
-            labelImg.style.backgroundColor = platformColor.paletteBackground;
+            
+            labelImg.classList.add('palette-icon');
             header.appendChild(labelImg);
 
             const label = document.createElement("span");
             label.textContent = toTitleCase(_(this.name));
-            label.style.fontWeight = "bold";
-            label.style.color = platformColor.textColor;
+            label.classList.add('palette-label');
             header.appendChild(label);
 
             const closeDownImg = document.createElement("span");
-            closeDownImg.style.height = `${this.palettes.cellSize}px`;
+            closeDownImg.classList.add('palette-close-button');
             const closeImg = makePaletteIcons(
                 CLOSEICON.replace("fill_color", platformColor.selectorSelected),
                 this.palettes.cellSize,


### PR DESCRIPTION
Fixes #4374

### Description:
This PR refactors palette.js by migrating inline styles to external CSS classes. The changes improve maintainability, reusability, and adherence to best practices by separating concerns between JavaScript and styling.

### Changes Made:

Removed inline styles applied using element.setAttribute("style", "...").
Introduced appropriate CSS classes in the stylesheet.
Updated palette.js to use classList.add() instead of inline styles.
Made it responsive 