### PR TITLE
Fix memory leak in GlobalCard when cards are removed (#5664)

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -26,6 +26,7 @@ class GlobalCard {
         this.ProjectData = null;
         this.id = null;
         this.likeTimeout = null;
+        this.clipboard = null;
         this.PlaceholderMBImage = "images/mbgraphic.png";
         this.PlaceholderTBImage = "images/tbgraphic.png";
 
@@ -67,7 +68,7 @@ class GlobalCard {
                                     <div class="card-content shareurltext"> 
                                             <div class="shareurltitle">${_("Share")}</div> 
                                             <input type="text" name="shareurl" class="shareurlinput" data-originalurl="https://musicblocks.sugarlabs.org/index.html?id={ID}"> 
-                                            <a class="copyshareurl tooltipped" onclick="copyURLToClipboard()" data-clipboard-text="https://musicblocks.sugarlabs.org/index.html?id={ID}&run=True" data-delay="50" data-tooltip="${_(
+                                            <a class="copyshareurl tooltipped" data-clipboard-text="https://musicblocks.sugarlabs.org/index.html?id={ID}&run=True" data-delay="50" data-tooltip="${_(
                                                 "Copy link to clipboard"
                                             )}"><i class="material-icons"alt="Copy!">file_copy</i></a>
                                             <div class="shareurl-advanced" id="global-advanced-{ID}"> 
@@ -207,6 +208,24 @@ class GlobalCard {
 
         document.getElementById("global-projects").appendChild(frag);
         updateCheckboxes(`global-sharebox-${this.id}`);
+
+        // set clipboard listener
+        const copyBtn = document
+            .getElementById(`global-sharebox-${this.id}`)
+            .querySelector(".copyshareurl");
+        this.clipboard = new ClipboardJS(copyBtn);
+
+        this.clipboard.on("success", e => {
+            // eslint-disable-next-line no-console
+            console.info("Copied:", e.text);
+            e.clearSelection();
+        });
+
+        this.clipboard.on("error", e => {
+            alert("Failed to copy!");
+            // eslint-disable-next-line no-console
+            console.error("Failed to copy:", e.action);
+        });
     }
 
     like() {
@@ -242,24 +261,19 @@ class GlobalCard {
         document.getElementById(`global-like-icon-${this.id}`).textContent = text;
     }
 
+    cleanup() {
+        if (this.clipboard) {
+            this.clipboard.destroy();
+            this.clipboard = null;
+        }
+        if (this.likeTimeout) {
+            clearTimeout(this.likeTimeout);
+            this.likeTimeout = null;
+        }
+    }
+
     init(id) {
         this.id = id;
         this.ProjectData = this.Planet.GlobalPlanet.cache[id];
     }
-}
-
-function copyURLToClipboard() {
-    const clipboard = new ClipboardJS(".copyshareurl");
-
-    clipboard.on("success", e => {
-        // eslint-disable-next-line no-console
-        console.info("Copied:", e.text);
-        e.clearSelection();
-    });
-
-    clipboard.on("error", e => {
-        alert("Failed to copy!");
-        // eslint-disable-next-line no-console
-        console.error("Failed to copy:", e.action);
-    });
 }

--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -132,6 +132,13 @@ class GlobalPlanet {
         const Planet = this.Planet;
 
         this.index = 0;
+
+        for (let i = 0; i < this.cards.length; i++) {
+            if (typeof this.cards[i].cleanup === "function") {
+                this.cards[i].cleanup();
+            }
+        }
+
         this.cards = [];
         document.getElementById("global-projects").innerHTML = "";
         this.showLoading();
@@ -196,6 +203,13 @@ class GlobalPlanet {
 
             this.oldSearchString = this.searchString;
             this.index = 0;
+
+            for (let i = 0; i < this.cards.length; i++) {
+                if (typeof this.cards[i].cleanup === "function") {
+                    this.cards[i].cleanup();
+                }
+            }
+
             this.cards = [];
             document.getElementById("global-projects").innerHTML = "";
             this.showLoading();
@@ -275,7 +289,7 @@ class GlobalPlanet {
                         this.addProjectToCache(tempid, d, callback);
                     }.bind(this)
                 );
-            }.bind(this)());
+            }).bind(this)();
         }
     }
 


### PR DESCRIPTION
## Summary

This PR addresses a memory leak issue (#5664) where `GlobalCard` instances were being removed from the DOM during navigation (pagination, search, filtering) without properly cleaning up their associated resources. This caused `ClipboardJS` instances and event listeners to accumulate, leading to increased memory usage over time.

## Changes

### `planet/js/GlobalCard.js`
- Implemented a `cleanup()` method to destroy `ClipboardJS` instances and clear pending timeouts
- Removed the inline `onclick="copyURLToClipboard()"` handler from the HTML template
- Initialized `ClipboardJS` within the `render()` method to ensure proper lifecycle management for each card instance
- Removed the global `copyURLToClipboard` function as it is no longer needed

### `planet/js/GlobalPlanet.js`
- Updated `refreshProjects()` to call `.cleanup()` on all existing cards before clearing the `this.cards` array
- Updated `search()` to call `.cleanup()` on all existing cards before clearing the `this.cards` array

## Issue

Closes #5664

## Verification

1. Open the application and navigate to the **Global Planet** view
2. Perform repeated searches or navigate through multiple pages of projects
3. Monitor memory usage (e.g., using Chrome DevTools → Memory tab) to confirm that `GlobalCard` instances and `ClipboardJS` listeners are properly garbage collected and do not accumulate
4. Verify that the **Copy Link** and **Like** features still function correctly on the cards