### PR TITLE
Encapsulate layout update rules inside Block (address FIXME in blocks.js)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2033,6 +2033,44 @@ class Block {
     }
 
     /**
+     * Determines what type of layout update this block requires when a child is connected
+     * at the specified connection index.
+     *
+     * This is a behavioral abstraction that encapsulates the logic of which blocks
+     * need pre-layout updates based on their child connections, rather than having
+     * the engine infer this from block type categories.
+     *
+     * @param {number} connectionIndex - The index of the connection where a child was attached
+     * @returns {string|null} - "ARG" for argument layout updates, "FLOW" for flow layout updates, null otherwise
+     */
+    getLayoutUpdateType(connectionIndex) {
+        // Guard against invalid indices (can occur during drag/undo/intermediate states)
+        if (connectionIndex < 0) {
+            return null;
+        }
+
+        // Two-argument blocks and expandable argument blocks need ARG layout updates
+        // when a child connects to their first argument slot (connection index 1)
+        if (connectionIndex === 1) {
+            if (this.isTwoArgBlock() || (this.isArgBlock() && this.isExpandableBlock())) {
+                return "ARG";
+            }
+        }
+
+        const n = this.connections.length;
+        if (
+            connectionIndex === n - 2 &&
+            !this.isArgClamp() &&
+            this.docks[n - 1] &&
+            this.docks[n - 1][2] === "in"
+        ) {
+            return "FLOW";
+        }
+
+        return null;
+    }
+
+    /**
      * Gets the unique identifier for the block.
      * @returns {string} - The unique identifier for the block.
      */

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2165,35 +2165,25 @@ class Blocks {
             }
 
             /** If it is an arg block, where is it coming from? */
-            /** FIXME: improve mechanism for testing block types. */
             if (myBlock.isArgumentLikeBlock() && newBlock != null) {
-                /** We care about twoarg blocks with connections to the first arg; */
-                if (this.blockList[newBlock].isTwoArgBlock()) {
-                    if (this.blockList[newBlock].connections[1] === thisBlock) {
-                        if (!this._checkTwoArgBlocks.includes(newBlock)) {
-                            this._checkTwoArgBlocks.push(newBlock);
-                        }
-                    }
-                } else if (
-                    this.blockList[newBlock].isArgBlock() &&
-                    this.blockList[newBlock].isExpandableBlock()
-                ) {
-                    if (this.blockList[newBlock].connections[1] === thisBlock) {
-                        if (!this._checkTwoArgBlocks.includes(newBlock)) {
-                            this._checkTwoArgBlocks.push(newBlock);
-                        }
-                    }
-                }
+                const parentBlock = this.blockList[newBlock];
 
-                /** We also care about the second-to-last connection to an arg block. */
-                const n = this.blockList[newBlock].connections.length;
-                if (this.blockList[newBlock].connections[n - 2] === thisBlock) {
-                    /** Only flow blocks, but not ArgClamps */
-                    if (
-                        !this.blockList[newBlock].isArgClamp() &&
-                        this.blockList[newBlock].docks[n - 1][2] === "in"
-                    ) {
-                        checkArgBlocks.push(newBlock);
+                // Find which connection index this block is attached to
+                const connectionIndex = parentBlock.connections.indexOf(thisBlock);
+
+                // Guard against invalid index (can happen during drag/undo/intermediate states)
+                if (connectionIndex !== -1) {
+                    // Ask the parent block what type of layout update it needs for this connection
+                    const updateType = parentBlock.getLayoutUpdateType(connectionIndex);
+
+                    if (updateType === "ARG") {
+                        if (!this._checkTwoArgBlocks.includes(newBlock)) {
+                            this._checkTwoArgBlocks.push(newBlock);
+                        }
+                    } else if (updateType === "FLOW") {
+                        if (!checkArgBlocks.includes(newBlock)) {
+                            checkArgBlocks.push(newBlock);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

Replaces block-type branching in `blocks.js` with a behavioural query on the `Block` instance via `getLayoutUpdateType(connectionIndex)`.

---

This resolves the `FIXME: improve mechanism for testing block types` comment by moving layout-update decision logic into the Block class instead of inferring behaviour from block categories during traversal.

---

### Changes
1. Added `Block.getLayoutUpdateType(connectionIndex),` which returns whether a connection triggers an ARG or FLOW relayout.
2. Replaced checks using `isTwoArgBlock`, `isArgBlock`, `isExpandableBlock`, and `isArgClamp` in `blocks.js` with a query to the parent block.
3. Preserved original relayout behaviour and duplicate protections.
4. Added guards for invalid connection indices during drag/undo intermediate states.
5. Removed the FIXME related to block type testing.

---

### Testing
- Repeated attach/detach of argument blocks (~30 cycles) — no size drift
- Expandable blocks: add inputs → remove middle → undo → redo → reinsert — stable layout
- Flow stacks: insert/remove blocks inthe  middle — no stretching or collapse
- Rapid drag across stacks, correct snapping behaviour
- Multiple undo/redo cycles, layout preserved
- No new console errors observed
- `npm run test`, all tests passed.

---

### Note
This change does not modify user-visible behaviour.
It centralises layout behaviour inside `Block` to reduce fragile type inference in traversal code and make future block additions safer.
