### PR TITLE
Prevent stored XSS in exported HTML files

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -224,6 +224,33 @@ class SaveInterface {
      * @method
      * @instance
      */
+   
+   escapeHTML(str) {
+    if (typeof str !== "string") return "";
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+sanitizeURL(url) {
+    if (typeof url !== "string") return "";
+    try {
+        const parsed = new URL(url, window.location.origin);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+            return parsed.href;
+        }
+    } catch (e) {
+        return "";
+    }
+    return "";
+}
+
+   
+   
+   
     prepareHTML() {
         let file = this.htmlSaveTemplate;
         let description = _("No description provided");
@@ -244,13 +271,19 @@ class SaveInterface {
             image = this.activity.PlanetInterface.getCurrentProjectImage();
         }
 
-        file = file
-            .replace(new RegExp("{{ project_description }}", "g"), description)
-            .replace(new RegExp("{{ project_name }}", "g"), name)
-            .replace(new RegExp("{{ data }}", "g"), data)
-            .replace(new RegExp("{{ project_image }}", "g"), image);
-        return file;
-    }
+        const safeDescription = this.escapeHTML(description);
+const safeName = this.escapeHTML(name);
+const safeData = this.escapeHTML(data);
+const safeImage = this.sanitizeURL(image);
+
+file = file
+    .replace(new RegExp("{{ project_description }}", "g"), safeDescription)
+    .replace(new RegExp("{{ project_name }}", "g"), safeName)
+    .replace(new RegExp("{{ data }}", "g"), safeData)
+    .replace(new RegExp("{{ project_image }}", "g"), safeImage);
+
+  return file;
+  }
 
     /**
      * Save HTML representation of an activity.


### PR DESCRIPTION
### Summary
This PR fixes a stored XSS vulnerability in exported HTML files by sanitizing
user-controlled project metadata during HTML generation.

### Changes
- Escaped HTML special characters in project name, description, and project data
- Validated project image URLs to allow only http/https schemes
- Limited changes to HTML export logic to minimize impact

### Testing
- Verified that injected HTML/JavaScript is rendered as text
- Exported HTML files no longer execute user-supplied scripts
