### PR TITLE
fix: store idle watcher interval ID and listeners for proper cleanup

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2247,7 +2247,7 @@ class Activity {
             const changeText = () => {
                 const randomLoadMessage =
                     messages.load_messages[
-                        Math.floor(Math.random() * messages.load_messages.length)
+                    Math.floor(Math.random() * messages.load_messages.length)
                     ];
                 document.getElementById("messageText").innerHTML = randomLoadMessage + "...";
                 counter++;
@@ -2922,8 +2922,16 @@ class Activity {
          * Initializes the Idle Watcher mechanism to throttle createjs.Ticker
          * when the application is inactive and no music is playing.
          * This significantly reduces CPU usage and improves battery life.
+         *
+         * The interval ID and event-listener handler are stored on `this`
+         * so they can be cleared by {@link _destroyIdleWatcher}.
          */
         this._initIdleWatcher = () => {
+            // Clean up any previous watcher before creating a new one.
+            if (this._idleWatcherIntervalId != null) {
+                this._destroyIdleWatcher();
+            }
+
             const IDLE_THRESHOLD = 5000; // 5 seconds
             const ACTIVE_FPS = 60;
             const IDLE_FPS = 1;
@@ -2931,8 +2939,10 @@ class Activity {
             let lastActivity = Date.now();
             let isIdle = false;
 
-            // Wake up function - restores full framerate
-            const resetIdleTimer = () => {
+            // Wake up function – restores full framerate.
+            // Stored on the instance so _destroyIdleWatcher can remove the
+            // listeners that reference it.
+            this._resetIdleTimer = () => {
                 lastActivity = Date.now();
                 if (isIdle) {
                     isIdle = false;
@@ -2943,14 +2953,13 @@ class Activity {
             };
 
             // Track user activity
-            window.addEventListener("mousemove", resetIdleTimer);
-            window.addEventListener("mousedown", resetIdleTimer);
-            window.addEventListener("keydown", resetIdleTimer);
-            window.addEventListener("touchstart", resetIdleTimer);
-            window.addEventListener("wheel", resetIdleTimer);
+            this._idleWatcherEvents = ["mousemove", "mousedown", "keydown", "touchstart", "wheel"];
+            for (const evt of this._idleWatcherEvents) {
+                window.addEventListener(evt, this._resetIdleTimer);
+            }
 
-            // Periodic check for idle state
-            setInterval(() => {
+            // Periodic check for idle state – store the interval ID
+            this._idleWatcherIntervalId = setInterval(() => {
                 // Check if music/code is playing
                 const isMusicPlaying = this.logo?._alreadyRunning || false;
 
@@ -2961,14 +2970,33 @@ class Activity {
                         console.log("⚡ Idle mode: Throttling to 1 FPS to save battery");
                     }
                 } else if (isIdle && isMusicPlaying) {
-                    // Music started playing - wake up immediately
-                    resetIdleTimer();
+                    // Music started playing – wake up immediately
+                    this._resetIdleTimer();
                 }
             }, 1000);
 
             // Expose activity instance for external checks
             if (typeof window !== "undefined") {
                 window.activity = this;
+            }
+        };
+
+        /**
+         * Tears down the Idle Watcher – clears the interval and removes
+         * all event listeners that were registered by {@link _initIdleWatcher}.
+         */
+        this._destroyIdleWatcher = () => {
+            if (this._idleWatcherIntervalId != null) {
+                clearInterval(this._idleWatcherIntervalId);
+                this._idleWatcherIntervalId = null;
+            }
+
+            if (this._resetIdleTimer && this._idleWatcherEvents) {
+                for (const evt of this._idleWatcherEvents) {
+                    window.removeEventListener(evt, this._resetIdleTimer);
+                }
+                this._resetIdleTimer = null;
+                this._idleWatcherEvents = null;
             }
         };
 
@@ -3341,9 +3369,9 @@ class Activity {
                                         that.blocks.moveBlock(
                                             newBlock,
                                             (x || that.blocksContainer.x + 100) -
-                                                that.blocksContainer.x,
+                                            that.blocksContainer.x,
                                             (y || that.blocksContainer.y + 100) -
-                                                that.blocksContainer.y
+                                            that.blocksContainer.y
                                         );
                                     }
                                 );
@@ -4795,8 +4823,8 @@ class Activity {
                         console.log(
                             "%cMusic Blocks",
                             "font-size: 24px; font-weight: bold; font-family: sans-serif; padding:20px 0 0 110px; background: url(" +
-                                imgUrl +
-                                ") no-repeat;"
+                            imgUrl +
+                            ") no-repeat;"
                         );
                         // eslint-disable-next-line no-console
                         console.log(
@@ -4868,10 +4896,10 @@ class Activity {
                 typeof flags !== "undefined"
                     ? flags
                     : {
-                          run: false,
-                          show: false,
-                          collapse: false
-                      };
+                        run: false,
+                        show: false,
+                        collapse: false
+                    };
             this.loading = true;
             document.body.style.cursor = "wait";
             this.doLoadAnimation();
@@ -5234,9 +5262,8 @@ class Activity {
                                 [
                                     "nameddo",
                                     {
-                                        value: `V: ${parseInt(lineId) + 1} Line ${
-                                            staffBlocksMap[lineId]?.baseBlocks?.length + 1
-                                        }`
+                                        value: `V: ${parseInt(lineId) + 1} Line ${staffBlocksMap[lineId]?.baseBlocks?.length + 1
+                                            }`
                                     }
                                 ],
                                 0,
@@ -5245,12 +5272,12 @@ class Activity {
                                     staffBlocksMap[lineId].baseBlocks.length === 0
                                         ? null
                                         : staffBlocksMap[lineId].baseBlocks[
-                                              staffBlocksMap[lineId].baseBlocks.length - 1
-                                          ][0][
-                                              staffBlocksMap[lineId].baseBlocks[
-                                                  staffBlocksMap[lineId].baseBlocks.length - 1
-                                              ][0].length - 4
-                                          ][0],
+                                        staffBlocksMap[lineId].baseBlocks.length - 1
+                                        ][0][
+                                        staffBlocksMap[lineId].baseBlocks[
+                                            staffBlocksMap[lineId].baseBlocks.length - 1
+                                        ][0].length - 4
+                                        ][0],
                                     null
                                 ]
                             ],
@@ -5266,9 +5293,8 @@ class Activity {
                                 [
                                     "text",
                                     {
-                                        value: `V: ${parseInt(lineId) + 1} Line ${
-                                            staffBlocksMap[lineId]?.baseBlocks?.length + 1
-                                        }`
+                                        value: `V: ${parseInt(lineId) + 1} Line ${staffBlocksMap[lineId]?.baseBlocks?.length + 1
+                                            }`
                                     }
                                 ],
                                 0,
@@ -5303,14 +5329,14 @@ class Activity {
                     staffBlocksMap[staffIndex].startBlock.length - 3
                 ][4][2] =
                     staffBlocksMap[staffIndex].baseBlocks[0][0][
-                        staffBlocksMap[staffIndex].baseBlocks[0][0].length - 4
+                    staffBlocksMap[staffIndex].baseBlocks[0][0].length - 4
                     ][0];
                 // Update the first namedo block with settimbre
                 staffBlocksMap[staffIndex].baseBlocks[0][0][
                     staffBlocksMap[staffIndex].baseBlocks[0][0].length - 4
                 ][4][0] =
                     staffBlocksMap[staffIndex].startBlock[
-                        staffBlocksMap[staffIndex].startBlock.length - 3
+                    staffBlocksMap[staffIndex].startBlock.length - 3
                     ][0];
                 const repeatblockids = staffBlocksMap[staffIndex].repeatArray;
                 for (const repeatId of repeatblockids) {
@@ -5322,7 +5348,7 @@ class Activity {
                             0,
                             [
                                 staffBlocksMap[staffIndex].startBlock[
-                                    staffBlocksMap[staffIndex].startBlock.length - 3
+                                staffBlocksMap[staffIndex].startBlock.length - 3
                                 ][0] /*setribmre*/,
                                 blockId + 1,
                                 staffBlocksMap[staffIndex].nameddoArray[staffIndex][0],
@@ -5331,8 +5357,8 @@ class Activity {
                                 ] === null
                                     ? null
                                     : staffBlocksMap[staffIndex].nameddoArray[staffIndex][
-                                          repeatId.end + 1
-                                      ]
+                                    repeatId.end + 1
+                                    ]
                             ]
                         ]);
                         staffBlocksMap[staffIndex].repeatBlock.push([
@@ -5366,7 +5392,7 @@ class Activity {
                             const secondnammedo = _searchIndexForMusicBlock(
                                 staffBlocksMap[staffIndex].baseBlocks[repeatId.end + 1][0],
                                 staffBlocksMap[staffIndex].nameddoArray[staffIndex][
-                                    repeatId.end + 1
+                                repeatId.end + 1
                                 ]
                             );
 
@@ -5389,13 +5415,13 @@ class Activity {
                         const prevnameddo = _searchIndexForMusicBlock(
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start - 1][0],
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                currentnammeddo
+                            currentnammeddo
                             ][4][0]
                         );
                         const afternamedo = _searchIndexForMusicBlock(
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.end][0],
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                currentnammeddo
+                            currentnammeddo
                             ][4][1]
                         );
                         let prevrepeatnameddo = -1;
@@ -5403,17 +5429,17 @@ class Activity {
                             prevrepeatnameddo = _searchIndexForMusicBlock(
                                 staffBlocksMap[staffIndex].repeatBlock,
                                 staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                    currentnammeddo
+                                currentnammeddo
                                 ][4][0]
                             );
                         }
                         const prevBlockId =
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                currentnammeddo
+                            currentnammeddo
                             ][4][0];
                         const currentBlockId =
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                currentnammeddo
+                            currentnammeddo
                             ][0];
 
                         // Needs null checking optmizie
@@ -5427,7 +5453,7 @@ class Activity {
                             0,
                             [
                                 staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
-                                    currentnammeddo
+                                currentnammeddo
                                 ][4][0],
                                 blockId + 1,
                                 currentBlockId,
@@ -6741,12 +6767,12 @@ class Activity {
                         return $j("<li></li>")
                             .append(
                                 '<img src="' +
-                                    (item.artwork || "") +
-                                    '" height = "20px">' +
-                                    "<a>" +
-                                    " " +
-                                    item.label +
-                                    "</a>"
+                                (item.artwork || "") +
+                                '" height = "20px">' +
+                                "<a>" +
+                                " " +
+                                item.label +
+                                "</a>"
                             )
                             .appendTo(ul.css("z-index", 35000));
                     };
@@ -6870,10 +6896,10 @@ class Activity {
             container.setAttribute(
                 "style",
                 "position: absolute; right:" +
-                    (document.body.clientWidth - x) +
-                    "px;  top: " +
-                    y +
-                    "px;"
+                (document.body.clientWidth - x) +
+                "px;  top: " +
+                y +
+                "px;"
             );
             document.getElementById("buttoncontainerBOTTOM").appendChild(container);
             return container;


### PR DESCRIPTION
## Description

Fixes #5768

The idle watcher in `_initIdleWatcher()` creates a `setInterval` and attaches window event listeners, but neither the interval ID nor the handler reference was preserved. This prevented cleanup on reinitialisation and caused duplicate intervals to accumulate.

## Changes

- Store the interval ID in `this._idleWatcherIntervalId`
- Store the event handler in `this._resetIdleTimer`
- Store the event names in `this._idleWatcherEvents`
- Add `_destroyIdleWatcher()` to clear interval and remove listeners
- Guard `_initIdleWatcher()` to destroy any existing watcher first

## Testing

- All 3114 existing Jest tests pass
- No new runtime errors introduced