### PR TITLE
Fix: Remove event listeners in destroy() method 

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -383,9 +383,6 @@ class WidgetWindow {
      * @returns {void}
      */
     close() {
-        document.removeEventListener("mouseup", this._dragTopHandler, true);
-        document.removeEventListener("mousemove", this._docMouseMoveHandler, true);
-        document.removeEventListener("mousedown", this._docMouseDownHandler, true);
         this.onclose();
     }
 
@@ -538,6 +535,10 @@ class WidgetWindow {
      * @returns {void}
      */
     destroy() {
+        document.removeEventListener("mouseup", this._dragTopHandler, true);
+        document.removeEventListener("mousemove", this._docMouseMoveHandler, true);
+        document.removeEventListener("mousedown", this._docMouseDownHandler, true);
+
         if (this._frame && this._frame.parentElement) {
             this._frame.parentElement.removeChild(this._frame);
         }


### PR DESCRIPTION
### Fixes #4901 
### Problem
Widget windows add three event listeners to `document` when created (`mouseup`, `mousemove`, `mousedown`) but these listeners are never removed when the widget is closed.
The cleanup code exists in the `close()` method, but all 20 widgets in the codebase override `onclose()` and call `destroy()` directly, so the cleanup code never runs.
This causes a memory leak where every widget open/close cycle leaves 3 orphaned event listeners attached to `document`. In longer sessions, this leads to degraded performance as hundreds of unused listeners accumulate.

### Solution
Moved the `removeEventListener` calls from `close()` to `destroy()` so cleanup happens regardless of which method is called.

## Testing

**Before**
<img width="827" height="573" alt="image" src="https://github.com/user-attachments/assets/bfaadf4e-a079-46f0-a06d-ae8102f18645" />

**After**
<img width="823" height="581" alt="image" src="https://github.com/user-attachments/assets/babbbff7-1d78-40e2-b235-4fc8168f4a5b" />
