### PR TITLE
fix: replace for-in with for-of on array in noteCounter

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -538,7 +538,7 @@ class Singer {
 
         for (const b in tur.endOfClampSignals) {
             tur.butNotThese[b] = [];
-            for (const i in tur.endOfClampSignals[b]) {
+            for (const i of tur.endOfClampSignals[b]) {
                 tur.butNotThese[b].push(i);
             }
         }


### PR DESCRIPTION
`noteCounter` iterates over `tur.endOfClampSignals[b]` (an array) using
`for...in`, which yields string keys instead of values.

Fix: Replace with `for...of` to correctly iterate array elements.