### PR TITLE
fix: skip caching non-http requests in service worker to resolve chrome-extension TypeError (Related to #6373)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -101,7 +101,7 @@ function shouldCacheResponse(request, response) {
     return isStaticAssetRequest(request) || isPrecachedRequest(request);
 }
 */
-//filter out unsupported URL schemes before caching
+// Filter out unsupported URL schemes before caching
 function updateCache(request, response) {
     // Cache API only supports http:// and https:// requests.
     // Attempting to cache other schemes (e.g. chrome-extension://, moz-extension://)
@@ -141,7 +141,7 @@ function fromCache(request) {
 
 // If any fetch fails, it will look for the request in the cache and
 // serve it from there first
-//add URL scheme check at the top
+// add URL scheme check at the top
 self.addEventListener("fetch", function (event) {
     // Only handle http/https requests.
     // chrome-extension:// and other schemes are not supported by Cache API.


### PR DESCRIPTION
## Description
The service worker (`sw.js`) attempts to cache all intercepted fetch
requests without checking the URL scheme first. The Cache API only
supports `http://` and `https://` requests. When Chrome extensions
inject requests with the `chrome-extension://` scheme, the service
worker tries to cache them and throws a repeated TypeError, flooding
the console with errors that obscure real issues.

## Fix
Added a URL scheme guard in two places in `sw.js`:

1. `updateCache()` function — returns early if the request URL does
   not start with `http`
2. `fetch` event listener — returns early for the same reason

## Changes Made
- `sw.js` — added `if (!request.url.startsWith("http")) return` check
  in `updateCache()` and at the top of the `fetch` event listener

## Type of Change
- [x] Bug fix

## Related Issue
Closes #6373 

## Screenshots

Before 

<img width="1919" height="962" alt="Screenshot 2026-03-24 095509" src="https://github.com/user-attachments/assets/b137f720-852e-47f8-bac3-8b46cd0d5ae7" />

After

<img width="1919" height="994" alt="Screenshot 2026-03-24 094322" src="https://github.com/user-attachments/assets/7f9a652f-913b-4610-88d2-71d944d1b614" />


## Checklist
- [x] I have read and followed the project's code of conduct.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally.
- [x] I have added comments to my code where necessary.