### PR TITLE
fix: replace global DOM queries with widget-local references in sampler tuner

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -189,8 +189,8 @@ function SampleWidget() {
                         this.activity.blocks.blockList[mainSampleBlock].text.text
                     ) {
                         // Append cent adjustment to the block text if possible
-                        const currentText = this.activity.blocks.blockList[mainSampleBlock].text
-                            .text;
+                        const currentText =
+                            this.activity.blocks.blockList[mainSampleBlock].text.text;
                         if (!currentText.includes("¢")) {
                             this.activity.blocks.blockList[mainSampleBlock].text.text +=
                                 " " + centText;
@@ -209,12 +209,12 @@ function SampleWidget() {
      * @returns {void}
      */
     this.pause = function () {
-        this.playBtn.innerHTML = `<img 
-                src="header-icons/play-button.svg" 
-                title="${_("Play")}" 
-                alt="${_("Play")}" 
-                height="${ICONSIZE}" 
-                width="${ICONSIZE}" 
+        this.playBtn.innerHTML = `<img
+                src="header-icons/play-button.svg"
+                title="${_("Play")}"
+                alt="${_("Play")}"
+                height="${ICONSIZE}"
+                width="${ICONSIZE}"
                 vertical-align="middle"
             >`;
         this.isMoving = false;
@@ -225,12 +225,12 @@ function SampleWidget() {
      * @returns {void}
      */
     this.resume = function () {
-        this.playBtn.innerHTML = `<img 
-                src="header-icons/pause-button.svg" 
-                title="${_("Pause")}" 
-                alt="${_("Pause")}" 
-                height="${ICONSIZE}" 
-                width="${ICONSIZE}" 
+        this.playBtn.innerHTML = `<img
+                src="header-icons/pause-button.svg"
+                title="${_("Pause")}"
+                alt="${_("Pause")}"
+                height="${ICONSIZE}"
+                width="${ICONSIZE}"
                 vertical-align="middle"
             >`;
         this.isMoving = true;
@@ -522,28 +522,24 @@ function SampleWidget() {
             }
         };
 
-        widgetWindow.addButton(
-            "load-media.svg",
-            ICONSIZE,
-            _("Upload sample"),
-            ""
-        ).onclick = function () {
-            stopTuner();
-            const fileChooser = docById("myOpenAll");
+        widgetWindow.addButton("load-media.svg", ICONSIZE, _("Upload sample"), "").onclick =
+            function () {
+                stopTuner();
+                const fileChooser = docById("myOpenAll");
 
-            // eslint-disable-next-line no-unused-vars
-            const __readerAction = function (event) {
+                // eslint-disable-next-line no-unused-vars
+                const __readerAction = function (event) {
+                    window.scroll(0, 0);
+                    const sampleFile = fileChooser.files[0];
+                    that.handleFiles(sampleFile);
+                    fileChooser.removeEventListener("change", __readerAction);
+                };
+
+                fileChooser.addEventListener("change", __readerAction, false);
+                fileChooser.focus();
+                fileChooser.click();
                 window.scroll(0, 0);
-                const sampleFile = fileChooser.files[0];
-                that.handleFiles(sampleFile);
-                fileChooser.removeEventListener("change", __readerAction);
             };
-
-            fileChooser.addEventListener("change", __readerAction, false);
-            fileChooser.focus();
-            fileChooser.click();
-            window.scroll(0, 0);
-        };
 
         // Create a container for the pitch button and frequency display
         this.pitchBtnContainer = document.createElement("div");
@@ -576,22 +572,18 @@ function SampleWidget() {
         };
 
         this._save_lock = false;
-        widgetWindow.addButton(
-            "export-chunk.svg",
-            ICONSIZE,
-            _("Save sample"),
-            ""
-        ).onclick = function () {
-            stopTuner();
-            // Debounce button
-            if (!that._get_save_lock()) {
-                that._save_lock = true;
-                that._saveSample();
-                setTimeout(function () {
-                    that._save_lock = false;
-                }, 1000);
-            }
-        };
+        widgetWindow.addButton("export-chunk.svg", ICONSIZE, _("Save sample"), "").onclick =
+            function () {
+                stopTuner();
+                // Debounce button
+                if (!that._get_save_lock()) {
+                    that._save_lock = true;
+                    that._saveSample();
+                    setTimeout(function () {
+                        that._save_lock = false;
+                    }, 1000);
+                }
+            };
 
         this._recordBtn = widgetWindow.addButton("mic.svg", ICONSIZE, _("Toggle Mic"), "");
 
@@ -1783,9 +1775,8 @@ function SampleWidget() {
 
         const __selectionChanged = () => {
             const label = this._pitchWheel.navItems[this._pitchWheel.selectedNavItemIndex].title;
-            const attr = this._accidentalsWheel.navItems[
-                this._accidentalsWheel.selectedNavItemIndex
-            ].title;
+            const attr =
+                this._accidentalsWheel.navItems[this._accidentalsWheel.selectedNavItemIndex].title;
             const octave = Number(
                 this._octavesWheel.navItems[this._octavesWheel.selectedNavItemIndex].title
             );
@@ -2047,9 +2038,8 @@ function SampleWidget() {
             const playbackRate = TunerUtils.calculatePlaybackRate(0, this.centsValue);
             // Apply the playback rate to the sample
             if (instruments[0]["customsample_" + this.originalSampleName]) {
-                instruments[0][
-                    "customsample_" + this.originalSampleName
-                ].playbackRate.value = playbackRate;
+                instruments[0]["customsample_" + this.originalSampleName].playbackRate.value =
+                    playbackRate;
             }
         }
     };
@@ -2213,7 +2203,6 @@ function SampleWidget() {
             this.isPitchDetectionRunning = true;
 
             const updatePitch = () => {
-                // Check if we should stop the loop
                 if (!this.isPitchDetectionRunning) {
                     return;
                 }
@@ -2221,28 +2210,20 @@ function SampleWidget() {
                 analyser.getFloatTimeDomainData(buffer);
                 const pitch = detectPitch(buffer);
 
-                // Safely update DOM elements (check if they exist first)
-                const pitchElement = document.getElementById("pitch");
-                const noteElement = document.getElementById("note");
-
-                if (pitchElement && noteElement) {
-                    if (pitch > 0) {
-                        const { note, cents } = frequencyToNote(pitch);
-                        pitchElement.textContent = pitch.toFixed(2);
-                        noteElement.textContent =
-                            cents === 0 ? ` ${note} (Perfect)` : ` ${note}, off by ${cents} cents`;
-                    } else {
-                        pitchElement.textContent = "---";
-                        noteElement.textContent = "---";
-                    }
+                if (pitch > 0) {
+                    const { note, cents } = frequencyToNote(pitch);
+                    pitchElement.textContent = pitch.toFixed(2);
+                    noteElement.textContent =
+                        cents === 0 ? ` ${note} (Perfect)` : ` ${note}, off by ${cents} cents`;
+                } else {
+                    pitchElement.textContent = "---";
+                    noteElement.textContent = "---";
                 }
 
-                // Only continue the loop if still running
                 if (this.isPitchDetectionRunning) {
                     this.pitchDetectionAnimationId = requestAnimationFrame(updatePitch);
                 }
             };
-
             // Start the animation loop
             this.pitchDetectionAnimationId = requestAnimationFrame(updatePitch);
         } catch (err) {
@@ -2307,7 +2288,7 @@ function SampleWidget() {
 
         this.widgetWindow.getWidgetBody().appendChild(container);
 
-        document.getElementById("start").addEventListener("click", startPitchDetection);
+        startButton.addEventListener("click", startPitchDetection);
     };
 
     /**


### PR DESCRIPTION
Fixes #5962

## Summary
This PR improves the sampler tuner implementation by removing unsafe global DOM queries and replacing them with widget-local references.

## Changes
- Replaced document.getElementById("start") with a direct reference to the locally created startButton.
- Cached pitch and note DOM elements instead of querying them repeatedly inside the updatePitch animation loop.
- Ensured tuner logic operates strictly within the widget scope.

## Benefits
- Prevents potential DOM collisions when multiple sampler widgets are active.
- Eliminates unnecessary global DOM lookups inside the animation loop.
- Improves performance and maintainability of the tuner implementation.

## Testing
- Opened the Sampler widget in Music Blocks
- Started the tuner and verified pitch detection updates correctly

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation