### PR TITLE
validate task never runs in default gulp workflow due to watchTask ordering

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,15 +87,16 @@ const validate = () => {
 // Watch task: watch SASS , CSS and JS files for changes
 // If any change, run sass, css and js tasks simultaneously
 const watchTask = () => {
-    watch([ files.jsPath, files.cssPath, files.sassPath ],
+    return watch([ files.jsPath, files.cssPath, files.sassPath ],
         parallel( jsTask, cssTask, sassTask));
 };
 
 // Export the default Gulp task so it can be run
 // Runs the sass ,css and js tasks simultaneously
-// then runs prettify, cacheBust, watch task, then validate
+// then runs prettify, cacheBust, validate, then starts watch (watch never completes)
 exports.default = series(
     parallel( jsTask, cssTask , sassTask ), prettify,
     cacheBustTask,
-    watchTask, validate
+    validate,
+    watchTask
 );


### PR DESCRIPTION

fixes - #5008 

## description

In the original gulpfile.js, the validate task was never executed in the default workflow.

This happened because validate was placed after watchTask inside a series().
Since watchTask starts a file watcher and never completes (by design), the series never reached validate.

This PR updates the task order and behavior so validation runs deterministically.

## What was Changed
1] Moved validate to run before watchTask in the default task series
2] Updated watchTask to return the watch() call, making its long-running nature explicit to Gulp

## Why This Change needed ?
1] Ensures validate runs at least once during the default workflow
2] Prevents silent skipping of validation
3] Aligns task structure with Gulp’s recommended lifecycle handling for long-running tasks
4] Improves developer feedback without changing build or watch behavior

## How to test
1] Run the default task:

gulp

Confirm that:
1] validate runs before watch mode starts
2] The watcher continues running as expected after validation

## Impact
1] No breaking changes
2] No behavior change to watch mode
3] Improves correctness and reliability of the default workflow.

## screenshots 
<img width="622" height="188" alt="image" src="https://github.com/user-attachments/assets/07d2cc33-e8e1-461a-a751-b80f2699eb3d" />
