### PR TITLE
Fix undefined values in template string formatting

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -143,7 +143,7 @@ let format = (str, data) => {
             x = x[v];
         });
 
-        return x;
+        return x === undefined ? "" : x;
     });
 
     return str.replace(/{_([a-zA-Z0-9]+)}/g, (match, item) => {


### PR DESCRIPTION
## Problem
The `format()` function returns the literal string "undefined" when a template 
placeholder references a nested property that doesn't exist.
This occurs because undefined values are concatenated directly into the string
instead of being treated as missing properties.

Example:
```javascript
format("Hello {user.age}", {user:{name:"John"}}) 
// Returns: "Hello undefined" 
```

### Solution
 This PR normalizes undefined template values by:
- Checking if resolved value is undefined
- Returning empty string instead of undefined
- Preserving clean UI text when properties are missing

### Testing
Tested locally:

- Template with missing nested property: [{user.age}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → outputs "" ✓
- Template with existing property: [{user.name}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → outputs "John" ✓
- No console errors
- No breaking changes

Notes
This fixes a silent failure in the template string system that affects any
UI text using dynamic template substitution. The fix prevents confusing
"undefined" text from appearing to users when optional properties are missing.