### PR TITLE
Fix undefined doSearch call on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,7 +548,9 @@ document.addEventListener("DOMContentLoaded", init);
     </script>
     <script>
         $(document).ready(function () {
-            doSearch();
+            if (typeof doSearch === "function") {
+                doSearch();
+            }    
         });
     </script>
 


### PR DESCRIPTION
This PR fixes a console error caused by calling doSearch() before it is defined.

The call is now guarded with a type check to ensure the function exists before execution, preventing runtime errors on page load.
