### PR TITLE
chore: remove debug console statements from js/toolbar.js

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -766,13 +766,11 @@ class Toolbar {
                 saveButtonAdvanced.style.display = "none";
                 saveButton.onclick = () => {
                     const saveHTML = docById("save-html-beg");
-                    console.debug(saveHTML);
                     saveHTML.onclick = () => {
                         html_onclick(this.activity);
                     };
 
                     const savePNG = docById("save-png-beg");
-                    console.debug(savePNG);
                     const svgData = doSVG_onclick(
                         this.activity.canvas,
                         this.activity.logo,
@@ -795,7 +793,6 @@ class Toolbar {
                 };
             }
         } else {
-            console.debug("ADVANCED MODE BUTTONS");
             saveButton.style.display = "none";
             saveButtonAdvanced.style.display = "block";
             saveButtonAdvanced.onclick = () => {
@@ -807,7 +804,6 @@ class Toolbar {
                 };
                 const saveSVG = docById("save-svg");
                 const savePNG = docById("save-png");
-                console.debug(savePNG);
                 const svgData = doSVG_onclick(
                     this.activity.canvas,
                     this.activity.logo,


### PR DESCRIPTION
Part of #5464



Removes 4 leftover `console.debug` statements from `js/toolbar.js` in the `renderSaveIcons` method. These are pure variable dumps not in catch blocks or error handlers — safe to remove per the issue guidelines.

### Statements removed

| Line (before) | Statement |
|---|---|
| 769 | `console.debug(saveHTML);` |
| 775 | `console.debug(savePNG);` |
| 798 | `console.debug("ADVANCED MODE BUTTONS");` |
| 810 | `console.debug(savePNG);` |

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npx prettier --write js/toolbar.js` with no errors.
