### PR TITLE
fix(ui): trigger immediate dock and clamp adjustments on collapse/expand

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2269,6 +2269,25 @@ class Block {
         this.updateCache();
         this.unhighlight();
         this.activity.refreshCanvas();
+        // Ensure surrounding docks and expandable clamps are updated
+        // immediately when a collapse/expand occurs (fixes layout not
+        // updating until mouse leaves the control).
+        try {
+            // Always adjust docks for this block's stack.
+            this.blocks.adjustDocks(thisBlock, true);
+
+            // If any nested clamp blocks need checking, collect them and
+            // run the expandable-clamp adjuster immediately.
+            const clampList = [];
+            this.blocks.findNestedClampBlocks(thisBlock, clampList);
+            if (clampList.length > 0) {
+                this.blocks.clampBlocksToCheck = clampList;
+                this.blocks.adjustExpandableClampBlock();
+            }
+        } catch (e) {
+            // Defensive: don't allow any errors here to break collapse flow.
+            console.debug("Error forcing immediate clamp/dock adjust:", e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where clicking a block's collapse/expand control (notably the Note Value block) did not immediately reflow surrounding blocks and the sidebar layout; the UI only refreshed once the mouse left the control.

Changes:

Call adjustDocks(...) and adjustExpandableClampBlock() immediately after collapseToggle to force instant reflow.
Manual verification:

Open the app and place a Note Value block near Start/Set Instrument.
Click collapse/expand and confirm neighboring blocks and sidebar reflow immediately.