### PR TITLE
Add block tooltips and expand tone block help

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7890,6 +7890,71 @@ class Activity {
     }
 
     /**
+     * Shows a tooltip with the specified text at the given coordinates.
+     * @param {string} text - The text to display.
+     * @param {number} x - The x coordinate.
+     * @param {number} y - The y coordinate.
+     */
+    showTooltip(text, x, y) {
+        if (!this.tooltipDiv) {
+            this.tooltipDiv = document.createElement("div");
+            this.tooltipDiv.id = "block-tooltip";
+            this.tooltipDiv.style.cssText = `
+                position: absolute;
+                background-color: rgba(30, 30, 30, 0.9);
+                color: white;
+                padding: 8px 12px;
+                border-radius: 4px;
+                font-size: 14px;
+                z-index: 10000;
+                pointer-events: none;
+                display: none;
+                max-width: 250px;
+                box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+                line-height: 1.4;
+                font-family: sans-serif;
+            `;
+            document.body.appendChild(this.tooltipDiv);
+        }
+
+        this.tooltipDiv.textContent = text;
+        this.tooltipDiv.style.display = "block";
+
+        // Position validation
+        const tooltipWidth = this.tooltipDiv.offsetWidth;
+        const tooltipHeight = this.tooltipDiv.offsetHeight;
+
+        let left = x + 15;
+        let top = y + 15;
+
+        // Keep within viewport width
+        if (left + tooltipWidth > window.innerWidth) {
+            left = x - tooltipWidth - 10;
+        }
+
+        // Keep within viewport height
+        if (top + tooltipHeight > window.innerHeight) {
+            top = y - tooltipHeight - 10;
+        }
+
+        // Ensure non-negative coordinates
+        left = Math.max(0, left);
+        top = Math.max(0, top);
+
+        this.tooltipDiv.style.left = left + "px";
+        this.tooltipDiv.style.top = top + "px";
+    }
+
+    /**
+     * Hides the tooltip.
+     */
+    hideTooltip() {
+        if (this.tooltipDiv) {
+            this.tooltipDiv.style.display = "none";
+        }
+    }
+
+    /**
      * Saves the current state locally
      * @returns {void}
      */

--- a/js/block.js
+++ b/js/block.js
@@ -2872,12 +2872,20 @@ class Block {
 
         this._calculateBlockHitArea();
 
-        this.container.on("mouseover", () => {
+        this.container.on("mouseover", event => {
             _getStatic("contextWheelDiv").style.display = "none";
 
             if (!that.activity.logo.runningLilypond) {
                 document.body.style.cursor = "pointer";
             }
+            
+            // Show tooltip if help string is available
+            if (that.protoblock.helpString && that.protoblock.helpString.length > 0 && event.nativeEvent) {
+                let tipText = that.protoblock.helpString[0];
+
+                that.activity.showTooltip(tipText, event.nativeEvent.clientX, event.nativeEvent.clientY);
+            }
+
             if (!that.blocks.selectionModeOn) {
                 that.blocks.highlight(thisBlock, true);
             }
@@ -3179,6 +3187,7 @@ class Block {
          * @param {Event} event - The mouseout event object.
          */
         this.container.on("mouseout", event => {
+            that.activity.hideTooltip();
             if (!that.blocks.getLongPressStatus()) {
                 that._mouseoutCallback(event, moved, haveClick, false);
             } else {

--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -636,7 +636,13 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("The Chorus block adds a chorus effect."),
+                _("The Chorus block adds a chorus effect.") +
+                " " +
+                _("The rate controls the speed of the oscillation.") +
+                " " +
+                _("The delay sets the time delay between voices.") +
+                " " +
+                _("The depth controls the intensity of the effect."),
                 "documentation",
                 null,
                 "chorushelp"
@@ -695,7 +701,11 @@ function setupToneBlocks(activity) {
             this.beginnerBlock(true);
 
             this.setHelpString([
-                _("The Vibrato block adds a rapid, slight variation in pitch."),
+                _("The Vibrato block adds a rapid, slight variation in pitch.") +
+                " " +
+                _("The intensity controls the strength of the pitch variation.") +
+                " " +
+                _("The rate controls the speed of the variation."),
                 "documentation",
                 null,
                 "vibratohelp"


### PR DESCRIPTION
This pull request introduces a tooltip feature for blocks and improves the help text for certain audio effect blocks. The main changes include implementing tooltip display logic in the `Activity` class, integrating tooltip triggers into the `Block` class, and enhancing help descriptions for the "Chorus" and "Vibrato" blocks.

**Tooltip feature implementation:**

* Added `showTooltip` and `hideTooltip` methods to the `Activity` class in `js/activity.js` to display and hide tooltips at specified screen coordinates, ensuring proper styling and viewport boundaries.
* Updated the `Block` class in `js/block.js` to show a tooltip with the block's help string on mouseover (if available) and hide it on mouseout, using the new methods from the `Activity` class. [[1]](diffhunk://#diff-0f58a5bd77c3a9041064b01bc86d6f498f4108fcf26187ca102efe17a3bffbafL2875-R2888) [[2]](diffhunk://#diff-0f58a5bd77c3a9041064b01bc86d6f498f4108fcf26187ca102efe17a3bffbafR3190)

**Help text improvements:**

* Expanded the help text for the "Chorus" block in `js/blocks/ToneBlocks.js` to include explanations for rate, delay, and depth parameters.
* Enhanced the help text for the "Vibrato" block in `js/blocks/ToneBlocks.js` to explain intensity and rate controls.