### PR TITLE
refactor: Remove debug console.log statements from widget files

### DIFF
--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -792,8 +792,6 @@ class Arpeggio {
             }
         }
 
-        // eslint-disable-next-line no-console
-        console.log(chordValues);
         setCustomChord(chordValues);
 
         // Also, save as an arpeggio block.

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1897,8 +1897,6 @@ function TemperamentWidget() {
                     this.notes[i].slice(-1)
                 ];
             }
-            // eslint-disable-next-line no-console
-            console.log(newTemperament);
             addTemperamentToDictionary(this.inTemperament, newTemperament);
             updateTemperaments();
         }


### PR DESCRIPTION
### Summary
Removes leftover debug `console.log` statements from widget files that were exposing internal data structures in the browser console.

### Changes
- **`js/widgets/temperament.js`**: Removed logging of the `newTemperament` object when saving a custom temperament.
- **`js/widgets/arpeggio.js`**: Removed logging of `chordValues` when saving an arpeggio.
- Removed related `eslint-disable no-console` comments.

### Why
- Cleans up browser console output for end users
- Improves code hygiene by removing production debug artifacts
- Aligns with the project’s ESLint `no-console` rule
