### PR TITLE
ci: add GitHub Actions workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,70 @@
+# Deploy Music Blocks to GitHub Pages
+#
+# Prerequisite (one-time): A repo admin must set the Pages source to
+# "GitHub Actions" under Settings > Pages > Build and deployment.
+#
+# Triggers on every push to master and via manual workflow_dispatch.
+# Runs Jest tests first; deploys only if tests pass.
+
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest tests
+        run: npm test
+
+  deploy:
+    name: Deploy
+    needs: test
+    if: github.repository == 'sugarlabs/musicblocks'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a CI/CD pipeline that automatically deploys Music Blocks to GitHub Pages on every push to `master`, with Jest test gating to prevent broken deployments.

Closes #4284

## PR Category

- [x] Feature
- [ ] Bug Fix
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Approach

Uses the **modern GitHub Actions Pages deployment** (`actions/deploy-pages`) instead of the legacy gh-pages branch approach. This is cleaner, avoids branch management complexity, and provides proper deployment environments with history and rollback in the GitHub UI.

### Workflow structure

| Job | Purpose |
|-----|---------|
| **test** | Runs Jest tests — deployment is blocked if tests fail |
| **deploy** | Uploads the repository as a static artifact and deploys to GitHub Pages |

### Key design decisions

- **Triggers**: `push` to `master` + `workflow_dispatch` (manual) — PRs do **not** trigger deployment
- **Fork guard**: Deploy job only runs on `sugarlabs/musicblocks`, preventing forks from wasting runner minutes
- **No build step**: The project serves static files directly, so no `npm ci` is needed in the deploy job — keeps the artifact lean
- **Concurrency control**: Only one deployment runs at a time; queued runs wait rather than cancelling in-progress deploys
- **Consistent tooling**: Uses Node 22, `actions/checkout@v4`, `npm ci` — matching all existing workflows

### One-time admin prerequisite

After merging, a repo admin must change the Pages source:
**Settings → Pages → Build and deployment → Source → "GitHub Actions"**

This is a one-time, 10-second change. The workflow includes a comment documenting this requirement.

## Prior work

This issue has had three previous PRs, all closed by the stale bot due to inactivity:

- **#4285** — Failed due to custom PAT token errors (`secrets.GH_TOKEN` instead of `GITHUB_TOKEN`)
- **#4290** — Most complete attempt, but targeted `main` instead of `master` and used the error-prone gh-pages branch approach
- **#4472** — Too minimal (no test gating), flagged as duplicate of #4290

This PR incorporates the lessons from all three: correct branch (`master`), proper token handling (`GITHUB_TOKEN` via permissions), test gating, and a modern deployment approach that avoids the gh-pages branch issues entirely.

## Test plan

- [x] Validated YAML syntax with `yaml-lint`
- [x] Tested on fork ([Anexus5919/musicblocks](https://github.com/Anexus5919/musicblocks)) — all jobs passed, site deployed successfully
- [ ] After merge: admin changes Pages source to "GitHub Actions"
- [ ] Verify https://sugarlabs.github.io/musicblocks/ loads correctly after first automated deployment

Screenshots:
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/1a7aec70-e60d-4190-9eee-c409466a42b5" />
<img width="1919" height="913" alt="image" src="https://github.com/user-attachments/assets/f2b5c9bc-b6c0-488e-a235-e0c59cb4972b" />