### PR TITLE
Fix toolbar button misalignment after theme change

### DIFF
--- a/js/themebox.js
+++ b/js/themebox.js
@@ -173,14 +173,18 @@ class ThemeBox {
         // Refresh UI components that depend on platformColor
         this.refreshUIComponents();
 
-        setTimeout(() => {
-            const topRightButtons = document.querySelectorAll("#buttoncontainerTOP .tooltipped");
-            const navHeight = document.querySelector("nav")?.offsetHeight || 64;
-            const BASE_TOP = navHeight + 12;
-            topRightButtons.forEach(btn => {
-                btn.style.top = BASE_TOP + globalActivity.toolbarHeight + "px";
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                const topRightButtons = document.querySelectorAll(
+                    "#buttoncontainerTOP .tooltipped"
+                );
+                const navHeight = document.querySelector("nav")?.offsetHeight || 64;
+                const BASE_TOP = navHeight + 12;
+                topRightButtons.forEach(btn => {
+                    btn.style.top = BASE_TOP + globalActivity.toolbarHeight + "px";
+                });
             });
-        }, 50);
+        });
 
         // Notify user
         this.activity.textMsg(_("Theme switched to " + this._theme + " mode."), 2000);


### PR DESCRIPTION
### Description
This PR fixes a UI layout issue where the top-right toolbar buttons shift upward after switching themes using applyThemeInstantly().
After a theme change, the buttons’ top position changes from 76px to 16px.
However, after a full page reload, the layout restores correctly.
This indicates that the issue is not with styling itself, but with layout recalculation during instant theme switching.

### Root Cause
When applyThemeInstantly() updates theme classes and refreshes canvas/UI components, the toolbar layout is partially recalculated. However, the top-right button container does not properly recompute its vertical offset.
As a result:
- The toolbar height is effectively reset visually
- The buttons inherit an incorrect top value (16px)
- A page reload fixes it because the layout initializes in the correct order

### What was changed:
After applying the theme, this PR explicitly restores the correct vertical position of the top-right toolbar buttons by recalculating and setting their top value.
This ensures:
- Consistent positioning after theme switch
- No visual regression
- Behavior identical to post-reload layout

### Video

https://github.com/user-attachments/assets/d5004454-46b1-4d42-bc1b-efaf8d5aaaa2

References the issue:
Fixes #6017 