### PR TITLE
fix: Add label prefix and block hotkeys for screen dimension blocks

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3140,6 +3140,10 @@ class Activity {
             if (document.getElementById("labelDiv").classList.contains("hasKeyboard")) {
                 return;
             }
+            // Skip hotkeys when value bar is visible (prevents accidental block creation)
+            if (this.printText && this.printText.classList.contains("show")) {
+                return;
+            }
 
             if (this.keyboardEnableFlag) {
                 if (

--- a/js/logo.js
+++ b/js/logo.js
@@ -1482,10 +1482,25 @@ class Logo {
             ) {
                 args.push(logo.parseArg(logo, turtle, blk, logo.receievedArg));
 
+                // Use label prefix for screen dimension blocks to clarify the display is informational
+                // Labels wrapped with _() for internationalization
+                const blockLabels = {
+                    width: _("width"),
+                    height: _("height"),
+                    rightpos: _("right (screen)"),
+                    leftpos: _("left (screen)"),
+                    toppos: _("top (screen)"),
+                    bottompos: _("bottom (screen)")
+                };
+                const blockName = logo.blockList[blk].name;
+                const label = blockLabels[blockName];
+
                 if (logo.blockList[blk].value == null) {
                     logo.activity.textMsg("null block value");
                 } else {
-                    logo.activity.textMsg(logo.blockList[blk].value.toString());
+                    const value = logo.blockList[blk].value.toString();
+                    const displayText = label ? label + ": " + value : value;
+                    logo.activity.textMsg(displayText);
                 }
             } else {
                 logo.activity.errorMsg(


### PR DESCRIPTION
Addresses #4788

## Summary
Clicking reporter blocks like "Width" displays a value bar that looks like an editable input, causing users to type and accidentally trigger hotkeys.

## Changes
1. **Add descriptive label prefix** to screen dimension blocks:
   - `width: 1536` instead of just `1536`
   - `left (screen): -768` for position blocks

2. **Block keyboard shortcuts** while the value bar is visible to prevent accidental block creation

## Depends on
- ~~#4917~~ (merged)

## Demo

https://github.com/user-attachments/assets/82e78562-f31e-4072-8fc0-156b2d781959

