### PR TITLE
fix: proxy GROQ API calls through Express to protect API key

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,30 @@ app.get("/env.js", (req, res) => {
             `window.MB_IS_DEV=${JSON.stringify(isDev)};`
     );
 });
+// Proxy endpoint for GROQ API — keeps the API key server-side only.
+// The client calls /api/groq instead of the GROQ API directly,
+// so the API key is never exposed in the browser.
+app.post("/api/groq", express.json(), async (req, res) => {
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) {
+        return res.status(503).json({ error: "GROQ API key not configured on the server." });
+    }
+
+    try {
+        const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${apiKey}`
+            },
+            body: JSON.stringify(req.body)
+        });
+        const data = await response.json();
+        res.json(data);
+    } catch (error) {
+        res.status(502).json({ error: "Failed to reach GROQ API" });
+    }
+});
 
 // Enable compression for all responses
 app.use(

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -1138,7 +1138,7 @@ function AIWidget() {
                 return;
             }
 
-            const apiUrl = "https://api.groq.com/openai/v1/chat/completions";
+            const apiUrl = "/api/groq";
             const prompt_eng = `
             Generate an ABC notation song based on the following description:
             
@@ -1184,8 +1184,7 @@ function AIWidget() {
             fetch(apiUrl, {
                 method: "POST",
                 headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${env.GROQ_API_KEY}` // Replace with your actual API key
+                    "Content-Type": "application/json"
                 },
                 body: requestBody
             })


### PR DESCRIPTION
## Summary
Fixes #6044

The AI Music widget ([js/widgets/aiwidget.js](cci:7://file:///Users/shreyash12/Files/Github/Contribution/sugarLab-musicblocks/js/widgets/aiwidget.js:0:0-0:0)) was making direct browser-to-GROQ API calls, exposing the API key to anyone with browser DevTools.

## Changes
[index.js](cci:7://file:///Users/shreyash12/Files/Github/Contribution/sugarLab-musicblocks/index.js:0:0-0:0)**: Added `/api/groq` POST endpoint that reads `GROQ_API_KEY` from `process.env` and proxies requests to the GROQ API
[aiwidget.js](cci:7://file:///Users/shreyash12/Files/Github/Contribution/sugarLab-musicblocks/js/widgets/aiwidget.js:0:0-0:0)**: Changed `fetch()` to call `/api/groq` instead of the external GROQ API, removed the `Authorization` header from client-side code

## Security
- API key is now server-side only (read from environment variable)
- Returns 503 if the key is not configured
- Returns 502 if the upstream GROQ API is unreachable
<img width="556" height="208" alt="screenshot 2026-03-03 at 8 12 16 PM" src="https://github.com/user-attachments/assets/a3598986-5459-47b6-86f8-59571bbd311d" />
<img width="677" height="81" alt="screenshot 2026-03-03 at 8 13 07 PM" src="https://github.com/user-attachments/assets/a5c09755-585f-49fa-bb7f-9f245b1790fe" />
