### PR TITLE
Fix: Replace blocking window.prompt() with non-blocking MBDialog.prompt() in 3 files

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -189,7 +189,7 @@ class SaveInterface {
 
             if (window.isElectron === true) {
                 filename = defaultfilename;
-            } else if (window.MBDialog && typeof window.MBDialog.prompt === "function") {
+            } else {
                 window.MBDialog.prompt({
                     title: _("Save file"),
                     message: _("Filename:"),
@@ -198,8 +198,6 @@ class SaveInterface {
                     cancelText: _("Cancel")
                 }).then(result => finishDownload(result));
                 return;
-            } else {
-                filename = prompt(_("Filename:"), defaultfilename);
             }
         } else {
             if (fileExt(defaultfilename) !== extension) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1931,27 +1931,34 @@ class Activity {
                     audioDestination = null;
                 }
                 mediaRecorder = null;
-                // Prompt to save file
-                const filename = window.prompt(_("Enter file name"));
-                if (filename === null || filename.trim() === "") {
-                    alert(_("File save canceled"));
+                // Prompt to save file using non-blocking dialog
+                window.MBDialog.prompt({
+                    title: _("Save Recording"),
+                    message: _("Enter file name"),
+                    defaultValue: "recording",
+                    okText: _("Save"),
+                    cancelText: _("Cancel")
+                }).then(filename => {
+                    if (filename === null || filename.trim() === "") {
+                        that.textMsg(_("File save canceled"));
+                        flag = 0;
+                        recording();
+                        doRecordButton();
+                        return;
+                    }
+                    const downloadLink = document.createElement("a");
+                    downloadLink.href = URL.createObjectURL(blob);
+                    downloadLink.download = `${filename}.webm`;
+                    document.body.appendChild(downloadLink);
+                    downloadLink.click();
+                    URL.revokeObjectURL(blob);
+                    document.body.removeChild(downloadLink);
                     flag = 0;
+                    // Allow multiple recordings
                     recording();
                     doRecordButton();
-                    return; // Exit without saving the file
-                }
-                const downloadLink = document.createElement("a");
-                downloadLink.href = URL.createObjectURL(blob);
-                downloadLink.download = `${filename}.webm`;
-                document.body.appendChild(downloadLink);
-                downloadLink.click();
-                URL.revokeObjectURL(blob);
-                document.body.removeChild(downloadLink);
-                flag = 0;
-                // Allow multiple recordings
-                recording();
-                doRecordButton();
-                that.textMsg(_("Recording stopped. File saved."));
+                    that.textMsg(_("Recording stopped. File saved."));
+                });
             }
             /**
              * Stops the recording process.

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1093,13 +1093,20 @@ function Synth() {
             }
             chunks = [];
             const url = URL.createObjectURL(blob);
-            // Prompt the user for the file name
-            const fileName = window.prompt("Enter file name", "recording");
-            if (fileName) {
-                download(url, fileName + (platform.FF ? ".wav" : ".ogg"));
-            } else {
-                alert("Download cancelled.");
-            }
+            // Prompt the user for the file name using non-blocking dialog
+            window.MBDialog.prompt({
+                title: _("Save Recording"),
+                message: _("Enter file name"),
+                defaultValue: _("recording"),
+                okText: _("Save"),
+                cancelText: _("Cancel")
+            }).then(fileName => {
+                if (fileName) {
+                    download(url, fileName + (platform.FF ? ".wav" : ".ogg"));
+                } else {
+                    window.MBDialog.alert(_("Download cancelled."));
+                }
+            });
         };
         // this.recorder.start();
         // setTimeout(()=>{this.recorder.stop();},5000);


### PR DESCRIPTION
Fixes #6395

## What's the Problem?

Three locations in the codebase still use the browser's native `window.prompt()` instead of the custom non-blocking `MBDialog.prompt()`. The native prompt is a **synchronous, blocking call** that freezes the entire Music Blocks UI and stops all audio playback until the user dismisses the dialog.

Additionally, `js/utils/synthutils.js` has hardcoded English strings without the `_()` i18n wrapper, making them untranslatable.

## Changes Made

### 1. `js/activity.js` — Screen Recording Save
- Replaced `window.prompt(_("Enter file name"))` → `window.MBDialog.prompt()`
- Moved all post-prompt logic into `.then()` callback to handle the async flow
- Replaced blocking `alert(_("File save canceled"))` → non-blocking `that.textMsg()`

### 2. `js/SaveInterface.js` — File Download
- Removed the unnecessary `else { prompt(...) }` fallback branch
- `MBDialog` is always loaded as part of the codebase, so the defensive check + blocking fallback was unnecessary and a UI-blocking hazard

### 3. `js/utils/synthutils.js` — Audio Recording Save
- Replaced `window.prompt("Enter file name", "recording")` → `window.MBDialog.prompt()`
- **Fixed i18n bug:** Wrapped hardcoded strings in `_()` for translation support:
  - `"Enter file name"` → `_("Enter file name")`
  - `"recording"` → `_("recording")`
  - `"Download cancelled."` → `_("Download cancelled.")`
- Replaced blocking `alert("Download cancelled.")` → non-blocking `window.MBDialog.alert()`

## How Has This Been Tested?

- Verified **zero** remaining `window.prompt()` or bare `prompt()` calls exist in the `js/` directory
- All 3 modified files pass **ESLint** with zero errors
- No functional logic was changed — only the dialog mechanism was swapped from blocking to non-blocking
