### PR TITLE
chore: remove obsolete TODO comment in LocalCard.js

### DIFF
--- a/planet/js/LocalCard.js
+++ b/planet/js/LocalCard.js
@@ -175,7 +175,6 @@ class LocalCard {
             frag.getElementById(`local-project-cloud-${this.id}`).style.display = "initial";
             // eslint-disable-next-line no-unused-vars
             frag.getElementById(`local-project-cloud-${this.id}`).addEventListener("click", evt => {
-                // TODO: Implement view-published-project thing
                 document.getElementById("global-tab").click();
                 Planet.GlobalPlanet.forceAddToCache(this.id, () => {
                     Planet.GlobalPlanet.ProjectViewer.open(this.id);


### PR DESCRIPTION
### Summary
Removed obsolete TODO comment from `planet/js/LocalCard.js` that indicated unimplemented functionality, but the feature was already fully implemented.

### Changes
- Removed TODO comment: "Implement view-published-project thing"
- The functionality this TODO referenced is already complete and working

### Technical Details
The TODO was placed above code that:
1. Switches to the global tab view
2. Forces the project to be added to the cache
3. Opens the project viewer for the published project

This functionality is fully implemented and functional, making the TODO comment misleading and unnecessary.

### Testing
- Code formatting verified with Prettier
- No functional changes - only removed an obsolete comment