### PR TITLE
Add musical examples of double-sharp and double-flat usage (#3855)

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -387,15 +387,15 @@ Double-sharps (𝄪) and double-flats (𝄫) are used in certain keys and advanc
 
 1. **G♯ Major Scale**  
    - Notes: G♯, A♯, B♯, C♯, D♯, E♯, F𝄪  
-   - F𝄪 is used instead of G to preserve stepwise motion in the scale.
+   - F𝄪 is used instead of G to keep the pattern of moving from one note to the next closest note in the scale.
 
 2. **D♯ Major Scale**  
    - Notes: D♯, E♯, F𝄪, G♯, A♯, B♯, C𝄪  
-   - F𝄪 and C𝄪 are enharmonic to G and D, respectively, but keep the scale consistent.
+   - F𝄪 and C𝄪 sound the same as G and D, respectively, but are written differently to maintain the scale's logical structure.
 
 3. **F♭ Major Scale**  
    - Notes: F♭, G♭, A♭, B𝄫, C♭, D♭, E♭  
-   - B𝄫 helps maintain the correct intervallic relationships.
+   - B𝄫 helps maintain the correct distances between notes in the scale.
 
 4. **Béla Bartók’s Mikrokosmos No. 136 – "Whole-tone Scale"**  
    - This piece uses double-flats to maintain theoretical clarity in whole-tone passages.  

--- a/guide/README.md
+++ b/guide/README.md
@@ -381,6 +381,25 @@ lower by one half step. In the example, on the left, just the *Pitch*
 block `re` is lowered by one half step; on the right, both *Pitch*
 blocks are raised by one half step. (You can also use a double-sharp
 or double-flat accidental.) [RUN LIVE](https://musicblocks.sugarlabs.org/index.html?id=1733231694757697&run=True)
+##### Examples of Double-Sharp and Double-Flat Usage
+
+Double-sharps (𝄪) and double-flats (𝄫) are used in certain keys and advanced compositions to preserve correct scale structure or harmonic context. Here are a few examples:
+
+1. **G♯ Major Scale**  
+   - Notes: G♯, A♯, B♯, C♯, D♯, E♯, F𝄪  
+   - F𝄪 is used instead of G to preserve stepwise motion in the scale.
+
+2. **D♯ Major Scale**  
+   - Notes: D♯, E♯, F𝄪, G♯, A♯, B♯, C𝄪  
+   - F𝄪 and C𝄪 are enharmonic to G and D, respectively, but keep the scale consistent.
+
+3. **F♭ Major Scale**  
+   - Notes: F♭, G♭, A♭, B𝄫, C♭, D♭, E♭  
+   - B𝄫 helps maintain the correct intervallic relationships.
+
+4. **Béla Bartók’s Mikrokosmos No. 136 – "Whole-tone Scale"**  
+   - This piece uses double-flats to maintain theoretical clarity in whole-tone passages.  
+   - Reference: [Mikrokosmos on Wikipedia](https://en.wikipedia.org/wiki/Mikrokosmos_(Bart%C3%B3k))
 
 #### <a name="ADJUST-TRANSPOSITION">3.2.3 Adjusting Transposition</a>
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -387,18 +387,18 @@ Double-sharps (𝄪) and double-flats (𝄫) are used in certain keys and advanc
 
 1. **G♯ Major Scale**  
    - Notes: G♯, A♯, B♯, C♯, D♯, E♯, F𝄪  
-   - F𝄪 is used instead of G to keep the pattern of moving from one note to the next closest note in the scale.
+   - F𝄪 is used instead of G to keep the pattern of moving step by step through the musical alphabet (A to G).
 
 2. **D♯ Major Scale**  
    - Notes: D♯, E♯, F𝄪, G♯, A♯, B♯, C𝄪  
-   - F𝄪 and C𝄪 sound the same as G and D, respectively, but are written differently to maintain the scale's logical structure.
+   - C𝄪 is written instead of D so that the note names follow the correct sequence and each letter is used only once.
 
 3. **F♭ Major Scale**  
    - Notes: F♭, G♭, A♭, B𝄫, C♭, D♭, E♭  
-   - B𝄫 helps maintain the correct distances between notes in the scale.
+   - B𝄫 is used instead of A to preserve the proper spacing between scale steps.
 
 4. **Béla Bartók’s Mikrokosmos No. 136 – "Whole-tone Scale"**  
-   - This piece uses double-flats to maintain theoretical clarity in whole-tone passages.  
+   - This piece uses double-flats to keep the note names in the right order, even if some notes sound the same as others.  
    - Reference: [Mikrokosmos on Wikipedia](https://en.wikipedia.org/wiki/Mikrokosmos_(Bart%C3%B3k))
 
 #### <a name="ADJUST-TRANSPOSITION">3.2.3 Adjusting Transposition</a>


### PR DESCRIPTION
# Fix: #3855 Add musical examples of double-sharp and double-flat usage

I have taken a simple and direct approach following the issue requirements:
1. Added examples of G♯ Major, D♯ Major, and F♭ Major scales showing where double-sharps/flats occur
2. Included the reference to Bartók's Mikrokosmos No. 136 as suggested
3. Added brief explanations of why these notation choices are necessary

Fixes #3855