### PR TITLE
Fix : RequestManager ignoring explicit 0 config values

### DIFF
--- a/planet/js/RequestManager.js
+++ b/planet/js/RequestManager.js
@@ -27,10 +27,10 @@ class RequestManager {
      * @param {number} options.maxConcurrent - Maximum concurrent requests (default: 3)
      */
     constructor(options = {}) {
-        this.minDelay = options.minDelay || 500;
-        this.maxRetries = options.maxRetries || 3;
-        this.baseRetryDelay = options.baseRetryDelay || 1000;
-        this.maxConcurrent = options.maxConcurrent || 3;
+        this.minDelay = options.minDelay ?? 500;
+        this.maxRetries = options.maxRetries ?? 3;
+        this.baseRetryDelay = options.baseRetryDelay ?? 1000;
+        this.maxConcurrent = options.maxConcurrent ?? 3;
 
         // Track pending requests to prevent duplicates
         this.pendingRequests = new Map();

--- a/planet/js/__tests__/RequestManager.test.js
+++ b/planet/js/__tests__/RequestManager.test.js
@@ -32,6 +32,20 @@ describe("RequestManager", () => {
             expect(rm.maxConcurrent).toBe(3);
         });
 
+        it("should preserve explicit 0 option values", () => {
+            const rm = new RequestManager({
+                minDelay: 0,
+                maxRetries: 0,
+                baseRetryDelay: 0,
+                maxConcurrent: 0
+            });
+
+            expect(rm.minDelay).toBe(0);
+            expect(rm.maxRetries).toBe(0);
+            expect(rm.baseRetryDelay).toBe(0);
+            expect(rm.maxConcurrent).toBe(0);
+        });
+
         it("should initialize with custom options", () => {
             expect(requestManager.minDelay).toBe(100);
             expect(requestManager.maxRetries).toBe(2);


### PR DESCRIPTION
## Summary

This PR fixes a silent misconfiguration bug in RequestManager where explicit numeric 0 configuration values were ignored and replaced with defaults.

It also adds a focused unit test to prevent regressions and to prove that explicit 0 values are preserved for all relevant options.

## What happened (bug / impact)

In the `RequestManager` constructor, defaults were applied using:  `options.foo || default`

Because `0` is falsy in JavaScript, passing any of the following valid and intentional configurations:

- `{ minDelay: 0 }` → disable throttling delay
- `{ maxRetries: 0 }` → disable retries
- `{ baseRetryDelay: 0 }` → disable backoff delay (common in tests)
- `{ maxConcurrent: 0 }` → edge case: caller expects “no concurrent execution” semantics

## Impact
- Callers attempting to disable throttling/retries (often in tests or special flows) still experienced delays and retries
- This caused unexpected latency, extra load, and confusing debugging (“why is it still retrying?”)
- The issue occurred silently in a reliability-critical component (rate limiting / retry logic)

Fix given (what changed / why it’s correct)

The constructor now uses nullish coalescing `(??)` instead of logical OR `(||)` for defaulting:

`this.minDelay = options.minDelay ?? 500;
this.maxRetries = options.maxRetries ?? 3;
this.baseRetryDelay = options.baseRetryDelay ?? 1000;
this.maxConcurrent = options.maxConcurrent ?? 3;`

### Why this is correct

- `??` only falls back when the value is `null` or `undefined`
- Explicit `0` is preserved (as intended)
- “Not provided” still correctly receives defaults

## Changed files

- `planet/js/RequestManager.js`
- `planet/js/__tests__/RequestManager.test.js`

## How I tested (what I ran)
**Targeted Jest run (clean, no coverage collection):**

`npm test -- --runTestsByPath "planet/js/__tests__/RequestManager.test.js" --coverage=false`

### New test added

**A unit test that constructs:**
`new RequestManager({
  minDelay: 0,
  maxRetries: 0,
  baseRetryDelay: 0,
  maxConcurrent: 0
});`

and asserts that all instance fields remain 0.

## Before fix - failing test

The new test fails when the constructor uses `||` , proving the bug existed.

How it was produced (local only, not committed):

<img width="814" height="138" alt="Screenshot 2026-02-18 231912" src="https://github.com/user-attachments/assets/d3aee333-bc62-4bb1-a75a-d5c4399b5920" />

**Before fix: explicit 0 values ignored (test fails)**

## After fix - passing test (proof of resolution)

With `??`  in place, the same test now passes, confirming the fix.

<img width="797" height="131" alt="Screenshot 2026-02-18 231958" src="https://github.com/user-attachments/assets/a46c1e27-b066-48a8-afa7-3d42809cbb00" />

## Scope / non-goals

### Scope

Constructor defaulting logic for four numeric options only

### Non-goals
- No changes to retry/backoff algorithms
- No changes to queue processing or request deduplication
- No new configuration options or features
- No logging or behavior refactors

## Edge note

`{ maxConcurrent: 0 }`  now remains 0 (previously defaulted to 3)

If any code relied on the old buggy behavior, it will now behave as configured, which matches the intended contract . 

## testing 

<img width="569" height="123" alt="image" src="https://github.com/user-attachments/assets/b6978939-c604-4eea-a76f-3f2a6a292213" />

<img width="767" height="113" alt="image" src="https://github.com/user-attachments/assets/eca80cda-1a26-4090-854e-bb59823f2b2d" />


