### PR TITLE
test: remove unnecessary console.log statements from palette tests

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -119,10 +119,8 @@ describe("Palettes Class", () => {
 
     test("hide and show functions modify visibility", () => {
         palettes.hide();
-        console.log("Visibility after hide:", docById("palette").style.visibility);
         expect(docById("palette").style.visibility).toBe("hidden");
         palettes.show();
-        console.log("Visibility after show:", docById("palette").style.visibility);
         expect(docById("palette").style.visibility).toBe("visible");
     });
 });


### PR DESCRIPTION
- Remove debug console.log statements from palette.test.js
- Improves test output clarity by removing noise
- Follows best practices for test file cleanliness