### PR TITLE
Bug: rationalSum throws fatal TypeError on undefined inputs from empt…

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1380,10 +1380,10 @@ const LCD = (a, b) => {
  * @returns {Array} The sum of the two rational numbers in the form [numerator, denominator].
  */
 let rationalSum = (a, b) => {
-    // TODO: handle undefined/null array inputs safely (see Issue #XXX)
-    // In block-based environments, empty blocks may pass undefined instead of [num, den].
-    // Accessing a[0] or b[0] below will currently throw a fatal TypeError.
-    //But if upstream guarantees: a = [num, den] then the issue may never occur
+    if (!Array.isArray(a) || !Array.isArray(b)) {
+        console.warn('utils.rationalSum received invalid inputs', a, b);
+        return [0, 1];
+    }
     if (a === 0 || b === 0) {
         // console.debug("divide by zero?");
         return [0, 1];


### PR DESCRIPTION
While exploring the math utilities in 'js/utils.js' , I noticed a vulnerability in the 'rationalSum(a, b)' function that can cause a fatal thread crash. The function expects 'a' and 'b' to be arrays (e.g., '[numerator, denominator]'). However, in a block-based environment, if a user leaves a fraction block empty or disconnected, the engine may pass 'undefined'. If 'a' is 'undefined', the check 'if (a === 0 || b === 0)' passes safely, but the subsequent line: 'if (Math.floor(a[0]) !== a[0])'
throws a fatal 'TypeError: Cannot read properties of undefined (reading '0')', crashing the execution.
### PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation

Fixes #6370