### PR TITLE
fix: audio buzzing/popping caused by unsafe volume scheduling

### DIFF
--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -27,7 +27,14 @@ class Sampler {
         this.triggerAttack = jest.fn().mockReturnThis();
         this.volume = {
             value: 0,
-            linearRampToValueAtTime: jest.fn().mockImplementation()
+            cancelScheduledValues: jest.fn().mockReturnThis(),
+            setValueAtTime: jest.fn().mockReturnThis(),
+            linearRampToValueAtTime: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            }),
+            rampTo: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            })
         };
         this.triggerRelease = jest.fn().mockReturnThis();
         this.triggerAttackRelease = jest.fn().mockReturnThis();
@@ -82,7 +89,14 @@ class Synth {
         this.chain = jest.fn().mockReturnThis();
         this.volume = {
             value: 0,
-            linearRampToValueAtTime: jest.fn().mockImplementation()
+            cancelScheduledValues: jest.fn().mockReturnThis(),
+            setValueAtTime: jest.fn().mockReturnThis(),
+            linearRampToValueAtTime: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            }),
+            rampTo: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            })
         };
     }
     toDestination() {
@@ -107,7 +121,14 @@ class PolySynth {
         this.triggerAttackRelease = jest.fn().mockReturnThis();
         this.volume = {
             value: 0,
-            linearRampToValueAtTime: jest.fn().mockImplementation()
+            cancelScheduledValues: jest.fn().mockReturnThis(),
+            setValueAtTime: jest.fn().mockReturnThis(),
+            linearRampToValueAtTime: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            }),
+            rampTo: jest.fn().mockImplementation(val => {
+                this.volume.value = val;
+            })
         };
     }
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2134,6 +2134,8 @@ function Synth() {
     };
 
     this.rampTo = (turtle, instrumentName, oldVol, volume, rampTime) => {
+        // guard invalid UI/programmatic input (audio boundary safety)
+        volume = Math.max(0, Math.min(volume, 100));
         if (
             percussionInstruments.includes(instrumentName) ||
             stringInstruments.includes(instrumentName)
@@ -2153,7 +2155,8 @@ function Synth() {
             nv = volume;
         }
 
-        const db = Tone.gainToDb(nv / 100);
+        const gain = Math.max(0.0001, nv / 100);
+        const db = Tone.gainToDb(gain);
 
         let synth = instruments[turtle]["electronic synth"];
         if (instrumentName in instruments[turtle]) {
@@ -2201,6 +2204,8 @@ function Synth() {
      * @param {number} volume - The volume level (0 to 100).
      */
     this.setVolume = (turtle, instrumentName, volume) => {
+        // guard invalid UI/programmatic input (audio boundary safety)
+        volume = Math.max(0, Math.min(volume, 100));
         // We pass in volume as a number from 0 to 100.
         // As per #1697, we adjust the volume of some instruments.
         let nv;
@@ -2216,10 +2221,18 @@ function Synth() {
             nv = volume;
         }
 
-        // Convert volume to decibals
-        const db = Tone.gainToDb(nv / 100);
+        const gain = Math.max(0.0001, nv / 100);
+        const db = Tone.gainToDb(gain);
         if (instrumentName in instruments[turtle]) {
-            instruments[turtle][instrumentName].volume.value = db;
+            const synth = instruments[turtle][instrumentName];
+            // Do not schedule a ramp if volume didn't actually change to avoid "flutter" buzz
+            if (Math.abs(synth.volume.value - db) < 0.001) return;
+
+            // Use a tiny ramp (10ms) to prevent clicks
+            const now = Tone.now();
+            synth.volume.cancelScheduledValues(now);
+            synth.volume.setValueAtTime(synth.volume.value, now);
+            synth.volume.linearRampToValueAtTime(db, now + 0.01);
         }
     };
 
@@ -2242,7 +2255,10 @@ function Synth() {
                 this.trigger(0, "G4", 1 / 4, "electronic synth", null, null, false);
             }, 200);
         } else {
-            const db = Tone.gainToDb(volume / 100);
+            // guard invalid UI/programmatic input (audio boundary safety)
+            volume = Math.max(0, Math.min(volume, 100));
+            const gain = Math.max(0.0001, volume / 100);
+            const db = Tone.gainToDb(gain);
             Tone.Destination.volume.rampTo(db, 0.01);
         }
     };


### PR DESCRIPTION
## Summary

Fixes audio buzzing, clicking, and occasional constant-tone glitches caused by unsafe volume updates in the WebAudio pipeline.

MusicBlocks was directly assigning gain values and repeatedly scheduling ramps, which created waveform discontinuities and unstable oscillator states, especially in fast block loops (e.g., crescendo/decrescendo patterns).
This PR introduces safe parameter scheduling, clamps invalid ranges, and prevents redundant ramps.

---

## Cause

Three separate issues were interacting:

1. **Invalid volume ranges**
   Block math could generate values < 0 or > 100 → produced invalid gain → unstable audio node behaviour.

2. **Hard gain assignment**
   Directly setting `AudioParam.value` caused discontinuities in the waveform → clicks and buzzing.

3. **Ramp flooding**
   Re-applying the same volume every frame, scheduled thousands of overlapping ramps → “flutter” / motorboat sound / constant tone.

---

## Changes

### 1. Clamp unsafe volume inputs

Ensures WebAudio never receives invalid gain values.

```js
volume = Math.max(0, Math.min(volume, 100));
```

Applied to:

* rampTo
* setVolume
* master volume updates

---

### 2. Replace hard value assignment with proper scheduling

Prevents waveform discontinuities.

```js
const now = Tone.now();
synth.volume.cancelScheduledValues(now);
synth.volume.setValueAtTime(synth.volume.value, now);
synth.volume.linearRampToValueAtTime(db, now + 0.01);
```

---

### 3. Prevent redundant ramp scheduling

Stops audio flutter when volume is repeatedly set to the same value.

```js
if (Math.abs(synth.volume.value - db) < 0.001) return;
```

---

### 4. Update Tone mock for WebAudio parity

Adds missing AudioParam methods in tests:

* cancelScheduledValues
* setValueAtTime
* linearRampToValueAtTime

---

## Result

Before:

* buzzing in fast loops
* random popping
* constant beeping tone
* occasional silent audio context

After:

* stable playback
* smooth transitions
* no oscillator lockups
* deterministic behaviour under stress patterns

---

## Testing

Manual stress test:

```
set instrument electronic synth
repeat 80:
    set volume 100
    decrescendo -200
    crescendo 200
    play A4 1/32
```

Previously produced a buzzing/constant tone after a few seconds.
Now plays cleanly.

Also verified:

```
npm test
```
