### PR TITLE
added coverage folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *~
+coverage


### PR DESCRIPTION
Fixes #4652 

When running the command npx jest --coverage, unnecessary files in the coverage folder were getting tracked by the git repository. This created a unexpectedly large amount of files to be tracked and committed to git, if files are not staged manually.

Changes:
- added coverage to gitignore