### PR TITLE
Added missing JSDoc comment for `kana_onclick()` in `LanguageBox.js`

### DIFF
--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -63,6 +63,10 @@ class LanguageBox {
         this.hide();
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     kana_onclick() {
         this._language = "ja-kana";
         this.activity.storage.kanaPreference = "kana";


### PR DESCRIPTION
## What
Added missing JSDoc comment for `kana_onclick()` in LanguageBox.js.
<img width="834" height="342" alt="Screenshot 2026-01-19 213022" src="https://github.com/user-attachments/assets/a9a0c87a-1881-481b-b7c9-357e7dcb5f8d" />

## Why
Improves code readability and keeps documentation consistent for public methods.

## Changes
- Added @public and  @returns {void} JSDoc for kana_onclick()
- 
<img width="887" height="139" alt="Screenshot 2026-01-19 213132" src="https://github.com/user-attachments/assets/e44ba213-1cc2-4ea9-99c1-4695a7202d86" />

## Testing
- Not required (documentation-only change)
