### PR TITLE
fix: update fullscreen tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,7 +667,6 @@
 
                 const container = document.getElementById("loading-media");
                 const content = lang.startsWith("ja")
-                    ? `<img src="loading-animation-ja.png" loading="eager" fetchpriority="high" style="width: 70%; height: 90%; object-fit: contain;" alt="Loading animation">`
                 ? `<img src="loading-animation-ja.svg" loading="eager" fetchpriority="high" style="width: 70%; height: 90%; object-fit: contain;" alt="Loading animation">`
                     : `<video loop autoplay muted playsinline fetchpriority="high" style="width: 90%; height: 100%; object-fit: contain;">
                         <source src="loading-animation.webm" type="video/webm">


### PR DESCRIPTION
This PR fixes the issue where the fullscreen button's tooltip remained static even after the screen state changed.

Changes:

Updated handleFullscreenChange to toggle the data-tooltip attribute.
Before::
<img width="1600" height="902" alt="image" src="https://github.com/user-attachments/assets/bee22167-3fd0-4e79-bef4-72ac4d3df07b" />
After::
![WhatsApp Image 2026-02-15 at 2 01 01 AM](https://github.com/user-attachments/assets/b8be40e3-5b82-41ac-a961-98e0bf180472)
