### PR TITLE
Fix: Disable horizontal scrolling when switching to beginner mode

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1031,6 +1031,11 @@ class Toolbar {
                 console.error(e);
             }
 
+            // Disable horizontal scrolling when switching to beginner mode
+            if (this.activity.beginnerMode && this.activity.scrollBlockContainer) {
+                setScroller(this.activity);
+            }
+
             updateUIForMode();
 
             // Reinitialize tooltips after mode switch


### PR DESCRIPTION
### **Description**

This PR addresses a UI inconsistency where horizontal scrolling persisted after switching from **Advanced** to **Beginner** mode. While Beginner mode hides the relevant UI icons, the `scrollBlockContainer` flag remained active, leading to unintended scrolling behavior in a simplified interface.

### **Problem**

The scrolling state was not being re-evaluated during the mode transition. If a user enabled horizontal scrolling in Advanced mode and then switched to Beginner mode, the container remained scrollable despite the controls being inaccessible.

### **Changes**

* **Logic Update:** Enhanced the mode-switching handler in `toolbar.js` to ensure the scrolling state is synchronized with the active mode.
* **State Reset:** Added a conditional check to trigger the scroller configuration update specifically when entering Beginner mode.
* **Execution Timing:** The fix is applied after the mode toggle but prior to the UI refresh to ensure a seamless transition for the user.
