### PR TITLE
Add error handling to localStorage operations

### DIFF
--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -234,7 +234,11 @@ class LanguageBox {
                 this._language = this._language.split("-")[0];
             }
 
-            localStorage.setItem("languagePreference", this._language);
+            try {
+                localStorage.setItem("languagePreference", this._language);
+            } catch (e) {
+                console.warn("Could not save language preference:", e);
+            }
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;

--- a/js/themebox.js
+++ b/js/themebox.js
@@ -263,7 +263,11 @@ class ThemeBox {
         } else {
             // Save preference to localStorage
             this.activity.storage.themePreference = this._theme;
-            localStorage.setItem("themePreference", this._theme);
+            try {
+                localStorage.setItem("themePreference", this._theme);
+            } catch (e) {
+                console.warn("Could not save theme preference:", e);
+            }
 
             // Apply theme instantly instead of reloading
             this.applyThemeInstantly();

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -575,7 +575,11 @@ class ReflectionMatrix {
      */
     saveReport(data) {
         const key = "musicblocks_analysis";
-        localStorage.setItem(key, data.response);
+        try {
+            localStorage.setItem(key, data.response);
+        } catch (e) {
+            console.warn("Could not save analysis report to localStorage:", e);
+        }
         console.log("Conversation saved in localStorage.");
     }
 


### PR DESCRIPTION
## Summary
This PR adds `try-catch` blocks to `localStorage.setItem()` operations across several components to prevent the application from crashing when browser storage is restricted (e.g., in Private Browsing mode or when the storage quota is exceeded).

Fixes #5326

## Problem
In many browsers (specifically Safari and Firefox in Private Mode), `localStorage` read/write operations can throw security exceptions. Additionally, if the disk space is full, it throws a `QuotaExceededError`. Previously, these were unhandled, causing parts of the UI (theme switching, language switching) to fail silently or crash the script execution.

## Solution
Wrapped `localStorage.setItem` calls in the following files with defensive `try-catch` blocks:
- [js/themebox.js]
- [js/languagebox.js]
- [js/widgets/reflection.js]

This ensures that even if persistence fails, the application logic continues to run, providing a better user experience through graceful degradation.

## Visual Proof

### Before Fix 
<img width="1019" height="584" alt="before error" src="https://github.com/user-attachments/assets/d0d8745f-0fb0-4f46-b618-88f09485b50c" />



> **Observation**: Attempting to change the theme while storage is blocked results in an uncaught `QuotaExceededError` at `themebox.js:266`, stopping the theme from applying.

### After Fix 
<img width="1455" height="828" alt="aftre error handling" src="https://github.com/user-attachments/assets/1df20480-ed8c-4ad3-b3bf-3fbbabfb870a" />




> **Observation**: With the fix, the error is caught at `themebox.js:269`. The UI remains functional, and a graceful warning is logged to the console instead of a crash.

## Checklist
- [x] I have read and followed the project's [CONTRIBUTING.md](CONTRIBUTING.md).
- [x] I have tested the changes locally in Safari Private Mode.
- [x] My code follows the project's style guidelines.
- [x] I have provided an AI usage disclosure below.

---

