### PR TITLE
fix(piemenus): fix custom pitch block preview sound (partial fix for …

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1193,7 +1193,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         docById("wheelDiv").style.display = "none";
     };
 
-    const __selectionChanged = () => {
+    const __selectionChanged = async () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
         that.value = note;
@@ -1212,23 +1212,109 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
 
-        const obj = getNote(note, octave, 0, "C major", false, null, that.activity.errorMsg, label);
-        const tur = that.activity.turtles.ithTurtle(0);
-
-        if (!tur.singer.instrumentNames.includes(DEFAULTVOICE)) {
-            that.activity.logo.synth.createDefaultSynth(0);
-            that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+        try {
+            // Ensure audio context is started (required by modern browsers)
+            await Tone.start();
+        } catch (e) {
+            console.debug("Tone.start() skipped or failed", e);
         }
 
-        that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
-        that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+        // Ensure synth is initialized before proceeding
+        if (!that.activity.logo.synth) {
+            return;
+        }
 
+        // Always ensure tone is initialized
+        if (!that.activity.logo.synth.tone) {
+            that.activity.logo.synth.newTone();
+        }
+
+        // Create and load synth if needed
+        if (!instruments[0] || !instruments[0][DEFAULTVOICE]) {
+            try {
+                that.activity.logo.synth.createDefaultSynth(0);
+                await that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+            } catch (e) {
+                return;
+            }
+        }
+
+        // Set volume
+        try {
+            that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
+            that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+        } catch (e) {
+            return;
+        }
+
+        // Trigger note with proper error handling
         if (!that._triggerLock) {
             that._triggerLock = true;
-            // Get the frequency of the custom note for the preview.
-            const no = that.activity.logo.synth.getCustomFrequency([note + obj[1]], that.customID);
-            if (no !== undefined && no !== "undefined") {
-                instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
+            try {
+                const customID = that.customID || label;
+                let freq = null;
+
+                // Try to compute frequency from the temperament data directly.
+                // noteLabels[customID] contains the temperament data. Entries can be:
+                //   - Plain numbers (ratios) when no custom notes are defined
+                //   - Arrays [ratio, noteName, octave] when custom notes are saved
+                const tempData = noteLabels[customID];
+                if (tempData) {
+                    // Find the entry that matches the displayed note label.
+                    for (const pitchNum in tempData) {
+                        if (pitchNum === "pitchNumber" || pitchNum === "interval") continue;
+                        const entry = tempData[pitchNum];
+                        let entryLabel, entryRatio, entryOctave;
+
+                        if (typeof entry === "number") {
+                            // Equal-style format: key is the label, value is the ratio
+                            entryLabel = pitchNum;
+                            entryRatio = entry;
+                            entryOctave = 4; // default octave
+                        } else if (Array.isArray(entry) && entry.length >= 3) {
+                            // Custom format: [ratio, noteName, octave]
+                            entryLabel = entry[1];
+                            entryRatio = entry[0];
+                            entryOctave = Number(entry[2]);
+                        }
+
+                        if (entryLabel === note && entryRatio != null) {
+                            // Compute frequency: ratio * startingPitchFrequency * octaveOffset
+                            const startPitch = that.activity.logo.synth.startingPitch;
+                            const startFreq = Tone.Frequency(startPitch).toFrequency();
+                            const octaveDiff = octave - entryOctave;
+                            freq = entryRatio * startFreq * Math.pow(2, octaveDiff);
+                            break;
+                        }
+                    }
+                }
+
+                // If direct computation failed, try getCustomFrequency
+                if (freq === null || isNaN(freq)) {
+                    const noteWithOctave = note + octave;
+                    const result = that.activity.logo.synth.getCustomFrequency(
+                        noteWithOctave,
+                        customID
+                    );
+                    if (typeof result === "number" && !isNaN(result)) {
+                        freq = result;
+                    }
+                }
+
+                if (freq !== null && typeof freq === "number" && !isNaN(freq)) {
+                    // Play the frequency directly via synth.trigger
+                    await that.activity.logo.synth.trigger(
+                        0,
+                        freq,
+                        1 / 8,
+                        DEFAULTVOICE,
+                        null,
+                        null,
+                        false
+                    );
+                }
+            } catch (e) {
+                console.error("Error in custom pitch preview:", e);
             }
         }
 


### PR DESCRIPTION
## Description

This PR partially addresses **#4724** — specifically fixing the **missing preview sound** when selecting notes in a Custom Pitch Block's pie menu. After this fix, clicking notes in the pie chart plays a clean pitch preview instead of static noise or silence.

> **Note:** This PR does not address the identity loss issue (Custom Pitch Blocks reverting to regular Pitch Blocks when dragged from the palette), which is the other part of #4724.

## Root Cause

The [__selectionChanged](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:2411:4-2418:6) handler in [piemenuCustomNotes](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:913:0-1337:2) ([js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0)) had three problems:

1. **Missing audio context initialization** — No call to `Tone.start()`, `synth.newTone()`, or async synth loading. Modern browsers require `Tone.start()` after user interaction before audio can play.

2. **[getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1) can't parse custom note names** — Custom notes like [C(+0¢)](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/block.js:2025:4-2031:5) were passed through [getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1), which only understands standard note names (C, D, E...), producing invalid output.

3. **Pitch index labels not handled** — When custom temperament data stores entries as plain ratio numbers (equal-temperament format), the pie chart shows pitch indices (0, 1, 2...) as labels. [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6) tries to match these against note names and never finds a match — returning a string instead of a frequency.

## Changes

**File:** [js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0) — `piemenuCustomNotes.__selectionChanged` function (line ~1196)

- Made [__selectionChanged](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:2411:4-2418:6) `async` with `Tone.start()`, `synth.newTone()`, and `await loadSynth()` for proper audio initialization
- Compute frequency directly from temperament ratio data (`noteLabels`), handling both data formats:
  - Pitch indices with raw ratios (equal-style: `"0": 1.0`)
  - Note name arrays (saved custom: `"0": [1.0, "C(+0¢)", 4]`)
- Use `synth.trigger()` instead of raw `triggerAttackRelease()` for robust playback
- Added [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6) fallback and error handling

## Testing

- All existing tests pass (3861 tests, 123 suites)
- Manually verified: Custom Pitch Block pie menu plays clean preview sounds for both regular and Define Temperament workflows

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

