### PR TITLE
Add License Header

### DIFF
--- a/js/blocks/__tests__/BooleanBlocks.test.js
+++ b/js/blocks/__tests__/BooleanBlocks.test.js
@@ -1,3 +1,25 @@
+/**
+ * MusicBlocks v3.6.2
+ *
+ * @author Om Santosh Suneri
+ *
+ * @copyright 2025 Om Santosh Suneri
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 const { setupBooleanBlocks } = require('../BooleanBlocks');
 global._ = jest.fn((str) => str);
 global.BooleanBlock = jest.fn().mockImplementation((type) => ({


### PR DESCRIPTION
## Summary

This PR adds license header to `BooleanBlocks.test.js`.

## Related Issue 

#4478 