### PR TITLE
fix: remove debug console.log from KeySignatureEnv initialization

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7864,11 +7864,12 @@ define(["domReady!"].concat(MYDEFINES), doc => {
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.
-        const globalsReady = typeof createDefaultStack !== "undefined" &&
-                           typeof createjs !== "undefined" &&
-                           typeof Tone !== "undefined" &&
-                           typeof GIFAnimator !== "undefined" &&
-                           typeof SuperGif !== "undefined";
+        const globalsReady =
+            typeof createDefaultStack !== "undefined" &&
+            typeof createjs !== "undefined" &&
+            typeof Tone !== "undefined" &&
+            typeof GIFAnimator !== "undefined" &&
+            typeof SuperGif !== "undefined";
 
         if (globalsReady) {
             activity.setupDependencies();


### PR DESCRIPTION
issue: #5691 

Problem:-
The Activity constructor in js/activity.js contains a leftover debugging console.log statement that logs the stored KeySignatureEnv value to the browser console during application startup.
This log is guarded by an ESLint suppression comment, indicating it was added temporarily during development but not removed before merging into production code.

This results in unnecessary console output every time Music Blocks loads.

Solution:-
-This PR removes the unintended debug logging from production code while preserving all existing behavior:
->Removes the debug console.log statement
->Removes the associated // eslint-disable-next-line no-console comment
->Keeps legitimate console.error logging for error handling
->Makes no functional or logic changes

Changes Made:-
-Files modified:
->js/activity.js – removed debug logging during KeySignatureEnv initialization
->js/loader.js – Prettier formatting only
->sw.js – Prettier formatting only

Note: Formatting changes were applied to ensure CI and Prettier checks pass cleanly.

Testing Performed:-
-Manual verification
-Loaded Music Blocks locally
-Confirmed no unnecessary console output during startup
-Verified application behavior remains unchanged
-Automated testing

Jest: ✅ All 1868 tests passed
Prettier: ✅ Formatting verified
ESLint: ⚠️ Pre-existing repository configuration issue (not introduced by this change)

Impact:-
-Cleaner production code
-Reduced console noise
-Improved ESLint compliance
-No breaking changes or regressions

Notes:
This change follows the same cleanup pattern as the recently merged removal of debug logging in js/toolbar.js.
The update is intentionally minimal and low-risk.

Happy to adjust if maintainers prefer a different approach.