### PR TITLE
Limit Lilypond Hertz export precision to 2 decimal places

### DIFF
--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -334,7 +334,8 @@ function setupPitchActions(activity) {
                         transformedHertz = pitchToFrequency(p, o, c, tur.singer.keySignature);
 
                         if (c !== 0) {
-                            activity.logo.notation.notationMarkup(turtle, transformedHertz);
+                            const formattedHertz = Number(transformedHertz.toFixed(2));
+                            activity.logo.notation.notationMarkup(turtle, formattedHertz);
                         }
                     }
                 }

--- a/js/turtleactions/__tests__/PitchActions.test.js
+++ b/js/turtleactions/__tests__/PitchActions.test.js
@@ -270,6 +270,34 @@ describe("Tests for Singer.PitchActions setup", () => {
         expect(spyMark).toHaveBeenCalled();
     });
 
+    test("playHertz exports Hertz rounded to 2 decimal places for Lilypond", () => {
+        turtle.singer.notePitches = { 1: [] };
+        turtle.singer.noteOctaves = { 1: [] };
+        turtle.singer.noteCents = { 1: [] };
+        turtle.singer.inNoteBlock = [1];
+        activity.logo.runningLilypond = true;
+
+        // Simulate a microtonal pitch producing a long decimal frequency
+        Singer.processPitch.mockImplementation(() => {
+            turtle.singer.notePitches[1].push("A");
+            turtle.singer.noteOctaves[1].push(4);
+            turtle.singer.noteCents[1].push(23); // non-clean cents value
+        });
+
+        const spyMark = jest.spyOn(activity.logo.notation, "notationMarkup");
+
+        Singer.PitchActions.playHertz(440, 0, blkId);
+
+        expect(spyMark).toHaveBeenCalled();
+
+        const exportedHertz = spyMark.mock.calls.at(-1)[1];
+
+        // proves value is rounded to 2 decimal places
+        expect(exportedHertz).toBe(Number(exportedHertz.toFixed(2)));
+
+        spyMark.mockRestore();
+    });
+
     test("playHertz notationMarkup occurs only when both inNoteBlock AND runningLilypond AND microtonal", () => {
         const spyMark = jest.spyOn(activity.logo.notation, "notationMarkup");
         turtle.singer.inNoteBlock = [1];


### PR DESCRIPTION
### Summary

Adjust Lilypond Hertz export to limit floating-point precision.

Pitch-to-frequency conversion can produce long decimal values due to floating-point calculations. This PR formats exported Hertz values to **2 decimal places** so Lilypond output is cleaner and easier to read while matching playback behaviour.

This is a follow-up improvement suggested during review of the Hertz Lilypond export fix PR (#5620).

---

### Changes

* Format Hertz values using `toFixed(2)` before Lilypond markup emission
* Apply formatting only in the Lilypond export path
* No changes to pitch processing or playback logic

---

### Testing

* Added unit test verifying exported Hertz values are rounded to 2 decimal places
* Existing `playHertz` tests continue to pass
* test for this change passes successfully.

---

### Note

This change affects only exported notation formatting and does not modify audio playback or internal pitch calculations.
