### PR TITLE
Remove outdated FIXME comment in RhythmRuler _undo()

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -1614,7 +1614,6 @@ class RhythmRuler {
      * @returns {void}
      */
     _undo() {
-        // FIXME: Add undo for REST
         this.activity.logo.synth.stop();
         this._startingTime = null;
         this._playing = false;


### PR DESCRIPTION
## Description
This PR removes an outdated FIXME comment in `js/widgets/rhythmruler.js`.

## Details
The comment `// FIXME: Add undo for REST` was misleading, as undo functionality
for REST operations is already implemented in the `_undo()` logic.

Removing the comment avoids confusion for future contributors and keeps the
codebase accurate.

## Changes
- Removed outdated FIXME comment in `_undo()`

## Testing
No functional changes; manual inspection only.
