### PR TITLE
fix calculation of the height and width as per viewport (for play-only-mode)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>
         Music Blocks
     </title>


### PR DESCRIPTION
fixes: #4493 

I believe this is more of a DPR issue because modern devices (like the iPhone XR) have high-resolution screens. The iPhone XR, for example, has a DPR of 2. This means:

The actual screen resolution is 828 x 1792 pixels (logical resolution × DPR).

The logical resolution (CSS pixels) is 414 x 896 pixels.

<img width="1346" alt="Screenshot 2025-03-05 at 12 22 16 PM" src="https://github.com/user-attachments/assets/cb442375-00df-475f-8b06-1475510d9a2d" />
Here you can see the values of the innerHeight and innerWidth are twice of the actual values.
<img width="626" alt="Screenshot 2025-03-05 at 12 45 41 PM" src="https://github.com/user-attachments/assets/019bbbab-24a4-49f0-807c-f6e8d854ebd3" />


The issue is the environment we are testing in. If you check the same code on an actual phone or device with a defined height and width, this issue will not arise. Browsers can simulate the width and height of the phone screens but don't match their respective DPR.

@walterbender Please take a look.