### PR TITLE
fix: guard AI widget async lifecycle and stale responses

### DIFF
--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -33,6 +33,20 @@ new Function(
 global._ = str => str;
 global._THIS_IS_MUSIC_BLOCKS_ = true;
 
+function createMockWidgetWindow() {
+    const widgetBody = document.createElement("div");
+    return {
+        clear: jest.fn(),
+        show: jest.fn(),
+        onclose: null,
+        onmaximize: null,
+        addButton: jest.fn(() => document.createElement("button")),
+        getWidgetBody: jest.fn(() => widgetBody),
+        sendToCenter: jest.fn(),
+        destroy: jest.fn()
+    };
+}
+
 describe("AIDebuggerWidget", () => {
     describe("Constructor", () => {
         test("initializes basic properties", () => {
@@ -48,6 +62,10 @@ describe("AIDebuggerWidget", () => {
             expect(debuggerWidget.chatLog).toBeNull();
             expect(debuggerWidget.messageInput).toBeNull();
             expect(debuggerWidget.sendButton).toBeNull();
+            expect(debuggerWidget._isProcessing).toBe(false);
+            expect(debuggerWidget._isInitializing).toBe(false);
+            expect(debuggerWidget._isMounted).toBe(false);
+            expect(debuggerWidget._pendingRequests.size).toBe(0);
         });
 
         test("_generateConversationId returns unique IDs", () => {
@@ -57,6 +75,150 @@ describe("AIDebuggerWidget", () => {
 
             expect(id1).not.toBe(id2);
             expect(id1.startsWith("conv_")).toBe(true);
+        });
+    });
+
+    describe("Async lifecycle handling", () => {
+        let debuggerWidget;
+        let mockWidgetWindow;
+        let mockActivity;
+
+        beforeEach(() => {
+            document.body.innerHTML = "";
+            jest.clearAllMocks();
+
+            mockWidgetWindow = createMockWidgetWindow();
+            window.widgetWindows = {
+                windowFor: jest.fn(() => mockWidgetWindow)
+            };
+
+            mockActivity = {
+                isInputON: false,
+                textMsg: jest.fn(),
+                prepareExport: jest.fn(() => "[]")
+            };
+
+            global.fetch = jest.fn();
+            debuggerWidget = new AIDebuggerWidget();
+        });
+
+        test("init aborts pending requests on close", () => {
+            jest.spyOn(debuggerWidget, "_loadProjectAndInitialize").mockImplementation(() => {});
+
+            debuggerWidget.init(mockActivity);
+
+            const abortSpy = jest.fn();
+            debuggerWidget._pendingRequests.add({ abort: abortSpy });
+            mockWidgetWindow.onclose();
+
+            expect(debuggerWidget._isMounted).toBe(false);
+            expect(abortSpy).toHaveBeenCalled();
+            expect(mockWidgetWindow.destroy).toHaveBeenCalled();
+            expect(mockActivity.isInputON).toBe(false);
+        });
+
+        test("_sendMessage skips while initialization is in progress", () => {
+            debuggerWidget.activity = mockActivity;
+            debuggerWidget.widgetWindow = mockWidgetWindow;
+            debuggerWidget.chatLog = document.createElement("div");
+            debuggerWidget.messageInput = document.createElement("input");
+            debuggerWidget.sendButton = document.createElement("button");
+            debuggerWidget.messageInput.value = "Help me debug";
+            debuggerWidget._isMounted = true;
+            debuggerWidget._isInitializing = true;
+
+            const sendSpy = jest.spyOn(debuggerWidget, "_sendToBackend");
+
+            debuggerWidget._sendMessage();
+
+            expect(debuggerWidget.chatHistory).toEqual([]);
+            expect(sendSpy).not.toHaveBeenCalled();
+        });
+
+        test("_sendToBackend ignores late responses after widget unmount", async () => {
+            debuggerWidget.activity = mockActivity;
+            debuggerWidget.widgetWindow = mockWidgetWindow;
+            debuggerWidget.chatLog = document.createElement("div");
+            debuggerWidget.messageInput = document.createElement("input");
+            debuggerWidget.sendButton = document.createElement("button");
+            debuggerWidget._isMounted = true;
+
+            let resolveFetch;
+            global.fetch.mockImplementation(
+                () =>
+                    new Promise(resolve => {
+                        resolveFetch = resolve;
+                    })
+            );
+
+            debuggerWidget._sendToBackend("Why is this broken?");
+            debuggerWidget._isMounted = false;
+
+            resolveFetch({
+                ok: true,
+                json: jest.fn().mockResolvedValue({ response: "Late response" })
+            });
+
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(debuggerWidget.chatHistory).toEqual([]);
+        });
+
+        test("_initializeBackendWithProject ignores late responses after widget unmount", async () => {
+            debuggerWidget.activity = mockActivity;
+            debuggerWidget.widgetWindow = mockWidgetWindow;
+            debuggerWidget.chatLog = document.createElement("div");
+            debuggerWidget.messageInput = document.createElement("input");
+            debuggerWidget.sendButton = document.createElement("button");
+            debuggerWidget._isMounted = true;
+
+            let resolveFetch;
+            global.fetch.mockImplementation(
+                () =>
+                    new Promise(resolve => {
+                        resolveFetch = resolve;
+                    })
+            );
+
+            debuggerWidget._initializeBackendWithProject("[]");
+            debuggerWidget._isMounted = false;
+
+            resolveFetch({
+                ok: true,
+                json: jest.fn().mockResolvedValue({ response: "Initial analysis" })
+            });
+
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(debuggerWidget.chatHistory).toEqual([]);
+        });
+
+        test("_resetConversation aborts pending work before reinitializing", () => {
+            debuggerWidget.activity = mockActivity;
+            debuggerWidget.widgetWindow = mockWidgetWindow;
+            debuggerWidget.chatLog = document.createElement("div");
+            debuggerWidget.messageInput = document.createElement("input");
+            debuggerWidget.sendButton = document.createElement("button");
+            debuggerWidget._isMounted = true;
+            debuggerWidget.chatHistory = [{ type: "user", content: "hello" }];
+            debuggerWidget.promptCount = 3;
+
+            const abortSpy = jest.fn();
+            debuggerWidget._pendingRequests.add({ abort: abortSpy });
+            const loadSpy = jest
+                .spyOn(debuggerWidget, "_loadProjectAndInitialize")
+                .mockImplementation(() => {});
+
+            debuggerWidget._resetConversation();
+
+            expect(abortSpy).toHaveBeenCalled();
+            expect(debuggerWidget.chatHistory).toEqual([]);
+            expect(debuggerWidget.promptCount).toBe(0);
+            expect(loadSpy).toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/__tests__/reflection.test.js
+++ b/js/widgets/__tests__/reflection.test.js
@@ -107,6 +107,10 @@ describe("ReflectionMatrix", () => {
             expect(reflection.triggerFirst).toBe(false);
             expect(reflection.projectAlgorithm).toBe("");
             expect(reflection.code).toBe("");
+            expect(reflection._isMounted).toBe(false);
+            expect(reflection._pendingRequests.size).toBe(0);
+            expect(reflection._typingTimeout).toBeNull();
+            expect(reflection.sendButton).toBeNull();
         });
     });
 
@@ -149,10 +153,14 @@ describe("ReflectionMatrix", () => {
 
             // Trigger close
             reflection.dotsInterval = setInterval(() => {}, 1000);
+            const abortSpy = jest.fn();
+            reflection._pendingRequests.add({ abort: abortSpy });
             mockWidgetWindow.onclose();
 
             expect(reflection.isOpen).toBe(false);
+            expect(reflection._isMounted).toBe(false);
             expect(mockActivity.isInputON).toBe(false);
+            expect(abortSpy).toHaveBeenCalled();
             expect(mockWidgetWindow.destroy).toHaveBeenCalled();
         });
 
@@ -236,6 +244,8 @@ describe("ReflectionMatrix", () => {
         test("showTypingIndicator creates indicator and animates dots", () => {
             const reflection = new ReflectionMatrix();
             reflection.chatLog = document.createElement("div");
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             reflection.showTypingIndicator("Thinking");
 
@@ -257,6 +267,8 @@ describe("ReflectionMatrix", () => {
         test("hideTypingIndicator removes indicator and clears interval", () => {
             const reflection = new ReflectionMatrix();
             reflection.chatLog = document.createElement("div");
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             reflection.showTypingIndicator("Thinking");
             const typingDiv = reflection.typingDiv;
@@ -297,10 +309,12 @@ describe("ReflectionMatrix", () => {
             reflection.chatLog = document.createElement("div");
             reflection.input = document.createElement("input");
             reflection.summaryButton = document.createElement("button");
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             jest.spyOn(reflection, "showTypingIndicator").mockImplementation(() => {});
             jest.spyOn(reflection, "hideTypingIndicator").mockImplementation(() => {});
-            jest.spyOn(reflection, "botReplyDiv").mockImplementation(() => {});
+            jest.spyOn(reflection, "botReplyDiv").mockImplementation(() => Promise.resolve());
         });
 
         test("startChatSession handles successful API response", async () => {
@@ -342,6 +356,8 @@ describe("ReflectionMatrix", () => {
         test("updateProjectCode skips if code unchanged", async () => {
             reflection.code = "mocked_code"; // Same as prepareExport mock
             jest.spyOn(reflection, "generateNewAlgorithm");
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             await reflection.updateProjectCode();
 
@@ -350,6 +366,8 @@ describe("ReflectionMatrix", () => {
 
         test("updateProjectCode updates algorithm and calls botReplyDiv on success", async () => {
             reflection.code = "old_code";
+            reflection._isMounted = true;
+            reflection.isOpen = true;
             jest.spyOn(reflection, "generateNewAlgorithm").mockResolvedValue({
                 algorithm: "new_algorithm",
                 response: "Updated"
@@ -370,18 +388,35 @@ describe("ReflectionMatrix", () => {
             );
         });
 
+        test("updateProjectCode ignores repeat clicks while typing indicator is visible", async () => {
+            reflection._isMounted = true;
+            reflection.isOpen = true;
+            reflection.typingDiv = document.createElement("div");
+            jest.spyOn(reflection, "generateNewAlgorithm");
+
+            await reflection.updateProjectCode();
+
+            expect(reflection.generateNewAlgorithm).not.toHaveBeenCalled();
+        });
+
         test("generateAlgorithm makes correct API call", async () => {
             global.fetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({ algorithm: "alg" })
             });
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             const data = await reflection.generateAlgorithm("some_code");
 
-            expect(global.fetch).toHaveBeenCalledWith(`${reflection.PORT}/projectcode`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ code: "some_code" })
-            });
+            expect(global.fetch).toHaveBeenCalledWith(
+                `${reflection.PORT}/projectcode`,
+                expect.objectContaining({
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ code: "some_code" }),
+                    signal: expect.any(Object)
+                })
+            );
             expect(data).toEqual({ algorithm: "alg" });
         });
 
@@ -398,14 +433,20 @@ describe("ReflectionMatrix", () => {
             global.fetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({ algorithm: "new_alg" })
             });
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             const data = await reflection.generateNewAlgorithm("new_code");
 
-            expect(global.fetch).toHaveBeenCalledWith(`${reflection.PORT}/updatecode`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ oldcode: "old_code", newcode: "new_code" })
-            });
+            expect(global.fetch).toHaveBeenCalledWith(
+                `${reflection.PORT}/updatecode`,
+                expect.objectContaining({
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ oldcode: "old_code", newcode: "new_code" }),
+                    signal: expect.any(Object)
+                })
+            );
             expect(data).toEqual({ algorithm: "new_alg" });
         });
 
@@ -413,26 +454,34 @@ describe("ReflectionMatrix", () => {
             global.fetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({ response: "AI reply" })
             });
+            reflection._isMounted = true;
+            reflection.isOpen = true;
 
             const data = await reflection.generateBotReply("msg", [], "meta", "alg");
 
             expect(reflection.showTypingIndicator).toHaveBeenCalled();
-            expect(global.fetch).toHaveBeenCalledWith(`${reflection.PORT}/chat`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    query: "msg",
-                    messages: [],
-                    mentor: "meta",
-                    algorithm: "alg"
+            expect(global.fetch).toHaveBeenCalledWith(
+                `${reflection.PORT}/chat`,
+                expect.objectContaining({
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        query: "msg",
+                        messages: [],
+                        mentor: "meta",
+                        algorithm: "alg"
+                    }),
+                    signal: expect.any(Object)
                 })
-            });
+            );
             expect(reflection.hideTypingIndicator).toHaveBeenCalled();
             expect(data).toEqual({ response: "AI reply" });
         });
 
         test("getAnalysis calls generateAnalysis and saveReport if length >= 10", async () => {
             reflection.chatHistory = new Array(10).fill({});
+            reflection._isMounted = true;
+            reflection.isOpen = true;
             jest.spyOn(reflection, "generateAnalysis").mockResolvedValue({
                 response: "Analysis body"
             });
@@ -449,8 +498,22 @@ describe("ReflectionMatrix", () => {
             expect(reflection.saveReport).toHaveBeenCalledWith({ response: "Analysis body" });
         });
 
+        test("getAnalysis ignores repeat clicks while typing indicator is visible", async () => {
+            reflection.chatHistory = new Array(10).fill({});
+            reflection._isMounted = true;
+            reflection.isOpen = true;
+            reflection.typingDiv = document.createElement("div");
+            jest.spyOn(reflection, "generateAnalysis");
+
+            await reflection.getAnalysis();
+
+            expect(reflection.generateAnalysis).not.toHaveBeenCalled();
+        });
+
         test("sendMessage skips if input is empty", () => {
             reflection.input.value = "   ";
+            reflection._isMounted = true;
+            reflection.isOpen = true;
             reflection.sendMessage();
 
             expect(reflection.chatHistory).toEqual([]);
@@ -458,6 +521,8 @@ describe("ReflectionMatrix", () => {
 
         test("sendMessage adds user msg to history, updates UI, and triggers botReplyDiv", () => {
             reflection.input.value = "Hello AI";
+            reflection._isMounted = true;
+            reflection.isOpen = true;
             reflection.sendMessage();
 
             // Check history
@@ -473,6 +538,44 @@ describe("ReflectionMatrix", () => {
 
             // Triggered bot
             expect(reflection.botReplyDiv).toHaveBeenCalledWith("Hello AI");
+        });
+
+        test("sendMessage skips while another response is pending", () => {
+            reflection.input.value = "Hello again";
+            reflection.typingDiv = document.createElement("div");
+            reflection._isMounted = true;
+            reflection.isOpen = true;
+
+            reflection.sendMessage();
+
+            expect(reflection.chatHistory).toEqual([]);
+            expect(reflection.botReplyDiv).not.toHaveBeenCalled();
+        });
+
+        test("botReplyDiv preserves the mentor selected when the request started", async () => {
+            reflection.botReplyDiv.mockRestore();
+            reflection._isMounted = true;
+            reflection.isOpen = true;
+            reflection.AImentor = "meta";
+
+            let resolveReply;
+            jest.spyOn(reflection, "generateBotReply").mockImplementation(
+                () =>
+                    new Promise(resolve => {
+                        resolveReply = resolve;
+                    })
+            );
+
+            const replyPromise = reflection.botReplyDiv("Hello");
+            reflection.AImentor = "code";
+            resolveReply({ response: "Still from Rohan" });
+            await replyPromise;
+
+            expect(reflection.chatHistory[reflection.chatHistory.length - 1]).toEqual({
+                role: "meta",
+                content: "Still from Rohan"
+            });
+            expect(reflection.chatLog.lastChild.firstChild.innerText).toBe("ROHAN");
         });
 
         test("renderChatHistory clears log and appends history", () => {

--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -97,6 +97,24 @@ function AIDebuggerWidget() {
     this._isProcessing = false;
 
     /**
+     * Flag to prevent sending messages while the initial analysis is loading.
+     * @type {boolean}
+     */
+    this._isInitializing = false;
+
+    /**
+     * Tracks whether the widget is still mounted and safe to update.
+     * @type {boolean}
+     */
+    this._isMounted = false;
+
+    /**
+     * Tracks fetch controllers so pending requests can be aborted on close/reset.
+     * @type {Set<AbortController>}
+     */
+    this._pendingRequests = new Set();
+
+    /**
      * Generates a unique conversation ID
      * @returns {string} Unique conversation identifier
      * @private
@@ -115,6 +133,9 @@ function AIDebuggerWidget() {
     this.init = function (activity) {
         this.activity = activity;
         this.activity.isInputON = true;
+        this._isMounted = true;
+        this._isProcessing = false;
+        this._isInitializing = false;
 
         if (!this.conversationId) {
             this.conversationId = this._generateConversationId();
@@ -129,6 +150,12 @@ function AIDebuggerWidget() {
         widgetWindow.getWidgetBody().style.height = CHATHEIGHT + "px";
 
         widgetWindow.onclose = () => {
+            this._isMounted = false;
+            this._abortPendingRequests();
+            this._hideTypingIndicator();
+            this._setInteractionDisabled(true);
+            this._isProcessing = false;
+            this._isInitializing = false;
             widgetWindow.destroy();
             this.activity.isInputON = false;
         };
@@ -149,6 +176,91 @@ function AIDebuggerWidget() {
         this._loadProjectAndInitialize();
         widgetWindow.sendToCenter();
         this.activity.textMsg(_("Debugger initialized"));
+    };
+
+    /**
+     * Returns true if the widget is still mounted and can safely update UI.
+     * @returns {boolean}
+     * @private
+     */
+    this._isWidgetActive = function () {
+        return Boolean(this._isMounted && this.widgetWindow && this.chatLog);
+    };
+
+    /**
+     * Enables or disables primary user interaction while async work runs.
+     * @param {boolean} disabled
+     * @returns {void}
+     * @private
+     */
+    this._setInteractionDisabled = function (disabled) {
+        if (this.messageInput) {
+            this.messageInput.disabled = disabled;
+        }
+
+        if (this.sendButton) {
+            this.sendButton.disabled = disabled;
+        }
+    };
+
+    /**
+     * Aborts all active backend requests.
+     * @returns {void}
+     * @private
+     */
+    this._abortPendingRequests = function () {
+        this._pendingRequests.forEach(controller => controller.abort());
+        this._pendingRequests.clear();
+    };
+
+    /**
+     * Sends a backend request while tracking widget lifecycle and cancellation.
+     * @param {object} payload
+     * @returns {Promise<object|null>}
+     * @private
+     */
+    this._postToBackend = async function (payload) {
+        const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+
+        if (controller) {
+            this._pendingRequests.add(controller);
+        }
+
+        try {
+            const request = {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(payload)
+            };
+
+            if (controller) {
+                request.signal = controller.signal;
+            }
+
+            const response = await fetch(
+                `${BACKEND_CONFIG.BASE_URL}${BACKEND_CONFIG.ENDPOINTS.ANALYZE}`,
+                request
+            );
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            return this._isWidgetActive() ? data : null;
+        } catch (error) {
+            if (error && error.name === "AbortError") {
+                return null;
+            }
+
+            throw error;
+        } finally {
+            if (controller) {
+                this._pendingRequests.delete(controller);
+            }
+        }
     };
 
     /**
@@ -279,7 +391,7 @@ function AIDebuggerWidget() {
     this._sendMessage = function () {
         const messageText = this.messageInput.value.trim();
         if (messageText === "") return;
-        if (this._isProcessing) return;
+        if (!this._isWidgetActive() || this._isProcessing || this._isInitializing) return;
         this._isProcessing = true;
 
         const userMessage = {
@@ -301,6 +413,10 @@ function AIDebuggerWidget() {
      * @private
      */
     this._addMessageToUI = function (message) {
+        if (!this._isWidgetActive()) {
+            return;
+        }
+
         const messageDiv = document.createElement("div");
         messageDiv.style.maxWidth = "80%";
         messageDiv.style.padding = "12px 16px";
@@ -349,11 +465,13 @@ function AIDebuggerWidget() {
      */
     this._sendToBackend = function (message) {
         this._showTypingIndicator();
+        this._setInteractionDisabled(true);
         this.promptCount++;
+
         let projectData;
         try {
             const rawProjectData = this.activity.prepareExport();
-            const parsedData = JSON.parse(rawProjectData);
+            JSON.parse(rawProjectData);
             projectData = rawProjectData;
         } catch (error) {
             console.error("Error getting project data:", error);
@@ -375,24 +493,13 @@ function AIDebuggerWidget() {
             prompt_count: this.promptCount
         };
 
-        fetch(`${BACKEND_CONFIG.BASE_URL}${BACKEND_CONFIG.ENDPOINTS.ANALYZE}`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
-            body: JSON.stringify(payload)
-        })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.json();
-            })
+        this._postToBackend(payload)
             .then(data => {
-                this._hideTypingIndicator();
-                this._isProcessing = false;
+                if (!this._isWidgetActive() || !data) {
+                    return;
+                }
 
-                if (data && data.response) {
+                if (data.response) {
                     const botResponse = {
                         type: "bot",
                         content: data.response,
@@ -408,8 +515,10 @@ function AIDebuggerWidget() {
                 }
             })
             .catch(error => {
-                this._hideTypingIndicator();
-                this._isProcessing = false;
+                if (!this._isWidgetActive()) {
+                    return;
+                }
+
                 console.error("Backend connection error:", error.message);
 
                 this.activity.textMsg(_("Server error: Unable to connect to AI backend."));
@@ -427,6 +536,14 @@ function AIDebuggerWidget() {
                 this.chatHistory.push(fallbackResponse);
                 this._addMessageToUI(fallbackResponse);
                 this._updateMessageCount();
+            })
+            .finally(() => {
+                this._hideTypingIndicator();
+                this._isProcessing = false;
+
+                if (this._isWidgetActive()) {
+                    this._setInteractionDisabled(false);
+                }
             });
     };
 
@@ -435,6 +552,10 @@ function AIDebuggerWidget() {
      * @private
      */
     this._showTypingIndicator = function () {
+        if (!this._isWidgetActive()) {
+            return;
+        }
+
         const typingDiv = document.createElement("div");
         typingDiv.className = "typing-indicator";
         typingDiv.style.alignSelf = "flex-start";
@@ -465,6 +586,10 @@ function AIDebuggerWidget() {
      * @private
      */
     this._hideTypingIndicator = function () {
+        if (!this.chatLog) {
+            return;
+        }
+
         const typingIndicators = this.chatLog.querySelectorAll(".typing-indicator");
         typingIndicators.forEach(indicator => {
             const animationId = indicator.getAttribute("data-animation-id");
@@ -489,6 +614,13 @@ function AIDebuggerWidget() {
      * @private
      */
     this._loadProjectAndInitialize = function () {
+        if (!this._isWidgetActive()) {
+            return;
+        }
+
+        this._isInitializing = true;
+        this._setInteractionDisabled(true);
+
         try {
             // Get current project data as JSON
             const projectData = this.activity.prepareExport();
@@ -526,6 +658,8 @@ function AIDebuggerWidget() {
 
             // Fallback to simple welcome
             this._addWelcomeMessage();
+            this._isInitializing = false;
+            this._setInteractionDisabled(false);
         }
     };
 
@@ -551,21 +685,11 @@ function AIDebuggerWidget() {
         // Show typing indicator during initialization
         this._showTypingIndicator();
 
-        fetch(`${BACKEND_CONFIG.BASE_URL}${BACKEND_CONFIG.ENDPOINTS.ANALYZE}`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
-            body: JSON.stringify(initPayload)
-        })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.json();
-            })
+        this._postToBackend(initPayload)
             .then(data => {
-                this._hideTypingIndicator();
+                if (!this._isWidgetActive() || !data) {
+                    return;
+                }
 
                 if (data.response) {
                     // Add the backend's initial response
@@ -585,7 +709,10 @@ function AIDebuggerWidget() {
                 }
             })
             .catch(error => {
-                this._hideTypingIndicator();
+                if (!this._isWidgetActive()) {
+                    return;
+                }
+
                 console.error("Backend initialization error:", error.message);
                 this.activity.textMsg(_("Server error: Failed to initialize AI debugger."));
 
@@ -601,6 +728,14 @@ function AIDebuggerWidget() {
                 this._addMessageToUI(errorMessage);
 
                 this._addWelcomeMessage();
+            })
+            .finally(() => {
+                this._hideTypingIndicator();
+                this._isInitializing = false;
+
+                if (this._isWidgetActive()) {
+                    this._setInteractionDisabled(false);
+                }
             });
     };
 
@@ -609,6 +744,10 @@ function AIDebuggerWidget() {
      * @private
      */
     this._resetConversation = function () {
+        this._abortPendingRequests();
+        this._hideTypingIndicator();
+        this._isProcessing = false;
+        this._isInitializing = false;
         this.chatHistory = [];
         this.promptCount = 0; // Reset prompt count
         this.conversationId = this._generateConversationId();

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -65,6 +65,30 @@ class ReflectionMatrix {
          * @type {string}
          */
         this.code = "";
+
+        /**
+         * Tracks whether the widget is mounted and can still update UI safely.
+         * @type {boolean}
+         */
+        this._isMounted = false;
+
+        /**
+         * Tracks in-flight fetch controllers so they can be aborted on close.
+         * @type {Set<AbortController>}
+         */
+        this._pendingRequests = new Set();
+
+        /**
+         * Delayed typing-indicator timeout for initial project loading.
+         * @type {number|null}
+         */
+        this._typingTimeout = null;
+
+        /**
+         * Reference to the send button so it can be disabled during async work.
+         * @type {HTMLButtonElement|null}
+         */
+        this.sendButton = null;
     }
 
     /**
@@ -74,6 +98,7 @@ class ReflectionMatrix {
     init(activity) {
         this.activity = activity;
         this.isOpen = true;
+        this._isMounted = true;
         this.isMaximized = false;
         this.activity.isInputON = true;
         this.PORT = "http://3.105.177.138:8000"; // http://127.0.0.1:8000
@@ -87,10 +112,15 @@ class ReflectionMatrix {
 
         widgetWindow.onclose = () => {
             this.isOpen = false;
+            this._isMounted = false;
             this.activity.isInputON = false;
-            if (this.dotsInterval) {
-                clearInterval(this.dotsInterval);
+            this._setControlsDisabled(true);
+            this.hideTypingIndicator();
+            if (this._typingTimeout) {
+                clearTimeout(this._typingTimeout);
+                this._typingTimeout = null;
             }
+            this._abortPendingRequests();
             widgetWindow.destroy();
         };
 
@@ -176,12 +206,12 @@ class ReflectionMatrix {
             }
         };
 
-        const sendBtn = document.createElement("button");
-        sendBtn.className = "confirm-button";
-        sendBtn.style.marginRight = "10px";
-        sendBtn.innerText = "Send";
-        sendBtn.onclick = () => this.sendMessage();
-        this.inputContainer.appendChild(sendBtn);
+        this.sendButton = document.createElement("button");
+        this.sendButton.className = "confirm-button";
+        this.sendButton.style.marginRight = "10px";
+        this.sendButton.innerText = "Send";
+        this.sendButton.onclick = () => this.sendMessage();
+        this.inputContainer.appendChild(this.sendButton);
 
         // first message
         this.chatInterface.appendChild(this.inputContainer);
@@ -200,7 +230,7 @@ class ReflectionMatrix {
      * @returns {void}
      */
     showTypingIndicator(action) {
-        if (this.typingDiv) return;
+        if (!this._isWidgetActive() || this.typingDiv) return;
 
         this.typingDiv = document.createElement("div");
         this.typingDiv.className = "typing-indicator";
@@ -233,6 +263,86 @@ class ReflectionMatrix {
             clearInterval(this.dotsInterval);
             this.typingDiv.remove();
             this.typingDiv = null;
+            this.dotsContainer = null;
+        }
+    }
+
+    /**
+     * Returns true if the widget is still mounted and safe to update.
+     * @returns {boolean}
+     */
+    _isWidgetActive() {
+        return this._isMounted && this.isOpen && this.chatLog;
+    }
+
+    /**
+     * Disables controls while async work is in progress.
+     * @param {boolean} disabled - Whether controls should be disabled.
+     * @returns {void}
+     */
+    _setControlsDisabled(disabled) {
+        [
+            this.summaryButton,
+            this.reloadButton,
+            this.metaButton,
+            this.codeButton,
+            this.musicButton,
+            this.sendButton,
+            this.input
+        ].forEach(control => {
+            if (control) {
+                control.disabled = disabled;
+            }
+        });
+    }
+
+    /**
+     * Aborts all in-flight widget requests.
+     * @returns {void}
+     */
+    _abortPendingRequests() {
+        this._pendingRequests.forEach(controller => controller.abort());
+        this._pendingRequests.clear();
+    }
+
+    /**
+     * Sends JSON to the backend while tracking widget lifecycle.
+     * @param {string} path - Backend path suffix.
+     * @param {Object} payload - Request payload.
+     * @returns {Promise<Object|null>}
+     */
+    async _postJSON(path, payload) {
+        const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+
+        if (controller) {
+            this._pendingRequests.add(controller);
+        }
+
+        try {
+            const request = {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload)
+            };
+
+            if (controller) {
+                request.signal = controller.signal;
+            }
+
+            const response = await fetch(`${this.PORT}${path}`, request);
+            const data = await response.json();
+            return this._isWidgetActive() ? data : null;
+        } catch (error) {
+            if (error && error.name === "AbortError") {
+                return null;
+            }
+
+            console.error("Error :", error);
+            return { error: "Failed to send message" };
+        } finally {
+            if (controller) {
+                this._pendingRequests.delete(controller);
+            }
         }
     }
 
@@ -267,25 +377,46 @@ class ReflectionMatrix {
      *  @returns {Promise<void>}
      */
     async startChatSession() {
-        if (this.triggerFirst == true) return;
+        if (this.triggerFirst === true || !this._isWidgetActive()) return;
 
         this.triggerFirst = true;
-        setTimeout(() => {
+        this._setControlsDisabled(true);
+        this._typingTimeout = setTimeout(() => {
             this.showTypingIndicator("Reading code");
         }, 1000);
 
-        const code = await this.activity.prepareExport();
-        const data = await this.generateAlgorithm(code);
+        try {
+            const code = await this.activity.prepareExport();
+            const data = await this.generateAlgorithm(code);
 
-        this.hideTypingIndicator();
+            if (this._typingTimeout) {
+                clearTimeout(this._typingTimeout);
+                this._typingTimeout = null;
+            }
 
-        if (data && !data.error) {
-            this.inputContainer.style.display = "flex";
-            this.botReplyDiv(data, false, false);
-            this.projectAlgorithm = data.algorithm;
-            this.code = code;
-        } else {
-            this.activity.errorMsg(_(data.error), 3000);
+            this.hideTypingIndicator();
+
+            if (!this._isWidgetActive() || !data) {
+                return;
+            }
+
+            if (!data.error) {
+                this.inputContainer.style.display = "flex";
+                this.botReplyDiv(data, false, false);
+                this.projectAlgorithm = data.algorithm;
+                this.code = code;
+            } else {
+                this.activity.errorMsg(_(data.error), 3000);
+            }
+        } finally {
+            if (this._typingTimeout) {
+                clearTimeout(this._typingTimeout);
+                this._typingTimeout = null;
+            }
+
+            if (this._isWidgetActive()) {
+                this._setControlsDisabled(false);
+            }
         }
     }
 
@@ -294,26 +425,42 @@ class ReflectionMatrix {
      * @returns {Promise<void>}
      */
     async updateProjectCode() {
+        if (this.typingDiv || !this._isWidgetActive()) {
+            return;
+        }
+
         const code = await this.activity.prepareExport();
         if (code === this.code) {
             return; // No changes in code
         }
 
+        this._setControlsDisabled(true);
         this.showTypingIndicator("Reading code");
-        const data = await this.generateNewAlgorithm(code);
-        this.hideTypingIndicator();
 
-        if (data && !data.error) {
-            if (data.algorithm !== "unchanged") {
-                this.projectAlgorithm = data.algorithm; // update algorithm
-                this.code = code;
+        try {
+            const data = await this.generateNewAlgorithm(code);
+            this.hideTypingIndicator();
+
+            if (!this._isWidgetActive() || !data) {
+                return;
             }
-            this.botReplyDiv(data, false, false);
-        } else {
-            this.activity.errorMsg(_(data.error), 3000);
-        }
 
-        this.projectAlgorithm = data.algorithm;
+            if (!data.error) {
+                if (data.algorithm !== "unchanged") {
+                    this.projectAlgorithm = data.algorithm; // update algorithm
+                    this.code = code;
+                }
+                this.botReplyDiv(data, false, false);
+                this.projectAlgorithm = data.algorithm;
+            } else {
+                this.activity.errorMsg(_(data.error), 3000);
+            }
+        } finally {
+            if (this._isWidgetActive()) {
+                this.hideTypingIndicator();
+                this._setControlsDisabled(false);
+            }
+        }
     }
 
     /**
@@ -322,20 +469,9 @@ class ReflectionMatrix {
      * @returns {Promise<Object>} - The server response containing the algorithm.
      */
     async generateAlgorithm(code) {
-        try {
-            const response = await fetch(`${this.PORT}/projectcode`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    code: code
-                })
-            });
-            const data = await response.json();
-            return data;
-        } catch (error) {
-            console.error("Error :", error);
-            return { error: "Failed to send message" };
-        }
+        return this._postJSON("/projectcode", {
+            code: code
+        });
     }
 
     /**
@@ -345,21 +481,10 @@ class ReflectionMatrix {
      * @returns {Promise<Object>} - The server response containing the updated algorithm.
      */
     async generateNewAlgorithm(code) {
-        try {
-            const response = await fetch(`${this.PORT}/updatecode`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    oldcode: this.code,
-                    newcode: code
-                })
-            });
-            const data = await response.json();
-            return data;
-        } catch (error) {
-            console.error("Error :", error);
-            return { error: "Failed to send message" };
-        }
+        return this._postJSON("/updatecode", {
+            oldcode: this.code,
+            newcode: code
+        });
     }
 
     /**
@@ -371,25 +496,15 @@ class ReflectionMatrix {
      *  @returns {Promise<Object>} - The server response containing the bot's reply.
      */
     async generateBotReply(message, chatHistory, mentor, algorithm) {
-        try {
-            this.showTypingIndicator();
-            const response = await fetch(`${this.PORT}/chat`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    query: message,
-                    messages: chatHistory,
-                    mentor: mentor,
-                    algorithm: algorithm
-                })
-            });
-            this.hideTypingIndicator();
-            const data = await response.json();
-            return data;
-        } catch (error) {
-            console.error("Error :", error);
-            return { error: "Failed to send message" };
-        }
+        this.showTypingIndicator();
+        const data = await this._postJSON("/chat", {
+            query: message,
+            messages: chatHistory,
+            mentor: mentor,
+            algorithm: algorithm
+        });
+        this.hideTypingIndicator();
+        return data;
     }
 
     /**
@@ -397,14 +512,27 @@ class ReflectionMatrix {
      * @returns {Promise<void>}
      */
     async getAnalysis() {
-        if (this.chatHistory.length < 10) return;
+        if (this.chatHistory.length < 10 || this.typingDiv || !this._isWidgetActive()) return;
+
+        this._setControlsDisabled(true);
         this.showTypingIndicator("Analyzing");
-        const data = await this.generateAnalysis();
-        this.hideTypingIndicator();
-        if (data) {
+
+        try {
+            const data = await this.generateAnalysis();
+            this.hideTypingIndicator();
+
+            if (!this._isWidgetActive() || !data) {
+                return;
+            }
+
             this.botReplyDiv(data, false, true);
+            await this.saveReport(data);
+        } finally {
+            if (this._isWidgetActive()) {
+                this.hideTypingIndicator();
+                this._setControlsDisabled(false);
+            }
         }
-        await this.saveReport(data);
     }
 
     /**
@@ -412,21 +540,10 @@ class ReflectionMatrix {
      *  @returns {Promise<Object>} - The server response containing the analysis.
      */
     async generateAnalysis() {
-        try {
-            const response = await fetch(`${this.PORT}/analysis`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    messages: this.chatHistory,
-                    summary: this.summary
-                })
-            });
-            const data = await response.json();
-            return data;
-        } catch (error) {
-            console.error("Error :", error);
-            return { error: "Failed to send message" };
-        }
+        return this._postJSON("/analysis", {
+            messages: this.chatHistory,
+            summary: this.summary
+        });
     }
 
     /**
@@ -437,17 +554,22 @@ class ReflectionMatrix {
      */
     async botReplyDiv(message, user_query = true, md = false) {
         let reply;
+        let replyMentor = this.AImentor;
         // check if message is from user or bot
         if (user_query === true) {
-            if (this.typingDiv) return;
+            if (this.typingDiv || !this._isWidgetActive()) return;
             reply = await this.generateBotReply(
                 message,
                 this.chatHistory,
-                this.AImentor,
+                replyMentor,
                 this.projectAlgorithm
             );
         } else {
             reply = message;
+        }
+
+        if (!this._isWidgetActive() || !reply) {
+            return;
         }
 
         if (reply.error) {
@@ -457,7 +579,7 @@ class ReflectionMatrix {
         }
 
         this.chatHistory.push({
-            role: this.AImentor,
+            role: replyMentor,
             content: reply.response
         });
 
@@ -474,7 +596,7 @@ class ReflectionMatrix {
         senderName.style.marginBottom = "4px";
         senderName.style.color = "#383838ff";
         senderName.style.alignSelf = "flex-start";
-        senderName.innerText = this.mentorsMap[this.AImentor];
+        senderName.innerText = this.mentorsMap[replyMentor];
 
         const botReply = document.createElement("div");
 
@@ -497,7 +619,7 @@ class ReflectionMatrix {
      */
     sendMessage() {
         const text = this.input.value.trim();
-        if (text === "") return;
+        if (text === "" || this.typingDiv || !this._isWidgetActive()) return;
         this.chatHistory.push({
             role: "user",
             content: text
@@ -523,7 +645,12 @@ class ReflectionMatrix {
 
         this.chatLog.appendChild(messageContainer);
         this.input.value = "";
-        this.botReplyDiv(text);
+        this._setControlsDisabled(true);
+        this.botReplyDiv(text).finally(() => {
+            if (this._isWidgetActive()) {
+                this._setControlsDisabled(false);
+            }
+        });
         this.chatLog.scrollTop = this.chatLog.scrollHeight;
     }
 


### PR DESCRIPTION
## Summary

Fixes #6289.

This PR addresses async lifecycle issues in the Reflection and AI Debugger widgets. Pending backend requests could still resolve after the widget was closed or reset, and those late responses could continue updating stale widget state or detached DOM. In Reflection, repeated async actions could also be triggered while an earlier request was still in flight.

## Root cause

- Reflection allowed overlapping async actions such as `Summary`, `Refresh`, and send while a previous request was still running.
- Both `reflection.js` and `aidebugger.js` could still apply async results after the widget had already been closed or reset.
- Reflection also had a mentor-label race where switching mentors during an in-flight request could label the response with the wrong mentor.

## What changed

- added mounted-state guards before applying async results
- added tracked backend request handling with abort support
- aborts pending requests on widget close/reset
- prevents duplicate in-flight Reflection actions
- disables controls during async work where needed
- preserves the mentor selected at request start for Reflection replies
- added regression tests for duplicate-click and stale-response cases

## Validation

- `npx.cmd jest js/widgets/__tests__/reflection.test.js js/widgets/__tests__/aidebugger.test.js --runInBand`
- `npx.cmd eslint js/widgets/reflection.js js/widgets/aidebugger.js js/widgets/__tests__/reflection.test.js js/widgets/__tests__/aidebugger.test.js`

## PR Category
- [x] Bug Fix
- [x] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation
