### PR TITLE
Fix: JSInterface Global Exposure (Fixes #5671)

### DIFF
--- a/js/js-export/interface.js
+++ b/js/js-export/interface.js
@@ -1810,3 +1810,7 @@ class JSInterface {
 if (typeof module !== "undefined" && module.exports) {
     module.exports = JSInterface;
 }
+
+if (typeof window !== "undefined") {
+    window.JSInterface = JSInterface;
+}


### PR DESCRIPTION

### Problem

The application threw the following runtime error on load:

```
Uncaught ReferenceError: JSInterface is not defined
at constraints.js
```

This occurred because `constraints.js` directly references `JSInterface`, but `JSInterface` was only exported using CommonJS (`module.exports`) and was not exposed to the browser global scope.

As a result, in browser environments, `JSInterface` was undefined at runtime.

---

### Root Cause

- `interface.js` exported `JSInterface` for Node environments only.
- `constraints.js` expected `JSInterface` to be globally available.
- In browser builds (RequireJS), `JSInterface` was never attached to `window`.

This mismatch caused a runtime `ReferenceError` during application initialization.

---

### Solution

Expose `JSInterface` to the browser global scope while preserving existing CommonJS behavior:

```js
if (typeof window !== "undefined") {
    window.JSInterface = JSInterface;
}
```

This solution:

- Maintains Node/CommonJS compatibility
- Preserves existing architecture
- Follows the same export pattern used in `export.js`
- Introduces no behavioral or structural changes
- Keeps the fix minimal and scoped strictly to the bug

---

### Verification

The fix was validated by:

- Confirming `typeof JSInterface === "function"` in the browser console
- Confirming `JSInterface._methodArgConstraints` is populated
- Verifying no console errors on application load
- Performing hard reload and incognito testing
- Running full Jest test suite (no regressions introduced)
<img width="1444" height="798" alt="shrey" src="https://github.com/user-attachments/assets/d3133205-88ca-4190-b109-91ec2bdcedac" />


---

### Result

- No runtime `ReferenceError`
- Application loads cleanly
- No functional regression
- Fully backward compatible with existing Node and browser usage

Fixes #5671.
