### PR TITLE
chore: remove obsolete TODO and commented code in Publisher.js

### DIFF
--- a/planet/js/Publisher.js
+++ b/planet/js/Publisher.js
@@ -242,11 +242,6 @@ class Publisher {
             submitobj.ProjectID = id;
             submitobj.ProjectName = title.value;
             submitobj.ProjectDescription = description.value;
-            //TODO: Convert these into real block names once integrated into MB
-            //let obj = palettes.getProtoNameAndPalette("MIDI");
-            //console.log(obj[0]);
-            //console.log(obj[1]);
-            //console.log(obj[2]);
             submitobj.ProjectSearchKeywords = this.parseProject(this.ProjectTable[id].ProjectData);
             submitobj.ProjectData = Planet.ProjectStorage.encodeTB(
                 this.ProjectTable[id].ProjectData


### PR DESCRIPTION
### Summary
Removed obsolete TODO comment and associated dead code from `planet/js/Publisher.js`.

### Changes
- Removed TODO comment about converting to "real block names"
- Removed commented-out code that referenced `palettes.getProtoNameAndPalette("MIDI")`
- The current implementation already handles project search keywords via `parseProject()` method

### Technical Details
The commented code appeared to be an old idea for extracting block names using palette methods. The current implementation uses the `parseProject()` method which parses the project data directly to extract keywords, making the commented code unnecessary.

### Testing
- Code formatting verified with Prettier
- No functional changes - only removed dead code