### PR TITLE
Fix/settimeout bugs

### DIFF
--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -105,17 +105,11 @@ class ModeWidget {
             }
         };
 
-        this.widgetWindow.addButton(
-            "export-chunk.svg",
-            ModeWidget.ICONSIZE,
-            _("Save")
-        ).onclick = this._save.bind(this);
+        this.widgetWindow.addButton("export-chunk.svg", ModeWidget.ICONSIZE, _("Save")).onclick =
+            this._save.bind(this);
 
-        this.widgetWindow.addButton(
-            "erase-button.svg",
-            ModeWidget.ICONSIZE,
-            _("Clear")
-        ).onclick = this._clear.bind(this);
+        this.widgetWindow.addButton("erase-button.svg", ModeWidget.ICONSIZE, _("Clear")).onclick =
+            this._clear.bind(this);
 
         this.widgetWindow.addButton(
             "rotate-left.svg",
@@ -129,17 +123,11 @@ class ModeWidget {
             _("Rotate clockwise")
         ).onclick = this._rotateRight.bind(this);
 
-        this.widgetWindow.addButton(
-            "invert.svg",
-            ModeWidget.ICONSIZE,
-            _("Invert")
-        ).onclick = this._invert.bind(this);
+        this.widgetWindow.addButton("invert.svg", ModeWidget.ICONSIZE, _("Invert")).onclick =
+            this._invert.bind(this);
 
-        this.widgetWindow.addButton(
-            "restore-button.svg",
-            ModeWidget.ICONSIZE,
-            _("Undo")
-        ).onclick = this._undo.bind(this);
+        this.widgetWindow.addButton("restore-button.svg", ModeWidget.ICONSIZE, _("Undo")).onclick =
+            this._undo.bind(this);
 
         this._piemenuMode();
 
@@ -157,7 +145,7 @@ class ModeWidget {
 
         //.TRANS: A circle of notes represents the musical mode.
         activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
-        setTimeout(this.widgetWindow.sendToCenter, 0);
+        setTimeout(() => this.widgetWindow.sendToCenter(), 0);
     }
 
     /**
@@ -689,7 +677,7 @@ class ModeWidget {
                     this.__playNextNote(i + 1);
                 } else {
                     this._locked = false;
-                    setTimeout(this._resetNotes(), 500);
+                    setTimeout(() => this._resetNotes(), 500);
                     return;
                 }
             }, 1000 * time);
@@ -744,7 +732,7 @@ class ModeWidget {
                     this.__playNextNote(i + 1);
                 } else {
                     this._locked = false;
-                    setTimeout(this._resetNotes(), 500);
+                    setTimeout(() => this._resetNotes(), 500);
                     return;
                 }
             }, 1000 * time);

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -475,25 +475,22 @@ class RhythmRuler {
          * @private
          * @returns {void}
          */
-        widgetWindow.addButton(
-            "export-chunk.svg",
-            iconSize,
-            _("Save rhythms")
-        ).onclick = async () => {
-            // this._save(0);
-            // Debounce button
-            if (!this._get_save_lock()) {
-                this._save_lock = true;
+        widgetWindow.addButton("export-chunk.svg", iconSize, _("Save rhythms")).onclick =
+            async () => {
+                // this._save(0);
+                // Debounce button
+                if (!this._get_save_lock()) {
+                    this._save_lock = true;
 
-                // Save a merged version of the rulers.
-                this._saveTupletsMerged(this._mergeRulers());
+                    // Save a merged version of the rulers.
+                    this._saveTupletsMerged(this._mergeRulers());
 
-                // Rather than each ruler individually.
-                // this._saveTuplets(0);
-                await delayExecution(1000);
-                this._save_lock = false;
-            }
-        };
+                    // Rather than each ruler individually.
+                    // this._saveTuplets(0);
+                    await delayExecution(1000);
+                    this._save_lock = false;
+                }
+            };
 
         /**
          * Event handler for the click event of the save drum machine button.
@@ -501,19 +498,16 @@ class RhythmRuler {
          * @private
          * @returns {void}
          */
-        widgetWindow.addButton(
-            "export-drums.svg",
-            iconSize,
-            _("Save drum machine")
-        ).onclick = async () => {
-            // Debounce button
-            if (!this._get_save_lock()) {
-                this._save_lock = true;
-                this._saveMachine(0);
-                await delayExecution(1000);
-                this._save_lock = false;
-            }
-        };
+        widgetWindow.addButton("export-drums.svg", iconSize, _("Save drum machine")).onclick =
+            async () => {
+                // Debounce button
+                if (!this._get_save_lock()) {
+                    this._save_lock = true;
+                    this._saveMachine(0);
+                    await delayExecution(1000);
+                    this._save_lock = false;
+                }
+            };
 
         // An input for setting the dissect number
         this._dissectNumber = widgetWindow.addInputButton("2");
@@ -639,7 +633,7 @@ class RhythmRuler {
                                 this._startingTime = null;
                                 this._elapsedTimes[id] = 0;
                                 this._offsets[id] = 0;
-                                setTimeout(this._calculateZebraStripes(id), 1000);
+                                setTimeout(() => this._calculateZebraStripes(id), 1000);
                             }
                         } else if (this._playingOne === false) {
                             this._rulerSelected = id;
@@ -946,9 +940,9 @@ class RhythmRuler {
                 if (this.Drums[this._rulerSelected] === null) {
                     drum = "snare drum";
                 } else {
-                    const drumBlockNo = this.activity.blocks.blockList[
-                        this.Drums[this._rulerSelected]
-                    ].connections[1];
+                    const drumBlockNo =
+                        this.activity.blocks.blockList[this.Drums[this._rulerSelected]]
+                            .connections[1];
                     drum = this.activity.blocks.blockList[drumBlockNo].value;
                 }
 
@@ -2224,8 +2218,8 @@ class RhythmRuler {
         if (this.Drums[selectedRuler] === null) {
             drum = "snare drum";
         } else {
-            const drumBlockNo = this.activity.blocks.blockList[this.Drums[selectedRuler]]
-                .connections[1];
+            const drumBlockNo =
+                this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1];
             drum = this.activity.blocks.blockList[drumBlockNo].value;
         }
 


### PR DESCRIPTION
### 🐛 Bug Fix

This PR fixes 3 instances where functions were being called **immediately** instead of being passed as callbacks to `setTimeout`, causing synchronous execution blocking the UI thread and breaking timing logic.

### Context
Several widgets use `setTimeout` to delay UI updates or processing. However, due to incorrect syntax (`setTimeout(func(), 1000)` instead of `setTimeout(() => func(), 1000)`), these functions were executing instantly.

###  Changes

1.  **[js/widgets/rhythmruler.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/widgets/rhythmruler.js:0:0-0:0)**:
    *   **Fixed**: [_calculateZebraStripes](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/widgets/rhythmruler.js:848:4-883:5) ran synchronously when pausing playback.
    *   **Impact**: Prevents UI freeze/jank on click by correctly deferring heavy DOM manipulation to 1000ms later.

2.  **[js/widgets/modewidget.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/widgets/modewidget.js:0:0-0:0)**:
    *   **Fixed**: [_resetNotes](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/widgets/modewidget.js:397:4-410:5) ran immediately when playing phrases.
    *   **Impact**: Ensures note highlights persist for the intended ~500ms duration instead of vanishing instantly before the sound ends.
    *   **Fixed**: `sendToCenter` context loss risk (wrapped in arrow function).

###  Results
| Widget | Before | After | Improvement |
| :--- | :--- | :--- | :--- |
| **RhythmRuler** | Pausing blocked UI instantly | Pausing is instant; update deferred | **Smoother UI** 🚀 |
| **ModeWidget** | Highlights vanished too early | Highlights sync with audio drift | **Better Visual Feedback** ✅ |

