### PR TITLE
Fix Dark Mode setPitch preview Bg and Grid Button Visibility Bug

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1730,10 +1730,6 @@ input.timbreName {
   position: fixed;
 }
 
-.dark #chooseKeyDiv {
-  background: #333;
-}
-
 #chooseKeyDiv > svg {
   width: 100%;
   height: 100%;
@@ -1749,11 +1745,6 @@ input.timbreName {
   font-family: sans-serif;
   text-align: center;
   margin-left: 24px;
-}
-
-.dark #movable {
-  background: #333;
-  color: white;
 }
 
 .radioBtn {

--- a/css/activities.css
+++ b/css/activities.css
@@ -1730,6 +1730,10 @@ input.timbreName {
   position: fixed;
 }
 
+.dark #chooseKeyDiv {
+  background: #333;
+}
+
 #chooseKeyDiv > svg {
   width: 100%;
   height: 100%;
@@ -1745,6 +1749,11 @@ input.timbreName {
   font-family: sans-serif;
   text-align: center;
   margin-left: 24px;
+}
+
+.dark #movable {
+  background: #333;
+  color: white;
 }
 
 .radioBtn {

--- a/css/themes.css
+++ b/css/themes.css
@@ -95,5 +95,15 @@
     color: #fff;
   }
 
+  .dark #chooseKeyDiv {
+    background: #333;
+  }
+  
+.dark #movable {
+  background: #333;
+  color: white;
+}
+
+
 
 /* Your Custom Theme can go here if you don't want to modify the existing dark mode */

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -994,7 +994,6 @@ Turtles.TurtlesView = class {
                 }
                 this._expandButton.style.visibility = "visible";
                 this._collapseButton.style.visibility = "hidden";
-                this.gridButton.style.visibility = "hidden";
                 this.activity.helpfulWheelItems.forEach(ele => {
                     if (ele.label === "Expand") {
                         ele.display = true;


### PR DESCRIPTION
This pr fixes two bugs:
1. The set pitch preview section was not updating when switching to dark mode.
2. The grid button was disappearing when clicking the expand or collapse button.

Before:-
<img src="https://github.com/user-attachments/assets/26c516de-f1eb-4d20-8d48-8376d21676e8" width="400">
<img src="https://github.com/user-attachments/assets/070785e5-0eb9-4209-bb18-0515d1913d6d" width="400">

After:-
<img src="https://github.com/user-attachments/assets/ed54be12-e2a4-44b4-a2ba-3666e8270294" width="400">
<img src="https://github.com/user-attachments/assets/d0623568-52ff-44a8-a568-bf9d4c9e8bc6" width="400">
