### PR TITLE
refactor: remove unused variables and fix bugs

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -569,18 +569,6 @@ class SaveInterface {
         // Check if we have buffered notation data (Issue #2330)
         // If so, use it directly; otherwise run the program
         if (activity.logo.recordingBuffer.hasData) {
-            // Restore buffered data temporarily for save operation
-            const savedNotationOutput = activity.logo.notationOutput;
-            const savedNotationNotes = activity.logo.notationNotes;
-            const savedNotationStaging = {};
-            const savedNotationDrumStaging = {};
-
-            // Save current state
-            for (let t = 0; t < activity.turtles.getTurtleCount(); t++) {
-                savedNotationStaging[t] = activity.logo.notation.notationStaging[t];
-                savedNotationDrumStaging[t] = activity.logo.notation.notationDrumStaging[t];
-            }
-
             // Load buffered data
             activity.logo.notationOutput = activity.logo.recordingBuffer.notationOutput;
             activity.logo.notationNotes = activity.logo.recordingBuffer.notationNotes;

--- a/js/logo.js
+++ b/js/logo.js
@@ -1786,19 +1786,7 @@ class Logo {
 
         const tur = this.activity.turtles.ithTurtle(turtle);
 
-        if (Object.keys) {
-            if (Object.keys(tur.singer.embeddedGraphics).length === 0) return;
-        } else {
-            const isEmpty = true;
-            for (const key in tur.singer.embeddedGraphics) {
-                if (tur.singer.embeddedGraphics.hasOwnProperty(key)) {
-                    isEmpty = false;
-                    break;
-                }
-            }
-
-            if (isEmpty) return;
-        }
+        if (Object.keys(tur.singer.embeddedGraphics).length === 0) return;
 
         if (!(blk in tur.singer.embeddedGraphics)) return;
 
@@ -2337,7 +2325,7 @@ class Logo {
                     break;
 
                 case "clear":
-                    __clear(turtle, waitTime);
+                    __clear();
                     break;
 
                 case "fill":


### PR DESCRIPTION
## Description
Cleanup unused variables and fix bugs identified by in #4942.

## Changes
- Remove unused local variables in [SaveInterface.js](cci:7://file:///home/vyagh/Work/oss/sugarlabs/musicblocks/js/SaveInterface.js:0:0-0:0) (`savedNotationOutput`, `savedNotationNotes`)
- Remove legacy ES5 `Object.keys` fallback containing `const isEmpty` bug in [logo.js](cci:7://file:///home/vyagh/Work/oss/sugarlabs/musicblocks/js/logo.js:0:0-0:0)
- Fix superfluous arguments passed to [__clear()](cci:1://file:///home/vyagh/Work/oss/sugarlabs/musicblocks/js/logo.js:1868:8-1883:10) function

## References
- Follow-up to #4942
- Addresses feedback from @walterbender

## Testing
- ✅ Ran `npm run lint` - no errors
- ✅ Ran `npm test` - all 2275 tests passed
- ✅ reviewed by Copilot on my fork: zero issues found