### PR TITLE
Fix/trash touch delete

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3184,7 +3184,15 @@ class Block {
                     event.stageY / this.activity.getStageScale()
                 )
             ) {
-                if (this.activity.trashcan.isVisible) {
+                // If the trash is visible OR the trash subsystem just
+                // completed its highlight (trashReady), treat this as a
+                // confirmed delete. This fixes a touch-device race where the
+                // highlight may become visible slightly after the release.
+                if (
+                    this.activity.trashcan.isVisible ||
+                    this.blocks.trashReady ||
+                    this.blocks.trashReadyBlock === thisBlock
+                ) {
                     this.blocks.sendStackToTrash(this);
                     this.activity.textMsg(
                         _(
@@ -3192,6 +3200,10 @@ class Block {
                         ),
                         3000
                     );
+
+                    // Clear pending flag after use.
+                    this.blocks.trashReady = false;
+                    this.blocks.trashReadyBlock = null;
                 }
             } else {
                 // Otherwise, process move.

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -239,6 +239,15 @@ class Blocks {
 
         this.selectedBlocks = [];
 
+    /**
+     * When the trash highlight animation completes we set this flag to
+     * indicate that a release over the trash should delete the active block.
+     * This avoids a timing/race condition on touch devices where the
+     * highlight becomes visible slightly after the release event.
+     */
+    this.trashReady = false;
+    this.trashReadyBlock = null;
+
         /**
          * We stage deletion of prototype action blocks on the palette so
          * as to avoid palette refresh race conditions.


### PR DESCRIPTION
Summary

Fixes a race on touch devices where dragging a block into the trash, waiting until the trash highlight turns red, and releasing could fail to delete the block because the highlight completed slightly after the release event.
Instead of immediately deleting when the highlight completes, the trash sets a small confirmation state (a trashReady flag recording the active block). The block's existing release handler now checks that flag and deletes on release. This preserves confirm-on-release UX while solving the timing race for touch users.