### PR TITLE
Increase PhraseMaker test coverage from 2% to 47%

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -668,7 +668,7 @@ describe("PhraseMaker Widget", () => {
 
         phraseMaker._deps.toFraction = jest.fn(v => v);
         phraseMaker.blockConnection = jest.fn();
-        jest.spyOn(global, "setTimeout").mockImplementation(fn => fn);
+        jest.spyOn(global, "setTimeout").mockImplementation(fn => fn());
 
         phraseMaker.activity = {
             blocks: {
@@ -1052,12 +1052,11 @@ describe("PhraseMaker Widget", () => {
                 loadNewBlocks: jest.fn()
             },
             refreshCanvas: jest.fn(),
+            textMsg: jest.fn(),
             logo: {
                 synth: { inTemperament: "custom" }
             }
         };
-
-        global.activity = { textMsg: jest.fn() };
 
         // RUN custom temperament first
         phraseMaker._deps.isCustomTemperament = jest.fn(() => true);
@@ -1095,12 +1094,11 @@ describe("PhraseMaker Widget", () => {
                 loadNewBlocks: jest.fn()
             },
             refreshCanvas: jest.fn(),
+            textMsg: jest.fn(),
             logo: {
                 synth: { inTemperament: "equal" }
             }
         };
-
-        global.activity = { textMsg: jest.fn() };
 
         phraseMaker._save();
 
@@ -1124,10 +1122,9 @@ describe("PhraseMaker Widget", () => {
                 loadNewBlocks: jest.fn()
             },
             refreshCanvas: jest.fn(),
+            textMsg: jest.fn(),
             logo: { synth: { inTemperament: "equal" } }
         };
-
-        global.activity = { textMsg: jest.fn() };
 
         phraseMaker._save();
     });


### PR DESCRIPTION
This PR significantly improves test coverage for phrasemaker.js, increasing overall coverage from ~2% to ~47% by adding structured unit tests that exercise major execution branches and complex UI-dependent logic.

**What was added-**
Added comprehensive test cases for major PhraseMaker methods including:
- init()
- _createColumnPieSubmenu()
- _lookForNoteBlocksOrRepeat()
- _noteWidth()
- _blockReplace()
- _export() (core execution path)
- Graphics and tuplets-related logic branches

Covered multiple execution branches such as:
- Grid initialization and measure calculation
- Lyrics-enabled rendering path
- Pitch block submenu logic
- Drum block submenu logic
- Accidentals and octave wheel branches
- Block connection and value update logic
- Note value rendering logic
- Export table generation path

Added appropriate mocking for:
- activity (turtles, blocks, logo.synth, canvas)
- wheelnav constructor and wheel instances
- PhraseMakerUI
- PhraseMakerUtils
- docById
- window.open
- getBoundingClientRect
- Nested block structures (blockList, connections, value)
- Platform color configuration
- Browser globals and DOM APIs

**Impact-**
- phrasemaker.js coverage increased from ~2% to ~47%
- Significant improvement in branch and function coverage
- Validates complex UI-driven logic without modifying production code
- Improves confidence in grid rendering, pitch selection, block mutation, and export logic

<img width="528" height="232" alt="Screenshot 2026-02-28 015318" src="https://github.com/user-attachments/assets/2e832223-fe1e-43c8-832b-2a1c34b9b996" />

- [x] Tests
