### PR TITLE
Change collapsed view background color in dark mode.

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -622,6 +622,8 @@ table {
 
 #canvas {
   overflow-y: visible;
+  background-color: #FFFFFF; 
+  width: 100%;
 }
 
 #statusDiv {

--- a/css/themes.css
+++ b/css/themes.css
@@ -4,6 +4,10 @@
     background-color: #022363 !important;
   }
   
+  .dark #canvas {
+    background-color: #1c1c1c;
+  }
+  
   .dark .blue.darken-1 {
     background-color: #01143b !important;
   }

--- a/index.html
+++ b/index.html
@@ -311,7 +311,6 @@
             id="canvas"
             width="100%"
             height="100%"
-            style="background-color:#FFFFFF; width:100%"
         >
         </canvas>
 


### PR DESCRIPTION
This PR resolves #4381

Earlier background color in collapsed view remained white after switching dark mode. 
Now it changes to dark color.

[background-view.webm](https://github.com/user-attachments/assets/33b80b5c-a120-4698-b25b-a608284f7361)

