### PR TITLE
Fix: remove console.log statements in Planet/js module

### DIFF
--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -55,7 +55,7 @@ class Planet {
 
     open(image) {
         if (this.LocalPlanet === null) {
-            console.log("Local Planet unavailable");
+            console.warn("Local Planet unavailable");
         } else {
             this.LocalPlanet.setCurrentProjectImage(image);
             this.LocalPlanet.updateProjects();

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -187,7 +187,7 @@ class ProjectStorage {
         try {
             return JSON.parse(jsonobj);
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return null;
         }
     }
@@ -203,7 +203,7 @@ class ProjectStorage {
         try {
             this.data = typeof currentData === "string" ? JSON.parse(currentData) : currentData;
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return null;
         }
     }

--- a/planet/js/Publisher.js
+++ b/planet/js/Publisher.js
@@ -305,7 +305,7 @@ class Publisher {
         try {
             tb = JSON.parse(tb);
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return "";
         }
 


### PR DESCRIPTION
Fixes #6388

# Changes:
- Removed unnecessary console.log statements from Planet.js, Publisher.js, and ProjectStorage.js
- Replaced console.log inside catch blocks with console.error
- Replaced appropriate logs with console.warn

# Checks:
- Passed ESLint
- Passed Prettier formatting
- Tested locally

# PR Category
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor

This improves code quality and maintains proper logging practices.