### PR TITLE
fix(aidebugger): clear typing indicator interval on widget close

### DIFF
--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -123,6 +123,7 @@ function AIDebuggerWidget() {
         widgetWindow.getWidgetBody().style.height = CHATHEIGHT + "px";
 
         widgetWindow.onclose = () => {
+            this._hideTypingIndicator();
             widgetWindow.destroy();
             this.activity.isInputON = false;
         };


### PR DESCRIPTION
Fixes #5523

## Summary

When the AI Debugger widget is closed while the typing indicator is active, the `setInterval` animation keeps running in the background. This PR fixes the leak by calling `_hideTypingIndicator()` in the `onclose` handler.

## Changes

- Added `_hideTypingIndicator()` call before `widgetWindow.destroy()` in the close handler

## Testing

- Opened AI Debugger, sent a message, closed while typing indicator was visible
- Verified interval no longer runs after widget close
- Ran `npm run lint` and `npx prettier --check .` - both pass