### PR TITLE
Add canvas + audio recording feature with Start/Stop buttons

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7093,3 +7093,76 @@ define(MYDEFINES, (compatibility) =>{
     activity.doContextMenus();
     activity.doPluginsAndPaletteCols();
 });
+
+// Create Start Button
+const startBtn = document.createElement("button");
+startBtn.textContent = "🎥 Start Recording";
+startBtn.style.position = "absolute";
+startBtn.style.top = "10px";
+startBtn.style.right = "160px";
+startBtn.style.zIndex = 9999;
+startBtn.onclick = startRecording;
+document.body.appendChild(startBtn);
+
+// Create Stop Button
+const stopBtn = document.createElement("button");
+stopBtn.textContent = "⏹️ Stop Recording";
+stopBtn.style.position = "absolute";
+stopBtn.style.top = "10px";
+stopBtn.style.right = "20px";
+stopBtn.style.zIndex = 9999;
+stopBtn.onclick = stopRecording;
+document.body.appendChild(stopBtn);
+
+//add recording functions
+let mediaRecorder;
+let recordedChunks = [];
+
+function startRecording() {
+  const canvas = document.querySelector("canvas");
+  const audioContext = window.audioContext || new AudioContext();
+
+  if (!canvas || !audioContext) {
+    alert("Canvas or AudioContext not found!");
+    return;
+  }
+
+  const canvasStream = canvas.captureStream(30);
+  const audioStream = audioContext.destination.stream;
+
+  const combinedStream = new MediaStream([
+    ...canvasStream.getVideoTracks(),
+    ...audioStream.getAudioTracks(),
+  ]);
+
+  mediaRecorder = new MediaRecorder(combinedStream);
+
+  mediaRecorder.ondataavailable = function (e) {
+    if (e.data.size > 0) {
+      recordedChunks.push(e.data);
+    }
+  };
+
+  mediaRecorder.onstop = function () {
+    const blob = new Blob(recordedChunks, { type: "video/webm" });
+    recordedChunks = [];
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "musicblocks_recording.webm";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  mediaRecorder.start();
+  console.log("🎬 Recording started...");
+}
+
+function stopRecording() {
+  if (mediaRecorder && mediaRecorder.state !== "inactive") {
+    mediaRecorder.stop();
+    console.log("🛑 Recording stopped.");
+  }
+}
+
+


### PR DESCRIPTION
fix #1673 

This PR adds a new feature to record the Music Blocks canvas animation along with audio as a video (.webm). This helps users, especially students, to export their mouse artwork and music performance as a downloadable video file.

### What was added?

- Added two new buttons:
  - 🎥 "Start Recording"
  - ⏹️ "Stop Recording"
- Used `canvas.captureStream()` and `audioContext.destination.stream` to create a combined media stream.
- Used `MediaRecorder` to capture and save the output as a downloadable `.webm` video file.

### Files Modified

- `js/activity.js`

### Motivation

This solves [Issue #1673 ] which requested the ability to record the canvas drawing and music together into a video format (e.g., MP4/WebM) for easy sharing or documentation.

### Demo

You can test the feature by:
1. Opening Music Blocks in browser (`http://127.0.0.1:3000/`)
2. Creating some music + mouse animations
3. Clicking "Start Recording", then "Stop Recording"
4. A `.webm` file will automatically download

---

Let me know if any improvements are needed. I'm happy to make further changes.
