### PR TITLE
feat: add space key shortcut to toggle play/stop

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3362,6 +3362,14 @@ class Activity {
                             this.__makeNewNote(5, "ti");
                         }
                         break;
+                    case SPACE:
+                        event.preventDefault();
+                        if (this.turtleContainer.scaleX === 1) {
+                            this.turtles.setStageScale(0.5);
+                        } else {
+                            this.turtles.setStageScale(1);
+                        }
+                        break;
                 }
             } else {
                 if (
@@ -3370,6 +3378,18 @@ class Activity {
                 ) {
                     if (document.getElementById("paste").value.length > 0) {
                         this.pasted();
+                    }
+                } else if (event.keyCode === SPACE) {
+                    // Check if any widget window is open
+                    const hasOpenWidget = Object.values(window.widgetWindows.openWindows).some(
+                        w => w
+                    );
+                    if (this.turtles.running()) {
+                        event.preventDefault();
+                        this._doHardStopButton();
+                    } else if (!disableKeys && !hasOpenWidget) {
+                        event.preventDefault();
+                        this._doFastButton();
                     }
                 } else if (!disableKeys) {
                     const solfnotes_ = _("ti la sol fa mi re do").split(" ");
@@ -3491,13 +3511,6 @@ class Activity {
                             this.stage.update();
                             break;
                         case TAB:
-                            break;
-                        case SPACE:
-                            if (this.turtleContainer.scaleX === 1) {
-                                this.turtles.setStageScale(0.5);
-                            } else {
-                                this.turtles.setStageScale(1);
-                            }
                             break;
                         case ESC:
                             if (this.searchWidget.style.visibility === "visible") {


### PR DESCRIPTION
## Description
Adds Space key shortcut to toggle play/stop. Common accessibility pattern for play/pause.
Previous Space behavior (zoom toggle) moved to Shift+Space.
## Related Issue
This PR fixes #4986
## Changes Made
-   Space now toggles play/stop
-   Shift+Space toggles zoom (old behavior preserved)
-   Stop works during playback, play only when not in modals/inputs
## Testing Performed
-   `npm run lint` - passed
-   `npx prettier --check .` - passed
-   `npm test` - 1794 tests pass
-   Manual: play, stop, zoom, input field scenarios
## Checklist
-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
## Additional Notes for Reviewers
Shift+Space preserves the original zoom functionality, so nothing is lost.