### PR TITLE
Fix dark mode issue of helpful Search and search results in light mode

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -16,7 +16,19 @@
   outline: none;
 }
 
+body:not(.dark) #helpfulSearch,
+body:not(.dark) .ui-autocomplete {
+    background-color: #fff !important;
+    color: #000 !important;
+}
 
+body:not(.dark) .ui-autocomplete li:hover {
+    background-color: #ddd !important;
+}
+
+body:not(.dark) #helpfulSearchDiv {
+    background-color: #f9f9f9 !important;
+}
 
 .modal {
   display: none;

--- a/css/themes.css
+++ b/css/themes.css
@@ -1,17 +1,3 @@
-body:not(.dark) #helpfulSearch,
-body:not(.dark) .ui-autocomplete {
-    background-color: #fff !important;
-    color: #000 !important;
-}
-
-body:not(.dark) .ui-autocomplete li:hover {
-    background-color: #ddd !important;
-}
-
-body:not(.dark) #helpfulSearchDiv {
-    background-color: #f9f9f9 !important;
-}
-
 /* Dark Mode */
 
 .dark .blue {

--- a/css/themes.css
+++ b/css/themes.css
@@ -1,3 +1,17 @@
+body:not(.dark) #helpfulSearch,
+body:not(.dark) .ui-autocomplete {
+    background-color: #fff !important;
+    color: #000 !important;
+}
+
+body:not(.dark) .ui-autocomplete li:hover {
+    background-color: #ddd !important;
+}
+
+body:not(.dark) #helpfulSearchDiv {
+    background-color: #f9f9f9 !important;
+}
+
 /* Dark Mode */
 
 .dark .blue {
@@ -68,16 +82,16 @@
   .dark #search,
   #helpfulSearch,
   .ui-autocomplete {
-    background-color: #1c1c1c;
-    color: #fff;
+    background-color: #1c1c1c !important;
+    color: #fff !important;
   }
   
   .dark .ui-autocomplete li:hover {
-    background-color: #225a91;
+    background-color: #225a91 !important;
   }
   
   .dark #helpfulSearchDiv {
-    background-color: transparent;
+    background-color: transparent !important;
   }
   
   .dark #crossButton {


### PR DESCRIPTION
Previously #4333  In this PR, the dark mode in search, helpful search, search results implemented. But after "Generalised Dark Mode into General Theme #4348" this PR MB has moved "darkmode.css" to "themes.css". 

So that, in light mode, helpful search and search results looks like dark mode.

Before : 
![Screenshot 2025-02-09 190838](https://github.com/user-attachments/assets/7541cefc-9bf1-4c60-a2b2-1a7f7b5c51ef)
![Screenshot 2025-02-09 190849](https://github.com/user-attachments/assets/10293c6c-d2fb-4af5-8900-dbebb418ef9c)

After this change properly dark mode and light mode has applied. 

Now : 
![Screenshot 2025-02-09 194516](https://github.com/user-attachments/assets/580ae153-6750-4698-93b7-fd5eb0011edc)
![Screenshot 2025-02-09 194528](https://github.com/user-attachments/assets/158c6c89-9a83-4c39-a13f-c7081701d2c8)

