### PR TITLE
perf(utils): prevent duplicate camera listeners and capture intervals

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1243,13 +1243,48 @@ let prepareMacroExports = (name, stack, macroDict) => {
 // Encapsulates camera-related operations for video/image capture
 const CameraManager = {
     isSetup: false,
-    canPlayHandler: null,
-    intervalId: null,
+    captureIntervalId: null,
+    canplayHandler: null,
+    listenerVideoElement: null,
+
+    startCapture(draw, setCameraID) {
+        this.stopCapture(setCameraID);
+        this.captureIntervalId = window.setInterval(draw, 100);
+        setCameraID(this.captureIntervalId);
+    },
+
+    stopCapture(setCameraID) {
+        if (this.captureIntervalId !== null) {
+            window.clearInterval(this.captureIntervalId);
+            this.captureIntervalId = null;
+        }
+
+        if (typeof setCameraID === "function") {
+            setCameraID(null);
+        }
+    },
+
+    setCanplayListener(video, handler) {
+        this.clearCanplayListener();
+        this.canplayHandler = handler;
+        this.listenerVideoElement = video;
+        video.addEventListener("canplay", handler, false);
+    },
+
+    clearCanplayListener() {
+        if (this.listenerVideoElement && this.canplayHandler) {
+            this.listenerVideoElement.removeEventListener("canplay", this.canplayHandler, false);
+        }
+        this.canplayHandler = null;
+        this.listenerVideoElement = null;
+    },
 
     /**
      * Resets the camera setup state
      */
     reset() {
+        this.stopCapture();
+        this.clearCanplayListener();
         this.isSetup = false;
     }
 };
@@ -1308,48 +1343,32 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
         streaming = true;
         video.play();
         if (isVideo) {
-            if (CameraManager.intervalId !== null) {
-                window.clearInterval(CameraManager.intervalId);
-                CameraManager.intervalId = null;
-            }
-            cameraID = window.setInterval(draw, 100);
-            CameraManager.intervalId = cameraID;
-            setCameraID(cameraID);
+            CameraManager.startCapture(draw, setCameraID);
         } else {
+            CameraManager.stopCapture(setCameraID);
             draw();
         }
     }
 
-    if (CameraManager.canPlayHandler) {
-        video.removeEventListener("canplay", CameraManager.canPlayHandler, false);
-    }
+    CameraManager.setCanplayListener(video, () => {
+            // console.debug("canplay", streaming, CameraManager.isSetup);
+            if (!streaming) {
+                video.setAttribute("width", w);
+                video.setAttribute("height", h);
+                canvas.setAttribute("width", w);
+                canvas.setAttribute("height", h);
+                streaming = true;
 
-    function handleCanPlay() {
-        // console.debug("canplay", streaming, CameraManager.isSetup);
-        if (!streaming) {
-            video.setAttribute("width", w);
-            video.setAttribute("height", h);
-            canvas.setAttribute("width", w);
-            canvas.setAttribute("height", h);
-            streaming = true;
-
-            if (isVideo) {
-                if (CameraManager.intervalId !== null) {
-                    window.clearInterval(CameraManager.intervalId);
-                    CameraManager.intervalId = null;
+                if (isVideo) {
+                    CameraManager.startCapture(draw, setCameraID);
+                } else {
+                    CameraManager.stopCapture(setCameraID);
+                    draw();
                 }
-                cameraID = window.setInterval(draw, 100);
-                CameraManager.intervalId = cameraID;
-                setCameraID(cameraID);
             } else {
                 draw();
             }
-        }
-    }
-
-    CameraManager.canPlayHandler = handleCanPlay;
-
-    video.addEventListener("canplay", CameraManager.canPlayHandler, false);
+        });
 };
 
 /**
@@ -1358,11 +1377,12 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
  * @param {function} setCameraID - Function to set the camera interval ID.
  */
 function doStopVideoCam(cameraID, setCameraID) {
-    if (cameraID !== null) {
+    if (cameraID !== null && cameraID !== CameraManager.captureIntervalId) {
         window.clearInterval(cameraID);
     }
 
-    setCameraID(null);
+    CameraManager.stopCapture(setCameraID);
+    CameraManager.clearCanplayListener();
     const video = document.querySelector("#camVideo");
     if (video) {
         video.pause();

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -802,7 +802,10 @@ const processPluginData = (activity, pluginData, pluginSource) => {
     try {
         obj = JSON.parse(pluginData);
     } catch (error) {
-        console.error(`PluginProcessor: Failed to parse plugin data from source "${pluginSource}":`, error);
+        console.error(
+            `PluginProcessor: Failed to parse plugin data from source "${pluginSource}":`,
+            error
+        );
         console.debug("Malformed plugin data:", pluginData);
         return null;
     }
@@ -1351,24 +1354,22 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
     }
 
     CameraManager.setCanplayListener(video, () => {
-            // console.debug("canplay", streaming, CameraManager.isSetup);
-            if (!streaming) {
-                video.setAttribute("width", w);
-                video.setAttribute("height", h);
-                canvas.setAttribute("width", w);
-                canvas.setAttribute("height", h);
-                streaming = true;
+        // console.debug("canplay", streaming, CameraManager.isSetup);
+        if (!streaming) {
+            video.setAttribute("width", w);
+            video.setAttribute("height", h);
+            canvas.setAttribute("width", w);
+            canvas.setAttribute("height", h);
+            streaming = true;
 
-                if (isVideo) {
-                    CameraManager.startCapture(draw, setCameraID);
-                } else {
-                    CameraManager.stopCapture(setCameraID);
-                    draw();
-                }
+            if (isVideo) {
+                CameraManager.startCapture(draw, setCameraID);
             } else {
+                CameraManager.stopCapture(setCameraID);
                 draw();
             }
-        });
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
## PR Category
- [x] Performance
- [ ] Bug Fix
- [ ] Feature
- [ ] Tests
- [ ] Documentation

## Summary
Improve camera capture lifecycle by centralizing interval/listener ownership in `CameraManager`.

## Changes
- Add managed camera state:
  - `captureIntervalId`
  - `canplayHandler`
  - `listenerVideoElement`
- Add lifecycle helpers:
  - `startCapture()`
  - `stopCapture()`
  - `setCanplayListener()`
  - `clearCanplayListener()`
- Ensure only one active capture interval at a time.
- Replace repeated `video.addEventListener(canplay, ...)` usage with managed listener replacement.
- Update `doStopVideoCam()` to clear managed interval + listener.

Fixes #6155

## Testing
- `npm test -- js/utils/__tests__/utils.test.js --runInBand`
- `npx eslint js/utils/utils.js`

Note: Jest output includes an existing coverage instrumentation warning from `js/block.js`; target suite passes.