### PR TITLE
Play widget

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -667,10 +667,14 @@ class Singer {
      */
     static setMasterVolume(logo, volume, blk) {
         const activity = logo.activity;
-        const firstConnection = activity.logo.blockList[blk].connections[0];
-        const lastConnection = last(activity.logo.blockList[blk].connections);
         volume = Math.min(Math.max(volume, 0), 100);
-        logo.synth.setMasterVolume(volume, firstConnection, lastConnection);
+        if (blk) {
+            const firstConnection = activity.logo.blockList[blk].connections[0];
+            const lastConnection = last(activity.logo.blockList[blk].connections);
+            logo.synth.setMasterVolume(volume, firstConnection, lastConnection);
+        } else {
+            logo.synth.setMasterVolume(volume);
+        }
         for (const turtle of activity.turtles.turtleList) {
             for (const synth in turtle.singer.synthVolume) {
                 turtle.singer.synthVolume[synth].push(volume);


### PR DESCRIPTION
Due to the recent changes in `setMasterVolume`, the playback was not working.  `setMasterVolume` now accounts `blk` which is only for blocks and hence widgets failed to use this function. 

This PR solves this issue. 

@walterbender, please review this PR.