### PR TITLE
Fix: Disable horizontal scrolling when switching to beginner mode

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1031,6 +1031,11 @@ class Toolbar {
                 console.error(e);
             }
 
+            // Disable horizontal scrolling when switching to beginner mode
+            if (this.activity.beginnerMode && this.activity.scrollBlockContainer) {
+                setScroller(this.activity);
+            }
+
             updateUIForMode();
 
             // Reinitialize tooltips after mode switch


### PR DESCRIPTION
### Description

This PR fixes a UI state inconsistency where the **Stop** button failed to update its visual state (turning red) when music playback was initiated using the **Space** key.

### **Problem**

While the Space key correctly triggered audio playback, it lacked the specific instruction to update the Stop button's appearance. This resulted in a "silent" playback state where the music was running, but the UI did not visually reflect that a stop action was available.

### **Changes**

* Updated the Space key input handler to include the visual state toggle for the playback controls.