### PR TITLE
Handle service worker fetch failures to prevent unhandled promise rej…

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -143,11 +143,16 @@ self.addEventListener("fetch", function (event) {
                 // This is where we call the server to get the newest
                 // version of the file to use the next time we show view
                 event.waitUntil(
-                    fetch(event.request).then(function (response) {
-                        if (response.ok) {
-                            return updateCache(event.request, response);
-                        }
-                    })
+                    fetch(event.request)
+                        .then(function (response) {
+                            if (response.ok) {
+                                return updateCache(event.request, response);
+                            }
+                        })
+                        .catch(function () {
+                            // Ignore network fetch failures when offline.
+                            // The cached response has already been returned.
+                        })
                 );
                 return response;
             },


### PR DESCRIPTION
issue: #5964 

Problem:-
The Service Worker attempts to refresh cached responses in the background using:

=> fetch(event.request)

inside event.waitUntil(). When the user is offline or the network request fails, this fetch promise rejects without a .catch() handler.
This results in:
-Uncaught (in promise) TypeError: Failed to fetch in the Service Worker context
-unnecessary runtime errors in offline scenarios
-noisy logs that obscure real issues
-Although the cached response or offline fallback is still served correctly, the unhandled rejection reduces reliability and violates safe offline handling practices.

Solution:-
-This PR adds safe promise handling to the background fetch operation.
-adds a .catch() handler to gracefully handle network failures
-prevents unhandled promise rejections when offline
-preserves existing caching and fallback behavior
-does not modify response handling or cache logic

Changes Made:-
-File modified:
->sw.js
-> added safe .catch() handler to background fetch inside event.waitUntil()
-> prevents runtime errors when offline

-ESLint: ✅ no lint errors
-Tests: ✅ all tests passed

Impact:-
-Prevents unhandled promise rejection errors
-Improves offline reliability and PWA stability
-Reduces console noise during offline operation
-No functional regressions

Notes:-
This change is intentionally minimal and non-breaking. It ensures safe background cache updates while preserving existing service worker behavior and offline fallback handling.

Happy to adjust if maintainers prefer alternative error handling strategies.