### PR TITLE
docs: clarify and document arpeggio export format as (scalar, semitone)

### DIFF
--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -761,31 +761,36 @@ class Arpeggio {
      */
     _save() {
         // Saves the current matrix as a custom Chord
+        // Export format: [scalar, semitone] where scalar is the scale degree (0-based)
+        // and semitone is the chromatic offset from that scale degree
         const pairs = this.__makePairsList();
         const chordValues = [];
         for (let i = 0; i < pairs.length; i++) {
-            // TODO: export as (scalar, semitone)
             if (pairs[i][0] === -1) {
                 chordValues.push(["-", "-"]); // rest
             } else {
                 const ii = this._rowBlocks.length - pairs[i][0] - 1;
                 if (this._inMode(ii)) {
-                    chordValues.push([this._modeNumbers.indexOf(ii.toString()), 0]);
+                    // Note is in the mode - export as (scalar, 0)
+                    const scalar = this._modeNumbers.indexOf(ii.toString());
+                    chordValues.push([scalar, 0]);
                 } else {
+                    // Note is not in the mode - find nearest lower scale degree
+                    // and calculate semitone offset
                     if (pairs[i][0] === 0) {
                         // top row -> octave
                         chordValues.push([this._modeNumbers.length, 0]);
                     } else {
-                        let j = 1;
-                        while (ii - j >= 0) {
-                            if (this._inMode(ii - j)) {
-                                chordValues.push([
-                                    this._modeNumbers.indexOf((ii - j).toString()),
-                                    j
-                                ]);
+                        let semitoneOffset = 1;
+                        while (ii - semitoneOffset >= 0) {
+                            if (this._inMode(ii - semitoneOffset)) {
+                                const scalar = this._modeNumbers.indexOf(
+                                    (ii - semitoneOffset).toString()
+                                );
+                                chordValues.push([scalar, semitoneOffset]);
                                 break;
                             }
-                            j += 1;
+                            semitoneOffset += 1;
                         }
                     }
                 }


### PR DESCRIPTION
### Summary
Clarified and documented the arpeggio widget's chord export format, removing the TODO comment and adding detailed inline documentation.

### Changes
- Removed TODO comment about exporting as (scalar, semitone) format
- Added comprehensive inline documentation explaining the export format
- Renamed variable `j` to `semitoneOffset` for better code clarity
- Extracted `scalar` calculation into named variable for improved readability
- Added comments explaining the logic for in-mode vs out-of-mode notes

### Technical Details
The arpeggio widget exports custom chords as an array of `[scalar, semitone]` pairs where:
- `scalar`: The scale degree index (0-based) in the current mode
- `semitone`: The chromatic offset from that scale degree (0 for diatonic notes, >0 for accidentals)

**Example:**
- A note that is the 3rd degree of the scale: `[2, 0]`
- A note that is 1 semitone above the 2nd degree: `[1, 1]` (like D# in C major)

The code already implemented this format correctly, but the TODO suggested it wasn't done yet. This PR clarifies that the format is indeed `(scalar, semitone)` and improves code readability with better variable names and comments.

### Testing
- Code formatting verified with Prettier
- ESLint check passed
- No functional changes - only documentation and variable naming improvements