### PR TITLE
Fix: Added auto reloading after choosing a language

### DIFF
--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -33,7 +33,7 @@ class LanguageBox {
      */
     enUS_onclick() {
         this._language = "enUS";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -42,7 +42,7 @@ class LanguageBox {
      */
     enUK_onclick() {
         this._language = "enUK";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -51,7 +51,7 @@ class LanguageBox {
      */
     ko_onclick() {
         this._language = "ko";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -61,7 +61,7 @@ class LanguageBox {
     ja_onclick() {
         this._language = "ja";
         this.activity.storage.kanaPreference = "kanji";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -71,7 +71,7 @@ class LanguageBox {
     kana_onclick() {
         this._language = "ja";
         this.activity.storage.kanaPreference = "kana";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -80,7 +80,7 @@ class LanguageBox {
      */
     es_onclick() {
         this._language = "es";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -89,7 +89,7 @@ class LanguageBox {
      */
     pt_onclick() {
         this._language = "pt";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -98,7 +98,7 @@ class LanguageBox {
      */
     zhCN_onclick() {
         this._language = "zhCN";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -107,7 +107,7 @@ class LanguageBox {
      */
     th_onclick() {
         this._language = "th";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -116,7 +116,7 @@ class LanguageBox {
      */
     hi_onclick() {
         this._language = "hi";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -125,7 +125,7 @@ class LanguageBox {
      */
     ibo_onclick() {
         this._language = "ibo";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -134,7 +134,7 @@ class LanguageBox {
      */
     ar_onclick() {
         this._language = "ar";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -143,7 +143,7 @@ class LanguageBox {
      */
     he_onclick() {
         this._language = "he";
-        this.hide();
+        this.setPreference();
     }
     /**
      * @public
@@ -151,7 +151,7 @@ class LanguageBox {
      */
     te_onclick() {
         this._language = "te";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -160,7 +160,7 @@ class LanguageBox {
      */
     ayc_onclick() {
         this._language = "ayc";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -169,7 +169,7 @@ class LanguageBox {
      */
     quz_onclick() {
         this._language = "quz";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -178,7 +178,7 @@ class LanguageBox {
      */
     gug_onclick() {
         this._language = "gug";
-        this.hide();
+        this.setPreference();
     }
 
     /**
@@ -187,7 +187,7 @@ class LanguageBox {
      */
     ur_onclick() {
         this._language = "ur"; 
-        this.hide();
+        this.setPreference();
     }
     
     
@@ -195,52 +195,18 @@ class LanguageBox {
      * @public
      * @returns {void}
      */
-    OnClick() {
+    reload() {
         window.location.reload();    
     }
-    hide() {
-        const MSGPrefix =
-        "<a href='#' class='language-link' " +
-            "onMouseOver='this.style.opacity = 0.5'" +
-            "onMouseOut='this.style.opacity = 1'>";
-        const MSGSuffix = "</a>";
-        const MSG = {
-            default: _("Refresh your browser to change your language preference."),
-            enUS: "Refresh your browser to change your language preference.",
-            enUK: "Refresh your browser to change your language preference.",
-            ja: "言語を変えるには、ブラウザをこうしんしてください。",
-            kana: "げんごを かえるには、ブラウザを こうしんしてください。",
-            ko: "언어 기본 설정을 변경하려면 브라우저를 새로 고치십시오.",
-            es: "Actualice su navegador para cambiar su preferencia de idioma.",
-            pt: "Atualize seu navegador para alterar sua preferência de idioma.",
-            zhCN: "刷新浏览器以更改您的语言偏好",
-            th: "รีเฟรชเบราเซอร์เพื่อเปลี่ยนการตั้งค่าภาษาของคุณ",
-            hi: "अपनी भाषा की वरीयता बदलने के लिए अपना ब्राउज़र ताज़ा करें",
-	    te: "మీ భాష ప్రాధాన్యతను మార్చడానికి మీ బ్రౌజర్‌ని రిఫ్రెష్ చేయండి.",
-            ibo: "Mee ka nchọgharị gị gbanwee mmasị asụsụ gị.",
-            ar: "حدث المتصفح لتغيير تفضيلات اللغة.",
-            he: "רענן את הדפדפן כדי לשנות את העדפת השפה שלך.",
-            ayc: "Actualice su navegador para cambiar su preferencia de idioma.",
-            quz: "Actualice su navegador para cambiar su preferencia de idioma.",
-            gug: "Actualice su navegador para cambiar su preferencia de idioma.",
-            ur:"اپنی زبان کی ترجیح کو تبدیل کرنے کے لئے اپنے براؤزر کو تازہ دم کریں۔"
-        };
+    setPreference() {
         if (localStorage.getItem("languagePreference") === this._language) {
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         }
         else{
             this.activity.storage.languagePreference = this._language;
-            if (this._language === "ja" && this.activity.storage.kanaPreference === "kana") {
-                this.activity.textMsg(MSGPrefix + MSG["kana"] + MSGSuffix);
-            } else {
-                this.activity.textMsg(MSGPrefix + MSG[this._language] + MSGSuffix);
-            }
+            this.reload();
         }
 
-         const languageLinks = document.querySelectorAll('.language-link');
-         languageLinks.forEach(link => {
-             link.addEventListener('click', () => this.OnClick());
-         });
     }
 }
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
This PR modifies the `LanguageBox` class in `js/languagebox.js` to improve the handling of language preferences. The main change is replacing the `hide` method with a new `setPreference` method, which updates the language preference and reloads the page automatically instead of a reload link.

Key changes include:

* [`js/languagebox.js`](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L36-R36): Replaced calls to `hide` with `setPreference` in language selection methods to ensure language preferences are set and the page is reloaded. [[1]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L36-R36) [[2]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L45-R45) [[3]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L54-R54) [[4]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L64-R64) [[5]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L74-R74) [[6]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L83-R83) [[7]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L92-R92) [[8]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L101-R101) [[9]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L110-R110) [[10]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L119-R119) [[11]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L128-R128) [[12]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L137-R137) [[13]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L146-R154) [[14]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L163-R163) [[15]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L172-R172) [[16]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L181-R181) [[17]](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L190-L243)
* [`js/languagebox.js`](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L190-L243): Removed the `hide` method and related code, and added the `reload` method to refresh the page.
* [`js/languagebox.js`](diffhunk://#diff-8fdfbc57753399fc2137ac10b64ee9999e063c79a50d355ec8aafc181d4de1a1L190-L243): Added the new `setPreference` method to handle setting the language preference and reloading the page.

Before:

https://github.com/user-attachments/assets/8ffcef57-2fa2-4a22-bad0-b33900cec7da

After: 

https://github.com/user-attachments/assets/9f11dbc4-2173-4030-87c2-4124e6323196


