### PR TITLE
PoC: Implement root-relative frequency computation for Just Intonation chords

### DIFF
--- a/README-temperament-poc.md
+++ b/README-temperament-poc.md
@@ -1,0 +1,50 @@
+# Temperament Engine PoC
+
+Proof of concept for the GSoC "Backporting v4 Temperament to v3" project.
+
+## The Problem
+
+Music Blocks v3 computes note frequencies using a **static lookup table** where every note is a fixed ratio from one starting pitch (`temperamentChanged()` in `synthutils.js`). This produces correct intervals from the starting pitch, but **wrong intervals between other pairs of notes**.
+
+Example: In Just Intonation starting from C, the D-to-F interval is 32/27 (Pythagorean minor third, ~294 cents) instead of 6/5 (just minor third, ~316 cents). The ~21.5-cent error (the syntonic comma) is clearly audible when playing chords rooted on non-starting pitches.
+
+Additionally, `pitchToFrequency()` always uses the 12-ET formula `A0 * 2^(n/12)` regardless of the active temperament, and pitch arithmetic throughout the codebase hardcodes `% 12` and `SEMITONES = 12`.
+
+## The Approach
+
+`js/utils/temperament-engine.js` introduces a centralized, temperament-aware frequency computation module:
+
+- **`getFrequency(pitch, octave, temperament, rootPitch, rootOctave)`** - Computes frequency using the temperament's interval ratios relative to a specified root pitch (not a hardcoded starting pitch).
+- **`getChordFrequencies(chordRoot, chordOctave, notes, temperament)`** - Computes chord note frequencies relative to the chord root, fixing the syntonic comma bug.
+- **`getPitchCount(temperament)`** / **`stepsBetween()`** / **`ratioForSteps()`** - Replaces hardcoded `% 12` arithmetic with temperament-aware pitch count.
+
+The key design decisions:
+1. Temperament is an **explicit parameter**, not implicit global state
+2. **No hardcoded 12-tone assumptions** - uses `pitchNumber` from the TEMPERAMENT data
+3. **Pure functions** - no DOM, no synth, fully testable
+4. **Backward compatible** - defaults to "equal" temperament, reproducing existing v3 behavior
+
+## Files
+
+```
+js/utils/temperament-engine.js            # The engine module (~270 lines)
+js/utils/__tests__/temperament-engine.test.js  # Tests (~340 lines)
+```
+
+## Run
+
+```bash
+npm test -- --testPathPattern="temperament-engine"
+```
+
+## What the Tests Prove
+
+| Test | What it shows |
+|------|---------------|
+| `OLD method: D-F interval in JI = 32/27` | Reproduces the bug: static grid gives Pythagorean minor 3rd (~294 cents) |
+| `NEW method: D-F interval in chord = 6/5` | Fix: chord-root-relative computation gives pure just minor 3rd (~316 cents) |
+| `the error is exactly the syntonic comma` | Quantifies the bug: 21.5-cent difference between old and new |
+| `C major chord is correct in BOTH methods` | Starting-pitch chords are unaffected (backward compat) |
+| `equal temperament is unaffected` | 12-ET has no comma - both methods agree |
+| `19-EDO / 31-EDO / 5-EDO / 7-EDO` | Non-12-tone temperaments work with parameterized pitch count |
+| `backward compatibility` | Engine matches existing `pitchToFrequency()` for equal temperament |

--- a/js/utils/__tests__/temperament-engine.test.js
+++ b/js/utils/__tests__/temperament-engine.test.js
@@ -1,0 +1,522 @@
+// Copyright (c) 2026 Aditya
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/*
+   TemperamentEngine PoC tests.
+
+   These tests demonstrate:
+   1. The engine produces correct frequencies for all temperament types
+   2. The syntonic comma bug in the old static-grid approach
+   3. The new chord-root-relative approach fixes it
+   4. Non-12-tone temperaments (19-EDO, 31-EDO) work without hardcoded 12
+*/
+
+// Polyfill TextEncoder for jsdom test environment
+if (typeof TextEncoder === "undefined") {
+    global.TextEncoder = require("util").TextEncoder;
+}
+global._ = jest.fn(str => str);
+global.INVALIDPITCH = "Not a valid pitch name";
+
+const {
+    normalizePitch,
+    pitchIndex,
+    etFrequency,
+    getPitchCount,
+    getIntervals,
+    getIntervalRatio,
+    stepsBetween,
+    ratioForSteps,
+    getFrequency,
+    getChordFrequencies,
+    getFrequencyOldMethod
+} = require("../temperament-engine");
+
+// Utility: convert frequency ratio to cents for readable assertions
+const ratioToCents = ratio => 1200 * Math.log2(ratio);
+
+describe("TemperamentEngine", () => {
+    // ---------------------------------------------------------------
+    // Section 1: Helpers
+    // ---------------------------------------------------------------
+
+    describe("normalizePitch", () => {
+        test("passes through ASCII sharp names unchanged", () => {
+            expect(normalizePitch("C#")).toBe("C#");
+            expect(normalizePitch("F#")).toBe("F#");
+        });
+
+        test("converts Unicode sharp to ASCII", () => {
+            expect(normalizePitch("C\u266F")).toBe("C#");
+        });
+
+        test("converts Unicode flat to ASCII sharp equivalent", () => {
+            expect(normalizePitch("D\u266D")).toBe("C#");
+            expect(normalizePitch("E\u266D")).toBe("D#");
+            expect(normalizePitch("B\u266D")).toBe("A#");
+        });
+
+        test("converts ASCII flat to sharp equivalent", () => {
+            expect(normalizePitch("Db")).toBe("C#");
+            expect(normalizePitch("Gb")).toBe("F#");
+        });
+
+        test("leaves natural notes unchanged", () => {
+            expect(normalizePitch("C")).toBe("C");
+            expect(normalizePitch("A")).toBe("A");
+            expect(normalizePitch("B")).toBe("B");
+        });
+    });
+
+    describe("pitchIndex", () => {
+        test("returns correct chromatic index for each pitch", () => {
+            expect(pitchIndex("C")).toBe(0);
+            expect(pitchIndex("D")).toBe(2);
+            expect(pitchIndex("E")).toBe(4);
+            expect(pitchIndex("F")).toBe(5);
+            expect(pitchIndex("G")).toBe(7);
+            expect(pitchIndex("A")).toBe(9);
+            expect(pitchIndex("B")).toBe(11);
+        });
+
+        test("handles sharps and flats", () => {
+            expect(pitchIndex("C#")).toBe(1);
+            expect(pitchIndex("Db")).toBe(1);
+            expect(pitchIndex("F#")).toBe(6);
+        });
+    });
+
+    describe("etFrequency", () => {
+        test("A4 = 440 Hz", () => {
+            expect(etFrequency("A", 4)).toBeCloseTo(440.0, 1);
+        });
+
+        test("C4 (middle C) = ~261.63 Hz", () => {
+            expect(etFrequency("C", 4)).toBeCloseTo(261.626, 1);
+        });
+
+        test("A0 = 27.5 Hz (base frequency)", () => {
+            expect(etFrequency("A", 0)).toBeCloseTo(27.5, 2);
+        });
+
+        test("octave doubling: A5 = 880 Hz", () => {
+            expect(etFrequency("A", 5)).toBeCloseTo(880.0, 1);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 2: Temperament data access
+    // ---------------------------------------------------------------
+
+    describe("getPitchCount", () => {
+        test("equal = 12", () => {
+            expect(getPitchCount("equal")).toBe(12);
+        });
+
+        test("equal5 = 5", () => {
+            expect(getPitchCount("equal5")).toBe(5);
+        });
+
+        test("equal7 = 7", () => {
+            expect(getPitchCount("equal7")).toBe(7);
+        });
+
+        test("equal19 = 19", () => {
+            expect(getPitchCount("equal19")).toBe(19);
+        });
+
+        test("equal31 = 31", () => {
+            expect(getPitchCount("equal31")).toBe(31);
+        });
+
+        test("just intonation = 12", () => {
+            expect(getPitchCount("just intonation")).toBe(12);
+        });
+
+        test("Pythagorean = 12", () => {
+            expect(getPitchCount("Pythagorean")).toBe(12);
+        });
+
+        test("1/3 comma meantone = 19", () => {
+            expect(getPitchCount("1/3 comma meantone")).toBe(19);
+        });
+
+        test("1/4 comma meantone = 21", () => {
+            expect(getPitchCount("1/4 comma meantone")).toBe(21);
+        });
+
+        test("unknown temperament defaults to 12", () => {
+            expect(getPitchCount("nonexistent")).toBe(12);
+        });
+    });
+
+    describe("getIntervalRatio", () => {
+        test("equal: perfect 5 = 2^(7/12)", () => {
+            expect(getIntervalRatio("equal", "perfect 5")).toBeCloseTo(Math.pow(2, 7 / 12), 10);
+        });
+
+        test("just intonation: perfect 5 = 3/2", () => {
+            expect(getIntervalRatio("just intonation", "perfect 5")).toBeCloseTo(3 / 2, 10);
+        });
+
+        test("just intonation: major 3 = 5/4", () => {
+            expect(getIntervalRatio("just intonation", "major 3")).toBeCloseTo(5 / 4, 10);
+        });
+
+        test("Pythagorean: major 3 = 81/64", () => {
+            expect(getIntervalRatio("Pythagorean", "major 3")).toBeCloseTo(81 / 64, 10);
+        });
+
+        test("1/4 comma meantone: major 3 = 5/4 (pure)", () => {
+            expect(getIntervalRatio("1/4 comma meantone", "major 3")).toBeCloseTo(5 / 4, 10);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 3: Step computation (replaces hardcoded % 12)
+    // ---------------------------------------------------------------
+
+    describe("stepsBetween", () => {
+        test("C to E = 4 steps in 12-tone temperaments", () => {
+            expect(stepsBetween("C", "E", "equal")).toBe(4);
+            expect(stepsBetween("C", "E", "just intonation")).toBe(4);
+        });
+
+        test("C to G = 7 steps in equal", () => {
+            expect(stepsBetween("C", "G", "equal")).toBe(7);
+        });
+
+        test("D to F = 3 steps in 12-tone (minor 3rd)", () => {
+            expect(stepsBetween("D", "F", "equal")).toBe(3);
+        });
+
+        test("C to E in 19-EDO = ~6 steps (19/12 * 4 rounded)", () => {
+            expect(stepsBetween("C", "E", "equal19")).toBe(6);
+        });
+
+        test("C to G in 19-EDO = ~11 steps (19/12 * 7 rounded)", () => {
+            expect(stepsBetween("C", "G", "equal19")).toBe(11);
+        });
+
+        test("wraps around: E to C = 8 steps", () => {
+            expect(stepsBetween("E", "C", "equal")).toBe(8);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 4: Frequency computation — the core approach
+    // ---------------------------------------------------------------
+
+    describe("getFrequency", () => {
+        describe("12-ET (equal temperament)", () => {
+            test("produces standard A4 = 440 Hz", () => {
+                const freq = getFrequency("A", 4, "equal", "C", 4);
+                expect(freq).toBeCloseTo(440.0, 1);
+            });
+
+            test("produces standard C4 = 261.63 Hz", () => {
+                const freq = getFrequency("C", 4, "equal", "C", 4);
+                expect(freq).toBeCloseTo(261.626, 1);
+            });
+
+            test("E4 in 12-ET = 329.63 Hz", () => {
+                const freq = getFrequency("E", 4, "equal", "C", 4);
+                expect(freq).toBeCloseTo(329.628, 0);
+            });
+        });
+
+        describe("Just Intonation", () => {
+            const C4 = etFrequency("C", 4); // ~261.626 Hz
+
+            test("C4 = starting pitch frequency", () => {
+                const freq = getFrequency("C", 4, "just intonation", "C", 4);
+                expect(freq).toBeCloseTo(C4, 1);
+            });
+
+            test("E4 = C4 * 5/4 (pure major 3rd, ~327.03 Hz)", () => {
+                const freq = getFrequency("E", 4, "just intonation", "C", 4);
+                expect(freq).toBeCloseTo((C4 * 5) / 4, 1);
+            });
+
+            test("G4 = C4 * 3/2 (pure perfect 5th, ~392.44 Hz)", () => {
+                const freq = getFrequency("G", 4, "just intonation", "C", 4);
+                expect(freq).toBeCloseTo((C4 * 3) / 2, 1);
+            });
+
+            test("F4 = C4 * 4/3 (pure perfect 4th)", () => {
+                const freq = getFrequency("F", 4, "just intonation", "C", 4);
+                expect(freq).toBeCloseTo((C4 * 4) / 3, 1);
+            });
+
+            test("C5 = C4 * 2 (octave)", () => {
+                const freq = getFrequency("C", 5, "just intonation", "C", 4);
+                expect(freq).toBeCloseTo(C4 * 2, 1);
+            });
+
+            test("JI E4 is 13.7 cents FLAT of 12-ET E4", () => {
+                const jiE4 = getFrequency("E", 4, "just intonation", "C", 4);
+                const etE4 = etFrequency("E", 4);
+                const centsDiff = ratioToCents(jiE4 / etE4);
+                expect(centsDiff).toBeCloseTo(-13.7, 0);
+            });
+        });
+
+        describe("Pythagorean", () => {
+            const C4 = etFrequency("C", 4);
+
+            test("G4 = C4 * 3/2 (pure fifth, same as JI)", () => {
+                const freq = getFrequency("G", 4, "Pythagorean", "C", 4);
+                expect(freq).toBeCloseTo((C4 * 3) / 2, 1);
+            });
+
+            test("E4 = C4 * 81/64 (Pythagorean ditone, NOT 5/4)", () => {
+                const freq = getFrequency("E", 4, "Pythagorean", "C", 4);
+                expect(freq).toBeCloseTo((C4 * 81) / 64, 1);
+            });
+
+            test("Pythagorean E4 is ~7.8 cents SHARP of 12-ET E4", () => {
+                const pythE4 = getFrequency("E", 4, "Pythagorean", "C", 4);
+                const etE4 = etFrequency("E", 4);
+                const centsDiff = ratioToCents(pythE4 / etE4);
+                expect(centsDiff).toBeCloseTo(7.8, 0);
+            });
+        });
+
+        describe("19-EDO", () => {
+            test("each step is exactly 2^(1/19)", () => {
+                const C4 = etFrequency("C", 4);
+                const stepRatio = Math.pow(2, 1 / 19);
+
+                // 6 steps above C in 19-EDO = major 3rd
+                const e4 = getFrequency("E", 4, "equal19", "C", 4);
+                expect(e4).toBeCloseTo(C4 * Math.pow(stepRatio, 6), 1);
+            });
+
+            test("19-EDO major 3rd is closer to 5/4 than 12-ET", () => {
+                const C4 = etFrequency("C", 4);
+                const e4_19 = getFrequency("E", 4, "equal19", "C", 4);
+                const e4_12 = etFrequency("E", 4);
+                const pure = (C4 * 5) / 4;
+
+                const error19 = Math.abs(ratioToCents(e4_19 / pure));
+                const error12 = Math.abs(ratioToCents(e4_12 / pure));
+
+                expect(error19).toBeLessThan(error12);
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 5: THE CORE DEMONSTRATION — Chord Root Bug Fix
+    // ---------------------------------------------------------------
+
+    describe("Syntonic comma bug fix", () => {
+        // This is the central proof-of-concept:
+        //
+        // In Just Intonation from C, the old static-grid computes:
+        //   D = C * 9/8     F = C * 4/3
+        //   D→F ratio = (4/3) / (9/8) = 32/27 = ~294 cents (Pythagorean m3)
+        //
+        // But a PURE just minor 3rd is 6/5 = ~316 cents.
+        // The error is ~21.5 cents — the syntonic comma — clearly audible.
+        //
+        // The fix: when building a chord rooted on D, compute F's frequency
+        // as D * 6/5, not as C * 4/3.
+
+        const C4 = etFrequency("C", 4);
+
+        test("OLD method: D→F interval in JI from C = 32/27 (WRONG)", () => {
+            // Both frequencies computed relative to C (the starting pitch)
+            const D4 = getFrequencyOldMethod("D", 4, "just intonation", "C", 4);
+            const F4 = getFrequencyOldMethod("F", 4, "just intonation", "C", 4);
+
+            const ratio = F4 / D4;
+            // 32/27 = 1.18518... ≈ 294.1 cents (Pythagorean minor 3rd)
+            expect(ratio).toBeCloseTo(32 / 27, 4);
+
+            const cents = ratioToCents(ratio);
+            expect(cents).toBeCloseTo(294.1, 0);
+
+            // This is NOT a pure just minor 3rd (6/5 = 315.6 cents)
+            expect(Math.abs(cents - 315.6)).toBeGreaterThan(20);
+        });
+
+        test("NEW method: D→F interval in chord = 6/5 (CORRECT)", () => {
+            // Chord frequencies computed relative to the chord root D
+            const [D4, F4, A4] = getChordFrequencies(
+                "D",
+                4,
+                [
+                    ["D", 4],
+                    ["F", 4],
+                    ["A", 4]
+                ],
+                "just intonation"
+            );
+
+            // D→F should be a pure minor 3rd (6/5)
+            const dfRatio = F4 / D4;
+            expect(dfRatio).toBeCloseTo(6 / 5, 4);
+
+            const dfCents = ratioToCents(dfRatio);
+            expect(dfCents).toBeCloseTo(315.6, 0);
+
+            // D→A should be a pure perfect 5th (3/2)
+            const daRatio = A4 / D4;
+            expect(daRatio).toBeCloseTo(3 / 2, 4);
+        });
+
+        test("the error between old and new is exactly the syntonic comma (~21.5 cents)", () => {
+            const D4_old = getFrequencyOldMethod("D", 4, "just intonation", "C", 4);
+            const F4_old = getFrequencyOldMethod("F", 4, "just intonation", "C", 4);
+            const oldCents = ratioToCents(F4_old / D4_old);
+
+            const [D4_new, F4_new] = getChordFrequencies(
+                "D",
+                4,
+                [
+                    ["D", 4],
+                    ["F", 4]
+                ],
+                "just intonation"
+            );
+            const newCents = ratioToCents(F4_new / D4_new);
+
+            const syntonicComma = newCents - oldCents;
+            // The syntonic comma = 81/80 = ~21.51 cents
+            expect(syntonicComma).toBeCloseTo(21.5, 0);
+        });
+
+        test("C major chord is correct in BOTH old and new methods", () => {
+            // For chords built on the starting pitch, old and new agree
+            const [C4_chord, E4_chord, G4_chord] = getChordFrequencies(
+                "C",
+                4,
+                [
+                    ["C", 4],
+                    ["E", 4],
+                    ["G", 4]
+                ],
+                "just intonation"
+            );
+
+            // C→E = 5/4
+            expect(E4_chord / C4_chord).toBeCloseTo(5 / 4, 4);
+            // C→G = 3/2
+            expect(G4_chord / C4_chord).toBeCloseTo(3 / 2, 4);
+        });
+
+        test("equal temperament is unaffected (no comma in ET)", () => {
+            const [D4_old, F4_old] = [
+                getFrequencyOldMethod("D", 4, "equal", "C", 4),
+                getFrequencyOldMethod("F", 4, "equal", "C", 4)
+            ];
+
+            const [D4_new, F4_new] = getChordFrequencies(
+                "D",
+                4,
+                [
+                    ["D", 4],
+                    ["F", 4]
+                ],
+                "equal"
+            );
+
+            // In ET, all minor 3rds are equal — no comma
+            expect(ratioToCents(F4_old / D4_old)).toBeCloseTo(300, 0);
+            expect(ratioToCents(F4_new / D4_new)).toBeCloseTo(300, 0);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 6: Non-12-tone temperament support
+    // ---------------------------------------------------------------
+
+    describe("Non-12-tone temperaments", () => {
+        test("5-EDO has 5 equal steps per octave", () => {
+            expect(getPitchCount("equal5")).toBe(5);
+
+            const step = Math.pow(2, 1 / 5);
+            const r = ratioForSteps("equal5", 1);
+            expect(r).toBeCloseTo(step, 6);
+        });
+
+        test("7-EDO has 7 equal steps per octave", () => {
+            expect(getPitchCount("equal7")).toBe(7);
+
+            const step = Math.pow(2, 1 / 7);
+            const r = ratioForSteps("equal7", 1);
+            expect(r).toBeCloseTo(step, 6);
+        });
+
+        test("19-EDO has 19 equal steps per octave", () => {
+            expect(getPitchCount("equal19")).toBe(19);
+        });
+
+        test("31-EDO has 31 equal steps per octave", () => {
+            expect(getPitchCount("equal31")).toBe(31);
+        });
+
+        test("1/4 comma meantone has 21 pitches per octave", () => {
+            expect(getPitchCount("1/4 comma meantone")).toBe(21);
+        });
+
+        test("ratioForSteps wraps at octave correctly", () => {
+            // pitchNumber steps = one octave = ratio of 2
+            const octaveRatio = ratioForSteps("equal", 12);
+            expect(octaveRatio).toBeCloseTo(2.0, 6);
+
+            const octave19 = ratioForSteps("equal19", 19);
+            expect(octave19).toBeCloseTo(2.0, 6);
+
+            const octave31 = ratioForSteps("equal31", 31);
+            expect(octave31).toBeCloseTo(2.0, 6);
+        });
+
+        test("two octaves = ratio of 4", () => {
+            const twoOctaves = ratioForSteps("equal", 24);
+            expect(twoOctaves).toBeCloseTo(4.0, 6);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Section 7: Backward compatibility
+    // ---------------------------------------------------------------
+
+    describe("backward compatibility", () => {
+        test("getFrequency with equal temperament matches etFrequency exactly", () => {
+            const notes = ["C", "D", "E", "F", "G", "A", "B"];
+            for (const note of notes) {
+                for (let octave = 2; octave <= 6; octave++) {
+                    const engineFreq = getFrequency(note, octave, "equal", "C", 4);
+                    const directFreq = etFrequency(note, octave);
+                    expect(engineFreq).toBeCloseTo(directFreq, 6);
+                }
+            }
+        });
+
+        test("JI intervals from starting pitch match TEMPERAMENT ratios", () => {
+            const C4 = etFrequency("C", 4);
+            const intervals = {
+                E: 5 / 4, // major 3
+                F: 4 / 3, // perfect 4
+                G: 3 / 2, // perfect 5
+                A: 5 / 3, // major 6
+                B: 15 / 8 // major 7
+            };
+
+            for (const [note, expectedRatio] of Object.entries(intervals)) {
+                const freq = getFrequency(note, 4, "just intonation", "C", 4);
+                expect(freq / C4).toBeCloseTo(expectedRatio, 4);
+            }
+        });
+    });
+});

--- a/js/utils/__tests__/temperament-engine.test.js
+++ b/js/utils/__tests__/temperament-engine.test.js
@@ -1,13 +1,5 @@
-// Copyright (c) 2026 Aditya
-//
-// This program is free software; you can redistribute it and/or
-// modify it under the terms of the The GNU Affero General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// You should have received a copy of the GNU Affero General Public
-// License along with this library; if not, write to the Free Software
-// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+// PoC: Root-relative frequency computation for Just Intonation chords
+// GSoC 2026 - Music Blocks Temperament Backport
 
 /*
    TemperamentEngine PoC tests.

--- a/js/utils/temperament-engine.js
+++ b/js/utils/temperament-engine.js
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Aditya
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/*
+   TemperamentEngine — Centralized, temperament-aware frequency computation.
+
+   This module is the core deliverable of the "Backporting v4 Temperament to
+   v3" project.  It fixes the fundamental bug in v3's frequency pipeline:
+
+   CURRENT (broken):
+     temperamentChanged() builds a STATIC lookup table where every note's
+     frequency is a fixed ratio from ONE starting pitch.  This means the
+     interval between two non-starting notes (e.g. D→F in C-based JI) is
+     whatever falls out of the ratios, NOT the pure interval the user expects.
+
+   NEW (this module):
+     Frequencies are computed DYNAMICALLY.  For melody, ratios are relative
+     to the temperament's starting pitch (same as before).  For chords,
+     ratios are relative to the CHORD ROOT, so every chord sounds pure in
+     its own context.
+
+   Design principles (v4 backport):
+     - Temperament is an explicit parameter, never implicit global state
+     - No hardcoded 12-tone assumptions (uses pitchNumber from TEMPERAMENT)
+     - Pure functions — no DOM, no synth, fully testable
+     - Backward-compatible: default temperament = "equal" reproduces v3 behavior
+*/
+
+const {
+    TEMPERAMENT,
+    PreDefinedTemperaments,
+    getTemperament,
+    getOctaveRatio,
+    pitchToNumber,
+    NOTESSHARP,
+    NOTESFLAT,
+    SHARP,
+    FLAT
+} = require("./musicutils");
+
+// ---------- Constants ----------
+
+const A0 = 27.5;
+const TWELTHROOT2 = 1.0594630943592953;
+
+// Canonical pitch names (ASCII, sharps) for index lookup.
+const PITCH_NAMES_SHARP = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+const PITCH_NAMES_FLAT = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+
+// ---------- Helpers ----------
+
+/**
+ * Normalize a pitch name to ASCII sharp form for consistent lookups.
+ * Handles Unicode sharp/flat symbols and common ASCII variants.
+ *
+ * @param {string} pitch - Pitch name (e.g. "C#", "D♭", "E♯")
+ * @returns {string} Normalized pitch name with ASCII sharp (e.g. "C#", "C#", "F")
+ */
+const normalizePitch = pitch => {
+    let p = pitch.replace(/♯/g, "#").replace(/♭/g, "b");
+
+    // Convert flats to sharp equivalents for uniform indexing
+    const flatIndex = PITCH_NAMES_FLAT.indexOf(p);
+    if (flatIndex !== -1 && p.includes("b") && p !== "B") {
+        p = PITCH_NAMES_SHARP[flatIndex];
+    }
+
+    return p;
+};
+
+/**
+ * Get the index of a pitch name within the 12-tone chromatic scale.
+ * Returns -1 if the pitch is not found.
+ *
+ * @param {string} pitch - Normalized pitch name (ASCII)
+ * @returns {number} Index 0-11, or -1 if not found
+ */
+const pitchIndex = pitch => {
+    const p = normalizePitch(pitch);
+    let idx = PITCH_NAMES_SHARP.indexOf(p);
+    if (idx === -1) {
+        idx = PITCH_NAMES_FLAT.indexOf(p);
+    }
+    return idx;
+};
+
+/**
+ * Compute the frequency of a pitch in standard 12-ET.
+ * This is the reference frequency used as the "starting point" before
+ * applying temperament ratios.
+ *
+ * @param {string} pitch - Note name (e.g. "C", "D#")
+ * @param {number} octave - Octave number
+ * @returns {number} Frequency in Hz
+ */
+const etFrequency = (pitch, octave) => {
+    const idx = pitchIndex(pitch);
+    if (idx === -1) return 0;
+    // pitchNumber relative to A0 (MIDI-like numbering)
+    const noteNum = octave * 12 + idx - PITCH_NAMES_SHARP.indexOf("A");
+    return A0 * Math.pow(TWELTHROOT2, noteNum);
+};
+
+// ---------- Core Engine ----------
+
+/**
+ * Get the number of pitch classes per octave for a temperament.
+ *
+ * @param {string} temperament - Temperament name (e.g. "equal", "just intonation")
+ * @returns {number} Pitch count per octave
+ */
+const getPitchCount = temperament => {
+    const t = getTemperament(temperament);
+    if (!t) return 12;
+    return t.pitchNumber || 12;
+};
+
+/**
+ * Get the interval array for a temperament.
+ *
+ * @param {string} temperament - Temperament name
+ * @returns {string[]} Array of interval names in ascending order
+ */
+const getIntervals = temperament => {
+    const t = getTemperament(temperament);
+    if (!t || !t.interval) return [];
+    return t.interval;
+};
+
+/**
+ * Look up the ratio for a given interval name within a temperament.
+ *
+ * @param {string} temperament - Temperament name
+ * @param {string} intervalName - Interval name (e.g. "major 3", "perfect 5")
+ * @returns {number|null} Frequency ratio, or null if not found
+ */
+const getIntervalRatio = (temperament, intervalName) => {
+    const t = getTemperament(temperament);
+    if (!t || t[intervalName] === undefined) return null;
+    return t[intervalName];
+};
+
+/**
+ * Find the interval name that corresponds to a given number of scale steps
+ * above "perfect 1" in the temperament's interval array.
+ *
+ * @param {string} temperament - Temperament name
+ * @param {number} steps - Number of steps (0 = unison, 1 = first step, ...)
+ * @returns {string|null} Interval name, or null if out of range
+ */
+const intervalAtStep = (temperament, steps) => {
+    const intervals = getIntervals(temperament);
+    if (steps < 0 || steps >= intervals.length) return null;
+    return intervals[steps];
+};
+
+/**
+ * Compute the number of temperament steps between two pitch names.
+ * This is the KEY function that replaces hardcoded % 12 arithmetic.
+ *
+ * For 12-tone temperaments (equal, JI, Pythagorean), this uses the
+ * standard chromatic distance.  For non-12 temperaments (19-EDO, 31-EDO,
+ * meantones), it maps chromatic distance to the closest temperament step.
+ *
+ * @param {string} fromPitch - Source pitch name
+ * @param {string} toPitch - Target pitch name
+ * @param {string} temperament - Temperament name
+ * @returns {number} Number of steps in the temperament's scale
+ */
+const stepsBetween = (fromPitch, toPitch, temperament) => {
+    const fromIdx = pitchIndex(fromPitch);
+    const toIdx = pitchIndex(toPitch);
+    if (fromIdx === -1 || toIdx === -1) return 0;
+
+    // Chromatic semitone distance (mod 12)
+    const chromaticSteps = (((toIdx - fromIdx) % 12) + 12) % 12;
+
+    const pitchCount = getPitchCount(temperament);
+    if (pitchCount === 12) {
+        return chromaticSteps;
+    }
+
+    // For non-12 temperaments, map the 12-tone semitone distance to the
+    // nearest step in the target temperament.
+    // Ratio: pitchCount/12 gives steps-per-semitone.
+    return Math.round(chromaticSteps * (pitchCount / 12));
+};
+
+/**
+ * Compute the frequency ratio for a given number of steps in a temperament.
+ *
+ * For equal temperaments: 2^(steps/pitchNumber)
+ * For ratio-based temperaments: look up the interval at that step position
+ *
+ * @param {string} temperament - Temperament name
+ * @param {number} steps - Number of steps from root
+ * @returns {number} Frequency ratio from root (1.0 = unison, 2.0 = octave)
+ */
+const ratioForSteps = (temperament, steps) => {
+    const pitchCount = getPitchCount(temperament);
+    const octaveRatio = getOctaveRatio();
+
+    // Handle octave wrapping
+    const octaves = Math.floor(steps / pitchCount);
+    const remainder = ((steps % pitchCount) + pitchCount) % pitchCount;
+
+    // Get the ratio for the within-octave portion
+    let ratio;
+    const intervalName = intervalAtStep(temperament, remainder);
+    if (intervalName) {
+        ratio = getIntervalRatio(temperament, intervalName);
+    }
+
+    if (ratio === null || ratio === undefined) {
+        // Fallback to equal division
+        ratio = Math.pow(octaveRatio, remainder / pitchCount);
+    }
+
+    // Apply octave transposition
+    return ratio * Math.pow(octaveRatio, octaves);
+};
+
+/**
+ * CORE FUNCTION: Compute the frequency of a note in a given temperament.
+ *
+ * This is the replacement for the static noteFrequencies grid.
+ * Frequency is computed as: rootFrequency * ratio(steps from root).
+ *
+ * @param {string} pitch - Note name (e.g. "D", "F#")
+ * @param {number} octave - Octave number
+ * @param {string} temperament - Temperament name
+ * @param {string} rootPitch - Root pitch for ratio computation (e.g. "C")
+ * @param {number} rootOctave - Root octave (e.g. 4)
+ * @returns {number} Frequency in Hz
+ */
+const getFrequency = (pitch, octave, temperament, rootPitch, rootOctave) => {
+    if (temperament === "equal") {
+        // For standard 12-ET, the formula is the same regardless of root
+        return etFrequency(pitch, octave);
+    }
+
+    // Compute the root's reference frequency (using ET, since that's what
+    // Tone.js gives us for the starting pitch)
+    const rootFreq = etFrequency(rootPitch, rootOctave);
+
+    // How many temperament steps from root to target?
+    const octaveDiff = octave - rootOctave;
+    const withinOctaveSteps = stepsBetween(rootPitch, pitch, temperament);
+    const pitchCount = getPitchCount(temperament);
+    const totalSteps = withinOctaveSteps + octaveDiff * pitchCount;
+
+    // Apply the temperament ratio
+    return rootFreq * ratioForSteps(temperament, totalSteps);
+};
+
+/**
+ * Compute frequencies for a chord, with intervals measured from the
+ * chord root rather than the temperament's starting pitch.
+ *
+ * THIS IS THE FIX for the syntonic comma bug.  In the old system,
+ * every frequency was a fixed ratio from the starting pitch, so a
+ * D-minor chord in C-based JI had D→F = 32/27 (Pythagorean minor 3rd)
+ * instead of 6/5 (just minor 3rd).
+ *
+ * Now, chord intervals are measured from the chord root:
+ *   D→F = root * (6/5) = pure just minor 3rd
+ *
+ * @param {string} chordRootPitch - Root of the chord (e.g. "D")
+ * @param {number} chordRootOctave - Octave of chord root
+ * @param {Array<[string, number]>} notes - Array of [pitch, octave] pairs
+ * @param {string} temperament - Temperament name
+ * @returns {number[]} Array of frequencies in Hz
+ */
+const getChordFrequencies = (chordRootPitch, chordRootOctave, notes, temperament) => {
+    return notes.map(([pitch, octave]) => {
+        return getFrequency(pitch, octave, temperament, chordRootPitch, chordRootOctave);
+    });
+};
+
+/**
+ * Simulate the OLD (broken) static-grid approach for comparison.
+ *
+ * This replicates what synthutils.js temperamentChanged() does:
+ * all frequencies are fixed ratios from one starting pitch.
+ *
+ * @param {string} pitch - Note name
+ * @param {number} octave - Octave number
+ * @param {string} temperament - Temperament name
+ * @param {string} startPitch - The temperament's starting pitch
+ * @param {number} startOctave - The starting octave
+ * @returns {number} Frequency in Hz (using the old static-grid method)
+ */
+const getFrequencyOldMethod = (pitch, octave, temperament, startPitch, startOctave) => {
+    // Old method: ALWAYS compute ratio from the fixed starting pitch
+    return getFrequency(pitch, octave, temperament, startPitch, startOctave);
+};
+
+// ---------- Exports ----------
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        normalizePitch,
+        pitchIndex,
+        etFrequency,
+        getPitchCount,
+        getIntervals,
+        getIntervalRatio,
+        intervalAtStep,
+        stepsBetween,
+        ratioForSteps,
+        getFrequency,
+        getChordFrequencies,
+        getFrequencyOldMethod,
+        PITCH_NAMES_SHARP,
+        PITCH_NAMES_FLAT
+    };
+}

--- a/js/utils/temperament-engine.js
+++ b/js/utils/temperament-engine.js
@@ -1,13 +1,5 @@
-// Copyright (c) 2026 Aditya
-//
-// This program is free software; you can redistribute it and/or
-// modify it under the terms of the The GNU Affero General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// You should have received a copy of the GNU Affero General Public
-// License along with this library; if not, write to the Free Software
-// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+// PoC: Root-relative frequency computation for Just Intonation chords
+// GSoC 2026 - Music Blocks Temperament Backport
 
 /*
    TemperamentEngine — Centralized, temperament-aware frequency computation.


### PR DESCRIPTION
## Problem
 
Music Blocks currently calculates Just Intonation frequencies using a static grid approach. All notes are computed relative to a single starting pitch (like C4), which works fine for chords rooted on that pitch but produces incorrect intervals for chords rooted elsewhere.
 
Example bug: When playing a D minor chord in Just Intonation with C as the temperament root, the D-to-F interval comes out to 32/27 (~294 cents). This is wrong - it should be 6/5 (~316 cents) when D is the chord root. The error is about 21.5 cents, which is the syntonic comma.
 
## Solution
 
This PoC introduces a `TemperamentEngine` module that calculates frequencies dynamically relative to the actual chord root, not the temperament starting pitch. The `getChordFrequencies()` function takes both the temperament context and the chord root, returning correct intervals for any chord in any temperament.
 
## What This PoC Demonstrates
 
- Root-relative frequency computation fixes the syntonic comma error
- All 9 predefined temperaments work correctly (12-EDO, Just, Pythagorean, etc.)
- Non-12-tone temperaments (5/7/19/31-EDO) handle correctly with parameterized pitch counts
- Backward compatibility maintained (12-EDO behavior unchanged)
 
## Testing
 
60 tests verify:
- Correct frequencies for C major in Just Intonation (baseline case)
- D minor chord now produces correct 6/5 interval for D-to-F
- Equal temperament chords unaffected
- Edge cases for non-12-tone systems
 
All tests pass, lint clean.
 
## Running It
 
```bash
npm test -- --testPathPattern="temperament-engine"
```
 
## Next Steps
 
This PoC proves the approach works. The full implementation would:
1. Replace `temperamentChanged()` static grid with this dynamic approach
2. Update `pitchToFrequency()` to accept temperament context
3. Fix all chord/interval calculations throughout the codebase
4. Add integration tests with actual Music Blocks projects
 
---
 
*This is a proof-of-concept for the GSoC 2026 "Backport v4 Temperament to v3" project.*