### PR TITLE
refactor turtle access in EnsembleBlocks

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -606,15 +606,11 @@ function setupEnsembleBlocks(activity) {
             this.hidden = this.deprecated = true;
         }
 
-        /**
-         * @todo FIXME
-         */
         arg(logo, turtle, blk, receivedArg) {
             const thisTurtle = _blockFindTurtle(activity, turtle, blk, receivedArg);
 
             if (thisTurtle) {
-                const tur = activity.turtles.ithTurtle(thisTurtle);
-                return tur.singer.notesPlayed[0] / tur.singer.notesPlayed[1];
+                return thisTurtle.singer.notesPlayed[0] / thisTurtle.singer.notesPlayed[1];
             }
 
             const tur = activity.turtles.ithTurtle(turtle);


### PR DESCRIPTION
When a user used the mouse notes played block to query a specific turtle (e.g., targeting "Mr. Mouse"), the code would incorrectly pass a Turtle object into activity.turtles.ithTurtle(), which expects an integer index. This was a failure and a crash (Error: Turtle [object Object] not found).