### PR TITLE
fixed logoconstants.js

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -53,6 +53,9 @@ requirejs.config({
             deps: ["utils/platformstyle"],
             exports: "_"
         },
+        "activity/logoconstants": {
+            deps: ["utils/utils"]
+        },
         "activity/turtledefs": {
             deps: ["utils/utils"],
             exports: "createDefaultStack"


### PR DESCRIPTION
I have applied the fix to js/loader.js

By adding activity/logoconstants to the RequireJS shim with a dependency on utils/utils, we ensure that the translation function _ is always defined before 

logoconstants.js tries to use it.

Changes made: 
"activity/logoconstants": {
    deps: ["utils/utils"]
},

closes #6019 