### PR TITLE
Add upstream source mapping for minified JS libraries

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,43 @@
+## What are `.min.js` files?
+
+Minified JavaScript files (`.min.js`) are versions of regular JavaScript files that have been compressed to reduce their file size. This is done by removing unnecessary characters such as whitespace, line breaks, comments, and shortening variable names without affecting the actual functionality of the code.
+
+These minified files are typically used in production environments to improve web performance by decreasing load times and bandwidth usage.
+
+If you need to view or modify the original source code, it's best to refer to the upstream (non-minified) versions, which are more readable and better suited for development and debugging.
+
+## Sources of Upstream Versions
+
+| S/N | Minified file                         | Upstream Source                                                                                      |
+| --- | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 01  | `abc.min.js`                          | [abcjs](https://github.com/paulrosen/abcjs) <!-- Used in MB: v6.3.0, Latest: v6.6.4 -->              |
+| 02  | `astring.min.js`                      | [astring](https://github.com/davidbonnet/astring)                                                    |
+| 03  | `Chart.js`                            | [Chart.js](https://github.com/chartjs/Chart.js) <!-- Used in MB: v1.0.2, Latest: v4.4.9 -->          |
+| 04  | `domReady.js`                         | [domReady](https://github.com/requirejs/domReady)                                                    |
+| 05  | `easeljs.min.js`                      | [EaselJS](https://github.com/CreateJS/EaselJS)                                                       |
+| 06  | `howler.js`                           | [howler.js](https://github.com/goldfire/howler.js) <!-- Used in MB: v1.1.25, Latest: v2.2.4 -->      |
+| 07  | `jquery-3.7.1.js`                     | [jquery](https://github.com/jquery/jquery)                                                           |
+| 08  | `jquery-ui.js`                        | [jquery-ui](https://github.com/jquery/jquery-ui) <!-- Used in MB: v1.11.4, Latest: v1.14.1 -->       |
+| 09  | `jquery.cookie.js`                    | [jquery-cookie](https://github.com/carhartl/jquery-cookie) (No longer maintained)                    |
+| 10  | `jquery.joyride-2.1.js`               | [joyride](https://github.com/zurb/joyride)                                                           |
+| 11  | `jquery.ruler.js`                     | [Ruler](https://github.com/hilliuse/Ruler)                                                           |
+| 12  | `materialize.min.js`                  | [materialize](https://github.com/Dogfalo/materialize) <!-- Used in MB: v0.100.2, Latest: v1.0.0 -->  |
+| 13  | `mespeak.js`                          | [speak.js](https://github.com/kripken/speak.js)                                                      |
+| 14  | `midi.js`                             | [midi.js]() (Upstream link TBD)                                                                      |
+| 15  | `modernizr-2.6.2.min.js`              | [Modernizr](https://github.com/Modernizr/Modernizr) <!-- Used in MB: v2.6.2, Latest: v3.13.1 -->     |
+| 16  | `p5.dom.min.js`                       | [p5.dom.min.js]() (Upstream link TBD)                                                                |
+| 17  | `p5.min.js`                           | [p5.js](https://github.com/processing/p5.js) <!-- Used in MB: v1.11.3, Latest: v1.11.4 -->           |
+| 18  | `p5.sound.min.js`                     | [p5.js-sound](https://github.com/processing/p5.js-sound) <!-- Used in MB: v1.0.1, Latest: v1.0.2 --> |
+| 19  | `prefixfree.min.js`                   | [prefixfree](https://github.com/LeaVerou/prefixfree) (No longer maintained)                          |
+| 20  | `preloadjs.min.js`                    | [PreloadJS](https://github.com/CreateJS/PreloadJS)                                                   |
+| 21  | `raphael.min.js`                      | [raphael](https://github.com/DmitryBaranovskiy/raphael)                                              |
+| 22  | `require.js`                          | [requirejs](https://github.com/requirejs/requirejs) <!-- Used in MB: v2.1.4, Latest: v2.3.7 -->      |
+| 23  | `reqwest.js`                          | [reqwest](https://github.com/ded/reqwest)                                                            |
+| 24  | `sw.js`                               | [sw.js]() (Upstream link TBD)                                                                        |
+| 25  | `text.js`                             | [text](https://github.com/requirejs/text) <!-- Used in MB: v2.0.10, Latest: v2.0.16 -->              |
+| 26  | `Tone.js`                             | [Tone.js](https://github.com/Tonejs/Tone.js) <!-- Used in MB: Not specified; Latest: v14.7.39 -->    |
+| 27  | `tweenjs.min.js`                      | [TweenJS](https://github.com/CreateJS/TweenJS)                                                       |
+| 28  | `webL10n.js` & `webL10n.sugarizer.js` | [webL10n](https://github.com/fabi1cazenave/webL10n)                                                  |
+| 29  | `wheelnav.js`                         | [wheelnav](https://github.com/softwaretailoring/wheelnav)                                            |
+
+<!-- TODO: Add a separate column for description for libs -->


### PR DESCRIPTION
## Summary

This PR documents the purpose of `.min.js` files and provides a comprehensive table linking commonly used minified JavaScript libraries to their upstream (non-minified) source repositories for reference and development use.

## Changes introduced

- Added a brief explanation of what `.min.js` files are and their usage in production.
- Created a structured table mapping JavaScript files to their corresponding upstream GitHub repositories.
- Noted version differences where applicable and flagged unmaintained libraries or missing upstream links.

## Checklist

- [x]  My changes adhere to the project's contribution guidelines. 

cc: @walterbender 