### PR TITLE
fixed visiblity issues

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1929,6 +1929,7 @@ table {
 #errorText {
   border: 2px solid red;
   background-color: pink;
+  color: #000000;
 }
 
 .contentWrapper {


### PR DESCRIPTION
### Summary
This PR improves the visibility of the error notification ("Cannot load project from the file. Please check the file type.") in **dark mode** 

### Related Issue
Fixes: #5286 

### Screenshot
BEFORE:
<img width="1108" height="137" alt="image" src="https://github.com/user-attachments/assets/5b9254c7-4da0-44b1-96b9-2f73d84f3dcb" />

AFTER:
<img width="1082" height="245" alt="image" src="https://github.com/user-attachments/assets/7884197c-2817-41e7-bbb2-d82ba63a2a87" />
