### PR TITLE
perf: add willReadFrequently to read-heavy canvas contexts

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -1360,7 +1360,7 @@ class Painter {
             turtles.canvas1 = document.createElement("canvas");
             turtles.canvas1.width = 3 * this.turtle.ctx.canvas.width;
             turtles.canvas1.height = 3 * this.turtle.ctx.canvas.height;
-            turtles.c1ctx = turtles.canvas1.getContext("2d");
+            turtles.c1ctx = turtles.canvas1.getContext("2d", { willReadFrequently: true });
             turtles.c1ctx.rect(
                 0,
                 0,

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -2535,7 +2535,7 @@ function LegoWidget() {
 
         // Create a temporary canvas to sample pixel data
         const tempCanvas = document.createElement("canvas");
-        const ctx = tempCanvas.getContext("2d");
+        const ctx = tempCanvas.getContext("2d", { willReadFrequently: true });
 
         // Set canvas size to match the media element's display size
         const mediaRect = mediaElement.getBoundingClientRect();


### PR DESCRIPTION
## Description

Addresses the console warning about `getImageData` performance by adding `willReadFrequently: true` to read-heavy canvas contexts.

The main effect is for the Legobricks color sampling animation, which does 32 pixel reads per frame. This flag tells the browser to keep the canvas in CPU memory instead of GPU, avoiding the GPU to CPU sync on each read.

Quick benchmark (100 consecutive `getImageData` calls):
- Without flag: ~40ms
- With flag: ~1ms

For Legobricks (32 reads/frame), that's roughly 10-12ms saved per animation frame.

## Related Issue

This PR fixes #5252 

## Note:
Deliberately **not** adding to `turtle.ctx` since it handles 60+ draw operations vs only 1 read, would hurt performance there.

## Testing Performed

- `npm run lint` — passes
- `npm test` — 2532/2532 tests pass
- `npx prettier --check` — passes
- Manual testing: canvas scroll, Legobricks widget, play/stop all work
- Verified no new console warnings from our code

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.