### PR TITLE
fix(widgets): remove keydown event listener on PitchSlider close

### DIFF
--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -60,6 +60,7 @@ class PitchSlider {
         activity.logo.pitchSlider = this;
 
         this.widgetWindow.onclose = () => {
+            document.removeEventListener("keydown", keyHandler, true);
             for (const osc of oscillators) osc.triggerRelease();
             this.isActive = false;
             activity.logo.pitchSlider = null;


### PR DESCRIPTION
Fixed a memory leak by removing the global keydown listener when the PitchSlider widget is closed.
