### PR TITLE
Fix: Mouse pointer getting stuck on blocks in widgets #6238

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1236,16 +1236,27 @@ describe("Palettes Class", () => {
         test("setupGrabScroll updates scrollTop on drag", () => {
             const paletteList = { scrollTop: 100 };
             document.body.style.cursor = "default";
+            document.addEventListener = jest.fn();
+            document.removeEventListener = jest.fn();
 
             palettes.add("test");
             const palette = palettes.dict.test;
             palette.setupGrabScroll(paletteList);
 
+            // mousedown registers document listeners for mousemove and mouseup
             paletteList.onmousedown({ clientY: 10 });
-            paletteList.onmousemove({ clientY: 5 });
 
+            const mouseMoveGrab = document.addEventListener.mock.calls.find(
+                call => call[0] === "mousemove"
+            )[1];
+            const mouseUpGrab = document.addEventListener.mock.calls.find(
+                call => call[0] === "mouseup"
+            )[1];
+
+            mouseMoveGrab({ clientY: 5 });
             expect(paletteList.scrollTop).toBe(105);
-            paletteList.onmouseup();
+
+            mouseUpGrab();
             expect(document.body.style.cursor).toBe("default");
         });
 
@@ -1675,7 +1686,11 @@ describe("Palettes Class", () => {
                 preventDefault: jest.fn()
             });
 
-            img.onmouseup({});
+            // mouseup handler is registered on document (not img.onmouseup) in the PR
+            const mouseUpHandler = document.addEventListener.mock.calls.find(
+                call => call[0] === "mouseup"
+            )[1];
+            mouseUpHandler({});
         });
 
         test("_showMenuItems handles touch drag", () => {
@@ -1752,7 +1767,12 @@ describe("Palettes Class", () => {
                 touches: [{ clientX: 12, clientY: 22 }],
                 preventDefault: jest.fn()
             });
-            img.ontouchend({});
+
+            // touchend handler is registered on document (not img.ontouchend) in the PR
+            const touchEndHandler = document.addEventListener.mock.calls.find(
+                call => call[0] === "touchend"
+            )[1];
+            touchEndHandler({});
         });
 
         test("_showMenuItems hides palette when mobile", () => {

--- a/js/palette.js
+++ b/js/palette.js
@@ -1625,6 +1625,14 @@ class Palette {
             img.ondragstart = () => false;
 
             const down = event => {
+                // Ensure a clear cleanup lifecycle: flush any pending or stalled global listeners
+                if (img._upHandler) {
+                    document.removeEventListener("mouseup", img._upHandler);
+                    document.removeEventListener("touchend", img._upHandler);
+                    document.removeEventListener("mousemove", img._moveHandler);
+                    document.removeEventListener("touchmove", img._moveHandler);
+                }
+
                 // (1) prepare to moving: make absolute and on top by z-index
                 const posit = img.style.position;
                 const zInd = img.style.zIndex;
@@ -1657,6 +1665,7 @@ class Palette {
                     }
                     moveAt(x, y);
                 };
+                img._moveHandler = onMouseMove;
                 onMouseMove(event);
 
                 document.addEventListener("touchmove", onMouseMove, { passive: false });
@@ -1667,8 +1676,10 @@ class Palette {
                     document.body.style.cursor = "default";
                     document.removeEventListener("mousemove", onMouseMove);
                     document.removeEventListener("touchmove", onMouseMove);
-                    img.onmouseup = null;
-                    img.ontouchend = null;
+                    document.removeEventListener("mouseup", up);
+                    document.removeEventListener("touchend", up);
+                    img._upHandler = null;
+                    img._moveHandler = null;
 
                     const x = parseInt(img.style.left);
                     const y = parseInt(img.style.top);
@@ -1692,8 +1703,9 @@ class Palette {
                     );
                 };
 
-                img.ontouchend = up;
-                img.onmouseup = up;
+                img._upHandler = up;
+                document.addEventListener("touchend", up);
+                document.addEventListener("mouseup", up);
             };
 
             img.ontouchstart = down;
@@ -1716,7 +1728,8 @@ class Palette {
         let posY, top;
 
         const mouseUpGrab = () => {
-            // paletteList.onmousemove = null;
+            document.removeEventListener("mousemove", mouseMoveGrab);
+            document.removeEventListener("mouseup", mouseUpGrab);
             document.body.style.cursor = "default";
         };
 
@@ -1727,12 +1740,15 @@ class Palette {
         };
 
         const mouseDownGrab = event => {
+            // Clean up any stray listeners to avoid cumulative memory leaks
+            document.removeEventListener("mousemove", mouseMoveGrab);
+            document.removeEventListener("mouseup", mouseUpGrab);
+
             posY = event.clientY;
             top = paletteList.scrollTop;
 
-            paletteList.onmousemove = mouseMoveGrab;
-            paletteList.onmouseup = mouseUpGrab;
-            paletteList.onmouseleave = mouseUpGrab;
+            document.addEventListener("mousemove", mouseMoveGrab);
+            document.addEventListener("mouseup", mouseUpGrab);
         };
 
         paletteList.onmousedown = mouseDownGrab;

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1429,6 +1429,12 @@ function MusicKeyboard(activity) {
         }
 
         let row, isMouseDown;
+
+        this._matrixMouseUpListener = () => {
+            isMouseDown = false;
+        };
+        document.addEventListener("mouseup", this._matrixMouseUpListener);
+
         for (let i = 0; i < this.layout.length; i++) {
             // The buttons get added to the embedded table.
             row = docById("mkb" + i);
@@ -1468,10 +1474,6 @@ function MusicKeyboard(activity) {
                             this._setNotes(j, true);
                         }
                     }
-                };
-
-                cell.onmouseup = function () {
-                    isMouseDown = false;
                 };
             }
         }

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -4107,7 +4107,16 @@ class PhraseMaker {
             }
         }
 
-        let isMouseDown;
+        if (this._matrixMouseUpListener) {
+            document.removeEventListener("mouseup", this._matrixMouseUpListener);
+        }
+
+        let isMouseDown = false;
+        this._matrixMouseUpListener = () => {
+            isMouseDown = false;
+        };
+        document.addEventListener("mouseup", this._matrixMouseUpListener);
+
         for (let i = 0; i < rowCount; i++) {
             // The buttons get added to the embedded table.
             row = this._rows[i];
@@ -4116,8 +4125,6 @@ class PhraseMaker {
                 // Give each clickable cell a unique id
                 cell.setAttribute("data-i", i);
                 cell.setAttribute("data-j", j);
-
-                isMouseDown = false;
 
                 cell.onmousedown = evt => {
                     isMouseDown = true;
@@ -4146,10 +4153,6 @@ class PhraseMaker {
                             if (!this._noteBlocks) this._setNotes(j, i, true);
                         }
                     }
-                };
-
-                cell.onmouseup = () => {
-                    isMouseDown = false;
                 };
             }
         }


### PR DESCRIPTION
### Summary
This PR fixes the issue where the mouse pointer gets "stuck" when dragging blocks in palettes or interacting with matrix widgets (Phrasemaker, Music Keyboard).

### Changes
- **Palette**: Moved `mouseup` and `touchend` event listeners to the `document` level to ensure drag state is cleaned up even if the mouse is released outside the element.
- - **Palette**: Refactored `setupGrabScroll` to use document-level listeners for a more robust drag-scroll experience.
- - **Phrasemaker & Music Keyboard**: Added a global `document` level `mouseup` listener to reset the `isMouseDown` state, preventing cells from getting caught in a "stuck" state if the mouse is released outside the widget.
- - **Tests**: Updated `palette.test.js` and `turtle-singer.test.js` to match the current implementation and fix unrelated master test failures to ensure CI passes.
- - **MathUtils**: Fixed a `DivByZeroError` case in `doMod` which was causing master tests to fail.
### Related Issue
Closes #6238 
### PR Category
- [x] Bug Fix
- [ ] - [ ] Feature
- [ ] - [ ] Refactor
- [x] - [x] Tests
- [ ] - [ ] Documentation