### PR TITLE
Fix broken Gulp setup and align it with repo structure

### DIFF
--- a/gulpfile.legacy.js
+++ b/gulpfile.legacy.js
@@ -1,3 +1,6 @@
+// Legacy gulpfile (non-functional)
+// Retained for reference only — use gulpfile.mjs instead.
+
 /*
   global
 

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -24,7 +24,7 @@ const paths = {
         dest: "dist/css"
     },
     sass: {
-        src: "scss/**/*.scss",
+        src: "css/**/*.sass",
         dest: "dist/css"
     }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-prettier": "^3.0.0",
+    "gulp-rename": "^2.0.0",
     "gulp-uglify": "^3.0.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
## PR Description

### Summary
This PR fixes the Gulp configuration so it matches the actual repository structure and does not fail immediately when contributors try to run it. 

## Problem

The current Gulp setup had multiple guaranteed breakpoints:
- The CommonJS `gulpfile.js` used an incorrect Babel preset and was not reliable to run.
- The ESM `gulpfile.mjs` referenced:
        - a SASS path that does not exist in this repo `(scss/**/*.scss)`
        - `gulp-rename`, which was not installed, causing an immediate runtime error

As a result, running Gulp would fail even before any build logic could execute. 

## Changes

- Retired the broken CommonJS gulpfile by renaming it to `gulpfile.legacy.js`  and marking it as legacy / reference-only.

- Updated `gulpfile.mjs` to match the repo’s actual SASS layout:
           - `scss/**/*.scss` → `css/**/*.sass`

- Added the missing dependency required by `gulpfile.mjs:`
      - added gulp-rename to devDependencies

## Why this change is safe

- No build system rewrite.
- No new tasks or output files added.
- No changes to existing CSS or JS output.
- This only aligns existing tooling with the files and dependencies already present in the repo. 

## How to test

<img width="271" height="105" alt="image" src="https://github.com/user-attachments/assets/18c4e489-4a13-4834-8b1e-b94f70c06264" />


### expected - 

<img width="986" height="617" alt="image" src="https://github.com/user-attachments/assets/a9bcfcf0-419a-4a9b-92eb-c074530094a7" /> 

- Gulp now loads the ESM gulpfile without crashing.

- Gulp runs successfully; Sass emits deprecation warnings for legacy @import usage, which existed before this change and are not addressed here to keep the PR focused. It’s a warning, not a failure, and nothing breaks . 

Notes

- `npm install` reports existing vulnerabilities via `npm audit.`
- This PR intentionally does not address them to keep the scope limited to fixing Gulp breakpoints only.
