### PR TITLE
fix/Sync tempo widget BPM changes to engine in real time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -213,7 +213,7 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.7",
+            "version": "0.6.6",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2089,13 +2089,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.2",
+            "version": "0.21.1",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.5"
+                "minimatch": "^3.1.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2149,7 +2149,7 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
+            "version": "3.3.4",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2160,7 +2160,7 @@
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.5",
+                "minimatch": "^3.1.3",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
@@ -2196,7 +2196,7 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
+            "version": "9.39.3",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3183,7 +3183,7 @@
                 "@parcel/watcher-win32-x64": "2.5.6"
             }
         },
-        "node_modules/@parcel/watcher-linux-x64-glibc": {
+        "node_modules/@parcel/watcher-win32-x64": {
             "version": "2.5.6",
             "cpu": [
                 "x64"
@@ -3191,7 +3191,7 @@
             "license": "MIT",
             "optional": true,
             "os": [
-                "linux"
+                "win32"
             ],
             "engines": {
                 "node": ">= 10.0.0"
@@ -3413,7 +3413,7 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.12.0",
+            "version": "24.11.0",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -4129,12 +4129,12 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.16",
+            "version": "0.4.15",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.7",
+                "@babel/helper-define-polyfill-provider": "^0.6.6",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -4142,11 +4142,11 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.14.1",
+            "version": "0.14.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.7",
+                "@babel/helper-define-polyfill-provider": "^0.6.6",
                 "core-js-compat": "^3.48.0"
             },
             "peerDependencies": {
@@ -4154,11 +4154,11 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.7",
+            "version": "0.6.6",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.7"
+                "@babel/helper-define-polyfill-provider": "^0.6.6"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4697,7 +4697,7 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001777",
+            "version": "1.0.30001776",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5262,7 +5262,7 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "3.2.1",
+            "version": "3.2.0",
             "license": "MIT",
             "dependencies": {
                 "mdn-data": "2.27.1",
@@ -5293,10 +5293,10 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "7.1.3",
+            "version": "7.1.2",
             "license": "MIT",
             "dependencies": {
-                "cssnano-preset-default": "^7.0.11",
+                "cssnano-preset-default": "^7.0.10",
                 "lilconfig": "^3.1.3"
             },
             "engines": {
@@ -5311,39 +5311,39 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "7.0.11",
+            "version": "7.0.10",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "css-declaration-sorter": "^7.2.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-calc": "^10.1.1",
-                "postcss-colormin": "^7.0.6",
-                "postcss-convert-values": "^7.0.9",
-                "postcss-discard-comments": "^7.0.6",
+                "postcss-colormin": "^7.0.5",
+                "postcss-convert-values": "^7.0.8",
+                "postcss-discard-comments": "^7.0.5",
                 "postcss-discard-duplicates": "^7.0.2",
                 "postcss-discard-empty": "^7.0.1",
                 "postcss-discard-overridden": "^7.0.1",
                 "postcss-merge-longhand": "^7.0.5",
-                "postcss-merge-rules": "^7.0.8",
+                "postcss-merge-rules": "^7.0.7",
                 "postcss-minify-font-values": "^7.0.1",
                 "postcss-minify-gradients": "^7.0.1",
-                "postcss-minify-params": "^7.0.6",
-                "postcss-minify-selectors": "^7.0.6",
+                "postcss-minify-params": "^7.0.5",
+                "postcss-minify-selectors": "^7.0.5",
                 "postcss-normalize-charset": "^7.0.1",
                 "postcss-normalize-display-values": "^7.0.1",
                 "postcss-normalize-positions": "^7.0.1",
                 "postcss-normalize-repeat-style": "^7.0.1",
                 "postcss-normalize-string": "^7.0.1",
                 "postcss-normalize-timing-functions": "^7.0.1",
-                "postcss-normalize-unicode": "^7.0.6",
+                "postcss-normalize-unicode": "^7.0.5",
                 "postcss-normalize-url": "^7.0.1",
                 "postcss-normalize-whitespace": "^7.0.1",
                 "postcss-ordered-values": "^7.0.2",
-                "postcss-reduce-initial": "^7.0.6",
+                "postcss-reduce-initial": "^7.0.5",
                 "postcss-reduce-transforms": "^7.0.1",
-                "postcss-svgo": "^7.1.1",
-                "postcss-unique-selectors": "^7.0.5"
+                "postcss-svgo": "^7.1.0",
+                "postcss-unique-selectors": "^7.0.4"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -6063,6 +6063,8 @@
         },
         "node_modules/environment": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6196,23 +6198,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
+            "version": "9.39.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-array": "^0.21.1",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.39.3",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "ajv": "^6.14.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
@@ -6231,7 +6233,7 @@
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.5",
+                "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -6903,7 +6905,7 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.1",
+            "version": "3.3.4",
             "dev": true,
             "license": "ISC"
         },
@@ -7085,6 +7087,8 @@
         },
         "node_modules/get-east-asian-width": {
             "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7581,6 +7585,8 @@
         },
         "node_modules/gulp-prettier/node_modules/prettier": {
             "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8006,6 +8012,8 @@
         },
         "node_modules/husky": {
             "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8019,7 +8027,7 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.17",
+            "version": "25.8.14",
             "funding": [
                 {
                     "type": "individual",
@@ -8036,7 +8044,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.6"
+                "@babel/runtime": "^7.28.4"
             },
             "peerDependencies": {
                 "typescript": "^5"
@@ -9635,6 +9643,8 @@
         },
         "node_modules/lint-staged": {
             "version": "15.5.2",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+            "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9661,6 +9671,8 @@
         },
         "node_modules/lint-staged/node_modules/ansi-escapes": {
             "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9675,6 +9687,8 @@
         },
         "node_modules/lint-staged/node_modules/ansi-regex": {
             "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9686,6 +9700,8 @@
         },
         "node_modules/lint-staged/node_modules/ansi-styles": {
             "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9697,6 +9713,8 @@
         },
         "node_modules/lint-staged/node_modules/chalk": {
             "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9708,6 +9726,8 @@
         },
         "node_modules/lint-staged/node_modules/cli-cursor": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9722,6 +9742,8 @@
         },
         "node_modules/lint-staged/node_modules/cli-truncate": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9737,6 +9759,8 @@
         },
         "node_modules/lint-staged/node_modules/commander": {
             "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9745,16 +9769,22 @@
         },
         "node_modules/lint-staged/node_modules/emoji-regex": {
             "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lint-staged/node_modules/eventemitter3": {
             "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lint-staged/node_modules/execa": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9777,6 +9807,8 @@
         },
         "node_modules/lint-staged/node_modules/get-stream": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9788,6 +9820,8 @@
         },
         "node_modules/lint-staged/node_modules/human-signals": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -9796,6 +9830,8 @@
         },
         "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9807,6 +9843,8 @@
         },
         "node_modules/lint-staged/node_modules/is-stream": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9818,6 +9856,8 @@
         },
         "node_modules/lint-staged/node_modules/listr2": {
             "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+            "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9834,6 +9874,8 @@
         },
         "node_modules/lint-staged/node_modules/log-update": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9852,6 +9894,8 @@
         },
         "node_modules/lint-staged/node_modules/log-update/node_modules/is-fullwidth-code-point": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9866,6 +9910,8 @@
         },
         "node_modules/lint-staged/node_modules/log-update/node_modules/slice-ansi": {
             "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9881,6 +9927,8 @@
         },
         "node_modules/lint-staged/node_modules/mimic-fn": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9892,6 +9940,8 @@
         },
         "node_modules/lint-staged/node_modules/npm-run-path": {
             "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9906,6 +9956,8 @@
         },
         "node_modules/lint-staged/node_modules/onetime": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9920,6 +9972,8 @@
         },
         "node_modules/lint-staged/node_modules/path-key": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9931,6 +9985,8 @@
         },
         "node_modules/lint-staged/node_modules/restore-cursor": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9946,6 +10002,8 @@
         },
         "node_modules/lint-staged/node_modules/restore-cursor/node_modules/onetime": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9960,6 +10018,8 @@
         },
         "node_modules/lint-staged/node_modules/signal-exit": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -9971,6 +10031,8 @@
         },
         "node_modules/lint-staged/node_modules/slice-ansi": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9986,6 +10048,8 @@
         },
         "node_modules/lint-staged/node_modules/string-width": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10002,6 +10066,8 @@
         },
         "node_modules/lint-staged/node_modules/strip-ansi": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10016,6 +10082,8 @@
         },
         "node_modules/lint-staged/node_modules/strip-final-newline": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10027,6 +10095,8 @@
         },
         "node_modules/lint-staged/node_modules/wrap-ansi": {
             "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10405,6 +10475,8 @@
         },
         "node_modules/mimic-function": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10622,7 +10694,7 @@
                 "node-bin-setup": "^1.0.0"
             },
             "bin": {
-                "node": "bin/node"
+                "node": "bin/node.exe"
             },
             "engines": {
                 "npm": ">=5.0.0"
@@ -11283,6 +11355,8 @@
         },
         "node_modules/pidtree": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -11455,10 +11529,10 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "caniuse-api": "^3.0.0",
                 "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
@@ -11471,10 +11545,10 @@
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "7.0.9",
+            "version": "7.0.8",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -11485,10 +11559,10 @@
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^7.1.1"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11579,13 +11653,13 @@
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "7.0.8",
+            "version": "7.0.7",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "caniuse-api": "^3.0.0",
                 "cssnano-utils": "^5.0.1",
-                "postcss-selector-parser": "^7.1.1"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11623,10 +11697,10 @@
             }
         },
         "node_modules/postcss-minify-params": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11638,11 +11712,11 @@
             }
         },
         "node_modules/postcss-minify-selectors": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "postcss-selector-parser": "^7.1.1"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11727,10 +11801,10 @@
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -11781,10 +11855,10 @@
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "7.0.6",
+            "version": "7.0.5",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
+                "browserslist": "^4.27.0",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
@@ -11819,11 +11893,11 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "7.1.1",
+            "version": "7.1.0",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^4.0.1"
+                "svgo": "^4.0.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >= 18"
@@ -11833,10 +11907,10 @@
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "7.0.5",
+            "version": "7.0.4",
             "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^7.1.1"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11859,6 +11933,8 @@
         },
         "node_modules/prettier": {
             "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -12987,6 +13063,8 @@
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13089,11 +13167,11 @@
             }
         },
         "node_modules/stylehacks": {
-            "version": "7.0.8",
+            "version": "7.0.7",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.1",
-                "postcss-selector-parser": "^7.1.1"
+                "browserslist": "^4.27.0",
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -13207,7 +13285,7 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.11",
+            "version": "7.5.10",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {


### PR DESCRIPTION
### **Summary**

This PR fixes a real-time desynchronization between the Tempo widget and the playback engine. When BPM was changed using the Tempo widget (slider, buttons, or input), `_updateBPM()` only updated the block’s visual value on the canvas. The engine continued using the old BPM until the program was stopped and run again.

---

### **What changed**

After updating the block value, `_updateBPM()` now also propagates the BPM to the engine:

- For `setmasterbpm` / `setmasterbpm2`: updates `Singer.masterBPM` and `Singer.defaultBPMFactor`
- For `setbpm3` / `setbpm2`: updates the top value of each running turtle’s `singer.bpm` stack

Example:

Singer.masterBPM = bpmValue;
Singer.defaultBPMFactor = TONEBPM / bpmValue;

---

### **Why this change was needed**

The engine computes note timing from:

TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);

Since `_updateBPM()` never updated these engine values, the metronome ticked at the new tempo while notes continued playing at the old one. This broke the expected real-time behavior of the Tempo widget.

---

### **Scope**

- Affects only `js/widgets/tempo.js`
- No changes to block execution flow
- No impact on programs that do not modify BPM during execution

---

### **Verification**

- Changed BPM during execution and confirmed notes adjust immediately
- Verified metronome and playback stay synchronized
- All tests pass and lint is clean
