### PR TITLE
Fix PO File Errors

### DIFF
--- a/po/ayc.po
+++ b/po/ayc.po
@@ -4835,7 +4835,7 @@ msgstr "mayman chiqas riq "
 #: js/blocks/ProgramBlocks.js:1048
 #.TRANS: número de conexion
 msgid "connection number"
-msgstr "hap’ichiypa yupaynin""
+msgstr "hap’ichiypa yupaynin"
 
 #: js/blocks/ProgramBlocks.js:1140
 #.TRANS: El bloque crear bloque crea un bloque.

--- a/po/he.po
+++ b/po/he.po
@@ -150,7 +150,7 @@ msgstr "קוד זה מאחסן נתונים על הבלוקים בפרויקט."
 #: js/blocks.js:5091
 #: js/blocks/MediaBlocks.js:888
 msgid "Show"
-msgstr ""לְהַרְאוֹ"
+msgstr "לְהַרְאוֹ"
 
 #: js/SaveInterface.js:91
 msgid "Hide"

--- a/po/quz.po
+++ b/po/quz.po
@@ -3992,7 +3992,7 @@ msgstr "campaneo"
 #.TRANS: a musical instrument
 #.TRANS: gong
 msgid "gong"
-msgstr ""                        "
+msgstr ""
 
 #: js/utils/musicutils.js:1146
 #: js/utils/synthutils.js:182

--- a/po/te.po
+++ b/po/te.po
@@ -2216,7 +2216,7 @@ msgstr "స్క్రీన్‌ను తిరిగిపెట్టం�
 #: js/turtledefs.js:750
 #: js/turtles.js:980
 msgid "Collapse"
-msgstr ""అసంగతి"
+msgstr "అసంగతి"
 
 #: js/turtledefs.js:751
 msgid "Collapse the graphics window."


### PR DESCRIPTION
Fixed errors in PO files:

- ayc.po (Line 4838): Removed extra quote in msgstr.
- quz.po (Line 3995): Fixed empty msgstr with spaces.
- te.po (Line 2219): Corrected misplaced quotes.
- he.po (Line 153): Removed extra quote in msgstr.

I found this internationalization project mentioned in GSOC Ideas really interesting. While looking into it, I wrote a Python script to convert PO files into JSON, which I think will be useful for moving from webL10n.js to i18next.

I feel this PR is the first step—fixing PO file errors so the conversion works smoothly. Really excited to work on the full i18n setup and make localization better! Would love to hear any feedback or suggestions.