### PR TITLE
Fixed Help Tutorial Scrollbar Placement

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1199,7 +1199,7 @@ table {
   left: 0 !important;
   border: 0 !important;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow: visible;
   width: calc(100% - 130px) !important;
   max-width: 350px;
   padding: 1rem 1rem 0 1rem;
@@ -1207,6 +1207,10 @@ table {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+#helpScrollWrapper {
+  overflow-y: auto;
 }
 
 #helpBodyDiv .heading,

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -82,8 +82,10 @@ class HelpWidget {
                     <div id="right-arrow" class="hover" tabindex="-1"></div>
                     <div id="left-arrow" class="hover" tabindex="-1"></div>
                     <div id="helpButtonsDiv" tabindex="-1"></div>
-                    <div id="helpBodyDiv" tabindex="-1"></div>
-                         `;
+                    <div id="helpScrollWrapper">
+                        <div id="helpBodyDiv" tabindex="-1"></div>
+                    </div>
+                          `;
 
         this._helpDiv.insertAdjacentHTML("afterbegin", innerHTML);
         this.widgetWindow.getWidgetBody().append(this._helpDiv);
@@ -467,7 +469,7 @@ class HelpWidget {
         // this._helpDiv.style.backgroundColor = "#e8e8e8";
 
         const helpDivHTML =
-            '<div id="right-arrow" class="hover" tabindex="-1"></div><div id="left-arrow" class="hover" tabindex="-1"></div><div id="helpButtonsDiv" tabindex="-1"></div><div id="helpBodyDiv" tabindex="-1"></div>';
+            '<div id="right-arrow" class="hover" tabindex="-1"></div><div id="left-arrow" class="hover" tabindex="-1"></div><div id="helpButtonsDiv" tabindex="-1"></div><div id="helpScrollWrapper"><div id="helpBodyDiv" tabindex="-1"></div></div>';
         this._helpDiv.insertAdjacentHTML("afterbegin", helpDivHTML);
 
         this.widgetWindow.getWidgetBody().append(this._helpDiv);


### PR DESCRIPTION
Fix: Move help tutorial scrollbar to modal edge #5841 (Issue)

## Summary

This PR fixes the placement of the scrollbar in the Help/Tutorial modal.

Previously, the scrollbar was attached to #helpBodyDiv, causing it to appear between the navigation arrows and the modal edge.

## Changes

- Introduced #helpScrollWrapper around #helpBodyDiv
- Moved scroll ownership from #helpBodyDiv to #helpScrollWrapper
- Updated CSS:
  - #helpBodyDiv → overflow: visible
  - #helpScrollWrapper → overflow-y: auto

## Result

- Scrollbar now appears at the modal’s rightmost edge
- Navigation arrows remain unchanged
- Text alignment and layout remain intact
- No visual regression

Preview of the change:

https://github.com/user-attachments/assets/0dec5a23-ab8d-4aa8-b9bc-cdf9a53d87a7

