### PR TITLE
ui:Fix Aux toolbar to show visiblity at all sizes

### DIFF
--- a/css/play-only-mode.css
+++ b/css/play-only-mode.css
@@ -117,20 +117,6 @@
     }
 }
 
-@media (max-width: 768px),
-(max-height: 600px) {
-
-    /* Hide the full auxiliary button */
-    .play-only #toggleAuxBtn {
-        display: none !important;
-    }
-
-    /* Hide the full auxiliary toolbar */
-    .play-only #aux-toolbar {
-        display: none !important;
-    }
-}
-
 /* Make the container background invisible without affecting child elements */
 .play-only #buttoncontainerBOTTOM {
     background: transparent !important;


### PR DESCRIPTION
Fixes: #5025 
This pull request removes a media query from the `css/play-only-mode.css` file that previously hid the auxiliary button and toolbar on small screens. This means that in play-only mode, the auxiliary controls will now remain visible regardless of screen size.

- **UI Behavior Update:**
  * Removed the media query that hid `#toggleAuxBtn` and `#aux-toolbar` in play-only mode on screens smaller than 768px wide or 600px tall, making these elements always visible.


https://github.com/user-attachments/assets/a8ff4af8-d26f-4098-a38f-00a459f2df48

