### PR TITLE
refactor(planet): improve error logging with contextual messages

### DIFF
--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -188,9 +188,8 @@ class ProjectStorage {
 
         try {
             return JSON.parse(jsonobj);
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.log(e);
+        } catch (error) {
+            console.error("ProjectStorage.get: Failed to parse JSON for key:", key, error);
             return null;
         }
     }
@@ -205,9 +204,8 @@ class ProjectStorage {
 
         try {
             this.data = typeof currentData === "string" ? JSON.parse(currentData) : currentData;
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.log(e);
+        } catch (error) {
+            console.error("ProjectStorage.restore: Failed to parse stored data from", this.LocalStorageKey, error);
             return null;
         }
     }

--- a/planet/js/Publisher.js
+++ b/planet/js/Publisher.js
@@ -294,9 +294,8 @@ class Publisher {
     parseProject(tb) {
         try {
             tb = JSON.parse(tb);
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.log(e);
+        } catch (error) {
+            console.error("Publisher.parseProject: Failed to parse project block data", error);
             return "";
         }
 


### PR DESCRIPTION
## Description
Fixes #5194

## Problem
Several catch blocks in `ProjectStorage.js` and `Publisher.js` use generic `console.log(e)` for error handling, which:
- Uses incorrect log severity (log vs error)
- Provides no context about which operation failed
- Requires `eslint-disable-next-line no-console` workarounds

## Solution
Replace generic error logging with descriptive `console.error` calls that include:
- Module name (`ProjectStorage`, `Publisher`)
- Method name (`get`, `restore`, `parseProject`)
- Relevant context (storage key, error object)

### Changes
- `ProjectStorage.get()`: Now logs key that failed to parse
- `ProjectStorage.restore()`: Now logs LocalStorageKey on failure
- `Publisher.parseProject()`: Now logs descriptive message for parse failures

## Testing
- [x] All Jest tests pass (2532/2532)
- [x] ESLint passes (no eslint-disable needed)