### PR TITLE
Fix #5056: prevent gray wheel overlay from appearing on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,10 +224,12 @@
                 <div id="helpElem" tabindex="-1"></div>
 
                 <div id="wheelDiv" class="wheelNav"
-                    style="background-size: contain;background-image: url(./images/gray.svg)" tabindex="-1"></div>
+                    style="background-size: contain; background-image: url(./images/gray.svg); display: none;"
+                    tabindex="-1">
+                </div>
 
                 <div id="wheelDiv2" class="wheelNav"
-                    style="background-size: contain;background-image: url(./images/gray.svg);visibility: hidden"
+                    style="background-size: contain; background-image: url(./images/gray.svg); display: none;"
                     tabindex="-1">
                 </div>
 


### PR DESCRIPTION
### Description

On iOS device viewports, a large gray circular overlay appears during the initial page load, particularly around the Help / tour UI. This overlay covers a significant portion of the interface and blocks interaction.

The issue was reproducible using Chrome DevTools with iPhone viewport emulation. Before this change, the overlay appeared immediately on load. After the change, the overlay no longer appears unless explicitly triggered.

This update ensures the wheel overlay elements are hidden during initial render to prevent unintended visibility on mobile-sized screens.

---

### Screenshots

Before (iPhone viewport / mobile emulation):
<img width="1237" height="1004" alt="Screenshot 2026-01-08 125051" src="https://github.com/user-attachments/assets/1efc44cb-3969-4330-a9cf-56a4c142e34c" />


After (iPhone viewport / mobile emulation): 
<img width="1209" height="981" alt="Screenshot 2026-01-08 131003" src="https://github.com/user-attachments/assets/ff404524-116c-4a80-8486-a4a3ea8d6a36" />

---

### Notes

- Verified using Chrome DevTools iPhone viewport emulation  
- All tests passed locally  
- No WidgetBlocks logic affected  

Fixes #5056