### PR TITLE
fix: Mock Tone.start() as a Promise to fix failing unit tests

### DIFF
--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -120,15 +120,12 @@ class PolySynth {
 }
 
 class context {
-    static resume() {
-    }
+    static resume() {}
 }
 
 class Transport {
-    static start() {
-    }
-    static stop() {
-    }
+    static start() {}
+    static stop() {}
 }
 
 class ToneAudioBuffer {
@@ -169,13 +166,13 @@ const Tone = {
     }),
     Context: jest.fn().mockReturnThis(),
     Loop: jest.fn((callback, interval) => ({
-        start: jest.fn((start) => {
+        start: jest.fn(start => {
             callback(start); // Simulate immediate execution of the callback
             return {}; // Mocked loop instance
-        }),
+        })
     })),
     Instrument: jest.fn().mockImplementation(() => ({
-        toDestination: jest.fn(),
+        toDestination: jest.fn()
     })),
     doNeighbor: jest.fn().mockReturnThis(),
     Destination: { volume: { rampTo: jest.fn() } },


### PR DESCRIPTION
Related Issue Fixes #4900 

Summary of Changes Updated the tonemock.js file to mock start using .mockResolvedValue() instead of a basic jest.fn().

Technical Details

Before: start: jest.fn() (returned undefined).

After: start: jest.fn().mockResolvedValue() (returns a resolved Promise).
The code in synthutils.js calls Tone.start().catch(...). This change ensures the mock adheres to the Promise interface expected by the application code, preventing the TypeError.
<img width="921" height="170" alt="image" src="https://github.com/user-attachments/assets/e2e47553-6b01-45fb-acce-e3108be0bcf9" />
