### PR TITLE
fix: replace blocking alert() with activity.textMsg() in ReturnToURLB…

### DIFF
--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -12,7 +12,7 @@
 /*
 global
 
-_, FlowBlock, LeftBlock, FlowClampBlock, StackClampBlock, ValueBlock,
+FlowBlock, LeftBlock, FlowClampBlock, StackClampBlock, ValueBlock,
 Queue, NOACTIONERRORMSG, NOINPUTERRORMSG
 */
 
@@ -201,7 +201,7 @@ function setupActionBlocks(activity) {
                 // Call a function when the state changes.
                 xmlHttp.onreadystatechange = () => {
                     if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
-                        alert(xmlHttp.responseText);
+                        activity.textMsg(xmlHttp.responseText);
                     }
                 };
 


### PR DESCRIPTION
## Fix: Replace blocking `alert()` with `activity.textMsg()` in `ReturnToURLBlock`

Closes #6234

### What changed

In `js/blocks/ActionBlocks.js`, the `ReturnToURLBlock` fires an XHR POST to an external URL and shows the server's response to the user. Previously this used a native browser `alert()`:

```js
// Before
xmlHttp.onreadystatechange = () => {
    if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
        alert(xmlHttp.responseText);
    }
};
```

```js
// After
xmlHttp.onreadystatechange = () => {
    if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
        activity.textMsg(xmlHttp.responseText);
    }
};
```

Also removed `_` from the `/* global */` comment — it is already declared as a browser built-in by the ESLint config, causing a pre-existing `no-redeclare` lint error.

### Why

`alert()` **freezes the entire page** until the user clicks OK — this interrupts music playback, animations, and all input. It also shows raw server text directly to the user with no localization.

`activity.textMsg()` is the standard non-blocking user notification used consistently throughout the codebase for exactly this kind of feedback.

### Testing

- ESLint: ✅ no errors or warnings on the modified file
- Prettier: ✅ formatted
- Only `js/blocks/ActionBlocks.js` is modified — no unrelated changes

### Checklist

- [x] I have read and followed the project's code of conduct.
- [x] I have searched for existing issues and PRs before opening this one.
- [x] I have provided enough context to understand and review the change.
- [x] I am willing to address review feedback.
- [x] Bug fix

---

📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md).

🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).
