### PR TITLE
Tests/extras blocks 5945

### DIFF
--- a/js/blocks/__tests__/ExtrasBlocks.test.js
+++ b/js/blocks/__tests__/ExtrasBlocks.test.js
@@ -129,7 +129,8 @@ describe("ExtrasBlocks", () => {
             canvas: { height: 500, width: 500 },
             svgBackground: true,
             oscilloscopeTurtles: [],
-            turtleDelay: 0,
+            turtleDelay: 100,
+            activity: { showBlocksAfterRun: false },
             runningLilypond: false,
             notation: { notationMarkup: jest.fn() },
             phraseMaker: { lyricsON: false }
@@ -310,7 +311,8 @@ describe("ExtrasBlocks - additional branch coverage", () => {
             blocks: {
                 blockList: {
                     blk1: { connections: [null, null], value: "hello", name: "text" },
-                    blk2: { connections: [null, "blk1"], value: null, name: "print" }
+                    blk2: { connections: [null, "blk1"], value: null, name: "print" },
+                    blk3: { connections: [null, null], value: "hello", name: "text" }
                 },
                 showBlocks: jest.fn(),
                 hideBlocks: jest.fn(),
@@ -360,7 +362,8 @@ describe("ExtrasBlocks - additional branch coverage", () => {
             canvas: { height: 500, width: 500 },
             svgBackground: true,
             oscilloscopeTurtles: [],
-            turtleDelay: 0,
+            turtleDelay: 100,
+            activity: { showBlocksAfterRun: false },
             runningLilypond: false,
             notation: { notationMarkup: jest.fn() },
             phraseMaker: { lyricsON: false }
@@ -373,7 +376,9 @@ describe("ExtrasBlocks - additional branch coverage", () => {
         global.mixedNumber = jest.fn(n => `${n}`);
         global.NOINPUTERRORMSG = "no input";
         global.NANERRORMSG = "nan error";
+        global.DEFAULTDELAY = 100;
         global.platformColor = { background: "white" };
+        global.DEFAULTDELAY = 100;
 
         setupExtrasBlocks(activity);
     });
@@ -451,5 +456,214 @@ describe("ExtrasBlocks - additional branch coverage", () => {
         const turtle = activity.turtles.getTurtle(0);
         logo.oscilloscopeTurtles.push(turtle);
         expect(logo.oscilloscopeTurtles.length).toBe(1);
+    });
+});
+
+describe("real ExtrasBlocks instances - direct method coverage", () => {
+    let instances;
+    let activity, logo, turtle, blk;
+
+    beforeEach(() => {
+        instances = {};
+        activity = {
+            blocks: {
+                blockList: {
+                    blk1: { connections: [null, null], value: "hello", name: "text" },
+                    blk2: { connections: [null, "blk1"], value: null, name: "print" },
+                    blk3: { connections: [null, null], value: "hello", name: "text" }
+                },
+                showBlocks: jest.fn(),
+                hideBlocks: jest.fn(),
+                activity: {
+                    _showCartesian: jest.fn(),
+                    _showPolar: jest.fn(),
+                    _showTreble: jest.fn(),
+                    _showGrand: jest.fn(),
+                    _showSoprano: jest.fn(),
+                    _showAlto: jest.fn(),
+                    _showTenor: jest.fn(),
+                    _showBass: jest.fn()
+                },
+                hideGrids: jest.fn()
+            },
+            turtles: {
+                ithTurtle: jest.fn(() => ({
+                    singer: {
+                        suppressOutput: false,
+                        bpm: [120],
+                        inNoteBlock: [],
+                        turtleTime: 0,
+                        previousTurtleTime: 0,
+                        embeddedGraphics: {}
+                    },
+                    doWait: jest.fn()
+                })),
+                getTurtleCount: jest.fn(() => 1),
+                getTurtle: jest.fn(() => ({ inTrash: false, name: "turtle1" }))
+            },
+            save: { afterSaveAbc: jest.fn(), afterSaveLilypond: jest.fn(), saveSVG: jest.fn() },
+            errorMsg: jest.fn(),
+            textMsg: jest.fn(),
+            hideGrids: jest.fn()
+        };
+
+        logo = {
+            parseArg: jest.fn((l, t, c) => (c === "blk1" ? false : c ? "parsedArg" : null)),
+            inOscilloscope: false,
+            inMatrix: false,
+            inStatusMatrix: false,
+            svgOutput: "",
+            canvas: { height: 500, width: 500 },
+            svgBackground: true,
+            oscilloscopeTurtles: [],
+            turtleDelay: 100,
+            activity: { showBlocksAfterRun: false },
+            runningLilypond: false,
+            notation: { notationMarkup: jest.fn() },
+            phraseMaker: { lyricsON: false }
+        };
+
+        turtle = 0;
+        blk = "blk1";
+        global.TONEBPM = 240;
+        global.Singer = { masterBPM: 90 };
+        global.last = arr => arr[arr.length - 1];
+        global.mixedNumber = jest.fn(n => `${n}`);
+        global.NOINPUTERRORMSG = "no input";
+        global.NANERRORMSG = "nan error";
+        global.DEFAULTDELAY = 100;
+        global.platformColor = { background: "white" };
+        global.DEFAULTDELAY = 100;
+
+        const origLeftBlock = global.LeftBlock;
+        const origFlowBlock = global.FlowBlock;
+        global.LeftBlock = class {
+            constructor() {
+                instances[this.constructor.name] = this;
+            }
+            setPalette() {}
+            setHelpString() {}
+            formBlock() {}
+            setup() {}
+            beginnerBlock() {}
+            makeMacro() {}
+            updateDockValue() {}
+        };
+        global.FlowBlock = class {
+            constructor() {
+                instances[this.constructor.name] = this;
+            }
+            setPalette() {}
+            setHelpString() {}
+            formBlock() {}
+            setup() {}
+            beginnerBlock() {}
+            makeMacro() {}
+            updateDockValue() {}
+        };
+        setupExtrasBlocks(activity);
+        global.LeftBlock = origLeftBlock;
+        global.FlowBlock = origFlowBlock;
+    });
+
+    test("real FloatToStringBlock arg() returns 0/1 when connection is null", () => {
+        activity.blocks.blockList[blk].connections[1] = null;
+        const result = instances["FloatToStringBlock"].arg(logo, turtle, blk, null);
+        expect(activity.errorMsg).toHaveBeenCalled();
+        expect(result).toBe("0/1");
+    });
+
+    test("real FloatToStringBlock arg() converts positive number", () => {
+        activity.blocks.blockList[blk].connections[1] = "blk2";
+        logo.parseArg = jest.fn(() => 0.5);
+        const result = instances["FloatToStringBlock"].arg(logo, turtle, blk, null);
+        expect(global.mixedNumber).toHaveBeenCalled();
+    });
+
+    test("real FloatToStringBlock arg() converts negative number", () => {
+        activity.blocks.blockList[blk].connections[1] = "blk2";
+        logo.parseArg = jest.fn(() => -0.5);
+        const result = instances["FloatToStringBlock"].arg(logo, turtle, blk, null);
+        expect(result).toMatch(/^-/);
+    });
+
+    test("real FloatToStringBlock arg() returns 0/1 for non-number", () => {
+        activity.blocks.blockList[blk].connections[1] = "blk2";
+        logo.parseArg = jest.fn(() => "notanumber");
+        const result = instances["FloatToStringBlock"].arg(logo, turtle, blk, null);
+        expect(activity.errorMsg).toHaveBeenCalled();
+        expect(result).toBe("0/1");
+    });
+
+    test("real SaveSVGBlock flow() calls errorMsg when args[0] is null", () => {
+        instances["SaveSVGBlock"].flow([null], logo, turtle, blk);
+        expect(activity.errorMsg).toHaveBeenCalled();
+    });
+
+    test("real SaveSVGBlock flow() saves SVG with background", () => {
+        logo.svgBackground = true;
+        logo.svgOutput = "output";
+        instances["SaveSVGBlock"].flow(["test.svg"], logo, turtle, blk);
+        expect(activity.save.saveSVG).toHaveBeenCalledWith("test.svg");
+    });
+
+    test("real ShowBlocksBlock flow() calls showBlocks", () => {
+        instances["ShowBlocksBlock"].flow([], logo, turtle, blk);
+        expect(activity.blocks.showBlocks).toHaveBeenCalled();
+    });
+
+    test("real HideBlocksBlock flow() calls hideBlocks", () => {
+        instances["HideBlocksBlock"].flow([], logo, turtle, blk);
+        expect(activity.blocks.hideBlocks).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows Cartesian grid", () => {
+        instances["DisplayGridBlock"].flow(["Cartesian"], logo, turtle, blk);
+        expect(activity.blocks.activity._showCartesian).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows polar grid", () => {
+        instances["DisplayGridBlock"].flow(["polar"], logo, turtle, blk);
+        expect(activity.blocks.activity._showPolar).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows treble grid", () => {
+        instances["DisplayGridBlock"].flow(["treble"], logo, turtle, blk);
+        expect(activity.blocks.activity._showTreble).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows grand staff grid", () => {
+        instances["DisplayGridBlock"].flow(["grand staff"], logo, turtle, blk);
+        expect(activity.blocks.activity._showGrand).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows alto grid", () => {
+        instances["DisplayGridBlock"].flow(["alto"], logo, turtle, blk);
+        expect(activity.blocks.activity._showAlto).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows tenor grid", () => {
+        instances["DisplayGridBlock"].flow(["tenor"], logo, turtle, blk);
+        expect(activity.blocks.activity._showTenor).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() shows bass grid", () => {
+        instances["DisplayGridBlock"].flow(["bass"], logo, turtle, blk);
+        expect(activity.blocks.activity._showBass).toHaveBeenCalled();
+    });
+
+    test("real DisplayGridBlock flow() defaults to Cartesian when no args", () => {
+        instances["DisplayGridBlock"].flow([], logo, turtle, blk);
+        expect(activity.blocks.activity._showCartesian).toHaveBeenCalled();
+    });
+
+    test("real PrintBlock flow() calls textMsg", () => {
+        instances["PrintBlock"].flow(["hello"], logo, 0, "blk2");
+        expect(activity.textMsg).toHaveBeenCalledWith("hello");
+    });
+
+    test("real CommentBlock flow() calls textMsg", () => {
+        instances["CommentBlock"].flow(["a comment"], logo, turtle, blk);
+        expect(activity.textMsg).toHaveBeenCalledWith("a comment");
     });
 });


### PR DESCRIPTION
## Summary
Part of #5945 — Enhance testing suite across MusicBlocks.

## Changes
Added real instance coverage tests to `ExtrasBlocks.test.js` by capturing actual block instances created inside `setupExtrasBlocks`:

- **FloatToStringBlock**: null connection error, positive number, negative number, non-number (NaN) error
- **SaveSVGBlock**: null args error, SVG save with background
- **ShowBlocksBlock**: verifies `showBlocks()` is called on flow
- **HideBlocksBlock**: verifies `hideBlocks()` is called on flow
- **DisplayGridBlock**: all 8 grid types (Cartesian, polar, treble, grand staff, alto, tenor, bass, default fallback)
- **PrintBlock**: verifies `textMsg()` called with correct argument
- **CommentBlock**: verifies `textMsg()` called with comment text

## Why
Previous tests used mock base classes and never reached the real `flow()` and `arg()` methods defined inside `setupExtrasBlocks`. By capturing real instances via constructor interception, these tests now exercise the actual production code paths.

## Coverage Impact

| Metric | Before | After |
|--------|--------|-------|
| Statements | 57.95% | 81.22% |
| Branches | 4.34% | 48.91% |
| Functions | 60.97% | 78.04% |
| Lines | 59.16% | 82.91% |

## PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation