### PR TITLE
Fix/ Add 30s timeout to prevent hanging requests

### DIFF
--- a/planet/js/RequestManager.js
+++ b/planet/js/RequestManager.js
@@ -232,15 +232,19 @@ class RequestManager {
      * @returns {Promise}
      */
     _withTimeout(promise, timeoutMs = 30000) {
+        let timeoutId;
+
+        const timeoutPromise = new Promise((_, reject) => {
+            timeoutId = setTimeout(() => {
+                const error = new Error(`Request timeout after ${timeoutMs}ms`);
+                error.name = "TimeoutError";
+                reject(error);
+            }, timeoutMs);
+        });
+
         return Promise.race([
-            promise,
-            new Promise((_, reject) =>
-                setTimeout(() => {
-                    const error = new Error(`Request timeout after ${timeoutMs}ms`);
-                    error.name = "TimeoutError";
-                    reject(error);
-                }, timeoutMs)
-            )
+            promise.finally(() => clearTimeout(timeoutId)),
+            timeoutPromise
         ]);
     }
 


### PR DESCRIPTION
## Summary
Add request timeout mechanism to prevent API calls from hanging indefinitely.

## Changes
- Added `_withTimeout()` helper method (30s default)
- Wrapped all requests with timeout in `_promisifyRequest()`
- Requests now reject instead of hanging on network failure

## Fixes
#5668

## Testing
1. Disable network in DevTools
2. Try loading global projects
3. After 30s, request should timeout gracefully