### PR TITLE
docs: add PERFORMANCE.md documenting ?performance flag

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,106 @@
+# Performance Instrumentation in Music Blocks
+
+Music Blocks includes an optional runtime performance instrumentation layer that helps developers understand how programs execute internally.
+
+This feature is primarily intended for **debugging and performance analysis during development**. It is disabled by default and does not affect normal users.
+
+The instrumentation collects a few useful runtime metrics such as execution time, memory usage changes, and interpreter depth.
+
+---
+
+## Enabling Performance Tracking
+
+Performance instrumentation can be enabled in two ways.
+
+### 1. URL Parameter
+
+You can enable performance tracking by adding the following parameter to the URL when launching Music Blocks:
+
+```
+?performance=true
+```
+
+Example:
+
+```
+http://localhost:8000/?performance=true
+```
+
+Once enabled, performance statistics will be printed to the browser console when a program finishes executing.
+
+---
+
+### 2. Global Debug Flag
+
+Performance tracking can also be enabled manually from the browser console:
+
+```
+window.DEBUG_PERFORMANCE = true
+```
+
+This is useful when debugging without restarting the application.
+
+---
+
+## Example Output
+
+When enabled, the console will show output similar to the following:
+
+```
+[Performance] Music Blocks Stats:
+- Execution Time: 1842ms
+- Memory Delta: +2.1MB
+- Max Execution Depth: 126
+```
+
+These metrics help developers understand how expensive a program execution was and whether changes affect runtime behavior.
+
+---
+
+## Metrics Collected
+
+### Execution Time
+
+The total time required to run the program, measured using `performance.now()` for high precision.
+
+### Memory Delta
+
+The difference in JavaScript heap memory usage before and after execution.
+
+If the browser does not support memory reporting (for example, some privacy-restricted environments), this metric is safely skipped.
+
+### Maximum Execution Depth
+
+Tracks the deepest level reached in the interpreter during program execution.
+
+This can help identify recursive or deeply nested block structures that may impact performance.
+
+---
+
+## Design Principles
+
+The performance instrumentation was implemented with a few guiding goals:
+
+* **No impact on normal users** – instrumentation is disabled by default.
+* **Developer-focused visibility** – metrics are printed to the console rather than displayed in the UI.
+* **Safe fallbacks** – memory APIs are detected at runtime to avoid crashes in unsupported browsers.
+* **Minimal overhead** – when the feature is disabled, it introduces virtually no runtime cost.
+
+---
+
+## Future Improvements
+
+This instrumentation layer is only the first step toward better performance analysis in Music Blocks. Possible future improvements include:
+
+* A visual performance panel for developers
+* Block-level execution profiling
+* Automated benchmarking in CI
+* Historical performance comparison between runs
+
+---
+
+## Notes for Contributors
+
+If you are working on performance-related changes in Music Blocks, enabling this instrumentation can help you quickly evaluate how your changes affect runtime behavior.
+
+Even small improvements in execution time or interpreter depth can significantly improve the experience when running large block programs.


### PR DESCRIPTION
This PR adds a PERFORMANCE.md file documenting the runtime performance instrumentation and the `?performance=true` flag.
This documentation was suggested during review of the instrumentation PR to help developers understand how to enable and use the performance metrics.

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation
#5959 