### PR TITLE
Refactor: Moved inline styles to external CSS classes-02

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1884,3 +1884,99 @@ table {
   stroke : #78E600;
   stroke-width: 3;
 }
+
+/*---------------------------------------------- palette.js(styling) -----------------------------------------*/
+:root {
+  --palette-text: #6b6b6b; 
+}
+
+.palette-container {
+    position: absolute;
+    z-index: 1000;
+    left: 0;
+}
+
+.palette-border {
+  border: 1px solid transparent; 
+}
+
+.palette-cover {
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  width: 100%;
+  height: 1px;
+}
+
+.palette-icon {
+  padding: 4px;
+  box-sizing: border-box;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  margin-right: 8px;
+}
+
+.palette-label {
+  color: var(--palette-text);
+  font-size: 16px;
+  padding: 4px;
+  font-weight: 500;
+}
+
+.palette-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  background-color: var(--palette-background);
+  margin-bottom: 4px;
+  gap: 8px;
+}
+
+.palette-hover {
+  background-color: var(--hover-color);
+}
+
+[kana-preference="kana"] .palette-label {
+  font-size: 12px;
+}
+
+.palette-body {
+  min-width: 180px;
+  width: auto;
+  background: var(--palette-background); 
+  float: left;
+  border: 1px solid var(--selector-selected); 
+}
+
+.palette-body-child {
+  box-sizing: border-box;
+  padding: 8px;
+}
+
+.palette-header {
+  background-color: var(--palette-label-background);
+  border-bottom: 1px solid #0CAFFF; 
+}
+
+.palette-header-cell {
+  width: 100%;
+  height: 42px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.palette-header-cell span {
+  font-size: 16px;
+  color: var(--palette-text);
+  margin-left: 8px; 
+  
+}
+
+
+
+

--- a/js/palette.js
+++ b/js/palette.js
@@ -175,7 +175,7 @@ class Palettes {
                 if (tr.children[j] && tr.children[j].children[1]) {
                     tr.children[j].children[1].style.background = platformColor.paletteLabelSelected;
                 }
-                
+
             } else {
                 img = makePaletteIcons(
                     PALETTEICONS[MULTIPALETTEICONS[j]]
@@ -188,7 +188,7 @@ class Palettes {
                 if (tr.children[j] && tr.children[j].children[1]) {
                     tr.children[j].children[1].style.background = platformColor.paletteLabelBackground;
                 }
-                
+
             }
             tr.children[j].children[0].src = img.src;
         }
@@ -296,55 +296,41 @@ class Palettes {
     }
 
     makeSearchButton(name, icon, listBody) {
-        const searchRow = listBody.insertRow(0);
-        searchRow.classList.add("palette-row", "search-bar");
-    
-        const searchCell = searchRow.insertCell(0);
-        searchCell.colSpan = 3;
-        const searchInput = document.createElement("input");
-        searchInput.type = "text";
-        searchInput.placeholder = "Search...";
-        searchInput.classList.add("search-input");
-        searchCell.appendChild(searchInput);
-
         const row = listBody.insertRow(-1);
-        row.classList.add("palette-row");
-    
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
-        
         img.appendChild(icon);
         img.classList.add("palette-icon");
         label.classList.add("palette-label");
-    
+        row.classList.add("palette-row");
         row.addEventListener("mouseover", () => {
             row.classList.add("palette-hover");
         });
-    
         row.addEventListener("mouseout", () => {
             row.classList.remove("palette-hover");
         });
-    
+
+
         this._loadPaletteButtonHandler(name, row);
     }
-    
+
 
     makeButton(name, icon, listBody) {
         const row = listBody.insertRow(-1);
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
         img.appendChild(icon);
-        
+
         label.textContent = toTitleCase(_(name));
         img.classList.add("palette-icon");
         label.classList.add("palette-label");
         row.classList.add("palette-row");
         row.addEventListener("mouseover", () => {
-        row.classList.add("palette-hover");
-});
+            row.classList.add("palette-hover");
+        });
         row.addEventListener("mouseout", () => {
-        row.classList.remove("palette-hover");
-});
+            row.classList.remove("palette-hover");
+        });
 
         row.addEventListener('mouseover', () => {
             row.style.backgroundColor = platformColor.hoverColor;
@@ -366,7 +352,7 @@ class Palettes {
         this.activePalette = name; // used to delete plugins
     }
 
-    _showMenus() {}
+    _showMenus() { }
 
     _hideMenus() {
         // Hide the menu buttons and the palettes themselves.
@@ -425,13 +411,13 @@ class Palettes {
                     }
                 }
             }
-    
+
             // Remove the palette DOM element if it exists
             const paletteElement = docById("palette");
             if (paletteElement) {
                 paletteElement.parentNode.removeChild(paletteElement);
             }
-    
+
             // Clear the dictionary and reset state
             this.dict = {};
             this.visible = false;
@@ -445,7 +431,7 @@ class Palettes {
             element.classList.add('flex-palette');
             element.setAttribute(
                 "style",
-                `position: fixed; z-index: 1000; left: 0px; top: ${60+this.top}px; overflow-y: auto;`
+                `position: fixed; z-index: 1000; left: 0px; top: ${60 + this.top}px; overflow-y: auto;`
             );
             element.innerHTML =
                 `<div style="height:fit-content">
@@ -464,8 +450,8 @@ class Palettes {
                         </tbody>
                     </table>
                 </div>`;
-                element.childNodes[0].classList.add("palette-border");
-                element.childNodes[0].style.borderColor = platformColor.selectorSelected;
+            element.childNodes[0].classList.add("palette-border");
+            element.childNodes[0].style.borderColor = platformColor.selectorSelected;
             document.body.appendChild(element);
 
         } catch (e) {
@@ -528,7 +514,7 @@ class Palettes {
             const actionBlock = this.dict["action"].protoList[blk];
             if (
                 ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].indexOf(actionBlock.name) !==
-                    -1 &&
+                -1 &&
                 actionBlock.defaults[0] === actionName
             ) {
                 // Remove the palette protoList entry for this block.
@@ -908,8 +894,8 @@ class Palette {
 
         palBody.classList.add("palette-body");
         [palBody.childNodes[0], palBody.childNodes[1]].forEach((item) => {
-        item.classList.add("palette-body-child");
-});
+            item.classList.add("palette-body-child");
+        });
 
         palDiv.appendChild(palBody);
 
@@ -919,27 +905,27 @@ class Palette {
             let table = this.menuContainer.children[0];
             let headerRow = table.insertRow(); // Create a new row
             headerRow.classList.add("palette-header");
-        
+
             let cell = headerRow.insertCell(); // Create a new cell
             cell.classList.add("palette-header-cell");
-        
+
             // Create the search icon
             let searchIcon = document.createElement("i");
             searchIcon.classList.add("palette-icon", "search-icon");
-        
+
             // Create the search text
             let searchText = document.createElement("span");
             searchText.classList.add("palette-label");
             searchText.textContent = "Search";
-        
+
             // Append elements properly
             cell.appendChild(searchIcon);
             cell.appendChild(searchText);
-        
-        
-    
-        
-        
+
+
+
+
+
             const labelImg = makePaletteIcons(
                 PALETTEICONS[this.name],
                 this.palettes.cellSize,
@@ -1314,11 +1300,11 @@ class Palette {
         ) {
             this._makeBlockFromProtoblock(protoblk, true, blkname, null, 100, 100);
             callback(lastBlock);
-            return(lastBlock);
+            return (lastBlock);
         } else {
             const newBlock = paletteBlockButtonPush(this.activity.blocks, newBlk, arg);
             callback(newBlock);
-            return(newBlock);
+            return (newBlock);
         }
     }
 
@@ -1370,7 +1356,7 @@ class Palette {
                 // the palette.
                 if (
                     this.activity.blocks.blockList[topBlk].container.x <
-                        this.activity.palettes.paletteWidth * 2
+                    this.activity.palettes.paletteWidth * 2
                 ) {
                     this.activity.blocks.moveBlock(
                         topBlk,
@@ -1431,7 +1417,7 @@ class Palette {
                 // the palette.
                 if (
                     this.activity.blocks.blockList[topBlk].container.x <
-                        this.activity.palettes.paletteWidth * 2
+                    this.activity.palettes.paletteWidth * 2
                 ) {
                     this.activity.blocks.moveBlock(
                         topBlk,
@@ -1449,7 +1435,7 @@ class Palette {
                 // the palette.
                 if (
                     this.activity.blocks.blockList[newBlock].container.x <
-                        this.activity.palettes.paletteWidth * 2
+                    this.activity.palettes.paletteWidth * 2
                 ) {
                     this.activity.blocks.moveBlock(
                         newBlock,

--- a/js/palette.js
+++ b/js/palette.js
@@ -112,10 +112,8 @@ class Palettes {
             element.id = "palette";
             element.setAttribute("class", "disable_highlighting");
             element.classList.add('flex-palette')
-            element.setAttribute(
-                "style",
-                "position: absolute; z-index: 1000; left :0px; top:" + this.top + "px"
-            );
+            element.classList.add("palette-container");
+            element.style.top = `${this.top}px`;
             element.innerHTML =
                 `<div style="height:fit-content">
                     <table width="${1.5 * this.cellSize}" bgcolor="white">
@@ -152,11 +150,7 @@ class Palettes {
             )
         );
         const cover = document.createElement("div");
-        cover.style.position = "absolute";
-        cover.style.zIndex = "10";
-        cover.style.top = "0";
-        cover.style.width = "100%";
-        cover.style.height = "1px";
+        cover.classList.add("palette-cover");
         cover.style.background = platformColor.paletteLabelBackground;
         td.appendChild(cover);
         td.onmouseover = () => {
@@ -178,7 +172,10 @@ class Palettes {
                     this.cellSize,
                     this.cellSize
                 );
-                tr.children[j].children[1].style.background = platformColor.paletteLabelSelected;
+                if (tr.children[j] && tr.children[j].children[1]) {
+                    tr.children[j].children[1].style.background = platformColor.paletteLabelSelected;
+                }
+                
             } else {
                 img = makePaletteIcons(
                     PALETTEICONS[MULTIPALETTEICONS[j]]
@@ -188,7 +185,10 @@ class Palettes {
                     this.cellSize,
                     this.cellSize
                 );
-                tr.children[j].children[1].style.background = platformColor.paletteLabelBackground;
+                if (tr.children[j] && tr.children[j].children[1]) {
+                    tr.children[j].children[1].style.background = platformColor.paletteLabelBackground;
+                }
+                
             }
             tr.children[j].children[0].src = img.src;
         }
@@ -296,46 +296,56 @@ class Palettes {
     }
 
     makeSearchButton(name, icon, listBody) {
+        const searchRow = listBody.insertRow(0);
+        searchRow.classList.add("palette-row", "search-bar");
+    
+        const searchCell = searchRow.insertCell(0);
+        searchCell.colSpan = 3;
+        const searchInput = document.createElement("input");
+        searchInput.type = "text";
+        searchInput.placeholder = "Search...";
+        searchInput.classList.add("search-input");
+        searchCell.appendChild(searchInput);
+
         const row = listBody.insertRow(-1);
+        row.classList.add("palette-row");
+    
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
+        
         img.appendChild(icon);
-        img.style.padding = "4px";
-        img.style.boxSizing = "content-box";
-        img.style.width = `${this.cellSize}px`;
-        img.style.height = `${this.cellSize}px`;
-        label.textContent = toTitleCase(_(name));
-        label.style.color = platformColor.paletteText;
-        row.style.borderBottom = "1px solid #0CAFFF";
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
-        label.style.padding = "4px";
-        row.style.display = "flex";
-        row.style.flexDirection = "row";
-        row.style.alignItems = "center";
-        row.style.width = "126px";
-        row.style.backgroundColor = platformColor.paletteBackground;
-
+        img.classList.add("palette-icon");
+        label.classList.add("palette-label");
+    
+        row.addEventListener("mouseover", () => {
+            row.classList.add("palette-hover");
+        });
+    
+        row.addEventListener("mouseout", () => {
+            row.classList.remove("palette-hover");
+        });
+    
         this._loadPaletteButtonHandler(name, row);
     }
+    
 
     makeButton(name, icon, listBody) {
         const row = listBody.insertRow(-1);
         const img = row.insertCell(-1);
         const label = row.insertCell(-1);
         img.appendChild(icon);
-        img.style.padding = "4px";
-        img.style.boxSizing = "content-box";
-        img.style.width = `${this.cellSize}px`;
-        img.style.height = `${this.cellSize}px`;
+        
         label.textContent = toTitleCase(_(name));
-        label.style.color = platformColor.paletteText;
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
-        label.style.padding = "4px";
-        row.style.display = "flex";
-        row.style.flexDirection = "row";
-        row.style.alignItems = "center";
-        row.style.width = "126px";
-        row.style.backgroundColor = platformColor.paletteBackground;
+        img.classList.add("palette-icon");
+        label.classList.add("palette-label");
+        row.classList.add("palette-row");
+        row.addEventListener("mouseover", () => {
+        row.classList.add("palette-hover");
+});
+        row.addEventListener("mouseout", () => {
+        row.classList.remove("palette-hover");
+});
+
         row.addEventListener('mouseover', () => {
             row.style.backgroundColor = platformColor.hoverColor;
         });
@@ -454,7 +464,8 @@ class Palettes {
                         </tbody>
                     </table>
                 </div>`;
-            element.childNodes[0].style.border = `1px solid ${platformColor.selectorSelected}`;
+                element.childNodes[0].classList.add("palette-border");
+                element.childNodes[0].style.borderColor = platformColor.selectorSelected;
             document.body.appendChild(element);
 
         } catch (e) {
@@ -895,28 +906,40 @@ class Palette {
             `<thead></thead><tbody style = "display: block;   width: 100% ; height:auto ; max-height: ${palBodyHeight}px;  overflow: auto; overflow-x: hidden;" id="PaletteBody_items" class="PalScrol"></tbody>`
         );
 
-        palBody.style.minWidth = "180px";
-        palBody.style.background = platformColor.paletteBackground;
-        palBody.style.float = "left";
-
-        palBody.style.border = `1px solid ${platformColor.selectorSelected}`;
+        palBody.classList.add("palette-body");
         [palBody.childNodes[0], palBody.childNodes[1]].forEach((item) => {
-            item.style.boxSizing = "border-box";
-            item.style.padding = "8px";
-        });
+        item.classList.add("palette-body-child");
+});
+
         palDiv.appendChild(palBody);
 
         this.menuContainer = palBody;
 
         if (createHeader) {
-            let header = this.menuContainer.children[0];
-            header = header.insertRow();
-            header.style.backgroundColor = platformColor.paletteLabelBackground;
-            header.innerHTML =
-                '<td style ="width: 100%; height: 42px; box-sizing: border-box; display: flex; flex-direction: row; align-items: center; justify-content: space-between;"></td>';
-            header = header.children[0];
-            header.style.padding = "8px";
-
+            let table = this.menuContainer.children[0];
+            let headerRow = table.insertRow(); // Create a new row
+            headerRow.classList.add("palette-header");
+        
+            let cell = headerRow.insertCell(); // Create a new cell
+            cell.classList.add("palette-header-cell");
+        
+            // Create the search icon
+            let searchIcon = document.createElement("i");
+            searchIcon.classList.add("palette-icon", "search-icon");
+        
+            // Create the search text
+            let searchText = document.createElement("span");
+            searchText.classList.add("palette-label");
+            searchText.textContent = "Search";
+        
+            // Append elements properly
+            cell.appendChild(searchIcon);
+            cell.appendChild(searchText);
+        
+        
+    
+        
+        
             const labelImg = makePaletteIcons(
                 PALETTEICONS[this.name],
                 this.palettes.cellSize,


### PR DESCRIPTION
Fixes #4374 

![image](https://github.com/user-attachments/assets/f5f8fa09-60a1-4816-b176-06fb4a9f6b34)


Description:
This PR refactors palette.js by migrating inline styles to external CSS classes. The changes improve maintainability, reusability, and adherence to best practices by separating concerns between JavaScript and styling.

Changes Made:
Removed inline styles applied using element.setAttribute("style", "...").
Introduced appropriate CSS classes in the stylesheet.
Updated palette.js to use classList.add() instead of inline styles.