### PR TITLE
Fix overlay canvas resize height

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4169,7 +4169,7 @@ class Activity {
                 canvas.width = defaultWidth;
                 canvas.height = defaultHeight;
                 overCanvas.width = canvas.width;
-                overCanvas.height = canvas.width;
+                overCanvas.height = canvas.height;
                 canvasHolder.width = defaultWidth;
                 canvasHolder.height = defaultHeight;
             } else {
@@ -4186,7 +4186,7 @@ class Activity {
                 canvas.width = windowWidth;
                 canvas.height = windowHeight;
                 overCanvas.width = canvas.width;
-                overCanvas.height = canvas.width;
+                overCanvas.height = canvas.height;
                 canvasHolder.width = canvas.width;
                 canvasHolder.height = canvas.height;
             }


### PR DESCRIPTION
Fixes #6326 

### Description
Corrected the overlay canvas (`overCanvas`) height assignment during resize.

Previously, `overCanvas.height` was incorrectly set using `canvas.width`, which caused distortion and misalignment on non-square viewports.

### Changes
- Updated `overCanvas.height` to use `canvas.height` instead of `canvas.width`
- Applied fix in both resize branches

### Testing
- Verified correct rendering after window resize
- Verified behavior on different aspect ratios

### PR Category
- [x] Bug Fix