### PR TITLE
Fix Sequential Note Playback in Simple Tuplet Block

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -975,7 +975,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 tur.singer.inNoteBlock.push(blk);
 
                 const bpmFactor =
-                    TONEBPM / tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM;
+                    TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
                 const beatValue = bpmFactor / noteBeatValue / arg0;
 
@@ -998,7 +998,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                     }
 
                     __rhythmPlayNote(
-                        noteBeatValue * arg0,
+                        noteBeatValue,
                         blk,
                         turtle,
                         __callback,


### PR DESCRIPTION
Hi @therealharshit,

This PR addresses the issue#4633 with the timing and behavior of tuplet blocks, building upon my earlier PRs. After reviewing and testing further, I have restructured and cleaned up the implementation to ensure accurate note scheduling in tuplet patterns.

Debug Logs for Verification(for an 7 1/4 tuplet block):
bpmFactor: 2.6666666666666665
RhythmBlockPaletteBlocks.js:1009 noteBeatValue: 4
RhythmBlockPaletteBlocks.js:1010 beatValue: 0.09523809523809523
RhythmBlockPaletteBlocks.js:1012 Scheduling note 1/7 with delay: 0ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 2/7 with delay: 95.23809523809523ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 3/7 with delay: 190.47619047619045ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 4/7 with delay: 285.7142857142857ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 5/7 with delay: 380.9523809523809ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 6/7 with delay: 476.19047619047615ms, duration: 4
RhythmBlockPaletteBlocks.js:1012 Scheduling note 7/7 with delay: 571.4285714285714ms, duration: 4

These logs confirm that the delays are now calculated and scheduled at accurate intervals for each note in the tuplet block.

I would really appreciate it if you could take a look and let me know:

If these changes fully resolve the timing issue
If there are any additional improvements or refinements you'd suggest

Thank you again for your time and guidance throughout this process!