### PR TITLE
Fix: Resolve p5 is not defined ReferenceError by adding p5-adapter

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -14,7 +14,7 @@
 requirejs.config({
     baseUrl: "lib",
     shim: {
-        easel: {
+        "easel": {
             exports: "createjs"
         },
         "p5.min": {
@@ -34,25 +34,25 @@ requirejs.config({
         }
     },
     paths: {
-        utils: "../js/utils",
-        widgets: "../js/widgets",
-        activity: "../js",
-        easel: "../lib/easeljs",
-        twewn: "../lib/tweenjs",
-        prefixfree: "../bower_components/prefixfree/prefixfree.min",
-        samples: "../sounds/samples",
-        planet: "../js/planet",
-        tonejsMidi: "../node_modules/@tonejs/midi/dist/Midi",
+        "utils": "../js/utils",
+        "widgets": "../js/widgets",
+        "activity": "../js",
+        "easel": "../lib/easeljs",
+        "twewn": "../lib/tweenjs",
+        "prefixfree": "../bower_components/prefixfree/prefixfree.min",
+        "samples": "../sounds/samples",
+        "planet": "../js/planet",
+        "tonejsMidi": "../node_modules/@tonejs/midi/dist/Midi",
         "p5.min": "../lib/p5.min",
         "p5.sound.min": "../lib/p5.sound.min",
         "p5.dom.min": "../lib/p5.dom.min",
         "p5-adapter": "../js/p5-adapter",
         "p5-sound-adapter": "../js/p5-sound-adapter",
-        i18next: [
+        "i18next": [
             "../lib/i18next.min",
             "https://cdn.jsdelivr.net/npm/i18next@23.11.5/dist/umd/i18next.min"
         ],
-        i18nextHttpBackend: [
+        "i18nextHttpBackend": [
             "../lib/i18nextHttpBackend.min",
             "https://cdn.jsdelivr.net/npm/i18next-http-backend@2.5.1/i18nextHttpBackend.min"
         ]
@@ -89,7 +89,7 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
                         console.error("i18next init failed:", err);
                     }
                     window.i18next = i18next;
-                    resolve(i18next); 
+                    resolve(i18next);
                 }
             );
         });

--- a/js/p5-adapter.js
+++ b/js/p5-adapter.js
@@ -10,7 +10,7 @@ define(["p5.min"], function (p5) {
     } else {
         console.warn("p5-adapter: window.Tone not found!");
     }
-    
+
     // Save original AudioContext constructors to prevent p5.sound from hijacking them
     if (window.AudioContext) {
         window.OriginalAudioContext = window.AudioContext;

--- a/js/p5-sound-adapter.js
+++ b/js/p5-sound-adapter.js
@@ -7,7 +7,10 @@ define(["p5.sound.min"], function () {
         console.log("p5-sound-adapter: Restoring AudioContext");
         window.AudioContext = window.OriginalAudioContext;
     }
-    if (window.OriginalWebkitAudioContext && window.webkitAudioContext !== window.OriginalWebkitAudioContext) {
+    if (
+        window.OriginalWebkitAudioContext &&
+        window.webkitAudioContext !== window.OriginalWebkitAudioContext
+    ) {
         console.log("p5-sound-adapter: Restoring webkitAudioContext");
         window.webkitAudioContext = window.OriginalWebkitAudioContext;
     }
@@ -25,27 +28,29 @@ define(["p5.sound.min"], function () {
     }
 
     // Fix AudioNode.prototype.connect return value
-    // We force this patch because p5.sound is known to break chaining, 
+    // We force this patch because p5.sound is known to break chaining,
     // and sometimes the reference check fails (e.g. if p5.sound wraps it in a way that preserves identity or if we missed the timing).
     // The error "s.connect(...) is undefined" confirms we MUST ensure a return value.
     if (window.AudioNode && window.AudioNode.prototype) {
         var currentConnect = window.AudioNode.prototype.connect;
-        
+
         // Avoid double-patching if we already did it
         if (!currentConnect.isP5AdapterPatched) {
-             console.log("p5-sound-adapter: Forcing patch of AudioNode.prototype.connect to support chaining");
-             
-             window.AudioNode.prototype.connect = function() {
-                 var result = currentConnect.apply(this, arguments);
-                 // If the result is undefined (which breaks Tone.js chaining), return the destination (arguments[0])
-                 if (result === undefined) {
-                     return arguments[0]; 
-                 }
-                 return result;
-             };
-             
-             // Mark as patched
-             window.AudioNode.prototype.connect.isP5AdapterPatched = true;
+            console.log(
+                "p5-sound-adapter: Forcing patch of AudioNode.prototype.connect to support chaining"
+            );
+
+            window.AudioNode.prototype.connect = function () {
+                var result = currentConnect.apply(this, arguments);
+                // If the result is undefined (which breaks Tone.js chaining), return the destination (arguments[0])
+                if (result === undefined) {
+                    return arguments[0];
+                }
+                return result;
+            };
+
+            // Mark as patched
+            window.AudioNode.prototype.connect.isP5AdapterPatched = true;
         } else {
             console.log("p5-sound-adapter: AudioNode.prototype.connect already patched");
         }


### PR DESCRIPTION
This PR resolves the ReferenceError: p5 is not defined crash by implementing an Adapter Pattern. This ensures window.p5 is globally available before its sub-libraries (sound and dom) attempt to load. It also prevents p5.sound from overwriting the global Tone.js instance used by MusicBlocks.

Fixes #4949