### PR TITLE
ci: fail fast when package-lock.json is out of sync

### DIFF
--- a/.github/scripts/validate-lockfile-sync.sh
+++ b/.github/scripts/validate-lockfile-sync.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Validating package-lock.json sync with package.json..."
+
+log_file="$(mktemp)"
+
+if npm ci --dry-run --ignore-scripts --no-audit --fund=false --loglevel=error >"$log_file" 2>&1; then
+    echo "package-lock.json is in sync with package.json."
+    rm -f "$log_file"
+    exit 0
+fi
+
+echo "::error::package-lock.json is out of sync with package.json. Run npm install locally and commit the updated package-lock.json."
+echo "npm ci --dry-run output (last 30 lines):"
+tail -n 30 "$log_file" || true
+rm -f "$log_file"
+exit 1

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Validate package-lock sync
+        run: bash .github/scripts/validate-lockfile-sync.sh
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/pr-cypress-e2e.yml
+++ b/.github/workflows/pr-cypress-e2e.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Validate package-lock sync
+        run: bash .github/scripts/validate-lockfile-sync.sh
+
       - name: Run Cypress E2E Tests
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Validate package-lock sync
+        run: bash .github/scripts/validate-lockfile-sync.sh
+
       - name: Install Dependencies
         run: npm install
 


### PR DESCRIPTION
Fixes #6168

## Summary
- add a reusable lockfile precheck script at `.github/scripts/validate-lockfile-sync.sh`
- run this validation before dependency installation in:
  - `pr-cypress-e2e.yml`
  - `lighthouse-ci.yml`
  - `pr-jest-tests.yml`

## Behavior
- workflows now fail early with a clear message when `package-lock.json` is out of sync with `package.json`
- avoids confusing downstream install failures and points contributors to run `npm install` and commit the updated lockfile

## PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation