### PR TITLE
Bounce blocks away from illegal connections on drag release

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1807,9 +1807,15 @@ class Blocks {
                                     myBlock.container.y = myBlock.lastGoodY;
                                 }
 
-                                // Directional push away from illegal dock
-                                myBlock.container.x -= (dx / distance) * bounceFactor;
-                                myBlock.container.y -= (dy / distance) * bounceFactor;
+                                // Directional push away from illegal dock based on block type
+                                if (myBlock.isArgBlock()) {
+                                    // Arg blocks bounce to the right
+                                    myBlock.container.x += bounceFactor;
+                                } else {
+                                    // Flow blocks bounce below and to the right
+                                    myBlock.container.x += bounceFactor * 0.7;
+                                    myBlock.container.y += bounceFactor;
+                                }
 
                                 bounced = true;
                             }


### PR DESCRIPTION
Adds a visible bounce-away when a block is released near an illegal connection, instead of failing silently.

This fills in a TODO around providing feedback for illegal connections. Blocks now snap back and push away on drag release so it’s clear what happened, and a `console.debug` message is logged when incompatible blocks are near each other. 

The bounce impulse is set to ~60px and can be tuned if needed.