### PR TITLE
Fix dark mode search text contrast

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -100,6 +100,10 @@
     color: #fff !important;
 }
 
+body.dark .ui-autocomplete a {
+    color: #fff !important;
+}
+
 .dark .ui-autocomplete li:hover {
     background-color: #225a91 !important;
 }


### PR DESCRIPTION
### **Summary**

This PR fixes a low-contrast issue in the search dropdown when using dark mode. The block labels inside the autocomplete list were rendered in dark gray text on a dark background, making them difficult to read.

What was happening

The search dropdown renders block labels inside <a> tags. The jQuery UI base theme applies:

.ui-widget-content a { color: #333333; }

This overrides the inherited white text color in dark mode, resulting in dark gray text on a dark background.

---

### **What changed**

Added a dark-mode specific override in css/themes.css:

body.dark .ui-autocomplete a {
    color: #fff !important;
}

This increases selector specificity and restores proper contrast in dark mode without affecting light mode.

---

### **Scope**

- Affects only the search autocomplete dropdown in dark mode
- No changes to logic or behavior
- No impact on light theme

---

### **Verification**

- Enabled dark mode
- Searched for blocks (e.g., "note")
- Confirmed dropdown text is clearly readable
- Verified light mode remains unchanged

---

### **Before**
<img width="483" height="328" alt="image" src="https://github.com/user-attachments/assets/3d2e642f-df92-47f9-b7f5-b695ffa650cd" />


### **After**
<img width="1828" height="1002" alt="image" src="https://github.com/user-attachments/assets/59b4ed34-268c-4456-998f-897ece397c28" />

<img width="1821" height="1002" alt="image" src="https://github.com/user-attachments/assets/d6006773-020b-4c69-b985-a5f49e82eae9" />
