### PR TITLE
Derive cents-per-octave constants from SEMITONES in frequencyToPitch

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -843,6 +843,19 @@ const DEGREES = _("1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th");
 const SEMITONES = 12;
 
 /**
+ * Number of cents per semitone in 12-TET tuning.
+ * @constant {number}
+ */
+const CENTS_PER_SEMITONE = 100;
+
+/**
+ * Number of cents in an octave.
+ * Derived from SEMITONES for future temperament support.
+ * @constant {number}
+ */
+const CENTS_PER_OCTAVE = SEMITONES * CENTS_PER_SEMITONE;
+
+/**
  * Array representing powers of 2.
  * @constant {number[]}
  */
@@ -2883,18 +2896,20 @@ const frequencyToPitch = hz => {
 
     // Calculate cents to keep track of drift
     let cents = 0;
-    for (let i = 0; i < 10 * 1200; i++) {
+    // Standard tuning uses CENTS_PER_OCTAVE cents per octave.
+
+    for (let i = 0; i < 10 * CENTS_PER_OCTAVE; i++) {
         const f = A0 * Math.pow(TWELVEHUNDRETHROOT2, i);
         if (hz < f * 1.0003 && hz > f * 0.9997) {
-            cents = i % 100;
-            let j = Math.floor(i / 100);
+            cents = i % CENTS_PER_SEMITONE;
+            let j = Math.floor(i / CENTS_PER_SEMITONE);
             if (cents > 50) {
-                cents -= 100;
+                cents -= CENTS_PER_SEMITONE;
                 j += 1;
             }
             return [
-                PITCHES[(j + PITCHES.indexOf("A")) % 12],
-                Math.floor((j + PITCHES.indexOf("A")) / 12),
+                PITCHES[(j + PITCHES.indexOf("A")) % SEMITONES],
+                Math.floor((j + PITCHES.indexOf("A")) / SEMITONES),
                 cents
             ];
         }


### PR DESCRIPTION
### Summary

The frequencyToPitch logic in `js/utils/musicutils.js` used hard-coded music theory constants such as `1200` cents per octave and `100` cents per semitone.
While correct for standard 12-TET Western tuning, these magic numbers reduce clarity and make future temperament-related work harder, since the project already defines a `SEMITONES` constant.

This created conceptual technical debt where the code was still implicitly tied to fixed values instead of being expressed through named musical constants.

---

### Changes

This PR removes the remaining hard-coded cents constants and links the cents calculations directly to `SEMITONES`.

1. Introduced:
```js
const CENTS_PER_SEMITONE = 100;
const CENTS_PER_OCTAVE = SEMITONES * CENTS_PER_SEMITONE;
```

2. Replaced:
```js
for (let i = 0; i < 10 * 1200; i++)
```
with:
```js
for (let i = 0; i < 10 * CENTS_PER_OCTAVE; i++)
```
3. Updated drift calculations to avoid fixed `100` and `12`:
```js
cents = i % CENTS_PER_SEMITONE;
j = Math.floor(i / CENTS_PER_SEMITONE);

PITCHES[...] % SEMITONES
... / SEMITONES
```

This keeps behaviour identical while removing magic numbers and improving maintainability.

---

### Testings

1. Ran full unit test suite:
```bash
npm test
→ 94 test suites passed
→ 2532 tests passed
```
2. Ran ESLint successfully:
```bash
npm run lint js/utils/musicutils.js
→ No warnings or errors
```
3. Manual runtime verification in browser console:
```js
frequencyToPitch(440);     // ['A', 4, 0]
frequencyToPitch(523.25);  // ['C', 5, 0]
frequencyToPitch(4186);    // ['C', 8, 0]
```

---


> NOTE: This change is purely a refactor and does not modify pitch detection behaviour, only replaces magic numbers with derived constants for clarity and future temperament support.
