### PR TITLE
fix(turtles): Clear intervals when removing turtles to prevent memory…

### DIFF
--- a/js/turtles.js
+++ b/js/turtles.js
@@ -467,6 +467,15 @@ Turtles.TurtlesModel = class {
      */
     removeTurtle(index) {
         if (index >= 0 && index < this._turtleList.length) {
+            const turtle = this._turtleList[index];
+
+            // Clear any active intervals to prevent memory leaks
+            if (turtle.interval !== undefined) {
+                const intervalId = turtle.interval;
+                clearInterval(intervalId);
+                turtle.interval = undefined;
+            }
+
             this._turtleList.splice(index, 1);
         }
     }


### PR DESCRIPTION
## Description

Fixes a memory leak where intervals created by `MeterActions.onEveryBeatDo()` were not cleared when turtles were removed.

### Problem
When a turtle with an active "On Every Beat Do" interval is deleted, the `setInterval` continues running as a "zombie" interval, causing:
- Memory leaks in long-running sessions
- Potential performance degradation
- Unexpected behavior from orphaned interval callbacks

### Solution
Added interval cleanup logic to [removeTurtle()] in [js/turtles.js]:
- Check if the turtle has an active `interval` property
- Clear it with `clearInterval()` before removal
- Set `turtle.interval = undefined` for clean state

### Testing
- `npm run lint` 
- `npm test` 
- Manual verification: Create turtle with "On Every Beat Do" block, delete turtle, confirm interval is cleared

### Impact
- Prevents memory leaks during normal usage
- Improves stability in extended sessions
- No breaking changes