### PR TITLE
fix: clear AI Debugger typing interval on widget close

### DIFF
--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("AIDebuggerWidget close cleanup", () => {
+    let AIDebuggerWidget;
+
+    const createWidgetWindowMock = () => {
+        const widgetBody = { style: {} };
+        return {
+            clear: jest.fn(),
+            show: jest.fn(),
+            getWidgetBody: jest.fn(() => widgetBody),
+            addButton: jest.fn(() => ({})),
+            sendToCenter: jest.fn(),
+            destroy: jest.fn(),
+            isMaximized: jest.fn(() => false),
+            onclose: null,
+            onmaximize: null
+        };
+    };
+
+    beforeAll(() => {
+        global._ = jest.fn(str => str);
+        const source = fs.readFileSync(path.join(__dirname, "..", "aidebugger.js"), "utf8");
+        AIDebuggerWidget = new Function(`${source}; return AIDebuggerWidget;`)();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("clears typing animation interval when widget closes", () => {
+        const widgetWindow = createWidgetWindowMock();
+        window.widgetWindows = { windowFor: jest.fn(() => widgetWindow) };
+
+        const widget = new AIDebuggerWidget();
+        widget._createLayout = jest.fn();
+        widget._loadProjectAndInitialize = jest.fn();
+
+        widget.chatLog = document.createElement("div");
+        const typingIndicator = document.createElement("div");
+        typingIndicator.className = "typing-indicator";
+        typingIndicator.setAttribute("data-animation-id", "42");
+        widget.chatLog.appendChild(typingIndicator);
+
+        const clearIntervalSpy = jest.spyOn(global, "clearInterval").mockImplementation(() => {});
+        const activity = { isInputON: false, textMsg: jest.fn() };
+
+        widget.init(activity);
+        widgetWindow.onclose();
+
+        expect(clearIntervalSpy).toHaveBeenCalledWith(42);
+        expect(widget.chatLog.querySelector(".typing-indicator")).toBeNull();
+        expect(widgetWindow.destroy).toHaveBeenCalledTimes(1);
+        expect(activity.isInputON).toBe(false);
+    });
+
+    test("does not throw on close when chat log is not initialized", () => {
+        const widgetWindow = createWidgetWindowMock();
+        window.widgetWindows = { windowFor: jest.fn(() => widgetWindow) };
+
+        const widget = new AIDebuggerWidget();
+        widget._createLayout = jest.fn();
+        widget._loadProjectAndInitialize = jest.fn();
+        widget.chatLog = null;
+
+        const activity = { isInputON: false, textMsg: jest.fn() };
+        widget.init(activity);
+
+        expect(() => widgetWindow.onclose()).not.toThrow();
+        expect(widgetWindow.destroy).toHaveBeenCalledTimes(1);
+        expect(activity.isInputON).toBe(false);
+    });
+});

--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -121,6 +121,7 @@ function AIDebuggerWidget() {
         widgetWindow.getWidgetBody().style.height = CHATHEIGHT + "px";
 
         widgetWindow.onclose = () => {
+            this._hideTypingIndicator();
             widgetWindow.destroy();
             this.activity.isInputON = false;
         };
@@ -453,6 +454,10 @@ function AIDebuggerWidget() {
      * @private
      */
     this._hideTypingIndicator = function () {
+        if (!this.chatLog) {
+            return;
+        }
+
         const typingIndicator = this.chatLog.querySelector(".typing-indicator");
         if (typingIndicator) {
             const animationId = typingIndicator.getAttribute("data-animation-id");


### PR DESCRIPTION
## Summary
- call `_hideTypingIndicator()` in `AIDebuggerWidget` close handler before destroying the window
- harden `_hideTypingIndicator()` to safely return when `chatLog` is unavailable
- add focused regression tests for close-time interval cleanup and null-chatLog safety

## Why
Closing the AI Debugger while the typing indicator animation is active leaves the interval running. This causes a timer leak and unnecessary background work.

Fixes #5523

## Testing
- `npx jest js/widgets/__tests__/aidebugger.test.js --runInBand --coverage=false`
- `npx eslint js/widgets/aidebugger.js js/widgets/__tests__/aidebugger.test.js`