### PR TITLE
feat: Implement right-click contextual menu for canvas background

### DIFF
--- a/js/turtles.js
+++ b/js/turtles.js
@@ -907,6 +907,24 @@ Turtles.TurtlesView = class {
         };
 
         /**
+         * Setup right-click context menu on canvas background.
+         * Shows the helpful wheel with options like Grid, Clean, Collapse, etc.
+         */
+        const setupContextMenu = () => {
+            // Add right-click handler to the main activity canvas
+            const canvas = activity.canvas;
+            if (canvas) {
+                canvas.addEventListener("contextmenu", event => {
+                    // Prevent default browser context menu
+                    event.preventDefault();
+
+                    // Show the helpful wheel menu
+                    activity._displayHelpfulWheel(event);
+                });
+            }
+        };
+
+        /**
          * Toggles visibility of menu and grids.
          * Scales down all 'turtles' in turtleList.
          * Removes the stage and adds it back at the top.
@@ -1256,6 +1274,9 @@ Turtles.TurtlesView = class {
         if (!this._locked) {
             __makeBoundary();
         }
+
+        // Setup right-click context menu for the canvas background
+        setupContextMenu();
 
         // Debounce or throttle the resize event based on device capability
         let resizeTimeout;


### PR DESCRIPTION
#  Feature: Right-Click Contextual Menu for Canvas Background

##  Overview

This PR implements the **right-click contextual menu** functionality for the Music Blocks canvas background. This feature was previously documented in the README but was not actually implemented in the interface.

## What's New?

Users can now **right-click on the canvas background** to access a circular pie menu (helpful wheel) with quick access to commonly used features:

### Menu Options Include:
-  **Set Pitch Preview** - Choose master key signature
-  **Grid** - Select grid type (Cartesian, Polar, Musical staff, etc.)
-  **Clean** - Clear all blocks and reset canvas
-  **Collapse** - Minimize the canvas view
-  **Search for Blocks** - Quick block search
-  **Home** - Center view on all blocks
-  **Show/Hide Blocks** - Toggle block visibility
-  **Expand/Collapse Blocks** - Toggle stack expansion
-  **Decrease Block Size** - Make blocks smaller
-  **Increase Block Size** - Make blocks larger
-  **Restore** - Recover deleted blocks from trash
-  **Turtle Wrap** - Toggle turtle wrapping behavior
-  **Horizontal Scrolling** - Enable/disable scrolling mode

##  Visual Demo

### Before:
Right-clicking on the canvas background

<img width="1919" height="1029" alt="Screenshot 2026-02-04 192039" src="https://github.com/user-attachments/assets/6c417d6f-07c9-451b-81bb-0eb51c2b6d86" />

### After:
Right-clicking now displays the helpful wheel with all options

<img width="1919" height="1028" alt="Screenshot 2026-02-04 192057" src="https://github.com/user-attachments/assets/bb17fc5c-8f84-4aa8-8d81-79d7b40ec170" />


##  Problem Solved

### Issue:
The Music Blocks README documentation mentioned:
> "When you **right-click on the background**, the following options are available..."

However, this functionality was **not implemented** in the actual interface. Right-clicking on the canvas would not open the pie menu.

### Solution:
This PR bridges the gap between documentation and implementation by adding the actual event handler for right-click interactions on the canvas background.

## ✅Testing

- [x] Right-click on empty canvas background shows circular menu
- [x] All menu options are functional
- [x] Browser's default context menu is suppressed
- [x] Menu positioning adjusts based on click location
- [x] Menu closes when clicking outside
- [x] No conflicts with existing block or turtle right-click handlers

##  Benefits

- **Improved UX**: Quick access to frequently used features
- **Better Discoverability**: Users can easily find available options
- **Consistency**: Matches documented behavior
- **Efficiency**: Reduces need to use toolbar buttons

## Files Modified

- `js/turtles.js` - Added contextual menu functionality
