### PR TITLE
fix/Removed incorrect node dependency causing Cl smoke test failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "http-server": "^14.1.1",
         "i18next": "^25.3.2",
         "i18next-http-backend": "^3.0.2",
-        "node": "^24.2.0",
         "postcss": "^8.5.6",
         "sass": "^1.97.2",
         "tone": "^15.1.22"


### PR DESCRIPTION
This PR is to remove the node dependency which was listed as npm package dependency and since it is a runtime environment and is already provided by the system, so having node as dependency caused the npm to install that package leading to 403 error and smoke test failure in the Cl. 