### PR TITLE
feat: display zoom percentage overlay when block scale changes (#6089)

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1935,6 +1935,23 @@ input.timbreName {
   color: black;
 }
 
+#zoomOverlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 20px 40px;
+  border-radius: 10px;
+  font-family: "Roboto", sans-serif;
+  font-size: 32px;
+  font-weight: bold;
+  pointer-events: none;
+  visibility: hidden;
+  z-index: 1000;
+}
+
 #palette td,
 thead,
 tr,

--- a/index.html
+++ b/index.html
@@ -207,6 +207,7 @@
                         <img class="msgCloseIcon" onclick="hideErrorText()" src="images/close.svg" alt="Close">
                     </div>
                 </div>
+                <div id="zoomOverlay" tabindex="-1"></div>
 
                 <div id="clear-modal-container"
                     style="display: none; z-index: 999; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.4); align-items: center; justify-content: center;">

--- a/js/activity.js
+++ b/js/activity.js
@@ -5659,6 +5659,30 @@ class Activity {
             }, duration);
         };
 
+        this.zoomOverlayTimeout = null;
+        this.showZoomOverlay = scale => {
+            const percentage = Math.round(scale * 100);
+            let zoomOverlay = document.getElementById("zoomOverlay");
+            if (zoomOverlay === null) {
+                zoomOverlay = document.createElement("div");
+                zoomOverlay.id = "zoomOverlay";
+                document.body.appendChild(zoomOverlay);
+            }
+
+            if (this.zoomOverlayTimeout !== null) {
+                clearTimeout(this.zoomOverlayTimeout);
+            }
+
+            zoomOverlay.textContent = percentage + "%";
+            zoomOverlay.style.visibility = "visible";
+
+            const that = this;
+            this.zoomOverlayTimeout = setTimeout(() => {
+                zoomOverlay.style.visibility = "hidden";
+                that.zoomOverlayTimeout = null;
+            }, 1500);
+        };
+
         this.errorMsg = (msg, blk, text, timeout) => {
             if (this.errorMsgTimeoutID !== null) {
                 clearTimeout(this.errorMsgTimeoutID);

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -303,6 +303,7 @@ class Blocks {
             /** Force a refresh. */
             await delayExecution(100);
             this.activity.refreshCanvas();
+            this.activity.showZoomOverlay(scale);
         };
 
         /**


### PR DESCRIPTION

Fixes #6089

This PR adds a temporary zoom percentage overlay when the block scale changes.

## PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Features:
- Displays zoom percentage using Math.round(scale * 100)
- Overlay appears centered on the screen
- Automatically disappears after ~1.5 seconds
- pointer-events set to none so it does not block user interaction
- Reuses the same DOM element for performance

The overlay appears whenever setBlockScale() is triggered (buttons, shortcuts, or programmatic calls).

Tested locally and verified that the overlay appears and disappears correctly without affecting existing zoom functionality.
<img width="1919" height="823" alt="Screenshot 2026-03-05 140924" src="https://github.com/user-attachments/assets/d8b7548d-9824-4808-b1af-e0903a7fdcb1" />
