### PR TITLE
chore:remove debug console statement from tempo widget

### DIFF
--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -404,7 +404,6 @@ class Tempo {
      */
     __save(i) {
         setTimeout(() => {
-            // console.debug("saving a BPM block for " + this.BPMs[i]);
             const delta = i * 42;
             const newStack = [
                 [0, ["setbpm3", {}], 100 + delta, 100 + delta, [null, 1, 2, 5]],


### PR DESCRIPTION
Part of #5464 

Removed a debug-only console.debug statement from js/widget/tempo.js

No functional Changes.

Manually tested by running MusicBlocks Locally.
