### PR TITLE
fix(rhythmruler): use meter-based count-off instead of hardcoded 4 beats

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -970,8 +970,12 @@ class RhythmRuler {
                     drum = this.activity.blocks.blockList[drumBlockNo].value;
                 }
 
-                // FIXME: Should be based on meter
-                for (let i = 0; i < 4; i++) {
+                // Get the meter from the current turtle's singer
+                const turtle = this.activity.turtles.ithTurtle(0);
+                const beatsPerMeasure = turtle.singer.beatsPerMeasure || 4;
+
+                // Play count-off based on meter (e.g., 4 beats for 4/4, 3 beats for 3/4)
+                for (let i = 0; i < beatsPerMeasure; i++) {
                     setTimeout(() => {
                         this.activity.logo.synth.trigger(
                             0,
@@ -981,7 +985,7 @@ class RhythmRuler {
                             null,
                             null
                         );
-                    }, (interval * i) / 4);
+                    }, (interval * i) / beatsPerMeasure);
                 }
 
                 setTimeout(() => {


### PR DESCRIPTION
- Get `beatsPerMeasure` from `turtle.singer` instead of using a hardcoded value of 4
- Count-off now correctly matches the current time signature (e.g., 3 beats for 3/4)
- Adjust timing calculation so count-off beats are evenly spaced across the interval

This resolves the FIXME comment at line 973 requesting that the count-off be based on the meter rather than always running four times.