### PR TITLE
fix(eslint): simplify config and restore safety rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,71 +1,59 @@
-import js from '@eslint/js';
-import globals from 'globals';
-import babelParser from '@babel/eslint-parser';
-import prettierConfig from 'eslint-config-prettier';
+import js from "@eslint/js";
+import globals from "globals";
+import prettierConfig from "eslint-config-prettier";
 
 export default [
     js.configs.recommended,
     prettierConfig,
+
     {
         ignores: [
-            '**/node_modules/**',
-            '**/lib/**',
-            '**/dist/**',
-            '**/build/**',
-            '**/coverage/**',
-            '**/*.min.js',
-            '**/bower_components/**',
-            '**/planet/libs/**',
-        ],
+            "**/node_modules/**",
+            "**/lib/**",
+            "**/dist/**",
+            "**/build/**",
+            "**/coverage/**",
+            "**/*.min.js",
+            "**/bower_components/**",
+            "**/planet/libs/**"
+        ]
     },
+
     {
-        linterOptions: {
-            reportUnusedDisableDirectives: 'off',
-        },
-    },
-    {
-        files: ['**/*.js', '**/*.mjs'],
+        files: ["**/*.js", "**/*.mjs"],
         languageOptions: {
-            ecmaVersion: 'latest',
-            sourceType: 'script',
-            parser: babelParser,
-            parserOptions: {
-                requireConfigFile: false,
-                ecmaFeatures: {
-                    globalReturn: false,
-                },
-            },
+            ecmaVersion: "latest",
+            sourceType: "script",
             globals: {
                 ...globals.browser,
                 ...globals.node,
                 ...globals.jest,
                 ...globals.jquery,
-                // Add specific Music Blocks globals if needed
-                Logo: 'readonly',
-                Blocks: 'readonly',
-                Turtles: 'readonly',
-                Activity: 'readonly',
-                _: 'readonly', // i18n
-            },
+
+                Logo: "readonly",
+                Blocks: "readonly",
+                Turtles: "readonly",
+                Activity: "readonly",
+                _: "readonly"
+            }
         },
+
         rules: {
-            'no-console': 'off',
-            'no-unused-vars': 'off',
-            'no-use-before-define': 'off',
-            'prefer-const': 'off',
-            'no-undef': 'off',
-            'no-redeclare': 'off',
-            'semi': ['error', 'always'],
-            'no-duplicate-case': 'error',
-            'no-irregular-whitespace': 'warn',
-            'no-prototype-builtins': 'off',
-            'no-useless-escape': 'off',
-            'no-inner-declarations': 'off',
-            'no-constant-assign': 'off',
-            'no-const-assign': 'off',
-            'no-dupe-keys': 'off',
-            'no-useless-catch': 'off',
-            'no-loss-of-precision': 'off',
-        },
+            "no-console": "off",
+            "no-unused-vars": "off",
+            "no-use-before-define": "off",
+            "prefer-const": "off",
+
+            "semi": ["error", "always"],
+            "no-duplicate-case": "error",
+            "no-irregular-whitespace": "warn"
+        }
     },
+
+    {
+        files: ["**/*.mjs"],
+        languageOptions: {
+            sourceType: "module"
+        }
+    }
 ];


### PR DESCRIPTION
## PR Category

- [x] Bug Fix


Removed:

- @babel/eslint-parser dependency and its parserOptions block
- linterOptions: { reportUnusedDisableDirectives: 'off' } 
- 9 dangerously disabled rules: `no-undef, no-redeclare, no-prototype-builtins, no-useless-escape, no-inner-declarations, no-constant-assign, no-const-assign, no-dupe-keys, no-useless-catch, no-loss-of-precision`


Added:

Separate { files: ['**/*.mjs'] } block with sourceType: 'module' correctly handles ES module files