### PR TITLE
fix: define missing toTitleCase helper in GlobalTag

### DIFF
--- a/planet/js/GlobalTag.js
+++ b/planet/js/GlobalTag.js
@@ -12,7 +12,7 @@
 /*
    global
 
-   _
+   _, toTitleCase
 */
 /*
    exported


### PR DESCRIPTION
This PR fixes a runtime ReferenceError caused by an undefined
toTitleCase function used in GlobalTag.render. The helper
function is now defined locally to prevent the application
from crashing during tag rendering.
