### PR TITLE
perf: optimize SVG generation using array push and join

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1323,7 +1323,7 @@ class Activity {
         this.printBlockSVG = () => {
             this.blocks.activeBlock = null;
             let startCounter = 0;
-            let svg = "";
+            const svgParts = [];
             let xMax = 0;
             let yMax = 0;
             let parts;
@@ -1345,18 +1345,19 @@ class Activity {
                     : this.blocks.blockArt[i];
 
                 if (this.blocks.blockList[i].isCollapsible()) {
-                    svg += "<g>";
+                    svgParts.push("<g>");
                 }
 
-                svg +=
+                svgParts.push(
                     '<g transform="translate(' +
-                    this.blocks.blockList[i].container.x +
-                    ", " +
-                    this.blocks.blockList[i].container.y +
-                    ')">';
+                        this.blocks.blockList[i].container.x +
+                        ", " +
+                        this.blocks.blockList[i].container.y +
+                        ')">'
+                );
 
                 if (!SPECIALINPUTS.includes(this.blocks.blockList[i].name)) {
-                    svg += extractSVGInner(rawSVG);
+                    svgParts.push(extractSVGInner(rawSVG));
                 } else {
                     // Safer SVG manipulation using DOM instead of string splitting
                     const parser = new DOMParser();
@@ -1398,10 +1399,10 @@ class Activity {
                     // remove outer svg tags because original code skipped them
                     serialized = serialized.replace(/^<svg[^>]*>/, "").replace(/<\/svg>$/, "");
 
-                    svg += serialized;
+                    svgParts.push(serialized);
                 }
 
-                svg += "</g>";
+                svgParts.push("</g>");
 
                 if (this.blocks.blockList[i].isCollapsible()) {
                     let y;
@@ -1411,12 +1412,13 @@ class Activity {
                         y = this.blocks.blockList[i].container.y + 12;
                     }
 
-                    svg +=
+                    svgParts.push(
                         '<g transform="translate(' +
-                        this.blocks.blockList[i].container.x +
-                        ", " +
-                        y +
-                        ') scale(0.5 0.5)">';
+                            this.blocks.blockList[i].container.x +
+                            ", " +
+                            y +
+                            ') scale(0.5 0.5)">'
+                    );
                     if (this.blocks.blockList[i].collapsed) {
                         parts = EXPANDBUTTON.split("><");
                     } else {
@@ -1424,16 +1426,16 @@ class Activity {
                     }
 
                     for (let p = 2; p < parts.length - 1; p++) {
-                        svg += "<" + parts[p] + ">";
+                        svgParts.push("<" + parts[p] + ">");
                     }
 
-                    svg += "</g>";
+                    svgParts.push("</g>");
                 }
 
                 if (this.blocks.blockList[i].name === "start") {
                     const x = this.blocks.blockList[i].container.x + 110;
                     const y = this.blocks.blockList[i].container.y + 12;
-                    svg += '<g transform="translate(' + x + ", " + y + ') scale(0.4 0.4)">';
+                    svgParts.push('<g transform="translate(' + x + ", " + y + ') scale(0.4 0.4)">');
 
                     parts = TURTLESVG.replace(/fill_color/g, FILLCOLORS[startCounter])
                         .replace(/stroke_color/g, STROKECOLORS[startCounter])
@@ -1445,18 +1447,18 @@ class Activity {
                     }
 
                     for (let p = 2; p < parts.length - 1; p++) {
-                        svg += "<" + parts[p] + ">";
+                        svgParts.push("<" + parts[p] + ">");
                     }
 
-                    svg += "</g>";
+                    svgParts.push("</g>");
                 }
 
                 if (this.blocks.blockList[i].isCollapsible()) {
-                    svg += "</g>";
+                    svgParts.push("</g>");
                 }
             }
 
-            svg += "</svg>";
+            svgParts.push("</svg>");
 
             return (
                 '<svg xmlns="http://www.w3.org/2000/svg" width="' +
@@ -1464,7 +1466,7 @@ class Activity {
                 '" height="' +
                 yMax +
                 '">' +
-                encodeURIComponent(svg)
+                encodeURIComponent(svgParts.join(""))
             );
         };
 


### PR DESCRIPTION
## PR Category
- [ ] Bug fix
- [x] Performance 
- [ ] Documentation
- [ ] Refactor

## Summary

This PR improves SVG generation performance by replacing repeated string concatenation with array accumulation followed by a single `join("")`.

## Problem

The existing implementation builds the SVG output by repeatedly appending to a string inside a loop over all blocks.

Using `+=` in a growing loop creates many intermediate string copies. As the SVG string gets larger, each new concatenation becomes more expensive because it copies all previously built content plus the new fragment.

This leads to unnecessary overhead and can cause noticeable slowdowns for larger projects.

## Fix

- Replaced repeated `svg += ...` operations with `svgParts.push(...)`
- Collected SVG fragments in an array during iteration
- Built the final SVG string once using `svgParts.join("")`

