### PR TITLE
Fix module export for oscilloscope.js to enable proper Jest coverage

### DIFF
--- a/js/widgets/__tests__/oscilloscope.test.js
+++ b/js/widgets/__tests__/oscilloscope.test.js
@@ -80,11 +80,7 @@ function createMockWidgetWindow() {
     };
 }
 
-// Load the Oscilloscope class by reading the source and wrapping it
-// so the class is assigned to global (class declarations are block-scoped)
-const fs = require("fs");
-const path = require("path");
-const oscilloscopeSource = fs.readFileSync(path.resolve(__dirname, "../oscilloscope.js"), "utf-8");
+const Oscilloscope = require("../oscilloscope.js");
 
 let mockWidgetWindow;
 
@@ -95,10 +91,6 @@ window.widgetWindows = {
     _posCache: {},
     windowFor: jest.fn(() => mockWidgetWindow)
 };
-
-// Wrap source: execute the class definition and assign to global
-const wrappedSource = oscilloscopeSource + "\nglobal.Oscilloscope = Oscilloscope;\n";
-new Function(wrappedSource)();
 
 beforeEach(() => {
     mockWidgetWindow = createMockWidgetWindow();

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -326,3 +326,7 @@ class Oscilloscope {
         }
     }
 }
+
+if (typeof module !== "undefined") {
+    module.exports = Oscilloscope;
+}


### PR DESCRIPTION
This PR updates oscilloscope.js to properly export the Oscilloscope class using module.exports.

Previously, the test file was loading the source dynamically using fs.readFileSync and new Function(), which prevented Jest from instrumenting the file for coverage. As a result, oscilloscope.js was showing 0% coverage, even though comprehensive tests already existed.

**Changes Made-**
- Added proper JS Export 
`module.exports = Oscilloscope;`

-Updated the test file to import the module using:
`const Oscilloscope = require("../oscilloscope.js");`

-Removed dynamic evaluation via new Function() and fs.readFileSync() from tests.

**Impact-**
Jest can now correctly instrument oscilloscope.js.
Coverage for oscilloscope.js went from 0% to 76%.
Existing test suite is now reflected in coverage metrics.

<img width="637" height="69" alt="Screenshot 2026-02-28 022514" src="https://github.com/user-attachments/assets/6ba16e50-d7ef-487d-aa07-baf063dbb586" />
