### PR TITLE
Add troubleshooting notes for local Music Blocks setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ Before you begin, ensure you have Docker installed on your machine. You can down
 To stop the Docker container, use `Ctrl + C` in your terminal. This
 will stop the container and free up the port it was using.
 
+## Troubleshooting
+When running Music Blocks locally using `npm run dev`, the UI may load successfully even if some interactions appear unresponsive.
+
+New contributors may observe console errors such as:
+- `$ is not defined`
+- `lang is not defined`
+- `p5 is not defined`
+
+These errors can occur due to script loading order and initialization differences in local environments.
+
+If the UI loads and assets render correctly, the setup is generally considered successful for development purposes.
+
+Future improvements may address these issues as part of ongoing refactoring efforts.
+
 ## Additional Notes
 
 - Make sure to replace `musicblocks` with the appropriate image name


### PR DESCRIPTION
This PR adds documentation clarifying expected behavior and common console errors when running Music Blocks locally.

This should help new contributors understand when their setup is working as intended and reduce confusion during onboarding.

Fixes #5187 
