### PR TITLE
fix: restore visible keyboard focus indicators

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -15,6 +15,11 @@
 @import url("play-only-mode.css");
 
 *:focus {
+  outline: 3px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+*:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -10,6 +10,11 @@ input[type="range"] {
 }
 
 input[type="range"]:focus {
+  outline: 3px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+input[type="range"]:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -114,4 +119,3 @@ input[type="range"]:focus::-ms-fill-upper {
 .lego-size-1 { width: 20px; height: 10px; }
 .lego-size-2 { width: 40px; height: 10px; }
 /* ... more sizes ... */
-

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -4,6 +4,10 @@ input[type="range"] {
   width: 250px;
 }
 input[type="range"]:focus {
+  outline: 3px solid #1a73e8;
+  outline-offset: 2px;
+}
+input[type="range"]:focus:not(:focus-visible) {
   outline: 0;
 }
 input[type="range"]:not(.pitchSlider)::-webkit-slider-runnable-track {


### PR DESCRIPTION
## Summary
- replace global focus suppression with keyboard-friendly `:focus-visible` behavior
- restore visible outlines for focused controls while avoiding persistent mouse-focus outlines
- update range control focus styles in both source CSS and shipped `dist/css/style.css`

## Testing
- `npm run lint`
- loaded app at `http://127.0.0.1:3000`, pressed `Tab`, and verified focused element receives a visible `3px` outline

Fixes #5440
