### PR TITLE
Phase 2: Extract Grid Logic into PhraseMakerGrid Module

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -165,6 +165,7 @@ if (_THIS_IS_MUSIC_BLOCKS_) {
         "widgets/modewidget",
         "widgets/meterwidget",
         "widgets/PhraseMakerUtils",
+        "widgets/PhraseMakerGrid",
         "widgets/phrasemaker",
         "widgets/arpeggio",
         "widgets/aiwidget",

--- a/js/widgets/PhraseMakerGrid.js
+++ b/js/widgets/PhraseMakerGrid.js
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Music Blocks contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/**
+ * @file PhraseMakerGrid.js
+ * @description Matrix/grid state handling and data structure updates for PhraseMaker.
+ */
+
+const PhraseMakerGrid = {
+    /**
+     * Clears block references within the PhraseMaker.
+     * @param {Object} pm - The PhraseMaker instance.
+     */
+    clearBlocks(pm) {
+        // When creating a new matrix, we want to clear out any old
+        // block references.
+        pm._rowBlocks = [];
+        pm._colBlocks = [];
+        pm._rowMap = [];
+        pm._rowOffset = [];
+    },
+
+    /**
+     * Adds a row block to the PhraseMaker matrix.
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {number} rowBlock - The pitch or drum block identifier to add to the matrix row.
+     */
+    addRowBlock(pm, rowBlock) {
+        // When creating a matrix, we add rows whenever we encounter a
+        // pitch or drum block (and some graphics blocks).
+        pm._rowMap.push(pm._rowBlocks.length);
+        pm._rowOffset.push(0);
+        // In case there is a repeat block, use a unique block number
+        // for each instance.
+        while (pm._rowBlocks.includes(rowBlock)) {
+            rowBlock = rowBlock + 1000000;
+        }
+
+        pm._rowBlocks.push(rowBlock);
+    },
+
+    /**
+     * Adds a column block to the PhraseMaker matrix.
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {number} rhythmBlock - The rhythm block identifier to add to the matrix column.
+     * @param {number} n - The index of the rhythm block within the matrix column.
+     */
+    addColBlock(pm, rhythmBlock, n) {
+        // When creating a matrix, we add columns when we encounter
+        // rhythm blocks.
+        // Search for previous instance of the same block (from a
+        // repeat).
+        let startIdx = 0;
+        let obj;
+        for (let i = 0; i < pm._colBlocks.length; i++) {
+            obj = pm._colBlocks[i];
+            if (obj[0] === rhythmBlock) {
+                startIdx += 1;
+            }
+        }
+
+        for (let i = startIdx; i < n + startIdx; i++) {
+            pm._colBlocks.push([rhythmBlock, i]);
+        }
+    },
+
+    /**
+     * Adds a node to the PhraseMaker matrix.
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {number} rowBlock - The pitch or drum block associated with the node.
+     * @param {number} rhythmBlock - The rhythm block associated with the node.
+     * @param {number} n - The index of the rhythm block within its column.
+     * @param {number} blk - The block identifier representing the matrix cell.
+     */
+    addNode(pm, rowBlock, rhythmBlock, n, blk) {
+        // A node exists for each cell in the matrix. It is used to
+        // preserve and restore the state of the cell.
+        if (pm._blockMap[blk] === undefined) {
+            pm._blockMap[blk] = [];
+        }
+
+        let j = 0;
+        let obj;
+        for (let i = 0; i < pm._blockMap[blk].length; i++) {
+            obj = pm._blockMap[blk][i];
+            if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
+                j += 1;
+            }
+        }
+
+        pm._blockMap[blk].push([rowBlock, [rhythmBlock, n], j]);
+    },
+
+    /**
+     * Removes a node from the PhraseMaker matrix.
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {number} rowBlock - The pitch or drum block associated with the node to remove.
+     * @param {number} rhythmBlock - The rhythm block associated with the node to remove.
+     * @param {number} n - The index of the rhythm block within its column.
+     */
+    removeNode(pm, rowBlock, rhythmBlock, n) {
+        // When the matrix is changed, we may need to remove nodes.
+        const blk = pm.blockNo;
+        let obj;
+        for (let i = 0; i < pm._blockMap[blk].length; i++) {
+            obj = pm._blockMap[blk][i];
+            if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
+                pm._blockMap[blk].splice(i, 1);
+            }
+        }
+    },
+
+    /**
+     * Maps and collects blocks with a specified block name or type.
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {string} blockName - The name of the block to map and collect.
+     * @param {boolean} [withName=false] - Indicates whether to include the block name in the map.
+     * @returns {Array<number | Array<number, string>>} An array of block IDs or [block ID, block name] pairs.
+     */
+    mapNotesBlocks(pm, blockName, withName) {
+        const notesBlockMap = [];
+        let blk = pm.activity.blocks.blockList[pm.blockNo].connections[1];
+        let myBlock = pm.activity.blocks.blockList[blk];
+
+        let bottomBlockLoop = 0;
+        if (
+            myBlock.name === blockName ||
+            (blockName === "all" &&
+                myBlock.name !== "hidden" &&
+                myBlock.name !== "vspace" &&
+                myBlock.name !== "hiddennoflow")
+        ) {
+            if (withName) {
+                notesBlockMap.push([blk, myBlock.name]);
+            } else {
+                notesBlockMap.push(blk);
+            }
+        }
+
+        while (pm._deps.last(myBlock.connections) != null) {
+            bottomBlockLoop += 1;
+            if (bottomBlockLoop > 2 * pm.activity.blocks.blockList) {
+                // Could happen if the block data is malformed.
+                break;
+            }
+
+            blk = pm._deps.last(myBlock.connections);
+            myBlock = pm.activity.blocks.blockList[blk];
+            if (
+                myBlock.name === blockName ||
+                (blockName === "all" &&
+                    myBlock.name !== "hidden" &&
+                    myBlock.name !== "vspace" &&
+                    myBlock.name !== "hiddennoflow")
+            ) {
+                if (withName) {
+                    notesBlockMap.push([blk, myBlock.name]);
+                } else {
+                    notesBlockMap.push(blk);
+                }
+            }
+        }
+
+        return notesBlockMap;
+    },
+
+    /**
+     * Checks for note blocks or repeat blocks within the current block map.
+     * Sets the '_noteBlocks' flag to 'true' if any 'newnote' or 'repeat' block is found.
+     * @param {Object} pm - The PhraseMaker instance.
+     */
+    lookForNoteBlocksOrRepeat(pm) {
+        pm._noteBlocks = false;
+        const bno = pm.blockNo;
+        let blk;
+        for (let i = 0; i < pm._blockMap[bno].length; i++) {
+            blk = pm._blockMap[bno][i][1][0];
+            if (blk === -1) {
+                continue;
+            }
+
+            if (pm.activity.blocks.blockList[blk] === null) {
+                continue;
+            }
+
+            if (pm.activity.blocks.blockList[blk] === undefined) {
+                //eslint-disable-next-line no-console
+                console.debug("block " + blk + " is undefined");
+                continue;
+            }
+
+            if (
+                pm.activity.blocks.blockList[blk].name === "newnote" ||
+                pm.activity.blocks.blockList[blk].name === "repeat"
+            ) {
+                pm._noteBlocks = true;
+                break;
+            }
+        }
+    },
+
+    /**
+     * Synchronizes marked blocks based on block mapping and helper information.
+     * @param {Object} pm - The PhraseMaker instance.
+     */
+    syncMarkedBlocks(pm) {
+        const newBlockMap = [];
+        const blk = pm.blockNo;
+        for (let i = 0; i < pm._blockMap[blk].length; i++) {
+            if (pm._blockMap[blk][i][0] === -1) {
+                continue;
+            }
+
+            for (let j = 0; j < pm._blockMapHelper.length; j++) {
+                if (
+                    JSON.stringify(pm._blockMap[blk][i][1]) ===
+                    JSON.stringify(pm._blockMapHelper[j][0])
+                ) {
+                    for (let k = 0; k < pm._blockMapHelper[j][1].length; k++) {
+                        newBlockMap.push([
+                            pm._blockMap[blk][i][0],
+                            pm._colBlocks[pm._blockMapHelper[j][1][k]],
+                            pm._blockMap[blk][i][2]
+                        ]);
+                    }
+                }
+            }
+        }
+
+        pm._blockMap[blk] = newBlockMap.filter((el, i) => {
+            return (
+                i ===
+                newBlockMap.findIndex(ele => {
+                    return JSON.stringify(ele) === JSON.stringify(el);
+                })
+            );
+        });
+    }
+};
+
+// Export for global use
+window.PhraseMakerGrid = PhraseMakerGrid;
+
+// Export for RequireJS/AMD
+if (typeof define === "function" && define.amd) {
+    define([], function () {
+        return PhraseMakerGrid;
+    });
+}
+
+// Export for Node.js/CommonJS (for testing)
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = PhraseMakerGrid;
+}

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -13,7 +13,7 @@
 /*
    global
 
-   _, PhraseMakerUtils, platformColor, docById, MATRIXSOLFEHEIGHT, toFraction, Singer,
+   _, PhraseMakerUtils, PhraseMakerGrid, platformColor, docById, MATRIXSOLFEHEIGHT, toFraction, Singer,
    SOLFEGECONVERSIONTABLE, slicePath, wheelnav, delayExecution,
    DEFAULTVOICE, getDrumName, MATRIXSOLFEWIDTH, getDrumIcon,
    noteIsSolfege, isCustomTemperament, i18nSolfege, getNote, DEFAULTDRUM, last,
@@ -360,12 +360,7 @@ class PhraseMaker {
      * Resets arrays used to track row and column blocks.
      */
     clearBlocks() {
-        // When creating a new matrix, we want to clear out any old
-        // block references.
-        this._rowBlocks = [];
-        this._colBlocks = [];
-        this._rowMap = [];
-        this._rowOffset = [];
+        PhraseMakerGrid.clearBlocks(this);
     }
 
     /**
@@ -374,17 +369,7 @@ class PhraseMaker {
      * @param {number} rowBlock - The pitch or drum block identifier to add to the matrix row.
      */
     addRowBlock(rowBlock) {
-        // When creating a matrix, we add rows whenever we encounter a
-        // pitch or drum block (and some graphics blocks).
-        this._rowMap.push(this._rowBlocks.length);
-        this._rowOffset.push(0);
-        // In case there is a repeat block, use a unique block number
-        // for each instance.
-        while (this._rowBlocks.includes(rowBlock)) {
-            rowBlock = rowBlock + 1000000;
-        }
-
-        this._rowBlocks.push(rowBlock);
+        PhraseMakerGrid.addRowBlock(this, rowBlock);
     }
 
     /**
@@ -394,22 +379,7 @@ class PhraseMaker {
      * @param {number} n - The index of the rhythm block within the matrix column.
      */
     addColBlock(rhythmBlock, n) {
-        // When creating a matrix, we add columns when we encounter
-        // rhythm blocks.
-        // Search for previous instance of the same block (from a
-        // repeat).
-        let startIdx = 0;
-        let obj;
-        for (let i = 0; i < this._colBlocks.length; i++) {
-            obj = this._colBlocks[i];
-            if (obj[0] === rhythmBlock) {
-                startIdx += 1;
-            }
-        }
-
-        for (let i = startIdx; i < n + startIdx; i++) {
-            this._colBlocks.push([rhythmBlock, i]);
-        }
+        PhraseMakerGrid.addColBlock(this, rhythmBlock, n);
     }
 
     /**
@@ -421,22 +391,7 @@ class PhraseMaker {
      * @param {number} blk - The block identifier representing the matrix cell.
      */
     addNode(rowBlock, rhythmBlock, n, blk) {
-        // A node exists for each cell in the matrix. It is used to
-        // preserve and restore the state of the cell.
-        if (this._blockMap[blk] === undefined) {
-            this._blockMap[blk] = [];
-        }
-
-        let j = 0;
-        let obj;
-        for (let i = 0; i < this._blockMap[blk].length; i++) {
-            obj = this._blockMap[blk][i];
-            if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
-                j += 1;
-            }
-        }
-
-        this._blockMap[blk].push([rowBlock, [rhythmBlock, n], j]);
+        PhraseMakerGrid.addNode(this, rowBlock, rhythmBlock, n, blk);
     }
 
     /**
@@ -447,15 +402,7 @@ class PhraseMaker {
      * @param {number} n - The index of the rhythm block within its column.
      */
     removeNode(rowBlock, rhythmBlock, n) {
-        // When the matrix is changed, we may need to remove nodes.
-        const blk = this.blockNo;
-        let obj;
-        for (let i = 0; i < this._blockMap[blk].length; i++) {
-            obj = this._blockMap[blk][i];
-            if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
-                this._blockMap[blk].splice(i, 1);
-            }
-        }
+        PhraseMakerGrid.removeNode(this, rowBlock, rhythmBlock, n);
     }
 
     /**
@@ -3197,33 +3144,7 @@ class PhraseMaker {
      * @private
      */
     _lookForNoteBlocksOrRepeat() {
-        this._noteBlocks = false;
-        const bno = this.blockNo;
-        let blk;
-        for (let i = 0; i < this._blockMap[bno].length; i++) {
-            blk = this._blockMap[bno][i][1][0];
-            if (blk === -1) {
-                continue;
-            }
-
-            if (this.activity.blocks.blockList[blk] === null) {
-                continue;
-            }
-
-            if (this.activity.blocks.blockList[blk] === undefined) {
-                //eslint-disable-next-line no-console
-                console.debug("block " + blk + " is undefined");
-                continue;
-            }
-
-            if (
-                this.activity.blocks.blockList[blk].name === "newnote" ||
-                this.activity.blocks.blockList[blk].name === "repeat"
-            ) {
-                this._noteBlocks = true;
-                break;
-            }
-        }
+        PhraseMakerGrid.lookForNoteBlocksOrRepeat(this);
     }
 
     /**
@@ -3231,37 +3152,7 @@ class PhraseMaker {
      * @private
      */
     _syncMarkedBlocks() {
-        const newBlockMap = [];
-        const blk = this.blockNo;
-        for (let i = 0; i < this._blockMap[blk].length; i++) {
-            if (this._blockMap[blk][i][0] === -1) {
-                continue;
-            }
-
-            for (let j = 0; j < this._blockMapHelper.length; j++) {
-                if (
-                    JSON.stringify(this._blockMap[blk][i][1]) ===
-                    JSON.stringify(this._blockMapHelper[j][0])
-                ) {
-                    for (let k = 0; k < this._blockMapHelper[j][1].length; k++) {
-                        newBlockMap.push([
-                            this._blockMap[blk][i][0],
-                            this._colBlocks[this._blockMapHelper[j][1][k]],
-                            this._blockMap[blk][i][2]
-                        ]);
-                    }
-                }
-            }
-        }
-
-        this._blockMap[blk] = newBlockMap.filter((el, i) => {
-            return (
-                i ===
-                newBlockMap.findIndex(ele => {
-                    return JSON.stringify(ele) === JSON.stringify(el);
-                })
-            );
-        });
+        PhraseMakerGrid.syncMarkedBlocks(this);
     }
 
     /**
@@ -3410,50 +3301,7 @@ class PhraseMaker {
      * @private
      */
     _mapNotesBlocks(blockName, withName) {
-        const notesBlockMap = [];
-        let blk = this.activity.blocks.blockList[this.blockNo].connections[1];
-        let myBlock = this.activity.blocks.blockList[blk];
-
-        let bottomBlockLoop = 0;
-        if (
-            myBlock.name === blockName ||
-            (blockName === "all" &&
-                myBlock.name !== "hidden" &&
-                myBlock.name !== "vspace" &&
-                myBlock.name !== "hiddennoflow")
-        ) {
-            if (withName) {
-                notesBlockMap.push([blk, myBlock.name]);
-            } else {
-                notesBlockMap.push(blk);
-            }
-        }
-
-        while (this._deps.last(myBlock.connections) != null) {
-            bottomBlockLoop += 1;
-            if (bottomBlockLoop > 2 * this.activity.blocks.blockList) {
-                // Could happen if the block data is malformed.
-                break;
-            }
-
-            blk = this._deps.last(myBlock.connections);
-            myBlock = this.activity.blocks.blockList[blk];
-            if (
-                myBlock.name === blockName ||
-                (blockName === "all" &&
-                    myBlock.name !== "hidden" &&
-                    myBlock.name !== "vspace" &&
-                    myBlock.name !== "hiddennoflow")
-            ) {
-                if (withName) {
-                    notesBlockMap.push([blk, myBlock.name]);
-                } else {
-                    notesBlockMap.push(blk);
-                }
-            }
-        }
-
-        return notesBlockMap;
+        return PhraseMakerGrid.mapNotesBlocks(this, blockName, withName);
     }
 
     /**


### PR DESCRIPTION

### Summary

This change extracts grid and matrix-related logic from `js/widgets/phrasemaker.js`
into a new module:

    js/widgets/PhraseMakerGrid.js

The goal is to reduce the size and responsibility of the PhraseMaker monolith
while preserving existing behavior.

### What Was Moved

The following grid/data-related methods were extracted:

- clearBlocks(pm)
- addRowBlock(pm, rowBlock)
- addColBlock(pm, rhythmBlock, n)
- addNode(pm, rowBlock, rhythmBlock, n, blk)
- removeNode(pm, rowBlock, rhythmBlock, n)
- mapNotesBlocks(pm, blockName, withName)
- lookForNoteBlocksOrRepeat(pm)
- syncMarkedBlocks(pm)

All methods now accept the PhraseMaker instance (`pm`) explicitly,
avoiding direct `this` usage.

### Architectural Notes

- No UI rendering logic was moved.
- No DOM manipulation was introduced in the new module.
- No audio playback logic was modified.
- No behavioral changes were made.
- Existing public method names and call flow remain intact.
- `PhraseMakerGrid` is registered in `MUSICBLOCKS_EXTRAS` to ensure proper loading.

### Scope

Files changed:
- js/widgets/PhraseMakerGrid.js (new)
- js/widgets/phrasemaker.js (delegation updates)
- js/activity.js (loader registration)

This PR is stacked on top of:
refactor/phrasemaker-modularization-phase-1

### Testing

Manually verified:
- Adding/removing notes
- Grid updates
- Block recalculation
- Undo/redo
- Save/reload
- No console errors

No functional or UI changes were introduced.

---

This is Phase 2 of the PhraseMaker modularization effort.
