### PR TITLE
Fix/to title case do search errors

### DIFF
--- a/planet/js/GlobalTag.js
+++ b/planet/js/GlobalTag.js
@@ -12,13 +12,26 @@
 /*
    global
 
-   _, toTitleCase
+   _
 */
 /*
    exported
 
    GlobalTag
 */
+
+/**
+ * Converts the first character of a string to uppercase.
+ * Defined locally because GlobalTag.js runs inside the Planet iframe
+ * and does not have access to the toTitleCase exported by js/utils/utils.js.
+ * @param {string} str - The string to convert.
+ * @returns {string|undefined} The converted string or undefined if input is not a string.
+ */
+const toTitleCase = (str) => {
+    if (typeof str !== "string") return;
+    return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
 class GlobalTag {
     /* 
      this.tagNames = [


### PR DESCRIPTION
## Description #5782 

Fixes JavaScript runtime errors that occur when running Music Blocks locally:

1. **`toTitleCase is not defined`** in [planet/js/GlobalTag.js](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:0:0-0:0)
   The [render()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:79:4-96:5) method calls [toTitleCase()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:22:0-32:2) which is defined in [js/utils/utils.js](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/utils/utils.js:0:0-0:0) and exported as a global. However, [GlobalTag.js](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:0:0-0:0) runs inside the Planet iframe and does not have access to that global. This PR adds a local [toTitleCase()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:22:0-32:2) function definition.

2. **`doSearch is not defined`** in [index.html](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/index.html:0:0-0:0)
   A `<script>` block calls [doSearch()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:2971:8-3044:10) at `$(document).ready()` time, but [doSearch](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:2971:8-3044:10) is only defined as a method on the Activity object (`this.doSearch`), which is created later via RequireJS. This PR removes the orphaned call since [doSearch()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:2971:8-3044:10) is already properly invoked from [showSearchWidget()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:2909:8-2969:10) inside [activity.js](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:0:0-0:0).

## Console Errors Fixed
Uncaught ReferenceError: doSearch is not defined at HTMLDocument. ((index):551:13)

Uncaught ReferenceError: toTitleCase is not defined at GlobalTag.render (GlobalTag.js:74)

## Changes

- **[planet/js/GlobalTag.js](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:0:0-0:0)**: Added local [toTitleCase()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/js/GlobalTag.js:22:0-32:2) helper function
- **[index.html](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/index.html:0:0-0:0)**: Removed broken [doSearch()](cci:1://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/js/activity.js:2971:8-3044:10) call at DOM ready time

## Testing

- All 2531 existing Jest tests pass
- Verified the application loads without console errors