### PR TITLE
Workflow to run test on PR instead the upstream master 

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
@chimosky @walterbender the changes here made the worflow to run on PR instead of the upstream master 
as even after resolving the test errors we are getting the comment with the failure of that test 
please review this !!