### PR TITLE
Added bar lines in PhraseMaker

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -483,18 +483,17 @@ class PhraseMaker {
         this.activity = activity;
 
         this._currentMusicalTime = 0; // Tracks duration used in the current bar
-        
+
         // Get the meter from the turtle's singer (Meter Block sets this)
-        const turtle = activity.turtles.ithTurtle(0);  // Get turtle 0
-        const beatsPerMeasure = turtle.singer.beatsPerMeasure || 4;  // Default to 4
-        const noteValuePerBeat = turtle.singer.noteValuePerBeat || 4;  // Default to 4
-        
+        const turtle = activity.turtles.ithTurtle(0); // Get turtle 0
+        const beatsPerMeasure = turtle.singer.beatsPerMeasure || 4; // Default to 4
+        const noteValuePerBeat = turtle.singer.noteValuePerBeat || 4; // Default to 4
+
         // Calculate the duration of ONE measure
         // beatsPerMeasure is the number of beats (e.g., 3 for 3/4)
         // noteValuePerBeat is the note type that gets one beat (e.g., 4 for quarter note)
         // For 3/4: 3 beats * (1/4) = 0.75
         this._measureLimit = beatsPerMeasure / noteValuePerBeat;
-
 
         this._noteStored = [];
         this._noteBlocks = false;
@@ -2845,7 +2844,7 @@ class PhraseMaker {
         const tupletTimeFactor = param[0][0] / param[0][1];
         const numberOfNotes = param[1].length;
         // Check if current bar position is at 0 (start of a measure)
-        const isBarLine = (this._currentMusicalTime < 0.001) && (this._notesToPlay.length > 0);
+        const isBarLine = this._currentMusicalTime < 0.001 && this._notesToPlay.length > 0;
         const barStyle = isBarLine ? "3px solid #555" : "1px solid #ccc";
 
         let totalNoteInterval = 0;
@@ -2952,7 +2951,7 @@ class PhraseMaker {
             cell.style.lineHeight = 60 + "%";
             cell.style.fontSize = this._cellScale * 75 + "%";
             cell.style.textAlign = "center";
-            cell.style.borderLeft = (i === 0) ? barStyle : "1px solid #ccc";
+            cell.style.borderLeft = i === 0 ? barStyle : "1px solid #ccc";
             obj = toFraction(numerator / (totalNoteInterval / tupletTimeFactor));
 
             if (obj[1] < 13) {
@@ -2997,7 +2996,7 @@ class PhraseMaker {
                 cell.style.minWidth = cell.style.width;
                 cell.style.maxWidth = cell.style.width;
                 cell.style.backgroundColor = cellColor;
-                cell.style.borderLeft = (i === 0) ? barStyle : "1px solid #ccc";
+                cell.style.borderLeft = i === 0 ? barStyle : "1px solid #ccc";
 
                 cell.onmouseover = event => {
                     if (event.target.style.backgroundColor !== "black") {
@@ -3043,10 +3042,10 @@ class PhraseMaker {
         cell.style.backgroundColor = platformColor.rhythmcellcolor;
         cell.style.borderLeft = barStyle;
         this._matrixHasTuplets = true;
-        
+
         // Update time by the total span of the tuplet
         this._currentMusicalTime += tupletTimeFactor;
-        
+
         // Reset if measure is full
         if (this._currentMusicalTime >= this._measureLimit - 0.001) {
             this._currentMusicalTime = 0;
@@ -3086,8 +3085,9 @@ class PhraseMaker {
 
             // Check if we are at the start of a new measure
             // Use a tiny epsilon (0.001) for float math safety
-            const isBarLine = (this._currentMusicalTime < 0.001) && (j > 0 || this._notesToPlay.length > numBeats);
-            
+            const isBarLine =
+                this._currentMusicalTime < 0.001 && (j > 0 || this._notesToPlay.length > numBeats);
+
             const barStyle = isBarLine ? "3px solid #555" : "1px solid #ccc";
 
             for (let i = 0; i < rowCount; i++) {


### PR DESCRIPTION
I’ve updated phrasemaker.js to calculate and display visual Bar Lines based on the current Meter (e.g., 4/4 or 3/4).

**Changes Made**

- **Tracked Musical Time**: Added a tracker in init() to keep count of the total duration as notes are added.
- **Boundary Logic:** In addNotes() and addTuplet(), the code now checks if the current column is at a "Measure End" using the beats-per-measure ratio.
- **Visual Styling:** When a boundary is hit, the column's left border is thickened and darkened (3px solid) to look like a bar line on sheet music.
- **Tuplet Support:** Applied the same logic to tuplets, ensuring the bar line appears at the start of the triplet/tuplet span.

<img width="1306" height="471" alt="image" src="https://github.com/user-attachments/assets/2bf5cef7-7294-4a15-8a41-b560f3756873" />

closes #4737