### PR TITLE
Fix spam-clicking Run button causing unhighlight error

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1692,6 +1692,11 @@ class Activity {
         };
 
         this._doFastButton = env => {
+            // Prevent spam-clicking by checking if already running
+            if (this.logo._alreadyRunning) {
+                return;
+            }
+
             this._onResize();
             this.blocks.activeBlock = null;
             hideDOMLabel();


### PR DESCRIPTION
Fixes #6010

### Problem
Rapidly clicking the Run button causes a runtime error:
Uncaught TypeError: Cannot read properties of undefined (reading 'unhighlight') at Blocks.unhighlight (blocks.js:2974)

This happens because overlapping executions create race conditions where blocks may be removed or modified while unhighlight operations are still queued.

### Solution
This PR implements two safeguards:

1. **Added existence check in `blocks.js`**: Before calling `unhighlight()` on a block, verify that the block exists in `blockList` to prevent accessing undefined objects.

2. **Prevent concurrent executions in `activity.js`**: Added a guard in `_doFastButton()` to check the existing `_alreadyRunning` flag, preventing multiple simultaneous executions when the Run button is spam-clicked.
- [x] Bug Fix

