### PR TITLE
fix(search): clicking search result text now creates block (not just icon)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3354,8 +3354,11 @@ class Activity {
                         };
 
                         // Capture phase fires BEFORE jQuery UI's event delegation
-                        img.addEventListener("mousedown", down, true);
-                        img.addEventListener("touchstart", down, { capture: true, passive: false });
+                        li[0].addEventListener("mousedown", down, true);
+                        li[0].addEventListener("touchstart", down, {
+                            capture: true,
+                            passive: false
+                        });
 
                         li.append(img);
                         li.append("<a> " + item.label + "</a>");


### PR DESCRIPTION
### Summary

Fixes unreliable behaviour in block search, where clicking the text label of a search result did not create a block. Only the icon was interactive, causing users to feel the search worked randomly.

---

### Testing
1. Search for a block and click the icon -> block appears
2. Search for a block and click text -> block appears
3. Rapid clicking on different parts of the result row -> consistent behaviour
4. Drag from the palette still works unchanged
5. Verified failures in turtles.test.js also occur on clean master

https://github.com/user-attachments/assets/c4ab05de-9707-4496-b863-3348988d9874

---

### Notes 

This PR fixes a UI hit-target issue only.
It does not modify block logic, turtle behaviour, scaling, or workspace internals.
Thanks!