### PR TITLE
Fix infinite loop protection in phrasemaker.js

### DIFF
--- a/js/widgets/PhraseMakerGrid.js
+++ b/js/widgets/PhraseMakerGrid.js
@@ -147,7 +147,7 @@ const PhraseMakerGrid = {
 
         while (pm._deps.last(myBlock.connections) != null) {
             bottomBlockLoop += 1;
-            if (bottomBlockLoop > 2 * pm.activity.blocks.blockList) {
+            if (bottomBlockLoop > 2 * pm.activity.blocks.blockList.length) {
                 // Could happen if the block data is malformed.
                 break;
             }


### PR DESCRIPTION
##summary
This PR fixes an issue in js/widgets/phrasemaker.js where the infinite loop protection in _mapNotesBlocks was not working correctly.
The code was comparing a number with the blockList array instead of its length, causing the condition to always fail.

##Updated:
if (bottomBlockLoop > 2 * this.activity.blocks.blockList.length) 

This restores proper infinite loop protection and improves stability without changing normal behavior.