### PR TITLE
Synchronize Stop Button State with Space Key Playback

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3286,6 +3286,10 @@ class Activity {
                         this._doHardStopButton();
                     } else if (!disableKeys && !hasOpenWidget) {
                         event.preventDefault();
+                        const stopbtn = document.getElementById("stop");
+                        if (stopbtn) {
+                            stopbtn.style.color = platformColor.stopIconcolor;
+                        }
                         this._doFastButton();
                     }
                 } else if (!disableKeys) {


### PR DESCRIPTION
### **Description**

This PR fixes a UI state inconsistency where the **Stop** button failed to update its visual state (turning red) when music playback was initiated using the **Space** key.

### **Problem**

While the Space key correctly triggered audio playback, it lacked the specific instruction to update the Stop button's appearance. This resulted in a "silent" playback state where the music was running, but the UI did not visually reflect that a stop action was available.

### **Changes**

* Updated the Space key input handler to include the visual state toggle for the playback controls.