### PR TITLE
feat(toolbar): disable Stop button until Play is triggered

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -410,6 +410,9 @@ class Toolbar {
             isPlayIconRunning = false;
             onclick(this.activity);
             handleClick();
+            // Enable stop button when play starts
+            stopIcon.disabled = false;
+            stopIcon.className = "";
             stopIcon.style.color = this.stopIconColorWhenPlaying;
             saveButton.disabled = true;
             saveButtonAdvanced.disabled = true;
@@ -440,9 +443,15 @@ class Toolbar {
     renderStopIcon(onclick) {
         const stopIcon = docById("stop");
         const recordButton = docById("record");
+        // Disable stop button on load - nothing is playing yet
+        stopIcon.disabled = true;
+        stopIcon.className = "grey-text inactiveLink";
         stopIcon.onclick = () => {
             onclick(this.activity);
             stopIcon.style.color = "white";
+            // Disable stop button after stopping
+            stopIcon.disabled = true;
+            stopIcon.className = "grey-text inactiveLink";
             saveButton.disabled = false;
             saveButtonAdvanced.disabled = false;
             saveButton.className = "";


### PR DESCRIPTION
Fixes #5000

## Summary
Improves playback UX by making Stop button state reflect actual playback status.

## Changes
- Stop button is disabled on page load
- Stop button becomes enabled when Play is clicked
- Stop button returns to disabled after stopping playback

## Testing
- Lint passes
- All 2275 tests pass
- Stop button greyed out on load
- Stop activates on Play, deactivates on Stop