### PR TITLE
Add unit tests for getStepSizeUp in musicutils

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -99,7 +99,9 @@ const {
     getNoteFromInterval,
     numberToPitch,
     GetNotesForInterval,
-    base64Encode
+    base64Encode,
+    getStepSizeUp,
+    getStepSizeDown
 } = require("../musicutils");
 
 describe("musicutils", () => {
@@ -2227,5 +2229,17 @@ describe("_calculate_pitch_number", () => {
         const valC4 = _calculate_pitch_number(activity, "C4", tur);
         const valC5 = _calculate_pitch_number(activity, "C5", tur);
         expect(valC5).toBeGreaterThan(valC4);
+    });
+});
+
+describe("getStepSizeUp", () => {
+    it("should return the correct step size for C in C major going up", () => {
+        const result = getStepSizeUp("C major", "C", 0, "equal");
+        expect(result).toBe(2);
+    });
+
+    it("should return 0 for an invalid temperament", () => {
+        const result = getStepSizeUp("C major", "C", 0, "invalid");
+        expect(result).toBe(0);
     });
 });


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `getStepSizeUp` utility function in `musicutils`.

### Changes
- Added focused unit tests for `getStepSizeUp`
- Ensures correct behavior for standard musical input
- Verifies graceful handling of invalid temperament values

### Test Coverage
- ✔️ Step size calculation for **C major**
- ✔️ Invalid temperament input handling

### Scope
- Tests only
- No changes to production code

### Verification
- All existing and new tests pass successfully  
  (**254 / 254 tests passing**)

### Notes
This change is part of an incremental effort to improve test coverage through
small, review-friendly pull requests.
