### PR TITLE
fix: Use classList.remove instead of style.display in hidePrintText

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5423,7 +5423,7 @@ class Activity {
          */
         this.hidePrintText = () => {
             if (this.printText) {
-                this.printText.style.display = "none";
+                this.printText.classList.remove("show");
             }
         };
 


### PR DESCRIPTION
Fixes #4916

The inline style was overriding the CSS class, preventing the value bar from reappearing after being closed.