### PR TITLE
fix: prevent zombie audio by tracking and stopping active voices on halt

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -290,6 +290,7 @@ class Logo {
 
         // Load the default synthesizer
         this.synth = new Synth();
+        this.synth.activity = this.activity; // Reference for voice tracking
         this.synth.changeInTemperament = false;
 
         // Mode widget
@@ -1002,7 +1003,13 @@ class Logo {
 
         this.sounds = [];
 
+        // Kill all active audio voices to prevent "zombie audio"
         for (const turtle in this.activity.turtles.turtleList) {
+            const tur = this.activity.turtles.getTurtle(turtle);
+            if (tur && tur.singer && typeof tur.singer.killAllVoices === "function") {
+                tur.singer.killAllVoices();
+            }
+
             for (const instrumentName in instruments[turtle]) {
                 this.synth.stopSound(turtle, instrumentName);
             }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -210,6 +210,38 @@ class Singer {
         this.dispatchFactor = 1; // scale factor for turtle graphics embedded in notes
 
         this.inverted = false; // tracks if the notes being played are inverted
+
+        // Voice Manager: Track active audio sources for proper cleanup
+        this.activeVoices = new Set();
+    }
+
+    /**
+     * Kills all active audio voices for this turtle.
+     * Called during stop/halt to prevent "zombie audio" that continues playing.
+     * Uses try/catch to handle nodes that may have already stopped.
+     *
+     * @returns {void}
+     */
+    killAllVoices() {
+        this.activeVoices.forEach(audioNode => {
+            try {
+                // Stop Tone.Player instances (drums/samples)
+                if (audioNode.stop && typeof audioNode.stop === "function") {
+                    audioNode.stop();
+                }
+                // Release all voices for PolySynth/Sampler instances
+                else if (audioNode.releaseAll && typeof audioNode.releaseAll === "function") {
+                    audioNode.releaseAll();
+                }
+                // Disconnect as fallback
+                else if (audioNode.disconnect && typeof audioNode.disconnect === "function") {
+                    audioNode.disconnect();
+                }
+            } catch (e) {
+                // Ignore errors from already-stopped nodes
+            }
+        });
+        this.activeVoices.clear();
     }
 
     // ========= Class variables ==============================================

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1910,6 +1910,31 @@ function Synth() {
         }
     };
 
+    /**
+     * Tracks an active audio source node for garbage collection on stop.
+     * Handles both Tone.Player instances (drums) and synthesizer voices.
+     * @function
+     * @memberof Synth
+     * @param {number} turtle - The turtle index.
+     * @param {Object} audioNode - The audio source node (Tone.Player, Synth, etc.).
+     */
+    this._trackVoice = (turtle, audioNode) => {
+        if (!this.activity || !this.activity.turtles) {
+            return;
+        }
+
+        try {
+            const singer = this.activity.turtles.ithTurtle(turtle).singer;
+            if (!singer || !singer.activeVoices) {
+                return;
+            }
+
+            singer.activeVoices.add(audioNode);
+        } catch (e) {
+            // Silently fail - tracking is optional
+        }
+    };
+
     // Generalised version of 'trigger and 'triggerwitheffects' functions
     /**
      * Triggers notes on a specified turtle with the given parameters.
@@ -2032,17 +2057,21 @@ function Synth() {
                         instrumentName.slice(0, 21) === "data:audio/wav;base64"
                     ) {
                         tempSynth.start(Tone.now() + future);
+                        this._trackVoice(turtle, tempSynth);
                     } else if (instrumentName.slice(0, 4) === "file") {
                         tempSynth.start(Tone.now() + future);
+                        this._trackVoice(turtle, tempSynth);
                     } else {
                         try {
                             tempSynth.start(Tone.now() + future);
+                            this._trackVoice(turtle, tempSynth);
                         } catch (e) {
                             console.debug("Error starting drum synth:", e);
                         }
                     }
                     break;
                 case 2: // voice sample
+                    this._trackVoice(turtle, tempSynth);
                     await this._performNotes(
                         tempSynth.toDestination(),
                         notes,
@@ -2058,6 +2087,7 @@ function Synth() {
                         tempNotes = notes[0];
                     }
 
+                    this._trackVoice(turtle, tempSynth);
                     await this._performNotes(
                         tempSynth.toDestination(),
                         tempNotes,
@@ -2069,10 +2099,12 @@ function Synth() {
                     );
                     break;
                 case 4:
+                    this._trackVoice(turtle, tempSynth);
                     tempSynth.triggerAttackRelease("c2", beatValue, Tone.now() + future);
                     break;
                 case 0: // default synth
                 default:
+                    this._trackVoice(turtle, tempSynth);
                     await this._performNotes(
                         tempSynth.toDestination(),
                         tempNotes,


### PR DESCRIPTION
## Problem  
Audio keeps playing after clicking the Stop button, which is known as the "zombie audio" bug. This happens because `doStopTurtles()` only clears scheduling timers and stops the Tone.Transport. It does not specifically stop active audio nodes, such as Tone.Player instances for drums or samples and PolySynth voices for notes.

## Root Cause  
- `doStopTurtles()` calls `Tone.Transport.stop()`, which pauses scheduling, but does not stop currently playing audio sources.  
- Individual Tone.Player instances for drums and PolySynth voices continue until their buffers naturally finish.  
- There is no central way to track active audio sources.

## Solution  
I implemented a Voice Manager pattern to track and shut down active audio.

### Changes Made  

**1. Voice Tracking State** (`js/turtle-singer.js`)  
- Added `this.activeVoices = new Set()` to the Singer constructor.  
- This allows for quick lookup and insertion when tracking active audio nodes.

**2. Tracking Helper** (`js/utils/synthutils.js`)  
- Added `_trackVoice(turtle, audioNode)` method.  
- This method is called for all audio types: drums (case 1), samples (case 2), synths (cases 3, 4, 0).  
- It silently fails if references are not available, ensuring graceful degradation.

**3. Kill Switch** (`js/turtle-singer.js`)  
- Added `killAllVoices()` method.  
- This method goes through tracked nodes and calls:  
  - `.stop()` for Tone.Player instances (drums and samples)  
  - `.releaseAll()` for PolySynth and Sampler instances  
  - `.disconnect()` as a fallback.  
- It uses try/catch to handle nodes that are already stopped.

**4. Integration** (`js/logo.js`)  
- Added `this.synth.activity` reference for turtle access.  
- Called `turtle.singer.killAllVoices()` in `doStopTurtles()`.

## Testing  
**Before:** Audio plays for several seconds after Stop is clicked.  
**After:** Audio stops immediately when Stop is clicked.

**Test Steps:**  
1. Create a project with repeating notes or drums.  
2. Click Run, then wait 2 seconds.  
3. Click Stop.  
4. **Expected:** Audio stops instantly.  
5. **Previous behavior:** Audio continues until the notes finish.

## Technical Details  
- **Performance:** Set operations are quick; there is no performance slowdown during playback.  
- **Memory:** Minimal memory use; it only stores references, not audio buffers.  
- **Compatibility:** If tracking fails, there is a smooth fallback; existing stop logic remains the same.  
- **Scope:** This affects all audio paths, including drums, samples, and synths.

## Files Changed  
- `js/turtle-singer.js` - Implementation of Voice Manager.  
- `js/utils/synthutils.js` - Voice tracking added in trigger().  
- `js/logo.js` - Integration with doStopTurtles().