### PR TITLE
feat(planet): implement progressive loading for project cards

### DIFF
--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -12,7 +12,7 @@
 /*
    global
 
-   _, GlobalTag, GlobalCard, jQuery, currentUserScrollPos:true,
+   GlobalTag, GlobalCard, currentUserScrollPos:true,
    maxScrollPos:true, ProjectViewer, debounce
 */
 /*
@@ -401,7 +401,7 @@ class GlobalPlanet {
     }
 
     renderSingleProject(id) {
-        if (this.cache.hasOwnProperty(id)) {
+        if (Object.prototype.hasOwnProperty.call(this.cache, id)) {
             const g = new GlobalCard(this.Planet);
             g.init(id);
             g.render();
@@ -541,7 +541,6 @@ class GlobalPlanet {
                 .getElementById("globalcontents")
                 .insertAdjacentHTML("afterbegin", this.offlineHTML);
         } else {
-            // eslint-disable-next-line no-unused-vars
             jQuery("#sort-select").material_select(evt => {
                 this.sortBy = document.getElementById("sort-select").value;
                 this.refreshProjects();
@@ -579,7 +578,6 @@ class GlobalPlanet {
 
             this.initTagList();
 
-            // eslint-disable-next-line no-unused-vars
             document.getElementById("load-more-projects").addEventListener("click", evt => {
                 if (this.loadButtonShown) {
                     this.loadMoreProjects();
@@ -588,7 +586,6 @@ class GlobalPlanet {
 
             const debouncedfunction = debounce(this.search.bind(this), 250);
 
-            // eslint-disable-next-line no-unused-vars
             document.getElementById("global-search").addEventListener("input", evt => {
                 this.searchString = document.getElementById("global-search").value;
                 debouncedfunction();
@@ -599,7 +596,6 @@ class GlobalPlanet {
                 debouncedfunction();
             });
 
-            // eslint-disable-next-line no-unused-vars
             document.getElementById("search-close").addEventListener("click", evt => {
                 document.getElementById("global-search").value = "";
                 this.searchString = "";


### PR DESCRIPTION
### Summary
Implements progressive loading while fetching Planet server projects in Global. Projects now appear incrementally as they load instead of waiting for all the 25 API requests to complete.
Fixes #6072
### PR Category
- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation 
### Problem
When scrolling to load more projects in Global:
1. downloadProjectList returns ~25 project IDs
2. Code makes 25 separate getProjectDetails API calls
3. UI waits for ALL requests to complete before showing anything
4. Users sees loader for 5-10 seconds
### Solution
Modified GlobalPlanet.js to render each project card immediately after its details are fetched:
- Added renderSingleProject(id) - renders individual card without clearing container
- Modified downloadProjectsToCache() - accepts onEachComplete and onAllComplete callbacks
- Modified addProjectToCache() - triggers render immediately on each completion
- Updated addProjects() - uses progressive callbacks
### Benefits
- Immediate feedback (first project visible within ~200ms)
- Better perceived performance
- No breaking changes to API
- Follows progressive loading UX pattern
### Testing
- Verified cards appear one-by-one as they load
- Load More button still works correctly
- Cached projects still render immediately
- Search functionality unaffected
- All Jest tests passed
- No linting issues
### Attachments
#### Before: Loading spinner shows for several seconds, then all cards appear at once
https://github.com/user-attachments/assets/e8c65f61-8bfb-44be-ad5c-f0caeb0bb2fe
#### After: Cards appearing one-by-one as they load
https://github.com/user-attachments/assets/5d897e36-34e7-4caf-917d-e9a351b49d7a