### PR TITLE
chore: improve loading text contrast in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
         <div id="loading-image-container"
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; background-color: #FFFFFF; z-index: 9999; contain: paint;">
             <div id="loading-media" style="width: 100%; padding: 0 20px; box-sizing: border-box;"></div>
-            <div class="loading-text" id="loadingText" style="margin-top: 2rem; min-height: 1.5em; font-size: 1.2rem;">
+            <div class="loading-text" id="loadingText" style="color:#333; margin-top: 2rem; min-height: 1.5em; font-size: 1.2rem;">
             </div>
             <a href="https://www.sugarlabs.org/" target="_blank" id="link-to-sugarLabs"
                 style="position: fixed; bottom: 20px; right: 20px;">


### PR DESCRIPTION
Resolves #5139

This PR improves the readability of the loading screen text in **light mode** by setting its color to `#333`.

Previously, the loading text used a very light gray that had low contrast against the white background, making it harder to read. The color `#333` is already widely used throughout the Music Blocks codebase for primary text, so using it here keeps the UI visually consistent while significantly improving contrast and accessibility.

The change was made in the loading text element:

```html
<div class="loading-text" id="loadingText"
     style="color:#333; margin-top: 2rem; min-height: 1.5em; font-size: 1.2rem;">
```

No functionality is affected — this is a small UI polish to improve clarity and user experience.
<img width="1362" height="711" alt="Screenshot from 2026-01-11 23-02-21" src="https://github.com/user-attachments/assets/a9a0deb2-74e8-4bf4-9b80-dec480a156c5" />
