### PR TITLE
fix(tests): correct doMod zero divisor test to match actual behavior

### DIFF
--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -556,8 +556,8 @@ describe("MathUtility", () => {
     });
 
     describe("edge cases - Infinity, NaN, and boundary values", () => {
-        test("doMod throws DivByZeroError when divisor is zero", () => {
-            expect(() => MathUtility.doMod(5, 0)).toThrow("DivByZeroError");
+        test("doMod returns NaN when divisor is zero", () => {
+            expect(MathUtility.doMod(5, 0)).toBeNaN();
         });
 
         test("doSqrt handles Infinity", () => {


### PR DESCRIPTION
## Description
The test `doMod throws DivByZeroError when divisor is zero` was incorrectly expecting `doMod(5, 0)` to throw a `DivByZeroError`. However, `doMod` uses JavaScript's `%` operator which returns `NaN` for a zero divisor — it does not throw.

## Changes
- Updated the failing test in `mathutils.test.js` to assert `toBeNaN()` instead of expecting a `DivByZeroError` throw
- Updated the test name to accurately describe the actual behavior: `doMod returns NaN when divisor is zero`

## Test Results
Before: 122 passed, 1 failed
<img width="483" height="124" alt="image" src="https://github.com/user-attachments/assets/3d630544-195e-4317-86a1-2e3c50c72687" />
After:  123 passed, 0 failed
<img width="487" height="115" alt="image" src="https://github.com/user-attachments/assets/45eb9339-865b-436e-aac7-2cd0a0b938f3" />

## PR Category
- [ ] Bug Fix
- [ ] Performance
- [ ] Features 
- [x] Tests
- [ ] Documentation