### PR TITLE
fixed nested clamp blocks not refreshing on inline collapse toggle

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2682,6 +2682,15 @@ class Block {
         }
 
         this.activity.refreshCanvas();
+
+        // Force additional refresh after a short delay to ensure all nested
+        // clamp blocks have completed their asynchronous artwork regeneration.
+        // This fixes the issue where nested clamp blocks (like setInstrument and
+        // start) don't visually update until the mouse moves away from the button.
+        const activity = this.activity;
+        setTimeout(() => {
+            activity.refreshCanvas();
+        }, 50);
     }
 
     /**


### PR DESCRIPTION
Fixes #3499

When you click the expand/collapse button on note value blocks, the outer clamps (setInstrument, start, etc.) wouldn't resize until you moved your mouse away. Kinda annoying.

Added a small delayed refresh after the toggle to make sure everything updates right away...