### PR TITLE
fix: guard GraphicsBlocks arg parent lookups

### DIFF
--- a/js/blocks/GraphicsBlocks.js
+++ b/js/blocks/GraphicsBlocks.js
@@ -97,13 +97,14 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The heading value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
-            const parentId = connections?.[0];
+            const blockList = activity.blocks?.blockList;
+            const parentId = blockList?.[blk]?.connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
-                parentId in activity.blocks.blockList &&
-                activity.blocks.blockList[parentId]?.name === "print"
+                blockList &&
+                parentId in blockList &&
+                blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "heading"]);
             } else {
@@ -182,13 +183,14 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The Y-coordinate value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
-            const parentId = connections?.[0];
+            const blockList = activity.blocks?.blockList;
+            const parentId = blockList?.[blk]?.connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
-                parentId in activity.blocks.blockList &&
-                activity.blocks.blockList[parentId]?.name === "print"
+                blockList &&
+                parentId in blockList &&
+                blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "y"]);
             } else {
@@ -268,13 +270,14 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The X-coordinate value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
-            const parentId = connections?.[0];
+            const blockList = activity.blocks?.blockList;
+            const parentId = blockList?.[blk]?.connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
-                parentId in activity.blocks.blockList &&
-                activity.blocks.blockList[parentId]?.name === "print"
+                blockList &&
+                parentId in blockList &&
+                blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "x"]);
             } else {


### PR DESCRIPTION
## Summary
- guard `HeadingBlock.arg`, `XBlock.arg`, and `YBlock.arg` against missing `blockList`/parent connections
- prevent undefined access when tests call `arg` with a missing `blk`

## Testing
- npx eslint js/blocks/GraphicsBlocks.js
- npm test -- js/blocks/__tests__/GraphicsBlocks.test.js --runInBand

## PR Category
- [x] Bug fix
- [ ] Feature
- [ ] Performance
- [ ] Documentation
- [ ] Tests

Fixes #6179
