### PR TITLE
fix(musicutils): extend frequencyToPitch upper bound from C8 to C10

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -740,6 +740,7 @@ describe("frequencyToPitch", () => {
     beforeEach(() => {
         global.A0 = 27.5;
         global.C8 = 4186.01;
+        global.C10 = 16744.04;
         global.TWELVEHUNDRETHROOT2 = Math.pow(2, 1 / 1200);
         global.PITCHES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
     });
@@ -748,9 +749,9 @@ describe("frequencyToPitch", () => {
         expect(frequencyToPitch(20)).toEqual(["A", 0, 0]);
         expect(frequencyToPitch(27.4)).toEqual(["A", 0, 0]);
     });
-    it("should handle frequencies above C8", () => {
-        expect(frequencyToPitch(4200)).toEqual(["C", 8, 0]);
-        expect(frequencyToPitch(5000)).toEqual(["C", 8, 0]);
+    it("should handle frequencies above C10", () => {
+        expect(frequencyToPitch(17000)).toEqual(["C", 10, 0]);
+        expect(frequencyToPitch(20000)).toEqual(["C", 10, 0]);
     });
     it("should handle frequencies with cents deviation", () => {
         const result = frequencyToPitch(442);
@@ -765,6 +766,40 @@ describe("frequencyToPitch", () => {
         const result = frequencyToPitch(intermediateFreq);
         expect(result[0]).toBe("D♭");
         expect(result[1]).toBe(1);
+    });
+    // Verify that pitch mapping for frequencies <= C8 remains unchanged
+    it("should correctly map standard A notes across octaves", () => {
+        // A0 = 27.5 Hz
+        const a0 = frequencyToPitch(27.5);
+        expect(a0[0]).toBe("A");
+        expect(a0[1]).toBe(0);
+
+        // A4 = 440 Hz (concert pitch)
+        const a4 = frequencyToPitch(440);
+        expect(a4[0]).toBe("A");
+        expect(a4[1]).toBe(4);
+    });
+    it("should correctly map middle C and other C notes", () => {
+        // C4 (middle C) ≈ 261.63 Hz
+        const c4 = frequencyToPitch(261.63);
+        expect(c4[0]).toBe("C");
+        expect(c4[1]).toBe(4);
+
+        // C8 ≈ 4186 Hz
+        const c8 = frequencyToPitch(4186);
+        expect(c8[0]).toBe("C");
+        expect(c8[1]).toBe(8);
+    });
+    it("should correctly map frequencies in the extended range C8-C10", () => {
+        // C9 ≈ 8372 Hz
+        const c9 = frequencyToPitch(8372);
+        expect(c9[0]).toBe("C");
+        expect(c9[1]).toBe(9);
+
+        // C10 ≈ 16744 Hz
+        const c10 = frequencyToPitch(16744);
+        expect(c10[0]).toBe("C");
+        expect(c10[1]).toBe(10);
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -851,8 +851,21 @@ const POWER2 = [1, 2, 4, 8, 16, 32, 64, 128];
 const TWELTHROOT2 = 1.0594630943592953;
 // eslint-disable-next-line no-loss-of-precision
 const TWELVEHUNDRETHROOT2 = 1.0005777895065549;
+/**
+ * Frequency of A in octave 0, in Hz.
+ * @constant {number}
+ */
 const A0 = 27.5;
+/**
+ * Frequency of C in octave 8, in Hz.
+ * @constant {number}
+ */
 const C8 = 4186.01;
+/**
+ * Frequency of C in octave 10, in Hz.
+ * @constant {number}
+ */
+const C10 = 16744.04;
 
 /**
  * Octave ratio.
@@ -2860,14 +2873,13 @@ const frequencyToPitch = hz => {
 
     if (hz < A0) {
         return ["A", 0, 0];
-    } else if (hz > C8) {
-        // FIXME: set upper bound of C10
-        return ["C", 8, 0];
+    } else if (hz > C10) {
+        return ["C", 10, 0];
     }
 
     // Calculate cents to keep track of drift
     let cents = 0;
-    for (let i = 0; i < 8 * 1200; i++) {
+    for (let i = 0; i < 10 * 1200; i++) {
         const f = A0 * Math.pow(TWELVEHUNDRETHROOT2, i);
         if (hz < f * 1.0003 && hz > f * 0.9997) {
             cents = i % 100;


### PR DESCRIPTION
## Summary
- Added a `C10` constant (`16744.04 Hz`) to extend the supported frequency range
- Updated `frequencyToPitch()` to cap at `C10` instead of `C8`
- Extended the conversion loop from 8 to 10 octaves
- Added tests to confirm:
  - Frequencies below `A0` behave unchanged
  - Frequencies ≤ `C8` map correctly (no regression)
  - Frequencies in the `C8–C10` range map correctly
  - Frequencies above `C10` cap at `C10`

This resolves the `FIXME` at line **2864**, which requested setting the upper bound to `C10`.
