### PR TITLE
fix(widgets): correct typo in timbre.js distortionEffect variable name

### DIFF
--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -693,7 +693,7 @@ class TimbreWidget {
         } else if (this.isActive["distortion"] === true) {
             docById("effectsButtonCell").style.backgroundColor = platformColor.selectorBackground;
             if (this.distortionEffect.length !== 1) {
-                blockValue = this.dstortionEffect.length - 1;
+                blockValue = this.distortionEffect.length - 1;
             }
 
             docById("myRangeFx0").value = parseFloat(this.distortionParams[0]);


### PR DESCRIPTION
Fixed typo in js/widgets/timbre.js where distortionEffect was misspelled.
