### PR TITLE
perf: defer non-critical scripts for faster initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,12 @@
     <!-- libgif.js (SuperGif) provides low-level GIF frame extraction.
      Browsers expose only the first frame of a GIF; SuperGif lets us
      step through frames so animated GIFs can be drawn onto our canvas. -->
-    <script src="https://cdn.jsdelivr.net/gh/buzzfeed/libgif-js/libgif.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/buzzfeed/libgif-js/libgif.js" defer></script>
 
     <!-- gif-animator.js integrates SuperGif with Music Blocks. It manages
      decoding and drawing GIF frames onto the turtle's overlay canvas.
      Canvas refreshing is handled separately by CreateJS Ticker. -->
-    <script src="js/gif-animator.js"></script>
+    <script src="js/gif-animator.js" defer></script>
     <script defer>
         document.addEventListener("DOMContentLoaded", function () {
             if (window.hljs) hljs.highlightAll();
@@ -84,9 +84,11 @@
     <script src="lib/tweenjs.min.js" defer></script>
     <script>
         let ast2blocklist_config;
-        fetch("js/js-export/ast2blocks.min.json")
-            .then(response => response.json())
-            .then(data => { ast2blocklist_config = data })
+        document.addEventListener("DOMContentLoaded", function () {
+            fetch("js/js-export/ast2blocks.min.json")
+                .then(response => response.json())
+                .then(data => { ast2blocklist_config = data });
+        });
     </script>
 </head>
 


### PR DESCRIPTION
Defers non-critical scripts in [index.html](cci:7://file:///home/vyagh/Work/oss/sugarlabs/musicblocks/index.html:0:0-0:0) to reduce render-blocking time during initial load.

### Changes

- Added `defer` to `libgif.js` and [gif-animator.js](cci:7://file:///home/vyagh/Work/oss/sugarlabs/musicblocks/js/gif-animator.js:0:0-0:0), only used when loading GIFs (user-initiated)
- Wrapped `ast2blocklist_config` fetch in `DOMContentLoaded`, only needed for JS editor's "Convert to Blocks" button

None of these are accessed during page initialization, so deferring them is safe.

### Not Deferred

jQuery remains synchronous because inline scripts like `$(document).ready()` depend on it being available immediately. Deferring it would require refactoring all consuming code, which i believe is outside the scope of this fix.

### Verification

- ESLint: ✅
- Jest (2327 tests): ✅
- Browser tested: App loads normally, all deferred resources available when needed

Closes #5224