### PR TITLE
Fix: Issue with ti# in Japanese

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -5791,9 +5791,14 @@ const i18nSolfege = (note) => {
     if (i !== -1) {
         return solfnotes_[i] + obj[1];
     } else {
-        // Wasn't solfege so it doesn't need translation.
-        return note;
+        // Check if the note is in a different language.
+        const i = Object.values(solfnotes_).indexOf(obj[0]);
+        if (i !== -1) {
+            return SOLFNOTES[i] + obj[1];
+        }
     }
+    // Wasn't solfege so it doesn't need translation.
+    return note;
 };
 
 /**


### PR DESCRIPTION
📌 **Problem**
Issue #4783 
When selecting シ# (ti#) in Japanese, the pitch automatically converts to ミb (mib). Upon switching back to English, the pitch becomes unrecognized (ミbNaN). This breaks expected behavior and causes confusion when working across languages.
✅ **Solution**
- Updated i18nSolfege() and mapping logic to ensure lossless and reversible pitch mapping between Japanese and English language.

🎥 **Demo: That issue resolved**

https://github.com/user-attachments/assets/ed41560e-b716-407b-bdcc-63cc3a8148da


📸 **Screenshot for all the testcases Passed**
<img width="438" height="319" alt="image" src="https://github.com/user-attachments/assets/536e6a01-f92a-4fcf-af88-888947f1471b" />
