### PR TITLE
fix: implement gradual lag correction to prevent note rushing (#3882)

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -152,6 +152,10 @@ class Singer {
         this.tieFirstDrums = [];
         this.synthVolume = {};
         this.drift = 0;
+        // Maximum fraction of note duration that can be used for lag correction per note.
+        // This prevents notes from being rushed when catching up to the master clock.
+        // Value of 0.25 means at most 25% of a note's duration can be skipped for catch-up.
+        this.maxLagCorrectionRatio = 0.25;
         this.drumStyle = [];
         this.voices = [];
         this.backward = [];
@@ -1570,8 +1574,18 @@ class Singer {
             const elapsedTime = (new Date().getTime() - activity.logo.firstNoteTime) / 1000;
 
             // When we are "drifting", we don't bother with lag.
-            const turtleLag =
-                tur.singer.drift === 0 ? Math.max(elapsedTime - tur.singer.turtleTime, 0) : 0;
+            // When not drifting, we limit the lag correction to prevent notes from being rushed.
+            // This ensures that note sequences play correctly even when the system is behind.
+            let turtleLag = 0;
+            if (tur.singer.drift === 0) {
+                const rawLag = Math.max(elapsedTime - tur.singer.turtleTime, 0);
+                // Calculate the maximum lag correction allowed for this note
+                // based on the note's duration to prevent rushing
+                const noteDuration = bpmFactor / noteBeatValue;
+                const maxLagCorrection = noteDuration * tur.singer.maxLagCorrectionRatio;
+                // Apply gradual lag correction: correct at most maxLagCorrection per note
+                turtleLag = Math.min(rawLag, maxLagCorrection);
+            }
 
             // Delay running graphics from second note in tie.
             let tieDelay = tur.singer.tie ? tur.singer.tieCarryOver : 0;

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -257,6 +257,7 @@ class Turtle {
         this.singer.tieCarryOver = 0;
         this.singer.tieFirstDrums = [];
         this.singer.drift = 0;
+        this.singer.maxLagCorrectionRatio = 0.25;
         this.singer.drumStyle = [];
         this.singer.voices = [];
         this.singer.backward = [];


### PR DESCRIPTION
Fixes #3882

Limits lag correction to 25% of each note's duration instead of catching up all at once. This prevents notes from being rushed while still synchronizing with the master clock over time.