### PR TITLE
Fix spelling mistake in BUILTINMACROS key(articulation help)

### DIFF
--- a/js/macros.js
+++ b/js/macros.js
@@ -1675,7 +1675,7 @@ const getMacroExpansion = (activity, blkname, x, y) => {
         actionhelp: ACTIONHELP,
         archelp: ARCHELP,
         amsynthhelp: AMSYNTHHELP,
-        acticulationhelp: ARTICULATIONHELP,
+        articulationhelp: ARTICULATIONHELP,
         beatvaluehelp: BEATVALUEHELP,
         bottomposhelp: BOTTOMPOSHELP,
         box1help: BOX1HELP,


### PR DESCRIPTION
Previously the key was misspelled as-
`acticulationhelp
`
It has been corrected to :
`articulationhelp
`

This ensures consistency with the block name used elsewhere in the codebase and prevents incorrect macro lookup behavior. 