### PR TITLE
docs: add initial SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Master  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The Music Blocks team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+### How to Report
+
+If you believe you have found a security vulnerability in Music Blocks, please **do not** report it through public GitHub issues.
+
+Instead, please report it via one of the following methods:
+
+1.  **Email:** Send the details to the project maintainers directly.
+2.  **Private Disclosure:** If available, use the "Report a vulnerability" button on the GitHub Security advisory page.
+
+Please include the following details in your report:
+* Description of the location and potential impact of the vulnerability.
+* A detailed description of the steps required to reproduce the vulnerability (POC scripts, screenshots, and compressed packet captures are all helpful to us).
+
+### Response Timeline
+
+We will make every effort to:
+* Acknowledge receipt of your report within 48 hours.
+* Provide a timeline for the fix once the vulnerability is verified.
+* Notify you when the fix is released.


### PR DESCRIPTION
Added a standard `SECURITY.md` file as requested in #4668 to establish a security policy.

**Note:** I did not include a specific security email address (e.g., `security@sugarlabs.org`) because I could not verify if one currently exists. I have kept the reporting instructions generic (directing to maintainers/private disclosure).

Please let me know if a specific email address should be added during review!