### PR TITLE
fix: support PORT environment variable for server port configuration

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -60,7 +60,11 @@ The development server fails to start because port 3000 is already in use.
 Solution:
 Start the server on a different port:
 
-npm start -- --port=3001
+PORT=3001 npm start
+
+Or for development mode:
+
+PORT=3001 npm run dev
 
 Then open http://localhost:3001 in your browser.
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ app.use(
     })
 );
 
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, "127.0.0.1", () => {
     console.log(`Music Blocks running at http://127.0.0.1:${PORT}/`);
     console.log("Compression enabled");


### PR DESCRIPTION
Fixes port configuration issue where troubleshooting docs suggested using 'npm start -- --port=3001' which doesn't work.

**Changes**:
- Update 'index.js' to read 'PORT' from environment variable (defaults to 3000)
- Update 'Docs/troubleshooting.md' to use correct 'PORT=3001 npm start' syntax

Tested: Server starts on both default port 3000 and custom port when PORT env var is set.