### PR TITLE
fix(paste): validate input before JSON.parse to prevent crash

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6588,11 +6588,18 @@ class Activity {
                 return;
             }
 
-            const cleanData = rawData.replace("\n", " ");
+            const cleanData = rawData.replace(/\n/g, " ").trim();
+
+            // Check if input looks like JSON (starts with [ or {)
+            if (!cleanData.startsWith("[") && !cleanData.startsWith("{")) {
+                this.errorMsg(_("Please paste valid Music Blocks code (JSON format)."));
+                return;
+            }
+
             try {
                 obj = JSON.parse(cleanData);
             } catch (e) {
-                this.errorMsg(_("Could not parse JSON input."));
+                this.errorMsg(_("Invalid JSON format. Please paste exported Music Blocks code."));
                 return;
             }
 


### PR DESCRIPTION
Fixes #5026

## Summary
Prevent crash when pasting plain text by validating input before JSON.parse.

## Changes
- Add pre-validation to check if input starts with `[` or `{`
- Show helpful error message when non-JSON text is pasted
- Fix newline replacement to handle all newlines (not just first)

## Testing
- Lint passes
- All 2275 tests pass
- Paste plain text - shows helpful error message
- Paste valid JSON - works correctly