### PR TITLE
fix: add tooltip and aria-label to guide tour navigation arrows

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -98,10 +98,14 @@ class HelpWidget {
             rightArrow = document.getElementById("right-arrow");
             rightArrow.style.display = "block";
             rightArrow.classList.add("hover");
+            rightArrow.setAttribute("title", _("Next"));
+            rightArrow.setAttribute("aria-label", _("Next"));
 
             leftArrow = document.getElementById("left-arrow");
             leftArrow.style.display = "block";
             leftArrow.classList.add("hover");
+            leftArrow.setAttribute("title", _("Previous"));
+            leftArrow.setAttribute("aria-label", _("Previous"));
 
             document.onkeydown = function handleArrowKeys(event) {
                 if (event.key === "ArrowLeft") {
@@ -146,8 +150,9 @@ class HelpWidget {
             };
         } else {
             if (this.activity.blocks.activeBlock.name !== null) {
-                const label = this.activity.blocks.blockList[this.activity.blocks.activeBlock]
-                    .protoblock.staticLabels[0];
+                const label =
+                    this.activity.blocks.blockList[this.activity.blocks.activeBlock].protoblock
+                        .staticLabels[0];
                 if (page == 0) {
                     this.widgetWindow.updateTitle(_("Take a tour"));
                 } else {
@@ -158,10 +163,14 @@ class HelpWidget {
             rightArrow = document.getElementById("right-arrow");
             rightArrow.style.display = "none";
             rightArrow.classList.remove("hover");
+            rightArrow.setAttribute("title", _("Next"));
+            rightArrow.setAttribute("aria-label", _("Next"));
 
             leftArrow = document.getElementById("left-arrow");
             leftArrow.style.display = "none";
             leftArrow.classList.remove("hover");
+            leftArrow.setAttribute("title", _("Previous"));
+            leftArrow.setAttribute("aria-label", _("Previous"));
         }
 
         if (!useActiveBlock) {
@@ -200,8 +209,9 @@ class HelpWidget {
                 // svg file, and an optional macro name for generating
                 // the help output.
 
-                const message = this.activity.blocks.blockList[this.activity.blocks.activeBlock]
-                    .protoblock.helpString;
+                const message =
+                    this.activity.blocks.blockList[this.activity.blocks.activeBlock].protoblock
+                        .helpString;
 
                 if (message) {
                     const helpBody = docById("helpBodyDiv");
@@ -377,8 +387,8 @@ class HelpWidget {
                 leftArrow.classList.remove("disabled");
 
                 this.widgetWindow.updateTitle(HELPCONTENT[page][0]);
-            this._showPage(page);
-        };
+                this._showPage(page);
+            };
             if (page === 0) {
                 leftArrow.classList.add("disabled");
             }


### PR DESCRIPTION
## Summary
Adds missing `title` and `aria-label` attributes to the left and right navigation arrows in the Guide/Tour dialog.

## Why
- Improves accessibility for screen readers
- Adds hover tooltip for clarity
- Keeps consistency with existing dialog controls (e.g., minimize/close use native title)

## Scope
Small UI/accessibility enhancement. No behavior changes.

## Before
<img width="1352" height="616" alt="Screenshot from 2026-02-14 11-55-42" src="https://github.com/user-attachments/assets/7b6a450a-560c-4565-8da9-af2d629f450d" />
<img width="1352" height="616" alt="Screenshot from 2026-02-14 11-56-09" src="https://github.com/user-attachments/assets/c9238b22-a247-4ffc-9501-2bc5b8e0a099" />

## After
<img width="1352" height="616" alt="Screenshot from 2026-02-14 11-55-23" src="https://github.com/user-attachments/assets/54a95ed2-9252-4c49-b53a-9113886b438f" />
<img width="1352" height="616" alt="Screenshot from 2026-02-14 11-55-54" src="https://github.com/user-attachments/assets/faa546ae-7ae5-410c-8cc9-a86ccdab648e" />