### PR TITLE
refactor(widgets): Remove deprecated DOMMouseScroll event listeners

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7657,7 +7657,6 @@ class Activity {
 
             /*
             document.addEventListener("mousewheel", scrollEvent, false);
-            document.addEventListener("DOMMouseScroll", scrollEvent, false);
             */
 
             const activity = this;

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -201,7 +201,6 @@ class WidgetWindow {
 
         this._widget = this._create("div", "wfbWidget", this._body);
         this._widget.addEventListener("wheel", disableScroll, false);
-        this._widget.addEventListener("DOMMouseScroll", disableScroll, false);
     }
 
     /**


### PR DESCRIPTION
## Description

Removes deprecated `DOMMouseScroll` event references and relies on the standard `wheel` event already used in the codebase.

This cleans up legacy code and aligns scroll handling with modern browser standards. No functional changes.

