### PR TITLE
Perf/cache get note from interval calls

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -581,91 +581,92 @@ function Synth() {
 
         const frequency = Tone.Frequency(startPitch).toFrequency();
 
+        // Cache getNoteFromInterval results to avoid duplicate calls (performance optimization)
+        const intervalCache = {
+            "minor 2": getNoteFromInterval(startingPitch, "minor 2"),
+            "augmented 1": getNoteFromInterval(startingPitch, "augmented 1"),
+            "major 2": getNoteFromInterval(startingPitch, "major 2"),
+            "minor 3": getNoteFromInterval(startingPitch, "minor 3"),
+            "augmented 2": getNoteFromInterval(startingPitch, "augmented 2"),
+            "major 3": getNoteFromInterval(startingPitch, "major 3"),
+            "augmented 3": getNoteFromInterval(startingPitch, "augmented 3"),
+            "diminished 4": getNoteFromInterval(startingPitch, "diminished 4"),
+            "perfect 4": getNoteFromInterval(startingPitch, "perfect 4"),
+            "augmented 4": getNoteFromInterval(startingPitch, "augmented 4"),
+            "diminished 5": getNoteFromInterval(startingPitch, "diminished 5"),
+            "perfect 5": getNoteFromInterval(startingPitch, "perfect 5"),
+            "augmented 5": getNoteFromInterval(startingPitch, "augmented 5"),
+            "minor 6": getNoteFromInterval(startingPitch, "minor 6"),
+            "major 6": getNoteFromInterval(startingPitch, "major 6"),
+            "augmented 6": getNoteFromInterval(startingPitch, "augmented 6"),
+            "minor 7": getNoteFromInterval(startingPitch, "minor 7"),
+            "major 7": getNoteFromInterval(startingPitch, "major 7"),
+            "augmented 7": getNoteFromInterval(startingPitch, "augmented 7"),
+            "diminished 8": getNoteFromInterval(startingPitch, "diminished 8"),
+            "perfect 8": getNoteFromInterval(startingPitch, "perfect 8")
+        };
+
         this.noteFrequencies = {
             // note: [octave, Frequency]
             [startingPitch.substring(0, len - 1)]: [Number(startingPitch.slice(-1)), frequency],
-            [getNoteFromInterval(startingPitch, "minor 2")[0]]: [
-                getNoteFromInterval(startingPitch, "minor 2")[1],
-                t["minor 2"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "augmented 1")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 1")[1],
+            [intervalCache["minor 2"][0]]: [intervalCache["minor 2"][1], t["minor 2"] * frequency],
+            [intervalCache["augmented 1"][0]]: [
+                intervalCache["augmented 1"][1],
                 t["augmented 1"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "major 2")[0]]: [
-                getNoteFromInterval(startingPitch, "major 2")[1],
-                t["major 2"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "minor 3")[0]]: [
-                getNoteFromInterval(startingPitch, "minor 3")[1],
-                t["minor 3"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "augmented 2")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 2")[1],
+            [intervalCache["major 2"][0]]: [intervalCache["major 2"][1], t["major 2"] * frequency],
+            [intervalCache["minor 3"][0]]: [intervalCache["minor 3"][1], t["minor 3"] * frequency],
+            [intervalCache["augmented 2"][0]]: [
+                intervalCache["augmented 2"][1],
                 t["augmented 2"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "major 3")[0]]: [
-                getNoteFromInterval(startingPitch, "major 3")[1],
-                t["major 3"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "augmented 3")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 3")[1],
+            [intervalCache["major 3"][0]]: [intervalCache["major 3"][1], t["major 3"] * frequency],
+            [intervalCache["augmented 3"][0]]: [
+                intervalCache["augmented 3"][1],
                 t["augmented 3"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "diminished 4")[0]]: [
-                getNoteFromInterval(startingPitch, "diminished 4")[1],
+            [intervalCache["diminished 4"][0]]: [
+                intervalCache["diminished 4"][1],
                 t["diminished 4"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "perfect 4")[0]]: [
-                getNoteFromInterval(startingPitch, "perfect 4")[1],
+            [intervalCache["perfect 4"][0]]: [
+                intervalCache["perfect 4"][1],
                 t["perfect 4"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "augmented 4")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 4")[1],
+            [intervalCache["augmented 4"][0]]: [
+                intervalCache["augmented 4"][1],
                 t["augmented 4"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "diminished 5")[0]]: [
-                getNoteFromInterval(startingPitch, "diminished 5")[1],
+            [intervalCache["diminished 5"][0]]: [
+                intervalCache["diminished 5"][1],
                 t["diminished 5"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "perfect 5")[0]]: [
-                getNoteFromInterval(startingPitch, "perfect 5")[1],
+            [intervalCache["perfect 5"][0]]: [
+                intervalCache["perfect 5"][1],
                 t["perfect 5"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "augmented 5")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 5")[1],
+            [intervalCache["augmented 5"][0]]: [
+                intervalCache["augmented 5"][1],
                 t["augmented 5"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "minor 6")[0]]: [
-                getNoteFromInterval(startingPitch, "minor 6")[1],
-                t["minor 6"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "major 6")[0]]: [
-                getNoteFromInterval(startingPitch, "major 6")[1],
-                t["major 6"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "augmented 6")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 6")[1],
+            [intervalCache["minor 6"][0]]: [intervalCache["minor 6"][1], t["minor 6"] * frequency],
+            [intervalCache["major 6"][0]]: [intervalCache["major 6"][1], t["major 6"] * frequency],
+            [intervalCache["augmented 6"][0]]: [
+                intervalCache["augmented 6"][1],
                 t["augmented 6"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "minor 7")[0]]: [
-                getNoteFromInterval(startingPitch, "minor 7")[1],
-                t["minor 7"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "major 7")[0]]: [
-                getNoteFromInterval(startingPitch, "major 7")[1],
-                t["major 7"] * frequency
-            ],
-            [getNoteFromInterval(startingPitch, "augmented 7")[0]]: [
-                getNoteFromInterval(startingPitch, "augmented 7")[1],
+            [intervalCache["minor 7"][0]]: [intervalCache["minor 7"][1], t["minor 7"] * frequency],
+            [intervalCache["major 7"][0]]: [intervalCache["major 7"][1], t["major 7"] * frequency],
+            [intervalCache["augmented 7"][0]]: [
+                intervalCache["augmented 7"][1],
                 t["augmented 7"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "diminished 8")[0]]: [
-                getNoteFromInterval(startingPitch, "diminished 8")[1],
+            [intervalCache["diminished 8"][0]]: [
+                intervalCache["diminished 8"][1],
                 t["diminished 8"] * frequency
             ],
-            [getNoteFromInterval(startingPitch, "perfect 8")[0]]: [
-                getNoteFromInterval(startingPitch, "perfect 8")[1],
+            [intervalCache["perfect 8"][0]]: [
+                intervalCache["perfect 8"][1],
                 t["perfect 8"] * frequency
             ]
         };
@@ -2773,13 +2774,12 @@ function Synth() {
                                         i < tempBlock._accidentalsWheel.navItems.length;
                                         i++
                                     ) {
-                                        tempBlock._accidentalsWheel.navItems[
-                                            i
-                                        ].navigateFunction = () => {
-                                            selectionState.accidental =
-                                                tempBlock._accidentalsWheel.navItems[i].title;
-                                            updateTargetNote();
-                                        };
+                                        tempBlock._accidentalsWheel.navItems[i].navigateFunction =
+                                            () => {
+                                                selectionState.accidental =
+                                                    tempBlock._accidentalsWheel.navItems[i].title;
+                                                updateTargetNote();
+                                            };
                                     }
                                 }
 
@@ -2790,16 +2790,15 @@ function Synth() {
                                         i < tempBlock._octavesWheel.navItems.length;
                                         i++
                                     ) {
-                                        tempBlock._octavesWheel.navItems[
-                                            i
-                                        ].navigateFunction = () => {
-                                            const octave =
-                                                tempBlock._octavesWheel.navItems[i].title;
-                                            if (octave && !isNaN(octave)) {
-                                                selectionState.octave = parseInt(octave);
-                                                updateTargetNote();
-                                            }
-                                        };
+                                        tempBlock._octavesWheel.navItems[i].navigateFunction =
+                                            () => {
+                                                const octave =
+                                                    tempBlock._octavesWheel.navItems[i].title;
+                                                if (octave && !isNaN(octave)) {
+                                                    selectionState.octave = parseInt(octave);
+                                                    updateTargetNote();
+                                                }
+                                            };
                                     }
                                 }
 


### PR DESCRIPTION
## Summary

This PR optimizes the [temperamentChanged](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/synthutils.js:554:4-692:6) function in [js/utils/synthutils.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/synthutils.js:0:0-0:0) by caching [getNoteFromInterval](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/musicutils.js:3653:0-3947:2) results to avoid duplicate function calls.

## Problem

Previously, [getNoteFromInterval](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/musicutils.js:3653:0-3947:2) was called **twice** for each musical interval in the [temperamentChanged](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/synthutils.js:554:4-692:6) function - once to get the note name (`[0]`) and once to get the octave (`[1]`). This resulted in **42 calls** where only **21 were needed**.

## Solution

Cache each [getNoteFromInterval](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/musicutils.js:3653:0-3947:2) result in an `intervalCache` object and reuse the cached values when building `noteFrequencies`.

## Performance Improvement

- **50% reduction** in [getNoteFromInterval](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/musicutils.js:3653:0-3947:2) calls (42 → 21) per temperament change