### PR TITLE
Add testsAdd Cypress tests for palette visibility

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -138,4 +138,17 @@ describe("MusicBlocks Application", () => {
                 .and("not.be.empty");
         });
     });
+    describe("Palette Functionality", () => {
+        it("should display palette row 1", () => {
+            cy.get('[width="126"] > tbody > :nth-child(1)').should("be.visible");
+        });
+
+        it("should display palette row 2", () => {
+            cy.get('[width="126"] > tbody > :nth-child(2)').should("be.visible");
+        });
+
+        it("should display palette row 3", () => {
+            cy.get('[width="126"] > tbody > :nth-child(3)').should("be.visible");
+        });
+    });
 });


### PR DESCRIPTION
## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary

This pull request adds Cypress end-to-end tests for verifying palette row visibility in Music Blocks.

## Changes

- Added Cypress tests in cypress/e2e/main.cy.js
- Tests cover palette rows 1–3 visibility
- Ensures UI loads with visible palettes

## Testing

Ran Cypress locally and confirmed all tests pass without failures.

## Motivation

These tests improve the test coverage for UI behavior and help catch regressions in the palette system.
