### PR TITLE
Fix: Palette Search interaction Issue

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3014,12 +3014,16 @@ class Activity {
                         //do nothing when clicked in the input field
                     } else if (
                         document.getElementById("ui-id-1") &&
-                        document.getElementById("ui-id-1").style.display === "block" &&
                         (e.target === document.getElementById("ui-id-1") ||
                             document.getElementById("ui-id-1").contains(e.target))
                     ) {
-                        //do nothing when clicked on the menu
-                    } else if (document.getElementsByTagName("tr")[2].contains(e.target)) {
+                        //do nothing when clicked on the autocomplete menu
+                    } else if (e.target.closest(".ui-menu")) {
+                        //do nothing when clicked on any autocomplete menu element
+                    } else if (
+                        document.getElementsByTagName("tr")[2] &&
+                        document.getElementsByTagName("tr")[2].contains(e.target)
+                    ) {
                         //do nothing when clicked on the search row
                     } else {
                         // this will hide the search bar if someone clicks on menu items
@@ -7796,11 +7800,12 @@ define(["domReady!"].concat(MYDEFINES), doc => {
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.
-        const globalsReady = typeof createDefaultStack !== "undefined" &&
-                           typeof createjs !== "undefined" &&
-                           typeof Tone !== "undefined" &&
-                           typeof GIFAnimator !== "undefined" &&
-                           typeof SuperGif !== "undefined";
+        const globalsReady =
+            typeof createDefaultStack !== "undefined" &&
+            typeof createjs !== "undefined" &&
+            typeof Tone !== "undefined" &&
+            typeof GIFAnimator !== "undefined" &&
+            typeof SuperGif !== "undefined";
 
         if (globalsReady) {
             activity.setupDependencies();

--- a/js/palette.js
+++ b/js/palette.js
@@ -960,6 +960,20 @@ class Palette {
                 return;
             }
 
+            // For search palette, also check if click is on search widget or autocomplete menu
+            if (this.name === "search") {
+                const searchWidget = document.getElementById("search");
+                const autocompleteMenu = document.getElementById("ui-id-1");
+
+                if (searchWidget && searchWidget.contains(event.target)) {
+                    return;
+                }
+
+                if (autocompleteMenu && autocompleteMenu.contains(event.target)) {
+                    return;
+                }
+            }
+
             this.hideMenu();
             document.removeEventListener("click", this._outsideClickListener);
             this._outsideClickListener = null;


### PR DESCRIPTION
## Overview
This PR fixes a bug where the search palette would snap shut immediately when a user tried to click a search result. This made the search feature effectively unusable for mouse users.

### **The Problem**
**Instant Close:** The search bar treated any click on a result as a signal to close the menu.
**Click-Through:** Clicks were passing "through" the search results and hitting the categories underneath.

### The Fix
Stopped "Event Bubbling": Added code to make sure a click on a search result stays on the search result and doesn't bleed into the background layers.

**Before Video:**

https://github.com/user-attachments/assets/10ecf8e3-aa89-49c9-938f-de58d76da576

**After Video:**

https://github.com/user-attachments/assets/0ae90c6f-024d-42b2-8c73-f477f829dcbd

