### PR TITLE
fix: prevent accidental toggle on repeated clicks in pitch pie menu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -637,32 +637,58 @@ const piemenuPitches = (
         selection["octave"] = octave;
     };
 
+    block.prevAccidental =
+    !custom && that._accidentalsWheel
+        ? that._accidentalsWheel.navItems[
+              that._accidentalsWheel.selectedNavItemIndex
+          ].title
+        : null;
+
+
     const __selectionChangedAccidental = () => {
-        selection["note"] = that._pitchWheel.navItems[that._pitchWheel.selectedNavItemIndex].title;
-        selection["attr"] =
-            that._accidentalsWheel.navItems[that._accidentalsWheel.selectedNavItemIndex].title;
+    const newAccidental =
+        that._accidentalsWheel.navItems[
+            that._accidentalsWheel.selectedNavItemIndex
+        ].title;
 
-        if (selection["attr"] === "♮") {
-            that.text.text = selection["note"];
-            that.value = selection["note"];
-        } else {
-            that.value = selection["note"] + selection["attr"];
-            that.text.text = that.value;
-        }
-        // Store the selected accidental in the block for later use.
-        prevAccidental = selection["attr"];
-        block.prevAccidental = prevAccidental;
-       
-        that.container.setChildIndex(that.text, that.container.children.length - 1);
-        that.updateCache();
+    //  Prevent toggling if same accidental is clicked again
+    if (block.prevAccidental === newAccidental) {
+        return;
+    }
 
-        // Ensure we have the current octave
-        if (hasOctaveWheel) {
-            selection["octave"] = Number(
-                that._octavesWheel.navItems[that._octavesWheel.selectedNavItemIndex].title
-            );
-        }
-    };
+    selection["note"] =
+        that._pitchWheel.navItems[
+            that._pitchWheel.selectedNavItemIndex
+        ].title;
+
+    selection["attr"] = newAccidental;
+
+    if (selection["attr"] === "♮") {
+        that.text.text = selection["note"];
+        that.value = selection["note"];
+    } else {
+        that.value = selection["note"] + selection["attr"];
+        that.text.text = that.value;
+    }
+
+    // Persist accidental
+    block.prevAccidental = selection["attr"];
+
+    that.container.setChildIndex(
+        that.text,
+        that.container.children.length - 1
+    );
+    that.updateCache();
+
+    // Ensure we have the current octave
+    if (hasOctaveWheel) {
+        selection["octave"] = Number(
+            that._octavesWheel.navItems[
+                that._octavesWheel.selectedNavItemIndex
+            ].title
+        );
+    }
+};
 
     // Set up handlers for pitch preview.
     const setupAudioContext = async () => {


### PR DESCRIPTION
# Summary
Fixes incorrect toggle behavior for sharp and flat accidentals in the Name Pitch Octave block.

# Problem
Repeated clicks on `#` or `b` toggled the accidental off, which is incorrect.

# Solution
- Track previously selected accidental
- Ignore repeated selections of the same accidental
- Preserve octave and preview behavior

# Testing
- Tested locally on Windows
- Verified sharp, flat, and natural cases
- Verified no regressions in preview or octave selection

Fixes #4886
