### PR TITLE
fix(toolbar): prevent event listener memory leak in play button

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -228,7 +228,7 @@ describe("Toolbar Class", () => {
             },
             stop: {
                 style: { color: "" },
-                addEventListener: jest.fn()
+                onclick: null
             },
             record: {
                 className: ""
@@ -253,10 +253,12 @@ describe("Toolbar Class", () => {
         expect(global.saveButtonAdvanced.disabled).toBe(true);
         expect(global.saveButton.className).toBe("grey-text inactiveLink");
         expect(elements.record.className).toBe("grey-text inactiveLink");
-        expect(elements.stop.addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
 
-        const stopClickHandler = elements.stop.addEventListener.mock.calls[0][1];
-        stopClickHandler();
+        // Verify stop button onclick handler is set (not addEventListener to prevent memory leak)
+        expect(elements.stop.onclick).toBeInstanceOf(Function);
+
+        // Test the stop button handler
+        elements.stop.onclick();
 
         expect(mockActivity.hideMsgs).toHaveBeenCalled();
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -417,12 +417,12 @@ class Toolbar {
                 handleClick();
             }, 2000);
 
-            stopIcon.addEventListener("click", function () {
+            stopIcon.onclick = function () {
                 clearTimeout(play_button_debounce_timeout);
                 isPlayIconRunning = true;
                 hideMsgs();
                 handleClick();
-            });
+            };
         });
     }
 


### PR DESCRIPTION
Replace addEventListener with onclick assignment to prevent duplicate event listeners from accumulating each time the play button is clicked.
## Problem
The stop button listener was added inside the play button's onclick handler. Since the play button can be clicked repeatedly, addEventListener keeps adding new listeners without removing previous ones, causing:
- Memory leak from accumulating listeners
- Multiple handlers executing on single stop click
- Performance degradation over time
## Solution
Use `.onclick` assignment which automatically replaces the previous handler instead of accumulating listeners. 
## Changes
- `js/toolbar.js`: Changed `addEventListener` to `.onclick`
- `js/__tests__/toolbar.test.js`: Updated test to match new implementation
## Testing
- [x] ESLint passed
- [x] Prettier formatted
- [x] All 29 toolbar tests pass
- [x] Full test suite passes
- [x] No breaking changes
Fixes #5099