### PR TITLE
Add documentation for program blocks

### DIFF
--- a/Docs/documentation/program-blocks.md
+++ b/Docs/documentation/program-blocks.md
@@ -2,65 +2,102 @@
 
 Music Blocks is a visual programming environment for learning music through code.
 Program blocks are the structural components of Music Blocks that control the
-**execution flow** and **organization** of a project.
+**execution flow** and **organization** of a project. While sound blocks (such as
+Pitch or Note) define what is played, program blocks define *how* and *when*
+those sounds are played.
 
 ## Introduction
 
-In Music Blocks, you create music by snapping blocks together. Some blocks represent musical sounds, while others represent the logic of the program. These logical blocks are known as **Program Blocks**. They are essential for turning a simple sequence of notes into a complex composition.
+In Music Blocks, users create music by snapping blocks together. Some blocks
+represent musical sounds, while others represent the logic of the program.
+These logical blocks are known as **Program Blocks**. They are essential for
+turning a simple sequence of notes into a structured and expressive musical
+composition.
 
 ## Role in Music Blocks
 
-Program blocks act as the "engine" of your project. They tell Music Blocks:
-*   **Where to start** (using the Start block)
-*   **How to repeat** a sequence of notes (using loops)
-*   **How to group** actions together (using action blocks)
-*   **When to perform** certain tasks based on conditions (using logic blocks)
+Program blocks act as the control system of a project. They tell Music Blocks:
 
-Crucially, **program blocks do not directly produce sound**. Instead, they contain and manage other blocks that do.
+- **Where to start** execution (using the Start block)
+- **How to repeat** a sequence of musical instructions (using loop blocks)
+- **How to group** related instructions together (using Action blocks)
+- **When to perform** certain tasks based on conditions (using flow and
+  conditional blocks)
 
-## Program vs. Sound Blocks
+Program blocks **do not directly produce sound**. Instead, they organize and
+manage other blocks that generate music.
 
-Think of a music project like a performance:
-*   **Sound Blocks** are the musicians and their instruments (e.g., "Play a C chord for 1/4 note").
-*   **Program Blocks** are the conductor and the musical score (e.g., "Repeat the chorus 3 times" or "When the Play button is clicked, start here").
+## Program Blocks vs. Sound Blocks
 
-| Block Type | Purpose | Example |
-| :--- | :--- | :--- |
-| **Program Blocks** | Control, structure, and flow | Start, Action, Repeat, If/Then |
-| **Sound Blocks** | Produce music and sound | Pitch, Note, Set Instrument |
+A Music Blocks project can be compared to a musical performance:
+
+- **Sound Blocks** are like the musicians and their instruments, producing
+  notes, rhythms, and sounds.
+- **Program Blocks** are like the conductor and the musical score, deciding
+  when parts repeat, where the music starts, and how sections are organized.
+
+| Block Type | Purpose | Examples |
+|-----------|---------|----------|
+| **Program Blocks** | Control structure and execution flow | Start, Action, Repeat, If/Then |
+| **Sound Blocks** | Produce musical sounds | Pitch, Note, Set Instrument |
 
 ## Common Program Blocks
 
 Program blocks are primarily found in the **Action** and **Flow** palettes.
 
-### 1. Start Block
-The **Start** block is the entry point of your program. Any blocks placed inside its "clamp" will run as soon as you click the **Play** button. You can use multiple Start blocks to create "counterpoint," where different voices play at the same time.
+### Start Block
 
-![Start Block](./start_block.svg "Start Block")
+The **Start** block defines the entry point of a program. Any blocks placed
+inside its clamp are executed when the **Play** button is pressed.
 
-### 2. Action Block
-An **Action** block allows you to group a set of blocks together and give them a name (like "Chorus" or "Bassline"). When you create an Action block, a new block with that name appears in your palette, allowing you to "call" that action whenever you need it.
+A project may contain multiple Start blocks, allowing different musical
+sequences to run at the same time. This makes it possible to create layered
+music or counterpoint.
 
-![Action Block](./action_block.svg "Action Block")
+### Action Block
 
-### 3. Loop Blocks
-Loops allow you to repeat a sequence of blocks multiple times. This is much easier than stacking the same blocks over and over!
-*   **Repeat**: Runs the blocks inside it for a specific number of times.
-*   **Forever**: Runs the blocks inside it until you click the Stop button.
-*   **While / Until**: Runs the blocks based on a certain condition (like "While the music is playing").
+An **Action** block allows users to group a set of blocks and give that group a
+name. Once an Action is defined, it can be reused anywhere in the project by
+calling the Action block with the same name.
 
-![Repeat Block](./repeat_block.svg "Repeat Block")
+Action blocks help:
+- Reduce repetition
+- Improve readability
+- Organize music into meaningful sections such as verses or choruses
+
+### Loop Blocks
+
+Loop blocks repeat the blocks placed inside them, making it easy to create
+patterns and rhythms.
+
+Common loop blocks include:
+- **Repeat** – runs the contained blocks a fixed number of times
+- **Forever** – repeats the contained blocks until the program is stopped
+- **While / Until** – repeats blocks based on a condition
 
 ## How to Use Program Blocks
 
-Most program blocks are **"clamp" blocks**. They have an open space (a clamp) where you can snap other blocks inside.
+Most program blocks are **clamp blocks**, meaning they contain space where other
+blocks can be placed.
 
-1.  **Stacking**: You can stack program blocks vertically to define a sequence.
-2.  **Nesting**: You can place program blocks inside other program blocks. For example, you can put a **Repeat** block inside an **Action** block to repeat a phrase within that action.
-3.  **Organization**: Use Action blocks to break your music into sections. This makes your code easier to read and edit.
+- **Stacking**: Program blocks can be stacked vertically to define the order of
+  execution.
+- **Nesting**: Program blocks can be placed inside other program blocks, such as
+  putting a Repeat block inside an Action block.
+- **Organization**: Using Action blocks to separate musical ideas makes projects
+  easier to understand and modify.
 
 ## Best Practices
 
-*   **Label your Actions**: Give your Action blocks descriptive names so you know exactly what each part of your program does.
-*   **Avoid "Invisible" Errors**: Since program blocks don't make sound, it can sometimes be hard to tell if one is working. Use the **Print** block (found in the Extras palette) to see messages that help you understand what your program is doing.
-*   **Keep it Simple**: Start with a single Start block. As your music gets more complex, start using Action blocks to keep things organized.
+- **Use descriptive names** for Action blocks so their purpose is clear.
+- **Organize large projects** by breaking music into smaller, reusable Actions.
+- **Avoid excessive nesting**, which can make projects harder to read.
+- **Debug logically**: since program blocks do not produce sound, using tools
+  like the Print block (from the Extras palette) can help track execution.
+
+## Summary
+
+Program blocks provide the structure that allows musical ideas to be organized,
+reused, and controlled. By combining program blocks with sound blocks, users can
+build complex musical compositions that are clear, expressive, and easy to
+maintain.


### PR DESCRIPTION
This PR adds documentation explaining program blocks in Music Blocks.

The documentation describes what program blocks are, their role in controlling
execution flow and organization, how they differ from sound blocks, and how
common program blocks such as Start, Action, and Loop blocks are used in
projects. It also includes best practices for organizing and structuring music
using program blocks.

I explored the existing documentation and codebase to understand how program
blocks function in Music Blocks and wrote the documentation accordingly. AI
tools were used to assist in understanding the code, but the documentation
content and structure were written manually.

Closes #3844
