### PR TITLE
Fix JS editor syntax highlighting regression (#5334)

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -550,15 +550,18 @@ class JSEditor {
         this._editor.appendChild(editorconsole);
 
         const highlight = editor => {
-            // Configure highlight.js for JavaScript
-            hljs.configure({
-                languages: ["javascript"]
-            });
+            if (window.hljs) {
+                hljs.configure({
+                    languages: ["javascript"]
+                });
 
-            // Apply highlight.js syntax highlighting for JavaScript
-            hljs.highlightElement(editor);
+                if (typeof hljs.highlightElement === "function") {
+                    hljs.highlightElement(editor);
+                } else if (typeof hljs.highlightBlock === "function") {
+                    hljs.highlightBlock(editor);
+                }
+            }
 
-            // Add error highlighting
             this._highlightErrors(editor);
         };
 


### PR DESCRIPTION
### Summary
This PR fixes a regression in the JavaScript editor where syntax highlighting
fails due to a highlight.js API mismatch.

### Problem
The current code assumes the presence of `hljs.highlightElement`, which is not
available in older highlight.js versions that are still used in some setups.
As a result, the editor opens without syntax highlighting, even though the
highlighter library is loaded.

While the issue mentions load order, the root cause here is an API mismatch.
The highlighter is already loaded, but the expected DOM-highlighting method
differs across highlight.js versions.

### Solution
This change keeps the existing behavior for newer highlight.js versions and
adds a backward-compatible fallback to `hljs.highlightBlock` when
`highlightElement` is not available. This restores syntax highlighting across
both old and new highlight.js APIs without changing load order or introducing
side effects.

### Why this approach
- Prevents silent failures where highlighting does not run
- Fully resolves the reported regression instead of only guarding the error
- Maintains compatibility across different highlight.js versions
- Minimal and safe change scoped to the editor highlighting logic

Fixes #5334
