### PR TITLE
Fix: Proper Lifecycle Management for GlobalCard to Prevent Memory Retention (#5664)

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -17,7 +17,7 @@
 /*
    exported
 
-   GlobalCard, copyURLToClipboard
+   GlobalCard
 */
 
 class GlobalCard {
@@ -26,6 +26,7 @@ class GlobalCard {
         this.ProjectData = null;
         this.id = null;
         this.likeTimeout = null;
+        this.clipboard = null;
         this.PlaceholderMBImage = "images/mbgraphic.png";
         this.PlaceholderTBImage = "images/tbgraphic.png";
 
@@ -67,7 +68,7 @@ class GlobalCard {
                                     <div class="card-content shareurltext"> 
                                             <div class="shareurltitle">${_("Share")}</div> 
                                             <input type="text" name="shareurl" class="shareurlinput" data-originalurl="https://musicblocks.sugarlabs.org/index.html?id={ID}"> 
-                                            <a class="copyshareurl tooltipped" onclick="copyURLToClipboard()" data-clipboard-text="https://musicblocks.sugarlabs.org/index.html?id={ID}&run=True" data-delay="50" data-tooltip="${_(
+                                            <a class="copyshareurl tooltipped" data-clipboard-text="https://musicblocks.sugarlabs.org/index.html?id={ID}&run=True" data-delay="50" data-tooltip="${_(
                                                 "Copy link to clipboard"
                                             )}"><i class="material-icons"alt="Copy!">file_copy</i></a>
                                             <div class="shareurl-advanced" id="global-advanced-{ID}"> 
@@ -206,6 +207,39 @@ class GlobalCard {
 
         document.getElementById("global-projects").appendChild(frag);
         updateCheckboxes(`global-sharebox-${this.id}`);
+
+        if (this.clipboard) {
+            this.clipboard.destroy();
+        }
+
+        this.clipboard = new ClipboardJS(`.copyshareurl[data-clipboard-text*="${this.id}"]`);
+
+        this.clipboard.on("success", e => {
+            // eslint-disable-next-line no-console
+            console.info("Copied:", e.text);
+            e.clearSelection();
+        });
+
+        this.clipboard.on("error", e => {
+            alert("Failed to copy!");
+            // eslint-disable-next-line no-console
+            console.error("Failed to copy:", e.action);
+        });
+    }
+
+    cleanup() {
+        if (this.likeTimeout) {
+            clearTimeout(this.likeTimeout);
+            this.likeTimeout = null;
+        }
+
+        if (this.clipboard) {
+            this.clipboard.destroy();
+            this.clipboard = null;
+        }
+
+        this.ProjectData = null;
+        this.Planet = null;
     }
 
     like() {
@@ -245,19 +279,4 @@ class GlobalCard {
         this.id = id;
         this.ProjectData = this.Planet.GlobalPlanet.cache[id];
     }
-}
-
-function copyURLToClipboard() {
-    const clipboard = new ClipboardJS(".copyshareurl");
-
-    clipboard.on("success", e => {
-        console.info("Copied:", e.text);
-        e.clearSelection();
-    });
-
-    clipboard.on("error", e => {
-        alert("Failed to copy!");
-
-        console.error("Failed to copy:", e.action);
-    });
 }

--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -132,7 +132,7 @@ class GlobalPlanet {
         const Planet = this.Planet;
 
         this.index = 0;
-        this.cards = [];
+        this._cleanupCards();
         document.getElementById("global-projects").innerHTML = "";
         this.showLoading();
         this.hideLoadMore();
@@ -196,7 +196,7 @@ class GlobalPlanet {
 
             this.oldSearchString = this.searchString;
             this.index = 0;
-            this.cards = [];
+            this._cleanupCards();
             document.getElementById("global-projects").innerHTML = "";
             this.showLoading();
             this.hideLoadMore();
@@ -208,6 +208,17 @@ class GlobalPlanet {
                 this.afterRefreshProjects.bind(this)
             );
         }
+    }
+
+    _cleanupCards() {
+        if (Array.isArray(this.cards)) {
+            this.cards.forEach(card => {
+                if (card && card.cleanup) {
+                    card.cleanup();
+                }
+            });
+        }
+        this.cards = [];
     }
 
     afterSearch() {


### PR DESCRIPTION
# Fix: Proper Lifecycle Management for GlobalCard to Prevent Memory Retention (#5664)

## Summary

This PR resolves the memory retention issue described in #5664 by introducing explicit lifecycle management for `GlobalCard` instances.

Previously, when cards were removed during pagination, search, or filtering, their associated resources (ClipboardJS instances, timeouts, and event listeners) were not consistently destroyed. Although the DOM nodes were removed, lingering references prevented proper garbage collection, resulting in gradual memory growth over repeated navigations.

This update ensures that each `GlobalCard` fully releases its resources before being discarded, eliminating retained instances and stabilizing heap usage.

---

## Root Cause

The memory retention occurred because:

- `ClipboardJS` instances were attached per card but not explicitly destroyed  
- Pending timeouts (e.g., like animations) were not cleared  
- Card references remained reachable during list refresh cycles  
- Cleanup logic was duplicated across methods, increasing the risk of incomplete teardown  

As a result, repeated search and pagination cycles caused retained objects and event listeners to accumulate.

---

## Solution

###  Explicit Card Lifecycle (`planet/js/GlobalCard.js`)

- Added an idempotent `cleanup()` method
  - Safely destroys `ClipboardJS` (if present)
  - Clears pending timeouts
  - Nullifies internal references to assist garbage collection
- Added defensive guards to prevent double-destroy or reinitialization
- Scoped ClipboardJS initialization correctly to card lifecycle
- Removed obsolete inline handler and global clipboard helper

Each `GlobalCard` is now fully responsible for its own resource management.

---

### Centralized Card Teardown (`planet/js/GlobalPlanet.js`)

- Introduced `_cleanupCards()` helper
  - Safely iterates over `this.cards`
  - Calls `.cleanup()` on each instance
  - Clears references before resetting the array
- Refactored `refreshProjects()` and `search()` to use centralized cleanup logic

This ensures consistent teardown across all refresh flows and reduces duplication.

---

## Architectural Improvements

- Follows Single Responsibility Principle
- Ensures idempotent and defensive cleanup
- Prevents resource retention across navigation cycles
- Improves maintainability and reduces regression risk
- Keeps changes localized to the Planet subsystem

No changes were made to core modules such as `SaveInterface`.

---

## Verification

Memory behavior was validated using Chrome DevTools:
1. Performed repeated:
   - Pagination
   - Sorting
   - Search filtering
2. Forced garbage collection
<img width="1461" height="798" alt="heap snap" src="https://github.com/user-attachments/assets/6d4bf860-1a96-4e92-bb84-4663c2d51403" />


### Observed Results

- `GlobalCard` instance count remains stable
- `ClipboardJS` instances do not accumulate
- No growth in detached DOM nodes
- Heap size stabilizes after forced GC

### Functional Testing

- Copy Link feature works
- Like interaction works
- Sorting and search behave as expected
- No regressions observed

---

## Scope

**Modified files:**
- `planet/js/GlobalCard.js`
- `planet/js/GlobalPlanet.js`

**Not modified:**
- `js/SaveInterface.js`
- Backend logic
- Core activity modules

---

Closes #5664
- [x] Bug Fix 
