### PR TITLE
Fix Trash View styling in dark mode

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -1,35 +1,55 @@
 /* Light Mode Defaults */
 body {
-  --bg: #e8e8e8;
-  --fg: #666666;
-  --overlay-bg: rgba(255, 255, 255, 0.75);
+    --bg: #e8e8e8;
+    --fg: #666666;
+    --overlay-bg: rgba(255, 255, 255, 0.75);
 }
 
 /* Dark Mode Overrides */
 body.dark {
-  --bg: #1d1d20;
-  --fg: #e8e8e8;
-  --overlay-bg: rgba(15, 15, 16, 0.75);
-
-  background: var(--bg);
-  color: var(--fg);
+    --bg: #1d1d20;
+    --fg: #e8e8e8;
+    --overlay-bg: rgba(15, 15, 16, 0.75);
+    background: var(--bg);
+    color: var(--fg);
 }
 
 /* Help widget colors */
 .dark #helpBodyDiv {
-  background: #1d1d20;
-  color: var(--fg);
+    background: #1d1d20;
+    color: var(--fg);
 }
 
-.dark #helpBodyDiv > .heading,
+.dark #helpBodyDiv>.heading,
 .dark #helpBodyDiv p {
-  color: var(--fg);
+    color: var(--fg);
 }
+
 /* Fix white side bars in Help / Tour widget */
 .dark #floatingWindows .wfWinBody {
-  background-color: var(--bg) !important;
+    background-color: var(--bg) !important;
 }
 
 .dark #floatingWindows .windowFrame {
-  background-color: var(--bg) !important;
+    background-color: var(--bg) !important;
+}
+
+/* Trash View Dark Mode */
+.dark .trash-view {
+    background-color: var(--bg);
+    color: var(--fg);
+    border-color: #000000;
+}
+
+.dark .trash-item {
+    color: var(--fg);
+}
+
+.dark .trash-item:hover {
+    background-color: #333;
+}
+
+.dark .button-container {
+    background: #022363;
+    border-bottom-color: #000000;
 }


### PR DESCRIPTION
### Summary
The Trash View panel was not following dark mode styling and continued to use light-mode colors, making it visually inconsistent with the rest of the interface.

This PR updates the Trash View styles so that they correctly respect dark mode, using the existing dark theme color variables and matching other dark-mode components.

### Changes Made
- Added dark-mode specific CSS rules for the Trash View panel
- Updated background, text, hover, and button container styles
- Reused existing dark-mode CSS variables for consistency
- Scoped changes under `.dark` to avoid affecting light mode

### Testing
- Verified Trash View appearance in light mode (unchanged)
- Verified dark background, readable text, and hover states in dark mode
- Toggled between light and dark modes to confirm correct behavior

### Result
- Trash View now renders correctly in dark mode
- Visual consistency with other dark-mode UI components
- No regressions in light mode

Fixes #5350