### PR TITLE
Fix metronome cleanup when Music Keyboard widget closes

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -637,6 +637,8 @@ function MusicKeyboard(activity) {
                 document.getElementById("keyboardHolder2").style.display = "none";
             }
 
+            this.stopMetronome();
+
             myNode = document.getElementById("myrow");
             if (myNode != null) {
                 myNode.innerHTML = "";
@@ -647,12 +649,7 @@ function MusicKeyboard(activity) {
                 myNode.innerHTML = "";
             }
 
-            this.tick = false;
-            this.firstNote = false;
-            this.metronomeON = false;
-
             selectedNotes = [];
-            if (this.loopTick) this.loopTick.stop();
             docById("wheelDivptm").style.display = "none";
             docById("wheelDivptm").style.display = "none";
             if (this._menuWheel) this._menuWheel.removeWheel();


### PR DESCRIPTION
Issue:#5853
- Call stopMetronome() in widget onclose handler instead of directly resetting flags
- This ensures proper cleanup: clearing countdown interval, stopping loop tick, removing countdown UI, and resetting metronome state
- Removes redundant flag resets and loopTick.stop() calls since stopMetronome() handles all of this