### PR TITLE
fix(resize): prevent crashes on hidden/zero viewport states (#5602)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3599,6 +3599,12 @@ class Activity {
                 return;
             }
 
+            // Skip resize when the tab is hidden — canvas reports 0×0
+            // and any layout work would corrupt positions.
+            if (document.hidden) {
+                return;
+            }
+
             const $j = window.jQuery;
             let w = 0,
                 h = 0;
@@ -3616,6 +3622,12 @@ class Activity {
             this._innerHeight = window.innerHeight;
             this._outerWidth = window.outerWidth;
             this._outerHeight = window.outerHeight;
+
+            // Guard against zero or invalid dimensions to prevent
+            // division-by-zero and ResizeObserver loop errors
+            if (w <= 0 || h <= 0) {
+                return;
+            }
 
             if (document.getElementById("labelDiv").classList.contains("hasKeyboard")) {
                 return;
@@ -3790,6 +3802,11 @@ class Activity {
         const defaultHeight = 900;
 
         function handleResize() {
+            // Skip resize when the tab is hidden to prevent 0×0 canvas
+            if (document.hidden) {
+                return;
+            }
+
             const isMaximized =
                 window.innerWidth === window.screen.width &&
                 window.innerHeight === window.screen.height;
@@ -3805,6 +3822,12 @@ class Activity {
             } else {
                 const windowWidth = window.innerWidth;
                 const windowHeight = window.innerHeight;
+
+                // Guard against zero or invalid dimensions
+                if (windowWidth <= 0 || windowHeight <= 0) {
+                    return;
+                }
+
                 container.style.width = windowWidth + "px";
                 container.style.height = windowHeight + "px";
                 canvas.width = windowWidth;
@@ -3824,11 +3847,28 @@ class Activity {
             resizeTimeout = setTimeout(() => {
                 handleResize();
                 this._setupPaletteMenu();
-            }, 100);
+            }, 200);
         };
         this.addEventListener(window, "resize", this._handleWindowResize);
         this._handleOrientationChangeResize = handleResize;
         this.addEventListener(window, "orientationchange", this._handleOrientationChangeResize);
+
+        // When the user returns to the Music Blocks tab after it was
+        // hidden, re-apply the correct dimensions.  While the tab was
+        // hidden the resize guards above intentionally skipped any
+        // layout work, so we need to catch up now.
+        this._handleVisibilityChange = () => {
+            if (!document.hidden && this.stage) {
+                // Use a short delay to let the browser finish
+                // exposing the tab and reporting real dimensions.
+                setTimeout(() => {
+                    handleResize();
+                    this._onResize(false);
+                }, 250);
+            }
+        };
+        this.addEventListener(document, "visibilitychange", this._handleVisibilityChange);
+
         const that = this;
         const resizeCanvas_ = () => {
             try {
@@ -7866,11 +7906,12 @@ define(["domReady!"].concat(MYDEFINES), doc => {
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.
-        const globalsReady = typeof createDefaultStack !== "undefined" &&
-                           typeof createjs !== "undefined" &&
-                           typeof Tone !== "undefined" &&
-                           typeof GIFAnimator !== "undefined" &&
-                           typeof SuperGif !== "undefined";
+        const globalsReady =
+            typeof createDefaultStack !== "undefined" &&
+            typeof createjs !== "undefined" &&
+            typeof Tone !== "undefined" &&
+            typeof GIFAnimator !== "undefined" &&
+            typeof SuperGif !== "undefined";
 
         if (globalsReady) {
             activity.setupDependencies();

--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -70,6 +70,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(activity.turtles._canvas.width / (2.0 * activity.turtles.scale));
         }
 
@@ -78,6 +85,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return activity.turtles._canvas.width / (2.0 * activity.turtles.scale);
         }
     }
@@ -132,6 +146,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(-1 * (activity.turtles._canvas.width / (2.0 * activity.turtles.scale)));
         }
 
@@ -140,6 +161,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return -1 * (activity.turtles._canvas.width / (2.0 * activity.turtles.scale));
         }
     }
@@ -193,6 +221,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(activity.turtles._canvas.height / (2.0 * activity.turtles.scale));
         }
 
@@ -201,6 +236,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return activity.turtles._canvas.height / (2.0 * activity.turtles.scale);
         }
     }
@@ -254,6 +296,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(
                 -1 * (activity.turtles._canvas.height / (2.0 * activity.turtles.scale))
             );
@@ -264,6 +313,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return -1 * (activity.turtles._canvas.height / (2.0 * activity.turtles.scale));
         }
     }
@@ -299,6 +355,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(activity.turtles._canvas.width / activity.turtles.scale);
         }
 
@@ -307,6 +370,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.width ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return activity.turtles._canvas.width / activity.turtles.scale;
         }
     }
@@ -342,6 +412,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The updated parameter value.
          */
         updateParameter() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return toFixed2(activity.turtles._canvas.height / activity.turtles.scale);
         }
 
@@ -350,6 +427,13 @@ function setupMediaBlocks(activity) {
          * @returns {number} - The argument value.
          */
         arg() {
+            if (
+                !activity.turtles._canvas ||
+                !activity.turtles._canvas.height ||
+                !activity.turtles.scale
+            ) {
+                return 0;
+            }
             return activity.turtles._canvas.height / activity.turtles.scale;
         }
     }
@@ -681,21 +765,7 @@ function setupMediaBlocks(activity) {
             // Set palette and activity for the block
             this.setPalette("media", activity);
             this.piemenuValuesC1 = [
-                220,
-                247,
-                262,
-                294,
-                330,
-                349,
-                392,
-                440,
-                494,
-                523,
-                587,
-                659,
-                698,
-                784,
-                880
+                220, 247, 262, 294, 330, 349, 392, 440, 494, 523, 587, 659, 698, 784, 880
             ];
             this.setHelpString();
 

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -685,28 +685,50 @@ Turtles.TurtlesView = class {
 
         this.currentGrid = null; // currently selected grid
 
-        // Attach an event listener to the 'resize' event
+        // Debounce timer for resize events
+        this._resizeTimer = null;
+
+        // Attach a debounced event listener to the 'resize' event
+        // This prevents rapid-fire resize calculations that can cause
+        // crashes when toggling DevTools or switching tabs.
         window.addEventListener("resize", () => {
-            // Call the updateDimensions function when resizing occurs
-            var screenWidth =
-                window.innerWidth ||
-                document.documentElement.clientWidth ||
-                document.body.clientWidth;
-            var screenHeight =
-                window.innerHeight ||
-                document.documentElement.clientHeight ||
-                document.body.clientHeight;
+            if (this._resizeTimer) {
+                clearTimeout(this._resizeTimer);
+            }
 
-            // Set a scaling factor to adjust the dimensions based on the screen size
-            var scale = Math.min(screenWidth / 1200, screenHeight / 900);
+            this._resizeTimer = setTimeout(() => {
+                // Skip dimension updates when the tab is hidden
+                // (canvas reports 0x0 in background tabs)
+                if (document.hidden) {
+                    return;
+                }
 
-            // Calculate the new dimensions
-            var newWidth = Math.round(1200 * scale);
-            var newHeight = Math.round(900 * scale);
+                // Call the updateDimensions function when resizing occurs
+                var screenWidth =
+                    window.innerWidth ||
+                    document.documentElement.clientWidth ||
+                    document.body.clientWidth;
+                var screenHeight =
+                    window.innerHeight ||
+                    document.documentElement.clientHeight ||
+                    document.body.clientHeight;
 
-            // Update the dimensions
-            this._w = newWidth;
-            this._h = newHeight;
+                // Guard against zero or invalid dimensions
+                if (screenWidth <= 0 || screenHeight <= 0) {
+                    return;
+                }
+
+                // Set a scaling factor to adjust the dimensions based on the screen size
+                var scale = Math.min(screenWidth / 1200, screenHeight / 900);
+
+                // Calculate the new dimensions
+                var newWidth = Math.round(1200 * scale);
+                var newHeight = Math.round(900 * scale);
+
+                // Update the dimensions
+                this._w = newWidth;
+                this._h = newHeight;
+            }, 150);
         });
     }
 
@@ -731,6 +753,12 @@ Turtles.TurtlesView = class {
      * @returns {void}
      */
     doScale(w, h, scale) {
+        // Guard against zero/invalid dimensions to prevent division-by-zero
+        // and layout corruption when canvas is hidden or mid-resize
+        if (!w || !h || !scale || w <= 0 || h <= 0 || scale <= 0) {
+            return;
+        }
+
         if (this._locked) {
             this._queue = [w, h, scale];
         } else {
@@ -808,6 +836,10 @@ Turtles.TurtlesView = class {
      * @returns {Number} inverted y coordinate
      */
     _invertY(y) {
+        // Guard against zero canvas height / scale to prevent NaN/Infinity
+        if (!this.canvas || !this.canvas.height || !this._scale) {
+            return -y; // Fallback: simple inversion around origin
+        }
         return this.canvas.height / (2.0 * this._scale) - y;
     }
 
@@ -818,6 +850,10 @@ Turtles.TurtlesView = class {
      * @returns {Number} turtle x coordinate
      */
     screenX2turtleX(x) {
+        // Guard against zero canvas width / scale
+        if (!this.canvas || !this.canvas.width || !this._scale) {
+            return 0; // Safe fallback when dimensions are unavailable
+        }
         return x - this.canvas.width / (2.0 * this._scale);
     }
 
@@ -838,6 +874,10 @@ Turtles.TurtlesView = class {
      * @returns {Number} screen x coordinate
      */
     turtleX2screenX(x) {
+        // Guard against zero canvas width / scale
+        if (!this.canvas || !this.canvas.width || !this._scale) {
+            return x; // Fallback: return raw coordinate
+        }
         return this.canvas.width / (2.0 * this._scale) + x;
     }
 


### PR DESCRIPTION
## Summary

Fixes #5602

When the browser tab is hidden or the viewport height changes abruptly (e.g., toggling DevTools, switching tabs), the layout engine attempts to calculate canvas dimensions based on invalid width/height values of 0. This causes **ResizeObserver loop limit exceeded** errors, **division-by-zero** scenarios that freeze the main thread, or complete tab crashes.

## Root Cause

The application has multiple resize handlers across [js/turtles.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:0:0-0:0), [js/blocks/MediaBlocks.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/blocks/MediaBlocks.js:0:0-0:0), and [js/activity.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/activity.js:0:0-0:0) that perform canvas dimension calculations without checking whether the viewport/canvas dimensions are valid (non-zero). When DevTools is toggled or the tab is switched:

1. `window.innerWidth`/`innerHeight` can momentarily report 0
2. `document.hidden` becomes `true` and canvas reports 0×0
3. Coordinate conversion methods divide by these zero values, producing `NaN`/`Infinity`
4. CreateJS tries to render with invalid coordinates, triggering cascading errors

## Changes

### [js/turtles.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:0:0-0:0) — Core coordinate system protection
- **Debounced resize listener** (150ms) prevents rapid-fire dimension recalculations
- **`document.hidden` check** skips updates when tab is in background
- **Zero-dimension guard** rejects `screenWidth <= 0 || screenHeight <= 0`
- **[doScale()](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:746:4-770:5) guard** rejects invalid `w`, `h`, or [scale](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:359:4-364:5) values
- **Guards on all 5 coordinate conversion methods** ([_invertY](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:830:4-843:5), [screenX2turtleX](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:845:4-857:5), [screenY2turtleY](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:859:4-867:5), [turtleX2screenX](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:869:4-881:5), [turtleY2screenY](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/turtles.js:883:4-891:5)) — return safe fallback values when canvas is 0×0

### [js/blocks/MediaBlocks.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/blocks/MediaBlocks.js:0:0-0:0) — Block parameter protection
- **Guards on all 6 screen position/dimension blocks** (RightPos, LeftPos, TopPos, BottomPos, Width, Height) — both [updateParameter()](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/blocks/MediaBlocks.js:135:8-144:9) and [arg()](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/blocks/MediaBlocks.js:75:8-81:9) return 0 when canvas/scale are invalid

### [js/activity.js](cci:7://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/activity.js:0:0-0:0) — Resize orchestration protection
- **`document.hidden` check** in `_onResize()` and [handleResize()](cci:1://file:///c:/Users/karns/Documents/GitHub/musicblocks/js/activity.js:3803:8-3841:9)
- **`w <= 0 || h <= 0` guard** prevents setting `stage.canvas.width = 0`
- **`visibilitychange` listener** re-applies correct dimensions when returning to tab (250ms delay)
- **Increased debounce** from 100ms → 200ms for better DevTools toggle tolerance

## Defense Strategy

The fix creates a **multi-layer defense**:

| Layer | Mechanism | Purpose |
|-------|-----------|---------|
| 1 | Debouncing | Prevents rapid-fire resize from overwhelming the layout engine |
| 2 | `document.hidden` | Skips all layout work when tab isn't visible |
| 3 | Zero-dimension guards | Catches edge cases at the calculation level |
| 4 | `visibilitychange` | Restores correct layout when user returns to tab |

## How to Test

1. Open Music Blocks in Chrome/Edge
2. Open DevTools (F12) — causes viewport resize
3. Switch to another browser tab (puts Music Blocks in background)
4. Wait 1–2 seconds
5. Switch back to the Music Blocks tab
6. Close DevTools
7. **Expected**: Application remains stable and responsive throughout
8. **Previous behavior**: Application freezes, becomes unresponsive, or tab crashes

## Checklist

- [x] No breaking changes
- [x] No performance impact (guards are simple boolean checks)
- [x] Preserves all existing functionality
- [x] Tested with DevTools toggle + tab switching scenario