### PR TITLE
deferring jquery breaks search

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <script src="lib/reqwest.js" defer></script>
 
     <!-- <script src="lib/jquery-3.7.1.js"></script> -->
-    <script src="lib/jquery-2.1.4.min.js" defer></script>
+    <script src="lib/jquery-2.1.4.min.js"></script>
     <script src="lib/jquery-ui.js" defer></script>
     <script src="lib/materialize.min.js" defer></script>
     <script src="lib/webL10n.js" defer></script>


### PR DESCRIPTION
We were a bit too aggressive deferring loading. We need to load jquery in order for search to work.

Fixes an issue introduced by 01cee2adc5cd290a5f8e6be16e1907d8a4845c37

To test, try using search. It should provide a pull down menu when typing characters.

<img width="553" height="365" alt="Screenshot From 2026-01-02 18-16-50" src="https://github.com/user-attachments/assets/4d9b2559-53a3-4966-8ad1-13e6cd34c1df" />

