### PR TITLE
test: add regression tests for turtle-singer note execution and counting behavior

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -40,6 +40,9 @@ global.last = jest.fn(array => array[array.length - 1]);
 
 global.SEMITONES = 12;
 global.pitchToFrequency = jest.fn().mockReturnValue(440);
+global.rationalSum = jest.fn((a, b) => {
+    return [a[0] + b[0], a[1] + b[1]];
+});
 
 const createTurtleMock = () => ({
     turtles: [],
@@ -837,5 +840,127 @@ describe("processPitch — note block execution path", () => {
         expect(turtleMock.singer.noteOctaves[0].length).toBe(1);
         expect(turtleMock.singer.noteBeatValues[0].length).toBe(1);
         expect(turtleMock.singer.pushedNote).toBe(true);
+    });
+});
+
+describe("noteCounter regression behavior", () => {
+    let turtleMock;
+    let activityMock;
+    let logoMock;
+    let singer;
+
+    beforeEach(() => {
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+
+        turtleMock.painter = {
+            color: 0,
+            value: 0,
+            chroma: 0,
+            stroke: 1,
+            canvasAlpha: 1,
+            penState: true,
+            doPenUp: jest.fn(),
+            doSetXY: jest.fn(),
+            doSetHeading: jest.fn()
+        };
+
+        turtleMock.x = 0;
+        turtleMock.y = 0;
+        turtleMock.orientation = 0;
+        turtleMock.endOfClampSignals = {};
+        turtleMock.butNotThese = {};
+        activityMock = createActivityMock(turtleMock);
+        logoMock = createLogoMock(activityMock);
+        activityMock.turtles.getTurtle = jest.fn().mockReturnValue({
+            queue: []
+        });
+        logoMock.boxes = {};
+        logoMock.turtleHeaps = { 0: {} };
+        logoMock.turtleDicts = { 0: {} };
+        activityMock.logo.runFromBlockNow = jest.fn();
+        singer = turtleMock.singer;
+    });
+
+    test("should restore execution state after counting notes", () => {
+        const originalSuppress = singer.suppressOutput;
+        const originalTime = singer.turtleTime;
+        const originalPrevTime = singer.previousTurtleTime;
+        Singer.noteCounter(logoMock, 0, 1);
+        expect(singer.suppressOutput).toBe(originalSuppress);
+        expect(singer.turtleTime).toBe(originalTime);
+        expect(singer.previousTurtleTime).toBe(originalPrevTime);
+    });
+
+    test("should push and pop justCounting correctly", () => {
+        const originalLength = singer.justCounting.length;
+        Singer.noteCounter(logoMock, 0, 1);
+        expect(singer.justCounting.length).toBe(originalLength);
+    });
+});
+
+describe("processNote regression behavior", () => {
+    let turtleMock;
+    let activityMock;
+    let singer;
+
+    beforeEach(() => {
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        activityMock = createActivityMock(turtleMock);
+        activityMock.logo.specialArgs = [];
+        activityMock.stage = {
+            update: jest.fn()
+        };
+        singer = turtleMock.singer;
+    });
+
+    test("should not modify bpm stack during execution", () => {
+        singer.bpm.push(120);
+        const originalLength = singer.bpm.length;
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+        expect(singer.bpm.length).toBe(originalLength);
+    });
+
+    test("should execute without mutating bpm stack", () => {
+        singer.bpm = [120];
+        const before = [...singer.bpm];
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+        expect(singer.bpm).toEqual(before);
+    });
+
+    test("should trigger stage update after processing note", () => {
+        const callback = jest.fn();
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, callback);
+        expect(activityMock.stage.update).toHaveBeenCalledTimes(1);
+    });
+
+    test("should use default BPM when bpm stack is empty", () => {
+        singer.bpm = [];
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+        expect(activityMock.stage.update).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("scalarDistance edge cases", () => {
+    let turtleMock;
+    let activityMock;
+    let logoMock;
+
+    beforeEach(() => {
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        activityMock = createActivityMock(turtleMock);
+        logoMock = createLogoMock(activityMock);
+    });
+
+    test("should return 0 when notes are equal", () => {
+        const result = Singer.scalarDistance(logoMock, turtleMock, 60, 60);
+        expect(result).toBe(0);
+    });
+
+    test("should return negative distance when lastNote < firstNote", () => {
+        const result = Singer.scalarDistance(logoMock, turtleMock, 65, 60);
+        expect(result).toBeLessThanOrEqual(0);
     });
 });


### PR DESCRIPTION
## Summary

This PR continues strengthening regression protection for the `turtle-singer.js` engine by adding focused tests for the note execution pipeline and note counting logic.

A previous PR introduced regression tests covering lifecycle and pitch execution paths (`killAllVoices`, `numberOfNotes`, `processPitch`).  
This PR extends that work by protecting additional execution behaviors related to note scheduling and counting.

This PR replaces #6113, which was closed to clean up commit history and remove unrelated changes introduced during rebasing.

No production code changes were made.


## Covered Areas

### 1. `noteCounter()`

Adds regression tests protecting the internal counting mechanism used when evaluating note blocks.

Tests verify:

- Execution state restoration after counting
- `suppressOutput` is restored correctly
- `justCounting` stack integrity
- Turtle timing state remains unchanged


### 2. `processNote()`

Adds regression tests protecting the core note execution entry point.

Tests verify:

- BPM stack integrity during execution
- Correct fallback behavior when the BPM stack is empty
- Stage update is triggered after note processing


### 3. `scalarDistance()` Edge Cases

Adds coverage for important edge cases including:

- Equal note distance
- Reverse note ordering


## Impact

- Improves functional coverage of `turtle-singer.js`
- Strengthens regression protection for note execution and counting behavior
- Ensures timing and counting behaviors remain stable during future refactors


## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation