### PR TITLE
Fix: Sidebar palette buttons not updating immediately on theme switch

### DIFF
--- a/js/themebox.js
+++ b/js/themebox.js
@@ -206,6 +206,8 @@ class ThemeBox {
                 if (paletteElement && paletteElement.childNodes[0]) {
                     paletteElement.childNodes[0].style.border = `1px solid ${window.platformColor.selectorSelected}`;
                 }
+
+                this.refreshPaletteColors();
             } catch (e) {
                 console.debug("Could not refresh palette:", e);
             }
@@ -246,6 +248,45 @@ class ThemeBox {
                 // Cross-origin restriction may prevent this
                 console.debug("Could not update planet iframe theme:", e);
             }
+        }
+    }
+    /**
+     * Refresh palette UI colors after theme change
+     * @private
+     */
+    refreshPaletteColors() {
+        if (!this.activity.palettes) return;
+
+        const palette = document.getElementById("palette");
+        if (!palette) return;
+
+        // Update selector buttons (top icons)
+        const selectorCells = palette.querySelectorAll("thead td");
+        selectorCells.forEach(td => {
+            td.style.backgroundColor = window.platformColor.selectorBackground;
+            td.style.borderColor = window.platformColor.selectorSelected;
+        });
+
+
+
+        // Update palette list rows (search + category buttons)
+        const rows = palette.querySelectorAll("tbody tr");
+        rows.forEach(row => {
+            row.style.backgroundColor = window.platformColor.paletteBackground;
+
+            const label = row.querySelector("td:nth-child(2)");
+            if (label) {
+                label.style.color = window.platformColor.paletteText;
+            }
+        });
+
+        // Update open PaletteBody if visible
+        const paletteBody = document.getElementById("PaletteBody");
+        if (paletteBody) {
+            paletteBody.style.background =
+                window.platformColor.paletteBackground;
+            paletteBody.style.border =
+                `1px solid ${window.platformColor.selectorSelected}`;
         }
     }
 


### PR DESCRIPTION
### Description
This PR fixes an issue where the sidebar palette UI did not immediately reflect the selected theme when switching between Light and Dark modes.

### Previously:
- Palette selector buttons (top icons) retained previous theme colors.
- Palette list rows (categories/search section) remained in old theme colors.
- The open PaletteBody panel did not update its background and border.
- Colors were only refreshed after hover or interaction.

This created visual inconsistency during theme switching

### Root Cause
While platformColor was updated correctly during theme switching, the palette DOM elements were not explicitly refreshed. As a result, previously applied inline styles remained until a user interaction (e.g., hover) triggered a repaint.

### Changes Made
- Added refreshPaletteColors() method.
- Updated:
   1. Selector buttons (thead td)
   2. Palette rows (tbody tr)
   3. Row label text color
   4. PaletteBody background and border

Ensured palette UI updates instantly after theme switch.

### Recording

https://github.com/user-attachments/assets/4ed9ebdf-b3e1-4148-90be-7d6adfd3dbe5



### Testing
- Verified Light → Dark switch
- Verified Dark → Light switch
- No console errors observed

closes #5825 