### PR TITLE
fix syntax error detected from pofilter

### DIFF
--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -8432,8 +8432,8 @@ msgstr "動き出し"
 #~ msgid "define"
 #~ msgstr "ていぎ"
 
-#~ msgid "bitcoin"
 # Maybe no need, but this did seem to come up in dictionary
+#~ msgid "bitcoin"
 #~ msgstr "ビットコイン"
 
 #~ msgid "You need to select a file."


### PR DESCRIPTION
This PR fixes issue #4721 

I investigated this issue and performed the following actions:

1. Utilized `pofilter` to identify a misplaced comment in the `ja-kana.po` file. _Which gave a syntax error_: 
```
processing 83 files...
pofilter: WARNING: Error processing: input ./ja-kana.po, output /home/suryaansh/pofilefailures/ja-kana.po, template None: Syntax error on line 8436: '#~ msgid "bitcoin"\n'
```

2. Employed a linter to highlight any other formatting issues, such as misplaced quotation marks.
3. Conducted a search for common errors within the `.po` files.

Currently, these methods have revealed a comment placement discrepancy in the `ja-kana.po` file, which I have addressed in the pull request.