### PR TITLE
fix: attach Singer class to global window object

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -2488,6 +2488,11 @@ class Singer {
     }
 }
 
+// Attach Singer to global scope for runtime access
+if (typeof window !== "undefined") {
+    window.Singer = Singer;
+}
+
 if (typeof module !== "undefined" && module.exports) {
     module.exports = Singer;
 }


### PR DESCRIPTION
##  Fix: Resolve `ReferenceError: Singer is not defined` at Runtime

### Summary
This PR fixes **Issue #5445**, where the `Singer` class was referenced globally at runtime
but was not attached to the global scope, resulting in a
`ReferenceError: Singer is not defined` in the browser console.

The fix ensures `Singer` is consistently available at runtime while preserving the
existing module-based architecture.

---

###  Root Cause
- `Singer` is exported as a module (`turtle-singer.js`)
- Several runtime paths and tests assume `Singer` exists on the global (`window`) scope
- This mismatch caused console errors when running Music Blocks locally

---

### Solution
- Explicitly attached the `Singer` class to the global scope (`window.Singer`)
- Ensured compatibility with existing runtime references and test mocks
- No breaking changes to public APIs or module imports

---

###  Runtime Verification (Proof)
The fix was verified **in a real browser runtime**, not just via tests.

Verification confirms:
- `typeof Singer === "function"`
- `Singer.masterBPM` is accessible
- `window.Singer === Singer`
- No runtime `ReferenceError` appears in the console

A visual runtime verification overlay was generated directly in the browser to confirm
global availability of `Singer`.  
(See attached screenshot: **Issue #5445 – Verification**)
<img width="1465" height="796" alt="bug verification" src="https://github.com/user-attachments/assets/a9a2072a-f0ab-4c31-ba8e-1ceb0e213007" />

---

###  Reproduction & Validation Steps
1. Run Music Blocks locally from the latest master
2. Open the app in the browser
3. Open DevTools → Console
4. Confirm no `ReferenceError: Singer is not defined`
5. Execute runtime verification script (shown in screenshot)

---

###  Commits
- `fix: Attach Singer class to global scope to resolve ReferenceError`

---

###  Checklist
- [x] Issue reproduced locally
- [x] Root cause identified
- [x] Runtime fix implemented
- [x] Verified in browser console
- [x] No breaking changes introduced

---

**Resolves #5445**
