### PR TITLE
Fix: add keyboard accessibility to popup close icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,13 +198,17 @@
                 <div class="popupMsg" id="printText" tabindex="-1">
                     <div class="contentWrapper">
                         <span id="printTextContent"></span>
-                        <img class="msgCloseIcon" onclick="hidePrintText()" src="images/close.svg" alt="Close">
+                        <img class="msgCloseIcon" role="button" tabindex="0" onclick="hidePrintText()"
+                            onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();hidePrintText();}"
+                            src="images/close.svg" alt="Close">
                     </div>
                 </div>
                 <div class="popupMsg" id="errorText" tabindex="-1">
                     <div class="contentWrapper">
                         <span id="errorTextContent"></span>
-                        <img class="msgCloseIcon" onclick="hideErrorText()" src="images/close.svg" alt="Close">
+                        <img class="msgCloseIcon" role="button" tabindex="0" onclick="hideErrorText()"
+                            onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();hideErrorText();}"
+                            src="images/close.svg" alt="Close">
                     </div>
                 </div>
 
@@ -709,16 +713,16 @@
 
             const languageDropdown = document.getElementById("languagedropdown");
             if (languageDropdown) {
-            const langLinks = languageDropdown.querySelectorAll("a");
-            langLinks.forEach(link => {
-            link.addEventListener("click", function (e) {
-                e.preventDefault(); // prevent default <a> behavior
-                const selectedLang = this.id; // ID corresponds to language code
-                localStorage.setItem("languagePreference", selectedLang);
-                location.reload(); // automatically reload
-            });
-        });
-    }
+                const langLinks = languageDropdown.querySelectorAll("a");
+                langLinks.forEach(link => {
+                    link.addEventListener("click", function (e) {
+                        e.preventDefault(); // prevent default <a> behavior
+                        const selectedLang = this.id; // ID corresponds to language code
+                        localStorage.setItem("languagePreference", selectedLang);
+                        location.reload(); // automatically reload
+                    });
+                });
+            }
         });
 
     </script>
@@ -946,38 +950,38 @@
             window.addEventListener("resize", togglePlayOnlyMode);
         });
 
-    (function () {
-        function setAppHeight() {
-            const vh = window.innerHeight * 0.01;
-            document.documentElement.style.setProperty('--vh', `${vh}px`);
-        }
+        (function () {
+            function setAppHeight() {
+                const vh = window.innerHeight * 0.01;
+                document.documentElement.style.setProperty('--vh', `${vh}px`);
+            }
 
-        window.addEventListener('resize', setAppHeight);
-        document.addEventListener('fullscreenchange', setAppHeight);
-        setAppHeight();
-    })();
+            window.addEventListener('resize', setAppHeight);
+            document.addEventListener('fullscreenchange', setAppHeight);
+            setAppHeight();
+        })();
 
-(function () {
-  function resizeCanvasesToScreen() {
-    const canvases = document.querySelectorAll("canvas");
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+        (function () {
+            function resizeCanvasesToScreen() {
+                const canvases = document.querySelectorAll("canvas");
+                const width = window.innerWidth;
+                const height = window.innerHeight;
 
-    canvases.forEach(c => {
-      c.width = width;
-      c.height = height;
-      c.style.width = "100%";
-      c.style.height = "100%";
-    });
-  }
+                canvases.forEach(c => {
+                    c.width = width;
+                    c.height = height;
+                    c.style.width = "100%";
+                    c.style.height = "100%";
+                });
+            }
 
-  window.addEventListener("resize", resizeCanvasesToScreen);
-  document.addEventListener("fullscreenchange", resizeCanvasesToScreen);
+            window.addEventListener("resize", resizeCanvasesToScreen);
+            document.addEventListener("fullscreenchange", resizeCanvasesToScreen);
 
-  setTimeout(resizeCanvasesToScreen, 150);
-})();
+            setTimeout(resizeCanvasesToScreen, 150);
+        })();
 
-</script>
+    </script>
 
 
 </body>


### PR DESCRIPTION
issue: #5878 

Problem:-
-Popup close controls (e.g., print preview and error dialogs) are implemented as  elements with onclick handlers. These elements are not focusable and cannot be activated via keyboard.
-Close icons are skipped when navigating with the Tab key
-Keyboard users cannot dismiss popup dialogs
-Assistive technologies do not recognize the icons as interactive controls
-This creates an accessibility barrier and does not meet WCAG 2.1 keyboard accessibility guidelines

Solution:-
-This PR adds keyboard accessibility support to the popup close icons while preserving existing behavior.
-adds role="button" for semantic meaning
-adds tabindex="0" to enable keyboard focus
-adds keyboard activation via Enter and Space
-preserves existing click functionality
-does not alter layout, styling, or popup logic

Changes Made:-
-File modified:
->index.html

added role="button" to popup close icons
added tabindex="0" to enable keyboard focus
added onkeydown handler for Enter/Space activation
ESLint: ✅ no lint errors
Tests: ⚠️ pre-existing failures on master (unrelated to this change)

Impact:-
-Enables keyboard users to dismiss popup dialogs
-Improves screen reader accessibility
-Enhances WCAG 2.1 compliance
-No functional regressions
-Minimal and safe change

Notes:-
This change is intentionally minimal and non-breaking. It improves accessibility without modifying popup logic, layout, or styling. The implementation follows standard accessibility best practices while preserving existing behavior.

Happy to refine further if maintainers prefer a different approach