### PR TITLE
chore: remove debug console statements from js/EnsembleBlocks.js

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -90,19 +90,19 @@ function setupEnsembleBlocks(activity) {
                 "ensemble",
                 _THIS_IS_MUSIC_BLOCKS_
                     ? [
-                        _(
-                            "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
-                        ),
-                        "documentation",
-                        ""
-                    ]
+                          _(
+                              "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
+                          ),
+                          "documentation",
+                          ""
+                      ]
                     : [
-                        _(
-                            "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
-                        ),
-                        "documentation",
-                        ""
-                    ]
+                          _(
+                              "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
+                          ),
+                          "documentation",
+                          ""
+                      ]
             );
 
             const formOptions = {
@@ -251,7 +251,6 @@ function setupEnsembleBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk, receivedArg, actionArgs, isflow) {
-
             if (args[0] === null) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 return;


### PR DESCRIPTION
part of #5464 

removed all the console logs/debugs from `js/EnsembleBlocks.js` 
however, some logs were logging imp edge cases. so just kept a comment with `//Debug:` for future context

e.g:
this log
```
// eslint-disable-next-line no-console
            console.debug("Mouse not found. Using current mouse value instead.");
```
is replaced by this comment
` // Debug: Mouse not found. Using current mouse value instead (fallback behavior)`

rest, all test cases have passed :) 