### PR TITLE
feat(logic): complete dynamic MakeBlock types for tempo, volume, and instrument

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -1255,21 +1255,72 @@ function setupProgramBlocks(activity) {
                     [8, "hidden", 0, 0, [0, null]]
                 ];
                 activity.blocks.loadNewBlocks(newNote);
-                // eslint-disable-next-line no-console
-                console.debug("BLOCKNUMBER " + blockNumber);
                 return blockNumber;
             } else if (name === _("start")) {
                 const newBlock = [[0, "start", x, y, [null, null, null]]];
                 activity.blocks.loadNewBlocks(newBlock);
-                // eslint-disable-next-line no-console
-                console.debug("BLOCKNUMBER " + blockNumber);
                 return blockNumber;
             } else if (name === _("silence")) {
-                // FIXME: others too
                 const newBlock = [[0, "rest2", x, y, [null, null]]];
                 activity.blocks.loadNewBlocks(newBlock);
-                // eslint-disable-next-line no-console
-                console.debug("BLOCKNUMBER " + blockNumber);
+                return blockNumber;
+            } else if (name === _("tempo")) {
+                let bpm, beat;
+                switch (blockArgs.length) {
+                    case 1:
+                        bpm = 90;
+                        beat = 4;
+                        break;
+                    case 2:
+                        bpm = blockArgs[1];
+                        beat = 4;
+                        break;
+                    default:
+                        bpm = blockArgs[1];
+                        beat = blockArgs[2];
+                        break;
+                }
+                const newTempo = [
+                    [0, "setbpm3", x, y, [null, 1, 2, 5]],
+                    [1, ["number", { value: bpm }], 0, 0, [0]],
+                    [2, "divide", 0, 0, [0, 3, 4]],
+                    [3, ["number", { value: 1 }], 0, 0, [2]],
+                    [4, ["number", { value: beat }], 0, 0, [2]],
+                    [5, "vspace", 0, 0, [0, null]]
+                ];
+                activity.blocks.loadNewBlocks(newTempo);
+                return blockNumber;
+            } else if (name === _("volume")) {
+                let synth, vol;
+                switch (blockArgs.length) {
+                    case 1:
+                        synth = "piano";
+                        vol = 50;
+                        break;
+                    case 2:
+                        synth = blockArgs[1];
+                        vol = 50;
+                        break;
+                    default:
+                        synth = blockArgs[1];
+                        vol = blockArgs[2];
+                        break;
+                }
+                const newVolume = [
+                    [0, "setsynthvolume", x, y, [null, 1, 2, null]],
+                    [1, ["voicename", { value: synth }], 0, 0, [0]],
+                    [2, ["number", { value: vol }], 0, 0, [0]]
+                ];
+                activity.blocks.loadNewBlocks(newVolume);
+                return blockNumber;
+            } else if (name === _("instrument")) {
+                let instr = blockArgs.length > 1 ? blockArgs[1] : "piano";
+                const newInstrument = [
+                    [0, "settimbre", x, y, [null, 1, null, 2]],
+                    [1, ["voicename", { value: instr }], 0, 0, [0]],
+                    [2, "hidden", 0, 0, [0, null]]
+                ];
+                activity.blocks.loadNewBlocks(newInstrument);
                 return blockNumber;
             } else {
                 const obj = activity.blocks.palettes.getProtoNameAndPalette(name);


### PR DESCRIPTION

## Description

This PR extends the `MakeBlock` capability in `ProgramBlocks.js` to support programmatic creation of tempo, volume, and instrument block stacks.

This resolves the existing `FIXME: others too` comment in the codebase and completes dynamic support for additional musical block types.

---

##  Key Changes

###  Dynamic Tempo
- Added support for creating `setbpm3` blocks dynamically.
- Accepts:
  - BPM value
  - Beat denominator

Example:
```
makeblock "tempo [120 4]
```

---

###  Dynamic Volume
- Added support for creating `setsynthvolume` blocks dynamically.
- Accepts:
  - Synth name
  - Volume level (percentage)

Example:
```
makeblock "volume ["piano" 75]
```

---

###  Dynamic Instrument
- Added support for creating `settimbre` blocks dynamically.
- Accepts:
  - Instrument/voice name

Example:
```
makeblock "instrument ["violin"]
```

---

###  Macro Precision
- Refined block construction arrays to exactly match internal block macros.
- Ensured correct dock alignment:
  - Proper `vspace` handling
  - Correct connection sequencing
  - Accurate stack structure replication

---

### Default Arguments

Implemented safe fallback defaults when insufficient arguments are provided:

| Block Type  | Default Values        |
|------------|----------------------|
| Tempo      | 90 BPM, beat = 4     |
| Volume     | "piano", 50%         |
| Instrument | "piano"              |

---

## Testing

###  Functional Verification

Verified via engine-level block creation:

```js
activity.blocks.makeBlock("tempo", [120,4]);
activity.blocks.makeBlock("volume", ["piano",75]);
activity.blocks.makeBlock("instrument", ["violin"]);
```

Confirmed:
- No runtime errors
- Block types correctly registered and recognized
- Block IDs returned successfully
<img width="477" height="396" alt="instrument" src="https://github.com/user-attachments/assets/8304be2a-6a98-4048-ade1-5c4886c45c7f" />


---

### Regression Testing
- Confirmed existing `note`, `start`, and `silence` types continue to function correctly.
- No impact on existing MakeBlock behavior.

---

### Code Quality
- Linted using ESLint
- Formatted using Prettier
- No new lint violations introduced

---

##  Summary

This PR completes dynamic `MakeBlock` support for:

- Tempo blocks
- Volume blocks
- Instrument blocks

All implementations strictly follow internal macro structure and maintain dock integrity.

The feature is verified and ready for review.
