### PR TITLE
fix: correct errorMsg reference in addScalarTransposition

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -377,7 +377,7 @@ class Singer {
                     tur.singer.keySignature,
                     tur.singer.movable,
                     null,
-                    activity.logo.errorMsg,
+                    activity.errorMsg,
                     logo.synth.inTemperament
                 );
             }


### PR DESCRIPTION
`addScalarTransposition` passed `activity.logo.errorMsg` which is undefined. `errorMsg` lives on `activity` directly, not on `activity.logo`.

**Fix:** Replace `activity.logo.errorMsg` with `activity.errorMsg`.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation