### PR TITLE
Refactor: doSearch() method initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,16 +613,6 @@
             }
         });
     </script>
-    <script>
-        $(document).ready(function () {
-            // Defensive check for doSearch global (now an Activity member)
-            if (typeof doSearch === "function") {
-                doSearch();
-            } else if (window.activity && typeof window.activity.doSearch === "function") {
-                window.activity.doSearch();
-            }
-        });
-    </script>
 
     <!-- Loading Dialog Script -->
     <script>

--- a/js/activity.js
+++ b/js/activity.js
@@ -7666,8 +7666,10 @@ class Activity {
 
             this.prepSearchWidget();
 
-            // create functionality of 2D drag to select blocks in bulk
+            // initialize doSearch
+            this.doSearch();
 
+            // create functionality of 2D drag to select blocks in bulk
             this._create2Ddrag();
 
             /*
@@ -7866,11 +7868,12 @@ define(["domReady!"].concat(MYDEFINES), doc => {
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.
-        const globalsReady = typeof createDefaultStack !== "undefined" &&
-                           typeof createjs !== "undefined" &&
-                           typeof Tone !== "undefined" &&
-                           typeof GIFAnimator !== "undefined" &&
-                           typeof SuperGif !== "undefined";
+        const globalsReady =
+            typeof createDefaultStack !== "undefined" &&
+            typeof createjs !== "undefined" &&
+            typeof Tone !== "undefined" &&
+            typeof GIFAnimator !== "undefined" &&
+            typeof SuperGif !== "undefined";
 
         if (globalsReady) {
             activity.setupDependencies();


### PR DESCRIPTION
### Description

`doSearch()` method was not being initialized during `Activity init()` phase. Currently the method is called in `/index.html` which is inconsistant. It the cause for search functionality breaking when the `/index.html` script calling `doSearch()` is removed.

### Solution
Refactored initialization of doSearch() method to occur Activity init() phase.

### Changes

- `/js/activity.js`
Added doSearch() initialization in Activity init().

- `/index.html`
Removed script for calling doSearch() method.

### Testing

- [x]  Browser testing passes
- [x] Search functionality works correctly
- [x] All jest tests are green