### PR TITLE
Fix missing return statement in docByTagName function

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -68,7 +68,7 @@ function _(text, options = {}) {
     if (!text) return "";
 
     try {
-        const removeChars = [",","(",")","?","¿","<",">",".","\n",'"',":","%s","%d","/","'",";","×","!","¡"];
+        const removeChars = [",", "(", ")", "?", "¿", "<", ">", ".", "\n", '"', ":", "%s", "%d", "/", "'", ";", "×", "!", "¡"];
         let cleanedText = text;
         for (let char of removeChars) cleanedText = cleanedText.split(char).join("");
 
@@ -145,16 +145,16 @@ function fnBrowserDetect() {
 
     if (userAgent.match(/chrome|chromium|crios/i)) {
         browserName = "chrome";
-    } else if(userAgent.match(/firefox|fxios/i)) {
+    } else if (userAgent.match(/firefox|fxios/i)) {
         browserName = "firefox";
-    } else if(userAgent.match(/safari/i)) {
+    } else if (userAgent.match(/safari/i)) {
         browserName = "safari";
-    } else if(userAgent.match(/opr\//i)) {
+    } else if (userAgent.match(/opr\//i)) {
         browserName = "opera";
-    } else if(userAgent.match(/edg/i)) {
+    } else if (userAgent.match(/edg/i)) {
         browserName = "edge";
     } else {
-        browserName="No browser detection";
+        browserName = "No browser detection";
     }
     return browserName;
 };
@@ -392,7 +392,7 @@ function docByClass(classname) {
  * @returns {NodeList} A collection of elements with the specified tag name.
  */
 function docByTagName(tag) {
-    document.getElementsByTagName(tag);
+    return document.getElementsByTagName(tag);
 }
 
 /**
@@ -1553,7 +1553,7 @@ let closeBlkWidgets = (name) => {
  * @returns {void}
  */
 let importMembers = (obj, className, modelArgs, viewArgs) => {
-    
+
     /**
      * Adds methods and variables of one class to another class's instance.
      *
@@ -1574,7 +1574,7 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
         } else {
             obj.added = new ctype(...args);
         }
-        
+
 
         // Loop for all method names of class type
         for (const name of Object.getOwnPropertyNames(ctype.prototype)) {


### PR DESCRIPTION
### Description
Fixed a bug in `js/utils/utils.js` where the `docByTagName` function was missing a `return` statement.

### Problem
The function was calling `document.getElementsByTagName(tag)` but not returning the result, causing it to return `undefined` instead of the expected `NodeList`.

### Solution
Added the missing `return` statement on line 395.

### Changes
- **File**: `js/utils/utils.js`
- **Line**: 395
- **Change**: Added `return` keyword before `document.getElementsByTagName(tag)`

### Impact
- Fixes the function to work as documented
- Makes the function actually usable by callers
- No breaking changes (function was broken before)

### Testing
- Verified the fix matches the pattern of similar helper functions (`docByClass`, `docById`, etc.)
