### PR TITLE
fix: compute _slotSize dynamically instead of hardcoded value

### DIFF
--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -74,7 +74,7 @@ class SVG {
         this._expandY2 = 0;
         this._clampCount = 1;
         this._clampSlots = [1];
-        this._slotSize = 21; // TODO: Compute this.
+        this._slotSize = 2 * this._innieY2 + this._inniesSpacer + this._padding;
         this._arm = true;
         this._else = false;
         this._draw_inniess = true;


### PR DESCRIPTION

## Summary

Compute `_slotSize` dynamically in the SVG class instead of using a hardcoded value.

Closes #5233

## Problem

In `js/blockfactory.js`, the SVG class hardcodes `_slotSize`:

```javascript
this._slotSize = 21; // TODO: Compute this.
```

While related geometry values like `_innieY2`, `_strokeWidth`, and `_padding` are computed dynamically, `_slotSize` was left as a magic number. This could cause incorrect spacing under non-default rendering conditions.

## Solution

Replace the hardcoded value with dynamic computation:

```javascript
this._slotSize = 2 * this._innieY2 + this._inniesSpacer + this._padding;
```

**Formula derivation:**
| Parameter | Default Value | Computation |
|-----------|---------------|-------------|
| `_innieY2` | 4 | `(9 - _strokeWidth) / 2` |
| `_inniesSpacer` | 9 | fixed |
| `_padding` | 4 | `_innieY1 + _strokeWidth` |
| **`_slotSize`** | **21** | `2*4 + 9 + 4 = 21` ✓ |

This ensures `_slotSize` stays consistent with the rest of the geometry system.

## Testing

### Unit Tests

All 2532 tests pass:

```
Test Suites: 94 passed, 94 total
Tests:       2532 passed, 2532 total
```

### Browser Testing

Tested multiple clamp block types to verify correct rendering:

| Test | Block Type     | Result                    |
| ---- | -------------- | ------------------------- |
| 1    | repeat         | ✓ clamp renders correctly |
| 2    | nested blocks  | ✓ snaps without gaps      |
| 3    | if-then-else   | ✓ both clamps consistent  |
| 4    | multiple slots | ✓ spacing correct         |
| 5    | forever        | ✓ geometry correct        |

**Steps to reproduce:**

1. Run `npm run serve`
2. Open musicblocks on your browser
3. Search for "repeat" and drag to canvas
4. Drag a "note" block into the repeat clamp
5. Verify proper snapping and spacing
6. Repeat with "if then else" and "forever" blocks

## Checklist

- [x] Follows project code style
- [x] Passes linting (`npm run lint`)
- [x] Passes all tests (`npm test`)
- [x] Formatted with Prettier
- [x] Browser tested clamp block rendering