### PR TITLE
fix: guard startup doSearch initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,7 +608,26 @@
     </script>
     <script>
         $(document).ready(function () {
-            doSearch();
+            const maxAttempts = 100;
+            let attempts = 0;
+
+            const initializeSearch = () => {
+                if (
+                    window.activity &&
+                    typeof window.activity.doSearch === "function" &&
+                    window.activity.searchWidget
+                ) {
+                    window.activity.doSearch();
+                    return;
+                }
+
+                if (attempts < maxAttempts) {
+                    attempts += 1;
+                    setTimeout(initializeSearch, 100);
+                }
+            };
+
+            initializeSearch();
         });
     </script>
 


### PR DESCRIPTION
## Summary
- replace the unconditional `doSearch()` call in `index.html` with a bounded readiness check
- initialize search only after `window.activity.doSearch` and `searchWidget` are available
- avoid startup race conditions from script load order

## Testing
- `npm run lint`
- loaded `http://127.0.0.1:3000` with Playwright CLI and confirmed no `doSearch is not defined` startup error

Fixes #5313
