### PR TITLE
Use HTML5 charset meta tag and clean up title

### DIFF
--- a/planet/index.html
+++ b/planet/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-            <title>Music Blocks </title>
-      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            <title>Music Blocks</title>
+        <meta charset="UTF-8">
         <!--Import Google Icon Font-->
         <link type="text/css" href="fonts/material-icons.css" rel="stylesheet">
         <!--Import materialize.css-->


### PR DESCRIPTION
This PR replaces the legacy http-equiv content-type meta tag with the
recommended HTML5 <meta charset="UTF-8"> declaration and removes an
extra space from the page title.

No functional behavior is changed.