### PR TITLE
Fix low contrast loading text in light mode

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -60,6 +60,10 @@
   background-color: #1a1a1a !important;
 }
 
+#loadingText{
+  color: #333 !important;
+}
+
 .dark #loadingText {
   color: white !important;
 }


### PR DESCRIPTION
Fixes #5139

The loading screen text had low contrast in light mode, making it difficult to read.
This PR improves readability by adding an explicit light-mode color (#333) for the #loadingText element while preserving the existing dark mode styling.

Screenshots:
<img width="1448" height="847" alt="image" src="https://github.com/user-attachments/assets/af0de4ce-6dc8-4533-95c8-e351aa68b3ce" />
