### PR TITLE
perf(piemenus): attach resize listener only while wheel menu is active

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3608,15 +3608,18 @@ const piemenuModes = (block, selectedMode) => {
         docById("wheelnav-_exitWheel-title-1").style.fill = "#ffffff";
         docById("wheelnav-_exitWheel-title-1").style.pointerEvents = "none";
         docById("wheelnav-_exitWheel-slice-1").style.pointerEvents = "none";
-        setTimeout(() => {
-            const playButtonTitle = docById("wheelnav-_exitWheel-title-1");
-            const playButtonSlice = docById("wheelnav-_exitWheel-slice-1");
-            if (playButtonTitle && playButtonSlice) {
-                playButtonTitle.style.fill = "#000000";
-                playButtonTitle.style.pointerEvents = "auto";
-                playButtonSlice.style.pointerEvents = "auto";
-            }
-        }, (20 * 1000) / 10);
+        setTimeout(
+            () => {
+                const playButtonTitle = docById("wheelnav-_exitWheel-title-1");
+                const playButtonSlice = docById("wheelnav-_exitWheel-slice-1");
+                if (playButtonTitle && playButtonSlice) {
+                    playButtonTitle.style.fill = "#000000";
+                    playButtonTitle.style.pointerEvents = "auto";
+                    playButtonSlice.style.pointerEvents = "auto";
+                }
+            },
+            (20 * 1000) / 10
+        );
 
         __playScale(activeTabs, 0);
     };


### PR DESCRIPTION
## PR Category
- [x] Performance
- [ ] Bug Fix
- [ ] Feature
- [ ] Tests
- [ ] Documentation

## Summary
Refactor pie menu wheel resize handling so the global `resize` listener is attached only when `wheelDiv` is active and detached when closed.

## Changes
- Added lifecycle helpers:
  - `enableWheelResizeHandling()`
  - `disableWheelResizeHandling()`
  - `showWheelDiv()`
  - `hideWheelDiv()`
- Removed eager module-level `window.addEventListener(resize, ...)` setup.
- Routed `wheelDiv` show/hide call sites through shared helpers.
- Kept behavior compatible with existing exit-flow expectations and tests.

Fixes #6177

## Testing
- `npx prettier --write js/piemenus.js`
- `npx eslint js/piemenus.js`
- `npm test -- js/__tests__/piemenus.test.js --runInBand`

Note: Jest output still includes an existing coverage instrumentation warning from `js/block.js`; target suite passes.