### PR TITLE
fix: replace undeclared body variable with document.body in theme preference loading

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -340,9 +340,9 @@ class Activity {
 
             for (let i = 0; i < this.themes.length; i++) {
                 if (this.themes[i] === activeTheme) {
-                    body.classList.add(this.themes[i]);
+                    document.body.classList.add(this.themes[i]);
                 } else {
-                    body.classList.remove(this.themes[i]);
+                    document.body.classList.remove(this.themes[i]);
                 }
             }
         } catch (e) {


### PR DESCRIPTION
What:
- Replaced two references to undeclared variable `body` with `document.body` 
  in the theme preference loading logic in the Activity constructor.

Why:
- `body` was never declared in this scope, causing a ReferenceError silently 
  swallowed by the surrounding try/catch block.
- This meant stored theme preference was never actually applied on load.
- `document.body` is already used elsewhere in this file, making this the 
  correct and consistent reference.

How:
- Minimal two-line change, no logic modification.