### PR TITLE
Fix: Add warning popup when audio is disabled or blocked

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -984,7 +984,6 @@ function Synth() {
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
-            // eslint-disable-next-line no-delete-var
         };
         this.recorder.onstop = () => {
             if (!chunks.length) return;
@@ -1801,7 +1800,6 @@ function Synth() {
         setNote,
         future
     ) => {
-       // --- FIX START ---
         // If audio is not running, try to start it
         if (Tone.context.state !== 'running') {
             Tone.start().catch(function(e) {
@@ -1817,8 +1815,6 @@ function Synth() {
                 }
             }, 2000);
         }
-        // --- FIX END ---
-        // ... existing code below ...
         try {
             // Ensure audio context is started
             if (Tone.context.state !== 'running') {


### PR DESCRIPTION
This PR addresses the issue where the Music Blocks audio engine would fail silently if the browser's audio context was blocked or suspended (e.g., due to autoplay policies).

This fixes the problem reported in my issue: Closes #4880

### Changes Made
* Modified `js/utils/synthutils.js` (specifically the `trigger` function).
* Added a safety check for `Tone.context.state`.
* Wrapped `Tone.start()` in a `try/catch` block to safely handle autoplay errors.
* Implemented a fallback: If the audio engine remains 'suspended' after a 2000ms timeout, a user-friendly alert popup appears instructing the user to check their Site Settings.
* Added a flag (`window.hasShownAudioWarning`) to ensure the alert only appears once per session.

### Testing
* **Case 1 (Blocked):** Set Site Settings > Sound to "Block". Reloaded. Verified the popup appears.
* **Case 2 (Allowed):** Set Site Settings > Sound to "Allow". Reloaded. Verified the popup DOES NOT appear.
* **Case 3 (Engine Check):** Confirmed via console that `Tone.context.state` transitions to 'running' correctly when allowed.