### PR TITLE
Feat: Add AI-powered debugger backend and chatbot UI 

### DIFF
--- a/musicblocks-ai-debugger/chatbot.html
+++ b/musicblocks-ai-debugger/chatbot.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Music Blocks AI Debugger</title>
+</head>
+<body>
+  <h2>Ask the AI</h2>
+  <input id="question" placeholder="Ask your question..." size="50">
+  <button onclick="askBot()">Ask</button>
+  <pre id="response"></pre>
+
+  <script>
+    function askBot() {
+      const question = document.getElementById("question").value;
+      fetch("http://localhost:8000/query", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question })
+      })
+      .then(res => res.json())
+      .then(data => {
+        document.getElementById("response").innerText = data.response;
+      });
+    }
+  </script>
+</body>
+</html>

--- a/musicblocks-ai-debugger/main.py
+++ b/musicblocks-ai-debugger/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI, Request
+from transformers import pipeline
+
+app = FastAPI()
+
+qa_pipeline = pipeline("text-generation", model="sshleifer/tiny-gpt2")
+
+@app.post("/query")
+async def ask_bot(request: Request):
+    data = await request.json()
+    question = data.get("question", "")
+    prompt = f"Answer this Music Blocks question:\n{question}\nAnswer:"
+    response = qa_pipeline(prompt, max_length=300)
+    return {"response": response[0]['generated_text']}
+


### PR DESCRIPTION
This PR adds the first version of the AI-powered debugger as described in issue #4538.

### What’s Included:
- `main.py`: FastAPI backend using a local language model (`tiny-gpt2`)
- `/query` endpoint: accepts user questions and returns AI-generated answers
- `chatbot.html`: Simple web-based chatbot interface for testing

### How It Works:
- Run `main.py` with `uvicorn`
- Open `chatbot.html` in browser
- Type a Music Blocks-related question
- The assistant returns a basic AI-generated answer

This sets up the foundation for future enhancements like:
- Retrieval-augmented generation (RAG)
- Better block context
- Inline assistant inside the Music Blocks UI
