### PR TITLE
feat: Add prefix-based sorting to block search

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3085,7 +3085,7 @@ class Activity {
                     }
                 });
                 $search.data("autocomplete-init", true);
-                
+
                 const instance = $search.autocomplete("instance");
                 if (instance) {
                     instance._renderItem = (ul, item) => {
@@ -6401,7 +6401,7 @@ class Activity {
                     }
                 });
                 $helpfulSearch.data("autocomplete-init", true);
-                
+
                 const instance = $helpfulSearch.autocomplete("instance");
                 if (instance) {
                     instance._renderItem = (ul, item) => {
@@ -7832,11 +7832,12 @@ define(["domReady!"].concat(MYDEFINES), doc => {
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.
-        const globalsReady = typeof createDefaultStack !== "undefined" &&
-                           typeof createjs !== "undefined" &&
-                           typeof Tone !== "undefined" &&
-                           typeof GIFAnimator !== "undefined" &&
-                           typeof SuperGif !== "undefined";
+        const globalsReady =
+            typeof createDefaultStack !== "undefined" &&
+            typeof createjs !== "undefined" &&
+            typeof Tone !== "undefined" &&
+            typeof GIFAnimator !== "undefined" &&
+            typeof SuperGif !== "undefined";
 
         if (globalsReady) {
             activity.setupDependencies();


### PR DESCRIPTION
## Description
Implements prefix-matching priority in the block search functionality to improve search relevance and user experience.

## Changes
- Modified search autocomplete to prioritize results that start with the search term
- Results are now sorted with prefix matches first, followed by substring matches
- Both groups are alphabetically sorted within their priority levels

## Example
When searching for "p":
- **Before**: Mixed results (stop mouse, mouse index, cursor button up, pitch, input, etc.)
- **After**: Prefix matches first (p, partial, pen down, pen size, pen up, perfect...), then others (stop mouse, input value, pixel color...)

## Screenshots

### Before
<img width="1125" height="722" alt="Screenshot 2026-01-26 180916" src="https://github.com/user-attachments/assets/c458faa8-a11e-4c4c-98c1-383e8db3dff5" />


### After
<img width="927" height="560" alt="Screenshot 2026-01-26 181656" src="https://github.com/user-attachments/assets/19854234-c964-4d61-8cbb-bed9dd17bf7f" />

## Testing
- [x] Tested search functionality with various search terms
- [x] Verified prefix matches appear first
- [x] Confirmed alphabetical sorting within priority groups
- [x] Tested with single letter searches (e.g., "p")
- [x] Tested with multi-letter searches