### PR TITLE
Fix fragile SVG export parsing in printBlockSVG

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1251,6 +1251,20 @@ class Activity {
             this.sendAllToTrash(true, true);
         };
 
+        const extractSVGInner = svgString => {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(svgString, "image/svg+xml");
+            const svgEl = doc.querySelector("svg");
+            if (!svgEl) return "";
+
+            // Remove drop shadow filters safely
+            svgEl.querySelectorAll("[filter]").forEach(el => {
+                el.removeAttribute("filter");
+            });
+
+            return svgEl.innerHTML;
+        };
+
         /**
          * @returns {SVG} returns SVG of blocks
          */
@@ -1274,11 +1288,9 @@ class Activity {
                     yMax = this.blocks.blockList[i].container.y + this.blocks.blockList[i].height;
                 }
 
-                if (this.blocks.blockList[i].collapsed) {
-                    parts = this.blocks.blockCollapseArt[i].split("><");
-                } else {
-                    parts = this.blocks.blockArt[i].split("><");
-                }
+                const rawSVG = this.blocks.blockList[i].collapsed
+                    ? this.blocks.blockCollapseArt[i]
+                    : this.blocks.blockArt[i];
 
                 if (this.blocks.blockList[i].isCollapsible()) {
                     svg += "<g>";
@@ -1290,7 +1302,13 @@ class Activity {
                     ", " +
                     this.blocks.blockList[i].container.y +
                     ')">';
-                if (SPECIALINPUTS.includes(this.blocks.blockList[i].name)) {
+
+                if (!SPECIALINPUTS.includes(this.blocks.blockList[i].name)) {
+                    svg += extractSVGInner(rawSVG);
+                } else {
+                    // Keep existing fragile logic for now
+                    parts = rawSVG.split("><");
+
                     for (let p = 1; p < parts.length; p++) {
                         // FIXME: This is fragile.
                         if (p === 1) {
@@ -1306,23 +1324,6 @@ class Activity {
                             } else {
                                 svg += parts[p] + ">" + this.blocks.blockList[i].value + "<";
                             }
-                        } else if (p === parts.length - 2) {
-                            svg += parts[p] + ">";
-                        } else if (p === parts.length - 1) {
-                            // skip final </svg>
-                        } else {
-                            svg += parts[p] + "><";
-                        }
-                    }
-                } else {
-                    for (let p = 1; p < parts.length; p++) {
-                        // FIXME: This is fragile.
-                        if (p === 1) {
-                            svg += "<" + parts[p] + "><";
-                        } else if (p === 2) {
-                            // skip filter
-                        } else if (p === 3) {
-                            svg += parts[p].replace("filter:url(#dropshadow);", "") + "><";
                         } else if (p === parts.length - 2) {
                             svg += parts[p] + ">";
                         } else if (p === parts.length - 1) {


### PR DESCRIPTION
### Summary

This PR refactors the block SVG export logic in `printBlockSVG` to avoid fragile string-based parsing (`split("><")`).
Non-`SPECIALINPUTS` blocks now use a DOM-based approach (`DOMParser`) to extract inner SVG markup more robustly, making the exporter whitespace/formatting insensitive.
`SPECIALINPUTS` retain the existing logic for now to avoid behaviour changes.

---

### Tests

1. `npm test` (92 suites, 2371 tests passed)
2. `npm run lint` for lint errors.
3. Verified that DOMParser-based extraction is whitespace-insensitive: compact and formatted SVG normalize to the same DOM output (`Normalized same? true`).
<img width="920" height="414" alt="image" src="https://github.com/user-attachments/assets/bd89aea7-3dbf-477f-8649-e6f56cef7d7e" />

---

### Note

Verified DOM-based parsing is resilient to SVG formatting/newlines (normalized DOM output matches for compact vs formatted SVG inputs).
