### PR TITLE
Fix undeclared variable in getPitchInfo

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6126,6 +6126,7 @@ const getPitchInfo = (activity, type, currentNote, tur) => {
     let pitch;
     let octave;
     let obj;
+    let cents;
     if (Number(currentNote)) {
         // If it is a frequency, convert it to a pitch/octave.
         obj = frequencyToPitch(currentNote);


### PR DESCRIPTION
## Description

This pull request fixes an undeclared variable in `getPitchInfo` that could create an implicit global variable or throw a `ReferenceError` in strict mode.

The fix is a small, localized change and does not alter the intended behavior of the function.

## Related Issue

Fixes #5487

## Changes Made

- Declared the `cents` variable locally inside `getPitchInfo` to prevent
  implicit global variable creation.

## Testing Performed

- Ran the full test suite locally using `npm test`.
- All tests passed successfully with no regressions.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

This is a minimal defensive fix that improves runtime safety without changing
existing functionality.