### PR TITLE
Fix guide TOC links and Documentation Links

### DIFF
--- a/Docs/guide-es/index.html
+++ b/Docs/guide-es/index.html
@@ -33,7 +33,7 @@ copia del código y se ejecuta directamente desde el archivo sistema de
 su computadora.</p>
 <p>Para más detalles sobre el uso de Bloques de Música, ver [Uso de
 Bloques de Música]
-(<a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation">http://github.com/sugarlabs/musicblocks/tree/master/documentation</a>)
+(<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md">https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md</a>)
 y para más detalles sobre cómo utilizar los bloques de la tortuga, ver
 [Uso de la tortuga bloques</p>
 <h2 id="acerca-de-esta-gu-a">ACERCA DE ESTA GUÍA</h2>

--- a/Docs/guide-ja/index.html
+++ b/Docs/guide-ja/index.html
@@ -22,7 +22,7 @@
 <h1 id="-">ミュージック・ブロックスのプログラミング案内</h1>
 <p>ミュージック・ブロックスは子供のための音楽とコードが合体されているプログラミング環境。子供さん達はこのツールで音楽、数学、またコードの基本な色々が楽しく発見することができます。ミュージック・ブロックスはタートルブロックから作られて、ピッチとリズムのツールもあります。</p>
 <p>タートルブロックの案内はミュージック・ブロックスより基本的なコンセプトがあります。この案内は音楽の基本があり、ミュージック・ブロックスの実例があります。</p>
-<h2 id="-a-name-a-"><a name="目次"></a> 目次</h2>
+<h2 id="table-of-contents"><a name="目次"></a> 目次</h2>
 <ol>
 <li><a href="#初めに">初めに</a></li>
 <li><a href="#音符">音の関係</a><ol>
@@ -80,17 +80,17 @@
 </ol>
 <p>この案内の中の例はコードのリンクもあります。そのすぐ楽しめるコードのリンクは<code>ライブで再生</code>と書いております。</p>
 <h2 id="-a-name-a-1-"><a name="初めに"></a>1. 初めに</h2>
-<p><a href="#目次">目次に戻す</a> | <a href="#音符">次のトピック (2. 音符の音を鳴らすのに)</a></p>
+<p><a href="#table-of-contents">目次に戻す</a> | <a href="#音符">次のトピック (2. 音符の音を鳴らすのに)</a></p>
 <p>ミュージック・ブロックスはブラウザーで実行するために作られています。クローム・ブラウザーで一番テストされていますがファイヤーフォックスも実行できます。<a href="https://musicblocks.sugarlabs.org">github io（ギットハーブ）</a>のウェブサイトから実行でき、ミュージック・ブロックスのソース・コードもダウンロードして自分のパソコンで実行できます。</p>
 <p>この案内よりミュージック・ブロックスの細かいを楽しみたかったら、<a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation">ミュージック・ブロックスの基本</a>をどうぞ、読んでください。
 ミュージック・ブロックスの元のタートル・ブロックスの細かいを楽しみたかったら、<a href="http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">タートル・ブロックスの基本</a>をどうぞ読んでください。</p>
-<h2 id="-a-name-a-"><a name="音符"></a></h2>
+<h2 id="table-of-contents"><a name="音符"></a></h2>
 <ol>
-<li>音の関係 <a href="#初めに">前のトピック (1. 初めに)</a> | <a href="#目次">目次に戻す</a> |
+<li>音の関係 <a href="#初めに">前のトピック (1. 初めに)</a> | <a href="#table-of-contents">目次に戻す</a> |
 <a href="#音楽でプログラミング">次のトピック (3. 音楽でプログラミング)</a></li>
 </ol>
 <p>ミュージック・ブロックスは音楽の基本の色々があります。例えば、<a href="#ピッチ">ピッチ</a>, <a href="#リズム・ブロック">リズム</a>, <a href="#他の転化">音量</a>,<a href="#シンセ">音色とシンセ</a>のツールもあります。</p>
-<h3 id="-a-name-a-"><a name="音価"></a></h3>
+<h3 id="table-of-contents"><a name="音価"></a></h3>
 <p>2.1 音価のブロック</p>
 <p>ミュージック・ブロックスの一番基本なブロックは<em>音価</em>ブロックです。<em>音価</em>ブロックの中に<a href="#ピッチ"><em>ピッチ</em>ブロック</a>が入られることができます。音価ブロックはピッチの長さがどのぐらいか決めます。</p>
 <p><img src="./note1.svg" alt="alt
@@ -104,7 +104,7 @@
 <p><img src="../charts/NotationRestChart.svg" alt="alt
  tag" title="音価とその音価の音価ブロックの図表です。"></p>
 <p>上の図表を使って音価とその音価のブロックを閲覧してください。</p>
-<h3 id="-a-name-a-"><a name="ピッチ"></a></h3>
+<h3 id="table-of-contents"><a name="ピッチ"></a></h3>
 <p>2.2 ピッチのブロック</p>
 <p><em>ピッチ</em>ブロックは<a href="#音価"><em>音価</em></a>ブロックの中に使われています。<em>ピッチ</em>ブロックはピッチの名前とピッチのオクターヴを決めます。ピッチの名前とオクターヴの数値を組み合わせて、音符の振動（音波の振動）を決めます。</p>
 <p><img src="./note3.svg" alt="alt
@@ -133,7 +133,7 @@
 <p><img src="./note5.svg" alt="alt tag" title="一つよりのドラムの音を同時に"></p>
 <p>この上の例のように<a href="#和音">和音</a>一つよりの<em>ドラム</em>ブロックが一緒に使えます。一つの<em>音価</em>ブロックの中に一つよりのドラム・ブロックと<em>ピッチ</em>ブロックとお好み組み合わせて音の楽しみができます。</p>
 <h2 id="-a-name-a-3-"><a name="音楽でプログラミング"></a>3. 音楽でプログラミング</h2>
-<p><a href="#音符">前のトピック (2. 音の関係)</a> | <a href="#目次">目次に戻す</a> | <a href="#ウィジェット">次のトピック (4. ウィジェット)</a></p>
+<p><a href="#音符">前のトピック (2. 音の関係)</a> | <a href="#table-of-contents">目次に戻す</a> | <a href="#ウィジェット">次のトピック (4. ウィジェット)</a></p>
 <p>このセクションのトピックはチャンクで<em>動作</em>ブロックを使って音楽とプログラミングができます。チャンクが自分で動作ブロックを使って作ることも、<a href="#ピッチ・タイム行列"><em>ピッチ・タイム行列</em></a>を使って作ることもできます。</p>
 <h3 id="-a-name-a-3-1-"><a name="チャンク"></a>3.1 チャンク</h3>
 <p><img src="./matrix4.svg" alt="alt tag" title="動作ブロックの使われる例"></p>
@@ -210,7 +210,7 @@ note.</p>
 <p><img src="./transform9.svg" alt="alt tag" title="相対的な音程ブロックと相対的な音量を設定ブロック"></p>
 <p><em>相対的な音程</em>は入っている音符から音程を計算してそのピッチも同時に鳴らします。例えば、音符から五度上の音も欲しかったら、このブロックを使います。上の例には、<code>レ</code>に&#39;ラ&#39;を<code>ミ</code>に&#39;シ&#39;を同時に鳴らします。</p>
 <p><em>相対的な音量を設定</em>ブロックは入っている音符の音量をブロックの数値で足すことか引くことをします。例えば、100の数値は現在の音量を倍にします。</p>
-<h4 id="-a-name-a-"><a name= "絶対音程"></a>絶対音程</h4>
+<h4 id="table-of-contents"><a name= "絶対音程"></a>絶対音程</h4>
 <p><img src="./transform14.svg" alt="alt tag" title="Using 絶対音程"></p>
 <p><em>増</em>ブロックが絶対音程を計算します。例えば、「像5程度」(&lt;===check this!!) はインプットのピッチふぁら像5程度のピッチの音符をインプットのピッチと一緒に鳴らします。 同様に、<em>短</em>のブロックはインプットのピッチから絶対の音程を計算して一緒に鳴らします。例えば、<em>短</em>のブロックを使えばインプットのピッチから<em>短</em>のピッチも一緒に鳴らします。他の絶対音程のブロックは<em>完全</em>のも、<em>減</em>のも、<em>長</em>のもあります。</p>
 <p>上の像５音程の例で二つの音符のインプットから四つの音符が鳴らして、D_55とA_5和音の音符も一緒に鳴らします。その後、E_5とC_5のピッチの音符も和音として鳴らします。短3音程の例にはオクターヴの転化ともまず、D_5とF_5の音符が鳴らして、次にE_5とG_6の和音が鳴らします。</p>
@@ -312,8 +312,8 @@ the volumne to 5. The resultant graphic is shown below.</p>
 <p><a href="https://musicblocks.sugarlabs.org/index.html?id=1518563680450252&amp;run=True">ライブで再生</a></p>
 <p><img src="./interactive3.svg" alt="alt tag" title="乱数的なものが音楽に入れる方法"></p>
 <p>乱数的なものが音楽と一緒に入れることができます。上の例に<em>これかそれ</em>ブロックは乱数的に<code>ド</code>、それとも<code>レ</code>を、<em>音価</em>ブロックが毎回鳴る時その音符のピッチにします。その下の例について、<em>これかそれ</em>のブロックが乱数的に<code>チャンク1</code>を、それとも<code>チャンク2</code>を選べます。</p>
-<h2 id="-a-name-a-"><a name="ウィジェット"></a>ウィジェット</h2>
-<p><a href="#音楽でプログラミング">前のトピック (3. 音楽でプログラミング)</a> | <a href="#目次">目次に戻す</a> | <a href="#ミュージック・ブロックスから以遠">次のトピック (5. ミュージック・ブロックスから以遠)</a></p>
+<h2 id="table-of-contents"><a name="ウィジェット"></a>ウィジェット</h2>
+<p><a href="#音楽でプログラミング">前のトピック (3. 音楽でプログラミング)</a> | <a href="#table-of-contents">目次に戻す</a> | <a href="#ミュージック・ブロックスから以遠">次のトピック (5. ミュージック・ブロックスから以遠)</a></p>
 <p>案内のこれからがミュージック・ブロックスの色々なウィジェットを紹介して使い方を案内します。ミュージック・ブロックスにあるウィジェットがコードと音楽をもともと分かりやすくするためです。</p>
 <h3 id="-a-name-a-4-1-"><a name="ステータス"></a>4.1 ステータス</h3>
 <p><img src="./status1.svg" alt="alt tag" title="given Music block"></p>
@@ -611,8 +611,8 @@ up</em> and <em>Slow down</em> buttons, and an input field for updating the
 <p>You can also update the テンポ by クリックing twice in spaced succession in the
 ウィジェット: the new BPM is determined as the time between the two クリックs. For
 example, if there is 1/2 seconds between クリックs, the new BPM will be set as 120.</p>
-<h2 id="-a-name-a-"><a name="ミュージック・ブロックスから以遠"></a>ミュージック・ブロックスから以遠</h2>
-<p><a href="#ウィジェット">前のトピック (4. ウィジェット)</a> | <a href="#目次">目次に戻す</a></p>
+<h2 id="table-of-contents"><a name="ミュージック・ブロックスから以遠"></a>ミュージック・ブロックスから以遠</h2>
+<p><a href="#ウィジェット">前のトピック (4. ウィジェット)</a> | <a href="#table-of-contents">目次に戻す</a></p>
 <p>ミュージック・ブロックス is a waypoint, not a destination. One of the goals is to
 point the learner towards other powerful tools. One such tool is
 <a href="http://lilypond.org">Lilypond</a>, a music engraving program.</p>

--- a/Docs/guide-pt/index.html
+++ b/Docs/guide-pt/index.html
@@ -184,7 +184,7 @@
         </p>
         <h2 id="1-getting-started"><a name="#GETTING-STARTED">1. Começando</a></h2>
         <p>
-          <a href="#TOC">Voltar para o Índice</a> |
+          <a href="#table-of-contents">Voltar ao Índice</a> |
           <a href="#NOTES">Próxima Seção (2. Fazendo Sons)</a>
         </p>
         <p>
@@ -215,7 +215,7 @@
         <h2 id="2-making-sounds"><a name="NOTES">2. Fazendo Sons</a></h2>
         <p>
           <a href="#1-getting-started">Seção Anterior (1. Começando)</a> |
-          <a href="#TOC">Voltar para o Índice</a> |
+          <a href="#table-of-contents">Voltar ao Índice</a> |
           <a href="#3-programming-with-music">Próxima Seção (3. Programando com Música)</a>
         </p>
         <p>
@@ -476,7 +476,7 @@
         </h2>
         <p>
           <a href="#2-making-sounds">Seção Anterior (2. Fazendo Sons)</a> |
-          <a href="#TOC">Voltar para o Índice</a> |
+          <a href="#table-of-contents">Voltar ao Índice</a> |
           <a href="#4-widgets">Próxima Seção (4. Widgets)</a>
         </p>
         <p>
@@ -960,7 +960,7 @@
         <h2 id="4-widgets"><a name="WIDGETS">4. Widgets</a></h2>
         <p>
           <a href="#3-programming-with-music">Seção Anterior (3. Programando com Música)</a> |
-          <a href="#TABLE-OF-CONTENTS">Voltar ao Índice</a> |
+          <a href="#table-of-contents">Voltar ao Índice</a> |
           <a href="#5-beyond-music-blocks">Próxima Seção (5. Além do Music Blocks)</a>
         </p>
         <p>
@@ -1720,7 +1720,7 @@
         <h2 id="5-beyond-music-blocks"><a name="BEYOND-MUSIC-BLOCKS">5. Além do Music Blocks</a></h2>
         <p>
           <a href="#4-widgets">Seção Anterior (4. Widgets)</a> |
-          <a href="#TABLE-OF-CONTENTS">Voltar ao Índice</a>
+          <a href="#table-of-contents">Voltar ao Índice</a>
         </p>
         <p>
           O Music Blocks é um ponto de passagem, não um destino. Um dos objetivos é apontar o aprendiz
@@ -1871,7 +1871,7 @@
         <h2 id="6-appendix"><a name="APPENDIX">6. Apêndice</a></h2>
         <p>
           <a href="#5-beyond-music-blocks">Seção Anterior (5. Além do Music Blocks)</a> |
-          <a href="#TABLE-OF-CONTENTS">Voltar ao Índice</a>
+          <a href="#table-of-contents">Voltar ao Índice</a>
         </p>
         <h3 id="61-beginner-palettes"><a name="BEGINNER_PALETTES">6.1 Paletas para Iniciantes</a></h3>
         <p>
@@ -3986,7 +3986,7 @@
             </tr>
           </tbody>
         </table>
-        <p><a href="#TABLE-OF-CONTENTS">Voltar ao Índice</a></p>
+        <p><a href="#table-of-contents">Voltar ao Índice</a></p>
       </div>
     </div>
   </body>

--- a/Docs/guide-zhCN/index.html
+++ b/Docs/guide-zhCN/index.html
@@ -24,7 +24,7 @@
 《音乐拼块》扩展另一个程序，《乌龟拼块》，加上了一集关于音调和韵律的功能。</p>
 <p>《音乐拼块》程序设计说明是一个开始学程序基础的好地方。
 在这个说明书里，我们会让读者看看了解几个程序例子，来展示《音乐拼块》的音乐功能。</p>
-<h2 id="-a-name-toc-a-"><a name="TOC"></a> 目录</h2>
+<h2 id="table-of-contents"><a name="TOC"></a> 目录</h2>
 <ol>
 <li><a href="#GETTING-STARTED">开始</a></li>
 <li><a href="#NOTES">发出声音</a><ol>
@@ -82,13 +82,13 @@
 </ol>
 <p>许多说明里给的例子可以链接到可以执行的程序，只需注意 <code>RUN LIVE</code> 链接.</p>
 <h2 id="-a-name-getting-started-a-1-"><a name="GETTING-STARTED"></a>1. 开始</h2>
-<p><a href="#TOC">回去目录</a> | <a href="#NOTES">下一章 (2. 发出声音)</a></p>
+<p><a href="#table-of-contents">回去目录</a> | <a href="#NOTES">下一章 (2. 发出声音)</a></p>
 <p>《音乐拼块》是设计在游览器上使用。大多数的程序发展是在 Google Chrome 上做的，可是程序也应该在 Mozilla Firefox 上使用。
 你可以从 <a href="http://sugarlabs.github.io/musicblocks">github.io</a> 执行程序， 或下载一个程序的复制，直接在自己的电脑上，使用文件系统执行下载的复制程序。</p>
 <p>想知道更多关于《音乐拼块》的详情，你可以看 <a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation">Using MusicBlocks</a>.
 想知道更多关于《乌龟拼块》的详情，你可以看 <a href="http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">Using TurtleBlocksJS</a>.</p>
 <h2 id="-a-name-notes-a-2-"><a name="NOTES"></a>2. 发出声音</h2>
-<p><a href="#GETTING-STARTED">上一章 (1. 开始)</a> | <a href="#TOC">回去目录</a> |<a href="#PROGRAMMING-WITH-MUSIC">下一章 (3. 使用音乐设计程序)</a></p>
+<p><a href="#GETTING-STARTED">上一章 (1. 开始)</a> | <a href="#table-of-contents">回去目录</a> |<a href="#PROGRAMMING-WITH-MUSIC">下一章 (3. 使用音乐设计程序)</a></p>
 <p>《音乐拼块》使用很多常见的音乐元素，相似<a href="#PITCH">音调</a>, <a href="#rhythms">音律</a>,<a href="#MORE-TRANSFORMATIONS">声音</a>,和一点 <a href="#VOICES">乐器的选择</a>。</p>
 <h3 id="-a-name-note-value-a-"><a name="NOTE-VALUE"></a></h3>
 <p>2.1 《音乐拼块》最有用的拼块是《音符长度》。《音符长度》里面有一个<a href="#PITCH">音调拼块</a>和音符的长度。</p>
@@ -130,7 +130,7 @@
 <p><img src="./note5.svg" alt="alt tag" title="Multiple Drum Sample blocks in combinations"></p>
 <p>上面有一个和弦的例子。这个例子的和弦使用鼓拼块。</p>
 <h2 id="-a-name-programming-with-music-a-3-"><a name="PROGRAMMING-WITH-MUSIC"></a>3. 使用音乐设计程序</h2>
-<p><a href="#NOTES">上一章 (2. 发出声音)</a> | <a href="#TOC">回去目录</a> | <a href="#WIDGETS">下一章 (4. 部件)</a></p>
+<p><a href="#NOTES">上一章 (2. 发出声音)</a> | <a href="#table-of-contents">回去目录</a> | <a href="#WIDGETS">下一章 (4. 部件)</a></p>
 <p>这一章将会说明怎么使用音乐砖块来产生音乐。
 一件必须注意的事是你可以使用自己做出来的音乐砖块来做出你的程序，
 或使用 <a href="#pitch-time"><em>音调-时间矩阵</em></a> 开始做出你的程序.</p>
@@ -333,7 +333,7 @@ LIVE</a></p>
 在上面的例子里，我们使用 <em>One-of</em> 拼块，每次执行 <em>Note Value</em> 拼块时，来随机定住 <code>Do</code> 或 <code>Re</code>。
 在下面的例子里，我们使用 <em>One-of</em> 拼块随机选择 <code>chunk1</code>或 <code>chunk2</code>。</p>
 <h2 id="-a-name-widgets-a-"><a name="WIDGETS"></a>部件</h2>
-<p><a href="#PROGRAMMING-WITH-MUSIC">上一章 (3. 使用音乐设计程序)</a> | <a href="#TOC">回去目录</a> | <a href="#BEYOND-MUSIC-BLOCKS">下一章 (5. 《音乐拼块》之外)</a></p>
+<p><a href="#PROGRAMMING-WITH-MUSIC">上一章 (3. 使用音乐设计程序)</a> | <a href="#table-of-contents">回去目录</a> | <a href="#BEYOND-MUSIC-BLOCKS">下一章 (5. 《音乐拼块》之外)</a></p>
 <p>说明书里的这一章将会解释《音乐拼块》的不同部件，你可以使用这些不同部件来提高你使用《音乐拼块》的经验。</p>
 <h3 id="-a-name-status-a-4-1-"><a name="status"></a>4.1 观察状况</h3>
 <p><img src="./status1.svg" alt="alt tag" title="given Music block"></p>
@@ -585,7 +585,7 @@ or between columns.</p>
 <p>您也可以通过点击小部件间隔连续两次来更新音乐速度：新的BPM被确定为两次点击之间的时间。
 例如，如果点击之间有1/2秒，新的BPM将被设置为120。</p>
 <h2 id="-a-name-beyond-music-blocks-a-"><a name="BEYOND-MUSIC-BLOCKS"></a>《音乐拼块》之外</h2>
-<p><a href="#WIDGETS">上一章 (4. 部件)</a> | <a href="#TOC">回去目录</a></p>
+<p><a href="#WIDGETS">上一章 (4. 部件)</a> | <a href="#table-of-contents">回去目录</a></p>
 <p>《音乐拼块》 是一个航点，而不是目的地。
 其中一个目标是把学习者指向其他强大的工具。
 一个这样的工具是 <a href="http://lilypond.org">Lilypond</a>, 一个音乐雕刻程序。</p>

--- a/Docs/guide/index.html
+++ b/Docs/guide/index.html
@@ -46,7 +46,7 @@
           musical features by walking the reader through numerous examples.
         </p>
         <p>
-          The Music Blocks <a href="../documentation/README.md">basic documentation</a> is also a
+          The Music Blocks <a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md">basic documentation</a> is also a
           good resource.
         </p>
         <p>
@@ -187,7 +187,7 @@
         </p>
         <h2 id="1-getting-started"><a name="#GETTING-STARTED">1. Getting Started</a></h2>
         <p>
-          <a href="#TOC">Back to Table of Contents</a> |
+          <a href="#table-of-contents">Back to Table of Contents</a> |
           <a href="#NOTES">Next Section (2. Making Sounds)</a>
         </p>
         <p>
@@ -208,7 +208,7 @@
         </p>
         <p>
           For more details on how to use Music Blocks, see
-          <a href="http://github.com/sugarlabs/musicblocks/tree/master/documentation"
+          <a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md"
             >Using Music Blocks</a
           >. For more details on how to use Turtle Blocks, see
           <a href="http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation"
@@ -218,7 +218,7 @@
         <h2 id="2-making-sounds"><a name="NOTES">2. Making Sounds</a></h2>
         <p>
           <a href="#1-getting-started">Previous Section (1. Getting Started)</a> |
-          <a href="#TOC">Back to Table of Contents</a> |
+          <a href="#table-of-contents">Back to Table of Contents</a> |
           <a href="#3-programming-with-music">Next Section (3. Programming with Music)</a>
         </p>
         <p>
@@ -480,7 +480,7 @@
         </h2>
         <p>
           <a href="#2-making-sounds">Previous Section (2. Making Sounds)</a> |
-          <a href="#TOC">Back to Table of Contents</a> |
+          <a href="#table-of-contents">Back to Table of Contents</a> |
           <a href="#4-widgets">Next Section (4. Widgets)</a>
         </p>
         <p>
@@ -2564,7 +2564,7 @@
         <h2 id="4-widgets"><a name="WIDGETS">4. Widgets</a></h2>
         <p>
           <a href="#3-programming-with-music">Previous Section (3. Programming with Music)</a> |
-          <a href="#TABLE-OF-CONTENTS">Back to Table of Contents</a> |
+          <a href="#table-of-contents">Back to Table of Contents</a> |
           <a href="#5-beyond-music-blocks">Next Section (5. Beyond Music Blocks)</a>
         </p>
         <p>
@@ -3326,7 +3326,7 @@ the stairs"
         <h2 id="5-beyond-music-blocks"><a name="BEYOND-MUSIC-BLOCKS">5. Beyond Music Blocks</a></h2>
         <p>
           <a href="#4-widgets">Previous Section (4. Widgets)</a> |
-          <a href="#TABLE-OF-CONTENTS">Back to Table of Contents</a>
+          <a href="#table-of-contents">Back to Table of Contents</a>
         </p>
         <p>
           Music Blocks is a waypoint, not a destination. One of the goals is to point the learner
@@ -3477,7 +3477,7 @@ MusicBlocks.run();</code></pre>
         <h2 id="6-appendix"><a name="APPENDIX">6. Appendix</a></h2>
         <p>
           <a href="#5-beyond-music-blocks">Previous Section (5. Beyond Music Blocks)</a> |
-          <a href="#TABLE-OF-CONTENTS">Back to Table of Contents</a>
+          <a href="#table-of-contents">Back to Table of Contents</a>
         </p>
         <h3 id="61-beginner-palettes"><a name="BEGINNER_PALETTES">6.1 Beginner Palettes</a></h3>
         <p>


### PR DESCRIPTION
This PR updates the guide HTML files to ensure the “Back to Table of Contents” links work correctly across the documentation.
It also fixes and updates the link to the documentation to point to the correct location.

These changes improve navigation and make it easier for users to move through the guides without broken or incorrect links.