### PR TITLE
De-globalize Activity access: introduce `ActivityContext`, remove `synthutils` `window.activity` stub, keep temporary bridge

### DIFF
--- a/js/activity-context.js
+++ b/js/activity-context.js
@@ -1,0 +1,59 @@
+/*
+ * ActivityContext
+ *
+ * Single authority for accessing the runtime Activity instance.
+ *
+ * NOTE: This repo uses RequireJS shims + globals for browser builds.
+ * This module supports AMD (RequireJS), CommonJS (Jest), and a browser global
+ * fallback (ActivityContext) without exporting the Activity instance onto
+ * window.activity.
+ */
+
+(function (root, factory) {
+    // Lazy singleton: factory runs once, under the loader's control when
+    // possible (AMD), but always exposes a global for non-AMD consumers.
+    let _mod;
+
+    function getModule() {
+        if (!_mod) _mod = factory();
+        return _mod;
+    }
+
+    if (typeof define === "function" && define.amd) {
+        define([], function () {
+            return getModule();
+        });
+    } else if (typeof module !== "undefined" && module.exports) {
+        module.exports = getModule();
+    }
+
+    // Ensure a global reference exists so non-AMD code (activity.js, synthutils.js)
+    // can access it immediately.
+    try {
+        root.ActivityContext = getModule();
+    } catch (e) {
+        // ignore if root is not writable in some hostile environments
+    }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+    "use strict";
+
+    let _activity = null;
+
+    function setActivity(activityInstance) {
+        if (!activityInstance) {
+            throw new Error("Cannot set ActivityContext with a falsy value");
+        }
+        _activity = activityInstance;
+    }
+
+    function getActivity() {
+        if (!_activity) {
+            throw new Error(
+                "Activity not initialized yet. Use dependency injection or wait for initialization."
+            );
+        }
+        return _activity;
+    }
+
+    return { setActivity, getActivity };
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -2969,7 +2969,19 @@ class Activity {
 
             // Expose activity instance for external checks
             if (typeof window !== "undefined") {
-                window.activity = this;
+                // Single authority: ActivityContext
+                // TODO: window.activity is deprecated; use ActivityContext instead
+                if (
+                    window.ActivityContext &&
+                    typeof window.ActivityContext.setActivity === "function"
+                ) {
+                    window.ActivityContext.setActivity(this);
+                }
+
+                // TEMP compatibility bridge
+                if (!window.activity) {
+                    window.activity = this;
+                }
             }
         };
 
@@ -3034,7 +3046,19 @@ class Activity {
 
             // Expose activity instance for external checks
             if (typeof window !== "undefined") {
-                window.activity = this;
+                // Single authority: ActivityContext
+                // TODO: window.activity is deprecated; use ActivityContext instead
+                if (
+                    window.ActivityContext &&
+                    typeof window.ActivityContext.setActivity === "function"
+                ) {
+                    window.ActivityContext.setActivity(this);
+                }
+
+                // TEMP compatibility bridge
+                if (!window.activity) {
+                    window.activity = this;
+                }
             }
         };
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -83,7 +83,7 @@ requirejs.config({
             exports: "Notation"
         },
         "utils/synthutils": {
-            deps: ["utils/utils"],
+            deps: ["utils/utils", "activity/activity-context"],
             exports: "Synth"
         },
         "activity/logo": {
@@ -96,7 +96,13 @@ requirejs.config({
             exports: "Logo"
         },
         "activity/activity": {
-            deps: ["utils/utils", "activity/logo", "activity/blocks", "activity/turtles"],
+            deps: [
+                "utils/utils",
+                "activity/activity-context",
+                "activity/logo",
+                "activity/blocks",
+                "activity/turtles"
+            ],
             exports: "Activity"
         },
         "materialize": {


### PR DESCRIPTION
## PR Description

### Why this change?

The codebase has historically relied on a global singleton pattern `(window.activity)` to access the runtime `Activity` instance. This causes a few recurring issues: 
- **Hidden dependencies** - any module can silently rely on `window.activity`, making load-order bugs hard to trace.
- **State masking**  - `synthutils` was fabricating a fake `window.activity` when Activity wasn’t ready, hiding real initialization problems.
- Poor testability -  globals get mutated instead of using explicit access or injection. 

**This PR begins the transition away from exporting the Activity instance onto `window`, without breaking existing consumers.** 

## What changed? 

### 1) Introduce a single Activity access API `(ActivityContext)` 
- New module: `activity-context.js`
- API: 
        - `setActivity(activityInstance)` - throws on falsy input
        -  `getActivity()` - throws if Activity isn’t initialized

- Works across this repo’s mixed environment:
 
- AMD / RequireJS
- CommonJS / Jest
- Browser global `(window.ActivityContext)`
- Important: this exposes an accessor, not the Activity instance itself. 

### 2] Stop exporting Activity directly onto `window` (keep a temporary bridge) 

Replaced direct `window.activity = this` assignments in `activity.js` with:
       - Preferred path: `ActivityContext.setActivity(this)`
       - Temporary compatibility bridge: keep `window.activity` if not already present

- The bridge is explicitly deprecated and intended for removal once consumers migrate. 

### 3] Remove fake Activity creation from synthutils 
- Removed the fallback stub that created a fake window.activity
- Added a safe accessor that:
     - Uses `ActivityContext.getActivity()` when available
     - Falls back to CommonJS for tests
     - Warns and exits early if Activity isn’t ready

`startTuner()`  now fails fast instead of fabricating partial state

This intentionally surfaces initialization errors rather than hiding them. 

### 4] Avoid mutating Activity from `synthutils` 

- Previously, `synthutils` attached properties (e.g. `logo`, `KeySignatureEnv`) directly onto the real Activity

This PR avoids that by:
- Creating a local `defaultLogo` (no-op safe)
- Using `Object.create(activity)` to build a short-lived proxy
- Attaching preview-only state to the proxy instead of the real Activity

Result: no hidden side-effects or “spooky action at a distance”. 

### 5] Ensure RequireJS load order

- Added activity/activity-context as a shim dependency for:
      - utils/synthutils
      - activity/activity

- Guarantees the accessor exists before consumers run.

## Reviewer notes

If you want to skim:

- activity-context.js -  new accessor (AMD + CJS + global)
- activity.js -  sets Activity via `ActivityContext` , keeps temporary bridge
- synthutils.js -  removes fake globals, avoids mutating Activity
- loader.js -  RequireJS shim dependencies 

## testing 

1] Jest 

<img width="423" height="133" alt="image" src="https://github.com/user-attachments/assets/311a71ac-0010-42ce-bc52-0a83d726a301" />

2] Console showing `ActivityContext` exists

<img width="337" height="61" alt="image" src="https://github.com/user-attachments/assets/9ad0f588-5dff-4dad-b861-3c5d6067da3b" />

3] Console showing Activity object returned

<img width="732" height="84" alt="image" src="https://github.com/user-attachments/assets/f9f6ac39-6ac2-4e5b-adb4-b057eb9c3056" />

4] Backward compatibility is preserved while migrating away from globals.

<img width="527" height="54" alt="image" src="https://github.com/user-attachments/assets/40e355e8-5532-4b75-8996-3335f570ce20" /> 

5] The dangerous `window.activity = {}` stub has been removed.

<img width="716" height="261" alt="image" src="https://github.com/user-attachments/assets/d85528d7-2ed4-4584-8723-81876c67dc5e" /> 


## Local note

`activity-context.js` is a new file - please ensure it’s included in the PR.



