### PR TITLE
perf: Cache rationalToFraction result in note frequency loop

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -2054,8 +2054,9 @@ class Singer {
                         0,
                         null
                     );
-                    const pitchNumber = getTemperament(activity.logo.synth.inTemperament)
-                        .pitchNumber;
+                    const pitchNumber = getTemperament(
+                        activity.logo.synth.inTemperament
+                    ).pitchNumber;
                     const ratio = [];
                     const number = [];
                     const numerator = [];
@@ -2068,8 +2069,10 @@ class Singer {
                                 pitchNumber *
                                 (Math.log10(ratio[k]) / Math.log10(getOctaveRatio()))
                             ).toFixed(0);
-                            numerator[k] = rationalToFraction(ratio[k])[0];
-                            denominator[k] = rationalToFraction(ratio[k])[1];
+                            // Cache rationalToFraction result to avoid duplicate calls
+                            const fraction = rationalToFraction(ratio[k]);
+                            numerator[k] = fraction[0];
+                            denominator[k] = fraction[1];
                         }
                     }
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1717,8 +1717,14 @@ function TemperamentWidget() {
             [4, ["number", { value: this.frequencies[0] }], 0, 0, [2]],
             [5, ["octavespace"], 0, 0, [2, 6, 9]],
             [6, ["divide"], 0, 0, [5, 7, 8]],
-            [7, ["number", { value: rationalToFraction(getOctaveRatio())[0] }], 0, 0, [6]],
-            [8, ["number", { value: rationalToFraction(getOctaveRatio())[1] }], 0, 0, [6]],
+            // Cache rationalToFraction result to avoid duplicate calls
+            ...(function () {
+                const octaveFraction = rationalToFraction(getOctaveRatio());
+                return [
+                    [7, ["number", { value: octaveFraction[0] }], 0, 0, [6]],
+                    [8, ["number", { value: octaveFraction[1] }], 0, 0, [6]]
+                ];
+            })(),
             [9, "vspace", 0, 0, [5, 10]]
         ];
         let previousBlock = 9;
@@ -1812,20 +1818,10 @@ function TemperamentWidget() {
                     [idx + 1]
                 ]);
                 newStack.push([idx + 3, ["divide"], 0, 0, [idx + 1, idx + 4, idx + 5]]);
-                newStack.push([
-                    idx + 4,
-                    ["number", { value: rationalToFraction(this.ratios[i])[0] }],
-                    0,
-                    0,
-                    [idx + 3]
-                ]);
-                newStack.push([
-                    idx + 5,
-                    ["number", { value: rationalToFraction(this.ratios[i])[1] }],
-                    0,
-                    0,
-                    [idx + 3]
-                ]);
+                // Cache rationalToFraction result to avoid duplicate calls
+                const ratioFraction = rationalToFraction(this.ratios[i]);
+                newStack.push([idx + 4, ["number", { value: ratioFraction[0] }], 0, 0, [idx + 3]]);
+                newStack.push([idx + 5, ["number", { value: ratioFraction[1] }], 0, 0, [idx + 3]]);
                 newStack.push([idx + 6, "vspace", 0, 0, [idx, idx + 7]]);
                 newStack.push([idx + 7, ["pitch"], 0, 0, [idx + 6, idx + 8, idx + 9, null]]);
 


### PR DESCRIPTION
This PR optimizes multiple locations by caching [rationalToFraction](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/utils.js:1166:0-1231:1) results to avoid duplicate function calls.

## Fixed Locations

### 1. turtle-singer.js (note frequency loop)
Previously called [rationalToFraction(ratio[k])](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/utils.js:1166:0-1231:1) twice per iteration - once for numerator and once for denominator. Now cached in a local variable.

### 2. temperament.js (octave ratio - lines 1720-1721)
Previously called [rationalToFraction(getOctaveRatio())](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/utils.js:1166:0-1231:1) twice. Now cached before use.

### 3. temperament.js (pitch number loop - lines 1817-1824)
Previously called [rationalToFraction(this.ratios[i])](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/utils.js:1166:0-1231:1) twice per loop iteration. Now cached in a local variable.

## Performance Improvement

- **50% reduction** in [rationalToFraction](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/utils/utils.js:1166:0-1231:1) calls at each location
- These are hot paths that affect note playback and temperament operations

