### PR TITLE
Add extended unit tests for MusicBlocks.init cleanup behavior

### DIFF
--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -322,3 +322,83 @@ describe("MusicBlocks Class", () => {
         expect(musicBlocks.MASTERVOLUME).toBe(1.0);
     });
 });
+
+describe("MusicBlocks.init", () => {
+    beforeEach(() => {
+        Mouse.MouseList = [];
+        Mouse.TurtleMouseMap = {};
+        Mouse.AddedTurtles = [];
+        MusicBlocks._methodList = {};
+        MusicBlocks._blockNo = 0;
+        MusicBlocks.isRun = false;
+    });
+
+    test("should set isRun to false when stopping", () => {
+        MusicBlocks.isRun = true;
+        MusicBlocks.init(false);
+        expect(MusicBlocks.isRun).toBe(false);
+    });
+
+    test("should clear _methodList when stopping", () => {
+        MusicBlocks._methodList = { TestClass: ["method1"] };
+        MusicBlocks.init(false);
+        expect(MusicBlocks._methodList).toEqual({});
+    });
+
+    test("should reset _blockNo to -1 when stopping", () => {
+        MusicBlocks._blockNo = 10;
+        MusicBlocks.init(false);
+        expect(MusicBlocks._blockNo).toBe(-1);
+    });
+
+    test("should clear MouseList when stopping", () => {
+        Mouse.MouseList = [{ id: 1 }, { id: 2 }];
+        MusicBlocks.init(false);
+        expect(Mouse.MouseList).toEqual([]);
+    });
+
+    test("should clear TurtleMouseMap when stopping", () => {
+        Mouse.TurtleMouseMap = { 1: { id: 1 } };
+        MusicBlocks.init(false);
+        expect(Mouse.TurtleMouseMap).toEqual({});
+    });
+
+    test("should cleanup AddedTurtles by hiding and trashing them", () => {
+        const mockTurtle = {
+            container: { visible: true },
+            inTrash: false
+        };
+        Mouse.AddedTurtles = [mockTurtle];
+        globalActivity.turtles.getIndexOfTurtle.mockReturnValue(0);
+
+        MusicBlocks.init(false);
+
+        expect(mockTurtle.container.visible).toBe(false);
+        expect(mockTurtle.inTrash).toBe(true);
+        expect(globalActivity.turtles.removeTurtle).toHaveBeenCalledWith(0);
+    });
+
+    test("should cleanup multiple AddedTurtles", () => {
+        const mockTurtle1 = { container: { visible: true }, inTrash: false };
+        const mockTurtle2 = { container: { visible: true }, inTrash: false };
+        Mouse.AddedTurtles = [mockTurtle1, mockTurtle2];
+        globalActivity.turtles.getIndexOfTurtle.mockReturnValueOnce(0).mockReturnValueOnce(1);
+
+        MusicBlocks.init(false);
+
+        expect(mockTurtle1.inTrash).toBe(true);
+        expect(mockTurtle2.inTrash).toBe(true);
+        expect(globalActivity.turtles.removeTurtle).toHaveBeenCalledTimes(2);
+    });
+
+    test("should handle empty AddedTurtles without error", () => {
+        Mouse.AddedTurtles = [];
+        expect(() => MusicBlocks.init(false)).not.toThrow();
+    });
+
+    test("should preserve isRun as false when already false", () => {
+        MusicBlocks.isRun = false;
+        MusicBlocks.init(false);
+        expect(MusicBlocks.isRun).toBe(false);
+    });
+});


### PR DESCRIPTION
### Summary
This PR adds extended unit test coverage for the `MusicBlocks.init` method, validating proper cleanup and state reset behavior when stopping execution.

### Changes
- Added comprehensive tests for `MusicBlocks.init(false)`
- Verified runtime state reset (`isRun`, `_blockNo`, `_methodList`)
- Ensured mouse-related data structures are cleared correctly
- Validated cleanup of dynamically added turtles, including visibility and trash handling

### Test Coverage
- ✔️ Reset of execution state and internal counters
- ✔️ Cleanup of method registry and mouse tracking structures
- ✔️ Proper handling of single and multiple added turtles
- ✔️ Safe behavior when no turtles are present
- ✔️ Idempotent behavior when already stopped

### Scope
- Tests only
- No production code changes

### Verification
- All existing and new tests pass successfully
