### PR TITLE
Restore non-deferred jQuery to unblock search

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <script src="lib/reqwest.js" defer></script>
 
     <!-- <script src="lib/jquery-3.7.1.js"></script> -->
-    <script src="lib/jquery-2.1.4.min.js" defer></script>
+    <script src="lib/jquery-2.1.4.min.js"></script>
     <script src="lib/jquery-ui.js" defer></script>
     <script src="lib/materialize.min.js" defer></script>
     <script src="lib/webL10n.js" defer></script>


### PR DESCRIPTION
This PR temporarily removes defer from the jQuery script to restore search functionality, which is currently broken on main.

The regression may not be immediately obvious because there is no visible error in the UI, but search/autocomplete does not initialize correctly due to reliance on global $ and inline execution order.

I traced this using git bisect to PR #4828 , which correctly deferred jQuery for performance and accessibility. That change exposed fragile assumptions in the existing search implementation rather than introducing an incorrect change.

I attempted multiple approaches to fix search while keeping deferred loading (moving initialization into JS ownership, aligning with DOM and activity lifecycle, decoupling initialization), but the current structure of doSearch tightly couples UI setup and execution and depends on implicit timing, making a safe fix non-trivial.

This PR is not intended as a long-term solution. It is meant as a temporary unblock while a proper refactor of search initialization is discussed and implemented.
Root-cause analysis and bisect details are documented in issue #4954 .

I’m happy to rework or drop this PR based on maintainer preference.