### PR TITLE
Fix: Add localized tooltips for Close and Minimize buttons

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -108,6 +108,7 @@ class WidgetWindow {
             };
         }
         const closeButton = this._create("div", "wftButton close", this._drag);
+        closeButton.title = _("Close");
         closeButton.onclick = e => {
             this.onclose();
             e.preventDefault();
@@ -152,6 +153,7 @@ class WidgetWindow {
         this._nonclosebuttons.style.display = "flex";
         this._rollButton = this._create("div", "wftButton rollup", this._nonclosebuttons);
         const rollButton = this._rollButton;
+        rollButton.title = _("Minimize");
         rollButton.onclick = e => {
             if (this._rolled) {
                 this.unroll();


### PR DESCRIPTION
### **Overview**
This Pull Request improves the user interface accessibility of the `WidgetWindow` component by adding descriptive tooltips to the **Close** and **Minimize** (Roll) buttons. These buttons previously lacked text descriptors, which could be confusing for new users or those using screen readers.

### **Changes**
* **Added localized titles**: Implemented `closeButton.title = _("Close");` to provide a hover descriptor for the close action.
* **Added minimize titles**: Implemented `rollButton.title = _("Minimize");` for the rollup/minimize functionality.
* **Localization Support**: Wrapped strings in the `_()` translation function to ensure they display in the user's selected language.

### **Technical Details**
* **File Modified**: `js/widgets/widgetWindows.js`
* **Approach**: Used native HTML `title` attributes for stability and to avoid unnecessary overhead or loading conflicts with external libraries.
* **Rule Compliance**: This change is submitted as a standalone PR to comply with the project's "one change per PR" guideline, keeping UI logic separate from bulk translation updates.

### **Testing Performed**
* Verified that the "Music Blocks" loading screen completes successfully without errors.
* Hovered over the "X" and "Minimize" buttons to confirm the tooltips appear correctly.
* Ran `npm run lint` to ensure code style consistency.

> **Note to Maintainers**: The Bengali translations for the "Close" and "Minimize" strings used here are included in my existing translation PR #5183.