### PR TITLE
Fix auxiliary menu misalignment after toolbar resizing changes

### DIFF
--- a/lib/materialize-iso.css
+++ b/lib/materialize-iso.css
@@ -3370,8 +3370,9 @@ i.left {
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 32px;  
+    font-size: 48px;  
     position: relative;
+    width: 20px;
     margin: 0;
     padding: 0;
   }
@@ -3382,14 +3383,12 @@ i.left {
     display: none;
   }
   .materialize-iso nav i.material-icons {
-    font-size: 28px;  
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 23px;  
     position: relative;
     margin: 0;
     padding: 0;
@@ -3401,14 +3400,14 @@ i.left {
     display: none;
   }
   .materialize-iso nav .main i.material-icons {
-    font-size: 26px;  
+    font-size: 5.3vw; 
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 23px;  
+    font-size: 5.3vw;  
     position: relative;
     margin: 0;
     padding: 0;
@@ -3421,14 +3420,12 @@ i.left {
   }
 
   .materialize-iso nav .main i.material-icons {
-    width: 20px;
     position: relative;
     margin: 0;
     padding: 0;
   }
 
   .materialize-iso nav  .aux i.material-icons{
-    width: 10px;
     position: relative;
     margin: 0;
     padding: 0;
@@ -3442,7 +3439,7 @@ i.left {
   }
 
   .materialize-iso nav .main i.material-icons {
-    font-size: 20px;
+    font-size: 7.5vw;
     position: relative;
     margin-left: -8px;
     margin-right: -8px;
@@ -3450,10 +3447,10 @@ i.left {
   }
 
   .materialize-iso nav .aux i.material-icons {
-    font-size: 17px;
+    font-size: 7.5vw;
     position: relative;
-    margin-left: -7.5px;
-    margin-right: -7.5px;
+    margin-left: -8px;
+    margin-right: -8px;
     padding: 0px;
   }
 }


### PR DESCRIPTION
Description:
This pull request addresses the misalignment issue with the auxiliary menu in Music Blocks that appeared after recent changes in the master branch. The problem stemmed from adjustments to the CSS properties, specifically the font sizes, widths, and margins of the auxiliary menu icons in materialize-iso.css.

Changes Made:
Restored the original font size for the auxiliary menu icons to ensure proper scaling and visibility.
Adjusted the width and margin of the icons to maintain the correct positioning and layout of the menu.
Issue Fixed:
The changes made in commit 1c46c506 to fix toolbar resizing inadvertently caused the auxiliary menu to display incorrectly. This fix restores the expected behavior, ensuring the menu appears correctly aligned as it did previously.

Testing:
Verified the auxiliary menu alignment after reverting and adjusting the CSS properties.
The menu now appears as expected without any misalignment or layout issues.
Please review