### PR TITLE
synth recording flow with MBDialog

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1108,12 +1108,36 @@ function Synth() {
             }
             chunks = [];
             const url = URL.createObjectURL(blob);
-            // Prompt the user for the file name
-            const fileName = window.prompt(_("Enter file name"), _("recording"));
-            if (fileName) {
-                download(url, fileName + (platform.FF ? ".wav" : ".ogg"));
+            const t = text => (typeof window._ === "function" ? window._(text) : text);
+            const ext = platform.FF ? ".wav" : ".ogg";
+            const showCancelMessage = () => {
+                if (window.MBDialog && typeof window.MBDialog.alert === "function") {
+                    window.MBDialog.alert(t("Download cancelled."), t("Save recording"));
+                } else {
+                    alert(t("Download cancelled."));
+                }
+            };
+            const finishDownload = name => {
+                if (name === null || name.trim() === "") {
+                    showCancelMessage();
+                    return;
+                }
+
+                download(url, name + ext);
+            };
+
+            if (window.MBDialog && typeof window.MBDialog.prompt === "function") {
+                window.MBDialog.prompt({
+                    title: t("Save recording"),
+                    message: t("Filename:"),
+                    defaultValue: t("recording"),
+                    okText: t("Save"),
+                    cancelText: t("Cancel")
+                }).then(result => finishDownload(result));
             } else {
-                alert(_("Download cancelled."));
+                // Fallback to browser prompt if MBDialog is not available.
+                const fileName = window.prompt(t("Enter file name"), t("recording"));
+                finishDownload(fileName);
             }
         };
         // this.recorder.start();


### PR DESCRIPTION
Depends on PR #5844 (MERGED) for MBDialog component

This PR replaces the native browser prompt in synthutils.js with the newly created MBDialog component. This ensures that the "Save music as WAV" action now uses a themed UI that is consistent with the rest of the application.

Clarification Needed: The recording saves only when the stop button is pressed after starting the music recording, is this a bug or a feature.

Images:
<img width="1012" height="482" alt="image" src="https://github.com/user-attachments/assets/54b5ae85-58f0-4331-bca5-6ce1e24ac26f" />

- [x] Feature
