### PR TITLE
Docs: clarify purpose and usage of rationalSum helper

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1365,6 +1365,10 @@ const LCD = (a, b) => {
 
 /**
  * Adds two rational numbers represented as arrays [numerator, denominator].
+ *
+ * This helper is used internally where rational arithmetic is required
+ * to avoid floating-point precision issues (e.g., turtle singer logic).
+ *
  * @param {Array} a - The first rational number.
  * @param {Array} b - The second rational number.
  * @returns {Array} The sum of the two rational numbers in the form [numerator, denominator].


### PR DESCRIPTION
This PR adds documentation specifically for the `rationalSum` helper function in
`js/utils/utils.js`.

`rationalSum` performs non-obvious rational arithmetic and is used in music logic
where floating-point precision matters, so documenting its purpose and expected
input/output helps future contributors understand and use it correctly. Other
helpers are intentionally left unchanged to keep this PR small and focused.

No functional or behavioral changes are introduced.
