### PR TITLE
Chore: Update outdated actions and remove redundant CI steps

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,7 +35,3 @@ jobs:
             - name: Build project
               run: npm run build --if-present
 
-            # Post-run cleanup to remove the build directory after the job finishes
-            - name: Post-run cleanup
-              if: always()
-              run: rm -rf ./build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v9
         with:
           stale-pr-message: 'This pull request has been open for more than 60 days without any activity. It will be closed in 3 days unless the `stale` label is removed or commented on.'
           close-pr-message: 'Closed pull request due to inactivity for more than 63 days.'


### PR DESCRIPTION
**Description:**
This PR cleans up a little bit of technical debt in the CI workflows to clear out GitHub warnings and shave off unnecessary execution time.

**Changes made:**

stale.yml: Updated actions/stale from v3 to v9. The v3 action relies on a deprecated version of Node.js (Node 12/16), which causes GitHub Actions to flag the run with deprecation warnings. Bumping to v9 clears the warnings and uses modern Node environments.

node.js.yml: Removed the final Post-run cleanup step (rm -rf ./build). Because GitHub Actions runners are ephemeral and automatically destroyed the moment the job finishes, manually deleting the build directory wastes runner compute time.

**Type of Change:**

[x] Chore (Maintenance, refactoring, or tooling upgrades)
[x]Performance improvement

CLOSES #6076