### PR TITLE
fix(action): correctly detect hasReturn and hasArgs metadata for palette derivatives

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -4527,20 +4527,14 @@ class Block {
                     // Rename both do <- name and nameddo blocks.
                     this.blocks.renameDos(oldValue, newValue);
 
+                    // eslint-disable-next-line no-case-declarations
+                    const metadata = this.blocks.actionMetadata(c);
                     if (oldValue === _("action")) {
-                        this.blocks.newNameddoBlock(
-                            newValue,
-                            this.blocks.actionHasReturn(c),
-                            this.blocks.actionHasArgs(c)
-                        );
+                        this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                         this.blocks.setActionProtoVisibility(false);
                     }
 
-                    this.blocks.newNameddoBlock(
-                        newValue,
-                        this.blocks.actionHasReturn(c),
-                        this.blocks.actionHasArgs(c)
-                    );
+                    this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                     // eslint-disable-next-line no-case-declarations
                     const blockPalette = this.blocks.palettes.dict["action"];
                     for (let blk = 0; blk < blockPalette.protoList.length; blk++) {
@@ -4557,11 +4551,7 @@ class Block {
                     }
 
                     if (oldValue === _("action")) {
-                        this.blocks.newNameddoBlock(
-                            newValue,
-                            this.blocks.actionHasReturn(c),
-                            this.blocks.actionHasArgs(c)
-                        );
+                        this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                         this.blocks.setActionProtoVisibility(false);
                     }
                     this.blocks.renameNameddos(oldValue, newValue);


### PR DESCRIPTION

### Description
This PR fixes the initialization logic for Action blocks to correctly determine whether an action has return values or arguments. Previously, this metadata was often hardcoded or missed during certain operations like block creation or renaming.

**Key Changes:**
1.  **New Helper `actionMetadata`**: Introduced a consolidated helper in `Blocks.js` that efficiently traverses an action's stack once to detect both `return` and `arg`/`namedarg` blocks.
2.  **Updated Initialization**: Updated [makeBlock](cci:1://file:///Users/vanshika/musicblocks/js/blocks.js:3141:8-3578:10) to use `actionMetadata` when creating new Action blocks, replacing hardcoded `false` values (fixes TODO).
3.  **Refactored Logic**:
    *   Updated `actionHasReturn` and `actionHasArgs` to use the shared `actionMetadata` helper.
    *   Updated `blockMoved` and [cleanupAfterLoad](cci:1://file:///Users/vanshika/musicblocks/js/blocks.js:6613:8-6695:10) in [js/blocks.js](cci:7://file:///Users/vanshika/musicblocks/js/blocks.js:0:0-0:0) to correctly propagate metadata.
    *   Updated [_labelChanged](cci:1://file:///Users/vanshika/musicblocks/js/block.js:4229:4-4557:5) in [js/block.js](cci:7://file:///Users/vanshika/musicblocks/js/block.js:0:0-0:0) to ensure renaming an action updates the palette with the correct block type (e.g., `nameddo` vs `nameddoArg`).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
- Verified that creating a new Action block correctly initializes its palette entry.
- Verified that adding `return` or `arg` blocks to an Action updates the palette entry type correctly when the stack is modified or reloaded.
- Verified that renaming an Action block preserves its type (`nameddo`, `namedcalc`, etc.) based on its content.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings