### PR TITLE
fix clamp sizing for long stacks

### DIFF
--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-20 Walter Bender
+// Copyright (c) 2015-25 Walter Bender
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the The GNU Affero General Public
@@ -705,7 +705,7 @@ class SVG {
             return this._rLineTo(0, -this._innieY2);
         }
         // Outie needs to be the first dock element.
-        this.docks.unshift([this._x * this._scale, this._y * this._scale]);
+        this.docks.unshift([(this._x) * this._scale, (this._y - 0.25) * this._scale]);
         return (
             this._rLineTo(0, -this._strokeWidth) +
             this._rLineTo(-this._innieX1 - 2 * this._strokeWidth, 0) +
@@ -770,7 +770,7 @@ class SVG {
             return this._rLineTo(-this._slotX, 0);
         }
         this.docks.push([
-            (this._x - this._slotX / 2.0) * this._scale,
+            (this._x - (this._slotX / 2.0)) * this._scale,
             (this._y + this._strokeWidth) * this._scale
         ]);
         return (
@@ -1444,7 +1444,7 @@ class SVG {
             if (this._clampSlots[clamp] > 1) {
                 svg += this._rLineTo(0, this._slotSize * (this._clampSlots[clamp] - 1));
             }
-            svg += this._rLineTo(0, this._expandY2);
+            svg += this._rLineTo(0, this._expandY2 + (0.25 * this._clampSlots[clamp]));
             svg += this._iCorner(1, 1, 90, 0, 0, true, true);
             const saveSlot = this._slot;
             this._slot = true;

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -726,7 +726,11 @@ class SVG {
     _doSlot() {
         // let x;
         if (this._slot) {
-            this.docks.push([(this._x + this._slotX / 2.0) * this._scale, (this._y + 0.125) * this._scale]);
+            if (this._scale == 1.5) {
+                this.docks.push([(this._x + this._slotX / 2.0) * this._scale, Math.floor(this._y * this._scale)]);
+            } else {
+                this.docks.push([(this._x + this._slotX / 2.0) * this._scale, this._y * this._scale]);
+            }
             return (
                 this._rLineTo(0, this._slotY) +
                 this._rLineTo(this._slotX, 0) +
@@ -769,10 +773,17 @@ class SVG {
         if (this._outie) {
             return this._rLineTo(-this._slotX, 0);
         }
-        this.docks.push([
-            (this._x - (this._slotX / 2.0)) * this._scale,
-            (this._y + this._strokeWidth + 0.125) * this._scale
-        ]);
+        if (this._scale == 1.5) {
+            this.docks.push([
+                (this._x - (this._slotX / 2.0)) * this._scale,
+                Math.floor((this._y + this._strokeWidth) * this._scale)
+            ]);
+        } else {
+            this.docks.push([
+                (this._x - (this._slotX / 2.0)) * this._scale,
+                (this._y + this._strokeWidth) * this._scale
+            ]);
+        }
         return (
             this._rLineTo(-this._strokeWidth, 0) +
             this._rLineTo(0, this._slotY) +
@@ -1445,6 +1456,12 @@ class SVG {
                 svg += this._rLineTo(0, (this._slotSize) * (this._clampSlots[clamp] - 1));
             }
             svg += this._rLineTo(0, this._expandY2);
+            // When the scale is non-integer, we introduce a rounding
+            // error since we are only able to position blocks on
+            // pixel boundaries.
+            if (this._scale == 1.5) {
+                svg += this._rLineTo(0, this._clampSlots[clamp] * 0.0625);
+            }
             svg += this._iCorner(1, 1, 90, 0, 0, true, true);
             const saveSlot = this._slot;
             this._slot = true;

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -677,7 +677,7 @@ class SVG {
     _doInnie() {
         this.docks.push([
             (this._x + this._strokeWidth) * this._scale,
-            (this._y + this._innieY2) * this._scale
+            (this._y + this._innieY2 + 0.25) * this._scale
         ]);
         if (this.margins[2] === 0) {
             this.margins[1] = (this._y - this._innieY1) * this._scale;
@@ -705,7 +705,7 @@ class SVG {
             return this._rLineTo(0, -this._innieY2);
         }
         // Outie needs to be the first dock element.
-        this.docks.unshift([(this._x) * this._scale, (this._y - 0.25) * this._scale]);
+        this.docks.unshift([(this._x) * this._scale, (this._y + 0.25) * this._scale]);
         return (
             this._rLineTo(0, -this._strokeWidth) +
             this._rLineTo(-this._innieX1 - 2 * this._strokeWidth, 0) +
@@ -726,7 +726,7 @@ class SVG {
     _doSlot() {
         // let x;
         if (this._slot) {
-            this.docks.push([(this._x + this._slotX / 2.0) * this._scale, this._y * this._scale]);
+            this.docks.push([(this._x + this._slotX / 2.0) * this._scale, (this._y + 0.125) * this._scale]);
             return (
                 this._rLineTo(0, this._slotY) +
                 this._rLineTo(this._slotX, 0) +
@@ -771,7 +771,7 @@ class SVG {
         }
         this.docks.push([
             (this._x - (this._slotX / 2.0)) * this._scale,
-            (this._y + this._strokeWidth) * this._scale
+            (this._y + this._strokeWidth + 0.125) * this._scale
         ]);
         return (
             this._rLineTo(-this._strokeWidth, 0) +
@@ -1442,9 +1442,9 @@ class SVG {
             svg += this._iCorner(-1, 1, 90, 0, 0, true, true);
             svg += this._rLineTo(0, this._padding);
             if (this._clampSlots[clamp] > 1) {
-                svg += this._rLineTo(0, this._slotSize * (this._clampSlots[clamp] - 1));
+                svg += this._rLineTo(0, (this._slotSize) * (this._clampSlots[clamp] - 1));
             }
-            svg += this._rLineTo(0, this._expandY2 + (0.25 * this._clampSlots[clamp]));
+            svg += this._rLineTo(0, this._expandY2);
             svg += this._iCorner(1, 1, 90, 0, 0, true, true);
             const saveSlot = this._slot;
             this._slot = true;


### PR DESCRIPTION
We have had a long-standing issue with the calculation of the clamp size. When you have a long stack inside of a clamp, you will notice that the clamp is not quite large enough. It is a 0.25 pixel adjustment (at standard scale) per clamp slot to fix the issue.