### PR TITLE
Added Pie Menu for Lego Bricks

### DIFF
--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -1379,7 +1379,7 @@ function LegoWidget() {
         const voiceLabels = [
             _("Electronic Synth"),
             _("Piano"),
-            _("Guitar"), 
+            _("Guitar"),
             _("Acoustic Guitar"),
             _("Electric Guitar"),
             _("Violin"),
@@ -1402,7 +1402,7 @@ function LegoWidget() {
 
         const voiceValues = [
             "electronic synth",
-            "piano", 
+            "piano",
             "guitar",
             "acoustic guitar",
             "electric guitar",
@@ -1512,7 +1512,7 @@ function LegoWidget() {
         // Set up the text update callback to update our button
         mockBlock.text._updateCallback = (newText) => {
             // Update the instrument when text is set by pie menu
-            const newInstrument = voiceValues[voiceLabels.findIndex(label => 
+            const newInstrument = voiceValues[voiceLabels.findIndex(label =>
                 label.toLowerCase() === newText.toLowerCase()
             )] || newText.toLowerCase();
             


### PR DESCRIPTION
As suggested by @pikurasa in the last meet, I've added the pie menu instead of a drop down menu for instrument selection in the Lego Bricks widget.

<img width="683" height="599" alt="image" src="https://github.com/user-attachments/assets/45b0c80d-bf30-4d4a-b45c-8b5856ec5791" />

