### PR TITLE
Add test for setDrum default fallback behavior

### DIFF
--- a/js/turtleactions/__tests__/DrumActions.test.js
+++ b/js/turtleactions/__tests__/DrumActions.test.js
@@ -211,6 +211,11 @@ describe("setupDrumActions", () => {
             expect(targetTurtle.singer.drumStyle).toContain("drum2");
         });
 
+        it("uses default drum for unknown drum name", () => {
+            Singer.DrumActions[actionName]("unknownDrum", 0, 1);
+            expect(targetTurtle.singer.drumStyle).toContain(DEFAULTDRUM);
+        });
+
         it("handles rhythm ruler", () => {
             activity.logo.inRhythmRuler = true;
             Singer.DrumActions[actionName]("d1", 0, 1);


### PR DESCRIPTION
## Summary

This PR adds a minimal unit test for the `setDrum` action to verify the default
fallback behavior when an unrecognized drum name is provided.

## Details

- `setDrum` already had shared test coverage with `mapPitchToDrum`
- The default fallback path (`DEFAULTDRUM`) was not explicitly asserted
- A focused test case has been added to cover this scenario

## Scope

- ✅ Test-only change
- ❌ No production code modifications
- ❌ No refactoring or behavior changes

## Verification

- All existing tests pass
- New test is deterministic and consistent with existing test patterns
