### PR TITLE
Fix immediate sidebar toggle on note value block expand/collapse

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2882,7 +2882,20 @@ class Block {
             let topBlk;
 
             const dx = event.stageX / that.activity.getStageScale() - that.container.x;
-            if (!moved && that.isCollapsible() && dx < 30 / that.activity.getStageScale()) {
+            
+            // Check if this was a collapse/expand button click that was already handled in mousedown
+            const hasColExpBtns = that.collapseButtonBitmap && that.expandButtonBitmap;
+            let wasColExpHandled = false;
+            
+            if (hasColExpBtns) {
+                const localPoint = that.container.globalToLocal(event.stageX, event.stageY);
+                const isColExpClick =
+                    that.collapseButtonBitmap.getBounds().contains(localPoint.x, localPoint.y) ||
+                    that.expandButtonBitmap.getBounds().contains(localPoint.x, localPoint.y);
+                wasColExpHandled = isColExpClick;
+            }
+            
+            if (!moved && that.isCollapsible() && dx < 30 / that.activity.getStageScale() && !wasColExpHandled) {
                 that.collapseToggle();
             } else if ((!window.hasMouse && getInput) || (window.hasMouse && !moved)) {
                 if (["media", "audiofile", "loadFile"].includes(that.name)) {
@@ -2960,6 +2973,10 @@ class Block {
 
                 if (isColExpClick) {
                     that.activity.trashcan.hide();
+                    // Trigger collapseToggle immediately on mousedown for instant sidebar updates
+                    if (that.isCollapsible()) {
+                        that.collapseToggle();
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
## Summary
Fixes timing issue where setInstrument and start sidebars expand/contract late when note value blocks are expanded/contracted.

## Problem
Previously, sidebars would only expand/contract when the cursor was removed from the note value expansion/contraction button (on mouseup), not immediately when the button was clicked.

## Solution
Modified the block click event handling in [js/block.js](cci:7://file:///home/noddy/superDev/musicblocks%201/js/block.js:0:0-0:0) to:
- Trigger [collapseToggle()](cci:1://file:///home/noddy/superDev/musicblocks%201/js/block.js:2168:4-2276:5) immediately on mousedown when collapse/expand buttons are clicked
- Prevent duplicate calls in mouseup handler
- Provide instant visual feedback for sidebar updates

## Changes
- **Mousedown handler**: Added immediate [collapseToggle()](cci:1://file:///home/noddy/superDev/musicblocks%201/js/block.js:2168:4-2276:5) call for collapse/expand button clicks
- **Mouseup handler**: Added logic to prevent duplicate toggle operations

## Issue Reference
Fixes #3499

## Testing
- Note value blocks now expand/contract sidebars immediately on button click
- No duplicate toggle operations occur
- Maintains existing functionality for other block interactions

cc @walterbender