### PR TITLE
Fix broken guide link in Musicblocks help (#5225)

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -73,7 +73,7 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
             GUIDEURL = "Docs/guide/index.html";
         } else {
             // Production environment
-            GUIDEURL = "https://musicblocks.sugarlabs.org/Docs/guide/";
+            GUIDEURL = "https://musicblocks.sugarlabs.org/Docs/guide/index.html";
         }
     }
 
@@ -472,7 +472,7 @@ const createHelpContent = activity => {
                 _("Guide"),
                 _("A detailed guide to Music Blocks is available."),
                 "data:image/svg+xml;base64," + window.btoa(base64Encode(LOGO)),
-                "https://musicblocks.sugarlabs.org/Docs/guide/",
+                GUIDEURL,
                 _("Music Blocks Guide")
             ],
             [


### PR DESCRIPTION
### Problem
The "Guide" link in the Music Blocks Help widget points to outdated URLs
which return 404.

### Solution
Updated the Music Blocks Help "Guide" entry to point to the correct
documentation URL:
https://musicblocks.sugarlabs.org/Docs/guide/

### Notes
- Fixes broken help link in production
- Keeps local development behavior unchanged

Fixes #5225
