### PR TITLE
Performance bottleneck on window resize

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -43,7 +43,6 @@ requirejs.config({
 requirejs(["i18next", "i18nextHttpBackend"], function(i18next, i18nextHttpBackend) {
 
     function updateContent() {
-        console.log("asdasdasd");
         console.log("updateContent() called");  // Debugging line
         const elements = document.querySelectorAll("[data-i18n]");
 

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1257,10 +1257,15 @@ Turtles.TurtlesView = class {
             __makeBoundary();
         }
 
-        window.addEventListener("resize", ()=>{
-            handleCanvasResize();
-            __makeBoundary();
-            __makeBoundary2();
+        // Debounce the resize event to prevent performance issues
+        let resizeTimeout;
+        window.addEventListener("resize", () => {
+            clearTimeout(resizeTimeout);
+            resizeTimeout = setTimeout(() => {
+                handleCanvasResize();
+                __makeBoundary();
+                __makeBoundary2();
+            }, 150); // Wait 150ms after the last resize event to execute
         });
 
         return this;


### PR DESCRIPTION
This PR addresses a performance bottleneck in js/turtles.js where the resize event listener was triggering expensive DOM and canvas recalculations (handleCanvasResize, __makeBoundary) on every single frame of a window resize action. This caused significant layout thrashing and UI lag.

Changes:
Implemented a standard debounce pattern for the window resize event listener in the Turtles.TurtlesView constructor.
The heavy recalculation logic now waits to execute until the user has stopped resizing for 150ms.

Impact:
Eliminates UI freezing/stuttering when resizing the browser window.
Reduces unnecessary CPU usage during layout changes.

Removed a dead debugging code from js/loader.js