### PR TITLE
perf: optimize mode widget piano rendering and playback performance

### DIFF
--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -309,8 +309,19 @@ class ModeWidget {
         modePianoDiv.style.border = "0px";
         modePianoDiv.style.top = "0px";
         modePianoDiv.style.left = "0px";
-        modePianoDiv.innerHTML =
+        let pianoHTML =
             '<img src="images/piano_keys.png"  id="modeKeyboard" style="top:0px; left:0px; position:relative;">';
+        for (let i = 0; i < 12; i++) {
+            pianoHTML += '<img id="pkey_' + i + '" style="top:0px; left:0px; position:absolute;">';
+        }
+        modePianoDiv.innerHTML = pianoHTML;
+
+        // Cache piano key elements to avoid repeated getElementById calls
+        this._pianoKeys = [];
+        for (let i = 0; i < 12; i++) {
+            this._pianoKeys[i] = document.getElementById("pkey_" + i);
+        }
+
         const highlightImgs = [
             "images/highlights/sel_c.png",
             "images/highlights/sel_c_sharp.png",
@@ -358,25 +369,9 @@ class ModeWidget {
             startingPosition = 0;
         }
 
-        modePianoDiv.innerHTML += '<img id="pkey_0" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_1" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_2" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_3" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_4" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_5" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_6" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_7" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_8" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML += '<img id="pkey_9" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML +=
-            '<img id="pkey_10" style="top:0px; left:0px; position:absolute;">';
-        modePianoDiv.innerHTML +=
-            '<img id="pkey_11" style="top:0px; left:0px; position:absolute;">';
-
         for (let i = 0; i < 12; ++i) {
             if (this._selectedNotes[i])
-                document.getElementById("pkey_" + i).src =
-                    highlightImgs[(i + startingPosition) % 12];
+                this._pianoKeys[i].src = highlightImgs[(i + startingPosition) % 12];
         }
     }
     /**
@@ -653,7 +648,7 @@ class ModeWidget {
                 setTimeout(() => {
                     // Did we just play the last note?
                     this._playing = false;
-                    const note_key = document.getElementById("pkey_" + 0);
+                    const note_key = this._pianoKeys ? this._pianoKeys[0] : null;
                     if (note_key !== null) {
                         note_key.src = highlightImgs[0];
                     }
@@ -675,7 +670,9 @@ class ModeWidget {
             setTimeout(() => {
                 if (this._lastNotePlayed !== null) {
                     this._playWheel.navItems[this._lastNotePlayed % 12].navItem.hide();
-                    const note_key = document.getElementById("pkey_" + (this._lastNotePlayed % 12));
+                    const note_key = this._pianoKeys
+                        ? this._pianoKeys[this._lastNotePlayed % 12]
+                        : null;
                     if (note_key !== null) {
                         note_key.src =
                             highlightImgs[(this._lastNotePlayed + startingposition) % 12];
@@ -686,7 +683,7 @@ class ModeWidget {
                 this._playWheel.navItems[note % 12].navItem.show();
 
                 if (note !== 12) {
-                    const note_key = document.getElementById("pkey_" + (note % 12));
+                    const note_key = this._pianoKeys ? this._pianoKeys[note % 12] : null;
                     if (note_key !== null) {
                         note_key.src = animationImgs[(note + startingposition) % 12];
                     }


### PR DESCRIPTION
## PR Category
- [ ] Bug fix
- [x] Performance
- [ ] Documentation
- [ ] Refactor

## Summary

* Replace 13 separate `innerHTML +=` calls in `_showPiano()` with a single `innerHTML` write, eliminating 12 unnecessary DOM teardown-and-rebuild cycles
* Cache all 12 piano key elements (`this._pianoKeys`) after creation to avoid repeated `document.getElementById()` lookups during note playback
* Use cached references in `__playNextNote()` instead of querying the DOM on every note played

---

## Problem

Each `innerHTML +=` forces the browser to:

* Serialize the entire DOM subtree
* Destroy all child nodes
* Concatenate the new HTML
* Re-parse the full string
* Rebuild the DOM

This happened **13 times** just to add 12 `<img>` elements.

During playback, `document.getElementById("pkey_" + i)` was called on every note, causing repeated DOM traversal for elements that never change.

---

## Fix

* Build the full HTML string in a local variable and assign `innerHTML` once (**13 reflows → 1**)
* After creation, cache all 12 key elements in an array
* Use cached references for O(1) access instead of repeated DOM queries

---

## Test plan

*  All 5 existing `modewidget.test.js` tests pass
* Manually verify:

  * Open Mode Widget → piano keys render correctly
  * Play a mode → key highlights animate correctly
  * Invert a mode starting with C → piano updates correctly
