### PR TITLE
Added coverage folder to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *~
+coverage/


### PR DESCRIPTION
This PR adds the coverage/ folder to .gitignore.
Jest generates this folder during test coverage runs, and the files inside it should not be committed.

Testing Done:
Ran npx jest --coverage
Verified the coverage/ folder is created
Verified it is not shown in git status
All tests pass

Fixes #4652 

I am willing to address any changes requested.