### PR TITLE
chore: remove debug console statements from js/widgets/sampler.js

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -2321,8 +2321,6 @@ function SampleWidget() {
                 instruments[0][instrumentName].playbackRate
             ) {
                 instruments[0][instrumentName].playbackRate.value = playbackRate;
-            } else {
-                // If the instrument doesn't exist yet, we'll apply the adjustment when playing
             }
         }
 


### PR DESCRIPTION
## Description
This PR removes the console.log and console.debug statements from sampler.js widget.

## Changes made:
Removed 'console.debug' when closing the audio context.
Removed 'console.log' from instrument playback logic.

##About:
This PR modifies only a single file: sampler.js before implementing the 'no-console' ESLint rule according to contribution guidelines given in the issue.

##Testing:
Ran 'npm run lint' to verify no syntax errors.
