### PR TITLE
test: add unit tests for statistics.js

### DIFF
--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -116,6 +116,6 @@ class StatsWindow {
             <li>ornaments used: ${stats["ornaments"]}</li>`;
     }
 }
-if (typeof module !== 'undefined') {
+if (typeof module !== "undefined") {
     module.exports = StatsWindow;
 }

--- a/js/widgets/statistics.test.js
+++ b/js/widgets/statistics.test.js
@@ -1,6 +1,6 @@
-const StatsWindow = require('./statistics.js');
+const StatsWindow = require("./statistics.js");
 
-describe('StatsWindow', () => {
+describe("StatsWindow", () => {
     let mockActivity;
     let mockWidgetWindow;
 
@@ -21,8 +21,10 @@ describe('StatsWindow', () => {
             sendToCenter: jest.fn(),
             onclose: null,
             onmaximize: null,
-            getWidgetBody: jest.fn().mockReturnValue(document.createElement('div')),
-            getWidgetFrame: jest.fn().mockReturnValue({ getBoundingClientRect: () => ({ height: 500 }) }),
+            getWidgetBody: jest.fn().mockReturnValue(document.createElement("div")),
+            getWidgetFrame: jest
+                .fn()
+                .mockReturnValue({ getBoundingClientRect: () => ({ height: 500 }) }),
             isMaximized: jest.fn().mockReturnValue(false)
         };
 
@@ -43,14 +45,14 @@ describe('StatsWindow', () => {
         global.runAnalytics = jest.fn();
         global.scoreToChartData = jest.fn().mockReturnValue({});
         global.getChartOptions = jest.fn().mockReturnValue({});
-        
+
         // Mock the Chart.js library
         global.Chart = jest.fn().mockImplementation(() => ({
             Radar: jest.fn()
         }));
     });
 
-    test('displayInfo should correctly format note statistics and Hz calculations', () => {
+    test("displayInfo should correctly format note statistics and Hz calculations", () => {
         const statsWindow = new StatsWindow(mockActivity);
 
         // Prepare dummy data
@@ -58,10 +60,10 @@ describe('StatsWindow', () => {
             duples: 5,
             triplets: 2,
             quintuplets: 0,
-            pitchNames: new Set(['A', 'C#', 'E']),
+            pitchNames: new Set(["A", "C#", "E"]),
             numberOfNotes: 20,
-            lowestNote: ['A4', 60, 440],
-            highestNote: ['C5', 72, 523.25],
+            lowestNote: ["A4", 60, 440],
+            highestNote: ["C5", 72, 523.25],
             rests: 4,
             ornaments: 1
         };
@@ -72,10 +74,10 @@ describe('StatsWindow', () => {
         // Check results
         const outputHtml = statsWindow.jsonObject.innerHTML;
 
-        expect(outputHtml).toContain('441Hz'); // 440 + 0.5 rounded
-        expect(outputHtml).toContain('524Hz'); // 523.25 + 0.5 rounded
-        expect(outputHtml).toContain('duples: 5');
-        expect(outputHtml).toContain('triplets: 2');
-        expect(outputHtml).toContain('pitch names: A, C#, E');
+        expect(outputHtml).toContain("441Hz"); // 440 + 0.5 rounded
+        expect(outputHtml).toContain("524Hz"); // 523.25 + 0.5 rounded
+        expect(outputHtml).toContain("duples: 5");
+        expect(outputHtml).toContain("triplets: 2");
+        expect(outputHtml).toContain("pitch names: A, C#, E");
     });
 });


### PR DESCRIPTION
Fixes #4969

**Description**
Added unit tests for `js/widgets/statistics.js` to verify the `displayInfo` logic and improve code coverage. Currently, this file has no tests.

**Changes**
- Created `js/widgets/statistics.test.js`.
- Added module export to `js/widgets/statistics.js` to verify testability.
- Mocked `docById`, `Chart`, and `widgetWindows` to support UI-free testing.

**Testing**
Verified locally:
- Test Suites: 1 passed, 1 total
- Tests: 1 passed, 1 total
- Coverage: Increased `statistics.js` coverage to **58%**
- 
<img width="809" height="914" alt="Screenshot 2025-12-31 212825" src="https://github.com/user-attachments/assets/d011a18f-9ee2-48aa-8155-17e43a4a0d13" />
