### PR TITLE
Save As WAV, input file name

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -972,7 +972,13 @@ function Synth() {
             }
             chunks = [];
             const url = URL.createObjectURL(blob);
-            download(url, "");
+                // Prompt the user for the file name
+            const fileName = window.prompt("Enter file name", "recording");
+            if (fileName) {
+                download(url, fileName + (platform.FF ? ".wav" : ".ogg"));
+            } else {
+                alert("Download cancelled.");
+            }
         };
         // this.recorder.start();
         // setTimeout(()=>{this.recorder.stop();},5000);


### PR DESCRIPTION
Earlier no prompt was given to save the WAV file with a name. In this PR, when recording is finished it will prompt the user to input the file name. 
@walterbender Sir please review this PR.


https://github.com/user-attachments/assets/8b402798-4851-4ff1-87b4-fac59baf11b3

