### PR TITLE
ci: add PR size warning workflow

### DIFF
--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,21 @@
+name: PR Size Warning
+
+on:
+  pull_request_target:
+
+jobs:
+  size-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const additions = context.payload.pull_request.additions;
+            const deletions = context.payload.pull_request.deletions;
+            const total = additions + deletions;
+
+            if (total > 500) {
+              core.warning(`⚠️ This PR is quite large (${total} lines changed). Consider splitting it.`);
+            }


### PR DESCRIPTION
Summary

This PR introduces a GitHub Action that warns when pull requests exceed 500 lines of changes.

Large PRs are harder to review and maintain. This workflow helps encourage contributors to submit smaller, more manageable pull requests.

Behavior
- If PR changes exceed 500 lines, a warning is shown in CI.
- This does not fail the CI run; it only provides a warning.

Benefits
- encourages smaller PRs
- improves maintainability
- simplifies review process

PR Category
- [x] Feature
- [ ] Bug Fix
- [ ] Performance
- [ ] Tests
- [ ] Documentation