### PR TITLE
perf(activity): avoid O(n^2) index lookups in prepareExport

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6326,6 +6326,7 @@ class Activity {
          */
         this.prepareExport = () => {
             const blockMap = [];
+            const blockIndexById = new Map();
             this.hasMatrixDataBlock = false;
             for (let blk = 0; blk < this.blocks.blockList.length; blk++) {
                 const myBlock = this.blocks.blockList[blk];
@@ -6334,6 +6335,7 @@ class Activity {
                     continue;
                 }
 
+                blockIndexById.set(blk, blockMap.length);
                 blockMap.push(blk);
             }
 
@@ -6477,17 +6479,19 @@ class Activity {
 
                 const connections = [];
                 for (let c = 0; c < myBlock.connections.length; c++) {
-                    const mapConnection = blockMap.indexOf(myBlock.connections[c]);
-                    if (myBlock.connections[c] === null || mapConnection === -1) {
+                    const connection = myBlock.connections[c];
+                    const mapConnection = blockIndexById.get(connection);
+                    if (connection === null || mapConnection === undefined) {
                         connections.push(null);
                     } else {
                         connections.push(mapConnection);
                     }
                 }
 
+                const blockIndex = blockIndexById.get(blk);
                 if (args === null) {
                     data.push([
-                        blockMap.indexOf(blk),
+                        blockIndex,
                         myBlock.name,
                         myBlock.container.x,
                         myBlock.container.y,
@@ -6495,7 +6499,7 @@ class Activity {
                     ]);
                 } else {
                     data.push([
-                        blockMap.indexOf(blk),
+                        blockIndex,
                         [myBlock.name, args],
                         myBlock.container.x,
                         myBlock.container.y,


### PR DESCRIPTION
## Description

Optimizes `Activity.prepareExport()` by replacing repeated linear `indexOf` searches with a precomputed block-id-to-export-index map.

## Related Issue

This PR fixes #6053

## Changes Made

- Added `blockIndexById` (`Map`) while constructing `blockMap`.
- Replaced per-connection `blockMap.indexOf(...)` with `blockIndexById.get(...)`.
- Replaced per-block `blockMap.indexOf(blk)` with cached `blockIndex` lookup.
- Preserved existing export JSON shape/ordering and null handling for missing connections.

## Testing Performed

- Ran:
  - `npm test -- --runTestsByPath js/__tests__/activity_state_management.test.js js/__tests__/activity_pure_functions.test.js`
- Result:
  - Both test suites passed (58 tests).
  - Existing coverage-collection parser issue in `js/block.js` was reported by Jest instrumentation, unrelated to this change.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

This is a small complexity reduction in a save/export path:
- before: repeated `indexOf` lookups inside nested loops (O(n^2) behavior)
- after: O(1) index resolution via `Map`