### PR TITLE
chore: remove  console debug statement from meter widget

### DIFF
--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -490,7 +490,6 @@ class MeterWidget {
             n += 3;
         }
 
-        // console.debug(newStack);
         this.activity.blocks.loadNewBlocks(newStack);
     }
 


### PR DESCRIPTION
Part of #5464
#### PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation

Removed a debug-only console.debug statement from js/widgets/meterwidget.js.

- No functional changes
- No console.error or console.warn affected
- Manually tested Music Blocks locally