### PR TITLE
chore: remove debug console statements from js/widgets/help.js

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -266,7 +266,6 @@ class HelpWidget {
                         loadButton.onclick = () => {
                             if (message.length < 4) {
                                 // If there is nothing specified, just load the block.
-                                // console.debug("CLICK: " + name);
 
                                 const protoblk = object[0];
                                 const paletteName = object[1];
@@ -292,12 +291,10 @@ class HelpWidget {
                                     100,
                                     100
                                 );
-                                // console.debug("CLICK: " + blocksToLoad);
                                 this.activity.blocks.loadNewBlocks(blocksToLoad);
                             } else {
                                 // Load the blocks.
                                 const blocksToLoad = message[3];
-                                // console.debug("CLICK: " + blocksToLoad);
                                 this.activity.blocks.loadNewBlocks(blocksToLoad);
                             }
                         };
@@ -355,7 +352,6 @@ class HelpWidget {
 
         if (HELPCONTENT[page].length > 3) {
             const link = HELPCONTENT[page][3];
-            // console.debug(page + " " + link);
             body += `<p><a href="${link}" target="_blank">${HELPCONTENT[page][4]}</a></p>`;
         }
 
@@ -600,7 +596,6 @@ class HelpWidget {
                         if (message.length < 4) {
                             // If there is nothing specified, just
                             // load the block.
-                            // console.debug("CLICK: " + name);
                             const obj = this.activity.blocks.palettes.getProtoNameAndPalette(name);
                             const protoblk = obj[0];
                             const paletteName = obj[1];
@@ -628,12 +623,10 @@ class HelpWidget {
                                 100,
                                 100
                             );
-                            // console.debug("CLICK: " + blocksToLoad);
                             this.activity.blocks.loadNewBlocks(blocksToLoad);
                         } else {
                             // Load the blocks.
                             const blocksToLoad = message[3];
-                            // console.debug("CLICK: " + blocksToLoad);
                             this.activity.blocks.loadNewBlocks(blocksToLoad);
                         }
                     };


### PR DESCRIPTION
Part of #5464

Removed debug-only console.log / console.debug statements from Help widget.
No error or warning logs were modified.
Tested Help widget manually in browser.