### PR TITLE
Fix Widget block gets disable after Restore #4670

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3502,7 +3502,7 @@ const piemenuBlockContext = (block) => {
 
     wheel.navItems[2].navigateFunction = () => {
         that.blocks.activeBlock = blockBlock;
-        that.blocks.extract();
+        
         that.blocks.sendStackToTrash(that.blocks.blockList[blockBlock]);
         docById("contextWheelDiv").style.display = "none";
         // prompting a notification on deleting any block 


### PR DESCRIPTION
The pie menu's "Delete" button was calling an extra function, that.blocks.extract(), before calling that.blocks.sendStackToTrash().
<img width="1221" height="404" alt="Screenshot 2025-11-17 at 4 24 33 AM" src="https://github.com/user-attachments/assets/52627107-c7f7-490e-86da-814a287244ce" />

The extract() function (which is meant to pull a block from the middle of a stack) was breaking the widget's internal state before it was even sent to the trash. The drag-and-drop delete function only calls sendStackToTrash(), which is why it worked correctly.


locally passed the test-cases
<img width="1221" height="404" alt="Screenshot 2025-11-17 at 4 24 33 AM" src="https://github.com/user-attachments/assets/b8db7f89-a05b-4978-8be8-09fdaf34642b" />
