### PR TITLE
This PR fixes a UI delay issue where the setInstrument and start sidebars only expand or contract after the mouse leaves the note value block expand/collapse button. 

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1508,7 +1508,14 @@ class Block {
                 }
 
                 that.collapseButtonBitmap.visible = !that.collapsed;
-
+                //changes made here
+                that.collapseButtonBitmap.on("click", () => {
+                    that.collapsed = true;
+                    that.show(); // Refresh block view
+                
+                    // Immediately update sidebar
+                    that.blocks.expandOrCollapseSidebars?.(); // Optional chaining if function exists
+                });
                 __finishCollapse(that);
             };
 
@@ -1533,6 +1540,13 @@ class Block {
 
                 that.container.addChild(that.expandButtonBitmap);
                 that.expandButtonBitmap.visible = that.collapsed;
+                that.expandButtonBitmap.on("click", () => {
+                    that.collapsed = false;
+                    that.show(); // Refresh block view
+                
+                    // Immediately update sidebar
+                    that.blocks.expandOrCollapseSidebars?.();
+                });
 
                 that.expandButtonBitmap.x = 2 * that.protoblock.scale;
                 if (that.isInlineCollapsible()) {


### PR DESCRIPTION
Description:

This PR fixes a UI delay issue where the setInstrument and start sidebars only expand or contract after the mouse leaves the note value block expand/collapse button. The new behavior ensures that the sidebar updates happen immediately on button click.

Changes Made:

Added onclick event listeners to collapseButtonBitmap and expandButtonBitmap inside _generateCollapseArtwork().

On click, the block's collapsed state updates and the visual state is refreshed with show().

Calls blocks.expandOrCollapseSidebars() (if defined) to update the sidebar instantly.

Expected Behavior:

When the user clicks the expand or collapse button on a note value block, the start and setInstrument sidebars now update immediately, without needing mouse movement.

Issue Reference:
Fixes issue: "Late expansion and contraction of setInstrument and start sidebar when note value blocks are expanded or contracted."