### PR TITLE
Solved avoid permanently attached global resize listener for wheel sizing

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -110,6 +110,8 @@ const debouncedSetWheelSize = () => {
 };
 const enableWheelResizeHandling = () => {
     if (wheelResizeListenerActive) return;
+    setWheelSize();
+    window.addEventListener("resize", debouncedSetWheelSize);
     wheelResizeListenerActive = true;
 };
 
@@ -117,9 +119,6 @@ const disableWheelResizeHandling = () => {
     window.removeEventListener("resize", debouncedSetWheelSize);
     wheelResizeListenerActive = false;
 };
-// Call the function initially and whenever the window is resized
-setWheelSize();
-window.addEventListener("resize", debouncedSetWheelSize);
 
 /**
  * Enables mouse-wheel scrolling to rotate a wheelnav instance


### PR DESCRIPTION
Problem
piemenus.js registered a global resize event listener (debouncedSetWheelSize) at module load time that remained active for the entire page lifecycle — even when no pie menu was visible. This caused unnecessary work on every resize/orientation change event, and repeated module initialization could accumulate duplicate listeners.
Changes Made

Removed the always-on window.addEventListener("resize", debouncedSetWheelSize) call from module scope.
Added a boolean guard wheelResizeListenerActive to prevent duplicate listener registration.
Added two lifecycle hooks:

enableWheelResizeHandling() — attaches the resize listener, called when any pie menu opens.
disableWheelResizeHandling() — removes the resize listener, called when any pie menu closes.


Updated all 14 pie menu functions (piemenuPitches, piemenuCustomNotes, piemenuNthModalPitch, piemenuAccidentals, piemenuNoteValue, piemenuNumber, piemenuColor, piemenuBasic, piemenuBoolean, piemenuChords, piemenuVoices, piemenuIntervals, piemenuModes, piemenuDissectNumber) to call enableWheelResizeHandling() on open and disableWheelResizeHandling() on close.

This will resolve the issue : https://github.com/sugarlabs/musicblocks/issues/6177

## PR Category
- [x] Bug Fix

## Testing Done

Manually tested the following scenarios in the browser:

1. Wheel resizes correctly on window resize while pie menu is open
   - Opened a pitch pie menu, resized the browser window wheel size updated correctly

2. Listener activates only when a pie menu opens
   - Opened browser DevTools console, added a log inside debouncedSetWheelSize
   - Confirmed no resize events fired before opening any pie menu
   - Confirmed resize events fired after opening a pie menu

3. Listener is removed when the pie menu closes
   - Opened a pie menu, then closed it via the × button
   - Resized the window confirmed no resize handler fired after closing

4. No duplicate listeners on opening/closing multiple times
   - Opened and closed pie menus repeatedly
   - Confirmed wheelResizeListenerActive guard prevented duplicate registration
   - Used browser DevTools Event Listeners panel to verify only one resize 
     listener exists at a time