### PR TITLE
Fix: Fixed the save menu not working after mode change

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -945,6 +945,19 @@ class Toolbar {
             const saveButtonAdvanced = docById('saveButtonAdvanced');
             if (saveButton) saveButton.style.display = this.activity.beginnerMode ? "block" : "none";
             if (saveButtonAdvanced) saveButtonAdvanced.style.display = this.activity.beginnerMode ? "none" : "block";
+            activity.toolbar.renderSaveIcons(
+                activity.save.saveHTML.bind(activity.save),
+                doSVG,
+                activity.save.saveSVG.bind(activity.save),
+                activity.save.saveMIDI.bind(activity.save),
+                activity.save.savePNG.bind(activity.save),
+                activity.save.saveWAV.bind(activity.save),
+                activity.save.saveLilypond.bind(activity.save),
+                activity.save.saveAbc.bind(activity.save),
+                activity.save.saveMxml.bind(activity.save),
+                activity.save.saveBlockArtwork.bind(activity.save),
+                activity.save.saveBlockArtworkPNG.bind(activity.save)
+            );
         };
 
         // Handle mode switching


### PR DESCRIPTION
This PR resolves issue https://github.com/sugarlabs/musicblocks/issues/4420 where the save menu was not functioning after mode changes. It will only work if you refresh the page with that mode.
For ex: if you are in beginner mode, and the page loads, only the beginner mode save menu would work and not the advanced menu.
Similarly, if you are in advanced mode, and the page loads, only the advanced mode save menu would work and not the beginner menu.
Probable cause was not handling rendering of save icons on mode switch.
Note: This issue is also addressed in PR https://github.com/sugarlabs/musicblocks/pull/4401

Before

https://github.com/user-attachments/assets/55ff9765-2b2c-49ed-97f6-60fb642c3b74

After

https://github.com/user-attachments/assets/d71b7dcd-1f82-41da-8c32-56056e0bd607

