### PR TITLE
Update DMP template from its source

### DIFF
--- a/.github/ISSUE_TEMPLATE/DMP_2024.yml
+++ b/.github/ISSUE_TEMPLATE/DMP_2024.yml
@@ -1,16 +1,17 @@
-name: DMP 2024 Project Template
-description: List a new project for Dedicated Mentoring Program (DMP) 2024 
-title: "[DMP 2024]: "
-labels: ["DMP 2024"]
+name: DMP 2025 Project Template
+description: List a new project for Dedicated Mentoring Program (DMP) 2025 
+title: "[DMP 2025]: "
+labels: ["DMP 2025"]
 body:
-    - type: textarea
+  - type: textarea
     id: ticket-description
     validations:
       required: true
     attributes:
       label: Ticket Contents
-      description: "Provide a brief description of the feature, including why it is needed and what it will accomplish. E.g., 'This feature aims to create an interactive UI for students to collaborate on assignments in real-time.'"
-
+      value: |
+        ## Description
+        [Provide a brief description of the feature, including why it is needed and what it will accomplish.]
 
   - type: textarea
     id: ticket-goals
@@ -74,7 +75,31 @@ body:
       description: Enter Organisation Name
       multiple: false
       options:
-        - Sugar Labs
+        - Bandhu
+        - Belongg
+        - Blockster Global (CREDBEL)
+        - Civis
+        - Dhwani
+        - Dhiway
+        - EGov
+        - EkShop Marketplace
+        - FIDE
+        - If Me
+        - Key Education Foundation
+        - Norwegian Meteorological Institute
+        - Planet Read
+        - Project Second Chance
+        - Reap Benefit
+        - SamagraX
+        - ShikshaLokam
+        - Tech4Dev
+        - Tekdi
+        - The Mifos Initiative
+        - Tibil
+        - Ushahidi
+        - Arghyam
+        - Piramal Swasthya Management Research Institute
+        - Belongg AI
     validations:
       required: true
 
@@ -83,12 +108,19 @@ body:
     attributes:
       label: Domain
       options:
+        - ⁠Healthcare 
         - ⁠Education
+        - Financial Inclusion
+        - ⁠Livelihoods
         - ⁠Skilling 
         - ⁠Learning & Development
+        - ⁠Agriculture
+        - ⁠Service Delivery
         - Open Source Library
+        - Water
     validations:
       required: true
+
 
   - type: dropdown
     id: ticket-technical-skills-required

--- a/.github/ISSUE_TEMPLATE/DMP_2024.yml
+++ b/.github/ISSUE_TEMPLATE/DMP_2024.yml
@@ -75,31 +75,7 @@ body:
       description: Enter Organisation Name
       multiple: false
       options:
-        - Bandhu
-        - Belongg
-        - Blockster Global (CREDBEL)
-        - Civis
-        - Dhwani
-        - Dhiway
-        - EGov
-        - EkShop Marketplace
-        - FIDE
-        - If Me
-        - Key Education Foundation
-        - Norwegian Meteorological Institute
-        - Planet Read
-        - Project Second Chance
-        - Reap Benefit
-        - SamagraX
-        - ShikshaLokam
-        - Tech4Dev
-        - Tekdi
-        - The Mifos Initiative
-        - Tibil
-        - Ushahidi
-        - Arghyam
-        - Piramal Swasthya Management Research Institute
-        - Belongg AI
+        - Sugar Labs
     validations:
       required: true
 
@@ -108,16 +84,10 @@ body:
     attributes:
       label: Domain
       options:
-        - ⁠Healthcare 
         - ⁠Education
-        - Financial Inclusion
-        - ⁠Livelihoods
         - ⁠Skilling 
         - ⁠Learning & Development
-        - ⁠Agriculture
-        - ⁠Service Delivery
         - Open Source Library
-        - Water
     validations:
       required: true
 


### PR DESCRIPTION
This PR updates our DMP file to its upstream (https://github.com/Code4GovTech/C4GT/blob/main/.github/ISSUE_TEMPLATE/DMP_2024.yml)

I have kept "2024" in the filename as it seems that the upstream has purposely kept that same name (there's a commit that reverts the name from "2025" to "2024").