### PR TITLE
Add unit tests for MusicBlocks.BLK static getter

### DIFF
--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -321,4 +321,21 @@ describe("MusicBlocks Class", () => {
     test("should get MASTERVOLUME", () => {
         expect(musicBlocks.MASTERVOLUME).toBe(1.0);
     });
+
+    describe("BLK static getter", () => {
+        beforeEach(() => {
+            MusicBlocks._blockNo = 0;
+        });
+
+        test("should return incrementing block numbers", () => {
+            expect(MusicBlocks.BLK).toBe("B0");
+            expect(MusicBlocks.BLK).toBe("B1");
+            expect(MusicBlocks.BLK).toBe("B2");
+        });
+
+        test("should handle reset to -1", () => {
+            MusicBlocks._blockNo = -1;
+            expect(MusicBlocks.BLK).toBe("B-1");
+        });
+    });
 });


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `BLK` static getter on the `MusicBlocks` class, ensuring correct block identifier generation.

### Changes
- Added tests verifying sequential block number generation
- Validated behavior when the internal block counter is reset

### Test Coverage
- ✔️ Incrementing block identifiers (`B0`, `B1`, `B2`)
- ✔️ Correct handling of negative block counter values

### Scope
- Tests only
- No production code changes

### Verification
- All existing and new tests pass successfully
