### PR TITLE
Fix XSS vulnerability in Reflection widget

### DIFF
--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -67,6 +67,33 @@ class ReflectionMatrix {
         this.code = "";
     }
 
+    escapeHTML(text) {
+        const escapeMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        };
+
+        return text.replace(/[&<>"']/g, char => escapeMap[char]);
+    }
+
+    sanitizeLinks(html) {
+        return html.replace(
+            /<a\s+[^>]*href\s*=\s*(['"]?)([^'">\s]+)\1/gi,
+            (match, quote, url) => {
+                const unsafeSchemes = /^(javascript|data|vbscript):/i;
+
+                if (unsafeSchemes.test(url.trim())) {
+                    return match.replace(url, "#");
+                }
+
+                return match;
+            }
+        );
+    }
+
     /**
      * Initializes the reflection widget.
      */
@@ -483,7 +510,10 @@ class ReflectionMatrix {
         const botReply = document.createElement("div");
 
         if (md) {
-            botReply.innerHTML = this.mdToHTML(reply.response);
+            const safeText = this.escapeHTML(reply.response);
+            let html = this.mdToHTML(safeText);
+            html = this.sanitizeLinks(html);
+            botReply.innerHTML = html;
         } else {
             botReply.innerText = reply.response;
         }


### PR DESCRIPTION
Fixes #5391

Prevent XSS via markdown rendering in Reflection widget.

This PR fixes an XSS vulnerability in the Reflection widget where markdown
responses were rendered as HTML without sufficient sanitization, allowing
potential script execution.

Changes:
- Added escapeHTML() to escape user-controlled input before rendering
- Added sanitizeLinks() to block javascript:, data:, and vbscript: URL schemes
- Ensured markdown rendering occurs only after sanitization

Testing:
- Verified raw <script> injection is blocked
- Verified inline event handlers are neutralized
- Verified javascript: URLs in markdown links are sanitized