### PR TITLE
fix: add resource cleanup for GlobalCard to prevent memory leaks

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -246,6 +246,39 @@ class GlobalCard {
         this.id = id;
         this.ProjectData = this.Planet.GlobalPlanet.cache[id];
     }
+
+    /**
+     * Cleanup resources when card is removed from DOM.
+     * Prevents memory leaks by clearing timeouts and removing event listeners.
+     */
+    cleanup() {
+        // Clear any pending timeout from like action
+        if (this.likeTimeout) {
+            clearTimeout(this.likeTimeout);
+            this.likeTimeout = null;
+        }
+
+        // Remove all event listeners by cloning elements (removes listeners)
+        const elementIds = [
+            `global-project-more-details-${this.id}`,
+            `global-project-open-${this.id}`,
+            `global-project-image-${this.id}`,
+            `global-project-merge-${this.id}`,
+            `global-project-share-${this.id}`,
+            `global-checkboxrun-${this.id}`,
+            `global-checkboxshow-${this.id}`,
+            `global-checkboxcollapse-${this.id}`,
+            `global-like-icon-${this.id}`
+        ];
+
+        elementIds.forEach(id => {
+            const elem = document.getElementById(id);
+            if (elem && elem.parentNode) {
+                const clone = elem.cloneNode(true);
+                elem.parentNode.replaceChild(clone, elem);
+            }
+        });
+    }
 }
 
 function copyURLToClipboard() {

--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -132,6 +132,7 @@ class GlobalPlanet {
         const Planet = this.Planet;
 
         this.index = 0;
+        this._cleanupAllCards();
         this.cards = [];
         document.getElementById("global-projects").innerHTML = "";
         this.showLoading();
@@ -196,6 +197,7 @@ class GlobalPlanet {
 
             this.oldSearchString = this.searchString;
             this.index = 0;
+            this._cleanupAllCards();
             this.cards = [];
             document.getElementById("global-projects").innerHTML = "";
             this.showLoading();
@@ -398,6 +400,20 @@ class GlobalPlanet {
         const element = document.getElementById("global-projects");
         element.innerHTML = "";
         element.insertAdjacentHTML("afterbegin", this.noProjects);
+    }
+
+    /**
+     * Cleanup all card resources before they are removed from DOM.
+     * Prevents memory leaks by releasing event listeners and timeouts.
+     */
+    _cleanupAllCards() {
+        if (this.cards && this.cards.length > 0) {
+            this.cards.forEach(card => {
+                if (card && typeof card.cleanup === "function") {
+                    card.cleanup();
+                }
+            });
+        }
     }
 
     hideLoading() {


### PR DESCRIPTION
GlobalCard instances retain event listeners and timeouts even after being removed from the DOM during pagination, causing memory accumulation.

### Solution
- Added `cleanup()` method to GlobalCard to clear timeouts and event listeners
- Added `_cleanupAllCards()` helper to GlobalPlanet
- Call cleanup before refreshing cards in `refreshProjects()` and `search()`

Fixes #5664 
- Resolves memory leak when navigating through planet project pages
- Prevents listener accumulation during search operations

### Testing
- Navigate Planet section and paginate 5-10 times
- Monitor DevTools memory to verify stable memory usage