### PR TITLE
test: Improve tempo.js coverage – clearInterval, pause button toggle, and save debounce branches

### DIFF
--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -906,7 +906,8 @@ describe("Tempo Widget", () => {
             const mockWindow = window.widgetWindows.windowFor();
             const addButtonCalls = mockWindow.addButton.mock.calls;
             const saveCall = addButtonCalls.find(call => call[0] === "export-chunk.svg");
-            const saveBtn = mockWindow.addButton.mock.results[addButtonCalls.indexOf(saveCall)].value;
+            const saveBtn =
+                mockWindow.addButton.mock.results[addButtonCalls.indexOf(saveCall)].value;
             saveBtn.onclick();
             expect(tempoWidget._get_save_lock()).toBe(true);
             jest.advanceTimersByTime(1000);


### PR DESCRIPTION
## Summary

Adds tests to cover previously uncovered branches in `tempo.js`,
bringing line coverage from 92.89% to 100%.

## Changes

| File | Tests Added | Lines Covered |
|---|---|---|
| `js/widgets/__tests__/tempo.test.js` | 4 | 63, 80-101, 113-116, 244 |

## Coverage
```
tempo.js | 98.95 | 95 | 92.3 | 100 |
```

## Verification
```
Tests: 74 passed, 74 total
```

## PR Category
- [ ] Bug Fix
- [ ] Performance
- [ ] Feature
- [x] Tests
- [ ] Documentation