### PR TITLE
Fixed ReferenceError in doSwitchMode caused by invalid saveLilypond binding

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1940,7 +1940,6 @@ class Activity {
                 activity.save.savePNG.bind(activity.save),
                 activity.save.saveWAV.bind(activity.save),
                 activity.save.saveLilypond.bind(activity.save),
-                activity.save.saveLilypond.bind(afterSaveLilypond),
                 activity.save.afterSaveLilypondLY.bind(activity.save),
                 activity.save.saveAbc.bind(activity.save),
                 activity.save.saveMxml.bind(activity.save),


### PR DESCRIPTION
### Summary
This PR fixes a runtime `ReferenceError` that occurs during mode switching due to an invalid function binding in `activity.js`.

### Details
The error was caused by passing an undefined identifier (`afterSaveLilypond`) to `.bind()` inside the `doSwitchMode()` logic. Since `afterSaveLilypond` is not defined or imported, this resulted in the following runtime error:

Sharing the link of doc for more details:

https://docs.google.com/document/d/1nDhnGIbmJsRB_24wqZa5ipXr88Jyoz10W7ndJAF96pc/edit?usp=sharing
closes #5153 

