### PR TITLE
Check for hiddennoflow blocks when extracting/deleting

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -198,11 +198,10 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.setBlockScale = async (scale) => {
+        this.setBlockScale = async scale => {
             // eslint-disable-next-line no-console
             console.debug("New block scale is " + scale);
             this.blockScale = scale;
-
 
             let palette;
             /** Regenerate all of the artwork at the new scale. */
@@ -279,7 +278,10 @@ class Blocks {
 
                 if (lastConnection != null) {
                     /** Is it a hidden block? Keep it attached. */
-                    if (this.blockList[lastConnection].name === "hidden" || this.blockList[lastConnection].name === "hiddennoflow") {
+                    if (
+                        this.blockList[lastConnection].name === "hidden" ||
+                        this.blockList[lastConnection].name === "hiddennoflow"
+                    ) {
                         lastConnection = last(this.blockList[lastConnection].connections);
 
                         this.blockList[last(blkObj.connections)].connections[
@@ -413,7 +415,7 @@ class Blocks {
          * @private
          * @returns boolean
          */
-        this._actionBlock = (name) => {
+        this._actionBlock = name => {
             return ["do", "doArg", "calc", "calcArg"].includes(name);
         };
 
@@ -423,7 +425,7 @@ class Blocks {
          * @private
          * @returns boolean
          */
-        this._namedActionBlock = (name) => {
+        this._namedActionBlock = name => {
             return ["nameddo", "nameddoArg", "namedcalc", "namedcalcArg"].includes(name);
         };
 
@@ -524,7 +526,7 @@ class Blocks {
          * @private
          * @returns depth
          */
-        this._getNestingDepth = (blk) => {
+        this._getNestingDepth = blk => {
             let rank = 0;
             while (blk !== null) {
                 blk = this.insideExpandableBlock(blk);
@@ -539,7 +541,7 @@ class Blocks {
          * @private
          * @returns block size
          */
-        this._getBlockSize = (blk) => {
+        this._getBlockSize = blk => {
             const myBlock = this.blockList[blk];
             /** Special case for collapsed note blocks. */
             if (["newnote", "interval", "osctime"].includes(myBlock.name) && myBlock.collapsed) {
@@ -555,7 +557,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._adjustArgClampBlock = (argBlocksToCheck) => {
+        this._adjustArgClampBlock = argBlocksToCheck => {
             if (argBlocksToCheck.length === 0) {
                 return;
             }
@@ -601,7 +603,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._adjustExpandableTwoArgBlock = (argBlocksToCheck) => {
+        this._adjustExpandableTwoArgBlock = argBlocksToCheck => {
             if (argBlocksToCheck.length === 0) {
                 return;
             }
@@ -631,7 +633,7 @@ class Blocks {
          * @private
          * @returns void
          */
-        this._addRemoveVspaceBlock = (blk) => {
+        this._addRemoveVspaceBlock = blk => {
             const myBlock = this.blockList[blk];
 
             const c = myBlock.connections[myBlock.connections.length - 2];
@@ -648,7 +650,7 @@ class Blocks {
              * @private
              * @returns number of vspace blocks found below this block
              */
-            const __howManyVSpaceBlocksBelow = (blk) => {
+            const __howManyVSpaceBlocksBelow = blk => {
                 const nextBlock = last(that.blockList[blk].connections);
                 if (nextBlock && that.blockList[nextBlock].name === "vspace") {
                     return 1 + __howManyVSpaceBlocksBelow(nextBlock);
@@ -682,7 +684,7 @@ class Blocks {
                  * @private
                  * @returns {void}
                  */
-                const __vspaceAdjuster = (args) => {
+                const __vspaceAdjuster = args => {
                     let thisBlock = args[0];
                     let nextBlock = args[1];
                     const vspace = args[2];
@@ -741,13 +743,15 @@ class Blocks {
          * @private
          * @returns int
          */
-        this._getStackSize = (blk) => {
+        this._getStackSize = blk => {
             /** How many block units in this stack? */
             let size = 0;
             this._sizeCounter += 1;
             if (this._sizeCounter > this.blockList.length * 2) {
                 // eslint-disable-next-line no-console
-                console.debug("Infinite loop encountered detecting size of expandable block? " + blk);
+                console.debug(
+                    "Infinite loop encountered detecting size of expandable block? " + blk
+                );
                 return size;
             }
 
@@ -926,14 +930,14 @@ class Blocks {
                     // eslint-disable-next-line no-console
                     console.debug(
                         "Did not find match for " +
-                        myBlock.name +
-                        " (" +
-                        blk +
-                        ") and " +
-                        this.blockList[cblk].name +
-                        " (" +
-                        cblk +
-                        ")"
+                            myBlock.name +
+                            " (" +
+                            blk +
+                            ") and " +
+                            this.blockList[cblk].name +
+                            " (" +
+                            cblk +
+                            ")"
                     );
                     // eslint-disable-next-line no-console
                     console.debug(myBlock.connections);
@@ -1010,7 +1014,7 @@ class Blocks {
                      * @public
                      * @returns {void}
                      */
-                    const postProcess = (args) => {
+                    const postProcess = args => {
                         const parentblk = args[0];
                         const oldBlock = args[1];
 
@@ -1038,10 +1042,14 @@ class Blocks {
                                     protoblock.name === "nameddo" &&
                                     protoblock.defaults[0] === that.blockList[oldBlock].value
                                 ) {
-                                    setTimeout(() =>{
-                                        blockPalette.remove(protoblock, that.blockList[oldBlock].value);
-                                        delete that
-                                            .protoBlockDict["myDo_" + that.blockList[oldBlock].value];
+                                    setTimeout(() => {
+                                        blockPalette.remove(
+                                            protoblock,
+                                            that.blockList[oldBlock].value
+                                        );
+                                        delete that.protoBlockDict[
+                                            "myDo_" + that.blockList[oldBlock].value
+                                        ];
                                         /** that.activity.palettes.hide(); */
                                         that.activity.palettes.updatePalettes("action");
                                         /** that.activity.palettes.show(); */
@@ -1080,7 +1088,7 @@ class Blocks {
             } else if (this.blockList[parentblk].name === "temperament1") {
                 cblk = this.blockList[parentblk].connections[1];
                 if (cblk == null) {
-                    const postProcess = (args) =>{
+                    const postProcess = args => {
                         const parentblk = args[0];
                         const oldBlock = args[1];
 
@@ -1109,7 +1117,7 @@ class Blocks {
                      * @public
                      * @returns {void}
                      */
-                    const postProcess = (args) => {
+                    const postProcess = args => {
                         const parentblk = args[0];
                         const oldBlock = args[1];
                         const blk = this.blockList.length - 1;
@@ -1142,7 +1150,7 @@ class Blocks {
                      * @public
                      * @returns {void}
                      */
-                    const postProcess = (args) => {
+                    const postProcess = args => {
                         const parentblk = args[0];
                         const value = args[1];
 
@@ -1204,7 +1212,7 @@ class Blocks {
                      * @public
                      * @returns {void}
                      */
-                    const postProcess = (args) => {
+                    const postProcess = args => {
                         const parentblk = args[0];
                         /** const oldBlock = args[1]; */
 
@@ -1255,7 +1263,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._deletePitchBlocks = (thisBlock) => {
+        this._deletePitchBlocks = thisBlock => {
             /** Find the top of the stack */
             let c = this.blockList[thisBlock].connections[0];
             if (c === null) {
@@ -1322,7 +1330,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.deleteNextDefault = (thisBlock) => {
+        this.deleteNextDefault = thisBlock => {
             if (thisBlock == undefined) {
                 return;
             }
@@ -1352,7 +1360,7 @@ class Blocks {
                     return;
                 }
             }
-            
+
             if (thisBlockobj.name === "rest2") {
                 this._deletePitchBlocks(thisBlock);
             } else {
@@ -1390,11 +1398,14 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.deletePreviousDefault = (thisBlock) => {
+        this.deletePreviousDefault = thisBlock => {
             let thisBlockobj = this.blockList[thisBlock];
 
             // Do not remove the silence block if only a vspace block is inserted after the silence block.
-            if (this.blockList[thisBlockobj.connections[0]]?.name === "rest2" && this.blockList[thisBlock]?.name === "vspace") {
+            if (
+                this.blockList[thisBlockobj.connections[0]]?.name === "rest2" &&
+                this.blockList[thisBlock]?.name === "vspace"
+            ) {
                 return thisBlockobj.connections[0];
             }
 
@@ -1456,7 +1467,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.blockMoved = async (thisBlock) => {
+        this.blockMoved = async thisBlock => {
             /**
              * When a block is moved, we have to check the following:
              * (0) Is it inside of a expandable block?
@@ -1724,8 +1735,9 @@ class Blocks {
                     if (this.blockList[newBlock].isArgClamp()) {
                         /** If it is an arg clamp, we may have to adjust the slot size. */
                         if (
-                            ["doArg", "calcArg", "makeblock"].indexOf(this.blockList[newBlock].name) !==
-                            -1 &&
+                            ["doArg", "calcArg", "makeblock"].indexOf(
+                                this.blockList[newBlock].name
+                            ) !== -1 &&
                             newConnection === 1
                         ) {
                             /** pass */
@@ -1775,8 +1787,9 @@ class Blocks {
                     insertAfterDefault = false;
                     if (this.blockList[newBlock].isArgClamp()) {
                         if (
-                            ["doArg", "calcArg", "makeblock"].indexOf(this.blockList[newBlock].name) !==
-                            -1 &&
+                            ["doArg", "calcArg", "makeblock"].indexOf(
+                                this.blockList[newBlock].name
+                            ) !== -1 &&
                             newConnection === 1
                         ) {
                             /**
@@ -1824,7 +1837,10 @@ class Blocks {
                             let emptyConnection = null;
                             /** Is there an empty slot below? */
                             for (let emptySlot = si; emptySlot < slotList.length; emptySlot++) {
-                                if (this.blockList[newBlock].connections[ci + emptySlot - si] == null) {
+                                if (
+                                    this.blockList[newBlock].connections[ci + emptySlot - si] ==
+                                    null
+                                ) {
                                     emptyConnection = ci + emptySlot - si;
                                     break;
                                 }
@@ -1919,7 +1935,8 @@ class Blocks {
                                     const protoblock = blockPalette.protoList[b];
                                     if (
                                         protoblock.name === "nameddo" &&
-                                        protoblock.staticLabels[0] === this.blockList[connection].value
+                                        protoblock.staticLabels[0] ===
+                                            this.blockList[connection].value
                                     ) {
                                         await delayExecution(50);
                                         blockPalette.remove(
@@ -1938,7 +1955,10 @@ class Blocks {
                                     }
                                 }
 
-                                this.renameNameddos(this.blockList[connection].value, myBlock.value);
+                                this.renameNameddos(
+                                    this.blockList[connection].value,
+                                    myBlock.value
+                                );
                                 this.renameDos(this.blockList[connection].value, myBlock.value);
                             }
                         } else if (this.blockList[newBlock].name === "storein") {
@@ -2170,7 +2190,7 @@ class Blocks {
             if (type1 === "vspacein" && type2 === "vspaceout") {
                 return true;
             }
-            
+
             if (type1 === "in" && type2 === "out") {
                 return true;
             }
@@ -2245,17 +2265,27 @@ class Blocks {
             }
             if (
                 type1 === "solfegein" &&
-                ["anyout", "solfegeout", "textout", "noteout", "scaledegreeout", "numberout"].includes(
-                    type2
-                )
+                [
+                    "anyout",
+                    "solfegeout",
+                    "textout",
+                    "noteout",
+                    "scaledegreeout",
+                    "numberout"
+                ].includes(type2)
             ) {
                 return true;
             }
             if (
                 type2 === "solfegein" &&
-                ["anyout", "solfegeout", "textout", "noteout", "scaledegreeout", "numberout"].includes(
-                    type1
-                )
+                [
+                    "anyout",
+                    "solfegeout",
+                    "textout",
+                    "noteout",
+                    "scaledegreeout",
+                    "numberout"
+                ].includes(type1)
             ) {
                 return true;
             }
@@ -2317,7 +2347,11 @@ class Blocks {
          */
         this.updateBlockPositions = () => {
             for (const blk in this.blockList) {
-                this._moveBlock(blk, this.blockList[blk].container.x, this.blockList[blk].container.y);
+                this._moveBlock(
+                    blk,
+                    this.blockList[blk].container.x,
+                    this.blockList[blk].container.y
+                );
             }
         };
 
@@ -2463,7 +2497,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.updateBlockText = (blk) => {
+        this.updateBlockText = blk => {
             const myBlock = this.blockList[blk];
             let maxLength = 8;
             if (myBlock.text == null) {
@@ -2653,7 +2687,7 @@ class Blocks {
          * @public
          * @returns blk
          */
-        this.findTopBlock = (blk) => {
+        this.findTopBlock = blk => {
             /** Find the top block in a stack. */
             if (blk == null) {
                 return null;
@@ -2677,14 +2711,14 @@ class Blocks {
                 // eslint-disable-next-line no-console
                 console.debug(
                     "WARNING: CORRUPTED BLOCK DATA. Block " +
-                    myBlock.name +
-                    " (" +
-                    blk +
-                    ") is connected to the same block " +
-                    this.blockList[myBlock.connections[0]].name +
-                    " (" +
-                    myBlock.connections[0] +
-                    ") twice."
+                        myBlock.name +
+                        " (" +
+                        blk +
+                        ") is connected to the same block " +
+                        this.blockList[myBlock.connections[0]].name +
+                        " (" +
+                        myBlock.connections[0] +
+                        ") twice."
                 );
                 return blk;
             }
@@ -2790,7 +2824,7 @@ class Blocks {
          * @public
          * @returns blk
          */
-        this.findBottomBlock = (blk) => {
+        this.findBottomBlock = blk => {
             /** Find the bottom block in a stack. */
             if (blk == null) {
                 return null;
@@ -2828,7 +2862,7 @@ class Blocks {
          * c = 0
          * @returns c
          */
-        this._countBlocksInStack = (blk) => {
+        this._countBlocksInStack = blk => {
             let c = 0;
             if (blk !== null) {
                 c += 1;
@@ -2909,14 +2943,20 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._searchForExpandables = (blk) => {
+        this._searchForExpandables = blk => {
             let c;
-            while (blk != null && this.blockList[blk] != null && !this.blockList[blk].isValueBlock()) {
+            while (
+                blk != null &&
+                this.blockList[blk] != null &&
+                !this.blockList[blk].isValueBlock()
+            ) {
                 /** More checks for malformed or corrupted block data. */
                 this._searchCounter += 1;
                 if (this._searchCounter > 2 * this.blockList.length) {
                     // eslint-disable-next-line no-console
-                    console.debug("infinite loop searching for Expandables? " + this._searchCounter);
+                    console.debug(
+                        "infinite loop searching for Expandables? " + this._searchCounter
+                    );
                     // eslint-disable-next-line no-console
                     console.debug(blk + " " + this.blockList[blk].name);
                     break;
@@ -3011,7 +3051,7 @@ class Blocks {
          * @public
          * return {void}
          */
-        this.unhighlight = (blk) => {
+        this.unhighlight = blk => {
             if (!this.visible) {
                 return;
             }
@@ -3190,7 +3230,7 @@ class Blocks {
         this.makeBlock = (name, arg) => {
             let postProcess;
             const that = this;
-            postProcess = (args) => {
+            postProcess = args => {
                 const thisBlock = args[0];
                 const value = args[1];
                 that.blockList[thisBlock].value = value;
@@ -3240,14 +3280,14 @@ class Blocks {
             let postProcessArg = null;
             let thisBlock = this.blockList.length;
             if (name === "start") {
-                postProcess = (thisBlock) => {
+                postProcess = thisBlock => {
                     that.blockList[thisBlock].value = that.turtles.getTurtleCount();
                     that.turtles.addTurtle(that.blockList[thisBlock]);
                 };
 
                 postProcessArg = thisBlock;
             } else if (name === "outputtools") {
-                postProcess = (args) => {
+                postProcess = args => {
                     that.blockList[thisBlock].value = null;
                     that.blockList[thisBlock].privateData = args[1];
                 };
@@ -3281,7 +3321,7 @@ class Blocks {
             } else if (name === "noisename") {
                 postProcessArg = [thisBlock, DEFAULTNOISE];
             } else if (name === "eastindiansolfege") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3291,7 +3331,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, "sol"];
             } else if (name === "modename") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3301,7 +3341,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, DEFAULTMODE];
             } else if (name === "chordname") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3311,7 +3351,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, DEFAULTCHORD];
             } else if (name === "accidentalname") {
-                postProcess = (args) =>{
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3322,7 +3362,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, DEFAULTACCIDENTAL];
             } else if (name === "intervalname") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3337,7 +3377,7 @@ class Blocks {
             } else if (name === "invertmode") {
                 postProcessArg = [thisBlock, DEFAULTINVERT];
             } else if (name === "number") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = Number(args[1]);
                     that.blockList[b].value = v;
@@ -3351,7 +3391,7 @@ class Blocks {
                     that.activity.logo.initMediaDevices();
                 };
             } else if (name === "media") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
@@ -3364,7 +3404,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, null];
             } else if (name === "camera") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = CAMERAVALUE;
@@ -3377,7 +3417,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, null];
             } else if (name === "video") {
-                postProcess = (args) => {
+                postProcess = args => {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = VIDEOVALUE;
@@ -3390,7 +3430,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, null];
             } else if (name === "loadFile") {
-                postProcess = (args) => {
+                postProcess = args => {
                     that.updateBlockText(args[0]);
                 };
 
@@ -3406,7 +3446,7 @@ class Blocks {
                     "namedarg"
                 ].includes(name)
             ) {
-                postProcess = (args) => {
+                postProcess = args => {
                     that.blockList[thisBlock].value = null;
                     that.blockList[thisBlock].privateData = args[1];
                 };
@@ -3414,7 +3454,7 @@ class Blocks {
                 postProcessArg = [thisBlock, arg];
             } else if (name === "newnote") {
                 // eslint-disable-next-line no-unused-vars
-                postProcess = (args) => { };
+                postProcess = args => {};
                 postProcessArg = [thisBlock, null];
             } else {
                 postProcess = null;
@@ -3447,7 +3487,7 @@ class Blocks {
                             break;
                         }
                     } else if (name === "storein2") {
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const c = that.blockList[thisBlock].connections[0];
                             if (args[1] === _("store in box")) {
                                 that.blockList[c].privateData = _("box");
@@ -3513,7 +3553,7 @@ class Blocks {
                         // eslint-disable-next-line no-console
                         console.debug("cannot set default value");
                     } else if (typeof value === "string") {
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const b = args[0];
                             const v = args[1];
                             that.blockList[b].value = v;
@@ -3530,7 +3570,7 @@ class Blocks {
 
                         this.makeNewBlock("text", postProcess, [thisBlock, value]);
                     } else {
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const b = args[0];
                             const v = Number(args[1]);
                             that.blockList[b].value = v;
@@ -3540,7 +3580,7 @@ class Blocks {
                         this.makeNewBlock("number", postProcess, [thisBlock, value]);
                     }
                 } else if (myBlock.docks[i + 1][2] === "textin") {
-                    postProcess = (args) => {
+                    postProcess = args => {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
@@ -3556,7 +3596,7 @@ class Blocks {
 
                     this.makeNewBlock("text", postProcess, [thisBlock, value]);
                 } else if (myBlock.docks[i + 1][2] === "solfegein") {
-                    postProcess = (args) => {
+                    postProcess = args => {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
@@ -3566,7 +3606,7 @@ class Blocks {
 
                     this.makeNewBlock("solfege", postProcess, [thisBlock, value]);
                 } else if (myBlock.docks[i + 1][2] === "notein") {
-                    postProcess = (args) => {
+                    postProcess = args => {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
@@ -3576,7 +3616,7 @@ class Blocks {
 
                     this.makeNewBlock("notename", postProcess, [thisBlock, value]);
                 } else if (myBlock.docks[i + 1][2] === "mediain") {
-                    postProcess = (args) => {
+                    postProcess = args => {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
@@ -3587,12 +3627,12 @@ class Blocks {
 
                     this.makeNewBlock("media", postProcess, [thisBlock, value]);
                 } else if (myBlock.docks[i + 1][2] === "filein") {
-                    postProcess = (blk) => {
+                    postProcess = blk => {
                         that.updateBlockText(blk);
                     };
                     this.makeNewBlock("loadFile", postProcess, thisBlock);
                 } else {
-                    postProcess = (args) => {
+                    postProcess = args => {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
@@ -3622,7 +3662,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.findDragGroup = (blk) => {
+        this.findDragGroup = blk => {
             if (blk == null) {
                 // eslint-disable-next-line no-console
                 console.debug("null block passed to findDragGroup");
@@ -3640,7 +3680,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._calculateDragGroup = (blk) => {
+        this._calculateDragGroup = blk => {
             this.dragLoopCounter += 1;
             if (this.dragLoopCounter > this.blockList.length) {
                 // eslint-disable-next-line no-console
@@ -3693,7 +3733,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.setActionProtoVisiblity = (state) => {
+        this.setActionProtoVisiblity = state => {
             /** By default, the nameddo protoblock is hidden. */
             const actionsPalette = this.activity.palettes.dict["action"];
             let stateChanged = false;
@@ -3731,11 +3771,16 @@ class Blocks {
             const actionNames = [];
             for (const blk in this.blockList) {
                 if (
-                    (this.blockList[blk].name === "text" || this.blockList[blk].name === "string") &&
+                    (this.blockList[blk].name === "text" ||
+                        this.blockList[blk].name === "string") &&
                     !this.blockList[blk].trash
                 ) {
                     const c = this.blockList[blk].connections[0];
-                    if (c !== null && this.blockList[c].name === "action" && !this.blockList[c].trash) {
+                    if (
+                        c !== null &&
+                        this.blockList[c].name === "action" &&
+                        !this.blockList[c].trash
+                    ) {
                         if (actionBlk !== c) {
                             actionNames.push(this.blockList[blk].value);
                         }
@@ -3759,12 +3804,16 @@ class Blocks {
          * @public
          * @returns value
          */
-        this.findUniqueCustomName = (name) => {
+        this.findUniqueCustomName = name => {
             const noteNames = [];
             for (const blk in this.blockList) {
                 if (this.blockList[blk].name === "text" && !this.blockList[blk].trash) {
                     const c = this.blockList[blk].connections[0];
-                    if (c != null && this.blockList[c].name === "pitch" && !this.blockList[c].trash) {
+                    if (
+                        c != null &&
+                        this.blockList[c].name === "pitch" &&
+                        !this.blockList[c].trash
+                    ) {
                         noteNames.push(this.blockList[blk].value);
                     }
                 }
@@ -3785,7 +3834,7 @@ class Blocks {
          * @public
          * @returns value
          */
-        this.findUniqueTemperamentName = (name) => {
+        this.findUniqueTemperamentName = name => {
             const temperamentNames = [];
             for (const blk in this.blockList) {
                 if (this.blockList[blk].name === "text" && !this.blockList[blk].trash) {
@@ -4082,7 +4131,7 @@ class Blocks {
                 const block = actionsPalette.protoList[blockId];
                 if (
                     ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].indexOf(block.name) !==
-                    -1 /** && block.defaults[0] !== _('action') */ &&
+                        -1 /** && block.defaults[0] !== _('action') */ &&
                     block.defaults[0] === oldName
                 ) {
                     block.defaults[0] = newName;
@@ -4106,7 +4155,7 @@ class Blocks {
          * Deprecated -- there is no need to add this block to the palette. The
          * short-from storein2 block covers all of the use cases.
          */
-        this.newStoreinBlock = (name) => {
+        this.newStoreinBlock = name => {
             if (name == null) {
                 // eslint-disable-next-line no-console
                 console.debug("null name passed to newStoreinBlock");
@@ -4146,7 +4195,7 @@ class Blocks {
          * @public
          * return {void}
          */
-        this.newStorein2Block = (name) => {
+        this.newStorein2Block = name => {
             if (name == null) {
                 // eslint-disable-next-line no-console
                 console.debug("null name passed to newStorein2Block");
@@ -4180,7 +4229,7 @@ class Blocks {
          * @public
          * return {void}
          */
-        this.newNamedboxBlock = (name) => {
+        this.newNamedboxBlock = name => {
             if (name == null) {
                 // eslint-disable-next-line no-console
                 console.debug("null name passed to newNamedboxBlock");
@@ -4213,7 +4262,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._newLocalArgBlock = async (name) => {
+        this._newLocalArgBlock = async name => {
             /** name === 1, 2, 3, ... */
             const blkname = "arg_" + name;
             if ("myArg_" + blkname in this.protoBlockDict) {
@@ -4245,7 +4294,7 @@ class Blocks {
          * @private
          * @returns {void}
          */
-        this._removeNamedoEntries = (name) => {
+        this._removeNamedoEntries = name => {
             /** Delete any old palette entries. */
             // eslint-disable-next-line no-console
             /** console.debug('DELETE: removing old palette entries for ' + name); */
@@ -4307,7 +4356,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.newNamedcalcBlock = (name) => {
+        this.newNamedcalcBlock = name => {
             if (this.protoBlockDict["myCalc_" + name] === undefined) {
                 const myCalcBlock = new ProtoBlock("namedcalc");
                 this.protoBlockDict["myCalc_" + name] = myCalcBlock;
@@ -4329,7 +4378,7 @@ class Blocks {
          * @public
          * return boolean
          */
-        this.newNameddoArgBlock = (name) => {
+        this.newNameddoArgBlock = name => {
             if (this.protoBlockDict["myDoArg_" + name] === undefined) {
                 const myDoArgBlock = new ProtoBlock("nameddoArg");
                 this.protoBlockDict["myDoArg_" + name] = myDoArgBlock;
@@ -4351,7 +4400,7 @@ class Blocks {
          * @public
          * return boolean
          */
-        this.newNamedcalcArgBlock = (name) => {
+        this.newNamedcalcArgBlock = name => {
             if (this.protoBlockDict["myCalcArg_" + name] === undefined) {
                 const myCalcArgBlock = new ProtoBlock("namedcalcArg");
                 this.protoBlockDict["myCalcArg_" + name] = myCalcArgBlock;
@@ -4367,7 +4416,7 @@ class Blocks {
             return false;
         };
 
-        this._insideArgClamp = (blk) => {
+        this._insideArgClamp = blk => {
             /** Returns a containing arg clamp block or null */
             if (this.blockList[blk] == null) {
                 /** race condition? */
@@ -4425,7 +4474,7 @@ class Blocks {
          * @public
          * @returns expandable block
          */
-        this.insideExpandableBlock = (blk) => {
+        this.insideExpandableBlock = blk => {
             if (this.blockList[blk] == null) {
                 /** race condition? */
                 // eslint-disable-next-line no-console
@@ -4459,7 +4508,7 @@ class Blocks {
          * @public
          * @returns note block
          */
-        this._insideNoteBlock = (blk) => {
+        this._insideNoteBlock = blk => {
             if (this.blockList[blk] == null) {
                 // eslint-disable-next-line no-console
                 console.debug("null block in blockList? " + blk);
@@ -4471,7 +4520,11 @@ class Blocks {
                 if (this.blockList[cblk].isExpandableBlock()) {
                     if (this.blockList[blk].name === "forever") {
                         if (this._isConnectedToNoteValue(cblk)) {
-                            this.activity.errorMsg(_("Forever loop detected inside a note value block. Unexpected things may happen."));
+                            this.activity.errorMsg(
+                                _(
+                                    "Forever loop detected inside a note value block. Unexpected things may happen."
+                                )
+                            );
                             return null;
                         }
                     }
@@ -4494,7 +4547,7 @@ class Blocks {
             }
         };
 
-        this._isConnectedToNoteValue = (blk) => {
+        this._isConnectedToNoteValue = blk => {
             if (NOTEBLOCKS.includes(this.blockList[blk].name)) {
                 return true;
             } else if (this.blockList[blk].connections[0] == null) {
@@ -4511,7 +4564,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.findBlockInstance = (blkName) => {
+        this.findBlockInstance = blkName => {
             /** Returns true if block of name blkName is loaded. */
             for (const blk in this.blockList) {
                 if (this.blockList[blk].name === blkName && !this.blockList[blk].trash) {
@@ -4528,7 +4581,7 @@ class Blocks {
          * @public
          * @returns null or collapsible block
          */
-        this.insideInlineCollapsibleBlock = (blk) => {
+        this.insideInlineCollapsibleBlock = blk => {
             if (blk === null) {
                 return null;
             }
@@ -4559,7 +4612,7 @@ class Blocks {
          * @public
          * @returns note block
          */
-        this.findNoteBlock = (blk) => {
+        this.findNoteBlock = blk => {
             if (blk === null) {
                 return null;
             }
@@ -4583,7 +4636,7 @@ class Blocks {
          * @public
          * @returns null or blk
          */
-        this.findNestedIntervalBlock = (blk) => {
+        this.findNestedIntervalBlock = blk => {
             if (blk === null) {
                 return null;
             }
@@ -4607,7 +4660,7 @@ class Blocks {
          * @public
          * @returns null or blk
          */
-        this.findFirstPitchBlock = (blk) => {
+        this.findFirstPitchBlock = blk => {
             if (blk === null) {
                 return null;
             }
@@ -4628,15 +4681,19 @@ class Blocks {
          * @public
          * @returns 4
          */
-        this.findPitchOctave = (blk) => {
+        this.findPitchOctave = blk => {
             if (blk === null) {
                 return 4;
             }
 
             if (
-                ["pitch", "setpitchnumberoffset", "invert1", "tofrequency", "nthmodalpitch"].includes(
-                    this.blockList[blk].name
-                )
+                [
+                    "pitch",
+                    "setpitchnumberoffset",
+                    "invert1",
+                    "tofrequency",
+                    "nthmodalpitch"
+                ].includes(this.blockList[blk].name)
             ) {
                 const oblk = this.blockList[blk].connections[2];
                 if (oblk === null) {
@@ -4664,9 +4721,13 @@ class Blocks {
             }
 
             if (
-                ["pitch", "setpitchnumberoffset", "invert1", "tofrequency", "nthmodalpitch"].includes(
-                    this.blockList[blk].name
-                )
+                [
+                    "pitch",
+                    "setpitchnumberoffset",
+                    "invert1",
+                    "tofrequency",
+                    "nthmodalpitch"
+                ].includes(this.blockList[blk].name)
             ) {
                 const oblk = this.blockList[blk].connections[2];
                 if (oblk !== null && this.blockList[oblk].name === "number") {
@@ -4688,7 +4749,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.intervalModifierNumber = (blk) => {
+        this.intervalModifierNumber = blk => {
             if (blk === null) {
                 return false;
             }
@@ -4696,7 +4757,11 @@ class Blocks {
             const myBlock = this.blockList[blk];
             const pblk = myBlock.connections[0];
             /** Are we connected to a plus block? */
-            if (myBlock.name === "number" && pblk !== null && this.blockList[pblk].name === "plus") {
+            if (
+                myBlock.name === "number" &&
+                pblk !== null &&
+                this.blockList[pblk].name === "plus"
+            ) {
                 /** Is the plus block connected to an interval block? */
                 const c = this.blockList[pblk].connections[0];
                 if (c === null) {
@@ -4727,7 +4792,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.octaveModifierNumber = (blk) => {
+        this.octaveModifierNumber = blk => {
             if (blk === null) {
                 return false;
             }
@@ -4772,7 +4837,11 @@ class Blocks {
             const myBlock = this.blockList[blk];
             const dblk = myBlock.connections[0];
             /** Are we connected to a divide block? */
-            if (myBlock.name === "number" && dblk !== null && this.blockList[dblk].name === "divide") {
+            if (
+                myBlock.name === "number" &&
+                dblk !== null &&
+                this.blockList[dblk].name === "divide"
+            ) {
                 /** Are we the denominator (c == 2) or numerator (c == 1)? */
                 if (this.blockList[dblk].connections[c] === this.blockList.indexOf(myBlock)) {
                     /** Is the divide block connected to a note value block? */
@@ -4826,7 +4895,7 @@ class Blocks {
          * @public
          * @returns 1
          */
-        this.noteValueValue = (blk) => {
+        this.noteValueValue = blk => {
             if (blk === null) {
                 return 1;
             }
@@ -4891,7 +4960,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.octaveNumber = (blk) => {
+        this.octaveNumber = blk => {
             if (blk === null) {
                 return false;
             }
@@ -4899,9 +4968,13 @@ class Blocks {
             const myBlock = this.blockList[blk];
             if (
                 myBlock.connections[0] !== null &&
-                ["pitch", "setpitchnumberoffset", "invert1", "tofrequency", "nthmodalpitch"].includes(
-                    this.blockList[myBlock.connections[0]].name
-                ) &&
+                [
+                    "pitch",
+                    "setpitchnumberoffset",
+                    "invert1",
+                    "tofrequency",
+                    "nthmodalpitch"
+                ].includes(this.blockList[myBlock.connections[0]].name) &&
                 this.blockList[myBlock.connections[0]].connections[2] === blk
             ) {
                 return true;
@@ -4924,7 +4997,7 @@ class Blocks {
          * @public
          * @returns void
          */
-        this.meter_block_changed = (blk) => {
+        this.meter_block_changed = blk => {
             if (blk === null || this.blockList[blk].name !== "meter") {
                 return;
             }
@@ -5043,13 +5116,21 @@ class Blocks {
             /** Reposition the paste location relative to the stage position. */
             if (this.selectedBlocksObj != null) {
                 if (docById("helpfulWheelDiv").style.display !== "none") {
-                    this.selectedBlocksObj[0][2] = docById("helpfulWheelDiv").offsetLeft + 240 - this.activity.blocksContainer.x;
-                    this.selectedBlocksObj[0][3] = docById("helpfulWheelDiv").offsetTop + 130 - this.activity.blocksContainer.y;
+                    this.selectedBlocksObj[0][2] =
+                        docById("helpfulWheelDiv").offsetLeft +
+                        240 -
+                        this.activity.blocksContainer.x;
+                    this.selectedBlocksObj[0][3] =
+                        docById("helpfulWheelDiv").offsetTop +
+                        130 -
+                        this.activity.blocksContainer.y;
 
                     docById("helpfulWheelDiv").style.display = "none";
                 } else {
-                    this.selectedBlocksObj[0][2] = 175 - this.activity.blocksContainer.x + this.pasteDx;
-                    this.selectedBlocksObj[0][3] = 75 - this.activity.blocksContainer.y + this.pasteDy;
+                    this.selectedBlocksObj[0][2] =
+                        175 - this.activity.blocksContainer.x + this.pasteDx;
+                    this.selectedBlocksObj[0][3] =
+                        75 - this.activity.blocksContainer.y + this.pasteDy;
                     this.pasteDx += 21;
                     this.pasteDy += 21;
                 }
@@ -5097,7 +5178,8 @@ class Blocks {
                     if (["show", "turtleshell", "customsample"].includes(blockObjs[i][1])) {
                         switch (blockObjs[i][1]) {
                             case "show":
-                                name = _("Show").toLowerCase() + "-" + MathUtility.doRandom(0, 1000);
+                                name =
+                                    _("Show").toLowerCase() + "-" + MathUtility.doRandom(0, 1000);
                                 break;
                             case "turtleshell":
                                 name = _("avatar") + "-" + MathUtility.doRandom(0, 1000);
@@ -5124,7 +5206,7 @@ class Blocks {
          * @public
          * @returns blockObj
          */
-        this._copyBlocksToObj = (saveStack) => {
+        this._copyBlocksToObj = saveStack => {
             /** If saveStack then don't override media or audiofile blocks. */
             const blockObjs = [];
             const blockMap = {};
@@ -5155,7 +5237,13 @@ class Blocks {
                             break;
                         case "namedbox":
                         case "namedarg":
-                            blockItem = [b, [myBlock.name, { value: myBlock.privateData }], x, y, []];
+                            blockItem = [
+                                b,
+                                [myBlock.name, { value: myBlock.privateData }],
+                                x,
+                                y,
+                                []
+                            ];
                             break;
                         default:
                             blockItem = [b, [myBlock.name, { value: myBlock.value }], x, y, []];
@@ -5201,7 +5289,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.addToMyPalette = (name) => {
+        this.addToMyPalette = name => {
             const myBlock = new ProtoBlock("macro_" + name);
             const blkName = "macro_" + name;
             this.protoBlockDict[blkName] = myBlock;
@@ -5223,7 +5311,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.findBlockInstance = (blkName) => {
+        this.findBlockInstance = blkName => {
             for (const blk in this.blockList) {
                 if (this.blockList[blk].name === blkName && !this.blockList[blk].trash) {
                     return true;
@@ -5238,7 +5326,7 @@ class Blocks {
          * @public
          * return {void}
          */
-        this.loadNewBlocks = (blockObjs) => {
+        this.loadNewBlocks = blockObjs => {
             /**
              * Playback Queue has been deprecated, but some old projects
              * may still have playback blocks appended, which we will
@@ -5257,7 +5345,10 @@ class Blocks {
             if (playbackQueueStartsHere !== null) {
                 // eslint-disable-next-line no-console
                 console.debug("Removing deprecated playback queue from project");
-                blockObjs.splice(playbackQueueStartsHere, blockObjs.length - playbackQueueStartsHere);
+                blockObjs.splice(
+                    playbackQueueStartsHere,
+                    blockObjs.length - playbackQueueStartsHere
+                );
             }
 
             /** Check for blocks connected to themselves, */
@@ -5288,7 +5379,9 @@ class Blocks {
 
                 if (this.blockList[b].name === "action") {
                     if (this.blockList[b].connections[1] != null) {
-                        currentActionNames.push(this.blockList[this.blockList[b].connections[1]].value);
+                        currentActionNames.push(
+                            this.blockList[this.blockList[b].connections[1]].value
+                        );
                     }
                 } else if (this.blockList[b].name === "storein") {
                     if (this.blockList[b].connections[1] != null) {
@@ -5474,9 +5567,7 @@ class Blocks {
                     } else {
                         blkName = thisBlkData[1][0];
                     }
-                    if (
-                        ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].includes(blkName)
-                    ) {
+                    if (["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].includes(blkName)) {
                         if (thisBlkData[1][1]["value"] === oldName) {
                             thisBlkData[1][1] = { value: name };
                         }
@@ -5584,10 +5675,10 @@ class Blocks {
                                 // eslint-disable-next-line no-console
                                 console.debug(
                                     "last connection of " +
-                                    name +
-                                    " is " +
-                                    nextName +
-                                    ": adding hidden block"
+                                        name +
+                                        " is " +
+                                        nextName +
+                                        ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][len - 1] = blockObjsLength + extraBlocksLength;
@@ -5722,10 +5813,10 @@ class Blocks {
                                 // eslint-disable-next-line no-console
                                 console.debug(
                                     "last connection of " +
-                                    name +
-                                    " is " +
-                                    nextName +
-                                    ": adding hidden block"
+                                        name +
+                                        " is " +
+                                        nextName +
+                                        ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][2] = blockObjsLength + extraBlocksLength;
@@ -5808,17 +5899,20 @@ class Blocks {
                     case "start":
                         blkData[4][0] = null;
                         blkData[4][2] = null;
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const blkInfo = args[1];
                             that.blockList[thisBlock].value = that.turtles.getTurtleCount();
                             that.turtles.addTurtle(that.blockList[thisBlock], blkInfo);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            blkInfo[1]
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, blkInfo[1]]
+                        );
                         break;
                     case "action":
                     case "hat":
@@ -5833,7 +5927,7 @@ class Blocks {
                         );
                         break;
                     case "temperament1":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const value = args[1];
                             let customName = "custom";
                             if (value.customName !== undefined) {
@@ -5841,7 +5935,10 @@ class Blocks {
                             }
                             if (value.customTemperamentNotes !== undefined) {
                                 deleteTemperamentFromList(customName);
-                                addTemperamentToDictionary(customName, value.customTemperamentNotes);
+                                addTemperamentToDictionary(
+                                    customName,
+                                    value.customTemperamentNotes
+                                );
                                 updateTemperaments();
                             }
                             /** Is this correct? */
@@ -5855,14 +5952,17 @@ class Blocks {
                             that.protoBlockDict["custompitch"].hidden = false;
                             that.activity.palettes.updatePalettes("pitch");
                         };
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            blkInfo[1]
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, blkInfo[1]]
+                        );
                         break;
                     case "storein2":
                         /** Named boxes and dos need private data. */
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
@@ -5877,13 +5977,16 @@ class Blocks {
                             that.blockList[thisBlock].regenerateArtwork();
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "namedbox":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
@@ -5900,29 +6003,35 @@ class Blocks {
                             that.blockList[thisBlock].regenerateArtwork();
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "namedarg":
                     case "namedcalc":
                     case "nameddo":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
                             that.blockList[thisBlock].value = null;
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "doArg":
                         /** Arg clamps may need extra slots added. */
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const extraSlots = args[1].length - 4;
                             if (extraSlots > 0) {
@@ -5954,7 +6063,7 @@ class Blocks {
                         );
                         break;
                     case "nameddoArg":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
@@ -5989,7 +6098,7 @@ class Blocks {
                         );
                         break;
                     case "calcArg":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const extraSlots = args[1].length - 3;
                             if (extraSlots > 0) {
@@ -6021,7 +6130,7 @@ class Blocks {
                         );
                         break;
                     case "namedcalcArg":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
@@ -6056,7 +6165,7 @@ class Blocks {
                         );
                         break;
                     case "makeblock":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const extraSlots = args[1].length - 3;
                             if (extraSlots > 0) {
@@ -6088,20 +6197,23 @@ class Blocks {
                         break;
                     /** Value blocks need a default value set. */
                     case "number":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = Number(value);
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "outputtools":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].privateData = value;
@@ -6132,59 +6244,66 @@ class Blocks {
                     case "intervalname":
                     case "grid":
                     case "boolean":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "drumname":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
 
                         /** Load the synth for this drum */
                         if (value === null) value = DEFAULTDRUM;
                         that.activity.logo.synth.loadSynth(0, getDrumSynthName(value));
                         break;
                     case "effectsname":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
 
                         /** Load the synth for this drum */
                         if (value === null) value = DEFAULTEFFECT;
                         that.activity.logo.synth.loadSynth(0, getDrumSynthName(value));
                         break;
                     case "voicename":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             let value = args[1];
-                            if (
-                                ["simple 1", "simple 2", "simple 3", "simple 4"].includes(value)
-                            ) {
+                            if (["simple 1", "simple 2", "simple 3", "simple 4"].includes(value)) {
                                 value = "sine";
                             }
 
@@ -6192,10 +6311,13 @@ class Blocks {
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
 
                         /** Load the synth for this voice */
                         try {
@@ -6209,17 +6331,20 @@ class Blocks {
                         }
                         break;
                     case "noisename":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
                             that.updateBlockText(thisBlock);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
 
                         /** Load the synth for this noise */
                         try {
@@ -6239,7 +6364,7 @@ class Blocks {
                         break;
                     case "media":
                         /** Load a thumbnail into a media blocks. */
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
@@ -6249,40 +6374,49 @@ class Blocks {
                             }
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "camera":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             /** const value = args[1]; */
                             that.blockList[thisBlock].value = CAMERAVALUE;
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "video":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             const thisBlock = args[0];
                             /** const value = args[1]; */
                             that.blockList[thisBlock].value = VIDEOVALUE;
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
 
                     /** Define some constants for backward compatibility with Python projects. */
                     case "red":
                     case "black":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 0;
                             that.updateBlockText(thisBlock);
                         };
@@ -6296,7 +6430,7 @@ class Blocks {
                         );
                         break;
                     case "white":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 100;
                             that.updateBlockText(thisBlock);
                         };
@@ -6310,7 +6444,7 @@ class Blocks {
                         );
                         break;
                     case "orange":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 10;
                             that.updateBlockText(thisBlock);
                         };
@@ -6324,7 +6458,7 @@ class Blocks {
                         );
                         break;
                     case "yellow":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 20;
                             that.updateBlockText(thisBlock);
                         };
@@ -6338,7 +6472,7 @@ class Blocks {
                         );
                         break;
                     case "green":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 40;
                             that.updateBlockText(thisBlock);
                         };
@@ -6352,7 +6486,7 @@ class Blocks {
                         );
                         break;
                     case "blue":
-                        postProcess = (thisBlock) => {
+                        postProcess = thisBlock => {
                             that.blockList[thisBlock].value = 70;
                             that.updateBlockText(thisBlock);
                         };
@@ -6366,42 +6500,51 @@ class Blocks {
                         );
                         break;
                     case "loadFile":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             that.blockList[args[0]].value = args[1];
                             that.updateBlockText(args[0]);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "wrapmode":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             that.blockList[args[0]].value = args[1];
                             that.updateBlockText(args[0]);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     case "audiofile":
-                        postProcess = (args) => {
+                        postProcess = args => {
                             that.blockList[args[0]].value = args[1];
                             that.updateBlockText(args[0]);
                         };
 
-                        this._makeNewBlockWithConnections(name, blockOffset, blkData[4], postProcess, [
-                            thisBlock,
-                            value
-                        ]);
+                        this._makeNewBlockWithConnections(
+                            name,
+                            blockOffset,
+                            blkData[4],
+                            postProcess,
+                            [thisBlock, value]
+                        );
                         break;
                     default:
                         /** Check that name is in the proto list */
                         if (!(name in this.protoBlockDict) || this.protoBlockDict[name] == null) {
-                            const postProcessUnknownBlock = (args) => {
+                            const postProcessUnknownBlock = args => {
                                 /** save original block name */
                                 that.blockList[args[0]].privateData = args[1];
                             };
@@ -6419,7 +6562,8 @@ class Blocks {
                                 if (typeof blockObjs[c][1] === "string") {
                                     if (this.protoBlockDict[blockObjs[c][1]] !== undefined) {
                                         if (
-                                            this.protoBlockDict[blockObjs[c][1]].dockTypes[cc] !== "in"
+                                            this.protoBlockDict[blockObjs[c][1]].dockTypes[cc] !==
+                                            "in"
                                         ) {
                                             flowBlock = false;
                                         }
@@ -6427,8 +6571,9 @@ class Blocks {
                                 } else {
                                     if (this.protoBlockDict[blockObjs[c][1][0]] !== undefined) {
                                         if (
-                                            this.protoBlockDict[blockObjs[c][1][0]].dockTypes[cc] !==
-                                            "in"
+                                            this.protoBlockDict[blockObjs[c][1][0]].dockTypes[
+                                                cc
+                                            ] !== "in"
                                         ) {
                                             flowBlock = false;
                                         }
@@ -6442,17 +6587,20 @@ class Blocks {
                                     if (typeof blockObjs[c][1] === "string") {
                                         if (this.protoBlockDict[blockObjs[c][1]] !== undefined) {
                                             if (
-                                                this.protoBlockDict[blockObjs[c][1]].dockTypes[cc] !==
-                                                "out"
+                                                this.protoBlockDict[blockObjs[c][1]].dockTypes[
+                                                    cc
+                                                ] !== "out"
                                             ) {
                                                 flowBlock = false;
                                             }
                                         } else {
-                                            if (this.protoBlockDict[blockObjs[c][1][0]] !== undefined) {
+                                            if (
+                                                this.protoBlockDict[blockObjs[c][1][0]] !==
+                                                undefined
+                                            ) {
                                                 if (
-                                                    this.protoBlockDict[blockObjs[c][1][0]].dockTypes[
-                                                        cc
-                                                    ] !== "out"
+                                                    this.protoBlockDict[blockObjs[c][1][0]]
+                                                        .dockTypes[cc] !== "out"
                                                 ) {
                                                     flowBlock = false;
                                                 }
@@ -6543,7 +6691,7 @@ class Blocks {
          * @returns {void}
          */
         // eslint-disable-next-line no-unused-vars
-        this.cleanupAfterLoad = async (name) => {
+        this.cleanupAfterLoad = async name => {
             this._loadCounter -= 1;
             if (this._loadCounter > 0) {
                 return;
@@ -6665,7 +6813,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.actionHasReturn = (blk) => {
+        this.actionHasReturn = blk => {
             if (this.blockList[blk].name !== "action") {
                 return false;
             }
@@ -6684,7 +6832,7 @@ class Blocks {
          * @public
          * @returns boolean
          */
-        this.actionHasArgs = (blk) => {
+        this.actionHasArgs = blk => {
             if (this.blockList[blk].name !== "action") {
                 return false;
             }
@@ -6706,7 +6854,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.raiseStackToTop = (blk) => {
+        this.raiseStackToTop = blk => {
             const topBlk = this.findTopBlock(blk);
             this.findDragGroup(topBlk);
 
@@ -6728,7 +6876,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.deleteActionBlock = async (myBlock) => {
+        this.deleteActionBlock = async myBlock => {
             const actionArg = this.blockList[myBlock.connections[1]];
             if (actionArg) {
                 const actionName = actionArg.value;
@@ -6825,7 +6973,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.sendStackToTrash = (myBlock) => {
+        this.sendStackToTrash = myBlock => {
             /** First, hide the palettes as they may need updating. */
             for (const name in this.activity.palettes.dict) {
                 this.activity.palettes.dict[name].hideMenu(true);
@@ -6910,9 +7058,13 @@ class Blocks {
                     ) {
                         this._checkTwoArgBlocks.push(blk);
                     } else if (
-                        ["clamp", "argclamp", "argclamparg", "doubleclamp", "argflowclamp"].includes(
-                            myBlock.protoblock.style
-                        )
+                        [
+                            "clamp",
+                            "argclamp",
+                            "argclamparg",
+                            "doubleclamp",
+                            "argflowclamp"
+                        ].includes(myBlock.protoblock.style)
                     ) {
                         this._checkArgClampBlocks.push(blk);
                     }
@@ -7038,11 +7190,11 @@ class Blocks {
             this.activity.refreshCanvas();
         };
 
-        this.setSelection = (selection) => {
+        this.setSelection = selection => {
             this.selectionModeOn = selection;
         };
 
-        this.setSelectionToActivity = (selection) => {
+        this.setSelectionToActivity = selection => {
             this.activity.setSelectionMode(selection);
         };
 
@@ -7050,27 +7202,29 @@ class Blocks {
             this.blockList[blk].unhighlightSelectedBlocks(blk, selection);
         };
 
-        this.setSelectedBlocks = (blocks) => {
+        this.setSelectedBlocks = blocks => {
             this.selectedBlocks = blocks;
         };
-        
+
         /**
-        * Checks if coordinates intersect with any block
-        * @public
-        * @param {number} x - The x coordinate to check
-        * @param {number} y - The y coordinate to check  
-        * @returns {boolean} True if coordinates intersect with a block
-        */
-        this.isCoordinateOnBlock = function(x, y) {
+         * Checks if coordinates intersect with any block
+         * @public
+         * @param {number} x - The x coordinate to check
+         * @param {number} y - The y coordinate to check
+         * @returns {boolean} True if coordinates intersect with a block
+         */
+        this.isCoordinateOnBlock = function (x, y) {
             return this.blockList.some(block => {
                 if (block.trash) return false;
-                
+
                 const blockX = block.container.x;
                 const blockY = block.container.y;
-                return x >= blockX &&
+                return (
+                    x >= blockX &&
                     x <= blockX + block.width &&
                     y >= blockY &&
-                    y <= blockY + block.height;
+                    y <= blockY + block.height
+                );
             });
         };
     }


### PR DESCRIPTION
Fixes #4670

Extract is called when using the secondary menu delete block command. This was causing an issue with widget blocks because the hiddennoflow block was getting removed from the end of the clamp. Thus, when the widget was restored from the trash, it would not run. This fix checks for hiddennoflow and includes it in the extracted stack. (Similar code was already in place for hidden blocks.)