### PR TITLE
fix: add defensive null checks to GraphicsBlocks to prevent test crashes

### DIFF
--- a/js/blocks/GraphicsBlocks.js
+++ b/js/blocks/GraphicsBlocks.js
@@ -97,11 +97,12 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The heading value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
+            const connections = activity.blocks.blockList?.[blk]?.connections;
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
+                activity.blocks.blockList &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -182,11 +183,12 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The Y-coordinate value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
+            const connections = activity.blocks.blockList?.[blk]?.connections;
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
+                activity.blocks.blockList &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -268,11 +270,12 @@ function setupGraphicsBlocks(activity) {
          * @returns {number} - The X-coordinate value.
          */
         arg(logo, turtle, blk) {
-            const connections = activity.blocks.blockList[blk]?.connections;
+            const connections = activity.blocks.blockList?.[blk]?.connections;
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
                 parentId != null &&
+                activity.blocks.blockList &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -335,7 +338,9 @@ function setupGraphicsBlocks(activity) {
                     if (!logo.pitchBlocks.includes(blk)) {
                         logo.pitchBlocks.push(blk);
                     }
-                    logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    }
                     logo.phraseMaker.rowArgs.push([args[0], args[1]]);
                 } else if (tur.singer.inNoteBlock.length > 0) {
                     tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -630,7 +635,9 @@ function setupGraphicsBlocks(activity) {
                         if (!logo.pitchBlocks.includes(blk)) {
                             logo.pitchBlocks.push(blk);
                         }
-                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                            logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        }
                         logo.phraseMaker.rowArgs.push([args[0], args[1]]);
                     } else if (tur.singer.inNoteBlock.length > 0) {
                         tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -702,7 +709,9 @@ function setupGraphicsBlocks(activity) {
                     if (!logo.pitchBlocks.includes(blk)) {
                         logo.pitchBlocks.push(blk);
                     }
-                    logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    }
                     logo.phraseMaker.rowArgs.push(args[0]);
                 } else if (tur.singer.inNoteBlock.length > 0) {
                     tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -789,7 +798,9 @@ function setupGraphicsBlocks(activity) {
                         if (!logo.pitchBlocks.includes(blk)) {
                             logo.pitchBlocks.push(blk);
                         }
-                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                            logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        }
                         logo.phraseMaker.rowArgs.push([args[0], args[1]]);
                     } else if (tur.singer.inNoteBlock.length > 0) {
                         tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -870,7 +881,9 @@ function setupGraphicsBlocks(activity) {
                     if (!logo.pitchBlocks.includes(blk)) {
                         logo.pitchBlocks.push(blk);
                     }
-                    logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    }
                     logo.phraseMaker.rowArgs.push(args[0]);
                 } else if (tur.singer.inNoteBlock.length > 0) {
                     tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -950,7 +963,9 @@ function setupGraphicsBlocks(activity) {
                     if (!logo.pitchBlocks.includes(blk)) {
                         logo.pitchBlocks.push(blk);
                     }
-                    logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                    }
                     logo.phraseMaker.rowArgs.push(args[0]);
                 } else if (tur.singer.inNoteBlock.length > 0) {
                     tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -1038,7 +1053,9 @@ function setupGraphicsBlocks(activity) {
                         if (!logo.pitchBlocks.includes(blk)) {
                             logo.pitchBlocks.push(blk);
                         }
-                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                            logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        }
                         logo.phraseMaker.rowArgs.push(args[0]);
                     } else if (tur.singer.inNoteBlock.length > 0) {
                         tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -1127,7 +1144,9 @@ function setupGraphicsBlocks(activity) {
                         if (!logo.pitchBlocks.includes(blk)) {
                             logo.pitchBlocks.push(blk);
                         }
-                        logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        if (activity.blocks.blockList && blk in activity.blocks.blockList) {
+                            logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                        }
                         logo.phraseMaker.rowArgs.push(args[0]);
                     } else if (tur.singer.inNoteBlock.length > 0) {
                         tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
@@ -1226,7 +1245,11 @@ function setupGraphicsBlocks(activity) {
             const listenerName = "_wrap_" + turtle;
             tur.painter.wrap = arg0 === "on";
 
-            if (blk !== undefined && blk in activity.blocks.blockList) {
+            if (
+                blk !== undefined &&
+                activity.blocks.blockList &&
+                blk in activity.blocks.blockList
+            ) {
                 logo.setDispatchBlock(blk, turtle, listenerName);
             } else if (MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);


### PR DESCRIPTION
## Summary
Fixes a regression in [js/blocks/GraphicsBlocks.js](cci:7://file:///home/appu/projects/sugar/musicblocks/js/blocks/GraphicsBlocks.js:0:0-0:0) that caused CI failures in unit tests.

## Problem
Unsafe access to `activity.blocks.blockList` caused `TypeError: Cannot read properties of undefined (reading '0')` when blocks were partially mocked in tests.

## Changes
- Added defensive null checks and optional chaining to [arg](cci:1://file:///home/appu/projects/sugar/musicblocks/js/blocks/IntervalsBlocks.js:1387:8-1407:9) methods of [HeadingBlock](cci:2://file:///home/appu/projects/sugar/musicblocks/js/blocks/GraphicsBlocks.js:39:4-114:5), [YBlock](cci:2://file:///home/appu/projects/sugar/musicblocks/js/blocks/GraphicsBlocks.js:120:4-201:5), and [XBlock](cci:2://file:///home/appu/projects/sugar/musicblocks/js/blocks/GraphicsBlocks.js:207:4-288:5).
- Added safety guards to [flow](cci:1://file:///home/appu/projects/sugar/musicblocks/js/blocks/IntervalsBlocks.js:1033:8-1066:9) methods for several graphics blocks.

## Verification
- `npm test js/blocks/__tests__/GraphicsBlocks.test.js` passes successfully.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

Closes #6179
