### PR TITLE
perf(blocks): remove redundant indexOf in noteValueNumber

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4789,7 +4789,7 @@ class Blocks {
                 this.blockList[dblk].name === "divide"
             ) {
                 /** Are we the denominator (c == 2) or numerator (c == 1)? */
-                if (this.blockList[dblk].connections[c] === this.blockList.indexOf(myBlock)) {
+                if (this.blockList[dblk].connections[c] === blk) {
                     /** Is the divide block connected to a note value block? */
                     const cblk = this.blockList[dblk].connections[0];
                     if (cblk !== null) {


### PR DESCRIPTION
## Description

Removes a redundant linear lookup in `Blocks.noteValueNumber()` by using the already-known block index (`blk`) directly.

## Related Issue

This PR fixes #6056

## Changes Made

- Replaced `this.blockList.indexOf(myBlock)` with `blk` in `noteValueNumber()`.
- No logic/behavior change; this is an equivalent comparison with lower cost.

## Testing Performed

- Ran:
  - `npm test -- --runTestsByPath js/blocks/__tests__/NumberBlocks.test.js`
- Result:
  - Test suite passed (24 tests).
  - Existing unrelated coverage parser issue in `js/block.js` was reported during coverage collection.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

This is intentionally small and low risk: same semantics, reduced per-call overhead in a frequently-invoked block analysis path.