### PR TITLE
fix: replace for-in with indexed for loop in unhighlightSelectedBlocks

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7291,7 +7291,7 @@ class Activity {
 
         this.unhighlightSelectedBlocks = (unhighlight, selectionModeOn) => {
             for (let i = 0; i < this.selectedBlocks.length; i++) {
-                for (const blk in this.blocks.blockList) {
+                for (let blk = 0; blk < this.blocks.blockList.length; blk++) {
                     if (this.isEqual(this.blocks.blockList[blk], this.selectedBlocks[i])) {
                         if (unhighlight) {
                             this.blocks.unhighlightSelectedBlocks(blk, true);


### PR DESCRIPTION
The `unhighlightSelectedBlocks` method in `activity.js` iterates over 
`this.blocks.blockList` using a `for...in` loop.

`for...in` on arrays yields string keys ("0", "1", "2") instead of 
numeric indices, which can cause silent failures when the index is 
passed to functions expecting a number.

Changes:
- Replace `for...in` with a standard indexed `for` loop

Consistent with the fix in #5888 which addressed the same pattern in 
`_saveHelpBlocks`.