### PR TITLE
Test: Improve boundary.js coverage – image onload callback

### DIFF
--- a/js/__tests__/boundary.test.js
+++ b/js/__tests__/boundary.test.js
@@ -108,6 +108,19 @@ describe("Boundary Class", () => {
         expect(mockImage.src).toContain("data:image/svg+xml;base64,");
         imgMock.mockRestore();
     });
+    it("should add bitmap to container when image loads", () => {
+        const mockImage = { onload: null, src: "" };
+        jest.spyOn(global, "Image").mockImplementation(() => mockImage);
+
+        boundary.create(800, 600, 2);
+
+        mockImage.onload();
+
+        expect(createjs.Bitmap).toHaveBeenCalledWith(mockImage);
+        expect(boundary._container.addChild).toHaveBeenCalled();
+
+        global.Image.mockRestore();
+    });
 });
 
 describe("offScreen edge cases", () => {


### PR DESCRIPTION
## Summary

Adds one test to fire the `img.onload` callback in `Boundary.create()`,
covering lines 87-88 and bringing line coverage to 100%.

## Changes

| File | Tests Added | Lines Covered |
|---|---|---|
| `js/__tests__/boundary.test.js` | 1 | 87-88 |

## Coverage
```
boundary.js | 100 | 90 | 100 | 100 |
```

## Verification
```
Tests: 31 passed, 31 total
```