### PR TITLE
test: fix broken tests after deps refactor and logoconstants update

### DIFF
--- a/js/__tests__/logoconstants.test.js
+++ b/js/__tests__/logoconstants.test.js
@@ -81,6 +81,7 @@ describe("logoconstants", () => {
             "TARGETBPM",
             "TURTLESTEP",
             "NOTEDIV",
+            "MIN_HIGHLIGHT_DURATION_MS",
             "NOMICERRORMSG",
             "NANERRORMSG",
             "NOSTRINGERRORMSG",

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1294,13 +1294,10 @@ describe("Palettes Class", () => {
         test("_makeBlockFromPalette handles null protoblk", () => {
             palettes.add("test");
             const palette = palettes.dict.test;
-            const consoleSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
 
             const result = palette._makeBlockFromPalette(null, "box", jest.fn());
 
             expect(result).toBeUndefined();
-            expect(consoleSpy).toHaveBeenCalled();
-            consoleSpy.mockRestore();
         });
 
         test("_makeBlockFromPalette uses namedbox default when undefined", () => {


### PR DESCRIPTION
Several tests in logo.test.js, logoconstants.test.js, and palette.test.js broke after recent source changes that weren't accompanied by test updates.

deps refactor #5593 moved globals into this.deps.*, but tests were still setting against the global. 

also stage.update() is now called in runFromBlockNow but neither stage mock had update
MIN_HIGHLIGHT_DURATION_MS was added to exports in #5726 but wasn't included in the test's expected keys list.

_makeBlockFromPalette no longer calls console.debug on null input, but the test still expected it

#5644, removed console.debug from _makeBlockFromPalette, but the test still expected it.