### PR TITLE
chore: remove debug console statements from jseditor widget

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -680,8 +680,6 @@ class JSEditor {
         } else {
             // console.error("EDITOR MISSING!");
         }
-        // eslint-disable-next-line
-        console.log("%c" + message, `color: ${color}`);
     }
 
     static clearConsole() {


### PR DESCRIPTION
Part of #5464

Removes remaining debug console.log usage from js/widgets/jseditor.js
as part of production code cleanup.
