### PR TITLE
fix: update status window colors in dark mode

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -62,3 +62,19 @@ body.dark {
   border-radius: 3px;
   padding: 2px;
 }
+
+/* Window table colors for dark mode */
+.dark .windowFrame td {
+  background-color: #022363 !important;
+  color: #eeeeee !important;
+}
+
+.dark .windowFrame td.headcol {
+  background-color: #363636 !important;
+  color: #ffffff !important;
+}
+
+/* Ensure bold text in cells is also light colored */
+.dark .windowFrame td b {
+  color: #ffffff !important;
+}


### PR DESCRIPTION
## Description  
This PR fixes display issues in the **STATUS window**  when Dark Mode is enabled.  

---

## Changes  

- **Updated `css/darkmode.css`**
  - Set `td.headcol` background to dark grey (`#363636`).
  - Set other `td` elements to dark blue (`#022363`) .
  - Changed text and bold colors to white for better readability.
  - Used !important to ensure these styles correctly override any inline background colors set by the widget's JavaScript logic
  
---

## Before

<img width="633" height="246" alt="Screenshot 2026-02-17 193032" src="https://github.com/user-attachments/assets/c50398b3-8935-4d25-b543-c6ea9df3c674" />

## After

<img width="525" height="184" alt="Screenshot 2026-02-17 195700" src="https://github.com/user-attachments/assets/7d0b39d5-089a-467d-99f4-76b5e0ddf558" />

## Verification

All the changes have been tested locally .