### PR TITLE
Fix: Preloading Fallback Font for slower connections

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
         <meta id="theme-color" name="theme-color" content="#2196F3" />
 
         <link type="text/css" href="fonts/material-icons.css" rel="stylesheet"/>
+        <link rel="preload" href="/fonts/material-icons.woff2" as="font" type="font/woff2" crossorigin="anonymous">
         <link rel="stylesheet" href="lib/materialize-iso.css" />
         <link rel="stylesheet" href="css/themes.css" />
 

--- a/planet/index.html
+++ b/planet/index.html
@@ -7,7 +7,8 @@
         <link type="text/css" href="fonts/material-icons.css" rel="stylesheet">
         <!--Import materialize.css-->
         <link type="text/css" rel="stylesheet" href="libs/materialize.min.css" media="screen,projection"/>
-
+        
+        <link rel="preload" href="./fonts/material-icons.woff2" as="font" type="font/woff2" crossorigin="anonymous">
         <!-- Import clipboard.js -->
         <script src="libs/clipboard.min.js"></script>
  


### PR DESCRIPTION
This PR resolves issue #4413 and includes changes to improve the loading performance of web pages by preloading fonts.
On slower connections, the material-icons.woff2 font would be loaded later, so the font is preloaded, and is then fetched from disk cache now.

Before

https://github.com/user-attachments/assets/eefd0823-e2ca-4763-bb15-58969bfa5f61

After

https://github.com/user-attachments/assets/06e12336-4f16-4a66-beee-9f8b51083ccc

Performance improvements:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R72): Added a `link` tag to preload the `material-icons.woff2` font.
* [`planet/index.html`](diffhunk://#diff-b11db06ff6c4f10ede00643f1201e7316a3258fc569f75b3f9d3bd51004517dfR11): Added a `link` tag to preload the `material-icons.woff2` font.