### PR TITLE
Resolve Remaining +/- Issues in PieMenuNumber Blocks

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -356,7 +356,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - halfWheelSize
             )
         ) + "px";
@@ -367,7 +367,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - halfWheelSize
             )
         ) + "px";
@@ -431,8 +431,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (block.name === "notename" &&
                 (block.connections[0] != undefined
                     ? !["setkey", "setkey2"].includes(
-                        block.blocks.blockList[block.connections[0]].name
-                    )
+                          block.blocks.blockList[block.connections[0]].name
+                      )
                     : true)))
     ) {
         if (scale[6 - i][0] === FIXEDSOLFEGE[note] || scale[6 - i][0] === note) {
@@ -670,8 +670,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (that.name === "notename" &&
                 (that.connections[0] != undefined
                     ? !["setkey", "setkey2"].includes(
-                        that.blocks.blockList[that.connections[0]].name
-                    )
+                          that.blocks.blockList[that.connections[0]].name
+                      )
                     : true))
         ) {
             let i = scale.indexOf(selection["note"]);
@@ -1054,7 +1054,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1065,7 +1065,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -1560,7 +1560,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1571,7 +1571,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2436,7 +2436,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2447,7 +2447,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2541,7 +2541,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2552,7 +2552,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2669,7 +2669,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2680,7 +2680,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2849,7 +2849,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2860,7 +2860,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2989,7 +2989,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3000,7 +3000,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3475,7 +3475,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3486,7 +3486,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -4033,9 +4033,9 @@ const piemenuKey = activity => {
                         activity.KeySignatureEnv[1];
                     activity.textMsg(
                         _("You have chosen key for your pitch preview.") +
-                        activity.KeySignatureEnv[0] +
-                        " " +
-                        activity.KeySignatureEnv[1]
+                            activity.KeySignatureEnv[0] +
+                            " " +
+                            activity.KeySignatureEnv[1]
                     );
                 }
             }


### PR DESCRIPTION
The issue with the + button not working in some cases like Beats per Minute, Master Beats per Minute, Chorus blocks, along with Note blocks and a few others, has now been fixed. I’ve tested it thoroughly across the major blocks, and all three buttons — increment, decrement, and close — are working smoothly.

This is an extension of PR #5354 and resolves the remaining edge cases related to the same issue.

Also, the increment and decrement logic is now aligned with the actual values available in the pie menu for that specific block, instead of blindly applying +1 or -1 in every case.

For example, in the case of Master Beats per Minute, the increment and decrement now happen in steps of 6, since the pie menu values are spaced at intervals of 6.