### PR TITLE
docs(ToneBlocks): add parameter descriptions to audio effect blocks

### DIFF
--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -484,7 +484,11 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("The Tremolo block adds a wavering effect."),
+                _(
+                    "The Tremolo block adds a wavering effect. " +
+                    "Rate controls oscillation speed (Hz). " +
+                    "Depth sets intensity (0-100%)."
+                ),
                 "documentation",
                 null,
                 "tremolohelp"
@@ -630,7 +634,11 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("The Chorus block adds a chorus effect."),
+                _(
+                    "The Chorus block creates a richer sound. " +
+                    "Rate sets LFO speed. Delay is time offset (ms). " +
+                    "Depth controls modulation (0-100%)."
+                ),
                 "documentation",
                 null,
                 "chorushelp"
@@ -689,7 +697,11 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("The Vibrato block adds a rapid, slight variation in pitch."),
+                _(
+                    "The Vibrato block adds a rapid pitch variation. " +
+                    "Intensity sets how much the pitch varies. " +
+                    "Rate controls oscillation speed."
+                ),
                 "documentation",
                 null,
                 "vibratohelp"


### PR DESCRIPTION
Fixes #4881

## Summary
Add parameter explanations to Tremolo, Chorus, and Vibrato block help strings.

## Changes
- Tremolo: explains rate (oscillation speed) and depth (intensity)
- Chorus: explains rate (LFO speed), delay (ms), and depth (modulation)
- Vibrato: explains intensity (pitch variation) and rate (oscillation speed)

## Testing
- Lint passes
- All 2275 tests pass