### PR TITLE
Fixed Simple Tuplet block playing all the notes simultaneously

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -167,7 +167,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 }
 
                 const bpmFactor =
-                    TONEBPM / tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM;
+                    TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
                 const beatValue = bpmFactor == null ? 1 : bpmFactor / noteBeatValue;
 
@@ -979,7 +979,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 tur.singer.inNoteBlock.push(blk);
 
                 const bpmFactor =
-                    TONEBPM / tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM;
+                    TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
                 const beatValue = bpmFactor / noteBeatValue / arg0;
 


### PR DESCRIPTION
This PR fixes a bug where "Simple Tuplet" and "Rhythm" blocks would play notes simultaneously or with incorrect timing due to an operator precedence error in the bpmFactor calculation.

**Changes:**

Added parentheses around the ternary operator in _RhythmBlockPaletteBlocks.js_ to ensure the division TONEBPM / (...) happens after the correct divisor is selected.

**Fixes:** #4633 

Simultaneous playback in Simple Tuplet blocks when no explicit BPM is set.
Incorrect tempo calculation for rhythm blocks.

before video: (audio on)
[before simple tuplet .webm](https://github.com/user-attachments/assets/1eb12689-03be-47c1-a66c-526223c3cb96)

after video: (audio on)
[Simple tuplet block.webm](https://github.com/user-attachments/assets/68cd9522-9151-4f99-aa8a-4f40e5a0893b)
