### PR TITLE
Workflow for the running tests 

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -1,13 +1,14 @@
 name: Run Jest Tests on PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -1,0 +1,54 @@
+name: Run Jest Tests on PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  test:
+    name: Run Jest Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run Jest Tests
+        id: jest
+        run: |
+          npm test -- --json --outputFile=jest-results.json || echo "TESTS_FAILED=true" >> $GITHUB_ENV
+
+      - name: Read Jest Results
+        id: results
+        run: |
+          if [ "$TESTS_FAILED" = "true" ]; then
+            echo "TESTS_PASSED=false" >> $GITHUB_ENV
+            echo "FAILED_TESTS<<EOF" >> $GITHUB_ENV
+            jq -c '[.testResults[] | select(.status == "failed") | {name: .name}]' jest-results.json >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "TESTS_PASSED=true" >> $GITHUB_ENV
+            echo "FAILED_TESTS=[]" >> $GITHUB_ENV
+          fi
+
+      - name: Post Comment on PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            ${{ env.TESTS_PASSED == 'true' && '✅ All Jest tests passed! This PR is ready to merge.' || '❌ Some Jest tests failed. Please check the logs and fix the issues before merging.' }}
+            
+            **Failed Tests:**
+            ```json
+            ${{ env.FAILED_TESTS }}
+            ```
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -1,7 +1,7 @@
 name: Run Jest Tests on PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  pull-requests: write
+
 jobs:
   test:
     name: Run Jest Tests
@@ -27,29 +30,33 @@ jobs:
         id: jest
         run: |
           npm test -- --json --outputFile=jest-results.json || echo "TESTS_FAILED=true" >> $GITHUB_ENV
-
       - name: Read Jest Results
         id: results
         run: |
           if [ "$TESTS_FAILED" = "true" ]; then
             echo "TESTS_PASSED=false" >> $GITHUB_ENV
+            FAILED_TESTS=$(jq -r '[.testResults[] | select(.status == "failed") | .name] | map(split("/") | last) | join("\n")' jest-results.json)
             echo "FAILED_TESTS<<EOF" >> $GITHUB_ENV
-            jq -c '[.testResults[] | select(.status == "failed") | {name: .name}]' jest-results.json >> $GITHUB_ENV
+            echo "$FAILED_TESTS" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
           else
             echo "TESTS_PASSED=true" >> $GITHUB_ENV
-            echo "FAILED_TESTS=[]" >> $GITHUB_ENV
+            echo "FAILED_TESTS=None" >> $GITHUB_ENV
           fi
-
-      - name: Post Comment on PR
-        uses: mshick/add-pr-comment@v2
-        with:
-          message: |
-            ${{ env.TESTS_PASSED == 'true' && '✅ All Jest tests passed! This PR is ready to merge.' || '❌ Some Jest tests failed. Please check the logs and fix the issues before merging.' }}
-            
-            **Failed Tests:**
-            ```json
-            ${{ env.FAILED_TESTS }}
-            ```
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post Comment on PR using GitHub CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          COMMENT_FILE=$(mktemp)
+          {
+            echo "${{ env.TESTS_PASSED == 'true' && '✅ All Jest tests passed! This PR is ready to merge.' || '❌ Some Jest tests failed. Please check the logs and fix the issues before merging.' }}"
+            echo ""
+            echo "**Failed Tests:**"
+            echo ""
+            echo '```'
+            echo "${{ env.FAILED_TESTS }}"
+            echo '```'
+          } > "$COMMENT_FILE"
+          gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
           

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -18,6 +18,19 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensures full history is fetched
+
+      - name: Configure Git User
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Merge PR with Master (Simulated)
+        run: |
+          git fetch origin master
+          git checkout -b test-merged-pr
+          git merge origin/master --no-edit
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -52,3 +52,4 @@ jobs:
             ${{ env.FAILED_TESTS }}
             ```
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -31,6 +31,7 @@ jobs:
         id: jest
         run: |
           npm test -- --json --outputFile=jest-results.json || echo "TESTS_FAILED=true" >> $GITHUB_ENV
+
       - name: Read Jest Results
         id: results
         run: |
@@ -44,6 +45,7 @@ jobs:
             echo "TESTS_PASSED=true" >> $GITHUB_ENV
             echo "FAILED_TESTS=None" >> $GITHUB_ENV
           fi
+
       - name: Post Comment on PR using GitHub CLI
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,4 +62,3 @@ jobs:
             echo '```'
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
-          


### PR DESCRIPTION
@walterbender I had created a github workflow for running jest test suites whenever a PR is raised please review this 
also this workflow creates a comment on the PR about the test result with the log of failed test suites 
which the author need to take note of after raising a PR. 
<img width="949" alt="Screenshot 2025-02-14 at 4 27 27 PM" src="https://github.com/user-attachments/assets/9e8d07b7-b78f-431b-95f9-84cef3e86231" />

