### PR TITLE
Fix issue when maximizing widget window

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -98,10 +98,8 @@ class WidgetWindow {
         this._drag.style.display = "flex";
         this._drag.style.justifyContent = "space-between";
 
-
-
         if (this._fullscreenEnabled) {
-            this._drag.ondblclick = (e) => {
+            this._drag.ondblclick = e => {
                 this._maximize();
                 this.takeFocus();
                 this.onmaximize();
@@ -110,7 +108,7 @@ class WidgetWindow {
             };
         }
         const closeButton = this._create("div", "wftButton close", this._drag);
-        closeButton.onclick = (e) => {
+        closeButton.onclick = e => {
             this.onclose();
             e.preventDefault();
             e.stopPropagation();
@@ -126,7 +124,7 @@ class WidgetWindow {
         titleEl.insertAdjacentHTML("afterbegin", _(this._title));
         titleEl.id = `${this._key}WidgetID`;
 
-        this._nonclose.onmousedown = (e) => {
+        this._nonclose.onmousedown = e => {
             this._dragging = true;
             if (this._maximized) {
                 // Perform special repositioning to make the drag feel right when
@@ -150,16 +148,14 @@ class WidgetWindow {
             e.preventDefault();
         };
 
-
         this._nonclosebuttons = this._create("div", "nonclosebuttons", this._nonclose);
         this._nonclosebuttons.style.display = "flex";
         this._rollButton = this._create("div", "wftButton rollup", this._nonclosebuttons);
         const rollButton = this._rollButton;
-        rollButton.onclick = (e) => {
+        rollButton.onclick = e => {
             if (this._rolled) {
                 this.unroll();
-            }
-            else {
+            } else {
                 this._rollup();
                 this._toggleClass(rollButton, "plus");
             }
@@ -173,7 +169,7 @@ class WidgetWindow {
 
         if (this._fullscreenEnabled) {
             const maxminButton = this._create("div", "wftButton wftMaxmin", this._nonclosebuttons);
-            maxminButton.onclick = (e) => {
+            maxminButton.onclick = e => {
                 if (this._maximized) {
                     this._restore();
                     this.sendToCenter();
@@ -216,8 +212,7 @@ class WidgetWindow {
     _docMouseMoveHandler(e) {
         if (!this._dragging) return;
 
-        if (this._fullscreenEnabled
-            && this._frame.style.top === "64px") {
+        if (this._fullscreenEnabled && this._frame.style.top === "64px") {
             this._overlay(true);
         } else {
             this._overlay(false);
@@ -268,9 +263,7 @@ class WidgetWindow {
      */
     _dragTopHandler(e) {
         this._dragging = false;
-        if (this._fullscreenEnabled
-            && this._frame.style.top === "64px"
-            && !this._maximized) {
+        if (this._fullscreenEnabled && this._frame.style.top === "64px" && !this._maximized) {
             this._maximize();
             this.takeFocus();
             this.onmaximize();
@@ -371,7 +364,7 @@ class WidgetWindow {
     modifyButton(index, icon, iconSize, label) {
         const innerHTML = `
             <img src="header-icons/${icon}" title="${label}" alt="${label}" height="${iconSize}" width="${iconSize}"/> 
-            ` ;
+            `;
 
         this._buttons[index].innerHTML = "";
         this._buttons[index].insertAdjacentHTML("afterbegin", innerHTML);
@@ -427,8 +420,7 @@ class WidgetWindow {
     addButton(icon, iconSize, label, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
 
-        const innerHTML =
-            `<img src="header-icons/${icon}" 
+        const innerHTML = `<img src="header-icons/${icon}" 
                   title="${label}" 
                   alt="${label}" 
                   height="${iconSize}" 
@@ -604,7 +596,7 @@ class WidgetWindow {
     /**
      * @public
      * @return {WidgetWindow} this
-     * 
+     *
      * Clears the widget window not the toolbar
      */
     clearScreen() {
@@ -661,7 +653,7 @@ window.widgetWindows.windowFor = (widget, title, saveAs, fullscreen) => {
 /**
  * @deprecated
  */
-window.widgetWindows.clear = (name) => {
+window.widgetWindows.clear = name => {
     const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     if (typeof win.onclose === "function") win.onclose();
@@ -672,7 +664,7 @@ window.widgetWindows.clear = (name) => {
  * @param {string} name
  * @returns {boolean}
  */
-window.widgetWindows.isOpen = (name) => {
+window.widgetWindows.isOpen = name => {
     return window.widgetWindows.openWindows[name] ? true : "";
 };
 
@@ -681,7 +673,7 @@ window.widgetWindows.isOpen = (name) => {
  * @returns {void}
  */
 window.widgetWindows.hideAllWindows = () => {
-    Object.values(window.widgetWindows.openWindows).forEach((win) => {
+    Object.values(window.widgetWindows.openWindows).forEach(win => {
         if (win !== undefined) win._frame.style.display = "none";
     });
 };
@@ -690,7 +682,7 @@ window.widgetWindows.hideAllWindows = () => {
  * @public
  * @param {string} name
  */
-window.widgetWindows.hideWindow = (name) => {
+window.widgetWindows.hideWindow = name => {
     const win = window.widgetWindows.openWindows[name];
     if (!win) return;
     win._frame.style.display = "none";
@@ -700,7 +692,7 @@ window.widgetWindows.hideWindow = (name) => {
  * @returns {void}
  */
 window.widgetWindows.showWindows = () => {
-    Object.values(window.widgetWindows.openWindows).forEach((win) => {
+    Object.values(window.widgetWindows.openWindows).forEach(win => {
         if (win !== undefined) win._frame.style.display = "block";
     });
 };


### PR DESCRIPTION


### Summary
This PR fixes a UI state inconsistency in widget windows where the rollup (plus/minus) icon displayed an incorrect state after maximizing the window.

The issue occurred when a window was rolled up and then expanded to fullscreen  the window expanded correctly, but the rollup icon incorrectly showed a plus (+) instead of a minus (−).


