### PR TITLE
 Translate 'JavaScript Editor' for all supported languages

### DIFF
--- a/po/ayc.po
+++ b/po/ayc.po
@@ -1585,7 +1585,7 @@ msgstr ""
 #: js/turtledefs.js:669
 #.TRANS: Editor de Javascript
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "JavaScript Editor"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/gn.po
+++ b/po/gn.po
@@ -3511,7 +3511,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "JavaScript Mohendaha"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/ja.po
+++ b/po/ja.po
@@ -1398,7 +1398,7 @@ msgstr "変化記号を設定"
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr "ジャバスクリプト エディタ"
+msgstr "JavaScript エディタ"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/ko.po
+++ b/po/ko.po
@@ -1397,7 +1397,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "자바스크립트 편집기"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/pt.po
+++ b/po/pt.po
@@ -1401,7 +1401,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "Editor de JavaScript"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/quz.po
+++ b/po/quz.po
@@ -1988,7 +1988,7 @@ msgstr ""
 #: js/turtledefs.js:669
 #.TRANS: Editor de Javascript
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "JavaScript Llamk'apusqa"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/th.po
+++ b/po/th.po
@@ -1397,7 +1397,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "ตัวแก้ไข JavaScript"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1792,7 +1792,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "JavaScript 编辑器"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1397,7 +1397,7 @@ msgstr ""
 #: js/toolbar.js:272
 #: js/turtledefs.js:669
 msgid "JavaScript Editor"
-msgstr ""
+msgstr "JavaScript 編輯器"
 
 #: js/toolbar.js:76
 #: js/toolbar.js:142


### PR DESCRIPTION
## Description  
This PR updates the translations for **"JavaScript Editor"** in all supported languages listed in the language selection dropdown.

No changes were made to `localisation.ini`. Let me know if it needs to be regenerated or if it is handled automatically.  

Additionally, I noticed that some `.po` files contain empty translation fields, which seems to be a separate issue. I will open a new issue for that.

## Solves Issue  
Resolves #3698 – Rename the button from **"Toggle JavaScript Editor"** to **"JavaScript Editor"** for all supported languages.  
