### PR TITLE
chore: remove debug console statement from OrnamentBlocks.js

### DIFF
--- a/js/blocks/OrnamentBlocks.js
+++ b/js/blocks/OrnamentBlocks.js
@@ -422,8 +422,6 @@ function setupOrnamentBlocks(activity) {
             }
 
             tur.singer.glideOverride = Singer.noteCounter(logo, turtle, args[1]);
-            // eslint-disable-next-line no-console
-            console.debug("length of glide " + tur.singer.glideOverride);
 
             const listenerName = "_glide_" + turtle;
             logo.setDispatchBlock(blk, turtle, listenerName);


### PR DESCRIPTION
Part of #5464

## Summary
- Remove `console.debug` statement from `js/blocks/OrnamentBlocks.js` (GlideBlock class)
- Remove associated eslint-disable comment

## Changes
- Removed debug output that was logging `glideOverride` length to browser console
- This debug statement leaks internal state and creates noise in the console

## Testing
- [x] JavaScript syntax verified with `node --check`
- [x] Module loads successfully
- [x] Changes verified twice (manual review + diff check)

## Guidelines Followed
Per the issue guidelines:
- This is a `console.debug()` statement - safe to remove
- Not inside a catch block
- Not a `console.error()` or `console.warn()`
- Pure debug output for inspection

---
*This contribution was made with AI assistance (Claude). The code was reviewed and tested before submission.*