### PR TITLE
tests(blocks): add branch coverage tests for ProgramBlocks.js (#5945)

### DIFF
--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -825,7 +825,10 @@ describe("ProgramBlocks", () => {
     describe("MakeBlockBlock branch coverage", () => {
         const setupArg = (name, argValues = []) => {
             activity.blocks.blockList = [
-                { connections: [null, 10, ...argValues.map((_, i) => i + 10)], argClampSlots: argValues.map((_, i) => i) }
+                {
+                    connections: [null, 10, ...argValues.map((_, i) => i + 10)],
+                    argClampSlots: argValues.map((_, i) => i)
+                }
             ];
             const allMocks = [...argValues, name];
             logo.parseArg = jest.fn();
@@ -902,7 +905,11 @@ describe("ProgramBlocks", () => {
 
         test("handles number arg with dock type mismatch", () => {
             setupArg("customblock", [42]);
-            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue(["proto1", "program", "customblock"]);
+            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue([
+                "proto1",
+                "program",
+                "customblock"
+            ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
             expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
@@ -910,7 +917,11 @@ describe("ProgramBlocks", () => {
 
         test("handles string arg with dock type mismatch", () => {
             setupArg("customblock", ["hello"]);
-            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue(["proto1", "program", "customblock"]);
+            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue([
+                "proto1",
+                "program",
+                "customblock"
+            ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "numberin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
             expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
@@ -918,7 +929,11 @@ describe("ProgramBlocks", () => {
 
         test("handles boolean arg with dock type mismatch", () => {
             setupArg("customblock", [true]);
-            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue(["proto1", "program", "customblock"]);
+            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue([
+                "proto1",
+                "program",
+                "customblock"
+            ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
             expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
@@ -926,7 +941,11 @@ describe("ProgramBlocks", () => {
 
         test("handles unhandled arg type (object)", () => {
             setupArg("customblock", [{ obj: true }]);
-            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue(["proto1", "program", "customblock"]);
+            activity.blocks.palettes.getProtoNameAndPalette.mockReturnValue([
+                "proto1",
+                "program",
+                "customblock"
+            ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
             expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));


### PR DESCRIPTION
## Summary

Part of #5945 — additional branch coverage tests for `ProgramBlocks.js`.

## Changes

- **MakeBlockBlock.arg()**: covered all special-cased block types: `note`, `start`, `silence`, `tempo`, `volume`, `instrument`
- **TempoBlock**: `tempo` with 1, 2, and 3 arguments (all switch branches)
- **VolumeBlock**: `volume` with 1, 2, and 3 arguments (all switch branches)
- **Unknown block lookup**: returns 0 with error message when block not found
- **Argument type handling**: number, string, boolean, and unhandled object types with dock type mismatch warnings

## Why

`ProgramBlocks.js` had 65% statement coverage with many branches in `MakeBlockBlock.arg()` completely untested. These tests exercise the actual production code paths by setting up real `blockList` state and invoking `arg()` directly.

## Coverage Impact

| Metric     | Before | After  |
|------------|--------|--------|
| Statements | 65.02% | 82.15% |
| Branches   | 58.60% | 74.73% |
| Functions  | 100%   | 100%   |
| Lines      | 65.47% | 82.61% |

## Testing

- All Jest tests pass locally using the existing test suite
- No production code was modified — only test files were updated

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation