### PR TITLE
Fix: GitHub Actions security issue with pull_request_target

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches: [master]

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -1,7 +1,7 @@
 name: Run Jest Tests on PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Hey! I found and fixed the security vulnerability mentioned in #5421.

What was the problem?
The workflows were using pull_request_target which gives PRs write access to the repo. This is dangerous because if someone creates a malicious PR from a fork, they could run bad code through npm install scripts with elevated permissions.

What I changed
I replaced pull_request_target with pull_request in these two files:

.github/workflows/lighthouse-ci.yml
 (line 4)
.github/workflows/pr-jest-tests.yml
 (line 4)
How does this fix it?
Now when PRs run, they don't get write access or access to secrets. The code runs in a sandboxed environment so even if someone tries something malicious, it can't actually do anything to our repo.

Testing
I checked all the workflow files to make sure there's no more pull_request_target being used. The YAML syntax looks good too.

One thing to note - PR comments might not work for external contributors anymore, but I think that's worth it for the security improvement. Comments should still work fine for PRs from branches in this repo.

Closes #5421

Let me know if there's anything else I should change or if the workflows need any other adjustments!