### PR TITLE
fix: deduplicate DOM query and add null guard in renderThemeSelectIcon

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -617,16 +617,17 @@ class Toolbar {
     }
 
     renderThemeSelectIcon(themeBox, themes) {
-        const icon = document.getElementById("themeSelectIcon");
+        const icon = docById("themeSelectIcon");
+        if (!icon) return;
+    
         themes.forEach(theme => {
             if (localStorage.themePreference === theme) {
-                icon.innerHTML = document.getElementById(theme).innerHTML;
+                icon.innerHTML = docById(theme).innerHTML;
             }
         });
-        const themeSelectIcon = docById("themeSelectIcon");
-        const themeList = themes;
-        themeSelectIcon.onclick = () => {
-            themeList.forEach(theme => {
+
+        icon.onclick = () => {
+            themes.forEach(theme => {
                 docById(theme).onclick = () => themeBox[`${theme}_onclick`](this.activity);
             });
         };


### PR DESCRIPTION
The `renderThemeSelectIcon` method queries `"themeSelectIcon"` twice 
using two different methods (`document.getElementById` and `docById`), 
and accesses `.innerHTML` without verifying the element exists.

Changes:
- Query element once using `docById` (consistent with codebase style)
- Add early null guard to prevent TypeError if element is absent
- Remove redundant `themeList` variable

No behavior change when element is present.