### PR TITLE
Guard optional doSearch call to prevent runtime error

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,9 @@ document.addEventListener("DOMContentLoaded", init);
     </script>
     <script>
         $(document).ready(function () {
-            doSearch();
+            if (typeof doSearch === "function") {
+                doSearch();
+            }
         });
     </script>
 


### PR DESCRIPTION
This PR adds a defensive check before calling doSearch() during document ready.

doSearch is conditionally defined depending on loaded features, and calling it unconditionally can result in a runtime error.

This change does not alter behavior when doSearch is available, and simply avoids a crash when it is not.