### PR TITLE
refactor: extract responsive breakpoint widths into constants

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -55,8 +55,8 @@ const _ERRORMSGTIMEOUT_ = 15000;
 const _MSGTIMEOUT_ = 60000;
 
 // Responsive breakpoint constants
-const BREAKPOINT_TABLET = 768;
-const BREAKPOINT_MOBILE = 600;
+const RESPONSIVE_BREAKPOINT_TABLET = 768;
+const RESPONSIVE_BREAKPOINT_MOBILE = 600;
 
 let MYDEFINES = [
     "utils/platformstyle",
@@ -766,14 +766,20 @@ class Activity {
                     };
                 }
 
-                if (canvasWidth < BREAKPOINT_TABLET && !referenceBlock.beforeMobilePosition) {
+                if (
+                    canvasWidth < RESPONSIVE_BREAKPOINT_TABLET &&
+                    !referenceBlock.beforeMobilePosition
+                ) {
                     referenceBlock.beforeMobilePosition = {
                         x: referenceBlock.container.x,
                         y: referenceBlock.container.y
                     };
                 }
 
-                if (canvasWidth >= BREAKPOINT_TABLET && referenceBlock.beforeMobilePosition) {
+                if (
+                    canvasWidth >= RESPONSIVE_BREAKPOINT_TABLET &&
+                    referenceBlock.beforeMobilePosition
+                ) {
                     const dx = referenceBlock.beforeMobilePosition.x - referenceBlock.container.x;
                     const dy = referenceBlock.beforeMobilePosition.y - referenceBlock.container.y;
                     group.forEach(blockId => {
@@ -785,14 +791,20 @@ class Activity {
                     //this prevents old groups from affecting new calculations.
                 }
 
-                if (canvasWidth < BREAKPOINT_MOBILE && !referenceBlock.before600pxPosition) {
+                if (
+                    canvasWidth < RESPONSIVE_BREAKPOINT_MOBILE &&
+                    !referenceBlock.before600pxPosition
+                ) {
                     referenceBlock.before600pxPosition = {
                         x: referenceBlock.container.x,
                         y: referenceBlock.container.y
                     };
                 }
 
-                if (canvasWidth >= BREAKPOINT_MOBILE && referenceBlock.before600pxPosition) {
+                if (
+                    canvasWidth >= RESPONSIVE_BREAKPOINT_MOBILE &&
+                    referenceBlock.before600pxPosition
+                ) {
                     const dx = referenceBlock.before600pxPosition.x - referenceBlock.container.x;
                     const dy = referenceBlock.before600pxPosition.y - referenceBlock.container.y;
 
@@ -856,7 +868,7 @@ class Activity {
             this.blocksContainer.y = 0;
 
             const screenWidth = window.innerWidth;
-            const isNarrowScreen = screenWidth < BREAKPOINT_MOBILE;
+            const isNarrowScreen = screenWidth < RESPONSIVE_BREAKPOINT_MOBILE;
             const minColumnWidth = 400;
             const numColumns = isNarrowScreen ? 1 : Math.floor(screenWidth / minColumnWidth);
 


### PR DESCRIPTION
- Add BREAKPOINT_TABLET (768px) and BREAKPOINT_MOBILE (600px) constants
- Replace 5 hardcoded breakpoint values with named constants
- Improves code maintainability and prevents magic numbers

Affected lines: 769, 776, 787, 794, 856 in js/activity.js