### PR TITLE
fix: LegoWidget event listener cleanup on close

### DIFF
--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -272,8 +272,15 @@ function LegoWidget() {
 
         widgetWindow.onclose = () => {
             this._stopWebcam();
-            this._deactivateEyeDropper(); // Clean up eye dropper mode
+            this._deactivateEyeDropper();
             this.running = false;
+
+            if (this._dragHandlers) {
+                document.removeEventListener("mousemove", this._dragHandlers.handleMouseMove);
+                document.removeEventListener("mouseup", this._dragHandlers.handleMouseUp);
+                this._dragHandlers = null;
+            }
+
             widgetWindow.destroy();
         };
 
@@ -1560,12 +1567,11 @@ function LegoWidget() {
         let isDragging = false;
         let startX, startY, initialX, initialY;
 
-        // Set fixed dimensions for the wrapper
         wrapper.style.width = "100%";
         wrapper.style.height = "100%";
         wrapper.style.overflow = "hidden";
 
-        wrapper.onmousedown = e => {
+        const handleMouseDown = e => {
             isDragging = true;
             startX = e.clientX;
             startY = e.clientY;
@@ -1575,7 +1581,7 @@ function LegoWidget() {
             e.preventDefault();
         };
 
-        document.onmousemove = e => {
+        const handleMouseMove = e => {
             if (!isDragging) return;
             const dx = e.clientX - startX;
             const dy = e.clientY - startY;
@@ -1583,12 +1589,18 @@ function LegoWidget() {
             wrapper.style.top = `${initialY + dy}px`;
         };
 
-        document.onmouseup = () => {
+        const handleMouseUp = () => {
             if (isDragging) {
                 isDragging = false;
                 wrapper.style.cursor = "grab";
             }
         };
+
+        wrapper.onmousedown = handleMouseDown;
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("mouseup", handleMouseUp);
+
+        this._dragHandlers = { handleMouseMove, handleMouseUp };
     };
 
     /**


### PR DESCRIPTION
Fixes #5247 
## Problem
LegoWidget drag handlers attach event listeners to the document 
(mousemove, mouseup) when widget opens but never remove them on close, 
causing memory accumulation on repeated open/close cycles.

## Solution
- Convert document.onmousemove/onmouseup to addEventListener
- Store handler references in this._dragHandlers instance variable
- Remove listeners properly in widgetWindow.onclose()

## Testing
- All 2,275 existing tests pass
- No breaking changes
- Prevents memory leaks on widget lifecycle

Fixes memory leak in LegoWidget drag handlers