### PR TITLE
Enable automatic page reload on language selection

### DIFF
--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -262,6 +262,7 @@ class LanguageBox {
             } catch (e) {
                 console.warn("Could not save language preference:", e);
             }
+            this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;
 


### PR DESCRIPTION
### Description:
Previously, changing the language in Music Blocks required users to manually reload the page to see the changes. The interface also displayed a message instructing users to refresh their browser:

-“Refresh your browser to change your language preference.”

This PR updates the language selector so that the page automatically reloads whenever a new language is selected. The manual reload is no longer needed and has been removed.

This improves the user experience by applying the selected language immediately, without extra steps or confusing messages.

### Changes Made:

- Updated the language selector click handler to trigger an automatic page reload when a new language is selected.
- Verified that the language now applies immediately after selection.

### Video
https://github.com/user-attachments/assets/491380ed-4ada-4579-b690-5eb6d3319e9c



### Testing / Validation:
1. Selected multiple languages from the dropdown.
2. Confirmed that the page reloads automatically and displays the selected language.
4. Tested on Chrome to ensure consistency.

closes #5861 