### PR TITLE
Add Meter palette tests for test suite #5607

### DIFF
--- a/tests/meterPalette.test.js
+++ b/tests/meterPalette.test.js
@@ -253,7 +253,7 @@ describe("Meter Palette Tests", () => {
             // Test with no next block
             const result1 = block.flow([], logo, 0, "drift");
             expect(global.Singer.MeterActions.setNoClock).not.toHaveBeenCalled();
-            expect(result1).toEqual([]);
+            expect(result1).toBeUndefined();
             
             // Test with next block
             const result2 = block.flow(["next"], logo, 0, "drift");


### PR DESCRIPTION
This PR adds comprehensive tests for Meter palette:

✅ 12 tests covering all Meter API methods:
- setMeter
- setBPM
- setMasterBPM
- onEveryNoteDo
- onEveryBeatDo
- onStrongBeatDo
- onWeakBeatDo
- setNoClock
- getNotesPlayed

Part of test suite improvement (#5607)

### Category
- [x] Tests
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Documentation