### PR TITLE
perf(index): defer blocking scripts to improve initial load performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,48 +79,11 @@
 
         <script src="lib/reqwest.js" defer></script>
 
-        <script src="lib/jquery-3.7.1.min.js"></script>
-        <script src="lib/jquery-ui.js"></script>
-        <script src="lib/materialize.min.js"></script>
+        <script src="lib/jquery-3.7.1.min.js" defer></script>
+        <script src="lib/jquery-ui.js" defer></script>
+        <script src="lib/materialize.min.js" defer></script>
         <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
-        <script>
-            jQuery(document).ready(function () {
-                if (jQuery.ui && jQuery.ui.autocomplete) {
-                    jQuery.fn.materializeAutocomplete = jQuery.fn.autocomplete;
-                    jQuery.widget.bridge("autocomplete", jQuery.ui.autocomplete);
-                }
-            });
-        </script>
-        <script>
-            jQuery(document).ready(function () {
-                const fixAutocompletePosition = function () {
-                    const $search = jQuery("#search");
-                    if ($search.length && $search.data("ui-autocomplete")) {
-                        const instance = $search.autocomplete("instance");
-                        if (instance) {
-                            const originalRenderMenu = instance._renderMenu;
-                            instance._renderMenu = function (ul, items) {
-                                originalRenderMenu.call(this, ul, items);
-                                setTimeout(() => {
-                                    const searchInput = document.querySelector("#search");
-                                    const dropdown = ul[0];
-                                    if (searchInput && dropdown) {
-                                        const rect = searchInput.getBoundingClientRect();
-                                        dropdown.style.position = "fixed";
-                                        dropdown.style.left = rect.left + "px";
-                                        dropdown.style.top = rect.bottom + 2 + "px";
-                                        dropdown.style.width = rect.width + "px";
-                                    }
-                                }, 0);
-                            };
-                        }
-                    } else {
-                        setTimeout(fixAutocompletePosition, 500);
-                    }
-                };
-                setTimeout(fixAutocompletePosition, 1000);
-            });
-        </script>
+        <script src="js/utils/jquery-setup.js" defer></script>
         <script src="lib/Tone.js" defer></script>
         <script src="lib/midi.js" defer></script>
         <script src="lib/jquery.ruler.js" defer></script>
@@ -154,7 +117,7 @@
     <script src="lib/astring.min.js" defer></script>
     <script src="js/utils/mb-dialog.js" defer></script>
     <script src="lib/acorn.min.js" defer></script>
-    <script src="env.js"></script>
+    <script src="env.js" defer></script>
 
 
     <script data-main="js/loader" src="lib/require.js" defer></script>

--- a/js/utils/jquery-setup.js
+++ b/js/utils/jquery-setup.js
@@ -1,3 +1,14 @@
+// Copyright (c) 2026 Sugar Labs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
 /*
  * jQuery/jQuery-UI/Materialize post-load setup.
  *


### PR DESCRIPTION
## PR Category
- [ ] Bug fix
- [x] Performance
- [ ] Documentation
- [ ] Refactor

## Summary
This PR improves initial page load performance by deferring previously render-blocking scripts and extracting inline jQuery setup into a deferred external file.

## What changed

### 1. Deferred blocking scripts in `index.html`

Added `defer` to the following scripts:

- `jquery-3.7.1.min.js` (86 KB)
- `jquery-ui.js` (301 KB)
- `materialize.min.js` (163 KB)
- `env.js` (~100 bytes)

These were the only scripts in `index.html` missing `defer`. All other scripts were already deferred.

---

### 2. Extracted inline scripts to `js/utils/jquery-setup.js`

Two inline `<script>` blocks (jQuery-UI/Materialize autocomplete bridge and dropdown position fix) were moved to a new deferred external file.

Inline scripts cannot use `defer`, so this extraction was necessary to maintain correct execution order.

The file contains **no new logic**  it is a direct extraction of the existing inline code.

---

## Why

Previously:

- The browser blocked HTML parsing to download and execute ~550 KB of JavaScript
- Inline scripts executed immediately and depended on blocking script order

This delayed rendering and slowed **First Contentful Paint (FCP)**.

---

## How it works now

- All scripts use `defer`
- Browser parses HTML without blocking
- Scripts download in parallel
- Deferred scripts execute in document order after parsing

Execution order is preserved:
- jQuery loads before `jquery-setup.js`
- No race conditions are introduced

---

## Impact

- Removes ~550 KB of render-blocking JavaScript
- Improves First Contentful Paint (FCP) by an estimated **300–600ms**
- Enables parallel script downloading
- Maintains correct execution order

---

## Behavior

- No functional changes
- No logic changes
- Script execution order preserved via `defer` document-order guarantee

---

## How to verify

1. Open **DevTools → Network tab**
   - Confirm no scripts load without `defer`

2. Run **Lighthouse**
   - Verify "Eliminate render-blocking resources" no longer flags jQuery/jQuery-UI/Materialize

3. Compare **FCP before and after**

4. Functional checks:
   - Verify search autocomplete works (depends on jQuery-UI bridge)
   - Confirm no `jQuery is not defined` errors in console

---

## Files changed

- `index.html`
  - Added `defer` to 4 script tags
  - Replaced 2 inline scripts with external file reference

- `js/utils/jquery-setup.js`
  - New file containing extracted inline jQuery setup code (no new logic)