### PR TITLE
Replaced actions/checkout@v2 and actions/setup-node@v1 with v3

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Updated the smoke test workflow to use the newer versions of Github Actions:
- Changed actions/checkout from v2 to v3
- Changed actions/setup-node from v1 to v3

This update improves performance, security, and compatibility with the latest Github Actions features.
Closes #4531 
