### PR TITLE
fix: Add input validation to BPMFactorBlock setter to prevent crashes

### DIFF
--- a/js/blocks/MeterBlocks.js
+++ b/js/blocks/MeterBlocks.js
@@ -191,11 +191,24 @@ function setupMeterBlocks(activity) {
         setter(logo, value, turtle) {
             const tur = activity.turtles.ithTurtle(turtle);
 
+            // Validate and clamp BPM to safe range [30, 1000]
+            let bpm = Number(value);
+            if (isNaN(bpm)) {
+                bpm = 60; // Default to 60 BPM
+                activity.errorMsg(_("BPM must be a number, defaulting to 60."));
+            } else if (bpm < 30) {
+                bpm = 30;
+                activity.errorMsg(_("BPM must be at least 30, clamping to 30."));
+            } else if (bpm > 1000) {
+                bpm = 1000;
+                activity.errorMsg(_("BPM must be at most 1000, clamping to 1000."));
+            }
+
             const len = tur.singer.bpm.length;
             if (len > 0) {
-                tur.singer.bpm[len - 1] = value;
+                tur.singer.bpm[len - 1] = bpm;
             } else {
-                tur.singer.bpm.push(value);
+                tur.singer.bpm.push(bpm);
             }
         }
 
@@ -931,25 +944,7 @@ function setupMeterBlocks(activity) {
             // Set palette, activity, piemenuValuesC1, and beginnerBlock for the block
             this.setPalette("meter", activity);
             this.piemenuValuesC1 = [
-                42,
-                46,
-                50,
-                54,
-                58,
-                63,
-                69,
-                76,
-                84,
-                90,
-                96,
-                104,
-                112,
-                120,
-                132,
-                144,
-                160,
-                176,
-                192,
+                42, 46, 50, 54, 58, 63, 69, 76, 84, 90, 96, 104, 112, 120, 132, 144, 160, 176, 192,
                 208
             ];
             this.beginnerBlock(true);
@@ -1077,25 +1072,7 @@ function setupMeterBlocks(activity) {
             // Set palette, piemenuValuesC1, beginnerBlock, and activity for the block
             this.setPalette("meter", activity);
             this.piemenuValuesC1 = [
-                42,
-                46,
-                50,
-                54,
-                58,
-                63,
-                69,
-                76,
-                84,
-                90,
-                96,
-                104,
-                112,
-                120,
-                132,
-                144,
-                160,
-                176,
-                192,
+                42, 46, 50, 54, 58, 63, 69, 76, 84, 90, 96, 104, 112, 120, 132, 144, 160, 176, 192,
                 208
             ];
             this.beginnerBlock(true);


### PR DESCRIPTION
## Summary

Fixes an input validation vulnerability in the `BPMFactorBlock` setter that allowed negative or zero BPM values, causing audio scheduler crashes.

## Changes
- Added input validation to `BPMFactorBlock.setter()` in `js/blocks/MeterBlocks.js`
- BPM values are now clamped to the safe range [30, 1000]
- Invalid inputs (NaN) default to 60 BPM
- Added user-friendly error messages for out-of-range values

## Testing
- Manually tested setting BPM factor to negative values (now clamped to 30)
- Manually tested setting BPM factor to zero (now clamped to 30)
- Manually tested setting BPM factor to values > 1000 (now clamped to 1000)
- Manually verified that valid values in [30, 1000] work correctly

## Rationale
The audio scheduler division operation involves using BPM values (e.g., `60 / BPM`). If BPM equals zero, division by zero occurs. If BPM is negative, a negative division operation occurs, causing issues with audio scheduling. This change in code was done to match the validation of the BPM value with other tempo settings in the code.