### PR TITLE
[Fix] Dark mode Canvas background color in collapsed-view

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -718,8 +718,6 @@ table {
 
 #canvas {
   overflow-y: visible;
-  background-color: #FFFFFF; 
-  width: 100%;
 }
 
 #statusDiv {

--- a/css/themes.css
+++ b/css/themes.css
@@ -26,7 +26,7 @@
 }
 
 .dark #canvas {
-  background-color: #1c1c1c;
+  background-color: #1c1c1c !important;
 }
 
 .dark .blue.darken-1 {


### PR DESCRIPTION
This PR addresses the resurface of issue https://github.com/sugarlabs/musicblocks/issues/4381

It occurred after https://github.com/sugarlabs/musicblocks/commit/f3df4cad7a1fc3b42b5da06853eaf8708fd87995. 

After changes, The Canvas Background color changes in Dark mode as expected.

### Screenshots-

Before changes- 

![Screenshot from 2025-03-12 01-25-15](https://github.com/user-attachments/assets/16d6b15c-925f-4fda-93df-e09f1a8626e8)

After changes-

![Screenshot from 2025-03-12 01-22-28](https://github.com/user-attachments/assets/0d45106f-a815-4038-a061-f6b59ec98898)


