### PR TITLE
Close Palette Menu on Outside Click

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -863,6 +863,7 @@ class Palette {
         this.fadedUpButton = null;
         this.fadedDownButton = null;
         this.count = 0;
+        this._outsideClickListener = null;
     }
 
     hide() {
@@ -948,6 +949,25 @@ class Palette {
         }
 
         this._showMenuItems();
+
+        // Close palette menu on outside click
+        if (this._outsideClickListener) {
+            // Remove any existing listener before attaching a new one
+            document.removeEventListener("click", this._outsideClickListener);
+        }
+
+        this._outsideClickListener = (event) => {
+            if (!this.menuContainer.contains(event.target)) {
+                this.hideMenu(); // Calls your existing hideMenu() → _hideMenuItems()
+                document.removeEventListener("click", this._outsideClickListener);
+                this._outsideClickListener = null;
+            }
+        };
+
+        // Delay listener to avoid capturing the click that opened the menu
+        setTimeout(() => {
+            document.addEventListener("click", this._outsideClickListener);
+        }, 0);
     }
 
     _hideMenuItems() {


### PR DESCRIPTION
## Description:

This PR resolves issue #4718  by introducing an **outside click handler** for the palette menu. With this enhancement, the palette now automatically closes when the user clicks anywhere outside of it, ensuring a more intuitive and streamlined user experience.

---

## Changes Made:

### Added Outside Click Detection Logic:
- Implemented a `click` event listener on `document` after the palette menu is shown.
- The listener checks if the click occurred outside the `menuContainer`.
- If true, it calls the existing `hideMenu()` method.
- The listener is automatically removed after the first invocation to prevent memory leaks.
- Introduced `this._outsideClickListener` in the `Palette` class constructor to store and manage the listener properly.
- Ensured multiple openings of the menu don’t register duplicate listeners.

---

## Screenshots/Video:


https://github.com/user-attachments/assets/c33f05f5-b6ce-4144-8a24-222d464051e6



---

## Checklist:

- [x] My changes adhere to the project's contribution guidelines.
- [x] Code changes are implemented cleanly and follow existing structure.
- [x] The outside click functionality works as expected.

