### PR TITLE
fix: prevent loading animation interval from running indefinitely

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -297,6 +297,9 @@ class Activity {
         //Flag to check if any other input box is active or not
         this.isInputON = false;
 
+        // Interval ID for the loading animation (to allow cleanup)
+        this.loadAnimationIntervalId = null;
+
         // Initialize GIF animator
         this.gifAnimator = new GIFAnimator();
 
@@ -2028,7 +2031,22 @@ class Activity {
                 }
             };
 
-            setInterval(changeText, 2000);
+            this.loadAnimationIntervalId = setInterval(changeText, 2000);
+        };
+
+        /**
+         * Stops the loading animation and clears the interval.
+         * This prevents the interval from running indefinitely in the background.
+         */
+        this.stopLoadAnimation = () => {
+            if (this.loadAnimationIntervalId !== null) {
+                clearInterval(this.loadAnimationIntervalId);
+                this.loadAnimationIntervalId = null;
+            }
+            const loadContainer = document.getElementById("load-container");
+            if (loadContainer) {
+                loadContainer.style.display = "none";
+            }
         };
 
         /**

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6760,6 +6760,10 @@ class Blocks {
 
             document.body.style.cursor = "default";
             document.getElementById("load-container").style.display = "none";
+            // Stop the loading animation interval to prevent CPU waste
+            if (this.activity.stopLoadAnimation) {
+                this.activity.stopLoadAnimation();
+            }
             const myCustomEvent = new Event("finishedLoading");
             document.dispatchEvent(myCustomEvent);
         };


### PR DESCRIPTION
- Add loadAnimationIntervalId property to track the setInterval ID
- Add stopLoadAnimation() method to clear the interval and hide the container
- Call stopLoadAnimation() when blocks finish loading

Previously, the loading message animation (which cycles through fun messages like 'Catching mice', 'Tuning string instruments', etc.) would continue running every 2 seconds forever in the background, even after loading completed. This wasted CPU cycles and could cause subtle UI glitches.

Now the interval is properly cleared when loading completes.