### PR TITLE
Fix auxiliary navigation visibility at 768px breakpoint

### DIFF
--- a/css/play-only-mode.css
+++ b/css/play-only-mode.css
@@ -1,73 +1,73 @@
 .play-only #palette {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
     overflow: hidden !important;
-}   
+}
 
 .play-only #Grid {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
-    overflow: hidden !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
 }
 
 .play-only #Clear {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
-    overflow: hidden !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
 }
 
 .play-only #Collapse {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
     overflow: hidden !important;
 }
 
 .play-only [id="Show/hide blocks"] {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
     overflow: hidden !important;
 }
 
 .play-only [id="Expand/collapse blocks"] {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
-    overflow: hidden !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
 }
 
-.play-only [id="Decrease block size"]{
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
-    overflow: hidden !important; 
+.play-only [id="Decrease block size"] {
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
 }
 
 .play-only [id="Increase block size"] {
-    display: none !important; 
-    visibility: hidden !important; 
-    height: 0 !important; 
-    width: 0 !important; 
-    pointer-events: none !important; 
-    overflow: hidden !important; 
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    width: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
 }
 
 .play-only #buttoncontainerBOTTOM {
@@ -88,40 +88,41 @@
     justify-content: center !important;
     align-items: center !important;
     position: fixed !important;
-    right: 15px !important; 
-    bottom: 15px !important; 
+    right: 15px !important;
+    bottom: 15px !important;
     width: auto !important;
     height: auto !important;
-    z-index: 10000 !important; 
-    background-color: rgba(255, 255, 255, 0.9) !important; 
+    z-index: 10000 !important;
+    background-color: rgba(255, 255, 255, 0.9) !important;
     padding: 5px !important;
     border-radius: 5px !important;
 }
 
 @media only screen and (max-width: 400px) {
     .play-only ul.main.right {
-      margin-top: 0px !important; 
-      position: relative !important;
-      display: flex !important;
-      flex-wrap: wrap !important;
-      justify-content: center !important;
-      align-items: center !important;
-      gap: 10px !important;
+        margin-top: 0px !important;
+        position: relative !important;
+        display: flex !important;
+        flex-wrap: wrap !important;
+        justify-content: center !important;
+        align-items: center !important;
+        gap: 10px !important;
     }
-  
-    .play-only nav {
-      min-height: 50px !important;
-      display: flex !important;
-      align-items: center !important;
-      justify-content: center !important;
-    }
-  }
 
-@media (max-width: 768px), (max-height: 600px) {
-    /* Enable the auxiliary button */
+    .play-only nav {
+        min-height: 50px !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+    }
+}
+
+@media (max-width: 768px),
+(max-height: 600px) {
+
+    /* Hide the full auxiliary button */
     .play-only #toggleAuxBtn {
-        pointer-events: auto !important;
-        opacity: 1 !important;  
+        display: none !important;
     }
 
     /* Hide the full auxiliary toolbar */
@@ -145,4 +146,3 @@
     display: flex !important;
     position: fixed !important;
 }
-


### PR DESCRIPTION
Fixes: #5025 

Problem:
At the 768px breakpoint (and also on shorter screens), the auxiliary navigation toolbar is hidden in play-only mode, but its toggle button is still shown.
This results in an inconsistent UI where a control is visible even though the navigation it is meant to control is not available.

This behavior can confuse users, as the button appears interactive but does not reveal any auxiliary navigation.

Solution:
Updated the responsive styles in play-only mode so that the auxiliary toolbar and its toggle button follow the same visibility rules at smaller screen sizes.
At the affected breakpoint, both the toolbar and the toggle button are now hidden together.

This keeps the interface consistent and avoids displaying unused or misleading controls on tablet-sized and smaller screens.

Testing:

Ran the application locally
Resized the browser viewport to 768px width and below
Verified that in play-only mode:

the auxiliary toolbar is hidden
the auxiliary toggle button is also hidden
Confirmed that behavior on larger screens remains unchanged

Notes

This fix follows the “hide both” approach mentioned in the issue description to keep the scope minimal and avoid introducing new layout or interaction changes on smaller screens.