### PR TITLE
Fix missing inCrescendo.pop() in crescendo end listener

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -97,6 +97,8 @@ function setupVolumeActions(activity) {
                     );
                     tur.singer.crescendoInitialVolume[synth].pop();
                 }
+
+                tur.singer.inCrescendo.pop();
             };
 
             activity.logo.setTurtleListener(turtle, listenerName, __listener);


### PR DESCRIPTION
### **Summary**
This PR fixes a crescendo state cleanup issue where `inCrescendo` entries accumulated after each crescendo block execution. Because `doCrescendo()` pushed to three parallel arrays but the end-of-clamp listener only popped from two, stale `inCrescendo` entries remained in memory. This caused unintended volume resets on subsequent notes after crescendos completed.

---

### **What changed**
Added `tur.singer.inCrescendo.pop()` to the crescendo end listener in `VolumeActions.js` to restore push/pop symmetry.
Ensured all three arrays pushed at the start of a crescendo (`crescendoDelta`, `crescendoInitialVolume`, and `inCrescendo`) are consistently cleaned up when the clamp exits.
Returned the fallback logic in `Singer.processNote()` to being a true safety net rather than a normal execution path.

---

### **Why this change was needed?**
When a crescendo block begins, `doCrescendo()` pushes state into three arrays:

    tur.singer.crescendoDelta.push(...);
    tur.singer.crescendoInitialVolume[synth].push(...);
    tur.singer.inCrescendo.push(true);

However, only two were cleaned up in the listener:

    tur.singer.crescendoDelta.pop();
    tur.singer.crescendoInitialVolume[synth].pop();

The missing cleanup of `inCrescendo` meant its length kept increasing with each crescendo execution.

In `Singer.processNote()`:

    if (tur.singer.inCrescendo.length > 0 &&
        tur.singer.crescendoDelta.length === 0) {
        tur.singer.inCrescendo.pop();
        Singer.setSynthVolume(...);
    }

This fallback branch executed once per stale entry. If a program executed N crescendos (for example inside a Repeat block), the next N notes after the final crescendo would have their volume forcibly reset. This silently overrode explicit Set Volume blocks and produced incorrect dynamics.

Restoring cleanup symmetry ensures crescendo state ends when the block ends.

---

### **Scope**
Affects only crescendo/decrescendo state handling in `VolumeActions.js`.
No changes to pitch logic, rhythm scheduling, or audio routing.
Does not affect programs that do not use crescendo blocks.
Preserves intended crescendo behavior during execution.

---

### **Verification**
Verified repeated crescendos inside a Repeat block no longer cause phantom volume resets.
Confirmed that Set Volume blocks placed after crescendos take effect immediately.
Verified normal crescendo ramp behavior remains unchanged.
Confirmed no unintended side effects in note playback or dynamic handling.
