### PR TITLE
fix(musickeyboard): cleanup metronome on widget close

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -15,7 +15,7 @@
    global
 
    docById, platformColor, FIXEDSOLFEGE, FIXEDSOLFEGE1, SHARP, FLAT,
-   last, Singer, _, noteToFrequency, EIGHTHNOTEWIDTH,
+   last, Singer, noteToFrequency, EIGHTHNOTEWIDTH,
    MATRIXSOLFEHEIGHT, i18nSolfege, MATRIXSOLFEWIDTH, toFraction,
    wheelnav, slicePath, getNote, PREVIEWVOLUME, DEFAULTVOICE,
    PITCHES3, SOLFEGENAMES, SOLFEGECONVERSIONTABLE, NOTESSHARP,


### PR DESCRIPTION
## PR Category
- [x] Bug Fix

## PR Category
System.Object[]

## Summary
- call `stopMetronome()` from Music Keyboard `onclose` to ensure metronome resources are cleaned up
- remove duplicate loop stop from `onclose` since cleanup is centralized

## Why
Closing the widget during metronome countdown/tick could leave cleanup fragmented across code paths. Centralizing on `stopMetronome()` ensures interval/loop/countdown UI state is always cleaned up on close.

Fixes #5853.

