### PR TITLE
Fix:  Temperament Widget Playing Wierd Notes

### DIFF
--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -628,16 +628,20 @@ function setupPitchActions(activity) {
                 return stepType === "up"
                     ? getStepSizeUp(
                         tur.singer.keySignature,
-                        tur.singer.lastNotePlayed[0].slice(0, len - 1)
+                        tur.singer.lastNotePlayed[0].slice(0, len - 1),
+                        null,
+                        activity.logo.synth.inTemperament
                     )
                     : getStepSizeDown(
                         tur.singer.keySignature,
-                        tur.singer.lastNotePlayed[0].slice(0, len - 1)
+                        tur.singer.lastNotePlayed[0].slice(0, len - 1),
+                        null,
+                        activity.logo.synth.inTemperament
                     );
             } else {
                 return stepType === "up"
-                    ? getStepSizeUp(tur.singer.keySignature, "G")
-                    : getStepSizeDown(tur.singer.keySignature, "G");
+                    ? getStepSizeUp(tur.singer.keySignature, "G", null, activity.logo.synth.inTemperament)
+                    : getStepSizeDown(tur.singer.keySignature, "G", null, activity.logo.synth.inTemperament);
             }
         }
     };


### PR DESCRIPTION
I read about temperament and related terms , in the codebase found temperament.js , musicutils.js and pitchactions.js related to it .

issue: https://github.com/sugarlabs/musicblocks/issues/4033

I figured out problem was that the consonantStepSize function in PitchActions.js wasn't passing the temperament parameter to the getStepSizeUp and getStepSizeDown functions. This meant that when using non-12EDO default temperaments, the step size calculation couldn't properly identify which temperament to use.

fix adds the activity.logo.synth.inTemperament parameter to the calls to these functions, ensuring that the correct temperament is used for the step size calculation. This allows the Scalar Step to properly navigate through all scale degrees (1-8) in any temperament, rather than stopping at the 5th degree