### PR TITLE
chore: remove console log statements from js/js-export/generate.js

### DIFF
--- a/js/js-export/__tests__/generate.test.js
+++ b/js/js-export/__tests__/generate.test.js
@@ -109,14 +109,7 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.printStacksTree();
 
-        expect(console.log).toHaveBeenCalledWith(
-            "\n   %c START ",
-            "background: navy; color: white; font-weight: bold"
-        );
-        expect(console.log).toHaveBeenCalledWith(
-            "\n   %c ACTION ",
-            "background: green; color: white; font-weight: bold"
-        );
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
 
     test("should handle empty start and action trees", () => {
@@ -125,8 +118,7 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.printStacksTree();
 
-        expect(console.log).toHaveBeenCalledWith("%cno start trees generated", "color: tomato");
-        expect(console.log).toHaveBeenCalledWith("%cno action trees generated", "color: tomato");
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
 
     test("should handle invalid action name", () => {
@@ -164,15 +156,7 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.run(true, true);
 
-        expect(console.log).toHaveBeenCalledWith(
-            "\n   %c STACK TREES ",
-            "background: greenyellow; color: midnightblue; font-weight: bold"
-        );
-        expect(console.log).toHaveBeenCalledWith(
-            "\n   %c CODE ",
-            "background: greenyellow; color: midnightblue; font-weight: bold"
-        );
-        expect(console.log).toHaveBeenCalledWith("generated code");
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
 
     test("should set generateFailed when astring.generate throws", () => {
@@ -228,10 +212,7 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.printStacksTree();
 
-        expect(console.log).toHaveBeenCalledWith(
-            "\n   %c START ",
-            "background: navy; color: white; font-weight: bold"
-        );
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
 
     test("should print tree with clamp sub-tree", () => {
@@ -240,7 +221,7 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.printStacksTree();
 
-        expect(console.log).toHaveBeenCalledTimes(4);
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
 
     test("should run without printing separator when printCode is false", () => {
@@ -252,16 +233,9 @@ describe("JSGenerate Class", () => {
 
         JSGenerate.run(true, false);
 
-        expect(console.log).not.toHaveBeenCalledWith(
-            "%c _______________________________________",
-            "color: darkorange"
-        );
-        expect(console.log).not.toHaveBeenCalledWith(
-            "\n   %c CODE ",
-            "background: greenyellow; color: midnightblue; font-weight: bold"
-        );
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
-  
+
     test("should generate stack trees with various block types and arguments", () => {
         globalActivity.blocks.stackList = [1, 20];
         const booleanGrandParent = { constructor: { name: "BooleanBlock" } };
@@ -403,20 +377,7 @@ describe("JSGenerate Class", () => {
         JSGenerate.actionTrees = [[["actionBlock", null, null]]];
 
         JSGenerate.printStacksTree();
-        expect(console.log).toHaveBeenCalledWith(
-            expect.stringContaining("(arg1, subArg)"),
-            "background: mediumslateblue",
-            "background; none",
-            "color: dodgerblue"
-        );
-        expect(console.log).toHaveBeenCalledWith(
-            expect.stringContaining("** NEXTFLOW **"),
-            "color: green"
-        );
-        expect(console.log).toHaveBeenCalledWith(
-            expect.stringContaining("ACTION"),
-            "background: green; color: white; font-weight: bold"
-        );
+        expect(() => JSGenerate.printStacksTree()).not.toThrow();
     });
     test("should handle astring generation errors", () => {
         JSGenerate.AST = { type: "Program", body: [] };

--- a/js/js-export/generate.js
+++ b/js/js-export/generate.js
@@ -252,16 +252,9 @@ class JSGenerate {
             for (const i of tree) {
                 let spaces = "";
                 for (let j = 0; j < 4 * level; j++) spaces += " ";
-                console.log(
-                    "%c" + spaces + "%c" + i[0] + " : " + "%c" + PrintArgs(i[1]),
-                    "background: mediumslateblue",
-                    "background; none",
-                    "color: dodgerblue"
-                );
                 if (i[2] !== null) {
                     PrintTree(i[2], level + 1);
                     if (i.length === 4 && i[3] !== null) {
-                        console.log("%c" + spaces + "** NEXTFLOW **", "color: green");
                         PrintTree(i[3], level + 1);
                     }
                 }
@@ -269,28 +262,20 @@ class JSGenerate {
         }
 
         if (JSGenerate.startTrees.length === 0) {
-            console.log("%cno start trees generated", "color: tomato");
+            // returning as no start trees generated
+            return;
         } else {
             for (const tree of JSGenerate.startTrees) {
-                console.log(
-                    "\n   " + "%c START ",
-                    "background: navy; color: white; font-weight: bold"
-                );
                 PrintTree(tree);
-                console.log("\n");
             }
         }
 
         if (JSGenerate.startTrees.length === 0) {
-            console.log("%cno action trees generated", "color: tomato");
+            // returning as no action trees generated
+            return;
         } else {
             for (const tree of JSGenerate.actionTrees) {
-                console.log(
-                    "\n   " + "%c ACTION ",
-                    "background: green; color: white; font-weight: bold"
-                );
                 PrintTree(tree);
-                console.log("\n");
             }
         }
     }
@@ -360,26 +345,10 @@ class JSGenerate {
     static run(printStacksTree, printCode) {
         JSGenerate.generateStacksTree();
         if (printStacksTree) {
-            console.log(
-                "\n   " + "%c STACK TREES ",
-                "background: greenyellow; color: midnightblue; font-weight: bold"
-            );
             JSGenerate.printStacksTree();
         }
 
         JSGenerate.generateCode();
-
-        if (printStacksTree & printCode) {
-            console.log("%c _______________________________________", "color: darkorange");
-        }
-
-        if (printCode) {
-            console.log(
-                "\n   " + "%c CODE ",
-                "background: greenyellow; color: midnightblue; font-weight: bold"
-            );
-            console.log(JSGenerate.code);
-        }
     }
 }
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
part of #5464

Removed all console logs from `js/js-export/generate.js` and its corresponding test file `js/js-export/__tests__/generate.test.js` file

ran tests all passed, no eslint or prettier issues. 