### PR TITLE
Fix: Fixed the save menu not working after mode change

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -935,7 +935,20 @@ class Toolbar {
             const saveButton = docById('saveButton');
             const saveButtonAdvanced = docById('saveButtonAdvanced');
             if (saveButton) saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
-            if (saveButtonAdvanced) saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
+            if (saveButtonAdvanced) saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";   
+            activity.toolbar.renderSaveIcons(
+                activity.save.saveHTML.bind(activity.save),
+                doSVG,
+                activity.save.saveSVG.bind(activity.save),
+                activity.save.savePNG.bind(activity.save),
+                activity.save.saveWAV.bind(activity.save),
+                activity.save.saveLilypond.bind(activity.save),
+                activity.save.afterSaveLilypondLY.bind(activity.save),
+                activity.save.saveAbc.bind(activity.save),
+                activity.save.saveMxml.bind(activity.save),
+                activity.save.saveBlockArtwork.bind(activity.save),
+                activity.save.saveBlockArtworkPNG.bind(activity.save)
+            );
         };
 
         // Handle mode switching


### PR DESCRIPTION
This PR resolves issue #4420 where the save menu was not functioning after mode changes. It will only work if you refresh the page with that mode.
For ex: if you are in beginner mode, and the page loads, only the beginner mode save menu would work and not the advanced menu.
Similarly, if you are in advanced mode, and the page loads, only the advanced mode save menu would work and not the beginner menu.
Probable cause was not handling rendering of save icons on mode switch.
Note: This issue is also addressed in PR #4401 

Before

https://github.com/user-attachments/assets/1d1b23f9-0527-4ae9-8c51-56c95d398e27

After

https://github.com/user-attachments/assets/5f1fa8df-347d-4712-9184-0a000875bb0e

