### PR TITLE
Fix: Restore parent connections when recovering blocks from trash

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3760,8 +3760,27 @@ class Activity {
             }
         };
 
-        this._restoreTrashById = blockId => {
-            const blockIndex = this.blocks.trashStacks.indexOf(blockId);
+        this._restoreTrashById = trashEntry => {
+            // Handle both old integer format and new object format
+            let blockId, parentBlock, parentSlot, blockIndex;
+
+            if (typeof trashEntry === "object" && trashEntry !== null) {
+                blockId = trashEntry.blockId;
+                parentBlock = trashEntry.parentBlock;
+                parentSlot = trashEntry.parentSlot;
+                blockIndex = this.blocks.trashStacks.findIndex(
+                    entry => (typeof entry === "object" ? entry.blockId : entry) === blockId
+                );
+            } else {
+                // Legacy: trashEntry is just a blockId
+                blockId = trashEntry;
+                parentBlock = null;
+                parentSlot = null;
+                blockIndex = this.blocks.trashStacks.findIndex(
+                    entry => (typeof entry === "object" ? entry.blockId : entry) === blockId
+                );
+            }
+
             if (blockIndex === -1) return; // Block not found in trash
 
             this.blocks.trashStacks.splice(blockIndex, 1); // Remove from trash
@@ -3786,6 +3805,23 @@ class Activity {
 
             this.blocks.raiseStackToTop(blockId);
             const restoredBlock = this.blocks.blockList[blockId];
+
+            // Restore parent connection if it was saved and parent still exists
+            if (parentBlock !== null && parentSlot !== null) {
+                if (
+                    this.blocks.blockList[parentBlock] &&
+                    !this.blocks.blockList[parentBlock].trash &&
+                    this.blocks.blockList[parentBlock].connections[parentSlot] === null
+                ) {
+                    // Reconnect child to parent
+                    restoredBlock.connections[0] = parentBlock;
+                    // Reconnect parent to child
+                    this.blocks.blockList[parentBlock].connections[parentSlot] = blockId;
+
+                    // Adjust docks and position
+                    this.blocks.adjustDocks(parentBlock, true);
+                }
+            }
 
             if (restoredBlock.name === "start" || restoredBlock.name === "drum") {
                 const turtle = restoredBlock.value;
@@ -3901,7 +3937,9 @@ class Activity {
             trashView.appendChild(buttonContainer);
 
             // Render trash items
-            this.blocks.trashStacks.forEach(blockId => {
+            this.blocks.trashStacks.forEach(trashEntry => {
+                // Handle both old integer format and new object format
+                const blockId = typeof trashEntry === "object" ? trashEntry.blockId : trashEntry;
                 const block = this.blocks.blockList[blockId];
                 const listItem = document.createElement("div");
                 listItem.classList.add("trash-item");
@@ -3923,7 +3961,7 @@ class Activity {
                 listItem.addEventListener("mouseover", () => listItem.classList.add("hover"));
                 listItem.addEventListener("mouseout", () => listItem.classList.remove("hover"));
                 listItem.addEventListener("click", () => {
-                    this._restoreTrashById(blockId);
+                    this._restoreTrashById(trashEntry);
                     trashView.classList.add("hidden");
                 });
                 handleClickOutsideTrashView(trashView);


### PR DESCRIPTION
 ### Problem

When you deleted a block that was inside another block (like a note inside a repeat loop) and then restored it, it came back as a loose block instead of reconnecting to its parent. Your project's structure was getting silently broken.

### Root Cause

In `sendStackToTrash()`, the parent connection was cut but we never saved where the block originally came from. When restoring, we had no way to know where to reconnect it.

## Solution

**js/blocks.js** - Save parent info when trashing:
```javascript
this.trashStacks.push({
    blockId: thisBlock,
    parentBlock: parentBlock,
    parentSlot: parentSlot
});
```

**js/activity.js** - Restore the connection:
```javascript
if (parentBlock !== null && parentSlot !== null) {
    restoredBlock.connections[0] = parentBlock;
    this.blocks.blockList[parentBlock].connections[parentSlot] = blockId;
    this.blocks.adjustDocks(parentBlock, true);
}
```

Also updated `_renderTrashView()` to handle the new format and added backward compatibility for old trash data.

## Files Changed

- `js/blocks.js` - Modified `sendStackToTrash()` to save parent connection info
- `js/activity.js` - Modified `_restoreTrashById()` and `_renderTrashView()` to restore connections