### PR TITLE
Test: Boost generate.js coverage to ~100% with complex stack scenarios

### DIFF
--- a/js/js-export/__tests__/generate.test.js
+++ b/js/js-export/__tests__/generate.test.js
@@ -304,8 +304,22 @@ describe("JSGenerate Class", () => {
         expect(warnSpy).toHaveBeenCalledWith('CANNOT PROCESS "badClamp" BLOCK');
         warnSpy.mockRestore();
     });
-
     test("should print complex stack trees with nested args and flows", () => {
+        JSGenerate.startTrees = [
+            [
+                ["block1", ["arg1", "subArg"], null],
+                ["block2", null, [["flow1Block", null, null]], [["flow2Block", null, null]]]
+            ]
+        ];
+        JSGenerate.actionTrees = [[["actionBlock", null, null]]];
+
+        JSGenerate.printStacksTree();
+        expect(console.log).toHaveBeenCalledWith(
+            expect.stringContaining("(arg1, subArg)"),
+            "background: mediumslateblue",
+            "background; none",
+            "color: dodgerblue"
+        );
         expect(console.log).toHaveBeenCalledWith(
             expect.stringContaining("** NEXTFLOW **"),
             "color: green"
@@ -315,7 +329,6 @@ describe("JSGenerate Class", () => {
             "background: green; color: white; font-weight: bold"
         );
     });
-
     test("should handle astring generation errors", () => {
         JSGenerate.AST = { type: "Program", body: [] };
         astring.generate


### PR DESCRIPTION
**Summary**
This PR significantly expands the test suite for `js/js-export/generate.js`, targeting the complex logic used to convert visual block stacks into JavaScript code. These tests ensure the generator correctly handles nested structures, arguments, and edge cases.

<img width="1067" height="68" alt="Screenshot 2026-02-07 224350" src="https://github.com/user-attachments/assets/cd76d1b9-0460-45a7-b697-64bc37e40c26" />


CLOSES #5588