### PR TITLE
fix: correct filename from toolbox.js to toolbar.js in README

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -632,11 +632,11 @@ connection 0 connects to the `newnote` block connection 1, etc.
 
 Checkbox regarding adding new languages to the Language pulldown menu.
 
-You must update three files: ```index.html```, ```js/toolbox.js``` and ```js/languagebox.js```
+You must update three files: ```index.html```, ```js/toolbar.js``` and ```js/languagebox.js```
 
 [ ] In ```index.html```, add an element for the language you are adding to ```"languagedropdown"```
 
-[ ] In ```toolbox.js```, add to the strings for both MUSIC BLOCKS and TURTLE ART
+[ ] In ```toolbar.js```, add to the strings for both MUSIC BLOCKS and TURTLE ART
 
 [ ] and add a click event to ```renderLanguageSelectIcon```
 


### PR DESCRIPTION
Updated README to reference the correct file (toolbar.js instead of toolbox.js) in the instructions for adding a new language.