### PR TITLE
Fix window.activity deprecation warning

### DIFF
--- a/js/__tests__/activity_context_regression.test.js
+++ b/js/__tests__/activity_context_regression.test.js
@@ -30,6 +30,7 @@
  * Test environment: jsdom (configured in jest.config.js).
  */
 
+const fs = require("fs");
 const path = require("path");
 
 // ─── Load ActivityContext via CommonJS (module supports both AMD and CJS) ────
@@ -195,5 +196,10 @@ describe("window.activity — deprecation guard contract", () => {
         const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
         expect(window.activity).toBeUndefined();
         warnSpy.mockRestore();
+    });
+
+    test("activity.js does not assign the Activity singleton back onto window.activity", () => {
+        const activitySource = fs.readFileSync(path.resolve(__dirname, "../activity.js"), "utf8");
+        expect(activitySource).not.toMatch(/\bwindow\.activity\s*=/);
     });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -3041,11 +3041,6 @@ class Activity {
                     this._resetIdleTimer();
                 }
             }, 1000);
-
-            // Expose activity instance for external checks
-            if (typeof window !== "undefined") {
-                window.activity = this;
-            }
         };
 
         /**


### PR DESCRIPTION
This PR fixes a console warning that was being triggered. 

We already moved away from using window.activity and added a deprecation guard that tells developers to use ActivityContext instead. But one part of activity.js was still trying to set window.activity = this, which caused the warning to appear in the console.
This change removes that old assignment and keeps ActivityContext as the only supported way to access the current activity instance.

A regression test is also added so we do not accidentally bring back window.activity = ... in the future.

<img width="1083" height="34" alt="image" src="https://github.com/user-attachments/assets/6f1c2156-a945-46b0-a2a7-479337154df0" />

- [x] Bug Fix