### PR TITLE
Improve Tremolo block tooltip with parameter explanations

### DIFF
--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -484,7 +484,13 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("Tremolo makes the sound pulse louder and quieter. Rate: how fast the sound pulses. Depth: how strong the pulsing effect is."),
+                _("The Tremolo block adds a wavering effect.") +
+                    " " +
+                    _("Tremolo makes the sound pulse louder and quieter.") +
+                    " " +
+                    _("The rate controls how fast the sound pulses.") +
+                    " " +
+                    _("The depth controls the strength of the pulsing effect."),
                 "documentation",
                 null,
                 "tremolohelp"
@@ -833,7 +839,7 @@ function setupToneBlocks(activity) {
             if (
                 logo.inStatusMatrix &&
                 activity.blocks.blockList[activity.blocks.blockList[blk].connections[0]].name ===
-                "print"
+                    "print"
             ) {
                 logo.statusFields.push([blk, "synthname"]);
             } else {
@@ -910,8 +916,8 @@ function setupToneBlocks(activity) {
             this.setPalette("tone", activity);
             this.setHelpString([
                 _("The Set instrument block selects a voice for the synthesizer,") +
-                " " +
-                _("eg guitar piano violin or cello."),
+                    " " +
+                    _("eg guitar piano violin or cello."),
                 "documentation",
                 ""
             ]);
@@ -944,8 +950,8 @@ function setupToneBlocks(activity) {
             } else {
                 this.setHelpString([
                     _("The Set instrument block selects a voice for the synthesizer,") +
-                    " " +
-                    _("eg guitar piano violin or cello."),
+                        " " +
+                        _("eg guitar piano violin or cello."),
                     "documentation",
                     null,
                     "settimbrehelp"
@@ -1070,7 +1076,7 @@ function setupToneBlocks(activity) {
             if (
                 logo.inStatusMatrix &&
                 activity.blocks.blockList[activity.blocks.blockList[blk].connections[0]].name ===
-                "print"
+                    "print"
             ) {
                 logo.statusFields.push([blk, "customsample"]);
             } else {


### PR DESCRIPTION
issue: #5066 

Problem:_
The Tremolo block does not clearly explain what its parameters do. Beginners see options like “rate” and “depth” but have no guidance on how they affect the sound.

Solution:-
I improved the existing Tremolo block tooltip to include short, beginner-friendly explanations of both parameters:

-Rate explains how fast the sound pulses
-Depth explains how strong the pulsing effect is
-This uses the existing setHelpString() system and does not change any behavior or UI logic.

Why this approach?
Music Blocks currently supports tooltips at the block level only. Adding parameter-level tooltips would require new UI infrastructure, which is outside the scope of this change. This update improves usability while staying consistent with the current design.

Testing:-
-Opened Music Blocks
-Navigated to the Tone palette
-Hovered over the Tremolo block
-Verified the updated tooltip text appears correctly

Scope:-
-No audio behavior changes
-No layout or styling changes
-No new systems introduced