### PR TITLE
Fix: prevent resize listener accumulation in makeBackground

### DIFF
--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1297,7 +1297,7 @@ Turtles.TurtlesView = class {
         let resizeTimeout;
         let ticking = false;
 
-        window.addEventListener("resize", () => {
+        const resizeHandler = () => {
             const isHighEndDevice =
                 navigator.hardwareConcurrency && navigator.hardwareConcurrency >= 4;
 
@@ -1319,7 +1319,14 @@ Turtles.TurtlesView = class {
                     __makeBoundary2();
                 }, 150); // Wait 150ms after the last resize event to execute
             }
-        });
+        };
+
+        if (this._resizeHandler) {
+            window.removeEventListener("resize", this._resizeHandler);
+        }
+
+        this._resizeHandler = resizeHandler;
+        window.addEventListener("resize", this._resizeHandler);
 
         return this;
     }


### PR DESCRIPTION
## Summary

This PR fixes a resize listener accumulation issue in `js/turtles.js`
inside the `Turtles.TurtlesView` class.

## Problem

In the `makeBackground()` method, a new `window.resize` event listener
was being registered each time the method was called.

Since the resize handler reference was not preserved across calls,
previously registered listeners were not removed before adding new ones,
leading to multiple active resize listeners.


Because `makeBackground()` may run multiple times during normal
canvas updates, this could result in multiple resize listeners
being attached.

## Solution

- Defined a named `resizeHandler` function inside `makeBackground()`.
- Stored the handler reference on the instance (`this._resizeHandler`).
- Before registering a new listener, the existing one (if present)
  is removed using:

  ```js
  window.removeEventListener("resize", this._resizeHandler);
