### PR TITLE
ci: add automated issue and PR labeling workflows

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,14 @@
+Issue-Bug:
+    - '(?i)^\s*\[bug\]'
+
+Issue-Documentation:
+    - '(?i)^\s*\[docs\]'
+
+Issue-Enhancement:
+    - '(?i)^\s*\[(feature|chore|ui/ux)\]'
+
+Issue-Performance:
+    - '(?i)^\s*\[performance\]'
+
+Issue-Testing:
+    - '(?i)^\s*\[test\]'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,28 @@
+javascript:
+    - changed-files:
+          - any-glob-to-any-file:
+                - "**/*.js"
+                - "**/*.mjs"
+                - "**/*.cjs"
+
+dependencies:
+    - changed-files:
+          - any-glob-to-any-file:
+                - "package.json"
+                - "package-lock.json"
+                - "yarn.lock"
+                - "pnpm-lock.yaml"
+
+Issue-Documentation:
+    - changed-files:
+          - any-glob-to-any-file:
+                - "Docs/**"
+                - "**/*.md"
+
+Issue-Testing:
+    - changed-files:
+          - any-glob-to-any-file:
+                - "js/__tests__/**"
+                - "test/**"
+                - "tests/**"
+                - "cypress/**"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,24 @@
+name: Issue Labeler
+
+on:
+    issues:
+        types:
+            - opened
+            - edited
+            - reopened
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    label:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Label issue
+              uses: github/issue-labeler@v3.4
+              with:
+                  configuration-path: .github/issue-labeler.yml
+                  include-title: 1
+                  include-body: 1
+                  repo-token: ${{ github.token }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,23 @@
+name: Pull Request Labeler
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - edited
+            - ready_for_review
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    label:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Label pull request by changed files
+              uses: actions/labeler@v5
+              with:
+                  configuration-path: .github/pr-labeler.yml


### PR DESCRIPTION
## Summary
- add an issue auto-labeler workflow using `github/issue-labeler@v3.4`
- add a PR auto-labeler workflow using `actions/labeler@v5`
- add dedicated configs:
  - `.github/issue-labeler.yml` for title/body regex matching on issues
  - `.github/pr-labeler.yml` for changed-file glob matching on pull requests
- use least-privilege workflow permissions (`issues: write` for issues, `pull-requests: write` for PRs)

## Why
Issue #3653 requests automated labeling for issues and pull requests to improve triage and contribution classification.

## Implementation Details
- issue labels are applied conservatively from template-style title prefixes (`[Bug]`, `[Docs]`, `[Feature]`, `[Chore]`, `[UI/UX]`, `[Performance]`, `[Test]`)
- PR labels are applied from file change patterns (`javascript`, `dependencies`, `Issue-Documentation`, `Issue-Testing`)
- no existing workflows were modified; this is additive and isolated

Fixes #3653

## Testing
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/issue-labeler.yml .github/pr-labeler.yml .github/workflows/issue-labeler.yml .github/workflows/pr-labeler.yml`
