### PR TITLE
Minimal fix: remove leftover debug logging from plugin evaluation

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -760,8 +760,7 @@ class Logo {
                 default:
                     // Is it a plugin?
                     if (logo.blockList[blk].name in logo.evalArgDict) {
-                        // eslint-disable-next-line no-console
-                        console.log("running eval on " + logo.blockList[blk].name);
+                        // Debug logging removed to avoid console noise in production
                         eval(logo.evalArgDict[logo.blockList[blk].name]);
                     } else {
                         // eslint-disable-next-line no-console


### PR DESCRIPTION
issue: #5811 
Problem:-
A debug logging statement remains in js/logo.js that prints plugin execution details to the browser console during normal operation.
-Logs "running eval on ..." whenever plugin blocks are evaluated
-Intended only for debugging purposes
-Allowed via an ESLint disable comment
-Creates unnecessary console noise in production
-Exposes internal execution details
-Although functionality is unaffected, this reduces developer experience and code professionalism.

Solution:-
-This PR removes the leftover debug logging while keeping plugin execution behavior unchanged.
-removes the debug console.log statement
-removes the associated ESLint disable comment
-preserves all existing functionality
-keeps console output clean during normal execution
-This refinement ensures the change is minimal and easy to review.

Changes Made:-
-File modified:
->js/logo.js
->removed debug console logging from plugin evaluation
->removed unnecessary eslint disable comment
->added brief comment noting intentional removal (if applicable)

Testing Performed:-
-Manual Verification
-Loaded projects using plugin blocks (e.g., hue block)
-Executed projects normally
-Verified plugin functionality remains unchanged
-Confirmed console no longer displays debug messages
-No console errors observed
-Automated Testing

Jest: ✅ all tests passed
ESLint: ✅ no new lint errors introduced

Impact:-
-Removes console clutter during normal execution
-Improves developer debugging experience
-Prevents exposure of internal execution details
-Enhances production code hygiene
-No functional changes

Notes:-
This PR is a refined version with minimal changes affecting only js/logo.js to ensure easy review and maintain code clarity.

Happy to adjust if maintainers prefer restricting such logs to a development-only debug mode.