### PR TITLE
Fix turtle avatar zoom duplication and position drift

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -680,6 +680,7 @@ Turtle.TurtleView = class {
     constructor() {
         // createjs object of start block (decoration)
         this._decorationBitmap = null;
+        this._decorationBaseScale = 0.5; // Base scale factor for decoration (27.5 / image.width)
 
         this._container = null; // createjs container
         this._bitmap = null; // createjs bitmap
@@ -855,16 +856,18 @@ Turtle.TurtleView = class {
                 startBlock.container.addChild(this._decorationBitmap);
                 this._decorationBitmap.name = "decoration";
 
+                // Store the base scale factor for use in resizeDecoration
+                this._decorationBaseScale = 27.5 / image.width;
+
                 const width = startBlock.width;
-                // FIXME: Why is the position off? Does it need a scale factor?
                 this._decorationBitmap.x = width - (30 * startBlock.protoblock.scale) / 2;
                 this._decorationBitmap.y = (20 * startBlock.protoblock.scale) / 2;
                 this._decorationBitmap.scaleX =
-                    ((27.5 / image.width) * startBlock.protoblock.scale) / 2;
+                    (this._decorationBaseScale * startBlock.protoblock.scale) / 2;
                 this._decorationBitmap.scaleY =
                     ((27.5 / image.height) * startBlock.protoblock.scale) / 2;
                 this._decorationBitmap.scale =
-                    ((27.5 / image.width) * startBlock.protoblock.scale) / 2;
+                    (this._decorationBaseScale * startBlock.protoblock.scale) / 2;
                 startBlock.updateCache();
             }
 
@@ -880,9 +883,9 @@ Turtle.TurtleView = class {
      */
     resizeDecoration(scale, width) {
         this._decorationBitmap.x = width - (30 * scale) / 2;
-        this._decorationBitmap.y = (35 * scale) / 2;
+        this._decorationBitmap.y = (20 * scale) / 2; // Use 20 to match doTurtleShell
         this._decorationBitmap.scaleX = this._decorationBitmap.scaleY = this._decorationBitmap.scale =
-            (0.5 * scale) / 2;
+            (this._decorationBaseScale * scale) / 2;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes the bug where zooming the workspace after running an avatar block would cause the decoration image on the start block to grow huge and drift downward.

Related to #5191

## Problem
When zooming the workspace after clicking Play with an avatar block:
1. The decoration image would grow to 100% size (becoming huge)
2. The decoration drifted downward from its correct position

## Root Cause
The resize logic used:
- A fixed scale formula instead of the image-based scale
- Inconsistent y-position values (35 vs 20)

## Solution
- Added a property to store the image-based scale factor
- Store this value when the avatar image is set
- Use the stored value during resize instead of the fixed value
- Fixed y-position to use consistent values

## Testing
- ✅ Manual testing: Zoom no longer causes duplication or position drift
- ✅ All 346 turtle-related tests pass

https://github.com/user-attachments/assets/4b88cebd-0f1c-4e31-9960-bcc1064bd1de

