### PR TITLE
Remove gif-animator from activity.js dependencies and load it exclusively via index.html.

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -74,7 +74,6 @@ let MYDEFINES = [
     "widgets/status",
     "widgets/help",
     "utils/munsell",
-    "activity/gif-animator",
     "activity/toolbar",
     "activity/trash",
     "activity/boundary",


### PR DESCRIPTION
GIFAnimator is a global singleton and not an AMD module. When loaded via both index.html and RequireJS, it is evaluated twice, leading to runtime errors due to duplicate class declarations.

<img width="725" height="39" alt="image" src="https://github.com/user-attachments/assets/818504e6-c221-4151-b3b4-83a2a538b408" />

To ensure single evaluation, predictable load order, and consistency with other global utilities, GIFAnimator is now loaded only at the HTML entry point.

Verification
- [x] Activity loads without errors on hard refresh
- [x] GIF animation functionality remains unchanged
- [x] No duplicate script execution observed