### PR TITLE
Standardize Search Menu Dark Mode Colors

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -98,10 +98,25 @@
 .dark .ui-autocomplete {
     background-color: #1c1c1c !important;
     color: #fff !important;
+    border-color: #444 !important;
 }
 
-.dark .ui-autocomplete li:hover {
-    background-color: #225a91 !important;
+/* Ensure all text inside autocomplete items is white */
+.dark .ui-autocomplete .ui-menu-item,
+.dark .ui-autocomplete .ui-menu-item a,
+.dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
+    color: #fff !important;
+    background-color: transparent !important;
+}
+
+/* Hover and keyboard-focus highlight — matches palette hoverColor */
+.dark .ui-autocomplete .ui-menu-item:hover,
+.dark .ui-autocomplete .ui-menu-item:hover a,
+.dark .ui-autocomplete .ui-menu-item:hover .ui-menu-item-wrapper,
+.dark .ui-autocomplete .ui-state-focus,
+.dark .ui-autocomplete .ui-state-active {
+    background-color: #808080 !important;
+    color: #fff !important;
 }
 
 .dark #helpfulSearchDiv {


### PR DESCRIPTION
### Description

This PR improves the visibility and consistency of the search autocomplete menu in dark mode. It ensures all text is readable and aligns the hover/focus states with the existing `#808080` palette used in the platform's sidebar.

### Changes

* **Text Color:** Forced all autocomplete list items, links, and wrappers to white in dark mode.
* **Navigation States:** Updated `.ui-state-focus` and `.ui-state-active` to use the standardized hover color for seamless keyboard navigation.
* **Consistency:** Matched the background highlight to `platformColor.hoverColor` (`#808080`).

Before:
<img width="383" height="480" alt="image" src="https://github.com/user-attachments/assets/d7eb4165-0f95-4454-bf1b-ec4bdf59af4f" />

After:
<img width="405" height="368" alt="image" src="https://github.com/user-attachments/assets/5ce213a1-aece-4179-a3bb-59748e6bf6cf" />
