### PR TITLE
fix(toolbar): sync horizontal scroll icon state on mode switch

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -938,18 +938,22 @@ class Toolbar {
                     delPluginIcon.onclick = () => delPlugin_onclick(this.activity);
                 }
 
-                // Horizontal Scroll
+                // Horizontal Scroll - sync icon state with current scroll setting
                 const enableHorizScrollIcon = docById("enableHorizScrollIcon");
                 const disableHorizScrollIcon = docById("disableHorizScrollIcon");
 
-                if (enableHorizScrollIcon) {
-                    enableHorizScrollIcon.style.display = "block";
+                if (enableHorizScrollIcon && disableHorizScrollIcon) {
+                    // Show correct icon based on current scroll state
+                    if (this.activity.scrollBlockContainer) {
+                        enableHorizScrollIcon.style.display = "none";
+                        disableHorizScrollIcon.style.display = "block";
+                    } else {
+                        enableHorizScrollIcon.style.display = "block";
+                        disableHorizScrollIcon.style.display = "none";
+                    }
                     enableHorizScrollIcon.onclick = () => {
                         setScroller(this.activity);
                     };
-                }
-
-                if (disableHorizScrollIcon) {
                     disableHorizScrollIcon.onclick = () => {
                         setScroller(this.activity);
                     };


### PR DESCRIPTION
Fixes #5077

## Summary
Fix UI-state desynchronization where horizontal scrolling icon shows wrong state after switching modes.

## Changes
- Check `scrollBlockContainer` state when switching to Advanced mode
- Show correct icon (Enable/Disable) based on actual scroll setting

## Testing
- Lint passes
- All 2275 tests pass
- Enable horizontal scrolling in Advanced mode
- Switch to Beginner mode
- Switch back to Advanced mode
- Icon correctly shows "Disable" (enabled state)