### PR TITLE
Fix immediate expansion and contraction of setInstrument and start sidebar

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1524,6 +1524,10 @@ class Blocks {
                 }
                 blk = this.insideExpandableBlock(blk);
             }
+            this.adjustExpandableClampBlock();
+            this.adjustDocks(thisBlock, true);
+            this.activity.refreshCanvas();
+
 
             this._checkTwoArgBlocks = [];
             const checkArgBlocks = [];


### PR DESCRIPTION

This PR fixes the delayed expansion and contraction of the setInstrument and start sidebar
when note value blocks are expanded or collapsed.

Previously, the UI updated only after moving the cursor away from the block.
Now the expansion/contraction happens immediately on click.

Changes:
Triggered clamp adjustment immediately after block movement
 Updated block docks to reflect size changes
 Refreshed canvas to apply UI updates instantly

 Testing:
 Ran Music Blocks locally using `npm start`
 Verified expand/collapse behavior on note value blocks
 Confirmed sidebar and clamp update immediately without cursor movement
 Ensured no lint errors using `npx eslint js/blocks.js --fix`

Proof:
https://github.com/user-attachments/assets/faa60fa4-79d2-46c4-a37c-0cd53a3799c9


