### PR TITLE
Fix chart SVG background transparency-2

### DIFF
--- a/Docs/charts/DotsChart.svg
+++ b/Docs/charts/DotsChart.svg
@@ -15,16 +15,13 @@
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
    style=""
    id="svg376">
-  <rect
-     id="backgroundrect"
-     width="100%"
-     height="100%"
-     x="0"
-     y="0"
-     fill="none"
-     stroke="none"
-     class=""
-     style="" />
+   <!-- White background -->
+   <rect
+    x="0"
+    y="0"
+    width="100%"
+    height="100%"
+    fill="#ffffff" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/Docs/charts/KeyboardChart.svg
+++ b/Docs/charts/KeyboardChart.svg
@@ -16,6 +16,13 @@
    version="1.1"
    inkscape:version="0.48.4 r9939"
    sodipodi:docname="5804776004517888_1484319518_KeyboardChart_3.0.svg">
+    <!-- White background -->
+   <rect
+    x="0"
+    y="0"
+    width="100%"
+    height="100%"
+    fill="#ffffff" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/Docs/charts/TiesChart.svg
+++ b/Docs/charts/TiesChart.svg
@@ -32,14 +32,13 @@
      inkscape:window-y="-9"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg1" />
-  <rect
-     id="backgroundrect"
-     width="100%"
-     height="100%"
-     x="-28.156382"
-     y="-26.747662"
-     fill="none"
-     stroke="none" />
+   <!-- White background -->
+   <rect
+    x="0"
+    y="0"
+    width="100%"
+    height="100%"
+    fill="#ffffff" />
   <title
      id="title4653">Ties Chart</title>
   <defs


### PR DESCRIPTION
# Add white background to SVG files for improved visibility

## Problem
Three SVG files (`DotsChart.svg` , `KeyboardChart.svg` and 'TiesChart.svg') had transparent backgrounds, making their dark text and musical notation elements illegible when displayed on dark backgrounds (such as in dark mode interfaces or documentation with dark themes).

## Solution
Added white background fills to the SVG files to ensure consistent visibility across all background colors and themes.


## Changes
- Added white background to `DotsChart.svg`
- Added white background to `KeyboardChart.svg`
- Added white background to `TiesChart.svg`

## Visual Impact
- Text and notation elements are now clearly visible regardless of the background color of the containing page
- Maintains visual consistency with the documentation design
- Improves accessibility and readability in dark mode environments

## Testing
- [x] Verified SVG files render correctly on light backgrounds
- [x] Verified SVG files render correctly on dark backgrounds
- [x] Confirmed no layout or sizing issues introduced