### PR TITLE
Mark locale JSON files as generated to hide from PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 *.md text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+# Mark locale files as generated - hides them from PR diffs by default
+# These files are auto-generated from PO files via convert_po_to_json.py
+locales/*.json linguist-generated=true


### PR DESCRIPTION
## Summary
Marks locale JSON files as `linguist-generated` in `.gitattributes` to hide them from PR diffs by default.

## Problem
Many contributors accidentally commit locale file changes (e.g., `bn.json`, `ja.json`) when:
- Running `convert_po_to_json.py`
- Using `git add .` instead of adding specific files

This clutters PRs with thousands of lines of unintended changes.

## Solution
Adding `locales/*.json linguist-generated=true` tells GitHub these files are auto-generated, so:
- They're collapsed by default in PR diffs
- Reviewers see only the actual code changes
- Files remain tracked and functional