### PR TITLE
Fixes the redundant block creation after SNAP-IN in Pitch Block

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2085,7 +2085,16 @@ class Blocks {
                         this.blockList[connection].connections[0] = null;
 
                         /** If we are replacing a number block, put it in the trash */
-                        if (this.blockList[connection].name === "number") {
+                        if (
+                            [
+                                "number",
+                                "solfege",
+                                "eastindiansolfege",
+                                "scaledegree2",
+                                "notename",
+                                "text"
+                            ].includes(this.blockList[connection].name)
+                        ) {
                             this.sendStackToTrash(this.blockList[connection]);
                         } else {
                             this.findDragGroup(connection);

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2084,7 +2084,7 @@ class Blocks {
                     } else if (myBlock.isArgBlock()) {
                         this.blockList[connection].connections[0] = null;
 
-                        /** If we are replacing a number block, put it in the trash */
+                        /** If we are replacing an arg block, put certain default blocks in the trash */
                         if (
                             [
                                 "number",


### PR DESCRIPTION
Summary

This fixes an issue where dragging a Name block out of a Pitch block and then dragging it back in caused a redundant Name block to appear, instead of the original block snapping back without duplication.

What’s fixed

Modified js/blocks.js to ensure solfege, eastindiansolfege, scaledegree2, notename, and text blocks are trashed when replaced.
Name blocks now behave like Octave blocks— detach cleanly and snap back into place.

Video:

https://github.com/user-attachments/assets/597b8898-3589-4b3a-acaa-b486b662f1f4


How to test

Create a Pitch Block
Drag the Name block out- a default duplicate must appear
Drop the Name block back - it should reattach without creating any redundant Name block

Fixes #4794 
Tested on macOS (Chrome) and verified consistent behavior with Name block logic.