### PR TITLE
Added examples of double-sharp and double-flat scales to theory guide

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -382,6 +382,25 @@ block `re` is lowered by one half step; on the right, both *Pitch*
 blocks are raised by one half step. (You can also use a double-sharp
 or double-flat accidental.) [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1733231694757697&run=True)
 
+## Understanding Double Sharps and Double Flats
+
+Here are some examples:
+
+### G♯ Major Scale:
+G♯, A♯, B♯, C♯, D♯, E♯, **F𝄪**
+
+### D♯ Major Scale:
+D♯, E♯, **F𝄪**, G♯, A♯, B♯, **C𝄪**
+
+### F♭ Major Scale:
+F♭, G♭, A♭, **B𝄫**, C♭, D♭, E♭
+
+### Bartók's Example:
+Mikrokosmos No. 136 contains double-flats.  
+See: [Wikipedia – Mikrokosmos](https://en.wikipedia.org/wiki/Mikrokosmos_(Bart%C3%B3k))
+
+
+
 #### <a name="ADJUST-TRANSPOSITION">3.2.3 Adjusting Transposition</a>
 
 ![transposition](./transform2.svg "Adjusting transpositions")

--- a/guide/README.md
+++ b/guide/README.md
@@ -382,6 +382,15 @@ block `re` is lowered by one half step; on the right, both *Pitch*
 blocks are raised by one half step. (You can also use a double-sharp
 or double-flat accidental.) [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1733231694757697&run=True)
 
+## Why Use Double-Sharps and Double-Flats?
+
+In musical notation, each note in a scale should have a unique letter name (A to G). Double-sharps (𝄪) and double-flats (𝄫) are used to maintain this structure and avoid repeating letters within a scale.
+For example:
+
+In G♯ Major, instead of ending on G again, we write F𝄪 to preserve the one-letter-per-note pattern.
+
+In D♯ Major, we use C𝄪 instead of D for the same reason. Though enharmonically equivalent (F𝄪 = G), using double-sharps ensures that music theory and notation rules are followed.
+
 ## Understanding Double Sharps and Double Flats
 
 Here are some examples:

--- a/guide/README.md
+++ b/guide/README.md
@@ -282,6 +282,66 @@ program music. Note that you can program with chunks you create by
 hand or use [*The Phrase Maker*](#42-generating-chunks-of-notes)
 widget to help you get started.
 
+### <a name="PROGRAM-BLOCKS">6.3 Program Blocks</a>
+
+### <a name="PROGRAM-BLOCKS">6.3 Program Blocks</a>
+
+The Program palette contains advanced blocks for data storage, file operations, and project interactions. These blocks are useful for saving/loading state, managing values across sessions, and enabling more complex behavior.
+
+---
+
+#### 🧱 `set heap`
+Initializes a heap (list-like structure) that can store multiple values. Useful for stacking or queuing data.
+
+---
+
+#### 🧱 `load heap`
+Loads a previously saved heap from the project storage. Use this to reuse or restore previously stored data.
+
+---
+
+#### 🧱 `save heap`
+Saves the current heap data into the project file, so it can be restored later using `load heap`.
+
+---
+
+#### 🧱 `set dictionary`
+Sets a named dictionary. A dictionary is a key–value pair structure, similar to JSON or maps in other languages.  
+Use this block to assign values to keys for flexible data storage.
+
+---
+
+#### 🧱 `load dictionary`
+Loads a dictionary from a file or the app storage, using the given name. The values can then be accessed using other dictionary blocks.
+
+---
+
+#### 🧱 `save dictionary`
+Saves the current dictionary to a file. This is useful when working on data-driven projects or loading configurations.
+
+---
+
+#### 🧱 `save heap to App`
+Stores the heap in the Music Blocks application’s local storage. Useful for persisting state across sessions without requiring a file download.
+
+---
+
+#### 🧱 `load heap from App`
+Loads heap data from the local App storage (previously saved via `save heap to App`). This allows you to resume a project or dataset easily.
+
+---
+
+#### 🧱 `open palette`
+Opens a specific block palette programmatically. For example, this can be used in a guided tutorial to focus on a certain category.
+
+---
+
+#### 🧱 `open project`
+Loads and opens a different Music Blocks project. Can be used to create menu-based or modular projects that jump between files.
+
+---
+
+
 ### <a name="ACTIONS">3.1 Actions</a>
 
 ![action](./chunk-2.svg "working of action stack")

--- a/guide/README.md
+++ b/guide/README.md
@@ -384,12 +384,16 @@ or double-flat accidental.) [RUN LIVE](https://musicblocks.sugarlabs.org/index.h
 
 ## Why Use Double-Sharps and Double-Flats?
 
-In musical notation, each note in a scale should have a unique letter name (A to G). Double-sharps (𝄪) and double-flats (𝄫) are used to maintain this structure and avoid repeating letters within a scale.
+## Why Use Double-Sharps and Double-Flats?
+
+In music, we try to give each note in a scale its own letter name (A to G) so it's easy to read and follow. Sometimes, we use double-sharps (𝄪) or double-flats (𝄫) to keep this rule, even if the note sounds the same as a more common one.
+
 For example:
+- In the **G♯ Major** scale, the last note is written as **F𝄪** instead of repeating **G**. This helps each step in the scale use a different letter.
+- In the **D♯ Major** scale, we write **C𝄪** instead of **D** for the same reason.
 
-In G♯ Major, instead of ending on G again, we write F𝄪 to preserve the one-letter-per-note pattern.
+Even though **F𝄪** and **G** sound the same on a keyboard, writing them differently helps show where you are in the scale and how the music is built.
 
-In D♯ Major, we use C𝄪 instead of D for the same reason. Though enharmonically equivalent (F𝄪 = G), using double-sharps ensures that music theory and notation rules are followed.
 
 ## Understanding Double Sharps and Double Flats
 


### PR DESCRIPTION
This PR addresses the issue where users are confused about the presence and use of double-sharps (𝄪) and double-flats (𝄫) in Music Blocks. I've added clear examples to the theory guide to improve understanding, including common scales and a reference to Bartók’s Mikrokosmos.

Changes Made:

Added a new section in the music theory guide for:

G♯ Major (includes F𝄪)

D♯ Major (includes F𝄪 and C𝄪)

F♭ Major (includes B𝄫)

Reference to Bartók’s Mikrokosmos No. 136, which features double flats

Used Unicode symbols to display sharps and flats clearly