### PR TITLE
Local planet

### DIFF
--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -55,9 +55,13 @@ class Planet {
     };
 
     open(image) {
-        this.LocalPlanet.setCurrentProjectImage(image);
-        this.LocalPlanet.updateProjects();
-        this.oldCurrentProjectID = this.ProjectStorage.getCurrentProjectID();
+        if (this.LocalPlanet === null) {
+            console.log("Local Planet unavailable");
+        } else {
+            this.LocalPlanet.setCurrentProjectImage(image);
+            this.LocalPlanet.updateProjects();
+            this.oldCurrentProjectID = this.ProjectStorage.getCurrentProjectID();
+        }
     };
 
     saveLocally(data, image) {

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -184,7 +184,7 @@ class ProjectStorage {
 
         //  prevent unnecessary crashing
 
-        if (savedjsonob == null)
+        if (savedjsonobj == null)
             throw new Error("Failed to save project data");
     };
 


### PR DESCRIPTION
Two issues were breaking the planet:
(1) a typo introduced to PlanetStorage was preventing the planet from loading at all has been fixed;
(2) the "toolbar disappears" issue seems to be due to a local storage issue that occasionally prevents the Local Planet from being defined. The root cause is not fixed but the error breaking the toolbar should be fixed.