### PR TITLE
Remove Unused Volo Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,6 @@
     "url": "https://github.com/sugarlabs/musicblocks/issues"
   },
   "amd": {},
-  "volo": {
-    "baseUrl": "lib",
-    "dependencies": {
-      "domReady": "github:requirejs/domReady/2.0.1",
-      "webL10n": "github:sugarlabs/webL10n/master"
-    }
-  },
   "scripts": {
     "lint": "eslint js/**/*.js",
     "serve": "http-server -a 127.0.0.1 -p 3000 --gzip --brotli",


### PR DESCRIPTION
## Summary 

This PR removes the unused Volo configuration from the codebase.  

## Methods Used for Verification 

### 1. Searched for Imports in the Codebase

#### a. Use VS Code's Global Search

- Searched for `require('domReady')` or `define(['domReady'], function(...) { ... })`but found no occurrences.
- Searched for `require('webL10n')` or `define(['webL10n'], function(...) { ... })`but found no occurrences.

#### b. Checked Volo Usage 

- Used VS Code's Global Search to check for any references to Volo in the codebase but found none.  

### 2. Manually Checked Package References

- Confirmed that Volo is not listed in `dependencies` or `devDependencies`. 

### 3. After removal

```js
npm install
npm run dev
```