### PR TITLE
Fix undefined pause() call in updateBounds

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -422,7 +422,7 @@ class Block {
 
                     if (that.bounds === null) {
                         const delayTime = INITIAL_DELAY * Math.pow(2, loopCount);
-                        await that.pause(delayTime);
+                        await new Promise(resolve => setTimeout(resolve, delayTime));
                         updateBounds(loopCount + 1);
                     } else {
                         that.container.updateCache();


### PR DESCRIPTION
Fixes a runtime error caused by calling an undefined `pause()` method inside `updateBounds()` in `js/block.js`.

Previously, the code used `await that.pause(delayTime)`, but `pause()` is not defined on the Block object, which could result in `TypeError: that.pause is not a function`.

This PR replaces it with a standard async delay using:
`await new Promise(resolve => setTimeout(resolve, delayTime));`

This preserves the intended retry behavior while preventing uncaught promise rejections.

closes #6038