### PR TITLE
Add .dockerignore to improve Docker build efficiency (#4571)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Exclude Node.js dependencies
+node_modules/
+*.log
+package-lock.json
+yarn.lock
+
+# Exclude version control metadata
+.git/
+.gitignore
+
+# Exclude documentation and markdown files
+docs/
+*.md
+
+# Exclude development configuration files
+.env
+.env.*
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Exclude test files and artifacts
+tests/
+__tests__/
+coverage/
+*.test.js
+*.spec.js
+*.snap
+screenshots/
+
+# Exclude build artifacts and temporary files
+dist/
+build/
+out/
+*.bak
+*.tmp
+*.cache
+
+# Exclude OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Overview
This PR adds a .dockerignore file to exclude unnecessary files (e.g., node_modules, documentation, tests) from the Docker build context.

### Impact
   -  Build context size went from ~401 MB down to ~201 MB.
   -  Final image remains functional and unchanged in behavior.

Closes #4571
By reducing the build context, Docker builds are now faster and more efficient.