### PR TITLE
refactor: consolidate duplicate readAsDataURL logic in block.js

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -979,19 +979,19 @@ class Block {
      */
     regenerateArtwork(collapse) {
         // First we need to remove the old artwork.
-        if (this.bitmap != null) {
+        if (this.bitmap !== null) {
             this.container.removeChild(this.bitmap);
         }
 
-        if (this.highlightBitmap != null) {
+        if (this.highlightBitmap !== null) {
             this.container.removeChild(this.highlightBitmap);
         }
 
-        if (this.disconnectedBitmap != null) {
+        if (this.disconnectedBitmap !== null) {
             this.container.removeChild(this.disconnectedBitmap);
         }
 
-        if (this.disconnectedHighlightBitmap != null) {
+        if (this.disconnectedHighlightBitmap !== null) {
             this.container.removeChild(this.disconnectedHighlightBitmap);
         }
 
@@ -1004,7 +1004,7 @@ class Block {
 
         // Temporarily remove imageBitmap to prevent it from corrupting bounds during regeneration
         let tempImageBitmap = null;
-        if (this.imageBitmap != null) {
+        if (this.imageBitmap !== null) {
             tempImageBitmap = this.imageBitmap;
             this.container.removeChild(this.imageBitmap);
             this.imageBitmap = null;
@@ -1014,7 +1014,7 @@ class Block {
         this.generateArtwork(false);
 
         // Restore the imageBitmap after artwork generation
-        if (tempImageBitmap != null) {
+        if (tempImageBitmap !== null) {
             this.imageBitmap = tempImageBitmap;
             this.container.addChild(this.imageBitmap);
             this._positionMedia(
@@ -1046,7 +1046,7 @@ class Block {
          * @param {object} that - Reference to the current object.
          */
         const __processHighlightBitmap = (bitmap, that) => {
-            if (that.highlightBitmap != null) {
+            if (that.highlightBitmap !== null) {
                 that.container.removeChild(that.highlightBitmap);
             }
 
@@ -1095,7 +1095,7 @@ class Block {
                         that.updateCache();
                     }
 
-                    if (that.postProcess != null) {
+                    if (that.postProcess !== null) {
                         that.postProcess(that.postProcessArg);
                         that.postProcess = null;
                     }
@@ -1111,7 +1111,7 @@ class Block {
          * @param {object} that - Reference to the current object.
          */
         const __processDisconnectedHighlightBitmap = (bitmap, that) => {
-            if (that.disconnectedHighlightBitmap != null) {
+            if (that.disconnectedHighlightBitmap !== null) {
                 that.container.removeChild(that.disconnectedHighlightBitmap);
             }
 
@@ -1151,7 +1151,7 @@ class Block {
          * @param {object} that - Reference to the current object.
          */
         const __processDisconnectedBitmap = (bitmap, that) => {
-            if (that.disconnectedBitmap != null) {
+            if (that.disconnectedBitmap !== null) {
                 that.container.removeChild(that.disconnectedBitmap);
             }
 
@@ -1194,7 +1194,7 @@ class Block {
          * @param {object} that - Reference to the current object.
          */
         const __processBitmap = (bitmap, that) => {
-            if (that.bitmap != null) {
+            if (that.bitmap !== null) {
                 that.container.removeChild(that.bitmap);
             }
 
@@ -1302,7 +1302,7 @@ class Block {
         let proto, obj, label, attr;
         // Value blocks get a modifiable text label.
         if (SPECIALINPUTS.includes(this.name)) {
-            if (this.value == null) {
+            if (this.value === null) {
                 switch (this.name) {
                     case "text":
                         this.value = "---";
@@ -1410,7 +1410,7 @@ class Block {
             } else if (this.name === "grid") {
                 label = _(this.value);
             } else {
-                if (this.value != null) {
+                if (this.value !== null) {
                     label = this.value.toString();
                 } else {
                     label = "???";
@@ -1467,7 +1467,7 @@ class Block {
             const postProcess = that => {
                 that.loadComplete = true;
 
-                if (that.postProcess != null) {
+                if (that.postProcess !== null) {
                     that.postProcess(that.postProcessArg);
                     that.postProcess = null;
                 }
@@ -2185,9 +2185,7 @@ class Block {
                     fileChooser.value = "";
                 }
             };
-            if (that.name === "media") {
-                reader.readAsDataURL(fileChooser.files[0]);
-            } else if (that.name === "audiofile") {
+            if (that.name === "media" || that.name === "audiofile") {
                 reader.readAsDataURL(fileChooser.files[0]);
             } else {
                 reader.readAsText(fileChooser.files[0]);
@@ -2718,7 +2716,7 @@ class Block {
         }
 
         // Reposition the blocks below.
-        if (this.connections[3] != null) {
+        if (this.connections[3] !== null) {
             // The last connection is flow. The second to last
             // connection is child flow.  FIX ME: This will not work
             // if there is more than one arg, e.g. n > 4.
@@ -3045,7 +3043,7 @@ class Block {
             that.blocks.raiseStackToTop(thisBlock);
 
             // And possibly the collapse button.
-            if (that.collapseContainer != null) {
+            if (that.collapseContainer !== null) {
                 that.activity.blocksContainer.setChildIndex(
                     that.collapseContainer,
                     that.activity.blocksContainer.children.length - 1
@@ -3075,7 +3073,7 @@ class Block {
             // mouse move event.
             _dragHasRest2 = false;
             let checkBlock = that.blocks.blockList[that.connections[1]];
-            while (checkBlock != null) {
+            while (checkBlock !== null) {
                 if (checkBlock?.name === "rest2") {
                     _dragHasRest2 = true;
                     break;
@@ -3167,13 +3165,13 @@ class Block {
                 }
             }
 
-            if (that.blocks.longPressTimeout != null) {
+            if (that.blocks.longPressTimeout !== null) {
                 clearTimeout(that.blocks.longPressTimeout);
                 that.blocks.longPressTimeout = null;
                 that.blocks.clearLongPress();
             }
 
-            if (!moved && that.label != null) {
+            if (!moved && that.label !== null) {
                 that.label.style.display = "none";
             }
 
@@ -3200,7 +3198,7 @@ class Block {
             // Move connected blocks using the cached drag group
             // (computed once on mousedown, not every pressmove).
             const cachedGroup = that.blocks._cachedDragGroup;
-            if (cachedGroup != null && cachedGroup.length > 0) {
+            if (cachedGroup !== null && cachedGroup.length > 0) {
                 for (let b = 0; b < cachedGroup.length; b++) {
                     const blk = cachedGroup[b];
                     if (blk !== thisBlock) {
@@ -3302,7 +3300,7 @@ class Block {
             this.activity.trashcan.hide();
         }
 
-        if (this.blocks.longPressTimeout != null) {
+        if (this.blocks.longPressTimeout !== null) {
             clearTimeout(this.blocks.longPressTimeout);
             this.blocks.longPressTimeout = null;
             this.blocks.clearLongPress();
@@ -3585,7 +3583,7 @@ class Block {
         }
 
         // A place in the DOM to put modifiable labels (textareas).
-        if (this.label != null) {
+        if (this.label !== null) {
             labelValue = this.label.value;
         } else {
             labelValue = this.value;
@@ -3680,7 +3678,7 @@ class Block {
                     selectedCustom = customLabels[0];
                 }
 
-                if (this.value != null) {
+                if (this.value !== null) {
                     selectedNote = this.value;
                 } else {
                     // Ensure we have a valid temperament before accessing its properties
@@ -3709,7 +3707,7 @@ class Block {
             }
         } else if (this.name === "notename") {
             const NOTENOTES = ["B", "A", "G", "F", "E", "D", "C"];
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedNote = this.value[0];
                 if (this.value.length === 1) {
                     selectedAttr = "♮";
@@ -3731,7 +3729,7 @@ class Block {
                 piemenuPitches(this, NOTENOTES, NOTENOTES, SOLFATTRS, selectedNote, selectedAttr);
             }
         } else if (this.name === "modename") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedMode = this.value;
             } else {
                 selectedMode = DEFAULTMODE;
@@ -3739,7 +3737,7 @@ class Block {
 
             piemenuModes(this, selectedMode);
         } else if (this.name === "chordname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedChord = this.value;
             } else {
                 selectedChord = DEFAULTCHORD;
@@ -3747,7 +3745,7 @@ class Block {
 
             piemenuChords(this, selectedChord);
         } else if (this.name === "accidentalname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedAccidental = this.value;
             } else {
                 selectedAccidental = DEFAULTACCIDENTAL;
@@ -3757,7 +3755,7 @@ class Block {
                 piemenuAccidentals(this, ACCIDENTALLABELS, ACCIDENTALNAMES, selectedAccidental);
             }
         } else if (this.name === "intervalname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedInterval = this.value;
             } else {
                 selectedInterval = DEFAULTINTERVAL;
@@ -3767,7 +3765,7 @@ class Block {
                 piemenuIntervals(this, selectedInterval);
             }
         } else if (this.name === "invertmode") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedInvert = this.value;
             } else {
                 selectedInvert = DEFAULTINVERT;
@@ -3785,7 +3783,7 @@ class Block {
                 piemenuBasic(this, invertLabels, invertValues, selectedInvert);
             }
         } else if (this.name === "drumname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedDrum = this.value;
             } else {
                 selectedDrum = DEFAULTDRUM;
@@ -3816,7 +3814,7 @@ class Block {
 
             piemenuVoices(this, drumLabels, drumValues, categories, selectedDrum);
         } else if (this.name === "effectsname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedDrum = this.value;
             } else {
                 selectedEffect = DEFAULTEFFECT;
@@ -3847,7 +3845,7 @@ class Block {
 
             piemenuVoices(this, effectLabels, effectValues, effectcategories, selectedEffect);
         } else if (this.name === "filtertype") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedType = this.value;
             } else {
                 selectedType = DEFAULTFILTERTYPE;
@@ -3868,7 +3866,7 @@ class Block {
                 platformColor.piemenuBasic
             );
         } else if (this.name === "oscillatortype") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedType = this.value;
             } else {
                 selectedType = DEFAULTOSCILLATORTYPE;
@@ -3883,7 +3881,7 @@ class Block {
 
             piemenuBasic(this, oscLabels, oscValues, selectedType, platformColor.piemenuBasic);
         } else if (this.name === "voicename") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedVoice = this.value;
             } else {
                 selectedVoice = DEFAULTVOICE;
@@ -3917,7 +3915,7 @@ class Block {
 
             piemenuVoices(this, voiceLabels, voiceValues, categories, selectedVoice);
         } else if (this.name === "noisename") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedNoise = this.value;
             } else {
                 selectedNoise = DEFAULTNOISE;
@@ -3946,7 +3944,7 @@ class Block {
 
             piemenuVoices(this, noiseLabels, noiseValues, categories, selectedNoise, 90);
         } else if (this.name === "temperamentname") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedTemperament = this.value;
             } else {
                 selectedTemperament = DEFAULTTEMPERAMENT;
@@ -3978,7 +3976,7 @@ class Block {
                 platformColor.piemenuBasic
             );
         } else if (this.name === "boolean") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedValue = this.value;
             } else {
                 selectedValue = true;
@@ -4040,7 +4038,7 @@ class Block {
             }
             piemenuBasic(this, labels, values, selectedValue, platformColor.piemenuBasic);
         } else if (this.name === "wrapmode") {
-            if (this.value != null) {
+            if (this.value !== null) {
                 selectedWrap = this.value;
             } else {
                 selectedWrap = "on";
@@ -4150,7 +4148,7 @@ class Block {
                         for (let i = 0; i < this.blocks.blockList.length; i++) {
                             if (
                                 this.blocks.blockList[i].name === "settemperament" &&
-                                this.blocks.blockList[i].connections[0] != null
+                                this.blocks.blockList[i].connections[0] !== null
                             ) {
                                 const index = this.blocks.blockList[i].connections[1];
                                 temperament = this.blocks.blockList[index].value;
@@ -4297,7 +4295,7 @@ class Block {
                 Math.round((20 * this.blocks.blockScale * this.protoblock.scale) / 2) + "px";
             this.label.style.display = "";
             this.label.focus();
-            if (this.labelattr != null) {
+            if (this.labelattr !== null) {
                 this.labelattr.style.display = "";
             }
 
@@ -4369,7 +4367,7 @@ class Block {
                         case "timbre":
                             lockInit = true;
                             if (
-                                this.blocks.blockList[topBlock].protoblock.staticLabels[0] ==
+                                this.blocks.blockList[topBlock].protoblock.staticLabels[0] ===
                                 widgetTitle[i].innerHTML
                             ) {
                                 this.blocks.reInitWidget(topBlock, 1500);
@@ -4401,7 +4399,7 @@ class Block {
 
         if (closeInput) {
             this.label.style.display = "none";
-            if (this.labelattr != null) {
+            if (this.labelattr !== null) {
                 this.labelattr.style.display = "none";
             }
             docById("wheelDiv").style.display = "none";
@@ -4415,7 +4413,7 @@ class Block {
         const oldValue = this.value;
         let newValue = this.label.value;
 
-        if (this.labelattr != null) {
+        if (this.labelattr !== null) {
             const attrValue = this.labelattr.value;
             switch (attrValue) {
                 case "𝄪":
@@ -4440,7 +4438,7 @@ class Block {
         }
 
         c = this.connections[0];
-        if (this.name === "text" && c != null) {
+        if (this.name === "text" && c !== null) {
             const cblock = this.blocks.blockList[c];
             let uniqueValue;
             switch (cblock.name) {
@@ -4502,7 +4500,7 @@ class Block {
             const cblk1 = this.connections[0];
             let cblk2;
 
-            if (cblk1 != null) {
+            if (cblk1 !== null) {
                 cblk2 = this.blocks.blockList[cblk1].connections[0];
             } else {
                 cblk2 = null;
@@ -4530,7 +4528,7 @@ class Block {
             }
 
             if (
-                cblk1 != null &&
+                cblk1 !== null &&
                 this.blocks.blockList[cblk1].name === "pitch" &&
                 (this.value > 8 || this.value < 1)
             ) {
@@ -4605,7 +4603,7 @@ class Block {
         this.container.setChildIndex(this.text, this.container.children.length - 1);
         this.updateCache();
 
-        if (this.name === "text" && c != null) {
+        if (this.name === "text" && c !== null) {
             const cblock = this.blocks.blockList[c];
             switch (cblock.name) {
                 case "action":


### PR DESCRIPTION
This PR refactors `js/block.js` to combine duplicate `readAsDataURL` calls into a single conditional branch (DRY).

**Formatting Note:**
Since PR #5388 (update gulp-prettier to v6) was merged recently, this file required reformatting to pass the new CI/CD standards. The large diff reflects the auto-formatting updates enforced by Prettier 2.8.8.

* Reduces code duplication
* Updates file to current formatting standards