### PR TITLE
Fix #6300: Clean up console.log in Planet module

### DIFF
--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -55,7 +55,7 @@ class Planet {
 
     open(image) {
         if (this.LocalPlanet === null) {
-            console.log("Local Planet unavailable");
+            console.warn("Local Planet unavailable");
         } else {
             this.LocalPlanet.setCurrentProjectImage(image);
             this.LocalPlanet.updateProjects();

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -187,7 +187,7 @@ class ProjectStorage {
         try {
             return JSON.parse(jsonobj);
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return null;
         }
     }
@@ -203,7 +203,7 @@ class ProjectStorage {
         try {
             this.data = typeof currentData === "string" ? JSON.parse(currentData) : currentData;
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return null;
         }
     }

--- a/planet/js/Publisher.js
+++ b/planet/js/Publisher.js
@@ -305,7 +305,7 @@ class Publisher {
         try {
             tb = JSON.parse(tb);
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return "";
         }
 


### PR DESCRIPTION
Fixes #6300

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Description
Replaced unprotected `console.log` statements in the `planet/js` module with `console.warn` and `console.error` for proper error and state handling.

### Changes Made:
- `planet/js/Planet.js`: Changed `console.log` to `console.warn`.
- `planet/js/Publisher.js`: Changed `console.log` to `console.error` in exception catch blocks.
- `planet/js/ProjectStorage.js`: Changed `console.log` to `console.error` in exception catch blocks.