### PR TITLE
Refactor fragile argument-like block type checks into helper method

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -804,10 +804,14 @@ class Block {
              * @returns {void}
              */
             const _postProcess = that => {
-                that.collapseButtonBitmap.scaleX = that.collapseButtonBitmap.scaleY = that.collapseButtonBitmap.scale =
-                    scale / 3;
-                that.expandButtonBitmap.scaleX = that.expandButtonBitmap.scaleY = that.expandButtonBitmap.scale =
-                    scale / 3;
+                that.collapseButtonBitmap.scaleX =
+                    that.collapseButtonBitmap.scaleY =
+                    that.collapseButtonBitmap.scale =
+                        scale / 3;
+                that.expandButtonBitmap.scaleX =
+                    that.expandButtonBitmap.scaleY =
+                    that.expandButtonBitmap.scale =
+                        scale / 3;
                 that.updateCache();
                 that._calculateBlockHitArea();
             };
@@ -1517,8 +1521,10 @@ class Block {
             const image = new Image();
             image.onload = () => {
                 that.collapseButtonBitmap = new createjs.Bitmap(image);
-                that.collapseButtonBitmap.scaleX = that.collapseButtonBitmap.scaleY = that.collapseButtonBitmap.scale =
-                    that.protoblock.scale / 3;
+                that.collapseButtonBitmap.scaleX =
+                    that.collapseButtonBitmap.scaleY =
+                    that.collapseButtonBitmap.scale =
+                        that.protoblock.scale / 3;
                 that.container.addChild(that.collapseButtonBitmap);
                 that.collapseButtonBitmap.x = 2 * that.protoblock.scale;
                 if (that.isInlineCollapsible()) {
@@ -1545,8 +1551,10 @@ class Block {
             const image = new Image();
             image.onload = () => {
                 that.expandButtonBitmap = new createjs.Bitmap(image);
-                that.expandButtonBitmap.scaleX = that.expandButtonBitmap.scaleY = that.expandButtonBitmap.scale =
-                    that.protoblock.scale / 3;
+                that.expandButtonBitmap.scaleX =
+                    that.expandButtonBitmap.scaleY =
+                    that.expandButtonBitmap.scale =
+                        that.protoblock.scale / 3;
 
                 that.container.addChild(that.expandButtonBitmap);
                 that.expandButtonBitmap.visible = that.collapsed;
@@ -2765,11 +2773,15 @@ class Block {
      */
     _positionMedia(bitmap, width, height, blockScale) {
         if (width > height) {
-            bitmap.scaleX = bitmap.scaleY = bitmap.scale =
-                ((MEDIASAFEAREA[2] / width) * blockScale) / 2;
+            bitmap.scaleX =
+                bitmap.scaleY =
+                bitmap.scale =
+                    ((MEDIASAFEAREA[2] / width) * blockScale) / 2;
         } else {
-            bitmap.scaleX = bitmap.scaleY = bitmap.scale =
-                ((MEDIASAFEAREA[3] / height) * blockScale) / 2;
+            bitmap.scaleX =
+                bitmap.scaleY =
+                bitmap.scale =
+                    ((MEDIASAFEAREA[3] / height) * blockScale) / 2;
         }
         bitmap.x = ((MEDIASAFEAREA[0] - 10) * blockScale) / 2;
         bitmap.y = (MEDIASAFEAREA[1] * blockScale) / 2;
@@ -4199,7 +4211,6 @@ class Block {
 
         return new Date().getTime() - this._piemenuExitTime > 200;
     }
-
 
     /**
      * Checks and reinitializes widget windows if their labels are changed.

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1838,10 +1838,7 @@ class Blocks {
                 if (connection == null) {
                     if (this.blockList[newBlock].isArgClamp()) {
                         /** If it is an arg clamp, we may have to adjust the slot size. */
-                        if (
-                            this.blockList[newBlock].isArgumentLikeBlock() &&
-                            newConnection === 1
-                        ) {
+                        if (this.blockList[newBlock].isArgumentLikeBlock() && newConnection === 1) {
                             /** pass */
                         } else if (
                             ["doArg", "nameddoArg"].includes(this.blockList[newBlock].name) &&
@@ -1884,10 +1881,7 @@ class Blocks {
                      */
                     insertAfterDefault = false;
                     if (this.blockList[newBlock].isArgClamp()) {
-                        if (
-                            this.blockList[newBlock].isArgumentLikeBlock() &&
-                            newConnection === 1
-                        ) {
+                        if (this.blockList[newBlock].isArgumentLikeBlock() && newConnection === 1) {
                             /**
                              * If it is the action name then treat it like
                              * a standard replacement.


### PR DESCRIPTION
### Summary

This PR improves the mechanism for testing block types by introducing a centralised helper for identifying argument-like blocks. 
1. Added a new `isArgumentLikeBlock()` method in `js/block.js`. 
2. Introduced an `ARG_LIKE_BLOCKS` constant to avoid scattered inline string-based checks. 
3. Refactored multiple fragile block-type tests in `js/blocks.js` (including the `FIXME` at ~line 2186) to use the new helper. 

This makes the codebase more maintainable and reduces the risk of regressions when new argument-style blocks are introduced.

---

### Changes

1. In `js/block.js`, Added:

```js
const ARG_LIKE_BLOCKS = ["doArg", "calcArg", "namedcalcArg", "makeblock"];

isArgumentLikeBlock() {
    return this.isArgBlock() || ARG_LIKE_BLOCKS.includes(this.name);
}

```

2. In `js/blocks.js`, replaced repeated patterns like:
```js
["doArg", "calcArg", "makeblock"].includes(myBlock.name)
```

with:
```js
myBlock.isArgumentLikeBlock()
```

3. Prettier formatting was done.

---

### Testing

1. All tests with `npm run test` passed successfully.
2. Refactor Verification `(js/block.js)`: Helper method and constant added cleanly with no behaviour change.
3. Refactor Verification `(js/blocks.js)`: All targeted fragile block-type checks replaced with the new helper. 

---

### Note
This is a behaviour-preserving refactor focused on improving maintainability and providing a more extensible mechanism for block-type classification.