### PR TITLE
refactor: remove unused variables and eslint-disable comments

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2667,8 +2667,7 @@ class Activity {
                 hitArea.y = 0;
                 container.hitArea = hitArea;
 
-                // eslint-disable-next-line no-unused-vars
-                container.on("click", event => {
+                container.on("click", () => {
                     container.visible = false;
                     // On the possibility that there was an error
                     // arrow associated with this container
@@ -2729,8 +2728,7 @@ class Activity {
                 container.hitArea = hitArea;
 
                 const that = this;
-                // eslint-disable-next-line no-unused-vars
-                container.on("click", event => {
+                container.on("click", () => {
                     container.visible = false;
                     // On the possibility that there was an error
                     // arrow associated with this container
@@ -4554,8 +4552,7 @@ class Activity {
             that.update = true;
         };
 
-        // eslint-disable-next-line no-unused-vars
-        this._loadProject = (projectID, flags, env) => {
+        this._loadProject = (projectID, flags) => {
             if (this.planet === undefined) {
                 return;
             }
@@ -5273,8 +5270,6 @@ class Activity {
             this.refreshCanvas();
         };
 
-        // Accessed from index.html
-        // eslint-disable-next-line no-unused-vars
         const hideArrows = () => {
             globalActivity._hideArrows();
         };
@@ -6507,8 +6502,7 @@ class Activity {
             });
 
             const that = this;
-            // eslint-disable-next-line no-unused-vars
-            container.onmouseover = event => {
+            container.onmouseover = () => {
                 if (!that.loading) {
                     document.body.style.cursor = "pointer";
                     container.style.transition = "0.12s ease-out";
@@ -6516,8 +6510,7 @@ class Activity {
                 }
             };
 
-            // eslint-disable-next-line no-unused-vars
-            container.onmouseout = event => {
+            container.onmouseout = () => {
                 if (!that.loading) {
                     document.body.style.cursor = "default";
                     container.style.transition = "0.15s ease-out";
@@ -6548,8 +6541,7 @@ class Activity {
          */
         this._loadButtonDragHandler = (container, actionClick, arg) => {
             const that = this;
-            // eslint-disable-next-line no-unused-vars
-            container.onmousedown = event => {
+            container.onmousedown = () => {
                 if (!that.loading) {
                     document.body.style.cursor = "default";
                 }
@@ -6612,8 +6604,7 @@ class Activity {
          * Ran once dom is ready and editable
          * Sets up dependencies and vars
          */
-        // eslint-disable-next-line no-unused-vars
-        this.domReady = async doc => {
+        this.domReady = async () => {
             this.saveLocally = undefined;
 
             // Do we need to update the stage?
@@ -7138,26 +7129,22 @@ class Activity {
             // Load custom mode saved in local storage.
             const custommodeData = this.storage.custommode;
             if (custommodeData !== undefined) {
-                // FIX ME
-                // eslint-disable-next-line no-unused-vars
-                const customMode = JSON.parse(custommodeData);
+                // FIX ME: customMode is loaded but not yet used
+                JSON.parse(custommodeData);
             }
 
-            // eslint-disable-next-line no-unused-vars
-            this.fileChooser.addEventListener("click", event => {
+            this.fileChooser.addEventListener("click", () => {
                 that.value = null;
             });
 
             this.fileChooser.addEventListener(
                 "change",
-                // eslint-disable-next-line no-unused-vars
-                event => {
+                () => {
                     // Read file here.
                     const reader = new FileReader();
                     const midiReader = new FileReader();
 
-                    // eslint-disable-next-line no-unused-vars
-                    reader.onload = theFile => {
+                    reader.onload = () => {
                         that.loading = true;
                         document.body.style.cursor = "wait";
                         that.doLoadAnimation();
@@ -7198,8 +7185,7 @@ class Activity {
 
                                     if (!that.merging) {
                                         // Wait for the old blocks to be removed.
-                                        // eslint-disable-next-line no-unused-vars
-                                        const __listener = event => {
+                                        const __listener = () => {
                                             that.blocks.loadNewBlocks(obj);
                                             that.stage.removeAllEventListeners("trashsignal");
                                             if (that.planet) {
@@ -7275,8 +7261,7 @@ class Activity {
                 const midiReader = new FileReader();
 
                 const abcReader = new FileReader();
-                // eslint-disable-next-line no-unused-vars
-                reader.onload = theFile => {
+                reader.onload = () => {
                     that.loading = true;
                     document.body.style.cursor = "wait";
                     // doLoadAnimation();
@@ -7309,8 +7294,7 @@ class Activity {
                                 };
 
                                 // Wait for the old blocks to be removed.
-                                // eslint-disable-next-line no-unused-vars
-                                const __listener = event => {
+                                const __listener = () => {
                                     that.blocks.loadNewBlocks(obj);
                                     that.stage.removeAllEventListeners("trashsignal");
 
@@ -7414,29 +7398,25 @@ class Activity {
             dropZone.addEventListener("dragover", __handleDragOver, false);
             dropZone.addEventListener("drop", __handleFileSelect, false);
 
-            // eslint-disable-next-line no-unused-vars
-            this.allFilesChooser.addEventListener("click", event => {
+            this.allFilesChooser.addEventListener("click", () => {
                 this.value = null;
             });
 
-            // eslint-disable-next-line no-unused-vars
-            this.pluginChooser.addEventListener("click", event => {
+            this.pluginChooser.addEventListener("click", () => {
                 window.scroll(0, 0);
                 this.value = null;
             });
 
             this.pluginChooser.addEventListener(
                 "change",
-                // eslint-disable-next-line no-unused-vars
-                event => {
+                () => {
                     window.scroll(0, 0);
 
                     // Read file here.
                     const reader = new FileReader();
                     const pluginFile = that.pluginChooser.files[0];
 
-                    // eslint-disable-next-line no-unused-vars
-                    reader.onload = theFile => {
+                    reader.onload = () => {
                         that.loading = true;
                         document.body.style.cursor = "wait";
                         //doLoadAnimation();
@@ -7610,8 +7590,7 @@ class Activity {
                                             const n = data.arg;
                                             env.push(parseInt(n));
                                         },
-                                        // eslint-disable-next-line no-unused-vars
-                                        status => {
+                                        () => {
                                             alert(
                                                 "Something went wrong reading JSON-encoded project data."
                                             );
@@ -7789,8 +7768,7 @@ require(["domReady!"], doc => {
     }, 5000);
 });
 
-// eslint-disable-next-line no-unused-vars
-define(MYDEFINES, compatibility => {
+define(MYDEFINES, () => {
     activity.setupDependencies();
     activity.doContextMenus();
     activity.doPluginsAndPaletteCols();

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3453,8 +3453,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, arg];
             } else if (name === "newnote") {
-                // eslint-disable-next-line no-unused-vars
-                postProcess = args => {};
+                postProcess = () => {};
                 postProcessArg = [thisBlock, null];
             } else {
                 postProcess = null;
@@ -6690,8 +6689,7 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        // eslint-disable-next-line no-unused-vars
-        this.cleanupAfterLoad = async name => {
+        this.cleanupAfterLoad = async () => {
             this._loadCounter -= 1;
             if (this._loadCounter > 0) {
                 return;

--- a/js/palette.js
+++ b/js/palette.js
@@ -474,7 +474,6 @@ class Palettes {
 
     // Palette Button event handlers
     _loadPaletteButtonHandler(name, row) {
-        // eslint-disable-next-line no-unused-vars
         let timeout;
 
         row.onmouseover = () => {
@@ -489,8 +488,7 @@ class Palettes {
 
         row.onmouseout = () => clearTimeout(timeout);
 
-        // eslint-disable-next-line no-unused-vars
-        row.onclick = event => {
+        row.onclick = () => {
             if (name == "search") {
                 this._hideMenus();
                 this.activity.showSearchWidget();
@@ -499,13 +497,11 @@ class Palettes {
             }
         };
 
-        // eslint-disable-next-line no-unused-vars
-        row.onmouseup = event => {
+        row.onmouseup = () => {
             document.body.style.cursor = "default";
         };
 
-        // eslint-disable-next-line no-unused-vars
-        row.onmouseleave = event => {
+        row.onmouseleave = () => {
             document.body.style.cursor = "default";
         };
     }
@@ -1094,8 +1090,7 @@ class Palette {
     setupGrabScroll(paletteList) {
         let posY, top;
 
-        // eslint-disable-next-line no-unused-vars
-        const mouseUpGrab = event => {
+        const mouseUpGrab = () => {
             // paletteList.onmousemove = null;
             document.body.style.cursor = "default";
         };

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -673,8 +673,7 @@ function TemperamentWidget() {
 
             const playImage = docById("play_" + i);
 
-            // eslint-disable-next-line no-unused-vars
-            playImage.onmouseover = function (event) {
+            playImage.onmouseover = function () {
                 this.style.cursor = "pointer";
             };
 
@@ -782,8 +781,7 @@ function TemperamentWidget() {
         menuItems[0].style.background = "#c8C8C8";
         that.equalEdit();
 
-        // eslint-disable-next-line no-unused-vars
-        menuItems[0].onclick = function (event) {
+        menuItems[0].onclick = function () {
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
@@ -791,8 +789,7 @@ function TemperamentWidget() {
             that.equalEdit();
         };
 
-        // eslint-disable-next-line no-unused-vars
-        menuItems[1].onclick = function (event) {
+        menuItems[1].onclick = function () {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
@@ -800,8 +797,7 @@ function TemperamentWidget() {
             that.ratioEdit();
         };
 
-        // eslint-disable-next-line no-unused-vars
-        menuItems[2].onclick = function (event) {
+        menuItems[2].onclick = function () {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[3].style.background = platformColor.selectorBackground;
@@ -809,8 +805,7 @@ function TemperamentWidget() {
             that.arbitraryEdit();
         };
 
-        // eslint-disable-next-line no-unused-vars
-        menuItems[3].onclick = function (event) {
+        menuItems[3].onclick = function () {
             menuItems[0].style.background = platformColor.selectorBackground;
             menuItems[1].style.background = platformColor.selectorBackground;
             menuItems[2].style.background = platformColor.selectorBackground;
@@ -2325,8 +2320,7 @@ function TemperamentWidget() {
 
         this._circleOfNotes();
 
-        // eslint-disable-next-line no-unused-vars
-        noteCell.onclick = function (event) {
+        noteCell.onclick = function () {
             that.editMode = null;
             if (that.circleIsVisible) {
                 that._circleOfNotes();
@@ -2335,12 +2329,7 @@ function TemperamentWidget() {
             }
         };
 
-        widgetWindow.addButton(
-            "add2.svg",
-            ICONSIZE,
-            _("Add pitches")
-            // eslint-disable-next-line no-unused-vars
-        ).onclick = function (event) {
+        widgetWindow.addButton("add2.svg", ICONSIZE, _("Add pitches")).onclick = function () {
             that.edit();
         };
 


### PR DESCRIPTION


## Description
Removes 35 `eslint-disable-next-line no-unused-vars` comments and their associated unused variables across 4 core files.

## Changes
| File | Instances | Type |
|------|-----------|------|
| [temperament.js](cci:7://file:///d:/ANIMTED%20ART/musicblocks/js/widgets/temperament.js:0:0-0:0) | 7 | Event handlers |
| [palette.js](cci:7://file:///d:/ANIMTED%20ART/musicblocks/js/palette.js:0:0-0:0) | 5 | Mouse handlers |
| [blocks.js](cci:7://file:///d:/ANIMTED%20ART/musicblocks/js/blocks.js:0:0-0:0) | 2 | Callback params |
| [activity.js](cci:7://file:///d:/ANIMTED%20ART/musicblocks/js/activity.js:0:0-0:0) | 21 | Various handlers |

## Testing
- [x] ESLint passes
- [x] Browser tested - all functionality works
- [x] Prettier formatted