### PR TITLE
Solved Multiple StatsWindow instances created when clicking the "Display statistics" button repeatedly

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5726,7 +5726,9 @@ class Activity {
         };
 
         const doAnalytics = (activity) => {
-            activity.statsWindow = new StatsWindow(activity);
+            if (!activity.statsWindow || !activity.statsWindow.isOpen) {
+                activity.statsWindow = new StatsWindow(activity);
+            }
         };
 
         /*


### PR DESCRIPTION
## Explanation of the Fix:
- The updated code checks if activity.statsWindow is already open before creating a new one.
- If the window exists (activity.statsWindow) and is open (activity.statsWindow.isOpen), it does nothing.
- If it's not open, a new StatsWindow instance is created.

Fixes #4557 