### PR TITLE
Palette: replace eval-based icon lookup with explicit mapping

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -17,8 +17,9 @@
    i18nSolfege, NUMBERBLOCKDEFAULT, TEXTWIDTH, STRINGLEN,
    DEFAULTBLOCKSCALE, SVG, DISABLEDFILLCOLOR, DISABLEDSTROKECOLOR,
    PALETTEFILLCOLORS, PALETTESTROKECOLORS, last, getTextWidth,
-   STANDARDBLOCKHEIGHT, CLOSEICON, BUILTINPALETTES,
-   safeSVG, blockIsMacro, getMacroExpansion
+    STANDARDBLOCKHEIGHT, CLOSEICON, BUILTINPALETTES,
+    safeSVG, blockIsMacro, getMacroExpansion,
+    cameraPALETTE, mediaPALETTE, videoPALETTE
 */
 
 /* exported Palettes, initPalettes */
@@ -51,6 +52,14 @@ const makePaletteIcons = (data, width, height) => {
     if (width) img.width = width;
     if (height) img.height = height;
     return img;
+};
+
+const buildPaletteImageMap = () => {
+    const map = {};
+    if (typeof mediaPALETTE !== "undefined") map.media = mediaPALETTE;
+    if (typeof cameraPALETTE !== "undefined") map.camera = cameraPALETTE;
+    if (typeof videoPALETTE !== "undefined") map.video = videoPALETTE;
+    return map;
 };
 
 class Palettes {
@@ -856,6 +865,14 @@ class Palette {
         this.fadedDownButton = null;
         this.count = 0;
         this._outsideClickListener = null;
+        this._paletteImageMap = null;
+    }
+
+    _getPaletteImageForBlockName(blkname) {
+        if (!this._paletteImageMap) {
+            this._paletteImageMap = buildPaletteImageMap();
+        }
+        return this._paletteImageMap[blkname] || null;
     }
 
     hide() {
@@ -989,15 +1006,15 @@ class Palette {
             if (b.hidden) {
                 continue;
             }
-            const itemRow = paletteList.insertRow();
-            const itemCell = itemRow.insertCell();
+            const itemRow = document.createElement("tr");
+            const itemCell = document.createElement("td");
+            itemRow.appendChild(itemCell);
             let img = makePaletteIcons(b.artwork);
 
             if (b.image) {
-                if (["media", "camera", "video"].includes(b.blkname)) {
-                    // Use artwork.js strings as images for:
-                    // cameraPALETTE, videoPALETTE, mediaPALETTE
-                    img = makePaletteIcons(eval(b.blkname + "PALETTE"));
+                const paletteImage = this._getPaletteImageForBlockName(b.blkname);
+                if (paletteImage) {
+                    img = makePaletteIcons(paletteImage);
                 } else {
                     // or use the plugin image...
                     img = makePaletteIcons(this.activity.pluginsImages[b.blkname]);
@@ -1084,6 +1101,7 @@ class Palette {
             itemCell.style.width = `${img.width}px`;
             itemCell.style.paddingRight = `${this.palettes.cellSize}px`;
             itemCell.appendChild(img);
+            paletteList.appendChild(itemRow);
         }
 
         if (this.palettes.mobile) {


### PR DESCRIPTION
## Summary
Replace eval-based palette icon lookup with an explicit mapping to improve maintainability and avoid dynamic evaluation in palette rendering.

## Changes
- Added `buildPaletteImageMap()` to replace dynamic `eval()` usage for palette icon resolution
- Updated `_getPaletteImageForBlockName()` to lazily initialize and use the palette image map
- Refactored DOM creation in `_showMenuItems()` to use `createElement` instead of `insertRow()`