### PR TITLE
ci: add lock file sync validation to prevent confusing npm install failures

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -28,6 +28,25 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Validate lock file sync
+        run: |
+          echo "Validating package-lock.json is in sync with package.json..."
+          if ! npm ci --dry-run > /dev/null 2>&1; then
+            echo ""
+            echo "ERROR: package-lock.json is out of sync with package.json"
+            echo ""
+            echo "This usually means package.json was modified but package-lock.json was not updated."
+            echo ""
+            echo "To fix this, run the following commands locally and commit the changes:"
+            echo "  1. npm install"
+            echo "  2. git add package-lock.json"
+            echo "  3. git commit -m 'chore: update lock file'"
+            echo "  4. git push"
+            echo ""
+            exit 1
+          fi
+          echo "Lock file is in sync. Proceeding with Lighthouse audit..."
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/pr-cypress-e2e.yml
+++ b/.github/workflows/pr-cypress-e2e.yml
@@ -24,6 +24,25 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Validate lock file sync
+        run: |
+          echo "Validating package-lock.json is in sync with package.json..."
+          if ! npm ci --dry-run > /dev/null 2>&1; then
+            echo ""
+            echo "ERROR: package-lock.json is out of sync with package.json"
+            echo ""
+            echo "This usually means package.json was modified but package-lock.json was not updated."
+            echo ""
+            echo "To fix this, run the following commands locally and commit the changes:"
+            echo "  1. npm install"
+            echo "  2. git add package-lock.json"
+            echo "  3. git commit -m 'chore: update lock file'"
+            echo "  4. git push"
+            echo ""
+            exit 1
+          fi
+          echo "Lock file is in sync. Proceeding with E2E tests..."
+
       - name: Run Cypress E2E Tests
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -26,6 +26,25 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Validate lock file sync
+        run: |
+          echo "Validating package-lock.json is in sync with package.json..."
+          if ! npm ci --dry-run > /dev/null 2>&1; then
+            echo ""
+            echo "ERROR: package-lock.json is out of sync with package.json"
+            echo ""
+            echo "This usually means package.json was modified but package-lock.json was not updated."
+            echo ""
+            echo "To fix this, run the following commands locally and commit the changes:"
+            echo "  1. npm install"
+            echo "  2. git add package-lock.json"
+            echo "  3. git commit -m 'chore: update lock file'"
+            echo "  4. git push"
+            echo ""
+            exit 1
+          fi
+          echo "Lock file is in sync. Proceeding with Jest tests..."
+
       - name: Install Dependencies
         run: npm install
 


### PR DESCRIPTION
## Problem

When developers update package.json but forget to run npm install locally before pushing, CI workflows fail with cryptic npm ETARGET errors that don't explain the real issue. Developers waste time debugging npm registry problems when the actual solution is simple: update the lock file.

Previously saw:
```
npm error code ETARGET
npm error notarget No matching version found for gulp@^6.0.0
```

This misleading error wastes debugging time.

## Solution

Add pre-installation validation to E2E, Lighthouse, and Jest workflows that detects when package-lock.json is out of sync with package.json. If detected, workflows fail immediately with a clear, actionable error message.

New behavior shows:
```
ERROR: package-lock.json is out of sync with package.json

This usually means package.json was modified but package-lock.json was not updated.

To fix this, run the following commands locally and commit the changes:
  1. npm install
  2. git add package-lock.json
  3. git commit -m 'chore: update lock file'
  4. git push
```

## What's Changed

Added lock file sync validation step to:
- .github/workflows/pr-cypress-e2e.yml (E2E Tests)
- .github/workflows/lighthouse-ci.yml (Lighthouse CI)
- .github/workflows/pr-jest-tests.yml (Jest Tests)

## Testing

Tested in fork with two scenarios:

**Test 1 - With Lock File Mismatch (PR #4)**
- Created PR with intentional package.json change without updating lock file
- Result: Validation correctly detected mismatch
- Result: Clear error message displayed with step-by-step fix instructions
- Result: Cryptic npm ETARGET errors prevented

**Test 2 - With Clean Lock Files (PR #5)**  
- Created PR with no lock file issues
- Result: Validation passes, workflows continue normally
- Result: Jest Tests PASSED, Security Scans PASSED

## Impact

- Improves developer experience with clear, actionable error messages
- Fails fast with correct diagnosis instead of confusing npm errors
- Reduces debugging time for contributors unfamiliar with npm lock mechanisms
- Works for both PRs and push events
- Minimal performance impact (npm ci --dry-run only)

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation