### PR TITLE
Fix Navbar Icon Height Issue on Responsive Screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,17 @@
                 doSearch();
             });
         </script>
+            <head>
+                ...
+                <style>
+                    .nav-wrapper .material-icons {
+                        height: 45px; /* Set a consistent height for all icons */
+                        min-height: 45px; /* Ensure minimum height for responsiveness */
+                        line-height: 45px; /* Center the icons vertically */
+                    }
+                </style>
+                ...
+            </head>
     </head>
 
     <!-- #96D3F3-->

--- a/index.html
+++ b/index.html
@@ -115,8 +115,7 @@
                 doSearch();
             });
         </script>
-            <head>
-                ...
+       ...
                 <style>
                     .nav-wrapper .material-icons {
                         height: 45px; /* Set a consistent height for all icons */
@@ -125,7 +124,6 @@
                     }
                 </style>
                 ...
-            </head>
     </head>
 
     <!-- #96D3F3-->


### PR DESCRIPTION
This pull request addresses an issue where the height of icons in the navbar would change when the screen width was minimized or maximized. The expected behavior is for the icons to maintain a consistent height across all screen sizes.    
Changes made:

Added CSS Flexbox to ensure consistent height for navbar icons.

Applied media queries to maintain icon height across different screen widths.

Ensured compatibility with Bootstrap classes, if applicable.

This update resolves the issue and ensures a uniform appearance for the navbar icons on all devices.
#4351 