### PR TITLE
perf: skip trashed blocks in iteration loops and free canvas cache on…

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4626,6 +4626,21 @@ class Activity {
                 this.blocks.blockList[blk].trash = true;
                 this.blocks.moveBlockRelative(blk, dx, dy);
                 this.blocks.blockList[blk].hide();
+
+                // Free the backing canvas memory for trashed blocks.
+                // Each cached block holds a bitmap canvas (~0.5-2 MB).
+                // This matches the cleanup pattern in sendStackToTrash().
+                if (this.blocks.blockList[blk].container) {
+                    this.blocks.blockList[blk].container.uncache();
+                }
+
+                // Clean up SVG art strings to free memory.
+                if (this.blocks.blockArt[blk]) {
+                    delete this.blocks.blockArt[blk];
+                }
+                if (this.blocks.blockCollapseArt[blk]) {
+                    delete this.blocks.blockCollapseArt[blk];
+                }
             }
 
             if (addStartBlock) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -288,6 +288,7 @@ class Blocks {
             let palette;
             /** Regenerate all of the artwork at the new scale. */
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 block.resize(scale);
             }
 
@@ -412,6 +413,7 @@ class Blocks {
         this.bottomMostBlock = () => {
             let maxy = -1000;
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.container.y > maxy) {
                     maxy = block.container.y;
                 }
@@ -2086,6 +2088,10 @@ class Blocks {
                             continue;
                         }
 
+                        if (this.blockList[b].trash) {
+                            continue;
+                        }
+
                         if (this.blockList[b].name === "action") {
                             if (this.blockList[b].connections[1] != null) {
                                 if (
@@ -2254,6 +2260,7 @@ class Blocks {
          */
         this.updateBlockPositions = () => {
             for (const [blk, block] of this.blockList.entries()) {
+                if (block.trash) continue;
                 this._moveBlock(blk, block.container.x, block.container.y);
             }
         };
@@ -2267,6 +2274,7 @@ class Blocks {
             this._adjustTheseStacks = [];
 
             for (const [blk, myBlock] of this.blockList.entries()) {
+                if (myBlock.trash) continue;
                 if (myBlock.connections[0] == null) {
                     this._adjustTheseStacks.push(blk);
                 }
@@ -2289,6 +2297,7 @@ class Blocks {
 
             let onScreen = true;
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.connections[0] == null) {
                     if (block.offScreen(this.boundary)) {
                         this.activity.setHomeContainers(true);
@@ -2428,6 +2437,7 @@ class Blocks {
             if (this._topBlockCache == null) {
                 this._topBlockCache = new Map();
                 for (let i = 0; i < this.blockList.length; i++) {
+                    if (this.blockList[i].trash) continue;
                     this._topBlockCache.set(i, this.findTopBlock(i));
                 }
             }
@@ -2436,6 +2446,7 @@ class Blocks {
             const excludeTop = blkIdx >= 0 ? this._topBlockCache.get(blkIdx) : -1;
 
             for (let i = 0; i < this.blockList.length; i++) {
+                if (this.blockList[i].trash) continue;
                 if (this._topBlockCache.get(i) !== excludeTop) {
                     this.moveBlockRelativeBatched(i, dx, dy);
                 }
@@ -2837,6 +2848,7 @@ class Blocks {
         this.findStacks = () => {
             this.stackList = [];
             for (let i = 0; i < this.blockList.length; i++) {
+                if (this.blockList[i].trash) continue;
                 if (this.blockList[i].connections[0] == null) {
                     this.stackList.push(i);
                 }
@@ -2867,6 +2879,7 @@ class Blocks {
         this._findTwoArgs = () => {
             this._expandablesList = [];
             for (let i = 0; i < this.blockList.length; i++) {
+                if (this.blockList[i].trash) continue;
                 if (this.blockList[i].isArgBlock() && this.blockList[i].isExpandableBlock()) {
                     this._expandablesList.push(i);
                 } else if (this.blockList[i].isTwoArgBlock()) {
@@ -2882,6 +2895,7 @@ class Blocks {
          */
         this._searchForArgFlow = () => {
             for (const [blk, block] of this.blockList.entries()) {
+                if (block.trash) continue;
                 if (block.isArgFlowClampBlock()) {
                     this._searchCounter = 0;
                     this._searchForExpandables(blk);
@@ -2979,6 +2993,7 @@ class Blocks {
          */
         this.changeDisabledStatus = (name, flag) => {
             for (const myBlock of this.blockList) {
+                if (myBlock.trash) continue;
                 if (myBlock.name === name) {
                     myBlock.protoblock.disabled = flag;
                     myBlock.regenerateArtwork(false);
@@ -2992,7 +3007,8 @@ class Blocks {
          * @returns {void}
          */
         this.unhighlightAll = () => {
-            for (const [blk] of this.blockList.entries()) {
+            for (const [blk, block] of this.blockList.entries()) {
+                if (block.trash) continue;
                 this.unhighlight(blk);
             }
         };
@@ -3061,6 +3077,7 @@ class Blocks {
          */
         this.show = () => {
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 block.show();
             }
             this.visible = true;
@@ -3840,6 +3857,7 @@ class Blocks {
          */
         this._findDrumURLs = () => {
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.name === "text" || block.name === "string") {
                     const c = block.connections[0];
                     if (
@@ -3871,6 +3889,7 @@ class Blocks {
             // Collect blocks to update for batched cache update
             const blocksToUpdate = [];
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.name === "text") {
                     const c = block.connections[0];
                     if (c != null && this.blockList[c].name === "box") {
@@ -3912,6 +3931,7 @@ class Blocks {
             // Collect blocks to update for batched cache update
             const blocksToUpdate = [];
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.name === "text") {
                     const c = block.connections[0];
                     if (c != null && this.blockList[c].name === "storein") {
@@ -3966,6 +3986,7 @@ class Blocks {
             // Collect blocks to update for batched cache update
             const blocksToUpdate = [];
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.name === "storein2") {
                     if (block.privateData === oldName) {
                         block.privateData = newName;
@@ -4011,6 +4032,7 @@ class Blocks {
             // Collect blocks to update for batched cache update
             const blocksToUpdate = [];
             for (const block of this.blockList) {
+                if (block.trash) continue;
                 if (block.name === "namedbox") {
                     if (block.privateData === oldName) {
                         block.privateData = newName;
@@ -4062,6 +4084,9 @@ class Blocks {
                 }
 
                 const myBlock = this.blockList[blk];
+                if (myBlock.trash) {
+                    continue;
+                }
                 const blkParent = this.blockList[myBlock.connections[0]];
                 if (blkParent == null) {
                     continue;
@@ -4116,6 +4141,10 @@ class Blocks {
 
             /** Update the blocks, do->oldName should be do->newName */
             for (const blk in this.blockList) {
+                if (this.blockList[blk].trash) {
+                    continue;
+                }
+
                 if (
                     ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].includes(
                         this.blockList[blk].name
@@ -5021,6 +5050,7 @@ class Blocks {
 
             const c2v = this.blockList[c2].value;
             for (let i = 0; i < this.blockList.length; i++) {
+                if (this.blockList[i].trash) continue;
                 if (["setbpm3", "setmasterbpm2"].includes(this.blockList[i].name)) {
                     const bn = this.blockList[i].connections[1];
                     if (bn === null || this.blockList[bn].name !== "number") {
@@ -6912,6 +6942,7 @@ class Blocks {
                 /** Look for any "orphan" action blocks. */
                 for (const blk in this.blockList) {
                     const thisBlock = this.blockList[blk];
+                    if (thisBlock.trash) continue;
 
                     /** We are only interested in do and nameddo blocks. */
                     if (


### PR DESCRIPTION
## What this PR does

Two tightly related performance fixes that **reduce RAM usage and CPU overhead** when working with Music Blocks projects.

### Fix 1: Skip trashed blocks in 22 `blockList` iteration loops ([blocks.js](cci:7://file:///home/ashutoshx7/musicblocks/js/blocks.js:0:0-0:0))

When blocks are deleted or a project is reloaded, [sendAllToTrash()](cci:1://file:///home/ashutoshx7/musicblocks/js/activity.js:4582:8-4666:10) marks blocks as `.trash = true` but **never removes them** from `blockList`. New blocks are appended on top. Over multiple project loads, hundreds of zombie block objects accumulate and are pointlessly iterated in critical loops.

**Changes**: Added `if (block.trash) continue;` to 22 loops that were missing it:

- **Core traversal**: [findStacks()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2841:8-2855:10), [_findTwoArgs()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2873:8-2888:10), [_searchForArgFlow()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2890:8-2904:10)
- **Layout/display**: `setBlockScale()`, [bottomMostBlock()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:407:8-422:10), [updateBlockPositions()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2255:8-2265:10), [bringToTop()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2267:8-2287:10), [checkBounds()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2289:8-2315:10), [moveAllBlocksExcept()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2424:8-2456:10), [show()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3072:8-3083:10) 
- **Block management**: [changeDisabledStatus()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:2984:8-3001:10), [unhighlightAll()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3003:8-3013:10), `deleteActionBlock()`, action name duplicate check, `meter_block_changed()`
- **Rename operations**: [_findDrumURLs()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3852:8-3874:10), [renameBoxes()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3876:8-3916:10), [renameStoreinBoxes()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3918:8-3971:10), [renameStorein2Boxes()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:3973:8-4017:10), [renameNamedboxes()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:4019:8-4064:10), [renameDos()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:4066:8-4127:10), [renameNameddos()](cci:1://file:///home/ashutoshx7/musicblocks/js/blocks.js:4129:8-4186:10)

### Fix 2: Free canvas cache memory in [sendAllToTrash()](cci:1://file:///home/ashutoshx7/musicblocks/js/activity.js:4582:8-4666:10) ([activity.js](cci:7://file:///home/ashutoshx7/musicblocks/js/activity.js:0:0-0:0))

The individual `sendStackToTrash()` in [blocks.js](cci:7://file:///home/ashutoshx7/musicblocks/js/blocks.js:0:0-0:0) properly calls `.uncache()` on containers and cleans up `blockArt`/`blockCollapseArt` strings. However, the bulk [sendAllToTrash()](cci:1://file:///home/ashutoshx7/musicblocks/js/activity.js:4582:8-4666:10) (called on every project load/clear) was **missing this cleanup**.

**Changes**: Added `container.uncache()` + SVG art cleanup after hiding each block, matching the existing pattern in `sendStackToTrash()`.

## Impact

| Metric | Before | After |
|---|---|---|
| Zombie block iteration | O(total blocks ever created) | O(active blocks only) |
| Canvas cache on reload | Retained (~0.5–2 MB per block) | Freed immediately |
| SVG art strings on reload | Retained in memory | Freed immediately |

## Testing

- ✅ **ESLint**: 0 errors
- ✅ **Prettier**: All files formatted  
- ✅ **Jest**: All 3967 tests pass
- ✅ **Browser**: App loads, palettes open, blocks render and can be placed on canvas

- [x] Performance
