### PR TITLE
fix: replace hardcoded IP with dynamic backend URL in reflection.js

### DIFF
--- a/js/widgets/__tests__/reflection.test.js
+++ b/js/widgets/__tests__/reflection.test.js
@@ -124,7 +124,7 @@ describe("ReflectionMatrix", () => {
             expect(reflection.isOpen).toBe(true);
             expect(reflection.isMaximized).toBe(false);
             expect(mockActivity.isInputON).toBe(true);
-            expect(reflection.PORT).toBe("http://3.105.177.138:8000");
+            expect(reflection.PORT).toBe("http://localhost:8000");
 
             expect(window.widgetWindows.windowFor).toHaveBeenCalledWith(
                 reflection,

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -76,7 +76,20 @@ class ReflectionMatrix {
         this.isOpen = true;
         this.isMaximized = false;
         this.activity.isInputON = true;
-        this.PORT = "http://3.105.177.138:8000"; // http://127.0.0.1:8000
+        this.PORT = (() => {
+            if (
+                window.location.hostname === "localhost" ||
+                window.location.hostname === "127.0.0.1"
+            ) {
+                return "http://localhost:8000";
+            } else if (
+                window.location.hostname.includes("musicblocks.sugarlabs.org")
+            ) {
+                return `${window.location.protocol}//api.musicblocks.sugarlabs.org`;
+            } else {
+                return `${window.location.protocol}//${window.location.hostname}:8000`;
+            }
+        })();
 
         const widgetWindow = window.widgetWindows.windowFor(this, "reflection", "reflection");
         this.widgetWindow = widgetWindow;

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -82,9 +82,7 @@ class ReflectionMatrix {
                 window.location.hostname === "127.0.0.1"
             ) {
                 return "http://localhost:8000";
-            } else if (
-                window.location.hostname.includes("musicblocks.sugarlabs.org")
-            ) {
+            } else if (window.location.hostname.includes("musicblocks.sugarlabs.org")) {
                 return `${window.location.protocol}//api.musicblocks.sugarlabs.org`;
             } else {
                 return `${window.location.protocol}//${window.location.hostname}:8000`;


### PR DESCRIPTION
## Description

Fixes #5918

The `PORT` value in `js/widgets/reflection.js` was hardcoded to a specific AWS IP address (`http://3.105.177.138:8000`), causing two problems:

1. **Mixed-content security error on production**: `musicblocks.sugarlabs.org` is served over HTTPS, so loading a `http://` resource from a raw AWS IP is blocked by the browser. The widget silently fails for all production users.
2. **Broken local development**: Developers must manually edit the source file to change the URL, with no environment detection.

## Changes Made

Replaced the hardcoded IP in `js/widgets/reflection.js` (`init()` method) with the same dynamic hostname-based resolver that `aidebugger.js` already uses:

```js
this.PORT = (() => {
    if (
        window.location.hostname === "localhost" ||
        window.location.hostname === "127.0.0.1"
    ) {
        return "http://localhost:8000";
    } else if (
        window.location.hostname.includes("musicblocks.sugarlabs.org")
    ) {
        return `${window.location.protocol}//api.musicblocks.sugarlabs.org`;
    } else {
        return `${window.location.protocol}//${window.location.hostname}:8000`;
    }
})();
```

## Testing

- On `localhost`: resolves to `http://localhost:8000` ✅
- On `musicblocks.sugarlabs.org`: resolves to `https://api.musicblocks.sugarlabs.org` ✅
- On any other host: uses `protocol//hostname:8000` ✅

## Checklist

- [x] I have read and followed the project's code of conduct.
- [x] The change is consistent with the existing codebase (`aidebugger.js` uses the identical pattern).
- [x] No tests needed — this is a configuration/URL resolution change with no logic side effects.
