### PR TITLE
Test Suite: Extend unit tests for status.js

### DIFF
--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -178,6 +178,14 @@ describe("StatusMatrix Widget", () => {
             statusMatrix.init(mockActivity);
             expect(statusMatrix.activity).toBe(mockActivity);
         });
+        test("onmaximize toggles isMaximized and updates cell styles", () => {
+            statusMatrix.init(mockActivity);
+            statusMatrix.isMaximized = false;
+            statusMatrix.widgetWindow.onmaximize();
+            expect(statusMatrix.isMaximized).toBe(true);
+            statusMatrix.widgetWindow.onmaximize();
+            expect(statusMatrix.isMaximized).toBe(false);
+        });
     });
 
     describe("Onclose Handler", () => {
@@ -227,6 +235,32 @@ describe("StatusMatrix Widget", () => {
         });
 
         test("handles namedbox with privateData as label", () => {
+            statusMatrix.init(mockActivity);
+            expect(statusMatrix._statusTable).toBeDefined();
+        });
+        test("handles bpm block with ja language preference", () => {
+            Object.defineProperty(global, "localStorage", {
+                value: { languagePreference: "ja" },
+                writable: true,
+                configurable: true
+            });
+            mockActivity.blocks.blockList = {
+                0: { name: "bpm", protoblock: { staticLabels: ["beats per minute"] }, value: 120 }
+            };
+            mockActivity.logo.statusFields = [[0, "bpm"]];
+            statusMatrix.init(mockActivity);
+            expect(statusMatrix._statusTable).toBeDefined();
+            Object.defineProperty(global, "localStorage", {
+                value: { languagePreference: "en" },
+                writable: true,
+                configurable: true
+            });
+        });
+        it("uses privateData for outputtools block", () => {
+            mockActivity.blocks.blockList = {
+                0: { name: "outputtools", privateData: "someData", value: null }
+            };
+            mockActivity.logo.statusFields = [[0, "outputtools"]];
             statusMatrix.init(mockActivity);
             expect(statusMatrix._statusTable).toBeDefined();
         });
@@ -437,6 +471,14 @@ describe("StatusMatrix Widget", () => {
 
             statusMatrix.updateAll();
             expect(mockActivity.logo.parseArg).toHaveBeenCalled();
+        });
+        test("handles default case for unknown block name", () => {
+            mockActivity.blocks.blockList = {
+                0: { name: "unknownblock", value: 99 }
+            };
+            mockActivity.logo.statusFields = [[0, "unknownblock"]];
+            statusMatrix.updateAll();
+            expect(statusMatrix._statusTable.rows[1].cells[1].innerHTML).toBe(99);
         });
     });
 


### PR DESCRIPTION
## Summary

Extends unit tests for `js/widgets/status.js`, improving line coverage to 100%.

### Coverage improvement
| Metric | Before | After |
|--------|--------|-------|
| Statements | 98.26% | 100% |
| Functions | 100% | 100% |
| Lines | 98.24% | 100% |
| Branches | 88.13% | 91.52% |

### What is added
- onmaximize toggle behaviour (isMaximized true/false)
- bpm label with Japanese language preference (localStorage branch)
- outputtools privateData label handling
- Default case for unknown block names in updateAll

All 123 test suites passing locally.

@walterbender @omsuneri