### PR TITLE
maintenance: update minor dependencies (cypress, i18next, jest-environment-jsdom, sass)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@babel/eslint-parser": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
         "cross-env": "^7.0.3",
-        "cypress": "^15.9.0",
+        "cypress": "^15.12.0",
         "electron": "40.8.5",
         "electron-builder": "26.8.1",
         "eslint": "^9.0.0",
@@ -43,7 +43,7 @@
         "gulp-uglify": "^3.0.2",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^30.2.0",
+        "jest-environment-jsdom": "^30.3.0",
         "lint-staged": "^15.5.2",
         "nodemon": "^3.1.9",
         "prettier": "^3.6.2"
@@ -60,10 +60,10 @@
         "gulp-sass": "^6.0.1",
         "gulp-sourcemaps": "^3.0.0",
         "http-server": "^14.1.1",
-        "i18next": "^25.3.2",
+        "i18next": "^25.8.18",
         "i18next-http-backend": "^3.0.2",
         "postcss": "^8.5.6",
-        "sass": "^1.97.2",
+        "sass": "^1.98.0",
         "tone": "^15.1.22"
     },
     "build": {


### PR DESCRIPTION
Updates 4 packages to their latest minor/patch versions:

- cypress: 15.11.0 -> 15.12.0
- i18next: 25.8.14 -> 25.8.18
- jest-environment-jsdom: 30.2.0 -> 30.3.0
- sass: 1.97.3 -> 1.98.0


## PR Category
- [ ] Bug Fix
- [x] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation