### PR TITLE
Add unit tests for NOTESTEP and ACCIDENTALNAMES in musicutils

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -106,6 +106,8 @@ const {
     numberToPitch,
     GetNotesForInterval,
     base64Encode,
+    NOTESTEP,
+    ACCIDENTALNAMES,
     NOTESFLAT
 } = require("../musicutils");
 
@@ -2575,5 +2577,31 @@ describe("getPitchInfo", () => {
         const infoFx10 = getPitchInfo("Fx10");
         expect(infoFx10.pitchNumber).toBe(139);
         expect(infoFx10.octave).toBe(10);
+    });
+
+    describe("NOTESTEP", () => {
+        it("should map all seven natural notes to their correct step values", () => {
+            expect(NOTESTEP).toEqual({
+                C: 1,
+                D: 3,
+                E: 5,
+                F: 6,
+                G: 8,
+                A: 10,
+                B: 12
+            });
+        });
+    });
+
+    describe("ACCIDENTALNAMES", () => {
+        it("should contain all five accidental names with correct symbols", () => {
+            expect(ACCIDENTALNAMES).toEqual([
+                "double sharp \ud834\udd2a",
+                "sharp \u266f",
+                "natural \u266e",
+                "flat \u266d",
+                "double flat \ud834\udd2b"
+            ]);
+        });
     });
 });


### PR DESCRIPTION
### PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

### Summary
This PR adds unit tests for core musical constants defined in `musicutils`, improving confidence in note-step mapping and accidental definitions.

### Changes
- Added tests validating the `NOTESTEP` mapping for natural notes
- Added tests ensuring correctness and structure of `ACCIDENTALNAMES`

### Test Coverage
- ✔️ Verifies correct step values for representative natural notes
- ✔️ Ensures all seven natural notes are present
- ✔️ Confirms accidental names include expected entries
- ✔️ Validates accidental list size and structure

### Scope
- Tests only
- No production code changes

### Verification
- All existing and new tests pass successfully
