### PR TITLE
fix: correct operator precedence bug in widget cleanup code

### DIFF
--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -794,10 +794,16 @@ function AIWidget() {
             this.running = false;
 
             docById("wheelDivptm").style.display = "none";
-            if (!this.pitchWheel === undefined) {
+            if (this._pitchWheel !== undefined) {
                 this._pitchWheel.removeWheel();
+            }
+            if (this._exitWheel !== undefined) {
                 this._exitWheel.removeWheel();
+            }
+            if (this._accidentalsWheel !== undefined) {
                 this._accidentalsWheel.removeWheel();
+            }
+            if (this._octavesWheel !== undefined) {
                 this._octavesWheel.removeWheel();
             }
             this.pitchAnalysers = {};

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -493,10 +493,16 @@ function SampleWidget() {
             }
 
             docById("wheelDivptm").style.display = "none";
-            if (!this.pitchWheel === undefined) {
+            if (this._pitchWheel !== undefined) {
                 this._pitchWheel.removeWheel();
+            }
+            if (this._exitWheel !== undefined) {
                 this._exitWheel.removeWheel();
+            }
+            if (this._accidentalsWheel !== undefined) {
                 this._accidentalsWheel.removeWheel();
+            }
+            if (this._octavesWheel !== undefined) {
                 this._octavesWheel.removeWheel();
             }
             this.pitchAnalysers = {};


### PR DESCRIPTION
The condition !this.pitchWheel === undefined was always false due to operator precedence - the NOT operator (!) has higher precedence than strict equality (===), causing pitchWheel to be converted to boolean first. A boolean is never === undefined.

This caused wheel objects to never be cleaned up, potentially leading to memory leaks.

Fixed by:
- Changing to proper undefined checks for each wheel
- Using the correct property name (_pitchWheel vs pitchWheel)
- Adding individual checks for each wheel object