### PR TITLE
test: Add GlideBlock __listener coverage for OrnamentBlocks.js

### DIFF
--- a/js/blocks/__tests__/OrnamentBlocks.test.js
+++ b/js/blocks/__tests__/OrnamentBlocks.test.js
@@ -259,6 +259,45 @@ describe("setupOrnamentBlocks", () => {
             expect(activity.errorMsg).toHaveBeenCalledWith(NOINPUTERRORMSG, "blkGlide");
             expect(result).toEqual([8, 1]);
         });
+        it("should call notationEndSlur in __listener when justCounting is empty", () => {
+            const glideBlock = createdBlocks["glide"];
+            const turtleIndex = 0;
+            const turtleObj = activity.turtles.ithTurtle(turtleIndex);
+            turtleObj.singer.glide = []; // ← empty, flow() will push 0.1
+            turtleObj.singer.justCounting = [];
+
+            let capturedListener = null;
+            logo.setTurtleListener = jest.fn((turtle, name, fn) => {
+                capturedListener = fn;
+            });
+
+            glideBlock.flow([0.1, 8], logo, turtleIndex, "blkGlide");
+            expect(capturedListener).not.toBeNull();
+            capturedListener({});
+
+            expect(logo.notation.notationEndSlur).toHaveBeenCalledWith(turtleIndex);
+            expect(turtleObj.singer.glide).toHaveLength(0); // pushed 0.1 then popped
+        });
+
+        it("should skip notationEndSlur in __listener when justCounting is non-empty", () => {
+            const glideBlock = createdBlocks["glide"];
+            const turtleIndex = 0;
+            const turtleObj = activity.turtles.ithTurtle(turtleIndex);
+            turtleObj.singer.glide = []; // ← empty, flow() will push 0.1
+            turtleObj.singer.justCounting = [true];
+
+            let capturedListener = null;
+            logo.setTurtleListener = jest.fn((turtle, name, fn) => {
+                capturedListener = fn;
+            });
+
+            glideBlock.flow([0.1, 8], logo, turtleIndex, "blkGlide");
+            expect(capturedListener).not.toBeNull();
+            capturedListener({});
+
+            expect(logo.notation.notationEndSlur).not.toHaveBeenCalled();
+            expect(turtleObj.singer.glide).toHaveLength(0); // pushed 0.1 then popped
+        });
     });
 
     describe("SlurBlock", () => {


### PR DESCRIPTION
## Summary

Adds two tests to cover the `__listener` callback in `GlideBlock` (lines 431-435),
bringing line coverage to 100%.

## Changes

| File | Tests Added | Lines Covered |
|---|---|---|
| `js/blocks/__tests__/OrnamentBlocks.test.js` | 2 | 431-435 |

## Coverage
```
OrnamentBlocks.js | 94.4 | 97.91 | 73.07 | 100 |
```

## Verification
```
Tests: 24 passed, 24 total
```
## PR Category
- [ ] Bug Fix
- [ ] Performance
- [ ] Feature
- [x] Tests
- [ ] Documentation