### PR TITLE
Fix: Run PO to JSON validation on PRs and bulletproof git diffs

### DIFF
--- a/.github/workflows/po-to-json-validation.yml
+++ b/.github/workflows/po-to-json-validation.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'po/**/*.po'
+  pull_request:
+    paths:
+      - 'po/**/*.po'
 
 jobs:
   convert-and-verify:
@@ -24,10 +27,21 @@ jobs:
       - name: Find changed .po files
         id: find_po
         run: |
-          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^po/.*\.po$' > changed_po_files.txt || true
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
+            git fetch origin $BASE
+          else
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.sha }}
+          fi
+
+          git diff --name-only $BASE $HEAD | grep '^po/.*\.po$' > changed_po_files.txt || true
+
           cat changed_po_files.txt
+
           echo "po_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$(cat changed_po_files.txt)" >> $GITHUB_OUTPUT
+          cat changed_po_files.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Convert PO files to JSON


### PR DESCRIPTION
**The Bug (Why we need this PR)**
Right now, the translation check only runs after a Pull Request is merged.
If a contributor changes a .po file but forgets to convert it to a .json file, their PR will still get a green checkmark ✅. But as soon as a maintainer clicks "Merge", the check runs on the master branch, fails, and breaks the repository for everyone.
Refer Image from Issue #6115 
<img width="762" height="295" alt="image" src="https://github.com/user-attachments/assets/3006d210-5c4d-4af9-a6a1-b70b779f0ad5" />

CLOSES #6115 
<img width="841" height="97" alt="proof2" src="https://github.com/user-attachments/assets/50f0256d-3cc2-4415-98d6-e5e026def837" />

**The Fix**
This PR forces the translation check to run before the PR is merged.
To make that work without crashing the bot, I made three small changes to the script:

****Added** ``` pull_request ``` to the triggers**: Now, if someone forgets to convert their translation files, the bot will block their PR with a red ❌ so maintainers don't accidentally merge broken files.
**Fixed the file checker:** The old script only knew how to check files for push events. I added an if/else statement so the script knows how to find changed files during a Pull Request.
**Prevented random crashes:** Sometimes GitHub Actions forgets to download the master branch before checking the files. I added one line (git fetch) to force it to download the branch so the script doesn't crash with a fatal: bad object error.

- [x] Bug Fix
- [ ] Feature
- [x] CI / Workflow
- [ ] Refactor