### PR TITLE
Fix oscilloscope RAF loop lifecycle and prevent infinite redraws

### DIFF
--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -48,7 +48,6 @@ class Oscilloscope {
 
         // RAF lifecycle state
         this._running = false;
-        this._rafId = null;
         this.drawVisualIDs = {};
 
         const widgetWindow = window.widgetWindows.windowFor(this, "oscilloscope");
@@ -94,13 +93,11 @@ class Oscilloscope {
     close() {
         this._running = false;
 
-        if (this._rafId !== null) {
-            cancelAnimationFrame(this._rafId);
-            this._rafId = null;
-        }
-
+        // Cancel all turtle animation frames
         for (const id in this.drawVisualIDs) {
-            cancelAnimationFrame(this.drawVisualIDs[id]);
+            if (this.drawVisualIDs[id] !== null) {
+                cancelAnimationFrame(this.drawVisualIDs[id]);
+            }
         }
 
         this.drawVisualIDs = {};
@@ -137,8 +134,10 @@ class Oscilloscope {
             const canDraw = (this.pitchAnalysers[turtleIdx] && turtle.running) || resizedOnce;
 
             if (!canDraw) {
-                this._running = false;
                 this.drawVisualIDs[turtleIdx] = null;
+
+                // Check if any turtle is still running
+                this._running = Object.values(this.drawVisualIDs).some(id => id !== null);
                 return;
             }
 
@@ -167,8 +166,7 @@ class Oscilloscope {
             canvasCtx.lineTo(canvas.width, canvas.height / 2);
             canvasCtx.stroke();
 
-            this._rafId = requestAnimationFrame(draw);
-            this.drawVisualIDs[turtleIdx] = this._rafId;
+            this.drawVisualIDs[turtleIdx] = requestAnimationFrame(draw);
         };
 
         draw();


### PR DESCRIPTION
fixes 2 of 3 - #5145 

## Description

This PR fixes a bug where the oscilloscope widget kept running its animation loop even when it was no longer needed.

Earlier, the oscilloscope could continue drawing:

after the widget was closed

when playback was stopped

or after a resize

This caused unnecessary CPU usage and hidden background activity.

## What this PR changes

### **a] Proper control of the animation loop**

The oscilloscope now tracks whether it is running using:
a] _running
b] _rafId

The next animation frame is scheduled only when:
a] the widget is open
b] and there is something to draw

### **b] Stop drawing when the widget is closed**

When the oscilloscope window is closed:
1] all active requestAnimationFrame loops are cancelled
2] internal state is cleared
3] the widget is safely destroyed

So no background drawing continues after closing.

### **c] Stop drawing when playback stops or nothing is drawn**

The draw loop now checks a single condition (canDraw).

If there is no sound or nothing to display:

a] the loop stops
b] no new animation frame is scheduled

### **d] Fix resize keeping the loop alive**

Resize now triggers only one redraw using a one-time flag (resizedOnce).
It no longer keeps the animation loop running forever after resizing.

### **e] Safe initialization of RAF tracking**

drawVisualIDs is now always initialized before use.
This prevents invalid cancelAnimationFrame calls and avoids errors.

## testing 
<img width="407" height="139" alt="Screenshot 2026-01-14 212655" src="https://github.com/user-attachments/assets/fb438efe-b39d-41ad-8699-6d5060cdcff5" />
