### PR TITLE
Add tests for platformstyle.js

### DIFF
--- a/js/utils/__tests__/platformstyle.test.js
+++ b/js/utils/__tests__/platformstyle.test.js
@@ -112,7 +112,14 @@ describe("platformstyle", () => {
         loadModule();
         const result = showButtonHighlightRef(1, 2, 3, { type: "click" }, 1, {});
         expect(result).toEqual({ highlight: true });
-        expect(global.showMaterialHighlight).toHaveBeenCalledWith(1, 2, 3, { type: "click" }, 1, {});
+        expect(global.showMaterialHighlight).toHaveBeenCalledWith(
+            1,
+            2,
+            3,
+            { type: "click" },
+            1,
+            {}
+        );
     });
 
     it("returns empty highlight when FFOS", () => {

--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const themePreference = localStorage.themePreference || undefined;
 
-
 window.platform = {
     android: /Android/i.test(navigator.userAgent),
     FF: /Firefox/i.test(navigator.userAgent),
@@ -350,7 +349,7 @@ const platformThemes = {
         modePieMenusIfColorPush: "#4b8b0e",
         modePieMenusElseColorPush: "#66a62d",
         wheelcolors: ["#808080", "#909090", "#808080", "#909090", "#707070"]
-    },
+    }
     // custom: {Your styling},
 };
 


### PR DESCRIPTION
This PR improves test coverage and testability for platform-related utilities, specifically `platformstyle.js`, and makes minor adjustments to support Jest-based testing without altering runtime behavior.

Fixes: #4867 

### Key Changes

* **Added explicit CommonJS export** for `showButtonHighlight` in `platformstyle.js` to allow direct importing in Jest tests, while preserving existing browser behavior.
* **Refactored `platformstyle.test.js`** to:

  * Use isolated module loading (`jest.isolateModules`) for predictable test execution.
  * Add comprehensive test cases covering:

    * Default platform color initialization
    * Dark theme preference handling
    * Firefox OS (FFOS) detection logic
    * Conditional delegation to `showMaterialHighlight`
    * FFOS-specific early return behavior
* **Improved test setup and cleanup** by explicitly resetting globals between tests to avoid cross-test interference.

Before:
<img width="765" height="291" alt="image" src="https://github.com/user-attachments/assets/0a1d84c1-308b-4889-9c07-407aef4f87db" />

After:
<img width="748" height="261" alt="image" src="https://github.com/user-attachments/assets/e6c25f3e-b227-4d4b-8dc4-be180e78ff6f" />