### PR TITLE
fix(widgets): clear dotsInterval on reflection widget close to prevent memory leak

### DIFF
--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -88,6 +88,9 @@ class ReflectionMatrix {
         widgetWindow.onclose = () => {
             this.isOpen = false;
             this.activity.isInputON = false;
+            if (this.dotsInterval) {
+                clearInterval(this.dotsInterval);
+            }
             widgetWindow.destroy();
         };
 


### PR DESCRIPTION
Fixed a memory leak in the Reflection widget by clearing the typing indicator interval when the widget is closed.