### PR TITLE
Fixed toTitleCase not defined error in GlobalTag file

### DIFF
--- a/planet/js/GlobalTag.js
+++ b/planet/js/GlobalTag.js
@@ -19,6 +19,14 @@
 
    GlobalTag
 */
+if (typeof window.toTitleCase !== "function") {
+    window.toTitleCase = function (str) {
+        if (typeof str !== "string") return "";
+        let tempStr = "";
+        if (str.length > 1) tempStr = str.substring(1);
+        return str.toUpperCase()[0] + tempStr;
+    };
+}
 
 class GlobalTag {
     /* 
@@ -71,7 +79,7 @@ class GlobalTag {
 
         if (this.selected) tag.classList.add(this.selectedClass);
 
-        tag.textContent = toTitleCase(_(this.name));
+        tag.textContent = window.toTitleCase(_(this.name));
 
         // eslint-disable-next-line no-unused-vars
         tag.addEventListener("click", evt => {


### PR DESCRIPTION
This PR fixes the Uncaught ReferenceError: toTitleCase is not defined error in GlobalTag.js.

The issue occurred because toTitleCase was not always available in the global scope at runtime, which caused tag labels to fail during rendering. To resolve this, the toTitleCase function has been added directly to GlobalTag.js, ensuring it is consistently available when the render() method runs.