### PR TITLE
fix: turtle reset using wrong instance in doClear

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -1259,7 +1259,7 @@ class Painter {
             turtles.gy = this.turtle.ctx.canvas.height;
         }
 
-        const i = turtles.getIndexOfTurtle(this) % 10;
+        const i = turtles.getIndexOfTurtle(this.turtle) % 10;
         if (resetPen) {
             this.color = i * 10;
             this.value = DEFAULTVALUE;


### PR DESCRIPTION
### Summary
Fixes incorrect turtle defaults after clearing.

### Problem
doClear passed the Painter instance to `getIndexOfTurtle`, but the
Turtles model stores Turtle instances. The lookup always returned -1.

This caused turtles to reset with incorrect colour and skin.

### Fix
Pass the correct Turtle model instance:
`getIndexOfTurtle(this.turtle)`

### Verification
Console check:
- getIndexOfTurtle(Painter) → -1
- getIndexOfTurtle(Turtle) → correct index
