### PR TITLE
Add unit tests for MusicBlocks.ENDMOUSE behavior

### DIFF
--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -171,6 +171,20 @@ describe("MusicBlocks Class", () => {
         expect(musicBlocks.turtle.doWait).toHaveBeenCalledWith(0);
     });
 
+    test("should handle ENDMOUSE and remove mouse from list", async () => {
+        Mouse.MouseList = [mouse];
+        Mouse.AddedTurtles = [];
+        await musicBlocks.ENDMOUSE;
+        expect(Mouse.MouseList).not.toContain(mouse);
+    });
+
+    test("should call init(false) when last mouse ends", async () => {
+        Mouse.MouseList = [mouse];
+        Mouse.AddedTurtles = [];
+        await musicBlocks.ENDMOUSE;
+        expect(MusicBlocks.isRun).toBe(false);
+    });
+
     test("should print a message", () => {
         musicBlocks.print("test message");
         expect(JSEditor.logConsole).toHaveBeenCalled();


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `ENDMOUSE` behavior in `MusicBlocks`, ensuring correct cleanup and state handling when mouse interactions end.

### Changes
- Added async unit tests for `ENDMOUSE`
- Verified removal of mouse instances from the active mouse list
- Ensured correct handling when the last mouse interaction ends

### Test Coverage
- ✔️ Mouse removal from `MouseList`
- ✔️ Proper update of runtime state when no mice remain

### Scope
- Tests only
- No production code changes

### Verification
- All existing and new tests pass successfully
