### PR TITLE
fix: Prevent event listener accumulation in New Project modal

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -470,6 +470,10 @@ class Toolbar {
         const modalContainer = docById("modal-container");
         const newDropdown = docById("newdropdown");
 
+        // Cleanup any existing modal listeners from previous opens
+        // Prevents listener accumulation when renderNewProjectIcon is called multiple times
+        this._cleanupModalListeners?.();
+
         newDropdown.innerHTML = "";
         const title = document.createElement("div");
         title.classList.add("new-project-title");
@@ -500,18 +504,9 @@ class Toolbar {
         newDropdown.appendChild(buttonRowLi);
 
         modalContainer.style.display = "flex";
-        confirmationButton.onclick = () => {
-            modalContainer.style.display = "none";
-            onclick(this.activity);
-        };
 
         // Add tabindex for accessibility
         cancelButton.setAttribute("tabindex", "0"); // Make focusable
-
-        cancelButton.onclick = () => {
-            modalContainer.style.display = "none";
-        };
-        modalContainer.style.display = "flex";
 
         // Make modal container focusable
         modalContainer.setAttribute("tabindex", "-1");
@@ -520,8 +515,51 @@ class Toolbar {
         const modalButtons = [confirmationButton, cancelButton];
         let currentModalFocusIndex = 0;
 
+        // Store handler references and focus handler map for proper cleanup
+        let modalKeyHandler = null;
+        const focusHandlerMap = new Map();
+
+        /**
+         * Clean up all modal event listeners to prevent accumulation.
+         * Called defensively at the start of renderNewProjectIcon and when modal closes.
+         */
+        const cleanupModalListeners = () => {
+            // Remove keyboard handlers
+            if (modalKeyHandler) {
+                modalButtons.forEach(btn => {
+                    if (btn) {
+                        btn.removeEventListener("keydown", modalKeyHandler);
+                    }
+                });
+                if (modalContainer) {
+                    modalContainer.removeEventListener("keydown", modalKeyHandler);
+                }
+                modalKeyHandler = null;
+            }
+
+            // Remove previously stored focus handlers
+            focusHandlerMap.forEach((handler, btn) => {
+                if (btn) {
+                    btn.removeEventListener("focus", handler);
+                }
+            });
+            focusHandlerMap.clear();
+
+            // Clear focus styles
+            modalButtons.forEach(btn => {
+                if (btn) {
+                    btn.classList.remove("modal-btn-focused");
+                }
+            });
+        };
+
+        // Store cleanup function for access from other calls
+        this._cleanupModalListeners = cleanupModalListeners;
+
         // Handle keyboard events for modal
-        const modalKeyHandler = e => {
+        modalKeyHandler = e => {
+            if (modalButtons.length === 0) return; // Guard clause
+
             switch (e.key) {
                 case "ArrowDown":
                     e.preventDefault();
@@ -557,20 +595,25 @@ class Toolbar {
             }
         };
 
-        // Add event listeners to each button AND the modal container
+        // Add keyboard handlers to each button AND the modal container
         modalButtons.forEach(btn => {
             btn.addEventListener("keydown", modalKeyHandler);
-            // Track focus changes
-            btn.addEventListener("focus", () => {
+        });
+        modalContainer.addEventListener("keydown", modalKeyHandler);
+
+        // Add focus handlers with proper tracking for cleanup
+        modalButtons.forEach(btn => {
+            const focusHandler = () => {
                 const index = modalButtons.indexOf(btn);
                 if (index >= 0) {
                     currentModalFocusIndex = index;
                     modalButtons.forEach(b => b.classList.remove("modal-btn-focused"));
                     btn.classList.add("modal-btn-focused");
                 }
-            });
+            };
+            btn.addEventListener("focus", focusHandler);
+            focusHandlerMap.set(btn, focusHandler); // Store for cleanup
         });
-        modalContainer.addEventListener("keydown", modalKeyHandler);
 
         // Auto-focus the Confirm button when modal opens
         setTimeout(() => {
@@ -578,26 +621,16 @@ class Toolbar {
             confirmationButton.classList.add("modal-btn-focused");
         }, 150);
 
-        // Clean up listener when modal closes
-        const closeModal = () => {
-            modalButtons.forEach(btn => {
-                btn.removeEventListener("keydown", modalKeyHandler);
-                btn.classList.remove("modal-btn-focused");
-            });
-            modalContainer.removeEventListener("keydown", modalKeyHandler);
-        };
-
-        // Update onclick handlers to clean up
-        const originalConfirmClick = confirmationButton.onclick;
+        // Setup onclick handlers with proper cleanup on close
         confirmationButton.onclick = () => {
-            closeModal();
-            originalConfirmClick();
+            cleanupModalListeners();
+            modalContainer.style.display = "none";
+            onclick(this.activity);
         };
 
-        const originalCancelClick = cancelButton.onclick;
         cancelButton.onclick = () => {
-            closeModal();
-            originalCancelClick();
+            cleanupModalListeners();
+            modalContainer.style.display = "none";
         };
     }
 


### PR DESCRIPTION
# PR Template - Issue #1.1: Modal Button Listener Accumulation

## Category
- [x] Bug Fix 
- [x] Performance Optimization
- [x] Component: New Project Modal Dialog
- [x] Priority: Medium
- [x] Scope: Single Function (renderNewProjectIcon)

## Problem Statement
When the "New Project" dialog is opened multiple times in the same session, event listeners accumulate without cleanup, causing:

- Listener Duplication: Each dialog open adds listeners without removing old ones
- Performance Degradation: Keyboard handlers execute 5x per keystroke after 5 opens
- Memory Leaks: Orphaned listeners persist in memory
- UI Lag: Noticeable slowdown in long working sessions

## Root Cause
The `renderNewProjectIcon()` function creates new event listeners on EVERY call but only removes them when modal CLOSES - not on RE-OPEN. Results in listener stacking (3 → 6 → 9 → 12...).

## Solution Implemented
Implemented defensive listener cleanup:

1. **Defensive Cleanup at Start** - Call `_cleanupModalListeners()` before adding new listeners
2. **Handler Reference Storage** - Store handlers for proper removal
3. **Centralized Cleanup Function** - Remove all listeners and reset state

## Changes Made
**File:** `js/toolbar.js`
- **Function:** `renderNewProjectIcon()`
- **Lines:** 469-620
- **Changes:** 64 insertions, 31 deletions

## Testing Environment Specifications

### Browser Compatibility
- [x] Chrome v118+
- [x] Firefox v121+
- [x] Safari v17+
- [x] Edge v121+

### Operating Systems
- [x] Windows 10/11
- [x] macOS 12+
- [x] Linux Ubuntu 20.04+

### Test Results
-  Opened dialog 5+ times, keyboard navigation smooth each time
-  DevTools confirms listener count stable (not increasing)
-  No memory growth during extended testing
-  All browsers tested and working

## Impact
-  Eliminates performance degradation on repeated opens
-  Prevents memory leaks
-  Maintains keyboard smoothness
-  Better battery life

## Related
- PR #5289 (accessibility improvements - this complements)
- PR #5753 (similar listener cleanup pattern)
- Issue #5288 (accessibility)

**Labels:** `bug, performance, memory-leak, event-handling, ui`
