### PR TITLE
feat(search): add 'No blocks found' feedback for empty searches

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,7 +156,7 @@ input[type="range"]:focus::-ms-fill-upper {
     font-size: 40px;
     font-weight: bold;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-    
+
     /* Cross-browser glass effect */
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);
@@ -172,4 +172,14 @@ input[type="range"]:focus::-ms-fill-upper {
 /* Class to trigger the fade-in */
 #zoomOverlay.visible {
     opacity: 1;
+}
+
+/* Search no results feedback */
+.ui-autocomplete-no-results {
+    padding: 10px 15px !important;
+    text-align: center;
+    color: #666;
+    font-style: italic;
+    background-color: #f5f5f5;
+    cursor: default;
 }

--- a/js/activity.js
+++ b/js/activity.js
@@ -3494,10 +3494,25 @@ class Activity {
                                 item.label.toLowerCase().indexOf(term) !== -1
                             );
                         });
-                        response(results);
+                        if (results.length === 0 && term.length > 0) {
+                            response([
+                                {
+                                    label: _("No blocks found"),
+                                    value: "",
+                                    artwork: "",
+                                    disabled: true
+                                }
+                            ]);
+                        } else {
+                            response(results);
+                        }
                     },
                     appendTo: "body",
                     select: (event, ui) => {
+                        if (ui.item.disabled) {
+                            event.preventDefault();
+                            return false;
+                        }
                         event.preventDefault();
                         that.searchWidget.value = ui.item.label;
                         that.searchWidget.idInput_custom = ui.item.value;
@@ -3513,6 +3528,18 @@ class Activity {
                 const instance = $search.autocomplete("instance");
                 if (instance) {
                     instance._renderItem = (ul, item) => {
+                        if (item.disabled) {
+                            return $j("<li class='ui-autocomplete-no-results'></li>")
+                                .text(item.label)
+                                .appendTo(
+                                    ul.css({
+                                        "z-index": 35000,
+                                        "max-height": "200px",
+                                        "overflow-y": "auto"
+                                    })
+                                );
+                        }
+
                         const li = $j("<li></li>");
 
                         const img = document.createElement("img");


### PR DESCRIPTION
## Description

Display a styled "No blocks found" message when block search returns no matches, instead of silently hiding the dropdown.

## Related Issue

This PR fixes #4841

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   Modified autocomplete `source` to detect empty results and return a disabled placeholder item
-   Added "No blocks found" message rendered via `_renderItem` for the disabled item
-   Added `.ui-autocomplete-no-results` CSS class for styling the empty-state message
-   Guarded `select` handler to prevent accidental selection of the disabled item

## Testing Performed

-   All 2275 Jest tests pass
-   ESLint and Prettier pass with no errors
-   Message displays correctly when searching for non-existent blocks
-   Normal search results continue to work correctly
-   Disabled item cannot be selected

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The empty-state message only shows when the user has typed a search term that yields no results. An empty search field (no term) still shows all blocks as before.

---

Thank you for contributing to our project! We appreciate your help in improving it.

📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md).

🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).