### PR TITLE
test: add unit tests for getStepSizeDown in musicutils

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2282,3 +2282,15 @@ describe("getStepSizeUp", () => {
         expect(result).toBe(0);
     });
 });
+
+describe("getStepSizeDown", () => {
+    it("should return the correct step size for C in C major going down", () => {
+        const result = getStepSizeDown("C major", "C", 0, "equal");
+        expect(result).toBe(-1);
+    });
+
+    it("should return 0 for an invalid temperament", () => {
+        const result = getStepSizeDown("C major", "C", 0, "invalid");
+        expect(result).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds unit tests for the getStepSizeDown function in musicutils.js which was previously imported in the test file but had no test coverage.

## Changes
- Added 2 comprehensive tests for `getStepSizeDown` in `musicutils.test.js`
- Verified correct calculation of downward step sizes in major scales
- Ensured proper error handling for invalid temperament inputs

## Scope
- Tests only
- No production code changes

## Verification
- All existing and new tests pass successfully 