### PR TITLE
Remove obsolete debug console output from abc widget

### DIFF
--- a/js/abc.js
+++ b/js/abc.js
@@ -282,10 +282,9 @@ const processABCNotes = function (logo, turtle) {
 
                         logo.notationNotes[turtle] +=
                             logo.notation.notationStaging[turtle][i + j][NOTATIONROUNDDOWN];
-                    
                     }
-                        j++; // Jump to next note.
-                        k++; // Increment notes in tuplet.
+                    j++; // Jump to next note.
+                    k++; // Increment notes in tuplet.
                 }
 
                 // FIXME: Debug for ABC


### PR DESCRIPTION
This PR removes obsolete debug console output from the abc widget.
No functional behavior is changed.

This follows recent cleanup work in the JavaScript codebase.
Feedback welcome. Thank you!
