### PR TITLE
Add tests for drum palette

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -15,6 +15,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * global MULTIPALETTES, platformColor, docById, TEXTWIDTH
  */
 
 /* global MULTIPALETTES, platformColor, docById, TEXTWIDTH */
@@ -2512,5 +2513,47 @@ describe("Drum Palette Tests", () => {
 
         expect(palettes.dict["drum"].showMenu).toHaveBeenCalledWith(true);
         expect(palettes.activePalette).toBe("drum");
+    });
+});
+
+describe("Meter Palette Tests", () => {
+    let mockActivity;
+    let palettes;
+
+    beforeEach(() => {
+        mockActivity = {
+            cellSize: 50,
+            blocks: {
+                protoBlockDict: {
+                    meterBlock1: { palette: { name: "meter" } },
+                    meterBlock2: { palette: { name: "meter" } },
+                    otherBlock: { palette: { name: "pitch" } }
+                }
+            },
+            hideSearchWidget: jest.fn(),
+            showSearchWidget: jest.fn(),
+            beginnerMode: true
+        };
+
+        palettes = new Palettes(mockActivity);
+        palettes.add("meter");
+    });
+
+    test("meter palette should be created", () => {
+        expect(palettes.dict["meter"]).toBeDefined();
+    });
+
+    test("meter palette should count meter blocks correctly", () => {
+        const count = palettes.countProtoBlocks("meter");
+        expect(count).toBe(2);
+    });
+
+    test("showPalette should activate meter palette", () => {
+        palettes.dict["meter"].showMenu = jest.fn();
+
+        palettes.showPalette("meter");
+
+        expect(palettes.dict["meter"].showMenu).toHaveBeenCalledWith(true);
+        expect(palettes.activePalette).toBe("meter");
     });
 });

--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -15,6 +15,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * /* global MULTIPALETTES, platformColor, docById, TEXTWIDTH
  */
 
 // A basic test file in jest framework for the mathutils.js


### PR DESCRIPTION
## PR Category
- [x] Tests

## Description
Adds unit tests for the Drum palette in palette.test.js.

Tests included:
- Drum palette initialization
- Counting drum blocks
- Palette activation behavior