### PR TITLE
fixes the issue of blocks being hidden in canvas

### DIFF
--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1016,10 +1016,7 @@ Turtles.TurtlesView = class {
                 menuIcon.innerHTML = "menu";
                 docById("toggleAuxBtn").className -= "blue darken-1";
             }
-            // Store the currently selected grid
-            if (this.activity.turtles.currentGrid !== undefined) {
-                this.selectedGrid = this.activity.turtles.currentGrid;
-            }
+
             this._expandButton.style.visibility = "visible";
             this._collapseButton.style.visibility = "hidden";
             this.gridButton.style.visibility = "hidden";
@@ -1117,11 +1114,7 @@ Turtles.TurtlesView = class {
             }
 
             // Restore the previously selected grid
-            if (this.selectedGrid !== undefined) {
-                this.activity.turtles.currentGrid = this.selectedGrid;
-                this.activity.turtles.doGrid(this.selectedGrid);
-            } else {
-                this.activity.turtles.currentGrid = 0;
+            if (this.currentGrid !== null) {
                 this.activity.turtles.doGrid(0);
             }
             


### PR DESCRIPTION
This PR resolves https://github.com/sugarlabs/musicblocks/issues/4455
Now using the collapse button does not hide blocks.
The issue started occurring after https://github.com/sugarlabs/musicblocks/pull/4347

After fix-

[collapse-fix-demo.webm](https://github.com/user-attachments/assets/37f023b7-a036-49d1-a05a-3a4973c34b4b)

