### PR TITLE
Fix ReferenceError when doSearch is not yet available

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,7 +548,11 @@ document.addEventListener("DOMContentLoaded", init);
     </script>
     <script>
         $(document).ready(function () {
-            doSearch();
+            if (window.activity && typeof window.activity.doSearch === 'function') {
+                window.activity.doSearch();
+            } else if (typeof doSearch === 'function') {
+                doSearch();
+            }
         });
     </script>
 


### PR DESCRIPTION
This PR fixes a ReferenceError that occurs when `doSearch()` is invoked
before it is available on page load.

In some load orders, `doSearch` is defined later (e.g. under
`window.activity`), causing the initial call in `$(document).ready()`
to fail and stop further script execution.

The fix safely checks for `doSearch` in both locations before calling
it, preventing the error while preserving existing behavior.

Fixes #5313

