### PR TITLE
fix(ux): disable stop button until play is triggered

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -227,8 +227,9 @@ describe("Toolbar Class", () => {
                 addEventListener: jest.fn()
             },
             stop: {
-                style: { color: "" },
-                addEventListener: jest.fn()
+                style: { color: "", pointerEvents: "" },
+                addEventListener: jest.fn(),
+                classList: { add: jest.fn(), remove: jest.fn() }
             },
             record: {
                 className: ""
@@ -249,22 +250,20 @@ describe("Toolbar Class", () => {
         elements.play.onclick();
 
         expect(mockOnClick).toHaveBeenCalledWith(mockActivity);
-        expect(elements.stop.style.color).toBe(toolbar.stopIconColorWhenPlaying);
+        // Stop button state is now managed by onRunTurtle/onStopTurtle in activity.js
         expect(global.saveButtonAdvanced.disabled).toBe(true);
         expect(global.saveButton.className).toBe("grey-text inactiveLink");
         expect(elements.record.className).toBe("grey-text inactiveLink");
-        expect(elements.stop.addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
-
-        const stopClickHandler = elements.stop.addEventListener.mock.calls[0][1];
-        stopClickHandler();
-
-        expect(mockActivity.hideMsgs).toHaveBeenCalled();
 
         delete global.play_button_debounce_timeout;
     });
 
     test("renderStopIcon sets onclick and updates stop button behavior", () => {
-        const stopIcon = { onclick: null, style: { color: "" } };
+        const stopIcon = {
+            onclick: null,
+            style: { color: "", pointerEvents: "" },
+            classList: { add: jest.fn(), remove: jest.fn() }
+        };
         const recordButton = { className: "recording" };
 
         global.docById.mockImplementation(id =>
@@ -277,7 +276,7 @@ describe("Toolbar Class", () => {
         stopIcon.onclick();
 
         expect(mockOnClick).toHaveBeenCalled();
-        expect(stopIcon.style.color).toBe("white");
+        // Stop button state is now managed by onStopTurtle in activity.js
         expect(global.saveButton.disabled).toBe(false);
         expect(global.saveButtonAdvanced.disabled).toBe(false);
         expect(global.saveButton.className).toBe("");

--- a/js/activity.js
+++ b/js/activity.js
@@ -4315,6 +4315,13 @@ class Activity {
          * When turtle stops running restore stop button to normal state
          */
         this.onStopTurtle = () => {
+            // Disable stop button when playback ends
+            const stopIcon = docById("stop");
+            if (stopIcon) {
+                stopIcon.style.pointerEvents = "none";
+                stopIcon.classList.add("grey-text", "inactiveLink");
+                stopIcon.style.color = "white";
+            }
             // TODO: plugin support
         };
 
@@ -4322,6 +4329,13 @@ class Activity {
          * When turtle starts running change stop button to running state
          */
         this.onRunTurtle = () => {
+            // Enable stop button when playback starts
+            const stopIcon = docById("stop");
+            if (stopIcon) {
+                stopIcon.style.pointerEvents = "auto";
+                stopIcon.classList.remove("grey-text", "inactiveLink");
+                stopIcon.style.color = platformColor.stopIconcolor;
+            }
             // TODO: plugin support
         };
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -1694,6 +1694,8 @@ class Logo {
                     queueStart === 0 &&
                     tur.singer.justCounting.length === 0
                 ) {
+                    // Ensure stop button is disabled when playback ends
+                    logo.onStopTurtle();
                     if (logo.runningLilypond) {
                         if (logo.collectingStats) {
                             // console.debug("stats collection completed");

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -389,44 +389,41 @@ class Toolbar {
         const playIcon = docById("play");
         const stopIcon = docById("stop");
         const recordButton = docById("record");
-        let isPlayIconRunning = false;
+        this._isPlayIconRunning = false;
+
+        const that = this;
+        this._restorePlayButton = function () {
+            if (that._isPlayIconRunning) {
+                playIcon.onclick = tempClick;
+                that._isPlayIconRunning = false;
+            }
+        };
 
         function handleClick() {
-            if (!isPlayIconRunning) {
+            if (!that._isPlayIconRunning) {
                 playIcon.onclick = null;
                 // eslint-disable-next-line no-console
                 console.log("Wait for next 2 seconds to play the music");
             } else {
-                // eslint-disable-next-line no-use-before-define
                 playIcon.onclick = tempClick;
-                isPlayIconRunning = false;
+                that._isPlayIconRunning = false;
             }
         }
 
         var tempClick = (playIcon.onclick = () => {
-            const hideMsgs = () => {
-                this.activity.hideMsgs();
-            };
-            isPlayIconRunning = false;
-            onclick(this.activity);
+            that._isPlayIconRunning = false;
+            onclick(that.activity);
             handleClick();
-            stopIcon.style.color = this.stopIconColorWhenPlaying;
+            // Stop button state is managed by onRunTurtle/onStopTurtle in activity.js
             saveButton.disabled = true;
             saveButtonAdvanced.disabled = true;
             saveButton.className = "grey-text inactiveLink";
             saveButtonAdvanced.className = "grey-text inactiveLink";
             recordButton.className = "grey-text inactiveLink";
-            isPlayIconRunning = true;
+            that._isPlayIconRunning = true;
             play_button_debounce_timeout = setTimeout(function () {
                 handleClick();
             }, 2000);
-
-            stopIcon.addEventListener("click", function () {
-                clearTimeout(play_button_debounce_timeout);
-                isPlayIconRunning = true;
-                hideMsgs();
-                handleClick();
-            });
         });
     }
 
@@ -440,9 +437,21 @@ class Toolbar {
     renderStopIcon(onclick) {
         const stopIcon = docById("stop");
         const recordButton = docById("record");
+
+        // Initially disable stop button until play is triggered
+        stopIcon.style.pointerEvents = "none";
+        stopIcon.classList.add("grey-text", "inactiveLink");
+
+        const that = this;
         stopIcon.onclick = () => {
-            onclick(this.activity);
-            stopIcon.style.color = "white";
+            // Clear play button debounce timeout and restore play button
+            clearTimeout(play_button_debounce_timeout);
+            that._isPlayIconRunning = true;
+            if (that._restorePlayButton) {
+                that._restorePlayButton();
+            }
+            onclick(that.activity);
+            // Stop button state is managed by onStopTurtle in activity.js
             saveButton.disabled = false;
             saveButtonAdvanced.disabled = false;
             saveButton.className = "";


### PR DESCRIPTION
## Summary
Disable the Stop button when playback is not active, improving UX by providing clear visual feedback.
## Changes
- Stop button is disabled (grey) on initial load
- Stop button enables (colored) when Play is clicked
- Stop button disables when Stop is clicked or playback ends naturally
## screenshots
<img width="3197" height="1730" alt="image" src="https://github.com/user-attachments/assets/a807894b-9c37-4d94-9a1f-e160b63e4a0e" />
<img width="3197" height="1730" alt="image" src="https://github.com/user-attachments/assets/ed430328-2f2f-45bc-9e36-05054417a1c0" />
<img width="3197" height="1730" alt="image" src="https://github.com/user-attachments/assets/d645f6c1-6b1c-4347-b3cd-6fc0eb4bf39c" />


## Testing
- All 1868 tests pass
- Manual testing: verified initial state, play, stop, and natural playback end
Fixes #5000