### PR TITLE
fix(sw): reduce stale production UI via cache invalidation + nav refresh

### DIFF
--- a/js/__tests__/sw.test.js
+++ b/js/__tests__/sw.test.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("Service worker cache refresh safeguards", () => {
+    let swSource;
+
+    beforeAll(() => {
+        swSource = fs.readFileSync(path.join(__dirname, "..", "..", "sw.js"), "utf8");
+    });
+
+    it("uses a versioned cache key", () => {
+        expect(swSource).toContain("const CACHE_PREFIX = \"pwabuilder-precache\";");
+        expect(swSource).toContain("const CACHE_VERSION = \"v2\";");
+        expect(swSource).toContain("const CACHE = `${CACHE_PREFIX}-${CACHE_VERSION}`;");
+    });
+
+    it("cleans stale pwabuilder caches during activate", () => {
+        expect(swSource).toMatch(
+            /caches\.keys\(\)[\s\S]*cacheName\.startsWith\(CACHE_PREFIX\)[\s\S]*caches\.delete\(cacheName\)/
+        );
+    });
+
+    it("uses network-first strategy for navigation requests", () => {
+        expect(swSource).toContain("const isNavigationRequest =");
+        expect(swSource).toContain("event.request.mode === \"navigate\"");
+        expect(swSource).toMatch(
+            /if \(isNavigationRequest\)[\s\S]*const response = await fetch\(event\.request\)[\s\S]*return await fromCache\(event\.request\)/
+        );
+    });
+
+    it("falls back to cached index on navigation network failure", () => {
+        expect(swSource).toContain("const cachedIndex = await caches.match(\"./index.html\");");
+    });
+});


### PR DESCRIPTION
## Summary
- introduce versioned service worker cache keys
- delete stale legacy `pwabuilder-precache` caches during activate
- use network-first strategy for navigation/document requests
- keep cache fallback for offline mode, including cached `index.html`
- add regression tests for cache versioning and navigation refresh behavior

## Why
Issue #5566 reports production UI changes not appearing despite merged fixes. A stale cache-first path can continue serving old HTML/assets. This change keeps offline behavior while prioritizing fresh navigation responses.

Fixes #5566

## Testing
- `npx jest js/__tests__/sw.test.js --runInBand --coverage=false`
- `npx eslint sw.js js/__tests__/sw.test.js`