### PR TITLE
fix(activity): prevent resize crashes on hidden/zero viewport states

### DIFF
--- a/js/__tests__/activity_resize_safety.test.js
+++ b/js/__tests__/activity_resize_safety.test.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("Activity resize safety guards", () => {
+    let activitySource;
+
+    beforeAll(() => {
+        activitySource = fs.readFileSync(path.join(__dirname, "..", "activity.js"), "utf8");
+    });
+
+    it("defines a viewport dimension validator", () => {
+        expect(activitySource).toContain("this._isValidViewportDimensions = (width, height) =>");
+    });
+
+    it("skips resize work for hidden tabs or invalid viewport dimensions", () => {
+        expect(activitySource).toMatch(
+            /document\.visibilityState === "hidden"[\s\S]*!this\._isValidViewportDimensions\(w, h\)/
+        );
+    });
+
+    it("calls saveLocally only when it is a function", () => {
+        expect(activitySource).toContain(
+            'if (!force && typeof this.saveLocally === "function") {'
+        );
+    });
+
+    it("guards save preview scale math when canvas dimensions are invalid", () => {
+        expect(activitySource).toMatch(
+            /const canvasWidth = this\.canvas \? this\.canvas\.width : 0;[\s\S]*!this\._isValidViewportDimensions\(canvasWidth, canvasHeight\)[\s\S]*320 \/ canvasWidth/
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add viewport-dimension guard logic to activity resize paths
- skip resize work while the document is hidden
- call autosave during resize only when `saveLocally` is callable
- guard save-preview SVG scale math against zero canvas dimensions
- add regression tests to lock in resize safety checks

## Why
Rapid resize + tab switching can produce zero/invalid viewport dimensions during layout updates. That can trigger unstable resize behavior and zero-dimension math in autosave preview generation.

Fixes #5602

## Testing
- `npx jest js/__tests__/activity_resize_safety.test.js --runInBand --coverage=false`
- `npx eslint js/activity.js js/__tests__/activity_resize_safety.test.js`