### PR TITLE
Add IndexedDB integration tests for Planet CacheManager.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "electron-builder": "26.4.0",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
+        "fake-indexeddb": "6.2.5",
         "gulp": "^5.0.1",
         "gulp-babel": "^8.0.0",
         "gulp-clean-css": "^4.3.0",
@@ -6664,6 +6665,16 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fancy-log": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "electron-builder": "26.4.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
+    "fake-indexeddb": "6.2.5",
     "gulp": "^5.0.1",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.3.0",

--- a/planet/js/__tests__/CacheManager.test.js
+++ b/planet/js/__tests__/CacheManager.test.js
@@ -6,6 +6,7 @@
 // version 3 of the License, or (at your option) any later version.
 
 const CacheManager = require("../CacheManager");
+const { IDBFactory, IDBKeyRange } = require("fake-indexeddb");
 
 // Mock IndexedDB
 const indexedDB = {
@@ -198,14 +199,391 @@ describe("CacheManager", () => {
     });
 });
 
-describe("CacheManager Integration", () => {
-    // These tests would require a real or mocked IndexedDB implementation
-    // For now, we'll skip the actual integration tests
+// IndexedDB integration tests
+describe("IndexedDB CacheManager integration", () => {
+    let cacheManager;
 
-    it.todo("should initialize IndexedDB database");
-    it.todo("should cache and retrieve metadata");
-    it.todo("should cache and retrieve projects");
-    it.todo("should cache and retrieve thumbnails");
-    it.todo("should clear expired entries");
-    it.todo("should enforce max cache size");
+    beforeEach(async () => {
+        // fake-indexeddb v6 uses structuredClone
+        if (!global.structuredClone) {
+            global.structuredClone = val => JSON.parse(JSON.stringify(val));
+        }
+        global.indexedDB = new IDBFactory();
+        global.IDBKeyRange = IDBKeyRange;
+        cacheManager = new CacheManager({
+            dbName: "TestCache",
+            metadataExpiry: 1000,
+            projectExpiry: 2000,
+            maxCacheSize: 5
+        });
+        await cacheManager.init();
+    });
+
+    afterEach(() => {
+        cacheManager.close();
+        jest.useRealTimers();
+    });
+
+    describe("init()", () => {
+        let freshManager;
+
+        beforeEach(() => {
+            global.indexedDB = new IDBFactory();
+            global.IDBKeyRange = IDBKeyRange;
+            freshManager = new CacheManager({
+                dbName: "InitTestCache",
+                metadataExpiry: 1000,
+                projectExpiry: 2000,
+                maxCacheSize: 5
+            });
+        });
+
+        afterEach(() => {
+            freshManager.close();
+        });
+
+        test("returns true on success and sets isInitialized", async () => {
+            const result = await freshManager.init();
+            expect(result).toBe(true);
+            expect(freshManager.isInitialized).toBe(true);
+        });
+
+        test("calls clearExpired() automatically on init", async () => {
+            const spy = jest.spyOn(freshManager, "clearExpired");
+            await freshManager.init();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        test("returns false when window.indexedDB is missing", async () => {
+            const saved = global.indexedDB;
+            delete global.indexedDB;
+            const result = await freshManager.init();
+            global.indexedDB = saved;
+            expect(result).toBe(false);
+            expect(freshManager.isInitialized).toBe(false);
+        });
+
+        test("second call returns true without re-opening DB", async () => {
+            await freshManager.init();
+            const spy = jest.spyOn(freshManager, "_openDatabase");
+            const result = await freshManager.init();
+            expect(result).toBe(true);
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        test("creates all three object stores", async () => {
+            await freshManager.init();
+            const storeNames = freshManager.db.objectStoreNames;
+            expect(storeNames.contains("projectMetadata")).toBe(true);
+            expect(storeNames.contains("projectData")).toBe(true);
+            expect(storeNames.contains("projectThumbnails")).toBe(true);
+        });
+    });
+
+    describe("cacheMetadata / getMetadata", () => {
+        test("caches and retrieves metadata by id", async () => {
+            const metadata = { name: "Project A", author: "ABC" };
+            await cacheManager.cacheMetadata("proj-1", metadata);
+            expect(await cacheManager.getMetadata("proj-1")).toEqual(metadata);
+        });
+
+        test("returns null for unknown id", async () => {
+            expect(await cacheManager.getMetadata("nonexistent")).toBeNull();
+        });
+
+        test("returns null for expired entry", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheMetadata("proj-exp", { name: "Expired" });
+            jest.setSystemTime(BASE + 1500);
+            expect(await cacheManager.getMetadata("proj-exp")).toBeNull();
+            jest.useRealTimers();
+        });
+
+        test("returns data for non-expired entry", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            const metadata = { name: "Fresh" };
+            await cacheManager.cacheMetadata("proj-fresh", metadata);
+            jest.setSystemTime(BASE + 500);
+            expect(await cacheManager.getMetadata("proj-fresh")).toEqual(metadata);
+            jest.useRealTimers();
+        });
+    });
+
+    describe("cacheProject / getProject", () => {
+        test("caches and retrieves project by id", async () => {
+            const data = { blocks: [], notes: [] };
+            await cacheManager.cacheProject("p-1", data);
+            expect(await cacheManager.getProject("p-1")).toEqual(data);
+        });
+
+        test("returns null for unknown id", async () => {
+            expect(await cacheManager.getProject("unknown")).toBeNull();
+        });
+
+        test("returns null for expired project", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheProject("p-exp", { data: "old" });
+            jest.setSystemTime(BASE + 2500);
+            expect(await cacheManager.getProject("p-exp")).toBeNull();
+            jest.useRealTimers();
+        });
+
+        test("project stored past metadataExpiry but within projectExpiry", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            const data = { data: "alive" };
+            await cacheManager.cacheProject("p-alive", data);
+            jest.setSystemTime(BASE + 1500);
+            expect(await cacheManager.getProject("p-alive")).toEqual(data);
+            jest.useRealTimers();
+        });
+    });
+
+    describe("cacheThumbnail / getThumbnail", () => {
+        test("cache and retrieves thumbnail data URL", async () => {
+            const url = "data:image/png;base64,abc123";
+            await cacheManager.cacheThumbnail("t-1", url);
+            expect(await cacheManager.getThumbnail("t-1")).toBe(url);
+        });
+
+        test("cacheThumbnail returns true", async () => {
+            expect(await cacheManager.cacheThumbnail("t-1", "data:image/png;base64,...")).toBe(
+                true
+            );
+        });
+
+        test("returns null for unknown id", async () => {
+            expect(await cacheManager.getThumbnail("unknown")).toBeNull();
+        });
+
+        test("returns null for expired thumbnail", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheThumbnail("t-exp", "data:image/png;base64...");
+            jest.setSystemTime(BASE + 1500);
+            expect(await cacheManager.getThumbnail("t-exp")).toBeNull();
+            jest.useRealTimers();
+        });
+
+        test("getThumbnail does not update lastAccessed", async () => {
+            await cacheManager.cacheThumbnail("t1", "data:image/png;base64...");
+            const before = await cacheManager._getFromStore("projectThumbnails", "t1");
+            await cacheManager.getThumbnail("t1");
+            const after = await cacheManager._getFromStore("projectThumbnails", "t1");
+            expect(after.lastAccessed).toBeUndefined();
+            expect(before).toEqual(after);
+        });
+    });
+
+    describe("clearExpired", () => {
+        test("returns 0 when nothing is expired", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            expect(await cacheManager.clearExpired()).toBe(0);
+        });
+
+        test("removes only expired metadata", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheMetadata("old", { name: "Old" });
+            jest.setSystemTime(BASE + 1500);
+            await cacheManager.cacheMetadata("new", { name: "New" });
+            jest.setSystemTime(BASE + 1600);
+            const cleared = await cacheManager.clearExpired();
+            expect(cleared).toBe(1);
+            expect(await cacheManager.getMetadata("old")).toBeNull();
+            expect(await cacheManager.getMetadata("new")).toEqual({ name: "New" });
+            jest.useRealTimers();
+        });
+
+        test("removes only expired projects", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheProject("old-p", { data: "old" });
+            jest.setSystemTime(BASE + 2500);
+            await cacheManager.cacheProject("new-p", { data: "new" });
+            jest.setSystemTime(BASE + 2600);
+            const cleared = await cacheManager.clearExpired();
+            expect(cleared).toBe(1);
+            expect(await cacheManager.getProject("old-p")).toBeNull();
+            expect(await cacheManager.getProject("new-p")).toEqual({ data: "new" });
+            jest.useRealTimers();
+        });
+
+        test("clears from all three stores. Returns 3 when all three entries are expired", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheMetadata("m-all", { name: "M" });
+            await cacheManager.cacheProject("p-all", { data: "P" });
+            await cacheManager.cacheThumbnail("t-all", "data:image/png;base64,...");
+            jest.setSystemTime(BASE + 2500);
+            const cleared = await cacheManager.clearExpired();
+            expect(cleared).toBe(3);
+            jest.useRealTimers();
+        });
+
+        test("returns 0 after clearAll()", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.clearAll();
+            expect(await cacheManager.clearExpired()).toBe(0);
+        });
+    });
+
+    describe("clearAll", () => {
+        test("clearAll returns true", async () => {
+            expect(await cacheManager.clearAll()).toBe(true);
+        });
+
+        test("getStats returns all zeros after clearing", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.cacheProject("p-1", { data: "B" });
+            await cacheManager.clearAll();
+            expect(await cacheManager.getStats()).toEqual({
+                metadata: 0,
+                projects: 0,
+                thumbnails: 0
+            });
+        });
+
+        test("cached items are inaccessible after clearing", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.cacheProject("p-1", { data: "B" });
+            await cacheManager.cacheThumbnail("t-1", "data:...");
+            await cacheManager.clearAll();
+            expect(await cacheManager.getMetadata("m-1")).toBeNull();
+            expect(await cacheManager.getProject("p-1")).toBeNull();
+            expect(await cacheManager.getThumbnail("t-1")).toBeNull();
+        });
+
+        test("calling twice returns true both times", async () => {
+            expect(await cacheManager.clearAll()).toBe(true);
+            expect(await cacheManager.clearAll()).toBe(true);
+        });
+    });
+
+    describe("getStats", () => {
+        test("returns all zeros after init", async () => {
+            expect(await cacheManager.getStats()).toEqual({
+                metadata: 0,
+                projects: 0,
+                thumbnails: 0
+            });
+        });
+
+        test("returns accurate counts after caching items", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.cacheMetadata("m-2", { name: "B" });
+            await cacheManager.cacheProject("p-1", { data: "C" });
+            await cacheManager.cacheThumbnail("t-1", "data:...");
+            expect(await cacheManager.getStats()).toEqual({
+                metadata: 2,
+                projects: 1,
+                thumbnails: 1
+            });
+        });
+
+        test("returns all zeros after clearAll()", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.clearAll();
+            expect(await cacheManager.getStats()).toEqual({
+                metadata: 0,
+                projects: 0,
+                thumbnails: 0
+            });
+        });
+
+        test("re-caching same id does not double-count", async () => {
+            await cacheManager.cacheMetadata("m-1", { name: "A" });
+            await cacheManager.cacheMetadata("m-1", { name: "B" });
+            expect((await cacheManager.getStats()).metadata).toBe(1);
+        });
+
+        test("counts expired entries", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheMetadata("m-exp", { name: "Expired" });
+            jest.setSystemTime(BASE + 1500);
+            expect(await cacheManager.getMetadata("m-exp")).toBeNull();
+            expect((await cacheManager.getStats()).metadata).toBe(1);
+            jest.useRealTimers();
+        });
+    });
+
+    describe("enforceMaxSize", () => {
+        test("count stays at maxCacheSize after insertion beyond max", async () => {
+            for (let i = 0; i < 7; i++) {
+                await cacheManager.cacheMetadata(`m-${i}`, { name: `Item ${i}` });
+            }
+            expect((await cacheManager.getStats()).metadata).toBe(5);
+        });
+
+        test("does not remove when count is below maxCacheSize", async () => {
+            for (let i = 0; i < 3; i++) {
+                await cacheManager.cacheMetadata(`m-${i}`, { name: `Item ${i}` });
+            }
+            expect((await cacheManager.getStats()).metadata).toBe(3);
+        });
+
+        test("LRU removal: oldest lastAccessed is removed first on overflow", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            for (let i = 0; i < 5; i++) {
+                jest.setSystemTime(BASE + i * 100);
+                await cacheManager.cacheMetadata(`m-${i}`, { name: `Item ${i}` });
+            }
+            jest.setSystemTime(BASE + 1000);
+            await cacheManager.cacheMetadata("m-5", { name: "Item 5" });
+            expect((await cacheManager.getStats()).metadata).toBe(5);
+            const isRemoved = await cacheManager._getFromStore("projectMetadata", "m-0");
+            expect(isRemoved).toBeUndefined();
+            jest.useRealTimers();
+        });
+    });
+
+    describe("updateLastAccessed", () => {
+        test("getMetadata updates lastAccessed", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheMetadata("m-ua", { name: "Test" });
+            const before = await cacheManager._getFromStore("projectMetadata", "m-ua");
+            jest.setSystemTime(BASE + 500);
+            await cacheManager.getMetadata("m-ua");
+            const after = await cacheManager._getFromStore("projectMetadata", "m-ua");
+            expect(before.lastAccessed).toBe(BASE);
+            expect(after.lastAccessed).toBe(BASE + 500);
+            jest.useRealTimers();
+        });
+
+        test("does not throw for non-existent key", async () => {
+            await expect(
+                cacheManager._updateLastAccessed("projectMetadata", "nonexistent")
+            ).resolves.not.toThrow();
+        });
+
+        test("getProject updates lastAccessed", async () => {
+            const BASE = 1000;
+            jest.useFakeTimers();
+            jest.setSystemTime(BASE);
+            await cacheManager.cacheProject("p-ua", { data: "test" });
+            const before = await cacheManager._getFromStore("projectData", "p-ua");
+            jest.setSystemTime(BASE + 500);
+            await cacheManager.getProject("p-ua");
+            const after = await cacheManager._getFromStore("projectData", "p-ua");
+            expect(before.lastAccessed).toBe(BASE);
+            expect(after.lastAccessed).toBe(BASE + 500);
+            jest.useRealTimers();
+        });
+    });
 });


### PR DESCRIPTION
### Summary

- This PR adds comprehensive integration tests for `planet/js/CacheManager.js`, covering IndexedDB initialization, all cache operations (metadata, project data, thumbnail), expiry logic, LRU cache removal, cache stats, and cleanup, using in-memory IndexedDB from `fake-indexeddb`.
- The tests include 6 todos in Jest tests (also shown in results for `npm run test`).
---

### Changes


#### **1. Added `fake-indexeddb` package for testing IndexedDB operations**<br>

   - **What it is:** `fake-indexeddb` is an in-memory implementation of the IndexedDB API for Node.js environments.
  - **Why it is needed:** Without a real IndexedDB implementation, its operations in `CacheManager.js` cannot be tested.
  - **How it is used:** The `IDBFactory` and `IDBKeyRange` from `fake-indexeddb` Package are used in the `IndexedDB CacheManager integration` test suite. This allows to open a in-memory IndexedDB database, and execute all DB operations as they would in a browser.

#### 2. Added 38 IndexedDB integration tests using `fake-indexeddb` for `CacheManager.js`
---

### Test Additions

| Describe Block | Tests Added | Tests |
|---|---|---|
| `init()` | 5 | <ul><li>returns `true` on success and sets `isInitialized`<br><li>calls `clearExpired` automatically<br><li>returns `false` when `indexedDB` is missing<br><li>skips re-opening DB on second call<br><li>creates all three object stores |
| `cacheMetadata / getMetadata` | 4 | <ul><li>cache and retrieve metadata by id<br><li>unknown id returns `null`<br><li>expired entry returns `null`<br><li>non-expired entry returns data |
| `cacheProject / getProject` | 4 | <ul><li>cache and retrieve project by id<br><li>unknown id returns `null`<br><li>expired project returns `null`<br><li>project stored past `metadataExpiry` but within `projectExpiry` |
| `cacheThumbnail / getThumbnail` | 5 | <ul><li>Cache and retrieve thumbnail data URL<br><li>`cacheThumbnail` returns value<br><li>unknown id returns `null`<br><li>expired thumbnail returns `null`<br><li>`getThumbnail` does not update `lastAccessed` |
| `clearExpired` | 5 | <ul><li>returns `0` when nothing expired<br><li>removes only expired metadata<br><li>removes only expired projects<br><li>clears from all three stores<br><li>returns `0` after `clearAll()` |
| `clearAll` | 4 | <ul><li>clearAll returns `true`<br><li>getStats return all zeros after clearing<br><li>cached items are inaccessible after clearing<br><li>calling twice returns `true` both times |
| `getStats` | 5 | <ul><li>All zeros after init<br><li>accurate counts after caching<br><li>Returns all zeros after `clearAll()`<br><li>re-caching same id does not double-count<br><li>counts expired entries |
| `enforceMaxSize` | 3 | <ul><li>count stays at `maxCacheSize` after insertion beyond max<br><li>does not remove when count below the limit<br><li>LRU removal: oldest `lastAccessed` entry is removed first on overflow |
| `updateLastAccessed` | 3 | <ul><li>`getMetadata` updates `lastAccessed`<br><li>does not throw for non-existent key<br><li>`getProject` updates `lastAccessed` |

**Total tests added: 38**

---

### Steps to Test PR

1. Install dependencies:
`npm install`
(Ensures `fake-indexeddb` package is added)

2. Run the test suite:
   `npm run test`

3. All test should pass

---

### Coverage

#### Before
<img width="75%" alt="Screenshot from 2026-02-26 01-13-18" src="https://github.com/user-attachments/assets/e5610157-f522-49df-8ced-501cc71c8f76" />

#### After
<img width="75%" alt="Screenshot from 2026-02-26 01-12-30" src="https://github.com/user-attachments/assets/c5984226-331c-4cfa-aa8a-604a1cb00dc1" />

---

### Verification

All `CacheManager.js` tests pass
