### PR TITLE
feat: Use audio clock for precise note scheduling

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -218,6 +218,7 @@ class Logo {
 
         this.time = 0;
         this.firstNoteTime = null;
+        this.firstNoteAudioTime = null;
         this._turtleDelay = 0;
         this.sounds = [];
         this.cameraID = null;
@@ -1099,6 +1100,7 @@ class Logo {
         // Run the Logo commands here.
         this.time = new Date().getTime();
         this.firstNoteTime = null;
+        this.firstNoteAudioTime = null;
 
         // Ensure we have at least one turtle.
         if (this.activity.turtles.getTurtleCount() === 0) {

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1574,6 +1574,9 @@ class Singer {
             // We start the music clock as the first note is being played
             if (activity.logo.firstNoteTime === null) {
                 activity.logo.firstNoteTime = new Date().getTime();
+                if (typeof Tone !== "undefined") {
+                    activity.logo.firstNoteAudioTime = Tone.now();
+                }
             }
 
             // Calculate a lag: In case this turtle has fallen behind,
@@ -1827,6 +1830,15 @@ class Singer {
             if (duration > 0) {
                 tur.singer.previousTurtleTime = tur.singer.turtleTime;
                 if (tur.singer.inNoteBlock.length === 1) {
+                    if (
+                        !tur.singer.suppressOutput &&
+                        activity.logo.firstNoteAudioTime !== null &&
+                        typeof Tone !== "undefined"
+                    ) {
+                        const audioElapsed = Tone.now() - activity.logo.firstNoteAudioTime;
+                        future = Math.max(tur.singer.previousTurtleTime - audioElapsed, 0);
+                    }
+
                     tur.singer.turtleTime += bpmFactor / duration;
                     if (!tur.singer.suppressOutput) {
                         tur.doWait(Math.max(bpmFactor / duration - turtleLag, 0));


### PR DESCRIPTION
### Summary
Using the audio clock to schedule notes more precisely. The lag correction system already evaluates note blocks ahead of time. Previously those notes would play immediately (`future = 0`), but now we compute a small offset so each note lands at its intended time on the audio clock.
Added `firstNoteAudioTime` (a `Tone.now()` reference) alongside the existing `firstNoteTime`. For outermost notes, we compute `future = max(intendedTime - audioElapsed, 0)` which feeds into the existing `Tone.now() + future` scheduling in synthutils.js.
When Tone.js isn't available, `future` stays at 0, same as current behavior.
### Verification
**Automated Tests:**
- Passed `npm test`, all 2655 tests pass
- Passed `npx eslint` on changed files
**Manual Verification:**
- Tested in browser, app loads correctly, Play button works on first click