### PR TITLE
fix: Sync Marathi translations in po/mr.po

### DIFF
--- a/po/mr.po
+++ b/po/mr.po
@@ -37,7 +37,7 @@ msgstr ""
 #: js/SaveInterface.js:93
 #: js/languagebox.js:208
 msgid "Refresh your browser to change your language preference."
-msgstr "अपनी भाषा बदलने के लिए अपने ब्राउज़र को रीफ़्रेश करें"
+msgstr "भाषा बदलण्यासाठी तुमचा ब्राउझर रिफ्रेश करा"
 
 #: js/languagebox.js:229
 msgid "Music Blocks is already set to this language."
@@ -104,7 +104,7 @@ msgstr "क्रिया"
 #: js/utils/synthutils.js:204
 #. TRANS: animal sound effect
 msgid "duck"
-msgstr "बत्तख"
+msgstr "बदक"
 
 #: js/themebox.js:66
 msgid "Music Blocks is already set to this theme."
@@ -316,7 +316,7 @@ msgstr "पैमाने की डिग्री"
 #: js/activity.js:2606
 #: js/palette.js:681
 msgid "voice name"
-msgstr "आवाज का नाम"
+msgstr "आवाजाचे नाव"
 
 #: js/activity.js:2609
 #: js/palette.js:678
@@ -489,7 +489,7 @@ msgstr "मिटवा"
 #: js/widgets/phrasemaker.js:4722
 #: plugins/rodi.rtp:191
 msgid "Play"
-msgstr "चलायें"
+msgstr "वाजवा"
 
 #: js/activity.js:3080
 #: js/toolbar.js:50
@@ -1073,7 +1073,7 @@ msgstr "नमूना"
 #: js/lilypond.js:948
 #: js/rubrics.js:526
 msgid "mouse"
-msgstr "चूहा"
+msgstr "उंदीर"
 
 #: js/lilypond.js:606
 msgid "brown rat"


### PR DESCRIPTION
This PR updates `po/mr.po` to match the localization fixes recently merged in PR #4869.

### Changes:
- Updated the PO file to replace incorrect Hindi words (e.g., 'Chuha') with the correct Marathi terms (e.g., 'Undir').
- Ensured `po/mr.po` is now consistent with `locales/mr.json`.

This prevents the incorrect Hindi words from being reintroduced if translations are regenerated from the PO file.