### PR TITLE
Fix Service Worker crash caused by window usage in beforeinstallprompt handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,6 +531,20 @@ document.addEventListener("DOMContentLoaded", init);
         }
     </script>
     <script>
+        let deferredPrompt;
+
+        window.addEventListener("beforeinstallprompt", (event) => {
+            event.preventDefault(); // Prevent automatic browser prompt
+            deferredPrompt = event;
+
+            // Show your install button here
+            const divInstall = document.getElementById("installButton");
+            if (divInstall) {
+                divInstall.classList.remove("hidden");
+            }
+        });
+    </script>
+    <script>
         $(document).ready(function () {
             doSearch();
         });

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 /*
   global
 
-  offlineFallbackPage, divInstall
+    offlineFallbackPage
 */
 
 // This is the "Offline page" service worker
@@ -101,21 +101,6 @@ self.addEventListener("fetch", function (event) {
             }
         )
     );
-});
-
-self.addEventListener("beforeinstallprompt", event => {
-    // eslint-disable-next-line no-console
-    console.log("done", "beforeinstallprompt", event);
-    // Stash the event so it can be triggered later.
-    event.preventDefault();
-
-    try {
-        self.deferredPrompt = event;
-    } catch (e) {
-        // Intentionally ignored: assignment may fail if not supported.
-    }
-
-    divInstall.classList.toggle("hidden", false);
 });
 
 // This is an event that can be fired from your page to tell the SW to


### PR DESCRIPTION
## Description

Fixes issue #4996.

This PR resolves a Service Worker runtime crash caused by handling the beforeinstallprompt event inside sw.js.

Service Workers run in a worker context and do not have access to window or DOM APIs. The previous implementation referenced window and UI elements, which could throw a ReferenceError and stop Service Worker execution, potentially affecting caching and fetch handling.

## What was changed
1]  Removed the entire beforeinstallprompt handler from sw.js
    ###  This includes the leftover divInstall reference and all install-related logic.
     ### sw.js now contains no references to:
     1] beforeinstallprompt
     2] window
     3] document
     4] deferredPrompt
     5] install UI elements

2] Added the correct beforeinstallprompt handling to page-level JavaScript
   2.a ]  Implemented in index.html, right after the Service Worker registration script.
   2.b]  This ensures the logic runs where window and document are available.
   2.c ]  UI updates for the install button are now handled safely in the page context.

## Why this change is needed
1] beforeinstallprompt is fired on the main page thread, not in the Service Worker
2] Accessing window or DOM APIs inside a Service Worker causes runtime errors
3] Uncaught Service Worker errors can silently break caching and offline functionality
Moving this logic to the page level aligns with the PWA (Progressive Web App) spec and prevents Service Worker crashes.

## Result
1] Prevents Service Worker runtime crashes
2] Keeps install prompt logic in the correct execution context
3] Improves stability and long-term maintainability
4] No change to intended user-facing behavior

## Verification 
### ESLint passes:
1] npm run lint
2] npx eslint sw.js
Confirmed sw.js contains no install-prompt or DOM-related code

## Testing 
<img width="415" height="119" alt="Screenshot 2026-01-04 190101" src="https://github.com/user-attachments/assets/ef8e5ed4-dbc3-4bb8-a5b6-8c12d2946dce" />
