### PR TITLE
Fix: ensure service worker always returns a Response and guard refreshOffline

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -97,6 +97,16 @@ self.addEventListener("fetch", function (event) {
                 } catch (error) {
                     // eslint-disable-next-line no-console
                     console.log("[PWA Builder] Network request failed and no cache." + error);
+
+                    if (typeof offlineFallbackPage !== "undefined") {
+                        const fallbackResponse = await caches.match(offlineFallbackPage);
+                        if (fallbackResponse) return fallbackResponse;
+                    }
+
+                    return new Response("Service Unavailable", {
+                        status: 503,
+                        statusText: "offline"
+                    });
                 }
             }
         )
@@ -106,6 +116,12 @@ self.addEventListener("fetch", function (event) {
 // This is an event that can be fired from your page to tell the SW to
 // update the offline page
 self.addEventListener("refreshOffline", function () {
+    if (typeof offlineFallbackPage !== "string" || offlineFallbackPage.trim().length === 0) {
+        // eslint-disable-next-line no-console
+        console.log("[PWA Builder] refreshOffline ignored: offlineFallbackPage is not set");
+        return Promise.resolve();
+    }
+
     const offlinePageRequest = new Request(offlineFallbackPage);
 
     return fetch(offlineFallbackPage).then(function (response) {


### PR DESCRIPTION
## Summary

Ensure the service worker never lets `event.respondWith()` resolve to undefined when both the network and cache fail, and make `refreshOffline` safely no-op when `offlineFallbackPage` is not set.

## What changed

- ### **Fetch handler**
      - Always returns a valid Response on network failure.
      - Uses a cached `offlineFallbackPage` if available.
      - Falls back to an explicit 503 Service Unavailable response otherwise.

- ### **refreshOffline handler**
       - Guards against missing or empty `offlineFallbackPage.`
       - Logs and safely no-ops instead of throwing.

## Why this is needed

- In the cache-miss + network-failure path, the fetch handler previously logged an error but returned nothing, allowing `event.respondWith()` to resolve to undefined and break requests in offline or flaky-network scenarios.

- `refreshOffline` assumed `offlineFallbackPage` always existed; `new Request(undefined)` could throw synchronously in some builds.

## Scope & risk

- Files changed: 1 `(sw.js)`
- Change size: small, localized
- Risk: low — changes only affect error and configuration-absent paths; normal cache and network behavior is unchanged.

## Behavior details

- ### **Cache miss + network failure**
     - Cached `offlineFallbackPage` → returned
     - Otherwise → 503 Service Unavailable response
- ### **refreshOffline**
     - `offlineFallbackPage` missing/empty → log and no-op
     - Present → existing behavior unchanged

## Testing
- All tests pass locally.
- ESLint reports no issues.

- ### **Notes for reviewers**

- Review is mainly around:
     - Ensuring the fetch handler always returns a Response
     - Confirming the early return in refreshOffline does not affect normal flows