### PR TITLE
fix: Prevent stop icon listener accumulation in play debounce logic

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -240,7 +240,8 @@ describe("Toolbar Class", () => {
             },
             stop: {
                 style: { color: "" },
-                addEventListener: jest.fn()
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn()
             },
             record: {
                 className: ""
@@ -267,6 +268,10 @@ describe("Toolbar Class", () => {
         expect(global.saveButtonAdvanced.disabled).toBe(true);
         expect(global.saveButton.className).toBe("grey-text inactiveLink");
         expect(elements.record.className).toBe("grey-text inactiveLink");
+        expect(elements.stop.removeEventListener).toHaveBeenCalledWith(
+            "click",
+            expect.any(Function)
+        );
         expect(elements.stop.addEventListener).toHaveBeenCalledWith("click", expect.any(Function));
 
         const stopClickHandler = elements.stop.addEventListener.mock.calls[0][1];

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -406,6 +406,14 @@ class Toolbar {
             }
         }
 
+        // Named handler to prevent memory leak from duplicate listeners
+        const stopClickHandler = () => {
+            clearTimeout(play_button_debounce_timeout);
+            isPlayIconRunning = true;
+            this.activity.hideMsgs();
+            handleClick();
+        };
+
         var tempClick = (playIcon.onclick = () => {
             const hideMsgs = () => {
                 this.activity.hideMsgs();
@@ -424,12 +432,9 @@ class Toolbar {
                 handleClick();
             }, 2000);
 
-            stopIcon.addEventListener("click", function () {
-                clearTimeout(play_button_debounce_timeout);
-                isPlayIconRunning = true;
-                hideMsgs();
-                handleClick();
-            });
+            // Remove existing listener before adding to prevent accumulation
+            stopIcon.removeEventListener("click", stopClickHandler);
+            stopIcon.addEventListener("click", stopClickHandler);
         });
     }
 


### PR DESCRIPTION
issue: #5753 

Problem:-
The stop icon click listener is attached inside the Play button debounce logic in js/toolbar.js. Each time the Play button is pressed, a new event listener is added to the stop icon without removing the previous one.
This causes identical listeners to accumulate over time, resulting in:-
-duplicate handler execution
-increased memory usage
-degraded performance during long sessions
-unnecessary CPU work when Stop is clicked

This behavior becomes noticeable when users repeatedly press Play while experimenting with projects.

Solution:-
-This PR prevents duplicate listener accumulation by ensuring only one stop icon click listener exists at any time.
-Replaced the anonymous handler with a named function
-Removed any existing listener before attaching a new one
-Presered existing debounce behavior and playback logic
-Added test support to reflect listener removal

Changes Made:-
-Code Changes
-js/toolbar.js
-Introduced a named stopClickHandler
-Removed existing listener before adding a new one
-Prevented event listener accumulation

Test Updates:-
-js/__tests__/toolbar.test.js
-Added removeEventListener mock
-Updated expectations to verify correct listener management

Testing Performed:-
-Manual Testing
-Clicked Play multiple times → Stop executes handler only once
-Verified playback and stop behavior unchanged
-Confirmed no UI regressions
-Automated Testing

Jest: ✅ All tests passed
Prettier: ✅ Formatting verified
ESLint: ⚠️ Pre-existing repository config issue (not introduced by this change)

Impact:-
-Prevents memory growth from listener accumulation
-Ensures consistent stop button behavior
-Improces performance during long sessions
-Improves resource management and code maintainability
-No breaking changes

Notes:-
This fix addresses a performance and memory issue affecting extended usage sessions.
The change is minimal, safe, and maintains full backward compatibility.

Happy to adjust the approach if maintainers prefer an alternative pattern