### PR TITLE
[Enhancements] Screen Recording Functionality

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1602,7 +1602,6 @@ class Activity {
                     alert(_("File save canceled"));
                     flag = 0;
                     recording();
-                    // doRecordButton();
                     return; // Exit without saving the file
                 }
 
@@ -1617,8 +1616,6 @@ class Activity {
                 flag = 0;
                 // eslint-disable-next-line no-use-before-define
                 recording();
-                // doRecordButton();
-                // that.textMsg(_("Click on stop saving"));
             }
             /**
              * Stops the recording process.
@@ -1626,9 +1623,6 @@ class Activity {
             function stopRec() {
                 flag = 0;
                 mediaRecorder.stop();
-                const node = document.createElement("p");
-                node.textContent = "Stopped recording";
-                document.body.appendChild(node);
             }
 
             /**
@@ -1640,16 +1634,10 @@ class Activity {
             function createRecorder (stream, mimeType) {
                 flag = 1;
                 recInside.classList.add("blink");
-                // start.removeEventListener(
-                //     "click",
-                //     createRecorder,
-                //     true
-                // );
                 let recordedChunks = [];
                 const mediaRecorder = new MediaRecorder(stream);
                 stream.oninactive = function () {
                     // eslint-disable-next-line no-console
-                    // console.log("Recording is ready to save");
                     stopRec();
                     flag = 0;
                 };
@@ -1669,11 +1657,6 @@ class Activity {
 
                 mediaRecorder.start(200);
                 start.addEventListener("click", stopRec);
-                // setTimeout(() => {
-                //     // eslint-disable-next-line no-console
-                //     console.log("Resizing for Record", that.canvas.height);
-                //     that._onResize();
-                // }, 500);
                 return mediaRecorder;
             }
 
@@ -1695,9 +1678,7 @@ class Activity {
                         if (flag == 1) {
                             this.removeEventListener("click",handler);
                         }
-                        // const node = document.createElement("p");
-                        // node.textContent = "Started recording";
-                        // document.body.appendChild(node);
+            
                         recInside.setAttribute("fill", "red");
                     }
                 );

--- a/js/activity.js
+++ b/js/activity.js
@@ -1633,9 +1633,9 @@ class Activity {
              */
             function createRecorder (stream, mimeType) {
                 flag = 1;
-                recInside.classList.add("blink");
                 let recordedChunks = [];
                 const mediaRecorder = new MediaRecorder(stream);
+                
                 stream.oninactive = function () {
                     // eslint-disable-next-line no-console
                     stopRec();
@@ -1656,6 +1656,8 @@ class Activity {
                 };
 
                 mediaRecorder.start(200);
+                recInside.classList.add("blink");
+                recInside.setAttribute("fill", "red");
                 start.addEventListener("click", stopRec);
                 return mediaRecorder;
             }
@@ -1679,7 +1681,6 @@ class Activity {
                             this.removeEventListener("click",handler);
                         }
             
-                        recInside.setAttribute("fill", "red");
                     }
                 );
             }

--- a/js/activity.js
+++ b/js/activity.js
@@ -1558,6 +1558,7 @@ class Activity {
             let mediaRecorder;
             var clickEvent = new Event("click");
             let flag = 0;
+            let stream = null;
 
             /**
              * Records the screen using the browser's media devices API.
@@ -1582,8 +1583,6 @@ class Activity {
                 );
             }
 
-            const that = this;
-
             /**
              * Saves the recorded chunks as a video file.
              * @param {Blob[]} recordedChunks - The recorded video chunks.
@@ -1603,7 +1602,7 @@ class Activity {
                     alert(_("File save canceled"));
                     flag = 0;
                     recording();
-                    doRecordButton();
+                    // doRecordButton();
                     return; // Exit without saving the file
                 }
 
@@ -1618,8 +1617,8 @@ class Activity {
                 flag = 0;
                 // eslint-disable-next-line no-use-before-define
                 recording();
-                doRecordButton();
-                that.textMsg(_("Click on stop saving"));
+                // doRecordButton();
+                // that.textMsg(_("Click on stop saving"));
             }
             /**
              * Stops the recording process.
@@ -1641,16 +1640,16 @@ class Activity {
             function createRecorder (stream, mimeType) {
                 flag = 1;
                 recInside.classList.add("blink");
-                start.removeEventListener(
-                    "click",
-                    createRecorder,
-                    true
-                );
+                // start.removeEventListener(
+                //     "click",
+                //     createRecorder,
+                //     true
+                // );
                 let recordedChunks = [];
                 const mediaRecorder = new MediaRecorder(stream);
                 stream.oninactive = function () {
                     // eslint-disable-next-line no-console
-                    console.log("Recording is ready to save");
+                    // console.log("Recording is ready to save");
                     stopRec();
                     flag = 0;
                 };
@@ -1669,47 +1668,47 @@ class Activity {
                 };
 
                 mediaRecorder.start(200);
-                setTimeout(() => {
-                    // eslint-disable-next-line no-console
-                    console.log("Resizing for Record", that.canvas.height);
-                    that._onResize();
-                }, 500);
+                start.addEventListener("click", stopRec);
+                // setTimeout(() => {
+                //     // eslint-disable-next-line no-console
+                //     console.log("Resizing for Record", that.canvas.height);
+                //     that._onResize();
+                // }, 500);
                 return mediaRecorder;
             }
 
             /**
              * Handles the recording process.
              */
-            function recording() {
+            async function recording() {
+
                 start.addEventListener(
                     "click",
                     async function handler() {
-                        const stream = await recordScreen();
+                        if (!stream || stream.active == false) {
+                            stream = await recordScreen();
+                            return;
+                        }
+
                         const mimeType = "video/webm";
                         mediaRecorder = createRecorder(stream, mimeType);
                         if (flag == 1) {
                             this.removeEventListener("click",handler);
                         }
-                        const node = document.createElement("p");
-                        node.textContent = "Started recording";
-                        document.body.appendChild(node);
+                        // const node = document.createElement("p");
+                        // node.textContent = "Started recording";
+                        // document.body.appendChild(node);
                         recInside.setAttribute("fill", "red");
                     }
                 );
             }
 
             // Start recording process if not already executing
-            if (flag == 0 && isExecuting) {
+            if (flag == 0) {
                 recording();
                 start.dispatchEvent(clickEvent);
                 flag = 1;
             };
-
-            // Stop recording if already executing
-            if (flag == 1 && isExecuting){
-                start.addEventListener("click", stopRec);
-                flag = 0;
-            }
 
         };
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -1665,14 +1665,13 @@ class Activity {
             /**
              * Handles the recording process.
              */
-            async function recording() {
+            function recording() {
 
                 start.addEventListener(
                     "click",
                     async function handler() {
                         if (!stream || stream.active == false) {
                             stream = await recordScreen();
-                            return;
                         }
 
                         const mimeType = "video/webm";


### PR DESCRIPTION


 This PR resolves https://github.com/sugarlabs/musicblocks/issues/4505


### Changes Made

- Screen sharing requires permission only once for recording multiple clips.
- Stop sharing does not need to be clicked every time for a recording.



### Working of Record feature after changes

- Clicking on Record button MB asks for screen share permission.
- Allowing permission shares current tab with MB and starts recording.
- Multiple clips can be recorded with record button.
- After stop sharing permission, above process can repeat.


[working_after_changes_2.webm](https://github.com/user-attachments/assets/6ff236a3-d773-4857-976b-be484a34f33a)





