### PR TITLE
Fix: remove debug console.log statements from reflection widget

### DIFF
--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -296,7 +296,6 @@ class ReflectionMatrix {
     async updateProjectCode() {
         const code = await this.activity.prepareExport();
         if (code === this.code) {
-            console.log("No changes in code detected.");
             return; // No changes in code
         }
 
@@ -308,8 +307,6 @@ class ReflectionMatrix {
             if (data.algorithm !== "unchanged") {
                 this.projectAlgorithm = data.algorithm; // update algorithm
                 this.code = code;
-            } else {
-                console.log("No changes in algorithm detected.");
             }
             this.botReplyDiv(data, false, false);
         } else {
@@ -416,7 +413,6 @@ class ReflectionMatrix {
      */
     async generateAnalysis() {
         try {
-            console.log("Summary stored", this.summary);
             const response = await fetch(`${this.PORT}/analysis`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -580,7 +576,6 @@ class ReflectionMatrix {
         } catch (e) {
             console.warn("Could not save analysis report to localStorage:", e);
         }
-        console.log("Conversation saved in localStorage.");
     }
 
     /** Reads the analysis report from localStorage.


### PR DESCRIPTION
issue: #5884 

Problem:-
-The reflection widget includes several leftover console.log statements used for development and debugging purposes.
-Debug messages are printed during normal widget operations (e.g., analysis generation and report saving).
-These logs do not indicate errors or user-facing issues.
-They create unnecessary console noise and expose internal execution details.
-While functionality is unaffected, retaining debug logs in production reduces code professionalism and makes real debugging more difficult.

Solution:-
-This PR removes debug-only logging from the reflection widget while preserving meaningful error handling.
-removes development/debug console.log statements
-preserves console.error and console.warn logs used for error handling
-removes an empty conditional branch created solely for debug logging
-does not modify logic or behavior

Changes Made:-
-File modified:
->js/widgets/reflection.js
- removed debug console logs
- removed empty conditional branch tied to debug logging

->ESLint: ✅ no lint errors
->Tests: ⚠️ pre-existing failures on master (unrelated to this change)

Impact:-
-Removes unnecessary console noise
-Improves developer debugging experience
-Enhances production code hygiene
-No functional changes

Notes:-
This change is intentionally minimal and non-breaking. It removes debug-only logs while preserving runtime error reporting and existing functionality.

Happy to adjust if maintainers prefer retaining any informational logs.