### PR TITLE
Remove leftover debug code from ABC tuplet processing

### DIFF
--- a/js/abc.js
+++ b/js/abc.js
@@ -287,19 +287,6 @@ const processABCNotes = function (logo, turtle) {
                     k++; // Increment notes in tuplet.
                 }
 
-                // FIXME: Debug for ABC
-                if (i + j - 1 < logo.notation.notationStaging[turtle].length - 1) {
-                    const nextObj = logo.notation.notationStaging[turtle][i + j];
-                    if (typeof nextObj === "string" && nextObj === ")") {
-                        // logo.notationNotes[turtle] += '';
-                        i += 1;
-                    } else {
-                        logo.notationNotes[turtle] += " ";
-                    }
-                } else {
-                    logo.notationNotes[turtle] += " ";
-                }
-
                 return j;
             };
 


### PR DESCRIPTION
### Summary

This PR removes leftover debug logic marked by `FIXME: Debug for ABC` in the ABC tuplet processing code.
The removed block was conditionally inspecting the next token and incrementing the loop index (i += 1) inside the tuplet helper. This index mutation did not affect the final control flow, as note consumption is already handled by the helper’s return value (i += processedCount - 1) in the caller. Spacing is also handled consistently outside this block, making the conditional logic redundant.

### Testing

1. Tested manually by executing processABCNotes with mocked notationStaging data:
2. A complete tuplet (triplet) followed by a normal note
3. A tuplet followed by a string token ")" (the edge case the debug code was guarding)

In both cases, the ABC output was unchanged, and no notes were skipped or malformed, confirming that the removed debug logic was not required.