### PR TITLE
Fix typo in drum state variable initialization globally/locally.

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -4,7 +4,7 @@
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the The GNU Affero General Public
-// License as published by the Free Software Foundatioff; either
+// License as published by the Free Software Foundation; either
 // version 3 of the License, or (at your option) any later version.
 //
 // You should have received a copy of the GNU Affero General Public
@@ -177,7 +177,7 @@ class Logo {
         this.inTempo = false;
         this.inPitchSlider = false;
         this.inMusicKeyboard = false;
-        this._currentDrumlock = null;
+        this._currentDrumBlock = null;
         this.inTimbre = false;
         this.inArpeggio = false;
         this.insideModeWidget = false;


### PR DESCRIPTION
- What this PR does

Fixes a typo in the Logo class where the drum state variable was
initialized with an incorrect property name.

The codebase consistently uses `_currentDrumBlock`, but the constructor
was initializing `_currentDrumlock` instead. Since JavaScript allows
dynamic property creation, this resulted in two separate properties
being created and caused incorrect drum state tracking.

screenshot:
<img width="485" height="368" alt="Screenshot 2026-01-15 195233" src="https://github.com/user-attachments/assets/18c101f7-c2a6-478d-befe-45372615ed6e" />


<img width="574" height="159" alt="Screenshot 2026-01-15 203009" src="https://github.com/user-attachments/assets/e901ec5a-b323-4393-9a8a-167fe39767fe" />

-Why this matters

-_currentDrumBlock` is the globally used and expected property
-_currentDrumlock` was an accidental, unused property
- This typo caused silent logic errors without throwing any runtime exception

 Fix :

The constructor now correctly initializes:

this._currentDrumBlock = null;
