### PR TITLE
JS Editor: add missing block coverage Phase 2

### DIFF
--- a/js/js-export/ASTutils.js
+++ b/js/js-export/ASTutils.js
@@ -29,6 +29,29 @@
  * JavaScript based Music Blocks code.
  */
 class ASTUtils {
+    static _isValidIdentifier(name) {
+        return typeof name === "string" && /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(name);
+    }
+
+    static _getMouseCallExpression(methodName, args) {
+        return {
+            type: "CallExpression",
+            callee: {
+                type: "MemberExpression",
+                object: {
+                    type: "Identifier",
+                    name: "mouse"
+                },
+                computed: false,
+                property: {
+                    type: "Identifier",
+                    name: methodName
+                }
+            },
+            arguments: args
+        };
+    }
+
     /**
      * @static
      * Abstract Syntax Tree for the bare minimum program code
@@ -304,8 +327,33 @@ class ASTUtils {
      * @returns {Object} Abstract Syntax Tree of increment assignment statement
      */
     static _getIncrementStmntAST(args, isIncrement) {
-        const identifier = args[0].split("_")[1];
+        const identifier =
+            typeof args[0] === "string" && args[0].startsWith("box_") ? args[0].slice(4) : args[0];
         const arg = ASTUtils._getArgsAST([args[1]])[0];
+
+        if (!ASTUtils._isValidIdentifier(identifier)) {
+            const deltaAst = isIncrement
+                ? arg
+                : {
+                      type: "UnaryExpression",
+                      operator: "-",
+                      argument: arg,
+                      prefix: true
+                  };
+            return {
+                type: "ExpressionStatement",
+                expression: {
+                    type: "AwaitExpression",
+                    argument: ASTUtils._getMouseCallExpression("incrementBox", [
+                        {
+                            type: "Literal",
+                            value: identifier
+                        },
+                        deltaAst
+                    ])
+                }
+            };
+        }
 
         return {
             type: "ExpressionStatement",
@@ -353,6 +401,22 @@ class ASTUtils {
                             {
                                 type: "Identifier",
                                 name: "mouse"
+                            },
+                            {
+                                type: "AssignmentPattern",
+                                left: {
+                                    type: "Identifier",
+                                    name: "actionArgs"
+                                },
+                                right: {
+                                    type: "ArrayExpression",
+                                    elements: [
+                                        {
+                                            type: "Literal",
+                                            value: null
+                                        }
+                                    ]
+                                }
                             }
                         ],
                         body: {
@@ -430,6 +494,18 @@ class ASTUtils {
                         name: "mouse"
                     }
                 ];
+                if (args !== undefined && args !== null) {
+                    AST["expression"]["argument"]["arguments"].push({
+                        type: "ArrayExpression",
+                        elements: [
+                            {
+                                type: "Literal",
+                                value: null
+                            },
+                            ...ASTUtils._getArgsAST(args)
+                        ]
+                    });
+                }
             }
             if (props.statement === false) {
                 AST = AST["expression"];
@@ -448,6 +524,44 @@ class ASTUtils {
      * @returns {Object} - Abstract Syntax Tree of method call
      */
     static _getArgExpAST(methodName, args) {
+        if (methodName === "arg") {
+            const indexAst = ASTUtils._getArgsAST(args)[0] || {
+                type: "Literal",
+                value: 1
+            };
+            return {
+                type: "MemberExpression",
+                object: {
+                    type: "Identifier",
+                    name: "actionArgs"
+                },
+                property: indexAst,
+                computed: true
+            };
+        }
+
+        if (methodName === "box") {
+            const nameAst = ASTUtils._getArgsAST(args)[0];
+            if (nameAst && nameAst.type === "Identifier") {
+                return nameAst;
+            }
+            if (nameAst && nameAst.type === "Literal" && typeof nameAst.value === "string") {
+                if (ASTUtils._isValidIdentifier(nameAst.value)) {
+                    return {
+                        type: "Identifier",
+                        name: nameAst.value
+                    };
+                }
+            }
+            if (!nameAst) {
+                return {
+                    type: "Identifier",
+                    name: "undefined"
+                };
+            }
+            return ASTUtils._getMouseCallExpression("getBox", [nameAst]);
+        }
+
         const mathOps = {
             plus: ["binexp", "+"],
             minus: ["binexp", "-"],
@@ -457,8 +571,8 @@ class ASTUtils {
             equal: ["binexp", "=="],
             less: ["binexp", "<"],
             greater: ["binexp", ">"],
-            or: ["binexp", "|"],
-            and: ["binexp", "&"],
+            or: ["binexp", "||"],
+            and: ["binexp", "&&"],
             xor: ["binexp", "^"],
             not: ["unexp", "!"],
             neg: ["unexp", "-"],
@@ -470,7 +584,10 @@ class ASTUtils {
 
         function getBinaryExpAST(operator, operand1, operand2) {
             return {
-                type: "BinaryExpression",
+                type:
+                    operator === "&&" || operator === "||"
+                        ? "LogicalExpression"
+                        : "BinaryExpression",
                 left: ASTUtils._getArgsAST([operand1])[0],
                 right: ASTUtils._getArgsAST([operand2])[0],
                 operator: `${operator}`
@@ -538,17 +655,35 @@ class ASTUtils {
                     );
                 }
             } else {
-                if (typeof arg === "string" && arg.split("_").length > 1) {
-                    const [type, argVal] = arg.split("_");
+                if (typeof arg === "string" && arg.includes("_")) {
+                    const sepIndex = arg.indexOf("_");
+                    const type = arg.slice(0, sepIndex);
+                    const argVal = arg.slice(sepIndex + 1);
                     if (type === "bool") {
                         ASTs.push({
                             type: "Literal",
                             value: argVal === "true"
                         });
                     } else if (type === "box") {
+                        if (ASTUtils._isValidIdentifier(argVal)) {
+                            ASTs.push({
+                                type: "Identifier",
+                                name: argVal
+                            });
+                        } else {
+                            ASTs.push(
+                                ASTUtils._getMouseCallExpression("getBox", [
+                                    {
+                                        type: "Literal",
+                                        value: argVal
+                                    }
+                                ])
+                            );
+                        }
+                    } else {
                         ASTs.push({
-                            type: "Identifier",
-                            name: argVal
+                            type: "Literal",
+                            value: arg
                         });
                     }
                 } else {
@@ -678,23 +813,13 @@ class ASTUtils {
             } else if (flow[0] === "decrementOne") {
                 ASTs.push(ASTUtils._getIncrementStmntAST([flow[1][0], 1], false));
             } else if (flow[0] === "storein") {
-                ASTs.push({
-                    type: "VariableDeclaration",
-                    kind: "var",
-                    declarations: [
-                        {
-                            type: "VariableDeclarator",
-                            id: {
-                                type: "Identifier",
-                                name: flow[1][0]
-                            },
-                            init: ASTUtils._getArgsAST([flow[1][1]])[0]
-                        }
-                    ]
-                });
-            } else if (flow[0].split("_").length > 1) {
-                const [instruction, idName] = flow[0].split("_");
-                if (instruction === "storein2") {
+                const nameAst = ASTUtils._getArgsAST([flow[1][0]])[0];
+                const valueAst = ASTUtils._getArgsAST([flow[1][1]])[0];
+                if (
+                    nameAst &&
+                    nameAst.type === "Literal" &&
+                    ASTUtils._isValidIdentifier(nameAst.value)
+                ) {
                     ASTs.push({
                         type: "VariableDeclaration",
                         kind: "var",
@@ -703,13 +828,62 @@ class ASTUtils {
                                 type: "VariableDeclarator",
                                 id: {
                                     type: "Identifier",
-                                    name: idName
+                                    name: nameAst.value
                                 },
-                                init: ASTUtils._getArgsAST(flow[1])[0]
+                                init: valueAst
                             }
                         ]
                     });
+                } else {
+                    ASTs.push({
+                        type: "ExpressionStatement",
+                        expression: {
+                            type: "AwaitExpression",
+                            argument: ASTUtils._getMouseCallExpression("setBox", [
+                                nameAst,
+                                valueAst
+                            ])
+                        }
+                    });
+                }
+            } else if (flow[0].split("_").length > 1) {
+                const splitIndex = flow[0].indexOf("_");
+                const instruction = flow[0].slice(0, splitIndex);
+                const idName = flow[0].slice(splitIndex + 1);
+                if (instruction === "storein2") {
+                    if (ASTUtils._isValidIdentifier(idName)) {
+                        ASTs.push({
+                            type: "VariableDeclaration",
+                            kind: "var",
+                            declarations: [
+                                {
+                                    type: "VariableDeclarator",
+                                    id: {
+                                        type: "Identifier",
+                                        name: idName
+                                    },
+                                    init: ASTUtils._getArgsAST(flow[1])[0]
+                                }
+                            ]
+                        });
+                    } else {
+                        ASTs.push({
+                            type: "ExpressionStatement",
+                            expression: {
+                                type: "AwaitExpression",
+                                argument: ASTUtils._getMouseCallExpression("setBox", [
+                                    {
+                                        type: "Literal",
+                                        value: idName
+                                    },
+                                    ASTUtils._getArgsAST(flow[1])[0]
+                                ])
+                            }
+                        });
+                    }
                 } else if (instruction === "nameddo") {
+                    ASTs.push(ASTUtils._getMethodCallAST(idName, flow[1], { action: true }));
+                } else if (instruction === "nameddoArg") {
                     ASTs.push(ASTUtils._getMethodCallAST(idName, flow[1], { action: true }));
                 }
             } else {

--- a/js/js-export/__tests__/ASTutils.test.js
+++ b/js/js-export/__tests__/ASTutils.test.js
@@ -244,7 +244,7 @@ describe("ASTUtils", () => {
 
     describe("_getIncrementStmntAST", () => {
         it("should return the AST for an increment statement", () => {
-            const args = ["var_testIdentifier", "testArg"];
+            const args = ["box_testIdentifier", "testArg"];
             const isIncrement = true;
             const result = ASTUtils._getIncrementStmntAST(args, isIncrement);
             expect(result).toEqual({
@@ -270,7 +270,7 @@ describe("ASTUtils", () => {
         });
 
         it("should return the AST for a decrement statement", () => {
-            const args = ["var_testIdentifier", "testArg"];
+            const args = ["box_testIdentifier", "testArg"];
             const isIncrement = false;
             const result = ASTUtils._getIncrementStmntAST(args, isIncrement);
             expect(result).toEqual({
@@ -316,6 +316,22 @@ describe("ASTUtils", () => {
                                 {
                                     type: "Identifier",
                                     name: "mouse"
+                                },
+                                {
+                                    type: "AssignmentPattern",
+                                    left: {
+                                        type: "Identifier",
+                                        name: "actionArgs"
+                                    },
+                                    right: {
+                                        type: "ArrayExpression",
+                                        elements: [
+                                            {
+                                                type: "Literal",
+                                                value: null
+                                            }
+                                        ]
+                                    }
                                 }
                             ],
                             body: {
@@ -397,6 +413,16 @@ describe("ASTUtils", () => {
                             {
                                 type: "Identifier",
                                 name: "mouse"
+                            },
+                            {
+                                type: "ArrayExpression",
+                                elements: [
+                                    {
+                                        type: "Literal",
+                                        value: null
+                                    },
+                                    ...ASTUtils._getArgsAST(args)
+                                ]
                             }
                         ]
                     }
@@ -796,6 +822,22 @@ describe("ASTUtils", () => {
                                 {
                                     type: "Identifier",
                                     name: "mouse"
+                                },
+                                {
+                                    type: "AssignmentPattern",
+                                    left: {
+                                        type: "Identifier",
+                                        name: "actionArgs"
+                                    },
+                                    right: {
+                                        type: "ArrayExpression",
+                                        elements: [
+                                            {
+                                                type: "Literal",
+                                                value: null
+                                            }
+                                        ]
+                                    }
                                 }
                             ],
                             body: {

--- a/js/js-export/ast2blocks.json
+++ b/js/js-export/ast2blocks.json
@@ -51,6 +51,26 @@
             }
         },
         {
+            "comment": "Logical expressions like 'a && b' or 'a || b' in the Boolean palette",
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "LogicalExpression"
+                    }
+                ],
+                "name_property": "operator",
+                "argument_properties": [
+                    "left",
+                    "right"
+                ]
+            },
+            "name_map": {
+                "&&": "and",
+                "||": "or"
+            }
+        },
+        {
             "comment": "Unary expressions such as ! in boolean palette or - in number palette",
             "ast": {
                 "identifiers": [
@@ -250,12 +270,74 @@
                 "SHADE": "shade",
                 "PENSIZE": "pensize",
                 "COLOR": "color",
+                    "BOTTOMPOS": "bottompos",
+                    "CAMERA": "camera",
                 "BEATCOUNT": "nopValueBlock",
                 "MEASURECOUNT": "nopValueBlock",
                 "BPM": "nopValueBlock",
                 "WHOLENOTESPLAYED": "elapsednotes",
                 "BEATFACTOR": "beatfactor",
                 "NOTEVALUE": "notevalue"
+            }
+        },
+        {
+            "comment": "Box getter function",
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "CallExpression"
+                    },
+                    {
+                        "property": "callee.type",
+                        "value": "MemberExpression"
+                    },
+                    {
+                        "property": "callee.object.name",
+                        "value": "mouse"
+                    },
+                    {
+                        "property": "callee.property.name",
+                        "value": "getBox"
+                    }
+                ],
+                "name_property": "callee.property.name",
+                "argument_properties": [
+                    "arguments[0]"
+                ]
+            },
+            "name_map": {
+                "getBox": "box"
+            }
+        },
+        {
+            "comment": "Action argument access (actionArgs[n])",
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "MemberExpression"
+                    },
+                    {
+                        "property": "object.type",
+                        "value": "Identifier"
+                    },
+                    {
+                        "property": "object.name",
+                        "value": "actionArgs"
+                    },
+                    {
+                        "property": "computed",
+                        "value": true
+                    }
+                ],
+                "name_property": "object.name",
+                "argument_properties": [
+                    "property"
+                ]
+            },
+            "name_map": {
+                "actionArgs": "arg"
             }
         },
         {
@@ -371,6 +453,55 @@
             ]
         },
         {
+            "name": "storein",
+            "comment": "Store in block using mouse.setBox(name, value)",
+            "arguments": [
+                {
+                    "type": "ValueExpression"
+                },
+                {
+                    "type": "ValueExpression"
+                }
+            ],
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "ExpressionStatement"
+                    },
+                    {
+                        "property": "expression.type",
+                        "value": "AwaitExpression"
+                    },
+                    {
+                        "property": "expression.argument.type",
+                        "value": "CallExpression"
+                    },
+                    {
+                        "property": "expression.argument.callee.type",
+                        "value": "MemberExpression"
+                    },
+                    {
+                        "property": "expression.argument.callee.property.name",
+                        "value": "setBox"
+                    }
+                ],
+                "argument_properties": [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            "blocklist_connections": [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            "default_vspaces": {
+                "body": 2
+            }
+        },
+        {
             "name": "decrementOne",
             "comment": "Decrement by one block in the Boxes palette 'box1 = box1 - 1;'",
             "arguments": [
@@ -444,6 +575,55 @@
                 "argument_properties": [
                     "expression.left",
                     "expression.right.right"
+                ]
+            },
+            "blocklist_connections": [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            "default_vspaces": {
+                "body": 2
+            }
+        },
+        {
+            "name": "increment",
+            "comment": "Increment block using mouse.incrementBox(name, delta)",
+            "arguments": [
+                {
+                    "type": "ValueExpression"
+                },
+                {
+                    "type": "NumberExpression"
+                }
+            ],
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "ExpressionStatement"
+                    },
+                    {
+                        "property": "expression.type",
+                        "value": "AwaitExpression"
+                    },
+                    {
+                        "property": "expression.argument.type",
+                        "value": "CallExpression"
+                    },
+                    {
+                        "property": "expression.argument.callee.type",
+                        "value": "MemberExpression"
+                    },
+                    {
+                        "property": "expression.argument.callee.property.name",
+                        "value": "incrementBox"
+                    }
+                ],
+                "argument_properties": [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
                 ]
             },
             "blocklist_connections": [
@@ -711,6 +891,55 @@
                 "parent_or_previous_sibling",
                 "next_sibling"
             ]
+        },
+        {
+            "name": "nameddoArg",
+            "comment": "Action palette, async block with arguments",
+            "arguments": [
+                {
+                    "type": "ValueExpression"
+                }
+            ],
+            "arguments_repeat": true,
+            "ast": {
+                "identifiers": [
+                    {
+                        "property": "type",
+                        "value": "ExpressionStatement"
+                    },
+                    {
+                        "property": "expression.type",
+                        "value": "AwaitExpression"
+                    },
+                    {
+                        "property": "expression.argument.type",
+                        "value": "CallExpression"
+                    },
+                    {
+                        "property": "expression.argument.callee.type",
+                        "value": "Identifier"
+                    },
+                    {
+                        "property": "expression.argument.arguments",
+                        "size": 2
+                    },
+                    {
+                        "property": "expression.argument.arguments[1].type",
+                        "value": "ArrayExpression"
+                    }
+                ],
+                "name_property": "expression.argument.callee.name",
+                "arguments_property": "expression.argument.arguments[1].elements",
+                "arguments_offset": 1
+            },
+            "blocklist_connections": [
+                "parent_or_previous_sibling",
+                "argument",
+                "next_sibling"
+            ],
+            "default_vspaces": {
+                "body": 2
+            }
         },
         {
             "name": "nameddo",

--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -18,7 +18,7 @@
  * Internal functions' names are in PascalCase.
  */
 
-/* global JSEditor, last, importMembers, Singer, JSInterface, globalActivity */
+/* global JSEditor, last, importMembers, Singer, JSInterface, globalActivity, CAMERAVALUE */
 
 /**
  * @class
@@ -319,6 +319,25 @@ class MusicBlocks {
         }
     }
 
+    // ============================== BOXES ==================================
+
+    getBox(name) {
+        if (name in globalActivity.logo.boxes) {
+            return globalActivity.logo.boxes[name];
+        }
+        JSEditor.logConsole(`No box named "${name}"`, "maroon");
+        return 0;
+    }
+
+    setBox(name, value) {
+        globalActivity.logo.boxes[name] = value;
+    }
+
+    incrementBox(name, delta) {
+        const current = name in globalActivity.logo.boxes ? globalActivity.logo.boxes[name] : 0;
+        globalActivity.logo.boxes[name] = current + delta;
+    }
+
     // ========= Getters/Setters ===================================================================
 
     // ============================== GRAPHICS ================================
@@ -333,6 +352,19 @@ class MusicBlocks {
 
     get HEADING() {
         return this.turtle.orientation;
+    }
+
+    get BOTTOMPOS() {
+        const canvas = globalActivity.turtles._canvas;
+        const scale = globalActivity.turtles.scale;
+        if (!canvas || !canvas.height || !scale) {
+            return 0;
+        }
+        return -1 * (canvas.height / (2.0 * scale));
+    }
+
+    get CAMERA() {
+        return CAMERAVALUE;
     }
 
     // ================================ PEN ===================================

--- a/js/js-export/generate.js
+++ b/js/js-export/generate.js
@@ -161,7 +161,7 @@ class JSGenerate {
             while (nextBlk !== undefined) {
                 // ignore vertical spacers and hidden blocks
                 if (nextBlk.name !== "hidden" && nextBlk.name !== "vspace") {
-                    if (["storein2", "nameddo"].includes(nextBlk.name)) {
+                    if (["storein2", "nameddo", "nameddoArg"].includes(nextBlk.name)) {
                         tree.push([nextBlk.name + "_" + nextBlk.privateData]);
                     } else {
                         tree.push([nextBlk.name]);

--- a/js/js-export/interface.js
+++ b/js/js-export/interface.js
@@ -123,6 +123,9 @@ class JSInterface {
         x: "X",
         y: "Y",
         heading: "HEADING",
+        // Media blocks
+        bottompos: "BOTTOMPOS",
+        camera: "CAMERA",
         // Pen blocks
         pensize: "PENSIZE",
         color: "COLOR",


### PR DESCRIPTION
## **Summary**

This PR significantly enhances the **JavaScript Editor** by bridging the gap between manual coding and visual blocks. It introduces robust handling for variable names (Boxes) with spaces/punctuation and fully enables "round-trip" support for Action arguments. Most importantly, it restores and wires several essential blocks into the JS export and conversion pipeline.


## **Newly Supported & Restored Blocks**

The following blocks are now fully functional. They generate clean JavaScript and, more importantly, **convert back from JS into Blocks** accurately:

 **Logic Blocks:**
* `and` / `or`: Now correctly map to `&&` and `||`.
* `boolean`: Full support for `true` / `false` toggles.


 **Variable & Argument Blocks:**
* `box`, `box1`, `box2`: Enhanced to support names with spaces and special characters.
* `arg`: Correctly identifies and maps values passed into Actions.


 **System & Position Blocks:**
* `bottompos`: Exposed in JS as `mouse.BOTTOMPOS`.
* `camera`: Exposed in JS as `mouse.CAMERA`.
* `camera`: Full integration for camera-related logic.


Images:
<img width="1291" height="569" alt="image" src="https://github.com/user-attachments/assets/63cb799e-51df-40aa-818c-31aad008286e" />

- [x] Feature
Previous Work: PR #5834 