### PR TITLE
CI: stop auto-committing i18n JSON and verify instead

### DIFF
--- a/.github/workflows/po-to-json-validation.yml
+++ b/.github/workflows/po-to-json-validation.yml
@@ -1,4 +1,4 @@
-name: Auto-convert PO to JSON and commit
+name: Convert PO to JSON and verify changes
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'po/**/*.po'
 
 jobs:
-  convert-and-commit:
+  convert-and-verify:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +30,7 @@ jobs:
           echo "$(cat changed_po_files.txt)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Run conversion script
+      - name: Convert PO files to JSON
         if: steps.find_po.outputs.po_files != ''
         run: |
           mkdir -p locales
@@ -39,18 +39,13 @@ jobs:
             python3 convert_po_to_json.py "$po_file" "locales"
           done < changed_po_files.txt
 
-      - name: Commit and push updated JSON
+      - name: Verify JSON conversion changes
         if: steps.find_po.outputs.po_files != ''
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git add locales/*.json
-
-          if git diff --cached --quiet; then
-            echo "✅ No JSON changes to commit."
+          if ! git diff --quiet locales/; then
+            echo "❌ Generated translation JSON files have changes that need to be committed."
+            echo "Please run the PO-to-JSON conversion locally and commit the generated files in locales/."
+            exit 1
           else
-            git commit -m "chore(i18n): auto-update JSON files from updated PO files"
-            git push origin ${{ github.ref }}
-            echo "🚀 Pushed updated JSON files."
+            echo "✅ Translation JSON files are verified and up to date."
           fi


### PR DESCRIPTION
## Problem: CI auto-committing generated i18n files in unrelated PRs

### Background
The repository contains a GitHub Actions workflow that converts translation `.po` files into generated `locales/*.json` files.
This workflow was originally designed to automatically commit and push generated JSON files whenever `.po` changes were detected.

As the project and contributor base grew, this behavior began to cause unintended side effects.

---

### Issues observed

- The workflow had **write access** to contributor branches.
- It relied on a `git diff` range that could detect `.po` changes **outside the actual changes introduced by the current PR** (e.g. inherited history from the base branch).
- As a result, **PRs that did not modify any `.po` files** (such as JS, RequireJS, CI, or UI changes) could:
  - Incorrectly trigger the i18n workflow
  - Have their branches **mutated by CI**
  - Pick up large, unrelated `locales/*.json` diffs generated without contributor intent

This led to:
- Noisy and confusing pull requests
- Generated files appearing unexpectedly
- CI mutating contributor branches, which is unsafe and contrary to standard CI practices

---

## Solution: Make the workflow verification-only

This PR updates the PO-to-JSON workflow to follow modern CI best practices by removing branch-mutating behavior.

### Changes introduced
- Removed automatic commit and push steps from the workflow
- Retained PO → JSON generation within CI for validation purposes
- Added a verification step to ensure committed `locales/*.json` files are in sync with their corresponding `.po` sources
- Ensured CI no longer writes to contributor branches

The workflow now:
1. Runs only when `.po` files change
2. Generates JSON files temporarily within CI
3. Verifies committed `locales/*.json` files against the generated output
4. Fails CI with a clear message if generated files are out of sync

---

### Summary
This change prevents CI from mutating contributor branches and ensures that generated translation files are updated intentionally, improving pull request clarity and overall contributor experience.

