### PR TITLE
Blocked right arrow button on last page

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -134,16 +134,14 @@ class HelpWidget {
             cell = docById("right-arrow");
 
             cell.onclick = () => {
+                if (page >= HELPCONTENT.length - 1) {
+                    return;
+                }
+
                 page = page + 1;
                 leftArrow.classList.remove("disabled");
-                if (page === HELPCONTENT.length) {
-                    page = 0;
-                }
-                if (page == 0) {
-                    this.widgetWindow.updateTitle(_("Take a tour"));
-                } else {
-                    this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
-                }
+
+                this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
                 this._showPage(page);
             };
         } else {
@@ -326,6 +324,11 @@ class HelpWidget {
         helpBody.innerHTML = "";
         const totalPages = HELPCONTENT.length;
         const pageCount = `${page + 1}/${totalPages}`;
+        const rightArrow = docById("right-arrow");
+        const leftArrow = docById("left-arrow");
+
+        rightArrow.classList.toggle("disabled", page === HELPCONTENT.length - 1);
+        leftArrow.classList.toggle("disabled", page === 0);
 
         // Previous HTML content is removed, and new one is generated.
         let body = "";
@@ -366,18 +369,16 @@ class HelpWidget {
             const cell = docById("right-arrow");
             const leftArrow = docById("left-arrow");
             cell.onclick = () => {
+                if (page >= HELPCONTENT.length - 1) {
+                    return;
+                }
+
                 page = page + 1;
                 leftArrow.classList.remove("disabled");
-                if (page === HELPCONTENT.length) {
-                    page = 0;
-                }
-                if (page == 0) {
-                    this.widgetWindow.updateTitle(_("Take a tour"));
-                } else {
-                    this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
-                }
-                this._showPage(page);
-            };
+
+                this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
+            this._showPage(page);
+        };
             if (page === 0) {
                 leftArrow.classList.add("disabled");
             }


### PR DESCRIPTION
### Summary:
This PR is a continuation of https://github.com/sugarlabs/musicblocks/pull/5150
I wasn’t able to push the correct changes earlier due to some issues on my end. In this PR, I’ve fixed the right-arrow behavior so that the right arrow button is now disabled on the last page.

Screenshots for reference:

**Before:**

<img width="1510" height="860" alt="Screenshot 2026-01-20 at 00 11 03" src="https://github.com/user-attachments/assets/4f61070a-838b-4cd9-898d-750d16fa4ed9" />

**After :**

<img width="1511" height="863" alt="Screenshot 2026-01-20 at 00 11 31" src="https://github.com/user-attachments/assets/5d60c200-cf2a-455a-9cba-c23edc197f2a" />
