### PR TITLE
Restore visible keyboard focus indicators

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -14,22 +14,29 @@
 
 @import url("play-only-mode.css");
 
-*:focus {
+/* Hide focus for mouse users, preserve for keyboard users */
+*:focus:not(:focus-visible) {
   outline: none;
+}
+
+/* Global accessible focus indicator for keyboard users */
+:focus-visible {
+  outline: 3px solid #4a90e2;
+  outline-offset: 2px;
 }
 
 body:not(.dark) #helpfulSearch,
 body:not(.dark) .ui-autocomplete {
-    background-color: #fff !important;
-    color: #000 !important;
+  background-color: #fff !important;
+  color: #000 !important;
 }
 
 body:not(.dark) .ui-autocomplete li:hover {
-    background-color: #ddd !important;
+  background-color: #ddd !important;
 }
 
 body:not(.dark) #helpfulSearchDiv {
-    background-color: #f9f9f9 !important;
+  background-color: #f9f9f9 !important;
 }
 
 #newdropdown {
@@ -208,7 +215,7 @@ body:not(.dark) #helpfulSearchDiv {
   margin-top: 60px;
 }
 
-#helpfulSearchDiv{
+#helpfulSearchDiv {
   display: block !important;
   position: absolute;
   background-color: #f0f0f0;
@@ -218,7 +225,7 @@ body:not(.dark) #helpfulSearchDiv {
   z-index: 1;
 }
 
-#helpfulSearch{
+#helpfulSearch {
   padding: 2px;
   border: 2px solid grey;
   width: 220px;
@@ -284,13 +291,14 @@ body:not(.dark) #helpfulSearchDiv {
   vertical-align: middle;
 }
 
-#restoreLastIcon, #restoreAllIcon {
+#restoreLastIcon,
+#restoreAllIcon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 48px;
   height: 48px;
-  cursor: pointer; 
+  cursor: pointer;
 }
 
 
@@ -425,7 +433,7 @@ body:not(.dark) #helpfulSearchDiv {
   display: block;
 }
 
-#popdown-palette.show ~ .canvasHolder {
+#popdown-palette.show~.canvasHolder {
   filter: blur(10px);
   -webkit-filter: blur(10px);
 }
@@ -1089,6 +1097,7 @@ table {
 }
 
 @media (max-width: 600px) {
+
   #right-arrow,
   #left-arrow {
     height: 30px;
@@ -1098,6 +1107,7 @@ table {
 }
 
 @media (max-width: 450px) {
+
   #right-arrow,
   #left-arrow {
     height: 25px;
@@ -1107,6 +1117,7 @@ table {
 }
 
 @media (max-width: 320px) {
+
   #right-arrow,
   #left-arrow {
     height: 20px;
@@ -1818,7 +1829,7 @@ input.timbreName {
   z-index: 10000;
 }
 
-.wheelNav > svg {
+.wheelNav>svg {
   width: 100%;
   height: 100%;
 }
@@ -1833,7 +1844,7 @@ input.timbreName {
   position: fixed;
 }
 
-#chooseKeyDiv > svg {
+#chooseKeyDiv>svg {
   width: 100%;
   height: 100%;
   transition: width 2s linear 1s;
@@ -1963,12 +1974,14 @@ table {
 .disable_highlighting {
   user-select: none;
 }
+
 #palette.flex-palette {
   display: flex !important;
   flex-direction: row !important;
 }
 
 @media (max-width: 390px) {
+
   #right-arrow,
   #left-arrow {
     position: relative;
@@ -1982,23 +1995,28 @@ table {
     clear: both;
   }
 }
-.logo-container{
+
+.logo-container {
   position: absolute;
-  bottom: 1px; /* Distance from the bottom */
-  right: 23px;  /* Distance from the right */
+  bottom: 1px;
+  /* Distance from the bottom */
+  right: 23px;
+  /* Distance from the right */
   padding: 0px;
   border-radius: 5px;
   cursor: pointer;
 }
-#link-to-sugarLabs:link ,
-#link-to-sugarLabs:visited ,
-#link-to-sugarLabs:hover ,
-#link-to-sugarLabs:active  {
+
+#link-to-sugarLabs:link,
+#link-to-sugarLabs:visited,
+#link-to-sugarLabs:hover,
+#link-to-sugarLabs:active {
   color: #000;
 }
+
 .color-change {
-  fill : #033CD2;
-  stroke : #78E600;
+  fill: #033CD2;
+  stroke: #78E600;
   stroke-width: 3;
 }
 
@@ -2007,7 +2025,7 @@ table {
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background-color: #1E88E5; 
+  background-color: #1E88E5;
   color: white;
   padding: 15px 20px;
   border-radius: 8px;
@@ -2022,7 +2040,7 @@ table {
 
 
 
-.chatInterface{
+.chatInterface {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -2074,14 +2092,22 @@ table {
 
 
 .lego-brick {
-    display: inline-block;
-    background-color: #FF0000;
-    border: 1px solid #880000;
-    margin: 2px;
+  display: inline-block;
+  background-color: #FF0000;
+  border: 1px solid #880000;
+  margin: 2px;
 }
 
-.lego-size-1 { width: 20px; height: 10px; }
-.lego-size-2 { width: 40px; height: 10px; }
+.lego-size-1 {
+  width: 20px;
+  height: 10px;
+}
+
+.lego-size-2 {
+  width: 40px;
+  height: 10px;
+}
+
 /* ... more sizes ... */
 /* ======================================================
    FIX: Responsive Tour Arrows (Mobile vs Desktop)
@@ -2090,56 +2116,61 @@ table {
 
 #left-arrow,
 #right-arrow {
-    /* 1. Center Vertically */
-    top: 50% !important; 
-    transform: translateY(-50%);
-    
-    /* 2. Ensure visibility */
-    z-index: 2000;
-    position: absolute;
+  /* 1. Center Vertically */
+  top: 50% !important;
+  transform: translateY(-50%);
+
+  /* 2. Ensure visibility */
+  z-index: 2000;
+  position: absolute;
 }
 
 /* --- Mobile / Default View --- */
 #left-arrow {
-    left: 10px !important;
+  left: 10px !important;
 }
 
 #right-arrow {
-    left: auto !important;  /* Unset the old fixed pixel value */
-    right: 10px !important; /* Stick to the right edge */
+  left: auto !important;
+  /* Unset the old fixed pixel value */
+  right: 10px !important;
+  /* Stick to the right edge */
 }
 
 /* --- Desktop View (Screens wider than 900px) --- */
 @media screen and (min-width: 900px) {
-    #left-arrow {
-        left: 20px !important; /* More space from the edge on desktop */
-    }
-    
-    #right-arrow {
-        right: 20px !important;
-    }
+  #left-arrow {
+    left: 20px !important;
+    /* More space from the edge on desktop */
+  }
+
+  #right-arrow {
+    right: 20px !important;
+  }
 }
+
 /* ======================================================
    FIX: Center the Welcome Modal on Mobile
    ====================================================== */
 @media screen and (max-width: 600px) {
-    #helpDiv {
-        /* 1. Fit the screen width */
-        width: 90% !important;
-        
-        /* 2. Center Horizontally */
-        left: 50% !important;
-        transform: translateX(-50%); /* Moves it back by half its width to center it */
-        
-        /* 3. Reset Top position if needed */
-        top: 15% !important;
-    }
+  #helpDiv {
+    /* 1. Fit the screen width */
+    width: 90% !important;
 
-    /* Fix the inner text box width so it doesn't overflow */
-    #helpBodyDiv {
-        width: 100% !important;
-        left: 0 !important;
-        padding: 0 10px;
-        box-sizing: border-box; 
-    }
+    /* 2. Center Horizontally */
+    left: 50% !important;
+    transform: translateX(-50%);
+    /* Moves it back by half its width to center it */
+
+    /* 3. Reset Top position if needed */
+    top: 15% !important;
+  }
+
+  /* Fix the inner text box width so it doesn't overflow */
+  #helpBodyDiv {
+    width: 100% !important;
+    left: 0 !important;
+    padding: 0 10px;
+    box-sizing: border-box;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
   overscroll-behavior-x: none;
 }
 
@@ -9,8 +10,13 @@ input[type="range"] {
   width: 250px;
 }
 
-input[type="range"]:focus {
+input[type="range"]:focus:not(:focus-visible) {
   outline: none;
+}
+
+input[type="range"]:focus-visible {
+  outline: 3px solid #4a90e2;
+  outline-offset: 2px;
 }
 
 input[type="range"]:not(.pitchSlider)::-webkit-slider-runnable-track {
@@ -105,13 +111,20 @@ input[type="range"]:focus::-ms-fill-upper {
 }
 
 .lego-brick {
-    display: inline-block;
-    background-color: #FF0000;
-    border: 1px solid #880000;
-    margin: 2px;
+  display: inline-block;
+  background-color: #FF0000;
+  border: 1px solid #880000;
+  margin: 2px;
 }
 
-.lego-size-1 { width: 20px; height: 10px; }
-.lego-size-2 { width: 40px; height: 10px; }
-/* ... more sizes ... */
+.lego-size-1 {
+  width: 20px;
+  height: 10px;
+}
 
+.lego-size-2 {
+  width: 40px;
+  height: 10px;
+}
+
+/* ... more sizes ... */

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -185,35 +185,35 @@
 	color: #fff !important;
 }
 
-#tagscontainer .container { 
-	padding: 0.5rem 0 ;  
-	display: flex ; 
-	flex-direction: column ; 
-	align-items: center ;
-	gap: 0.5rem ; 
+#tagscontainer .container {
+	padding: 0.5rem 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
 }
 
-#tagscontainer #primarychips, 
-#tagscontainer .open#morechips { 
-	display: flex ; 
-	flex-wrap: wrap ;
-	justify-content: center ;
-	gap: 0.5rem ; 
+#tagscontainer #primarychips,
+#tagscontainer .open#morechips {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 0.5rem;
 }
 
 #tagscontainer #view-more-chips {
-	left: 0 ; 
-	transform: translateX(0) ; 
+	left: 0;
+	transform: translateX(0);
 }
 
-.global-tags-container {  
-	min-height: 30px ; 
-	display: flex ; 
+.global-tags-container {
+	min-height: 30px;
+	display: flex;
 	flex-direction: row;
-	justify-content: flex-start; 
-	align-items: center ;
-	gap: 0.5rem ; 
-	flex-wrap: wrap ;
+	justify-content: flex-start;
+	align-items: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
 }
 
 .chipselect {
@@ -226,7 +226,7 @@
 	padding: 0 12px;
 	border-radius: 16px;
 	background-color: #e4e4e4;
-	margin: auto 5px auto 0 ; 
+	margin: auto 5px auto 0;
 }
 
 .chipselect.selected {
@@ -243,12 +243,12 @@
 	cursor: pointer;
 }
 
-div.select-wrapper * {  
-	cursor: pointer ;
+div.select-wrapper * {
+	cursor: pointer;
 }
 
-.select-wrapper ul.dropdown-content { 
-	top: 100% !important ;
+.select-wrapper ul.dropdown-content {
+	top: 100% !important;
 }
 
 .centre-button {
@@ -307,13 +307,13 @@ div.select-wrapper * {
 		font-size: 0;
 	}
 
-	#globalcontents .row:first-child  { 
-		display: flex ; 
-		justify-content: center ;
+	#globalcontents .row:first-child {
+		display: flex;
+		justify-content: center;
 	}
 
-	#globalcontents .input-field { 
-		margin-left: 0 !important ;
+	#globalcontents .input-field {
+		margin-left: 0 !important;
 	}
 }
 
@@ -348,50 +348,66 @@ a {
 	cursor: pointer;
 }
 
-#projectviewer-report-project, #projectviewer-report-project-disabled {
+#projectviewer-report-project,
+#projectviewer-report-project-disabled {
 	padding-top: 10px;
 	padding-right: 5px;
 }
 
-#projectviewer-download-file, #projectviewer-open-mb {
+#projectviewer-download-file,
+#projectviewer-open-mb {
 	margin-left: -1%;
 }
 
 @media only screen and (max-width: 1100px) {
-	#projectviewer-download-file, #projectviewer-open-mb, #projectviewer-merge-mb {
+
+	#projectviewer-download-file,
+	#projectviewer-open-mb,
+	#projectviewer-merge-mb {
 		margin-left: -25px !important;
 	}
 
-	#projectviewer-report-project, #projectviewer-report-project-disabled {
+	#projectviewer-report-project,
+	#projectviewer-report-project-disabled {
 		padding-left: 0px;
 		padding-right: 0px;
 	}
 }
 
 @media only screen and (max-width: 650px) {
-	#projectviewer-download-file, #projectviewer-open-mb, #projectviewer-merge-mb {
+
+	#projectviewer-download-file,
+	#projectviewer-open-mb,
+	#projectviewer-merge-mb {
 		font-size: 70%;
 	}
 }
 
 @media only screen and (max-width: 900px) {
-	#projectviewer-download-file, #projectviewer-open-mb, #projectviewer-merge-mb {
+
+	#projectviewer-download-file,
+	#projectviewer-open-mb,
+	#projectviewer-merge-mb {
 		font-size: 60%;
 	}
+
 	#searchcontainer {
 		display: flex;
 		width: 100%;
-		padding-top: 0px ;
+		padding-top: 0px;
 		margin-top: 0px;
 	}
-	#s_one{
-        display: none;
+
+	#s_one {
+		display: none;
 	}
-	#searchcontainer.nav-content{
+
+	#searchcontainer.nav-content {
 		height: 56px;
 		position: absolute;
 		z-index: -1;
 	}
+
 	/* #searchicon,#search-close-2{
 		flex: 1;
 	} */
@@ -399,32 +415,39 @@ a {
 		display: block;
 		height: 56px;
 		position: -webkit-sticky;
-        position: sticky;
-        top: 56px;
+		position: sticky;
+		top: 56px;
 	}
+
 	.input-field-2 {
-       display: flex;
+		display: flex;
 	}
-	#two-header.nav-extended.light-green.lighten-1{
+
+	#two-header.nav-extended.light-green.lighten-1 {
 		position: relative;
 	}
-	.input-field-2.search{
+
+	.input-field-2.search {
 		position: absolute;
 		z-index: 2;
 		width: 90%;
 		margin-left: 5%;
 		margin-right: 5%;
 	}
-	#global-search-2{
-		flex:1;
+
+	#global-search-2 {
+		flex: 1;
 	}
+
 	.input-field {
 		display: block;
 	}
+
 	#global-search {
 		flex: 1;
 	}
 }
+
 @media only screen and (max-width: 978px) {
 	#two_header {
 		visibility: visible;
@@ -471,15 +494,16 @@ a {
 .inactiveLink {
 	pointer-events: none;
 	cursor: default;
- }
- #globalcontents .col.m6 {
-    margin-top: 2em;
+}
+
+#globalcontents .col.m6 {
+	margin-top: 2em;
 }
 
 #globalcontents .card {
 	display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+	flex-direction: column;
+	justify-content: space-between;
 }
 
 .nav-extended {
@@ -491,6 +515,7 @@ a {
 #searchcontainer-one {
 	width: 250px;
 }
+
 .nav-content {
 	display: none;
 }
@@ -507,5 +532,13 @@ a {
 	border-radius: 5px;
 	cursor: pointer;
 	font-size: 16px;
+}
+
+#backToTopBtn:focus:not(:focus-visible) {
 	outline: none;
+}
+
+#backToTopBtn:focus-visible {
+	outline: 3px solid #fff;
+	outline-offset: 2px;
 }


### PR DESCRIPTION
Fixes #5440

### Summary
This PR restores visible keyboard focus indicators across the Music Blocks UI.
Global CSS rules were disabling focus outlines, making keyboard navigation
impossible and breaking WCAG 2.1 Success Criterion 2.4.7 (Focus Visible).

### Changes
- Replaced global `outline: none` rules with `:focus-visible` patterns
- Added clear, consistent focus indicators for keyboard users
- Preserved clean UI behavior for mouse users
- Applied fixes across all affected CSS files

### Accessibility Impact
- Keyboard users can clearly see focus when navigating with Tab / Shift+Tab
- Meets WCAG 2.1 AA requirement for Focus Visible (SC 2.4.7)
- No JavaScript changes required (CSS-only fix)

### Testing
- Verified keyboard navigation across buttons, inputs, sliders, and links
- Confirmed focus indicators appear only for keyboard interaction
- Tested in Chrome