### PR TITLE
Fix help tutorial scrollbar placement

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -87,7 +87,12 @@ class HelpWidget {
 
         this._helpDiv.insertAdjacentHTML("afterbegin", innerHTML);
         this.widgetWindow.getWidgetBody().append(this._helpDiv);
+         
+        const helpBodyDiv = this._helpDiv.querySelector("#helpBodyDiv");
 
+        helpBodyDiv.style.overflowY = "auto";
+        helpBodyDiv.style.height = "100%";
+        helpBodyDiv.style.paddingRight = "12px";
         let leftArrow, rightArrow;
         if (!useActiveBlock) {
             if (page == 0) {
@@ -175,8 +180,8 @@ class HelpWidget {
 
         if (!useActiveBlock) {
             // display help menu
-            docById("helpBodyDiv").style.height = "325px";
-            docById("helpBodyDiv").style.width = "345px";
+            //docById("helpBodyDiv").style.height = "325px";
+            //docById("helpBodyDiv").style.width = "345px";
             this._showPage(page);
         } else {
             // display help for this block
@@ -215,7 +220,7 @@ class HelpWidget {
 
                 if (message) {
                     const helpBody = docById("helpBodyDiv");
-                    helpBody.style.height = "70vh";
+                    //helpBody.style.height = "70vh";
 
                     let body = "";
                     if (message.length > 1) {
@@ -546,7 +551,9 @@ class HelpWidget {
             const message = block.helpString;
 
             const helpBody = docById("helpBodyDiv");
-            helpBody.style.height = "70vh";
+            helpBody.style.overflowY = "auto";
+            helpBody.style.height = "100%";
+            helpBody.style.paddingRight = "12px";
             // helpBody.style.backgroundColor = "#e8e8e8";
             if (message) {
                 let body = "";


### PR DESCRIPTION
### Issue
The help/tutorial scrollbar was appearing inside the navigation arrows, leading to awkward UI placement.

### Fix
- Moved vertical scrolling to the help content area (`helpBodyDiv`)
- Ensured navigation arrows remain fixed while content scrolls

### Result
- Scrollbar now appears on the right side of the tutorial
- Short pages do not show a scrollbar; long pages scroll correctly

Closes #5841