### PR TITLE
fix: replace global focus outline removal with :focus-visible for key…

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -14,8 +14,15 @@
 
 @import url("play-only-mode.css");
 
-*:focus {
+/* Hide focus ring for mouse/touch interactions */
+*:focus:not(:focus-visible) {
   outline: none;
+}
+
+/* Show visible focus ring for keyboard navigation (WCAG 2.4.7) */
+*:focus-visible {
+  outline: 2px solid #0066FF;
+  outline-offset: 2px;
 }
 
 body:not(.dark) #helpfulSearch,

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ input[type="range"] {
   width: 250px;
 }
 
-input[type="range"]:focus {
+input[type="range"]:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -507,5 +507,5 @@ a {
 	border-radius: 5px;
 	cursor: pointer;
 	font-size: 16px;
-	outline: none;
+	/* outline preserved for keyboard focus via global :focus-visible rule */
 }


### PR DESCRIPTION
## Description

Fixes #5828

The CSS rule `*:focus { outline: none; }` in [css/activities.css](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/css/activities.css:0:0-0:0) removes visible focus indicators from **all** elements, making it impossible for keyboard users to track which element is focused. This violates [WCAG 2.4.7 (Focus Visible)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html).

This PR replaces the blanket suppression with a `:focus-visible` approach that:
- **Shows** a visible blue (`#0066FF`) focus ring when navigating with the keyboard (Tab key)
- **Hides** the focus ring for mouse/touch interactions (preserving the original aesthetic intent)

## Changes

| File | Change |
|------|--------|
| [css/activities.css](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/css/activities.css:0:0-0:0) | Replaced `*:focus { outline: none }` with `*:focus:not(:focus-visible)` + `*:focus-visible` rule |
| [css/style.css](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/css/style.css:0:0-0:0) | Scoped `input[type="range"]` outline suppression to mouse-only via `:focus:not(:focus-visible)` |
| [planet/css/style.css](cci:7://file:///Users/manvirsingh/contribution/sugelabs/musicblocks/planet/css/style.css:0:0-0:0) | Removed hardcoded `outline: none` from `#backToTopBtn` (now handled by global rule) |

## How to Test

1. Open Music Blocks in a browser
2. Press **Tab** repeatedly — a blue focus ring should appear around each interactive element
3. **Click** any button with the mouse — no focus ring should appear
4. Verify keyboard navigation is trackable across the entire interface

## Before & After

- **Before:** No visible focus indicator when pressing Tab — impossible to identify the active element
- **After:** Clear blue outline appears on keyboard focus; mouse clicks remain clean
