### PR TITLE
Fix: Custom Pitch block pie menu note ordering 

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -225,6 +225,17 @@ describe("Pie Menus Module", () => {
             expect(piemenusContent).toContain("__pitchPreview");
         });
 
+        it("should compute pitch wrapping using noteLabels length", () => {
+            expect(piemenusContent).toContain("const noteCount = noteLabels.length");
+            expect(piemenusContent).toContain("const halfSpan = noteCount / 2");
+        });
+
+        it("should adjust octave direction correctly on pitch wrapping", () => {
+            expect(piemenusContent).toContain("deltaOctave = 1");
+            expect(piemenusContent).toContain("deltaOctave = -1");
+            expect(piemenusContent).toContain("if (prevPitch + delta > noteCount - 1)");
+        });
+
         it("should have voice preview function", () => {
             expect(piemenusContent).toContain("__voicePreview");
         });

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -549,21 +549,23 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             }
 
             const deltaPitch = i - prevPitch;
+            const noteCount = noteLabels.length;
+            const halfSpan = noteCount / 2;
             let delta;
-            if (deltaPitch > 3) {
-                delta = deltaPitch - 7;
-            } else if (deltaPitch < -3) {
-                delta = deltaPitch + 7;
+            if (deltaPitch > halfSpan) {
+                delta = deltaPitch - noteCount;
+            } else if (deltaPitch < -halfSpan) {
+                delta = deltaPitch + noteCount;
             } else {
                 delta = deltaPitch;
             }
 
             // If we wrapped across C, we need to adjust the octave.
             let deltaOctave = 0;
-            if (prevPitch + delta > 6) {
-                deltaOctave = -1;
-            } else if (prevPitch + delta < 0) {
+            if (prevPitch + delta > noteCount - 1) {
                 deltaOctave = 1;
+            } else if (prevPitch + delta < 0) {
+                deltaOctave = -1;
             }
             let attr;
             prevPitch = i;


### PR DESCRIPTION
### Summary
Fixed incorrect note ordering in the custom pitch pie menu.

### Changes
- Corrected note sequence to standard musical order (do → re → mi → fa → sol → la → ti)
- Updated corresponding test cases in piemenus.test.js
- Ensured proper circular arrangement of notes

### PR Category
- [x] Bug Fix
- [x] Tests

### Testing
- Cypress tests: 17/17 passed
- Manual testing:
  - Verified correct note order
  - Confirmed pitch preview works as expected
  - No UI glitches observed
  
  ### Before
(incorrect order)
<img width="609" height="486" alt="Screenshot 2026-03-26 094625" src="https://github.com/user-attachments/assets/dfa289f9-7a5d-4fb4-aabd-89818c15873d" />




### After
(correct order: do → re → mi → fa → sol → la → ti)
<img width="1004" height="704" alt="Screenshot 2026-03-26 102403" src="https://github.com/user-attachments/assets/fc7e7c91-654a-43dc-b847-257767688c43" />


Fixes #2255