### PR TITLE
fix(widget): clean up resize event listeners on close to prevent memory leaks

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -273,6 +273,15 @@ class JSEditor {
      */
 
     _setup() {
+        this.widgetWindow.onclose = () => {
+            if (this._resizeHandlers) {
+                document.removeEventListener("mousemove", this._resizeHandlers.doResize);
+                document.removeEventListener("mouseup", this._resizeHandlers.stopResize);
+                this._resizeHandlers = null;
+            }
+            this.isOpen = false;
+        };
+
         this.widgetWindow.onmaximize = () => {
             const editor = this.widgetWindow.getWidgetBody().childNodes[0];
             editor.style.width = this.widgetWindow._maximized ? "100%" : "39rem";
@@ -807,6 +816,9 @@ class JSEditor {
 
         document.addEventListener("mousemove", doResize);
         document.addEventListener("mouseup", stopResize);
+
+        // Store references so onclose can remove them
+        this._resizeHandlers = { doResize, stopResize };
     }
 
     /**


### PR DESCRIPTION
## PR Category
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor

## Summary

This PR fixes a memory leak in the JS editor widget by properly cleaning up resize event listeners when the widget is closed.

## Problem

The JS editor widget registers `mousemove` and `mouseup` event listeners for resize handling, but never removes them when the widget is closed.

As a result:
- Each open/close cycle adds new listeners
- Listeners accumulate over time
- Multiple handlers run on every mouse movement
- Closures retain references to DOM elements, preventing garbage collection

This leads to performance degradation and memory leaks.

## Fix

- Stored resize handler references (`doResize`, `stopResize`) in `this._resizeHandlers`
- Added an `onclose` handler to:
  - Remove `mousemove` and `mouseup` event listeners
  - Clear stored handler references
  - Update widget state (`isOpen = false`)

## Before

- Event listeners added on open
- No cleanup on close
- Repeated open/close cycles caused listener accumulation

## After

- Event listeners are removed when the widget closes
- No accumulation of handlers
- Memory is properly released

## Impact

- Prevents memory leaks
- Avoids multiple event handlers firing
- Improves performance during long sessions
- Aligns JS editor widget behavior with other widgets

## Testing

- Verified no duplicate listeners are triggered
- Confirmed resize behavior still works correctly
- Confirmed no regression in widget functionality

