### PR TITLE
fix: scope articulation volume pop to synths present at push time

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -114,8 +114,9 @@ function setupVolumeActions(activity) {
          */
         static setRelativeVolume(volume, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
+            const synthList = Object.keys(tur.singer.synthVolume);
 
-            for (const synth in tur.singer.synthVolume) {
+            for (const synth of synthList) {
                 let newVolume = (last(tur.singer.synthVolume[synth]) * (100 + volume)) / 100;
                 newVolume = Math.max(Math.min(newVolume, 100), -100);
 
@@ -143,7 +144,7 @@ function setupVolumeActions(activity) {
             }
 
             const __listener = () => {
-                for (const synth in tur.singer.synthVolume) {
+                for (const synth of synthList) {
                     tur.singer.synthVolume[synth].pop();
                     Singer.setSynthVolume(
                         activity.logo,


### PR DESCRIPTION
fix: prevent Articulation block from muting instruments added inside its scope

Wrapping Set Timbre + notes inside Articulation silently mutes that instrument for the rest of the run.

**Root cause:** `setRelativeVolume()` pushes volume adjustments to synths existing at entry time, but the listener's pop loop re-iterates `tur.singer.synthVolume` at exit—which now includes synths added inside the scope (e.g., by Set Timbre). Those new synths never received a push, so the pop drains their only volume entry. `last([])` returns null, which `setSynthVolume` clamps to 0, permanently muting the instrument.

**Fix:** Capture the synth list once before the push loop and use that same list in both push and pop:

```javascript
// js/turtleactions/VolumeActions.js:117
const synthList = Object.keys(tur.singer.synthVolume);

// Push loop (line 118): iterate captured list
for (const synth of synthList) {
    tur.singer.synthVolume[synth].push(newVolume);
}

// Pop loop (line 146): iterate same captured list
for (const synth of synthList) {
    tur.singer.synthVolume[synth].pop();
    // ...
}
```
This ensures only synths that received a push get popped, preventing empty stack corruption.

**Testing:**
[x] Guitar inside Articulation → continues working after block ends
[x] Multiple instruments → only scoped ones affected
[x] Nested articulations → correct stack depth maintained
[x] No Articulation → original behavior unchanged