### PR TITLE
fix: use rest parameter in $ utility function to restore intended behavior

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -13,7 +13,7 @@
 /*
    global
 
-    ACCIDENTALLABELS, ACCIDENTALNAMES, addTemperamentToDictionary,
+   _, ACCIDENTALLABELS, ACCIDENTALNAMES, addTemperamentToDictionary,
    blockBlocks, COLLAPSEBUTTON, COLLAPSETEXTX, COLLAPSETEXTY,
    createjs, DEFAULTACCIDENTAL, DEFAULTDRUM, DEFAULTEFFECT,
    DEFAULTFILTERTYPE, DEFAULTINTERVAL, DEFAULTINVERT, DEFAULTMODE,
@@ -21,9 +21,9 @@
    DEFAULTVOICE, DEGREES, delayExecution, deleteTemperamentFromList,
    DISABLEDFILLCOLOR, DISABLEDSTROKECOLOR, docById, DOUBLEFLAT,
    DOUBLESHARP, DRUMNAMES, EASTINDIANSOLFNOTES, EFFECTSNAMES,
-    EXPANDBUTTON, FILTERTYPES, FLAT, getDrumName, getDrumSynthName,
+   EXPANDBUTTON, FILTERTYPES, FLAT, getDrumName, getDrumSynthName,
    getModeNumbers, getNoiseName, getTemperament, getTemperamentKeys,
-    getTemperamentsList, getTextWidth, hideDOMLabel, HIGHLIGHTSTROKECOLORS,
+   getTemperamentsList, getTextWidth, hideDOMLabel, HIGHLIGHTSTROKECOLORS,
    i18nSolfege, INVERTMODES, isCustomTemperament, last, MEDIASAFEAREA,
    NATURAL, NOISENAMES, NSYMBOLS, NUMBERBLOCKDEFAULT, OSCTYPES,
    PALETTEFILLCOLORS, PALETTEHIGHLIGHTCOLORS, PALETTESTROKECOLORS,
@@ -31,9 +31,9 @@
    piemenuBoolean, piemenuColor, piemenuCustomNotes, piemenuIntervals,
    piemenuModes, piemenuNoteValue, piemenuNumber, piemenuPitches,
    piemenuVoices, piemenuChords, platformColor, ProtoBlock, RSYMBOLS,
-    safeSVG, SCALENOTES, SHARP, SOLFATTRS, SOLFNOTES, splitScaleDegree,
+   safeSVG, SCALENOTES, SHARP, SOLFATTRS, SOLFNOTES, splitScaleDegree,
    splitSolfege, STANDARDBLOCKHEIGHT, TEXTX, TEXTY,
-    topBlock, updateTemperaments, VALUETEXTX, DEFAULTCHORD, base64Encode,
+   topBlock, updateTemperaments, VALUETEXTX, DEFAULTCHORD,
    VOICENAMES, WESTERN2EISOLFEGENAMES, _THIS_IS_TURTLE_BLOCKS_
  */
 
@@ -71,7 +71,7 @@
         platformColor
  */
 
-/* exported Block */
+/* exported Block, $ */
 
 // Length of a long touch
 
@@ -274,11 +274,6 @@ class Block {
         this.name = protoblock.name;
         this.activity = this.blocks.activity;
 
-        // Cached index in blocks.blockList — set when block is added
-        // to blockList. Avoids O(N) blockList.indexOf() lookups that
-        // are scattered across the codebase (33+ call sites).
-        this.blockIndex = -1;
-
         this.collapsed = false; // Is this collapsible block collapsed?
         this.inCollapsed = false; // Is this block in a collapsed stack?
         this.trash = false; // Is this block in the trash?
@@ -404,13 +399,6 @@ class Block {
     updateCache() {
         const that = this;
         return new Promise((resolve, reject) => {
-            // If the container has no active bitmap cache (e.g., trashed
-            // blocks whose cache was freed), skip the update silently.
-            if (that.container && !that.container.bitmapCache) {
-                resolve();
-                return;
-            }
-
             let loopCount = 0;
             const MAX_RETRIES = 15;
             const INITIAL_DELAY = 100;
@@ -427,8 +415,7 @@ class Block {
 
                     if (that.bounds === null) {
                         const delayTime = INITIAL_DELAY * Math.pow(2, loopCount);
-                        await delayExecution(delayTime);
-                        await new Promise(resolve => setTimeout(resolve, delayTime));
+                        await that.pause(delayTime);
                         updateBounds(loopCount + 1);
                     } else {
                         that.container.updateCache();
@@ -1074,7 +1061,7 @@ class Block {
     generateArtwork(firstTime) {
         // Get the block labels from the protoblock.
         const that = this;
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
         let block_label = "";
 
         /**
@@ -1106,7 +1093,7 @@ class Block {
 
             const __callback = (that, firstTime) => {
                 that.activity.refreshCanvas();
-                const thisBlock = that.blockIndex;
+                const thisBlock = that.blocks.blockList.indexOf(that);
 
                 if (firstTime) {
                     that._loadEventHandlers();
@@ -1324,7 +1311,7 @@ class Block {
             artwork = artwork.replace("arg_label_" + i, this.protoblock.staticLabels[i]);
         }
 
-        that.blocks.blockArt[that.blockIndex] = artwork;
+        that.blocks.blockArt[that.blocks.blockList.indexOf(that)] = artwork;
 
         _blockMakeBitmap(artwork, __processBitmap, this);
     }
@@ -1335,7 +1322,7 @@ class Block {
      * @returns {void}
      */
     _finishImageLoad() {
-        // const thisBlock = this.blockIndex;
+        // const thisBlock = this.blocks.blockList.indexOf(this);
         let proto, obj, label, attr;
         // Value blocks get a modifiable text label.
         if (SPECIALINPUTS.includes(this.name)) {
@@ -1525,7 +1512,7 @@ class Block {
      * @returns {void}
      */
     _generateCollapseArtwork(postProcess) {
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
 
         /**
          * Run the postprocess function after the artwork is loaded.
@@ -1781,7 +1768,7 @@ class Block {
             that._ensureDecorationOnTop();
 
             // Save the collapsed block artwork for export.
-            that.blocks.blockCollapseArt[that.blockIndex] = that.collapseArtwork
+            that.blocks.blockCollapseArt[that.blocks.blockList.indexOf(that)] = that.collapseArtwork
                 .replace(/fill_color/g, PALETTEFILLCOLORS[that.protoblock.palette.name])
                 .replace(/stroke_color/g, PALETTESTROKECOLORS[that.protoblock.palette.name])
                 .replace("block_label", safeSVG(that.collapseText.text));
@@ -2111,7 +2098,7 @@ class Block {
      */
     getBlockId() {
         // Generate a UID based on the block index into the blockList.
-        const number = this.blockIndex;
+        const number = blockBlocks.blockList.indexOf(this);
         return "_" + number.toString();
     }
 
@@ -2134,7 +2121,7 @@ class Block {
      */
     loadThumbnail(imagePath) {
         // Load an image thumbnail onto block.
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
         const that = this;
 
         if (this.blocks.blockList[thisBlock].value === null && imagePath === null) {
@@ -2271,7 +2258,7 @@ class Block {
     collapseToggle() {
         // Find the blocks to collapse/expand inside of a collapable
         // block.
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
         this.blocks.findDragGroup(thisBlock);
 
         if (this.collapseBlockBitmap === null) {
@@ -2390,7 +2377,7 @@ class Block {
         const intervals = [];
         let i = 0;
 
-        let c = this.blockIndex,
+        let c = this.blocks.blockList.indexOf(this),
             lastIntervalBlock;
         while (c !== null) {
             lastIntervalBlock = c;
@@ -2904,7 +2891,7 @@ class Block {
      */
     _loadEventHandlers() {
         const that = this;
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
 
         this._calculateBlockHitArea();
 
@@ -2925,11 +2912,6 @@ class Block {
         let moved = false;
         let locked = false;
         let getInput = window.hasMouse;
-
-        // Cached drag state: computed once at mousedown, reused during pressmove.
-        // This avoids redundant O(N) findDragGroup and O(D) rest2 chain walks
-        // on every mouse move event (which fires 60+ times per second).
-        let _dragHasRest2 = false;
 
         /**
          * Handles the click event on the block container.
@@ -3053,7 +3035,7 @@ class Block {
             that.blocks.mouseDownTime = new Date().getTime();
 
             that.blocks.longPressTimeout = setTimeout(() => {
-                that.blocks.activeBlock = that.blockIndex;
+                that.blocks.activeBlock = that.blocks.blockList.indexOf(that);
                 that._triggerLongPress = true;
                 that.blocks.triggerLongPress();
             }, LONGPRESSTIME);
@@ -3097,33 +3079,10 @@ class Block {
                 x: Math.round(that.container.x - that.original.x),
                 y: Math.round(that.container.y - that.original.y)
             };
-
-            // Cache the drag group once on mousedown instead of
-            // recomputing the tree traversal on every pressmove.
-            that.blocks.cacheDragGroup(thisBlock);
-            // Invalidate the top-block cache since a drag may
-            // disconnect blocks, changing the topology.
-            that.blocks.invalidateTopBlockCache();
-
-            // Pre-compute whether the chain below contains a rest2 block.
-            // This avoids walking the entire connection chain on every
-            // mouse move event.
-            _dragHasRest2 = false;
-            let checkBlock = that.blocks.blockList[that.connections[1]];
-            while (checkBlock != null) {
-                if (checkBlock?.name === "rest2") {
-                    _dragHasRest2 = true;
-                    break;
-                }
-                checkBlock = checkBlock?.blocks.blockList[checkBlock.connections[1]];
-            }
         });
 
         /**
          * Handles the pressmove event on the block container.
-         * Performance-optimized: uses cached drag group, batched block
-         * moves, throttled edge scroll, and a single deferred
-         * checkBounds + refreshCanvas per frame.
          * @param {Event} event - The pressmove event.
          */
         this.container.on("pressmove", event => {
@@ -3143,11 +3102,14 @@ class Block {
                 return;
             }
 
-            // Use the cached rest2 check from mousedown instead of
-            // walking the chain on every mouse move event.
-            if (_dragHasRest2) {
-                this.activity.errorMsg(_("Silence block cannot be removed."), that);
-                return;
+            // Do not allow a stack of blocks to be dragged if the stack contains a silence block.
+            let block = that.blocks.blockList[that.connections[1]];
+            while (block != null) {
+                if (block?.name === "rest2") {
+                    this.activity.errorMsg(_("Silence block cannot be removed."), block);
+                    return;
+                }
+                block = block?.blocks.blockList[block.connections[1]];
             }
 
             if (window.hasMouse) {
@@ -3180,27 +3142,14 @@ class Block {
                 dy += 45 - finalPos;
             }
 
-            // Edge-scroll: throttled to ~60fps (16ms) to avoid
-            // running moveAllBlocksExcept on every mouse event.
-            const now = Date.now();
-            if (now - that.blocks._lastEdgeScrollTime >= 16) {
-                if (event.stageX < 10 && that.activity.scrollBlockContainer) {
-                    that.blocks.moveAllBlocksExcept(that, 10, 0);
-                    that.blocks._lastEdgeScrollTime = now;
-                } else if (
-                    event.stageX > window.innerWidth - 10 &&
-                    that.activity.scrollBlockContainer
-                ) {
-                    that.blocks.moveAllBlocksExcept(that, -10, 0);
-                    that.blocks._lastEdgeScrollTime = now;
-                } else if (event.stageY > window.innerHeight - 10) {
-                    that.blocks.moveAllBlocksExcept(that, 0, -10);
-                    that.blocks._lastEdgeScrollTime = now;
-                } else if (event.stageY < 60) {
-                    that.blocks.moveAllBlocksExcept(that, 0, 10);
-                    that.blocks._lastEdgeScrollTime = now;
-                }
-            }
+            // scroll when reached edges.
+            if (event.stageX < 10 && that.activity.scrollBlockContainer)
+                that.blocks.moveAllBlocksExcept(that, 10, 0);
+            else if (event.stageX > window.innerWidth - 10 && that.activity.scrollBlockContainer)
+                that.blocks.moveAllBlocksExcept(that, -10, 0);
+            else if (event.stageY > window.innerHeight - 10)
+                that.blocks.moveAllBlocksExcept(that, 0, -10);
+            else if (event.stageY < 60) that.blocks.moveAllBlocksExcept(that, 0, 10);
 
             if (that.blocks.longPressTimeout != null) {
                 clearTimeout(that.blocks.longPressTimeout);
@@ -3212,8 +3161,7 @@ class Block {
                 that.label.style.display = "none";
             }
 
-            // Move the dragged block itself (batched — no checkBounds).
-            that.blocks.moveBlockRelativeBatched(thisBlock, dx, dy);
+            that.blocks.moveBlockRelative(thisBlock, dx, dy);
 
             // If we are over the trash, warn the user.
             if (
@@ -3232,31 +3180,17 @@ class Block {
                 that.container.setChildIndex(that.text, that.container.children.length - 1);
             }
 
-            // Move connected blocks using the cached drag group
-            // (computed once on mousedown, not every pressmove).
-            const cachedGroup = that.blocks._cachedDragGroup;
-            if (cachedGroup != null && cachedGroup.length > 0) {
-                for (let b = 0; b < cachedGroup.length; b++) {
-                    const blk = cachedGroup[b];
-                    if (blk !== thisBlock) {
-                        that.blocks.moveBlockRelativeBatched(blk, dx, dy);
-                    }
-                }
-            } else {
-                // Fallback: recompute if cache is missing
-                that.blocks.findDragGroup(thisBlock);
-                if (that.blocks.dragGroup.length > 0) {
-                    for (let b = 0; b < that.blocks.dragGroup.length; b++) {
-                        const blk = that.blocks.dragGroup[b];
-                        if (b !== 0) {
-                            that.blocks.moveBlockRelativeBatched(blk, dx, dy);
-                        }
+            // ...and move any connected blocks.
+            that.blocks.findDragGroup(thisBlock);
+            if (that.blocks.dragGroup.length > 0) {
+                for (let b = 0; b < that.blocks.dragGroup.length; b++) {
+                    const blk = that.blocks.dragGroup[b];
+                    if (b !== 0) {
+                        that.blocks.moveBlockRelative(blk, dx, dy);
                     }
                 }
             }
 
-            // Single deferred checkBounds + single canvas refresh per frame
-            that.blocks.scheduleCheckBounds();
             that.activity.refreshCanvas();
         });
 
@@ -3279,12 +3213,7 @@ class Block {
                 that.blocks.unhighlight(thisBlock, true);
             }
             that.blocks.activeBlock = null;
-            // Release cached drag group and top-block map
-            that.blocks.clearCachedDragGroup();
-            that.blocks.invalidateTopBlockCache();
 
-            // Clear cached drag state.
-            _dragHasRest2 = false;
             moved = false;
         });
 
@@ -3306,12 +3235,7 @@ class Block {
 
             that.blocks.unhighlight(thisBlock, true);
             that.blocks.activeBlock = null;
-            // Release cached drag group and top-block map
-            that.blocks.clearCachedDragGroup();
-            that.blocks.invalidateTopBlockCache();
 
-            // Clear cached drag state.
-            _dragHasRest2 = false;
             moved = false;
         });
     }
@@ -3327,7 +3251,7 @@ class Block {
      * @returns {void}
      */
     _mouseoutCallback(event, moved, haveClick, hideDOM) {
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
         if (!this.activity.logo.runningLilypond) {
             document.body.style.cursor = "default";
         }
@@ -3369,7 +3293,7 @@ class Block {
                 // Just in case the blocks are not properly docked after
                 // the move (workaround for issue #38 -- Blocks fly
                 // apart). Still need to get to the root cause.
-                this.blocks.adjustDocks(this.blockIndex, true);
+                this.blocks.adjustDocks(this.blocks.blockList.indexOf(this), true);
             }
         } else if (SPECIALINPUTS.includes(this.name) || ["media", "loadFile"].includes(this.name)) {
             if (!haveClick) {
@@ -3427,7 +3351,7 @@ class Block {
         }
 
         // Numeric pie menus
-        const blk = this.blockIndex;
+        const blk = this.blocks.blockList.indexOf(this);
 
         if (this.blocks.octaveNumber(blk)) {
             return true;
@@ -3487,7 +3411,7 @@ class Block {
             return false;
         }
 
-        return this.blocks.blockList[cblk].connections[1] === this.blockIndex;
+        return this.blocks.blockList[cblk].connections[1] === this.blocks.blockList.indexOf(this);
     }
 
     /**
@@ -3512,7 +3436,7 @@ class Block {
             return false;
         }
 
-        return this.blocks.blockList[cblk].connections[2] === this.blockIndex;
+        return this.blocks.blockList[cblk].connections[2] === this.blocks.blockList.indexOf(this);
     }
 
     /**
@@ -3537,7 +3461,7 @@ class Block {
             return false;
         }
 
-        return this.blocks.blockList[cblk].connections[3] === this.blockIndex;
+        return this.blocks.blockList[cblk].connections[3] === this.blocks.blockList.indexOf(this);
     }
 
     /**
@@ -4084,7 +4008,7 @@ class Block {
         } else {
             // If the number block is connected to a pitch block, then
             // use the pie menu for octaves. Other special cases as well.
-            const blk = this.blockIndex;
+            const blk = this.blocks.blockList.indexOf(this);
             if (this.blocks.octaveNumber(blk)) {
                 piemenuNumber(this, [8, 7, 6, 5, 4, 3, 2, 1], this.value);
             } else if (this.blocks.noteValueNumber(blk, 2)) {
@@ -4232,7 +4156,7 @@ class Block {
             }
         }
 
-        // const blk = this.blockIndex;
+        // const blk = this.blocks.blockList.indexOf(this);
         if (!this._usePiemenu()) {
             let focused = false;
 
@@ -4257,7 +4181,7 @@ class Block {
                 labelElem.classList.remove("hasKeyboard");
 
                 window.scroll(0, 0);
-
+                // eslint-disable-next-line no-use-before-define
                 that.label.removeEventListener("keypress", __keypress);
 
                 if (movedStage) {
@@ -4364,7 +4288,7 @@ class Block {
     _checkWidgets(closeInput) {
         // Detect if label is changed, then reinit widget windows
         // if they are open.
-        const thisBlock = this.blockIndex;
+        const thisBlock = this.blocks.blockList.indexOf(this);
         const topBlock = this.blocks.findTopBlock(thisBlock);
         const widgetTitle = document.getElementsByClassName("wftTitle");
         let lockInit = false;
@@ -4543,7 +4467,7 @@ class Block {
             }
 
             if (isNaN(this.value)) {
-                const thisBlock = this.blockIndex;
+                const thisBlock = this.blocks.blockList.indexOf(this);
                 this.activity.errorMsg(newValue + ": " + _("Not a number"), thisBlock);
                 this.activity.refreshCanvas();
                 this.value = oldValue;
@@ -4554,7 +4478,7 @@ class Block {
                 this.blocks.blockList[cblk1].name === "pitch" &&
                 (this.value > 8 || this.value < 1)
             ) {
-                const thisBlock = this.blockIndex;
+                const thisBlock = this.blocks.blockList.indexOf(this);
                 this.activity.errorMsg(_("Octave value must be between 1 and 8."), thisBlock);
                 this.activity.refreshCanvas();
                 this.label.value = oldValue;
@@ -4562,7 +4486,7 @@ class Block {
             }
 
             if (String(this.value).length > 10) {
-                const thisBlock = this.blockIndex;
+                const thisBlock = this.blocks.blockList.indexOf(this);
                 this.activity.errorMsg(_("Numbers can have at most 10 digits."), thisBlock);
                 this.activity.refreshCanvas();
                 this.label.value = oldValue;
@@ -4670,7 +4594,10 @@ class Block {
                     // Check to see which connection we are using in
                     // cblock.  We only do something if blk is attached to
                     // the name connection (1).
-                    if (cblock.connections[1] === this.blockIndex && closeInput) {
+                    if (
+                        cblock.connections[1] === this.blocks.blockList.indexOf(this) &&
+                        closeInput
+                    ) {
                         // If the label was the name of a storein, update the
                         // associated box this.blocks and the palette buttons.
                         if (this.value !== "box") {
@@ -4717,6 +4644,26 @@ class Block {
         }
     }
 }
+
+/**
+ * Set elements to an array; if element is string, then set element's id to element.
+ * @public
+ * @returns {Array|HTMLElement} - An array of elements or a single element.
+ */
+const $ = (...args) => {
+    const elements = [];
+    for (let i = 0; i < args.length; i++) {
+        let element = args[i];
+        if (typeof element === "string") {
+            element = docById(element);
+        }
+        if (args.length === 1) {
+            return element;
+        }
+        elements.push(element);
+    }
+    return elements;
+};
 
 // Track mouse presence
 window.hasMouse = false;


### PR DESCRIPTION
The $ utility function in block.js was broken during a refactor from a 
standard function to an arrow function. Arrow functions lack the arguments 
object, so the loop iterated over an empty array and always returned [], 
silently ignoring all inputs.

Changes:
- Replace empty array iteration with rest parameter (...args)
- Function now correctly processes passed arguments as intended

Note: No current call sites found in the codebase. This PR fixes the broken 
implementation for correctness.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation