### PR TITLE
Fix staccato/slur listener name collision on nested blocks

### DIFF
--- a/js/turtleactions/OrnamentActions.js
+++ b/js/turtleactions/OrnamentActions.js
@@ -47,7 +47,7 @@ function setupOrnamentActions(activity) {
 
             tur.singer.staccato.push(1 / value);
 
-            const listenerName = "_staccato_" + turtle;
+            const listenerName = "_staccato_" + turtle + "_" + blk;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
             } else if (MusicBlocks.isRun) {
@@ -77,7 +77,7 @@ function setupOrnamentActions(activity) {
                 activity.logo.notation.notationBeginSlur(turtle);
             }
 
-            const listenerName = "_staccato_" + turtle;
+            const listenerName = "_staccato_" + turtle + "_" + blk;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
             } else if (MusicBlocks.isRun) {

--- a/js/turtleactions/__tests__/OrnamentActions.test.js
+++ b/js/turtleactions/__tests__/OrnamentActions.test.js
@@ -109,12 +109,13 @@ describe("OrnamentActions", () => {
                     global.MusicBlocks.isRun = isRun;
                     if (nullMouse) global.Mouse.getMouseFromTurtle = () => null;
                     Singer.OrnamentActions.setStaccato(2, 0, blk);
+                    const expectedName = "_staccato_0_" + blk;
                     expect(turtle.singer.staccato).toEqual([0.5]);
                     expect(dispatchCalls.length).toBe(expectDispatch ? 1 : 0);
                     expect(listenerCalls.length).toBe(1);
-                    if (expectMouseListener) expect(mouseMB.listeners).toContain("_staccato_0");
-                    else expect(mouseMB.listeners).not.toContain("_staccato_0");
-                    listenerFunctions["_staccato_0"]();
+                    if (expectMouseListener) expect(mouseMB.listeners).toContain(expectedName);
+                    else expect(mouseMB.listeners).not.toContain(expectedName);
+                    listenerFunctions[expectedName]();
                     expect(turtle.singer.staccato).toEqual([]);
                 });
             }
@@ -195,9 +196,10 @@ describe("OrnamentActions", () => {
                     expect(beginSlurCalls.length).toBe(expectBeginSlur ? 1 : 0);
                     expect(dispatchCalls.length).toBe(expectDispatch ? 1 : 0);
                     expect(listenerCalls.length).toBe(1);
-                    if (expectMouseListener) expect(mouseMB.listeners).toContain("_staccato_0");
-                    else expect(mouseMB.listeners).not.toContain("_staccato_0");
-                    listenerFunctions["_staccato_0"]();
+                    const expectedName = "_staccato_0_" + blk;
+                    if (expectMouseListener) expect(mouseMB.listeners).toContain(expectedName);
+                    else expect(mouseMB.listeners).not.toContain(expectedName);
+                    listenerFunctions[expectedName]();
                     expect(turtle.singer.staccato).toEqual([]);
                     expect(endSlurCalls.length).toBe(expectBeginSlur ? 1 : 0);
                 });


### PR DESCRIPTION
## Summary

Fixes a listener name collision between Staccato and Slur blocks that caused articulation state to leak when nested.

Both blocks registered their cleanup listeners under the same name (`"_staccato_" + turtle`). When nested, the inner block overwrote the outer block’s listener, preventing the outer cleanup from running. This left a phantom entry in `tur.singer.staccato`, causing incorrect articulation for subsequent notes.

---

## What changed

Updated the listener name in both `setStaccato()` and `setSlur()` to include the block id:

Before:

`const listenerName = "_staccato_" + turtle;`

After:

`const listenerName = "_staccato_" + turtle + "_" + blk;`
This ensures each block instance registers a unique listener.

---

## Impact

- Fixes Slur inside Staccato and Staccato inside Slur nesting
- Prevents phantom articulation entries
- Restores correct clamp isolation behavior
- No changes to scheduling or audio logic

---

## Verification

- Tested nested Slur/Staccato combinations
- Confirmed articulation resets correctly after block exit
- No regressions in standalone articulation behavior