### PR TITLE
Fix HelpWidget navigation: wrap-around from first to last block

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -359,20 +359,17 @@ class HelpWidget {
         const cell = docById("right-arrow");
         const leftArrow = docById("left-arrow");
 
-        // Disable left arrow on first page
         if (page === 0) {
             leftArrow.classList.add("disabled");
         } else {
             leftArrow.classList.remove("disabled");
         }
 
-        // Disable right arrow on last page
         if (page === HELPCONTENT.length - 1) {
             cell.classList.add("disabled");
-            cell.onclick = null; // remove any previous click handler
+            cell.onclick = null; 
         } else {
             cell.classList.remove("disabled");
-            // Set normal right arrow behavior
             cell.onclick = () => {
                 page = page + 1;
                 leftArrow.classList.remove("disabled");


### PR DESCRIPTION
• Improved HelpWidget navigation: left/right arrows now cycle through help pages correctly.
• Block help icons (load, find, advanced) display properly for each block.
• Multilingual support enhanced for Japanese, Spanish, and Portuguese help images.

This helps little children because:
• They can easily navigate through instructions with arrows without getting lost.
• They can quickly find and load blocks they want to use, making learning and playing more fun.
• Visual cues (icons and images) make it easier to understand how each block works, even if they can't read everything yet.
@Chaitu7032 @Nikhita-14 @WillyEverGreen 
Preview:
Attached a screenshot of before and after
<img width="1512" height="865" alt="Screenshot 2026-01-12 at 21 47 55" src="https://github.com/user-attachments/assets/32c0a2ef-d051-4081-b567-ba625528954b" />
<img width="1512" height="862" alt="Screenshot 2026-01-12 at 21 48 08" src="https://github.com/user-attachments/assets/650650b8-a0d1-4042-abe9-23001adddfe3" />
