### PR TITLE
perf(startup): lazy-load ABCJS library to reduce startup blocking

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -41,7 +41,7 @@
    SHARP, FLAT, buildScale, TREBLE_F, TREBLE_G, GIFAnimator,
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
-   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS
+   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS
  */
 
 /*
@@ -7814,11 +7814,12 @@ class Activity {
                 };
 
                 // Music Block Parser from abc to MB
-                abcReader.onload = event => {
+                abcReader.onload = async event => {
                     //get the abc data and replace the / so that the block does not break
                     let abcData = event.target.result;
                     abcData = abcData.replace(/\\/g, "");
 
+                    await ensureABCJS();
                     const tunebook = new ABCJS.parseOnly(abcData);
 
                     console.log(tunebook);

--- a/js/utils/abcLoader.js
+++ b/js/utils/abcLoader.js
@@ -1,0 +1,61 @@
+/**
+ * @file Lazy loader for the ABCJS library.
+ * @author Parth Dagia
+ *
+ * @copyright 2026 Parth Dagia
+ *
+ * @license
+ * This program is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this
+ * library; if not, write to the Free Software Foundation, 51 Franklin Street, Suite 500 Boston,
+ * MA 02110-1335 USA.
+ */
+
+/* exported ensureABCJS */
+
+/**
+ * Ensures the ABCJS library is loaded before proceeding.
+ * Dynamically appends the script tag if not already present.
+ * @returns {Promise<void>}
+ */
+function ensureABCJS() {
+    if (typeof window !== "undefined" && window.ABCJS) {
+        return Promise.resolve();
+    }
+
+    if (typeof window === "undefined") {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+        const existing = document.querySelector('script[src="lib/abc.min.js"]');
+
+        if (existing) {
+            if (existing.hasAttribute("data-loaded")) {
+                resolve();
+            } else {
+                existing.addEventListener("load", resolve);
+            }
+            return;
+        }
+
+        const script = document.createElement("script");
+        script.src = "lib/abc.min.js";
+
+        script.onload = () => {
+            script.setAttribute("data-loaded", "true");
+            resolve();
+        };
+
+        script.onerror = reject;
+
+        document.head.appendChild(script);
+    });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = ensureABCJS;
+}

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -14,7 +14,7 @@
 
    _, docById, DOUBLEFLAT, FLAT, NATURAL, SHARP, DOUBLESHARP,
    CUSTOMSAMPLES, wheelnav, getVoiceSynthName, Singer, DRUMS, Tone,
-   instruments, slicePath, platformColor
+   instruments, slicePath, platformColor, ABCJS, ensureABCJS
 */
 
 /* exported Abhijeet Singh */
@@ -717,7 +717,8 @@ function AIWidget() {
      * @private
      * @returns {void}
      */
-    this.__save = function () {
+    this.__save = async function () {
+        await ensureABCJS();
         const tunebook = new ABCJS.parseOnly(abcNotationSong);
 
         tunebook.forEach(tune => {
@@ -885,7 +886,8 @@ function AIWidget() {
         return _sharedAudioContext;
     }
 
-    this._playABCSong = function () {
+    this._playABCSong = async function () {
+        await ensureABCJS();
         const abc = abcNotationSong;
         const stopAudioButton = document.querySelector(".stop-audio");
 


### PR DESCRIPTION
Summary

Closes #5998 

This PR implements Phase 4C of the startup performance optimization plan.

The ABCJS library (`lib/abc.min.js`, ~552KB) was previously loaded during application startup via a `<script defer>` tag in `index.html`.

However, ABCJS is only required when users perform ABC-related operations such as:

- Importing ABC notation
- Rendering ABC notation
- Certain AI widget operations

Loading the library during startup caused unnecessary JavaScript parsing and increased Total Blocking Time.

Changes

• Removed the `<script defer src="lib/abc.min.js">` tag from `index.html`
• Implemented a dynamic loader to load the library only when needed
• Ensured ABCJS is loaded before any code paths that use the `ABCJS` global

Before

ABCJS was loaded and parsed during startup regardless of user interaction.

After

ABCJS loads dynamically only when ABC functionality is triggered.

Impact

• ~552KB JavaScript removed from startup parsing
• Reduced Total Blocking Time
• Improved First Contentful Paint and Speed Index

Risk

Low risk.

ABCJS is only used in user-triggered flows and does not affect core runtime logic.

All functionality related to ABC import and notation rendering continues to work as expected.

---
PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [x] Performance