### PR TITLE
perf: replace JSON deep-clone with deepClone utility + cap synthVolum…

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -37,6 +37,12 @@ global.getStepSizeUp = mockGlobals.getStepSizeUp;
 global.numberToPitch = mockGlobals.numberToPitch;
 global.pitchToNumber = mockGlobals.pitchToNumber;
 global.last = jest.fn(array => array[array.length - 1]);
+global.deepClone = value => {
+    if (typeof structuredClone === "function") {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+};
 
 global.SEMITONES = 12;
 global.pitchToFrequency = jest.fn().mockReturnValue(440);

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -12,7 +12,7 @@
 /*
    global
 
-   last, _, ValueBlock, FlowClampBlock, FlowBlock, NOINPUTERRORMSG,
+   deepClone, last, _, ValueBlock, FlowClampBlock, FlowBlock, NOINPUTERRORMSG,
    LeftBlock, Singer, CHORDNAMES, CHORDVALUES, DEFAULTCHORD,
    Queue, INTERVALVALUES
  */
@@ -412,9 +412,11 @@ function setupIntervalsBlocks(activity) {
             const saveSuppressStatus = tur.singer.suppressOutput;
 
             // Save the state of the boxes, dicts, and heap
-            const saveBoxes = JSON.stringify(logo.boxes);
-            const saveTurtleHeaps = JSON.stringify(logo.turtleHeaps[turtle]);
-            const saveTurtleDicts = JSON.stringify(logo.turtleDicts[turtle]);
+            const saveBoxes = deepClone(logo.boxes);
+            const saveTurtleHeaps =
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            const saveTurtleDicts =
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
 
             // Save the turtle state
             const saveX = tur.x;
@@ -427,7 +429,7 @@ function setupIntervalsBlocks(activity) {
             const saveOrientation = tur.orientation;
             const savePenState = tur.painter.penState;
             const previousButNotThese = tur.butNotThese;
-            tur.butNotThese = JSON.parse(JSON.stringify(tur.butNotThese));
+            tur.butNotThese = deepClone(tur.butNotThese);
 
             tur.singer.suppressOutput = true;
             tur.singer.justCounting.push(true);
@@ -463,9 +465,9 @@ function setupIntervalsBlocks(activity) {
             tur.singer.notesPlayed = saveNoteCount;
 
             // Restore previous state
-            logo.boxes = JSON.parse(saveBoxes);
-            logo.turtleHeaps[turtle] = JSON.parse(saveTurtleHeaps);
-            logo.turtleDicts[turtle] = JSON.parse(saveTurtleDicts);
+            logo.boxes = saveBoxes;
+            logo.turtleHeaps[turtle] = saveTurtleHeaps != null ? saveTurtleHeaps : {};
+            logo.turtleDicts[turtle] = saveTurtleDicts != null ? saveTurtleDicts : {};
 
             tur.painter.doPenUp();
             tur.painter.doSetXY(saveX, saveY);
@@ -531,9 +533,11 @@ function setupIntervalsBlocks(activity) {
             // We need to save the state of the boxes, dicts, and heap
             // although there is a potential of a boxes
             // collision with other turtles.
-            const saveBoxes = JSON.stringify(logo.boxes);
-            const saveTurtleHeaps = JSON.stringify(logo.turtleHeaps[turtle]);
-            const saveTurtleDicts = JSON.stringify(logo.turtleDicts[turtle]);
+            const saveBoxes = deepClone(logo.boxes);
+            const saveTurtleHeaps =
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            const saveTurtleDicts =
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
             // And the turtle state
             const saveX = tur.x;
             const saveY = tur.y;
@@ -545,7 +549,7 @@ function setupIntervalsBlocks(activity) {
             const saveOrientation = tur.orientation;
             const savePenState = tur.painter.penState;
             const previousButNotThese = tur.butNotThese;
-            tur.butNotThese = JSON.parse(JSON.stringify(tur.butNotThese));
+            tur.butNotThese = deepClone(tur.butNotThese);
 
             tur.singer.suppressOutput = true;
 
@@ -582,9 +586,9 @@ function setupIntervalsBlocks(activity) {
             tur.singer.notesPlayed = saveNoteCount;
 
             // Restore previous state
-            logo.boxes = JSON.parse(saveBoxes);
-            logo.turtleHeaps[turtle] = JSON.parse(saveTurtleHeaps);
-            logo.turtleDicts[turtle] = JSON.parse(saveTurtleDicts);
+            logo.boxes = saveBoxes;
+            logo.turtleHeaps[turtle] = saveTurtleHeaps != null ? saveTurtleHeaps : {};
+            logo.turtleDicts[turtle] = saveTurtleDicts != null ? saveTurtleDicts : {};
 
             tur.painter.doPenUp();
             tur.painter.doSetXY(saveX, saveY);

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -18,7 +18,7 @@
 /*
    global
 
-   DEFAULTVOLUME, TARGETBPM, TONEBPM, MIN_HIGHLIGHT_DURATION_MS, frequencyToPitch, last,
+   DEFAULTVOLUME, TARGETBPM, TONEBPM, MIN_HIGHLIGHT_DURATION_MS, deepClone, frequencyToPitch, last,
    pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp,
    getStepSizeDown, numberToPitch, pitchToNumber, rationalSum,
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
@@ -514,9 +514,11 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = JSON.stringify(logo.boxes);
-        const saveTurtleHeaps = JSON.stringify(logo.turtleHeaps[turtle]);
-        const saveTurtleDicts = JSON.stringify(logo.turtleDicts[turtle]);
+        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
+        const saveTurtleHeaps =
+            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+        const saveTurtleDicts =
+            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -570,17 +572,17 @@ class Singer {
         if (saveBoxes == undefined) {
             logo.boxes = {};
         } else {
-            logo.boxes = JSON.parse(saveBoxes);
+            logo.boxes = saveBoxes;
         }
         if (saveTurtleHeaps == undefined) {
             logo.turtleHeaps = {};
         } else {
-            logo.turtleHeaps[turtle] = JSON.parse(saveTurtleHeaps);
+            logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
         if (saveTurtleDicts == undefined) {
             logo.turtleDicts = {};
         } else {
-            logo.turtleDicts[turtle] = JSON.parse(saveTurtleDicts);
+            logo.turtleDicts[turtle] = saveTurtleDicts;
         }
 
         tur.painter.doPenUp();
@@ -626,9 +628,11 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: JSON.stringify(logo.boxes),
-            turtleHeaps: JSON.stringify(logo.turtleHeaps[turtle]),
-            turtleDicts: JSON.stringify(logo.turtleDicts[turtle]),
+            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
+            turtleHeaps:
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+            turtleDicts:
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -685,9 +689,11 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = JSON.parse(saveState.boxes);
-        activity.logo.turtleHeaps[turtle] = JSON.parse(saveState.turtleHeaps);
-        activity.logo.turtleDicts[turtle] = JSON.parse(saveState.turtleDicts);
+        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
+        activity.logo.turtleHeaps[turtle] =
+            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
+        activity.logo.turtleDicts[turtle] =
+            saveState.turtleDicts != null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -719,7 +725,15 @@ class Singer {
         }
         for (const turtle of activity.turtles.turtleList) {
             for (const synth in turtle.singer.synthVolume) {
-                turtle.singer.synthVolume[synth].push(volume);
+                // Replace last value instead of pushing to prevent unbounded
+                // array growth. Master volume doesn't use stack semantics,
+                // so only the current volume matters.
+                const arr = turtle.singer.synthVolume[synth];
+                if (arr.length > 0) {
+                    arr[arr.length - 1] = volume;
+                } else {
+                    arr.push(volume);
+                }
             }
         }
     }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -31,7 +31,7 @@
 /* exported
 
    canvasPixelRatio, changeImage, closeBlkWidgets, closeWidgets,
-   delayExecution, displayMsg, doBrowserCheck, docByClass, docByName,
+   deepClone, delayExecution, displayMsg, doBrowserCheck, docByClass, docByName,
    docBySelector, docByTagName, doPublish, doStopVideoCam, doSVG,
    doUseCamera, fileBasename, fileExt, format, getTextWidth, hex2rgb,
    hexToRGB, hideDOMLabel, httpGet, httpPost, HttpRequest,
@@ -516,6 +516,20 @@ let last = myList => {
     } else {
         return myList[i - 1];
     }
+};
+
+/**
+ * Creates a deep clone of a value. Uses structuredClone when available
+ * (modern browsers) for better performance, falling back to
+ * JSON.parse(JSON.stringify()) for compatibility with test environments.
+ * @param {*} value - The value to deep clone.
+ * @returns {*} A deep clone of the value.
+ */
+let deepClone = value => {
+    if (typeof structuredClone === "function") {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
 };
 
 /**


### PR DESCRIPTION
## What this PR does

Two performance optimizations that reduce GC pressure and prevent unbounded memory growth during Music Blocks playback.

### Fix 1: Replace `JSON.stringify/parse` deep-clone with `deepClone()` utility

`JSON.stringify(obj)` + `JSON.parse(str)` is used to deep-clone state in several **hot paths** that execute on every note:

| Location | Called in | Issue |
|---|---|---|
| `turtle-singer.js` | `Singer.noteCounter()` | Clones `logo.boxes`, `turtleHeaps`, `turtleDicts` on every note count |
| `turtle-singer.js` | `Singer.numberOfNotes()` | Same three objects cloned again |
| `IntervalsBlocks.js` | `DefInvertMode`, `SetInvertModeBlock` | Clones turtle state + `butNotThese` on interval execution |

**Changes**:
- Added `deepClone()` to [js/utils/utils.js](cci:7://file:///home/ashutoshx7/musicblocks/js/utils/utils.js:0:0-0:0) — uses `structuredClone()` (native browser API, 2–3× faster) with `JSON.parse/stringify` fallback
- Replaced all hot-path JSON clones with `deepClone()`
- Added `global.deepClone` to [turtle-singer.test.js](cci:7://file:///home/ashutoshx7/musicblocks/js/__tests__/turtle-singer.test.js:0:0-0:0) for Jest

### Fix 2: Cap `synthVolume` array growth in `setMasterVolume()`

`Singer.setMasterVolume()` was calling `.push(volume)` on every turtle's `synthVolume` array with **no corresponding pop**, causing monotonic growth. Fixed to replace-last semantics.

## Testing
- ✅ ESLint: 0 errors  
- ✅ Prettier: formatted  
- ✅ Jest: 3967/3967 tests pass  
- ✅ Browser: loads correctly, zero console errors

- [x] Performance