### PR TITLE
fix: handle nested rhythm blocks correctly (resolves FIXME)

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -175,9 +175,10 @@ function setupRhythmActions(activity) {
                     tur.singer.multipleVoices = false;
                 }
 
-                /** @todo FIXME: broken when nesting */
-                activity.logo.pitchBlocks = [];
-                activity.logo.drumBlocks = [];
+                if (tur.singer.inNoteBlock.length === 0) {
+                    activity.logo.pitchBlocks = [];
+                    activity.logo.drumBlocks = [];
+                }
             };
 
             activity.logo.setTurtleListener(turtle, listenerName, __listener);


### PR DESCRIPTION

## Summary

This PR fixes the FIXME comment: `/** @todo FIXME: broken when nesting */` in `js/turtleactions/RhythmActions.js`.

When rhythm blocks are nested (like `Tie` inside `Note`), the inner block's completion would clear the `pitchBlocks` and `drumBlocks` arrays before the outer block could read them. This caused data loss and incorrect behavior during nested execution.

## The Fix

Previously, the code cleared arrays every time a note finished:
```javascript
// Before (bug):
tur.singer.pitchBlocks = [];
tur.singer.drumBlocks = [];
```

I added a check to ensure we only clear when ALL nested blocks are complete:
```javascript
// After (fix):
if (tur.singer.inNoteBlock.length === 0) {
    tur.singer.pitchBlocks = [];
    tur.singer.drumBlocks = [];
}
```

This ensures that outer blocks can still access the data they need before it gets cleared.

## Technical Details

The `inNoteBlock` array tracks the nesting depth of rhythm blocks. When it's empty (`length === 0`), all notes have completed and it's safe to clear the shared pitch/drum data. When it's not empty, we're still inside nested blocks and need to preserve the data.

## Scope Note

This PR specifically addresses the FIXME comment about nesting logic. It does **not** address the "???" error banner display issue mentioned in #5041, which requires separate changes to `logo.js` error handling.

---

Resolves the FIXME comment in `js/turtleactions/RhythmActions.js`

Related to #5041 (partial fix - addresses nesting logic only, not error banner display)
