### PR TITLE
Test: Improve pitchslider.js coverage – mousedown listener branch

### DIFF
--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -521,6 +521,15 @@ describe("PitchSlider Widget", () => {
                 expect.any(Function)
             );
         });
+        test("mousedown event sets activeSlider to slider id", () => {
+            const mousedownCall = slider.sliders[0].addEventListener.mock.calls.find(
+                call => call[0] === "mousedown"
+            );
+            const mousedownHandler = mousedownCall[1];
+            slider.activeSlider = null;
+            mousedownHandler();
+            expect(slider.activeSlider).toBe("0");
+        });
     });
 
     describe("Block Generation (_save)", () => {


### PR DESCRIPTION
## Summary

Adds one test to fire the `mousedown` event listener on the slider element,
covering line 129 and bringing line coverage to 100%.

## Changes

| File | Tests Added | Lines Covered |
|---|---|---|
| `js/widgets/__tests__/pitchslider.test.js` | 1 | 129 |

## Coverage
```
pitchslider.js | 100 | 90 | 100 | 100 |
```

## Verification
```
Tests: 61 passed, 61 total
```
## PR Category
- [ ] Bug Fix
- [ ] Performance
- [ ] Feature
- [x] Tests
- [ ] Documentation