### PR TITLE
perf: Batch palette DOM insertions using DocumentFragment

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1547,6 +1547,9 @@ describe("Palettes Class", () => {
                 })),
                 appendChild: jest.fn()
             };
+            document.createDocumentFragment = jest.fn(() => ({
+                appendChild: jest.fn()
+            }));
             global.docById = jest.fn(id => {
                 if (id === "PaletteBody_items") return paletteList;
                 return null;
@@ -1577,6 +1580,9 @@ describe("Palettes Class", () => {
             const paletteList = {
                 appendChild: jest.fn()
             };
+            document.createDocumentFragment = jest.fn(() => ({
+                appendChild: jest.fn()
+            }));
 
             global.docById = jest.fn(id => {
                 if (id === "PaletteBody_items") return paletteList;
@@ -1673,6 +1679,9 @@ describe("Palettes Class", () => {
             const paletteList = {
                 appendChild: jest.fn()
             };
+            document.createDocumentFragment = jest.fn(() => ({
+                appendChild: jest.fn()
+            }));
 
             global.docById = jest.fn(id => {
                 if (id === "PaletteBody_items") return paletteList;

--- a/js/palette.js
+++ b/js/palette.js
@@ -1390,9 +1390,8 @@ class Palette {
     }
 
     hideMenu() {
-        docById(
-            "palette"
-        ).childNodes[0].style.borderRight = `1px solid ${platformColor.selectorSelected}`;
+        docById("palette").childNodes[0].style.borderRight =
+            `1px solid ${platformColor.selectorSelected}`;
         if (this._outsideClickListener) {
             document.removeEventListener("click", this._outsideClickListener);
             this._outsideClickListener = null;
@@ -1506,6 +1505,7 @@ class Palette {
         blocks.reverse();
         const protoListScope = [...this.protoList];
         if (last(blocks).blkname != last(protoListScope).name) protoListScope.reverse();
+        const fragment = document.createDocumentFragment();
         for (const blk in blocks) {
             const b = blocks[blk];
 
@@ -1607,8 +1607,10 @@ class Palette {
             itemCell.style.width = `${img.width}px`;
             itemCell.style.paddingRight = `${this.palettes.cellSize}px`;
             itemCell.appendChild(img);
-            paletteList.appendChild(itemRow);
+            fragment.appendChild(itemRow);
         }
+
+        paletteList.appendChild(fragment);
 
         if (this.palettes.mobile) {
             this.hide();


### PR DESCRIPTION
## Summary

This PR improves palette rendering performance by batching DOM insertions with `DocumentFragment` instead of appending each row directly to `paletteList` inside the loop.

## What changed

- Created a `DocumentFragment` before the palette item loop
- Appended each `itemRow` to the fragment during iteration
- Appended the fragment to `paletteList` once after the loop
- Updated affected tests to mock `document.createDocumentFragment()` since existing test mocks use plain objects instead of real DOM nodes

## Why

Previously, `paletteList.appendChild(itemRow)` was called inside the loop. Repeated DOM insertions can trigger unnecessary browser reflow/repaint work and slow down rendering.

Using `DocumentFragment` allows rows to be collected in memory first and inserted into the DOM in a single operation, reducing rendering overhead.

## Testing

- Ran palette tests:
  - `npx jest js/__tests__/palette.test.js --no-coverage`
- Updated the failing tests to support `DocumentFragment` in the mocked DOM setup

## Notes
The diagnostics seen during the change were pre-existing hints and not introduced by this PR.

## PR Category
- [ ] Bug fix
- [x] Performance
- [ ] Documentation
- [ ] Refactor