### PR TITLE
refactor: Extract camera functionality into CameraManager module

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1063,9 +1063,19 @@ let prepareMacroExports = (name, stack, macroDict) => {
     return JSON.stringify(macroDict);
 };
 
-// Some block-specific code
-// TODO: Move to camera plugin
-let hasSetupCamera = false;
+// Camera functionality module
+// Encapsulates camera-related operations for video/image capture
+const CameraManager = {
+    isSetup: false,
+
+    /**
+     * Resets the camera setup state
+     */
+    reset() {
+        this.isSetup = false;
+    }
+};
+
 /**
  * Uses the camera to capture images or video frames and displays them on the turtle's canvas.
  * @param {Array} args - Arguments passed to the function.
@@ -1100,7 +1110,7 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
         turtles.getTurtle(turtle).doShowImage(args[0], data);
     }
 
-    if (!hasSetupCamera) {
+    if (!CameraManager.isSetup) {
         navigator.getMedia(
             { video: true, audio: false },
             stream => {
@@ -1111,7 +1121,7 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
                 }
 
                 video.play();
-                hasSetupCamera = true;
+                CameraManager.isSetup = true;
             },
             error => {
                 errorMsg("Could not connect to camera");
@@ -1133,7 +1143,7 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
     video.addEventListener(
         "canplay",
         () => {
-            // console.debug("canplay", streaming, hasSetupCamera);
+            // console.debug("canplay", streaming, CameraManager.isSetup);
             if (!streaming) {
                 video.setAttribute("width", w);
                 video.setAttribute("height", h);


### PR DESCRIPTION
## Changes
- Replaced global 'hasSetupCamera' variable with 'CameraManager' module
- Encapsulated camera state management within a dedicated object
- Added `reset()` method for better state control
- Improvements in Code Organization and Maintenance

## Motivation

Implements TODO comment asking for reorganization of the camera into a plugin structure. This is a refactoring step that makes the code somewhat easier to work with as to concern separation.
### Testing
- Existing camera functionality is unchanged - All mentions of camera setup state updated to make use of CameraManager - Code was formatted with Prettier