### PR TITLE
Remove Unsafe DOM Prototype Overrides in _allClear()

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1594,18 +1594,6 @@ class Activity {
                 this.blocksContainer.x = 0;
                 this.blocksContainer.y = 0;
 
-                Element.prototype.remove = () => {
-                    this.parentElement.removeChild(this);
-                };
-
-                NodeList.prototype.remove = HTMLCollection.prototype.remove = () => {
-                    for (let i = 0, len = this.length; i < len; i++) {
-                        if (this[i] && this[i].parentElement) {
-                            this[i].parentElement.removeChild(this[i]);
-                        }
-                    }
-                };
-
                 const table = document.getElementById("myTable");
                 if (table !== null) {
                     table.remove();


### PR DESCRIPTION
### Summary
Remove Unsafe DOM Prototype Overrides in `_allClear()`. This PR fixes a critical bug in `js/activity.js` where `_allClear()` overwrites native DOM prototype methods:
1. `Element.prototype.remove`
2. `NodeList.prototype.remove`
3. `HTMLCollection.prototype.remove`

These overrides were implemented using arrow functions, which bind `this` lexically. As a result, `this` no longer refers to the DOM element being removed, causing the `element.remove()` calls to fail at runtime.

In addition, modifying global DOM prototypes introduces dangerous side effects across the entire application and can break browser-native behaviour or third-party libraries.

---

### Fix
Removed the prototype assignments entirely. Modern browsers already support native `element.remove()`, so these overrides are unnecessary.

---

### Testing / Reproduction
The issue was reproduced directly in the browser console:
1. Native behaviour works correctly:
```js
let d = document.createElement("div");
document.body.appendChild(d);
d.remove(); // Works normally
```

2. After applying the same override used in MusicBlocks:
```js
Element.prototype.remove = () => {
  this.parentElement.removeChild(this);
};
```

Calling `.remove()` fails:
```js
let x = document.createElement("p");
document.body.appendChild(x);
x.remove();
```

Result:
```bash
TypeError: Cannot read properties of undefined (reading 'removeChild')
```

This confirms that the arrow function breaks `this` binding and causes the removal to crash.