### PR TITLE
Speed up security scans by removing npm ci

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -20,8 +20,5 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Dependencies
-        run: npm ci
-
       - name: Run npm Audit
         run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
npm audit does not require node_modules to run. This PR removes the unnecessary npm ci step from security_scan.yml to save CI compute time and speed up the pipeline.

types of Change:


- [x] Bug Fix
- [x] Performance improvement


CLOSES #6378
