### PR TITLE
Feature Added: Reflective Prompts for Pause and Save Events

### DIFF
--- a/lib/sugar-web/activity/activity.js
+++ b/lib/sugar-web/activity/activity.js
@@ -36,14 +36,18 @@ define(["webL10n.sugarizer",
         l10n.start();
 
         /**
-         * Sends a pause event when notified by the bus.
+         * Sends a pause event when notified by the bus and triggers a reflective prompt.
          */
         function sendPauseEvent() {
-			var pauseEvent = document.createEvent("CustomEvent");
-			pauseEvent.initCustomEvent('activityPause', false, false, {
-				'cancelable': true
-			});
+            var pauseEvent = document.createEvent("CustomEvent");
+            pauseEvent.initCustomEvent('activityPause', false, false, {
+                'cancelable': true
+            });
             window.dispatchEvent(pauseEvent);
+
+            // Trigger reflective prompt
+            const reflectionPrompt = `What did you do? Why did you do it? What did you learn? What will you do next?`;
+            alert(reflectionPrompt);
         }
 
         // Listen for 'activity.pause' notification to send pause event

--- a/lib/sugar-web/graphics/activitypalette.js
+++ b/lib/sugar-web/graphics/activitypalette.js
@@ -33,6 +33,11 @@ define(["sugar-web/graphics/palette",
             // Trigger reflective prompt
             const reflectionPrompt = `What did you do? Why did you do it? What did you learn? What will you do next?`;
             alert(reflectionPrompt);
+
+            // Reapply reflective prompt if not saved
+            if (!datastoreObject.getMetadata().title_set_by_user) {
+                alert(reflectionPrompt);
+            }
         };
 
         this.descriptionElem.onblur = function () {
@@ -44,6 +49,11 @@ define(["sugar-web/graphics/palette",
             // Trigger reflective prompt
             const reflectionPrompt = `What did you do? Why did you do it? What did you learn? What will you do next?`;
             alert(reflectionPrompt);
+
+            // Reapply reflective prompt if not saved
+            if (!datastoreObject.getMetadata().description) {
+                alert(reflectionPrompt);
+            }
         };
     };
 

--- a/lib/sugar-web/graphics/activitypalette.js
+++ b/lib/sugar-web/graphics/activitypalette.js
@@ -29,6 +29,10 @@ define(["sugar-web/graphics/palette",
                 "title_set_by_user": "1"
             });
             datastoreObject.save();
+
+            // Trigger reflective prompt
+            const reflectionPrompt = `What did you do? Why did you do it? What did you learn? What will you do next?`;
+            alert(reflectionPrompt);
         };
 
         this.descriptionElem.onblur = function () {
@@ -36,6 +40,10 @@ define(["sugar-web/graphics/palette",
                 "description": this.value
             });
             datastoreObject.save();
+
+            // Trigger reflective prompt
+            const reflectionPrompt = `What did you do? Why did you do it? What did you learn? What will you do next?`;
+            alert(reflectionPrompt);
         };
     };
 


### PR DESCRIPTION
#4542  Feature Added: Reflective Prompts for Pause and Save Events

This update introduces reflective prompts to enhance the learning experience in Music Blocks. The changes include:

Pause Event:

A reflective prompt is triggered when the activity is paused, asking the user:
What did you do?
Why did you do it?
What did you learn?
What will you do next?
Save Event:

Reflective prompts are displayed when the title or description fields are updated and saved in the activity palette.
These changes aim to encourage learners to reflect on their actions, aligning with the Constructionist learning pedagogy.