### PR TITLE
perf(palette): cache drag image dimensions to reduce layout thrashing

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -1390,9 +1390,8 @@ class Palette {
     }
 
     hideMenu() {
-        docById(
-            "palette"
-        ).childNodes[0].style.borderRight = `1px solid ${platformColor.selectorSelected}`;
+        docById("palette").childNodes[0].style.borderRight =
+            `1px solid ${platformColor.selectorSelected}`;
         if (this._outsideClickListener) {
             document.removeEventListener("click", this._outsideClickListener);
             this._outsideClickListener = null;
@@ -1544,10 +1543,14 @@ class Palette {
                 // to make it positioned relative to the body
                 document.body.appendChild(img);
 
+                // Cache dimensions once to avoid forced layout on every mousemove
+                const halfW = img.offsetWidth / 2;
+                const halfH = img.offsetHeight / 2;
+
                 // centers the img at (pageX, pageY) coordinates
                 const moveAt = (pageX, pageY) => {
-                    img.style.left = pageX - img.offsetWidth / 2 + "px";
-                    img.style.top = pageY - img.offsetHeight / 2 + "px";
+                    img.style.left = pageX - halfW + "px";
+                    img.style.top = pageY - halfH + "px";
                 };
 
                 const onMouseMove = e => {


### PR DESCRIPTION
## Summary

Improve drag performance by caching image dimensions and avoiding repeated layout reads during `mousemove`.

## Problem

In `_showMenuItems()`, the `moveAt()` function reads `img.offsetWidth` and `img.offsetHeight` on every mouse move event (~60 times/sec).

Since `style.left` and `style.top` are written just before these reads, the browser is forced to recalculate layout on each frame. This results in layout thrashing and can cause dropped frames during drag operations.

## Fix

- Cache `img.offsetWidth / 2` and `img.offsetHeight / 2` once after appending the image to the DOM
- Reuse the cached values (`halfW`, `halfH`) inside `moveAt()` instead of reading layout properties repeatedly

## PR Category
- [ ] Bug fix
- [x] Performance
- [ ] Documentation
- [ ] Refactor