### PR TITLE
chore(deps): update Jest to v30 and fix JSDOM compatibility issues

### DIFF
--- a/js/__tests__/artwork.test.js
+++ b/js/__tests__/artwork.test.js
@@ -67,7 +67,7 @@ describe("artwork.js Test Suite", () => {
         const circles = { highlight: {}, active: {} };
         hideButtonHighlight(circles, mockStage);
         jest.runAllTimers();
-        expect(mockStage.removeChild).toBeCalledWith(circles.active, circles.highlight);
+        expect(mockStage.removeChild).toHaveBeenCalledWith(circles.active, circles.highlight);
         jest.useRealTimers();
     });
 
@@ -76,7 +76,7 @@ describe("artwork.js Test Suite", () => {
         const paletteText = {};
         hidePaletteNameDisplay(paletteText, mockStage);
         jest.runAllTimers();
-        expect(mockStage.removeChild).toBeCalledWith(paletteText);
+        expect(mockStage.removeChild).toHaveBeenCalledWith(paletteText);
         jest.useRealTimers();
     });
 

--- a/js/__tests__/languagebox.test.js
+++ b/js/__tests__/languagebox.test.js
@@ -35,11 +35,6 @@ Object.defineProperty(global, "localStorage", {
     writable: true
 });
 
-delete global.window.location;
-global.window.location = {
-    reload: jest.fn()
-};
-
 document.querySelectorAll = jest.fn(() => []);
 
 global._ = jest.fn(str => str);
@@ -53,8 +48,10 @@ describe("LanguageBox Class", () => {
     });
 
     it("should reload the window when OnClick is called", () => {
+        const reloadSpy = jest.spyOn(languageBox, "reload").mockImplementation(() => {});
         languageBox.OnClick();
-        expect(global.window.location.reload).toHaveBeenCalled();
+        expect(reloadSpy).toHaveBeenCalled();
+        reloadSpy.mockRestore();
     });
 
     it("should display 'already set' message when the selected language is the same", () => {

--- a/js/__tests__/themebox.test.js
+++ b/js/__tests__/themebox.test.js
@@ -56,11 +56,6 @@ describe("ThemeBox", () => {
         });
         jest.spyOn(global.Storage.prototype, "setItem").mockImplementation(() => {});
 
-        Object.defineProperty(window, "location", {
-            value: { reload: jest.fn() },
-            writable: true
-        });
-
         // Reset body classes
         document.body.classList.remove("light", "dark");
 
@@ -85,33 +80,39 @@ describe("ThemeBox", () => {
     });
 
     test("dark_onclick() sets theme to dark and applies instantly", () => {
+        const reloadSpy = jest.spyOn(themeBox, "reload").mockImplementation(() => {});
         themeBox.dark_onclick();
         expect(themeBox._theme).toBe("dark");
         expect(mockActivity.storage.themePreference).toBe("dark");
         // Should NOT reload - instant theme switch
-        expect(window.location.reload).not.toHaveBeenCalled();
+        expect(reloadSpy).not.toHaveBeenCalled();
         // Should show theme switched message
         expect(mockActivity.textMsg).toHaveBeenCalledWith("Theme switched to dark mode.", 2000);
+        reloadSpy.mockRestore();
     });
 
     test("setPreference() applies theme instantly without reload", () => {
+        const reloadSpy = jest.spyOn(themeBox, "reload").mockImplementation(() => {});
         localStorage.getItem.mockReturnValue("light");
         themeBox._theme = "dark";
         themeBox.setPreference();
         expect(mockActivity.storage.themePreference).toBe("dark");
         // Should NOT reload - instant theme switch
-        expect(window.location.reload).not.toHaveBeenCalled();
+        expect(reloadSpy).not.toHaveBeenCalled();
         // Body should have dark class
         expect(document.body.classList.contains("dark")).toBe(true);
         expect(document.body.classList.contains("light")).toBe(false);
+        reloadSpy.mockRestore();
     });
 
     test("setPreference() does not change if theme is unchanged", () => {
+        const reloadSpy = jest.spyOn(themeBox, "reload").mockImplementation(() => {});
         themeBox.light_onclick();
-        expect(window.location.reload).not.toHaveBeenCalled();
+        expect(reloadSpy).not.toHaveBeenCalled();
         expect(mockActivity.textMsg).toHaveBeenCalledWith(
             "Music Blocks is already set to this theme."
         );
+        reloadSpy.mockRestore();
     });
 
     test("applyThemeInstantly() updates body classes correctly", () => {

--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -150,6 +150,17 @@ function setupActionBlocks(activity) {
         }
 
         /**
+         * Gets the current window location URL.
+         *
+         * @memberof ReturnToURLBlock
+         * @method
+         * @returns {string} The current window location URL.
+         */
+        getURL() {
+            return window.location.href;
+        }
+
+        /**
          * Handles the flow of the Return to URL block.
          *
          * @memberof ReturnToURLBlock
@@ -157,7 +168,7 @@ function setupActionBlocks(activity) {
          * @param {Array} args - The arguments for the flow.
          */
         flow(args) {
-            const URL = window.location.href;
+            const URL = this.getURL();
             let urlParts;
             let outurl;
 

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -160,11 +160,6 @@ describe("ActionBlocks", () => {
             parseArg: jest.fn()
         };
 
-        global.window = {
-            location: {
-                href: "http://localhost"
-            }
-        };
         global.XMLHttpRequest = jest.fn();
         global.alert = jest.fn();
 
@@ -241,14 +236,11 @@ describe("ActionBlocks", () => {
             };
             global.XMLHttpRequest.mockImplementation(() => mockHttp);
 
-            Object.defineProperty(window, "location", {
-                value: {
-                    href: "http://localhost?outurl=http://callback&dummy=1"
-                },
-                writable: true
-            });
-
             const block = getBlock("returnToUrl");
+            jest.spyOn(block, "getURL").mockReturnValue(
+                "http://localhost?outurl=http://callback&dummy=1"
+            );
+
             block.flow([100]);
 
             expect(mockHttp.open).toHaveBeenCalledWith("POST", "http://callback", true);
@@ -263,14 +255,9 @@ describe("ActionBlocks", () => {
             };
             global.XMLHttpRequest.mockImplementation(() => mockHttp);
 
-            Object.defineProperty(window, "location", {
-                value: {
-                    href: "http://localhost"
-                },
-                writable: true
-            });
-
             const block = getBlock("returnToUrl");
+            jest.spyOn(block, "getURL").mockReturnValue("http://localhost");
+
             block.flow([42]);
 
             expect(mockHttp.open).toHaveBeenCalledWith("POST", undefined, true);

--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -199,8 +199,17 @@ class LanguageBox {
      * @returns {void}
      */
     OnClick() {
+        this.reload();
+    }
+
+    /**
+     * @public
+     * @returns {void}
+     */
+    reload() {
         window.location.reload();
     }
+
     hide() {
         const MSGPrefix =
             "<a href='#' class='language-link' " +

--- a/js/themebox.js
+++ b/js/themebox.js
@@ -257,6 +257,10 @@ class ThemeBox {
         window.location.reload();
     }
 
+    /**
+     * @public
+     * @returns {void}
+     */
     setPreference() {
         if (localStorage.getItem("themePreference") === this._theme) {
             this.activity.textMsg(_("Music Blocks is already set to this theme."));


### PR DESCRIPTION
### Summary
Update Jest to v30.2.0 and resolve JSDOM 26 compatibility issues regarding `window.location` mocking.

### Implementation Details
- **Refactored for Testability**: Extracted `window.location` operations into mockable class methods ([reload()](cci:1://file:///Users/vanshika/musicblocks/js/themebox.js:250:4-257:5), `getURL()`) in [LanguageBox](cci:2://file:///Users/vanshika/musicblocks/js/languagebox.js:19:0-261:1), [ThemeBox](cci:2://file:///Users/vanshika/musicblocks/js/themebox.js:98:0-275:1), and [ReturnToURLBlock](cci:2://file:///Users/vanshika/musicblocks/js/blocks/ActionBlocks.js:102:4-199:5).
- **JSDOM 26 Fix**: Resolved `TypeError: Cannot redefine property: location` caused by JSDOM's stricter implementation of the Location object.
- **Matchers Update**: Replaced deprecated `toBeCalledWith` with the recommended `toHaveBeenCalledWith`.

### Verification Results
- Ran `npm test` and confirmed all 2,532 tests pass.
- Verified that page reload logic in the UI remains fully functional.

Closes #5380 #5364 #5369