### PR TITLE
Fix zero-step SVG arc rendering for thin strokes in turtle-painter

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -346,7 +346,7 @@ class Painter {
             let sa = oAngleRadians - Math.PI;
             let ea = oAngleRadians;
 
-            const steps = Math.max(Math.floor(savedStroke, 1));
+            const steps = Math.max(Math.floor(savedStroke), 1);
             this._svgArc(steps, cx, cy, step, sa, ea, false, true);
 
             this.turtle.ctx.lineTo(ox + dx, oy + dy);
@@ -364,7 +364,7 @@ class Painter {
             sa = oAngleRadians - Math.PI;
             ea = oAngleRadians;
 
-            const stepsFinal = Math.max(Math.floor(savedStroke, 1));
+            const stepsFinal = Math.max(Math.floor(savedStroke), 1);
             this._svgArc(stepsFinal, cx, cy, step, sa, ea, false, true);
 
             this.closeSVG();
@@ -604,7 +604,7 @@ class Painter {
                 diff -= 2 * Math.PI;
             }
             const nsteps = Math.max(Math.floor((radius * Math.abs(diff)) / 2), 2);
-            const steps = Math.max(Math.floor(savedStroke, 1));
+            const steps = Math.max(Math.floor(savedStroke), 1);
 
             this._svgArc(nsteps, cx, cy, radius + step, sa, ea, anticlockwise, true);
 
@@ -1038,7 +1038,7 @@ class Painter {
             this.turtle.ctx.lineCap = "round";
 
             const step = savedStroke < 3 ? 0.5 : (savedStroke - 2) / 2;
-            const steps = Math.max(Math.floor(savedStroke, 1));
+            const steps = Math.max(Math.floor(savedStroke), 1);
 
             let degreesInitial = Math.atan2(cp1x - this.turtle.x, cp1y - this.turtle.y);
             degreesInitial = (180 * degreesInitial) / Math.PI;


### PR DESCRIPTION
## Summary

This PR fixes an incorrect use of `Math.floor()` in `turtle-painter.js` that allowed arc step calculations to become zero for thin stroke values. This silently broke SVG arc cap rendering for hollow lines and bezier curves.

## Changes

1. Corrected improper `Math.floor` usage where the minimum guard was mistakenly passed as a second argument:

   - Before:
     const steps = Math.max(Math.floor(savedStroke, 1));

   - After:
     const steps = Math.max(Math.floor(savedStroke), 1);

2. Applied the same fix consistently in all four affected locations:
   - Line 349
   - Line 367
   - Line 607
   - Line 1041

This ensures that `steps` is always at least `1`, preventing `_svgArc()` from receiving `0` steps.

## Testing

1. Set very thin pen sizes (e.g., 0.5, 1).
2. Drew hollow lines, SVG arcs, and bezier curves.
3. Verified:
   - No zero-step arcs
   - Proper round cap rendering
   - No regression in normal stroke rendering

## Note

`Math.floor(x, 1)` ignores the second argument in JavaScript. The previous implementation effectively allowed `steps` to become `0`, causing silent rendering issues. This fix enforces the intended minimum guard correctly.