### PR TITLE
fix: theme switch without reload

### DIFF
--- a/js/themebox.js
+++ b/js/themebox.js
@@ -132,7 +132,7 @@ class ThemeBox {
     applyThemeInstantly() {
         const body = document.body;
         // Update body classes
-        this._themes.forEach((theme) => {
+        this._themes.forEach(theme => {
             if (theme === this._theme) {
                 body.classList.add(theme);
             } else {
@@ -212,7 +212,7 @@ class ThemeBox {
 
         // Refresh floating windows
         const floatingWindows = document.querySelectorAll("#floatingWindows > .windowFrame");
-        floatingWindows.forEach((win) => {
+        floatingWindows.forEach(win => {
             if (this._theme === "dark") {
                 win.style.backgroundColor = "#454545";
                 win.style.borderColor = "#000000";
@@ -233,7 +233,7 @@ class ThemeBox {
             try {
                 const planetBody = planetIframe.contentDocument.body;
                 if (planetBody) {
-                    this._themes.forEach((theme) => {
+                    this._themes.forEach(theme => {
                         if (theme === this._theme) {
                             planetBody.classList.add(theme);
                         } else {


### PR DESCRIPTION
theme now switches instantly without refreshing the whole page

added applyThemeInstantly() to update colors in real-time quick.
updates body classes, canvas bg, platformColor, meta tags
refreshes palettes and floating windows on the fly
updated tests....




https://github.com/user-attachments/assets/0c7d2d80-2286-465e-a5aa-2750b4699d1c






fixes #4520