### PR TITLE
Fixes broken Note Value piemenu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1696,7 +1696,7 @@ const piemenuNoteValue = (block, noteValue) => {
 
     docById("wheelDiv").style.position = "absolute";
     setWheelSize(300);
-
+    const halfWheelSize = wheelSize / 2;
     const selectorWidth = 150;
     const left = Math.round(
         (x + block.activity.blocksContainer.x) * block.activity.getStageScale() + canvasLeft


### PR DESCRIPTION
There was a regression that broke the denominator NoteValue Piemenu: halfWheelSize was used but not defined.