### PR TITLE
fix(musicutils): remove undeclared cents assignment in getPitchInfo

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2168,6 +2168,22 @@ describe("getPitchInfo", () => {
         };
     });
 
+    it("does not create a global `cents` variable for frequency inputs", () => {
+        const hadCents = Object.prototype.hasOwnProperty.call(global, "cents");
+        const previousCents = global.cents;
+
+        delete global.cents;
+
+        expect(() => getPitchInfo(activity, "alphabet", 440, tur)).not.toThrow();
+        expect(Object.prototype.hasOwnProperty.call(global, "cents")).toBe(false);
+
+        if (hadCents) {
+            global.cents = previousCents;
+        } else {
+            delete global.cents;
+        }
+    });
+
     it("returns correct pitch for 'alphabet'", () => {
         expect(getPitchInfo(activity, "alphabet", "C4", tur)).toBe("C");
     });

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6133,7 +6133,6 @@ const getPitchInfo = (activity, type, currentNote, tur) => {
         obj = frequencyToPitch(currentNote);
         pitch = obj[0];
         octave = obj[1];
-        cents = obj[2];
     } else {
         // Turn the note into pitch and octave.
         pitch = currentNote.substr(0, currentNote.length - 1);


### PR DESCRIPTION
## Summary
- remove the undeclared `cents` assignment in `getPitchInfo` when handling frequency input
- avoid implicit-global writes / strict-mode `ReferenceError` risk in pitch conversion
- add a regression test that ensures frequency-based calls do not leak `global.cents`

## Why
`getPitchInfo` was assigning to `cents` without a declaration. In strict mode this can throw, and in non-strict mode it can leak globals.

Fixes #5487

## Testing
- `npm run test -- js/utils/__tests__/musicutils.test.js --runInBand --coverage=false`
- `npm run lint`
