### PR TITLE
fix: correct gulp workflow and resolve postcss/cssnano dependency issues

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,21 +26,20 @@ const files = {
     jsPath: "js/**/*.js",
     cssPath: "css/*.css",
     sassPath: "css/*.sass"
-
 };
 
 const sassTask = () => {
     return src(files.sassPath)
         .pipe(sourcemaps.init()) // initialize sourcemaps first
         .pipe(sass()) // compile SASS to CSS
-        .pipe(postcss([ autoprefixer(), cssnano() ])) // PostCSS plugins
+        .pipe(postcss([autoprefixer(), cssnano()])) // PostCSS plugins
         .pipe(sourcemaps.write(".")) // write sourcemaps file in current directory
         .pipe(dest("dist/css")); // put final CSS in dist folder
 };
 
 const cssTask = () => {
     return src(files.cssPath)
-        .pipe(minifyCSS({compatibility: "ie8"}))
+        .pipe(minifyCSS({ compatibility: "ie8" }))
         .pipe(gulp.dest("dist/css"));
 };
 
@@ -48,14 +47,13 @@ const cssTask = () => {
 const jsTask = () => {
     return src([files.jsPath])
         .pipe(concat("app.min.js"))
-        .pipe(babel(
-            {
+        .pipe(
+            babel({
                 presets: ["@babel/env"]
-            }
-        ))
+            })
+        )
         .pipe(uglify())
-        .pipe(dest("dist")
-        );
+        .pipe(dest("dist"));
 };
 
 // Cachebust
@@ -69,33 +67,39 @@ const cacheBustTask = () => {
 //This gulp task formats the js files
 
 const prettify = () => {
-    return gulp.src(files.jsPath)
-        .pipe(prettier({
-            singleQuote: true,
-            trailingComma: "all"
-        }))
+    return gulp
+        .src(files.jsPath)
+        .pipe(
+            prettier({
+                singleQuote: true,
+                trailingComma: "all"
+            })
+        )
         .pipe(gulp.dest("./dist/js"));
 };
 
 //to check whether or not files adhere to Prettier's formatting
 
 const validate = () => {
-    return gulp.src(files.jsPath)
-        .pipe(prettier.check({ singleQuote: true, trailingComma: "all"}));
+    return gulp.src(files.jsPath).pipe(prettier.check({ singleQuote: true, trailingComma: "all" }));
 };
 
 // Watch task: watch SASS , CSS and JS files for changes
 // If any change, run sass, css and js tasks simultaneously
 const watchTask = () => {
-    watch([ files.jsPath, files.cssPath, files.sassPath ],
-        parallel( jsTask, cssTask, sassTask));
+    return watch(
+        [files.jsPath, files.cssPath, files.sassPath],
+        parallel(jsTask, cssTask, sassTask)
+    );
 };
 
 // Export the default Gulp task so it can be run
 // Runs the sass ,css and js tasks simultaneously
-// then runs prettify, cacheBust, watch task, then validate
+// then runs prettify, cacheBust, validate, then starts watch (long-running)
 exports.default = series(
-    parallel( jsTask, cssTask , sassTask ), prettify,
+    parallel(jsTask, cssTask, sassTask),
+    prettify,
     cacheBustTask,
-    watchTask, validate
+    validate,
+    watchTask
 );


### PR DESCRIPTION
fixes - #5008 

## description 

1] The validate task was never executed in the default Gulp workflow because it was placed after watchTask, which is a long-running task that never completes.

2] The PostCSS toolchain was broken due to a dependency mismatch (cssnano v7 installed while the project expects v6).

## What was Changed
1. Gulp workflow fix
1] Moved validate to run before watchTask in the default task sequence
2] Updated watchTask to return the watch() call, so Gulp correctly treats it as a long-running task

2. Dependency alignment
1] Added the missing postcss dependency required by gulp-postcss
2] Aligned cssnano to v6, which matches the project’s expected PostCSS toolchain and prevents module resolution errors

## Why This Change Is Needed
1] Ensures validate actually runs during the default Gulp workflow
2] Prevents silent skipping of code validation
3] Fixes build failures on fresh installs caused by mismatched PostCSS dependencies
4] Makes the development setup more stable and reproducible

## Impact
1] No breaking changes
2] No change to watch behavior
3] Improves reliability of both the Gulp workflow and the CSS build pipeline.

## testing 
<img width="462" height="135" alt="image" src="https://github.com/user-attachments/assets/79b305c0-c4cc-4837-a20b-aeb74d04cc41" />


