### PR TITLE
Add unit tests for MusicBlocks.PICKUP setter

### DIFF
--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -227,9 +227,25 @@ describe("MusicBlocks Class", () => {
         expect(musicBlocks.NOTEVALUE).toBe(1);
     });
 
-    test("should set PICKUP", () => {
-        musicBlocks.PICKUP = 2;
-        expect(Singer.MeterActions.setPickup).toHaveBeenCalledWith(2, musicBlocks.turIndex);
+    describe("PICKUP setter", () => {
+        beforeEach(() => {
+            Singer.MeterActions.setPickup.mockClear();
+        });
+
+        test("should set PICKUP with positive value", () => {
+            musicBlocks.PICKUP = 2;
+            expect(Singer.MeterActions.setPickup).toHaveBeenCalledWith(2, musicBlocks.turIndex);
+        });
+
+        test("should clamp negative PICKUP value to 0", () => {
+            musicBlocks.PICKUP = -5;
+            expect(Singer.MeterActions.setPickup).toHaveBeenCalledWith(0, musicBlocks.turIndex);
+        });
+
+        test("should allow PICKUP value of 0", () => {
+            musicBlocks.PICKUP = 0;
+            expect(Singer.MeterActions.setPickup).toHaveBeenCalledWith(0, musicBlocks.turIndex);
+        });
     });
 
     test("should get WHOLENOTESPLAYED", () => {


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `PICKUP` setter in `MusicBlocks`, ensuring correct handling of pickup values passed to the meter actions.

### Changes
- Added unit tests validating `PICKUP` setter behavior
- Verified correct handling of positive values
- Ensured negative values are clamped to zero
- Confirmed correct behavior when pickup is set to zero

### Scope
- Tests only
- No production code changes

### Verification
- All existing and new tests pass successfully
