### PR TITLE
chore: remove debug console statements from js/widgets/musickeyboard.js

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2188,7 +2188,7 @@ function MusicKeyboard(activity) {
                         key.objId; //convet solfege to alphabetic.
                 }, 500);
             } else {
-                // eslint-disable-next-line no-console
+                console.warn("Could not find anywhere to insert new block.")
                 
             }
         };


### PR DESCRIPTION
 Part of #5464
 
**Summary**
removed debug console statements from js/widgets/musickeyboard.js

**Changes**
Removed 2 debug console statements 
Preserved all actual functionality
No logic changes

All tests passed