### PR TITLE
fix: add root true to prevent ESLint config leakage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "es6": true,
     "browser": true,
@@ -13,8 +14,12 @@
       "globalReturn": false
     }
   },
-  "extends": ["eslint:recommended"],
-  "ignorePatterns": ["lib/**"],
+  "extends": [
+    "eslint:recommended"
+  ],
+  "ignorePatterns": [
+    "lib/**"
+  ],
   "rules": {
     "no-console": "off",
     "no-unused-vars": "off",
@@ -25,12 +30,12 @@
     "semi": "error",
     "no-duplicate-case": "error",
     "no-irregular-whitespace": "warn",
-    "no-prototype-builtins" : "off",
-    "no-useless-escape" : "off",
-    "no-inner-declarations" : "off",
-    "no-constant-assign" : "off",
-    "no-const-assign" : "off",
-    "no-dupe-keys" : "off",
-    "no-useless-catch" : "off"
+    "no-prototype-builtins": "off",
+    "no-useless-escape": "off",
+    "no-inner-declarations": "off",
+    "no-constant-assign": "off",
+    "no-const-assign": "off",
+    "no-dupe-keys": "off",
+    "no-useless-catch": "off"
   }
 }


### PR DESCRIPTION
Title:-Fix ESLint configuration leakage by setting root to true

Problem

Running npm run lint could fail because ESLint was traversing parent directories and loading unrelated ESLint configuration files from the system (for example, a user-level .eslintrc.js requiring eslint-plugin-react). Since MusicBlocks does not use React or include this plugin, linting would break in such environments.

Solution

This PR adds "root": true to .eslintrc.json, instructing ESLint to stop searching for configuration files beyond the project root. This ensures that only MusicBlocks’ own ESLint configuration is applied.

Result

Prevents ESLint from loading system or parent directory configurations

Avoids unnecessary plugin dependency errors

Makes linting behavior consistent across different developer environments

🔧 Change Summary

Added "root": true to .eslintrc.json