### PR TITLE
Fix Menu & Search Bar Interaction Bug in Music Block

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2787,7 +2787,8 @@ class Activity {
                         //do nothing when clicked on the menu
                     } else if (document.getElementsByTagName("tr")[2].contains(e.target)) {
                         //do nothing when clicked on the search row
-                    } else if (e.target.id === "myCanvas") {
+                    } else {
+                        // this will hide the search bar if someone clicks on menu items 
                         that.hideSearchWidget();
                         document.removeEventListener("mousedown", closeListener);
                     }


### PR DESCRIPTION
Description

This PR addresses a UI issue in the Music Blocks toolbox where:
Clicking on the search bar causes the first menu item (like "Flow", "Action") to disappear.


Fixes Implemented
Prevent menu items from hiding when the search bar is focused.

before 


https://github.com/user-attachments/assets/865e150d-ab18-41e8-9cd4-a671e63b2b7a



after 

https://github.com/user-attachments/assets/f8913041-8bc5-48db-8cc1-fce3bbb810dc



