### PR TITLE
fix/pitch preview not playing after first trigger due to trigger lock

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -676,11 +676,11 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                         false
                     );
                 } catch (e) {
-                    // Ensure trigger lock is released after a delay
-                    setTimeout(() => {
-                        that._triggerLock = false;
-                    }, 125); // 1/8 second in milliseconds
+                    console.error("Synth trigger error:", e);
                 }
+                setTimeout(() => {
+                    that._triggerLock = false;
+                }, 125);
             }
         } catch (e) {
             console.error("Error in pitch preview:", e);


### PR DESCRIPTION
**Issue-**
The pitch preview in the pitch pie menu stops producing sound after the first successful trigger in certain scenarios (e.g., after changing the voice).

The preview works correctly the first time, but subsequent attempts produce no sound.

**Root Cause-** 
The issue was caused by the _triggerLock mechanism used to prevent rapid successive audio triggers.
Previously, _triggerLock was set to true before calling synth.trigger(), but it was only reset inside the catch block:
```
catch (e) {
    setTimeout(() => {
        that._triggerLock = false;
    }, 125);
}
```
If synth.trigger() executed successfully (which is the normal case), the catch block never ran. As a result, _triggerLock remained true, blocking all future preview triggers.

**Fix-**
The fix ensures that _triggerLock is released regardless of whether synth.trigger() succeeds or fails.
The unlock logic has been moved outside the catch block so it always executes after the trigger attempt.
```
if (!that._triggerLock) {
    that._triggerLock = true;
    try {
        await that.activity.logo.synth.trigger(
            0,
            [obj[0] + obj[1]],
            1 / 8,
            DEFAULTVOICE,
            null,
            null,
            false
        );
    } catch (e) {
        console.error("Error triggering pitch preview:", e);
    }

    setTimeout(() => {
        that._triggerLock = false;
    }, 125);
}
```

**Current Behavior(After Fix)-**
- Pitch preview works consistently for all selections.
- Changing voices in pitch block no longer breaks preview functionality.

**PR Category-**
- [x]  Bug Fix
- [ ]  Feature
- [ ]  Performance
- [ ]  Tests
- [ ]  Documentation

