### PR TITLE
fix: prevent event listener memory leaks in new project flow

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6829,15 +6829,16 @@ class Activity {
             // createjs.Ticker.addEventListener('tick', this.stage);
             // createjs.Ticker.addEventListener('tick', that.__tick);
 
+            // Named event handlers for proper cleanup
             let mouseEvents = 0;
-            document.addEventListener("mousemove", () => {
+            this.handleMouseMove = () => {
                 mouseEvents++;
                 if (mouseEvents % 4 === 0) {
                     that.__tick();
                 }
-            });
+            };
 
-            document.addEventListener("click", e => {
+            this.handleDocumentClick = e => {
                 if (!this.hasMouseMoved) {
                     if (this.selectionModeOn) {
                         this.deselectSelectedBlocks();
@@ -6845,7 +6846,11 @@ class Activity {
                         this._hideHelpfulSearchWidget(e);
                     }
                 }
-            });
+            };
+
+            // Use managed addEventListener for automatic cleanup
+            this.addEventListener(document, "mousemove", this.handleMouseMove);
+            this.addEventListener(document, "click", this.handleDocumentClick);
 
             this._createMsgContainer(
                 "#ffffff",
@@ -7483,10 +7488,14 @@ class Activity {
             document.addEventListener("DOMMouseScroll", scrollEvent, false);
             */
 
+            // Named event handler for proper cleanup
             const activity = this;
-            document.onkeydown = () => {
+            this.handleKeyDown = event => {
                 activity.__keyPressed(event);
             };
+
+            // Use managed addEventListener instead of onkeydown assignment
+            this.addEventListener(document, "keydown", this.handleKeyDown);
 
             if (this.planet !== undefined) {
                 this.planet.planet.setAnalyzeProject(doAnalyzeProject);


### PR DESCRIPTION

## Problem
Event listener memory leak in the "New Project" flow caused zombie listeners to persist across project resets.

**Symptom:**
- **Initial state:** 6 global listeners
- **After reset:** 10 global listeners **(+4 zombies)**

**Root cause:** Three anonymous event listeners were not being removed:
1. Line 6845: `document.addEventListener("mousemove", () => {...})`
2. Line 6852: `document.addEventListener("click", e => {...})`  
3. Line 7499: `document.onkeydown = () => {...}` (assignment, not addEventListener)

Anonymous functions cannot be referenced for removal with `removeEventListener()`.

---

## Solution
Refactored anonymous listeners to **named class methods** that can be tracked and cleaned up.

### Changes:
1. **Created named handlers:**
   - `this.handleMouseMove` - mousemove throttling for __tick()
   - `this.handleDocumentClick` - click handler for search widget hiding
   - `this.handleKeyDown` - keydown handler for keyboard events

2. **Used managed addEventListener:**
   - Changed from `document.addEventListener()` → `this.addEventListener()`
   - This tracks listeners in `this._listeners` array
   - Existing `cleanupEventListeners()` now properly removes them

3. **Fixed onkeydown assignment:**
   - Changed `document.onkeydown = ...` → `this.addEventListener(document, "keydown", ...)`
   - Ensures keydown listener is also tracked and cleaned up

### Architecture:
```javascript
// Before (leaky):
document.addEventListener("click", e => {...}); // ❌ Cannot remove

// After (tracked):
this.handleDocumentClick = e => {...};
this.addEventListener(document, "click", this.handleDocumentClick); // ✅ Tracked