### PR TITLE
fix(ci): prevent linter crash on deleted files

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get changed JavaScript files
         id: get_files
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- '*.js')
+          CHANGED_FILES=$(git diff --diff-filter=ACMRT --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- '*.js')
           echo "files<<EOF" >> $GITHUB_ENV
           echo "$CHANGED_FILES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes #4951

**Description**
This PR fixes a bug in the `Lint updated JavaScript files` workflow where the CI fails with "No files matching the pattern" if a Pull Request deletes files (e.g., `electron-main.js`).

**Root Cause**
The `git diff` command in the workflow was including deleted files in its output. ESLint then attempted to lint these non-existent files, causing a crash.

**Changes**
- Updated `.github/workflows/linter.yml` to include the `--diff-filter=ACMRT` flag.
- This ensures `git diff` only returns Added, Copied, Modified, Renamed, or Type-changed files, explicitly excluding Deleted (D) files.

**Testing**
Verified locally:
1. Created a dummy file and committed it.
2. Deleted the file and committed the deletion.
3. Ran `git diff --diff-filter=ACMRT --name-only HEAD~1 HEAD` and confirmed it returns an empty list instead of the deleted filename.