### PR TITLE
fix: changing icon from `export-button.svg` to `download.svg` in debugger 

### DIFF
--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -139,7 +139,7 @@ function AIDebuggerWidget() {
         };
 
         this._exportButton = widgetWindow.addButton(
-            "export-button.svg",
+            "download.svg",
             ICONSIZE,
             _("Export chat")
         );


### PR DESCRIPTION
@walterbender please review this replaces the old icon for the export chat with the new download icon 