### PR TITLE
Fix: Display error message when PDF export fails

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -827,7 +827,7 @@ class SaveInterface {
       if (!success) {
         // eslint-disable-next-line no-console
         console.debug("Error: " + dataurl);
-        //TODO: Error message box
+        this.activity.errorMsg(_("Error generating PDF") + ": " + dataurl);
       } else {
         this.activity.save.download("pdf", dataurl, filename);
       }

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -566,6 +566,7 @@ describe("saveLilypond Methods", () => {
                 runLogoCommands: jest.fn(),
             },
             textMsg: jest.fn(),
+            errorMsg: jest.fn(),
             download: jest.fn(),
         };
 
@@ -699,7 +700,7 @@ describe("saveLilypond Methods", () => {
         expect(activity.save.download).toHaveBeenCalledWith("pdf", dataurl, filename);
     });
 
-    it('should reset cursor to "default" and log an error on failure', () => {
+    it('should reset cursor to "default" and display error message on failure', () => {
         const errorMessage = "Conversion failed";
 
         window.Converter.ly2pdf.mockImplementation((lydata, callback) => {
@@ -713,6 +714,8 @@ describe("saveLilypond Methods", () => {
 
         expect(document.body.style.cursor).toBe("default");
         expect(console.debug).toHaveBeenCalledWith("Error: " + errorMessage);
+        // Verify errorMsg is called with the error message
+        expect(activity.errorMsg).toHaveBeenCalledWith("Error generating PDF" + ": " + errorMessage);
         // Verify activity.save.download is not called
         expect(activity.save.download).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
### Description
This PR addresses a TODO in `SaveInterface.js` where PDF export errors were previously only logged to the console.

### Changes
- Replaced the TODO comment with a call to `this.activity.errorMsg()` so PDF export failures are surfaced to the user.
- Ensured that when the `ly2pdf` conversion fails, a visible error message is displayed instead of a silent failure.

### Testing
- Verified locally that the error handler is invoked correctly and that normal PDF export behavior remains unchanged.
