### PR TITLE
fixes some incorrect links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ This documentation provides a basic setup for running Music Blocks locally using
 ## <a name="USING_MUSIC_BLOCKS"></a>Using Music Blocks
 
 Once Music Blocks is running, you'll want suggestions on how to use
-it. Follow [Using Music Blocks](./documentation/README.md) and [Music
-Blocks Guide](./guide/README.md).
+it. Follow [Using Music Blocks](./Docs/documentation/README.md) and [Music
+Blocks Guide](./Docs/guide/README.md).
 
 For Scratch and Snap users, you may want to look at [Music Blocks for
 Snap Users](./Music_Blocks_for_Snap_Users.md).
 
 Looking for a block? Find it in the
-[Palette Tables](./guide/README.md#6-appendix).
+[Palette Tables](./Docs/guide/README.md#6-appendix).
 
 ## <a name="CODEOFCONDUCT"></a>Code of Conduct
 


### PR DESCRIPTION
## Issue
Some links in the README were redirecting to a 404 Not Found page.

<details>
<summary>Issue</summary>
<img width="860" height="307" alt="issue" src="https://github.com/user-attachments/assets/bff6a807-02a1-4d6b-a4ac-f0a22f6e66f1" />
</details>

## Solution 
I corrected the links in the README so that they now redirect to the appropriate README files instead of the 404 page.
<details>
<summary>After the changes</summary>
<img width="1425" height="790" alt="image" src="https://github.com/user-attachments/assets/64d577ac-5bb4-4301-a345-80c10063cc0c" />
</details>