### PR TITLE
Refactor Jest ci & Added comment workflow

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -10,6 +10,7 @@ jobs:
   lighthouse:
     name: Lighthouse Performance Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       pull-requests: write
       contents: read
@@ -33,8 +34,12 @@ jobs:
       - name: Install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x
 
+      - name: Validate Lighthouse config
+        run: test -f ./lighthouserc.js || (echo "::error::lighthouserc.js not found" && exit 1)
+
       - name: Run Lighthouse CI
         id: lighthouse
+        continue-on-error: true
         run: lhci autorun --config=./lighthouserc.js 2>&1 | tee lighthouse-output.txt
 
       - name: Parse Lighthouse Results
@@ -56,8 +61,8 @@ jobs:
               BP_SCORE=$(jq '[.[].summary["best-practices"]] | add / length * 100 | floor' "$MANIFEST" 2>/dev/null || echo "N/A")
               SEO_SCORE=$(jq '[.[].summary.seo] | add / length * 100 | floor' "$MANIFEST" 2>/dev/null || echo "N/A")
               
-              # Get report URL from temporary-public-storage
-              REPORT_URL=$(jq -r '.[0].url // "N/A"' "$MANIFEST" 2>/dev/null)
+              # Get hosted report URL (links key) or fall back to audited page URL
+              REPORT_URL=$(jq -r '.[0].links["lighthouse-viewer"] // .[0].url // "N/A"' "$MANIFEST" 2>/dev/null)
               
               echo "PERF_SCORE=$PERF_SCORE" >> $GITHUB_OUTPUT
               echo "A11Y_SCORE=$A11Y_SCORE" >> $GITHUB_OUTPUT
@@ -71,8 +76,8 @@ jobs:
         id: emoji
         run: |
           get_emoji() {
-            score=$1
-            if [ "$score" = "N/A" ]; then
+            score="${1:-0}"
+            if ! [[ "$score" =~ ^[0-9]+$ ]]; then
               echo "⚪"
             elif [ "$score" -ge 90 ]; then
               echo "🟢"
@@ -89,7 +94,10 @@ jobs:
           echo "SEO_EMOJI=$(get_emoji '${{ steps.parse.outputs.SEO_SCORE }}')" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.number != ''
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.number != ''
+          && github.event.pull_request.head.repo.full_name == github.repository
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,7 +1,7 @@
 name: Lighthouse CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches: [master]
@@ -13,20 +13,19 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-      issues: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -36,9 +35,7 @@ jobs:
 
       - name: Run Lighthouse CI
         id: lighthouse
-        run: |
-          lhci autorun --config=./lighthouserc.js 2>&1 | tee lighthouse-output.txt
-          echo "LIGHTHOUSE_EXIT_CODE=$?" >> $GITHUB_ENV
+        run: lhci autorun --config=./lighthouserc.js 2>&1 | tee lighthouse-output.txt
 
       - name: Parse Lighthouse Results
         id: parse
@@ -92,7 +89,7 @@ jobs:
           echo "SEO_EMOJI=$(get_emoji '${{ steps.parse.outputs.SEO_SCORE }}')" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.number != ''
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |

--- a/.github/workflows/pr-jest-comment.yml
+++ b/.github/workflows/pr-jest-comment.yml
@@ -41,7 +41,7 @@ jobs:
             # that marks the end of the value. It must appear alone on its own line.
             echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
             echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
-            echo "⚠️ Jest results not found. Tests may have failed to run." >> $GITHUB_OUTPUT
+            echo " Jest results not found. Tests may have failed to run." >> $GITHUB_OUTPUT
             echo "EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -55,9 +55,9 @@ jobs:
           if [ "$SUCCESS" = "true" ]; then
             echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
             echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
-            echo "## ✅ Jest Tests Passed" >> $GITHUB_OUTPUT
+            echo "## Jest Tests Passed" >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT
-            echo "All $TOTAL tests passed 🎉" >> $GITHUB_OUTPUT
+            echo "All $TOTAL tests passed " >> $GITHUB_OUTPUT
             echo "EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
           else
             # Assumption: no Jest test name will contain the exact string
@@ -71,7 +71,7 @@ jobs:
             # Markdown closing fence below would be ambiguous to renderers.
             echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
             echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
-            echo "## ❌ Jest Tests Failed" >> $GITHUB_OUTPUT
+            echo "##  Jest Tests Failed" >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT
             echo "**Results:** $PASSED/$TOTAL passed, $FAILED failed" >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-jest-comment.yml
+++ b/.github/workflows/pr-jest-comment.yml
@@ -1,0 +1,131 @@
+name: Comment Jest Results on PR
+
+on:
+  workflow_run:
+    workflows: ["Run Jest Tests on PR"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Post PR Comment
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts
+
+      - name: Get PR Number and Generate Comment
+        id: pr_info
+        run: |
+          # Find and read PR number
+          PR_FILE=$(find artifacts -name 'pr-number.txt' -type f | head -1)
+          if [ -z "$PR_FILE" ]; then
+            echo "::warning::No PR number artifact found"
+            exit 0
+          fi
+          PR_NUMBER=$(cat "$PR_FILE")
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+          # Find jest results
+          # Note: jq is pre-installed on ubuntu-latest runners
+          RESULTS_FILE=$(find artifacts -name 'jest-results.json' -type f | head -1)
+          if [ -z "$RESULTS_FILE" ]; then
+            # GitHub Actions multiline output syntax: the string after << is the delimiter
+            # that marks the end of the value. It must appear alone on its own line.
+            echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+            echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
+            echo "⚠️ Jest results not found. Tests may have failed to run." >> $GITHUB_OUTPUT
+            echo "EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Parse test results
+          SUCCESS=$(jq '.success // false' "$RESULTS_FILE")
+          TOTAL=$(jq '.numTotalTests // 0' "$RESULTS_FILE")
+          PASSED=$(jq '.numPassedTests // 0' "$RESULTS_FILE")
+          FAILED=$(jq '.numFailedTests // 0' "$RESULTS_FILE")
+
+          if [ "$SUCCESS" = "true" ]; then
+            echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+            echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
+            echo "## ✅ Jest Tests Passed" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "All $TOTAL tests passed 🎉" >> $GITHUB_OUTPUT
+            echo "EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+          else
+            # Assumption: no Jest test name will contain the exact string
+            # "EOF_COMMENT_BODY" on a line by itself. If it did, the $GITHUB_OUTPUT
+            # multiline block would terminate early and the rest of the body would
+            # be silently dropped. Jest test names are code identifiers so this is
+            # safe in practice, but worth noting for future delimiter changes.
+            FAILED_TESTS=$(jq -r '[.testResults[] | select(.status == "failed") | .assertionResults[]? | select(.status == "failed") | "- " + .fullName] | join("\n")' "$RESULTS_FILE")
+            FAILED_TESTS="${FAILED_TESTS:-Failed tests found but details unavailable}"
+            # Assumption: no test name is the bare string "\`\`\`". If it were, the
+            # Markdown closing fence below would be ambiguous to renderers.
+            echo "COMMENT_BODY<<EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+            echo "<!-- jest-results -->" >> $GITHUB_OUTPUT
+            echo "## ❌ Jest Tests Failed" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "**Results:** $PASSED/$TOTAL passed, $FAILED failed" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "**Failed Tests:**" >> $GITHUB_OUTPUT
+            echo '```' >> $GITHUB_OUTPUT
+            echo "$FAILED_TESTS" >> $GITHUB_OUTPUT
+            echo '```' >> $GITHUB_OUTPUT
+            echo "EOF_COMMENT_BODY" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post or Update PR Comment
+        if: steps.pr_info.outputs.PR_NUMBER != ''
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ steps.pr_info.outputs.COMMENT_BODY }}
+          PR_NUMBER: ${{ steps.pr_info.outputs.PR_NUMBER }}
+        with:
+          script: |
+            const marker = "<!-- jest-results -->";
+            const body = process.env.COMMENT_BODY;
+            const prNumber = parseInt(process.env.PR_NUMBER);
+
+            if (!prNumber) {
+              console.log("Skipping comment: no PR number available");
+              return;
+            }
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+
+              const existing = comments.find(c => c.body.includes(marker));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  comment_id: existing.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                });
+                console.log("Updated existing Jest comment");
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: prNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                });
+                console.log("Created new Jest comment");
+              }
+            } catch (error) {
+              console.error("Failed to post comment:", error.message);
+              throw error;
+            }

--- a/.github/workflows/pr-jest-comment.yml
+++ b/.github/workflows/pr-jest-comment.yml
@@ -16,11 +16,14 @@ jobs:
   comment:
     name: Post PR Comment
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'cancelled'
     permissions:
       pull-requests: write
 
     steps:
       - name: Download Artifacts
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -29,12 +32,13 @@ jobs:
 
       - name: Get PR Number and Generate Comment
         id: pr_info
+        if: steps.download.outcome == 'success'
         run: |
           # Find and read PR number
           PR_FILE=$(find artifacts -name 'pr-number.txt' -type f | head -1)
           if [ -z "$PR_FILE" ]; then
-            echo "::warning::No PR number artifact found"
-            exit 0
+            echo "::error::No PR number artifact found"
+            exit 1
           fi
           PR_NUMBER=$(cat "$PR_FILE")
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
@@ -89,7 +93,7 @@ jobs:
           fi
 
       - name: Post or Update PR Comment
-        if: steps.pr_info.outputs.PR_NUMBER != ''
+        if: steps.download.outcome == 'success' && steps.pr_info.outputs.PR_NUMBER != ''
         uses: actions/github-script@v7
         env:
           COMMENT_BODY: ${{ steps.pr_info.outputs.COMMENT_BODY }}

--- a/.github/workflows/pr-jest-comment.yml
+++ b/.github/workflows/pr-jest-comment.yml
@@ -6,6 +6,12 @@ on:
     types:
       - completed
 
+# Prevent duplicate comments if the triggering workflow is re-run or retried
+# while a previous comment job is still in progress for the same run.
+concurrency:
+  group: jest-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   comment:
     name: Post PR Comment

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -68,11 +68,11 @@ jobs:
           FAILED_TESTS: ${{ steps.results.outputs.FAILED_TESTS }}
         run: |
           if [ "$JEST_OUTCOME" = "success" ]; then
-            echo "### ✅ Jest Tests Passed" >> $GITHUB_STEP_SUMMARY
+            echo "### Jest Tests Passed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "All $TOTAL tests passed!" >> $GITHUB_STEP_SUMMARY
           else
-            echo "### ❌ Jest Tests Failed" >> $GITHUB_STEP_SUMMARY
+            echo "### Jest Tests Failed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Results:** $PASSED/$TOTAL passed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -108,6 +108,6 @@ jobs:
           JEST_OUTCOME: ${{ steps.jest.outcome }}
         run: |
           if [ "$JEST_OUTCOME" = "failure" ]; then
-            echo "❌ Tests failed."
+            echo " Tests failed."
             exit 1
           fi

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -1,7 +1,7 @@
 name: Run Jest Tests on PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -10,82 +10,104 @@ jobs:
   test:
     name: Run Jest Tests
     runs-on: ubuntu-latest
-    permissions: 
-      pull-requests: write
+    permissions:
       contents: read
-      issues: write
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install Dependencies
         run: npm ci
 
       - name: Run Jest Tests
         id: jest
-        run: |
-          npm test -- --json --outputFile=jest-results.json || echo "TESTS_FAILED=true" >> $GITHUB_ENV
+        continue-on-error: true
+        run: npm test -- --json --outputFile=jest-results.json --forceExit
 
-      - name: Read Jest Results
+      - name: Process Jest Results
         id: results
+        env:
+          JEST_OUTCOME: ${{ steps.jest.outcome }}
         run: |
-          # Default TESTS_FAILED to false
-          if [ -z "$TESTS_FAILED" ]; then
-            TESTS_FAILED=false
+          if [ ! -f jest-results.json ]; then
+            echo "Jest results file not found"
+            echo "PASSED=0" >> $GITHUB_OUTPUT
+            echo "TOTAL=0" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
-          # Set TESTS_PASSED properly
-          if [ "$TESTS_FAILED" = "true" ]; then
-            TESTS_PASSED=false
-            echo "TESTS_PASSED=false" >> $GITHUB_ENV
-            FAILED_TESTS=$(jq -r '[.testResults[] | select(.status == "failed") | .name] | map(split("/") | last) | join("\n")' jest-results.json)
-            echo "FAILED_TESTS<<EOF" >> $GITHUB_ENV
-            echo "$FAILED_TESTS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+          TOTAL=$(jq '.numTotalTests // 0' jest-results.json)
+          PASSED=$(jq '.numPassedTests // 0' jest-results.json)
+          FAILED=$(jq '.numFailedTests // 0' jest-results.json)
+
+          echo "PASSED=$PASSED" >> $GITHUB_OUTPUT
+          echo "TOTAL=$TOTAL" >> $GITHUB_OUTPUT
+
+          if [ "$JEST_OUTCOME" = "failure" ]; then
+            FAILED_TESTS=$(jq -r '[.testResults[] | select(.status == "failed") | .assertionResults[]? | select(.status == "failed") | "- " + .fullName] | join("\n")' jest-results.json)
+            echo "FAILED_TESTS<<EOF_JEST_RESULTS" >> $GITHUB_OUTPUT
+            echo "$FAILED_TESTS" >> $GITHUB_OUTPUT
+            echo "EOF_JEST_RESULTS" >> $GITHUB_OUTPUT
+          fi
+          # Note: FAILED_TESTS is intentionally only set on failure.
+          # If outcome is 'cancelled', the summary will show an empty block.
+
+      - name: Generate Summary
+        env:
+          JEST_OUTCOME: ${{ steps.jest.outcome }}
+          PASSED: ${{ steps.results.outputs.PASSED }}
+          TOTAL: ${{ steps.results.outputs.TOTAL }}
+          FAILED_TESTS: ${{ steps.results.outputs.FAILED_TESTS }}
+        run: |
+          if [ "$JEST_OUTCOME" = "success" ]; then
+            echo "### ✅ Jest Tests Passed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "All $TOTAL tests passed!" >> $GITHUB_STEP_SUMMARY
           else
-            TESTS_PASSED=true
-            echo "TESTS_PASSED=true" >> $GITHUB_ENV
-            echo "FAILED_TESTS=None" >> $GITHUB_ENV
+            echo "### ❌ Jest Tests Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Results:** $PASSED/$TOTAL passed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Failed Tests:**" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$FAILED_TESTS" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Extract PR number
-          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-
-          # Generate a temporary file for the comment
-          COMMENT_FILE=$(mktemp)
-
-          # Save variables to GITHUB_OUTPUT
-          echo "TESTS_PASSED=$TESTS_PASSED" >> $GITHUB_ENV
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "COMMENT_FILE=$COMMENT_FILE" >> $GITHUB_OUTPUT
-
-          # Generate content for the comment file
-          {
-            if [ "$TESTS_PASSED" = "true" ]; then
-              echo "✅ All Jest tests passed! This PR is ready to merge."
-            else
-              echo "❌ Some Jest tests failed. Please check the logs and fix the issues before merging."
-              echo ""
-              echo "**Failed Tests:**"
-              echo ""
-              echo '```'
-              echo "$FAILED_TESTS"
-              echo '```'
-            fi
-          } > "$COMMENT_FILE"
-
-      - name: PR comment
-        uses: thollander/actions-comment-pull-request@v3
+      - name: Upload Jest Results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          file-path: ${{ steps.results.outputs.COMMENT_FILE }}
-          pr-number: ${{ steps.results.outputs.PR_NUMBER }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: jest-results
+          path: jest-results.json
+          retention-days: 1
+
+      - name: Save PR Number
+        if: always()
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR Number
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 1
+
+      - name: Enforce Test Results
+        if: always()
+        env:
+          JEST_OUTCOME: ${{ steps.jest.outcome }}
+        run: |
+          if [ "$JEST_OUTCOME" = "failure" ]; then
+            echo "❌ Tests failed."
+            exit 1
+          fi

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -5,11 +5,13 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
 
 jobs:
   test:
     name: Run Jest Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -30,7 +32,7 @@ jobs:
       - name: Run Jest Tests
         id: jest
         continue-on-error: true
-        run: npm test -- --json --outputFile=jest-results.json --forceExit
+        run: npm test -- --json --outputFile=jest-results.json --detectOpenHandles --forceExit
 
       - name: Process Jest Results
         id: results
@@ -71,15 +73,21 @@ jobs:
             echo "### Jest Tests Passed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "All $TOTAL tests passed!" >> $GITHUB_STEP_SUMMARY
+          elif [ "$JEST_OUTCOME" = "cancelled" ]; then
+            echo "### Jest Tests Cancelled" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Tests were cancelled before completion." >> $GITHUB_STEP_SUMMARY
           else
             echo "### Jest Tests Failed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Results:** $PASSED/$TOTAL passed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Failed Tests:**" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$FAILED_TESTS" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            if [ -n "$FAILED_TESTS" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Failed Tests:**" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "$FAILED_TESTS" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
       - name: Upload Jest Results
@@ -107,7 +115,7 @@ jobs:
         env:
           JEST_OUTCOME: ${{ steps.jest.outcome }}
         run: |
-          if [ "$JEST_OUTCOME" = "failure" ]; then
-            echo " Tests failed."
+          if [ "$JEST_OUTCOME" = "failure" ] || [ "$JEST_OUTCOME" = "cancelled" ]; then
+            echo "Tests did not pass (outcome: $JEST_OUTCOME)."
             exit 1
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
                 "http-server": "^14.1.1",
                 "i18next": "^25.3.2",
                 "i18next-http-backend": "^3.0.2",
-                "node": "^24.2.0",
                 "postcss": "^8.5.6",
                 "sass": "^1.97.2",
                 "tone": "^15.1.22"
@@ -2793,7 +2792,9 @@
             }
         },
         "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3183,6 +3184,246 @@
                 "@parcel/watcher-win32-x64": "2.5.6"
             }
         },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@parcel/watcher-win32-x64": {
             "version": "2.5.6",
             "cpu": [
@@ -3207,7 +3448,9 @@
             "optional": true
         },
         "node_modules/@parcel/watcher/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -8987,7 +9230,9 @@
             }
         },
         "node_modules/jest-environment-jsdom/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10686,20 +10931,6 @@
             "version": "1.1.0",
             "license": "ISC"
         },
-        "node_modules/node": {
-            "version": "24.14.0",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "node-bin-setup": "^1.0.0"
-            },
-            "bin": {
-                "node": "bin/node.exe"
-            },
-            "engines": {
-                "npm": ">=5.0.0"
-            }
-        },
         "node_modules/node-abi": {
             "version": "4.26.0",
             "dev": true,
@@ -10839,10 +11070,6 @@
         "node_modules/node-releases": {
             "version": "2.0.36",
             "license": "MIT"
-        },
-        "node_modules/node/node_modules/node-bin-setup": {
-            "version": "1.1.4",
-            "license": "ISC"
         },
         "node_modules/nodemon": {
             "version": "3.1.14",
@@ -11308,7 +11535,9 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "8.3.0",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+            "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -11343,7 +11572,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13481,7 +13712,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14312,7 +14545,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"


### PR DESCRIPTION
Splits the Jest workflow into two:

`pr-jest-tests.yml` — runs tests, enforces results, uploads artifacts
`pr-jest-comment.yml`  — posts/updates a PR comment with test results via workflow_run

Why

This follows GitHub's recommended pattern for PR workflows: untrusted code runs under the safer pull_request event (read-only permissions), while comment posting runs in a trusted workflow_run context with only pull-requests: write.

### Key Changes

`pr-jest-tests.yml`

`pull_request_target` → `pull_request`; permissions reduced to contents: read
Added --forceExit, continue-on-error: true, and step outputs instead of env vars
Replaced PR comment posting with a GitHub Step Summary + artifact upload

`pr-jest-comment.yml`

Downloads artifacts from the test run, generates a pass  / fail  comment
Posts a new comment or updates an existing one (deduped via <!-- jest-results --> marker)

### PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [x] Tests
- [ ] Documentation