### PR TITLE
perf(ast2blocklist): cache block entry and connection index lookups

### DIFF
--- a/js/js-export/ast2blocklist.js
+++ b/js/js-export/ast2blocklist.js
@@ -373,7 +373,8 @@ class AST2BlockList {
                 const block_name = Array.isArray(block[1]) ? block[1][0] : block[1];
                 const entry = entryByBlockName.get(block_name);
                 if (entry) {
-                    const connectionsArray = entry.blocklist_connections || config.default_connections;
+                    const connectionsArray =
+                        entry.blocklist_connections || config.default_connections;
                     const connections = _getConnectionIndices(connectionsArray);
 
                     // Use default_vspaces if not specified in the block


### PR DESCRIPTION
## Summary
`AST2BlockList._propertyOf()` repeatedly:
- scans `config.body_blocks` to resolve block metadata
- computes connection slot indexes (`prev/child/next/second_child`) via repeated `indexOf`

This work is on a hot path during AST -> blockList conversion.

Fixes #6126.

## PR Category
- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation

## What Changed
- Added `entryByBlockName` map (built once per conversion) for O(1) block entry resolution.
- Added `_getConnectionIndices()` with `WeakMap` caching by connection-array identity.
- Updated `_propertyOf()` to use these caches while keeping output format unchanged.

## Complexity Impact
- Entry resolution: from repeated O(body_blocks) scans per block to O(1) map lookup.
- Connection index lookup: computed once per connection-array instance, then reused.

## Behavior / Risk
- No intended behavior change.
- Same connection semantics and blockList structure are preserved.
- Fallback path for unknown blocks (vspace handling) remains unchanged.

## Validation
- Ran: `npm test -- --runTestsByPath js/js-export/__tests__/ast2blocklist.test.js`
- Result: pass (21 tests).
- Note: repository has an existing unrelated coverage parser warning in `js/block.js`.
