### PR TITLE
Fix overlay canvas height incorrectly set to width during resize

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4169,7 +4169,7 @@ class Activity {
                 canvas.width = defaultWidth;
                 canvas.height = defaultHeight;
                 overCanvas.width = canvas.width;
-                overCanvas.height = canvas.width;
+                overCanvas.height = canvas.height;
                 canvasHolder.width = defaultWidth;
                 canvasHolder.height = defaultHeight;
             } else {
@@ -4183,10 +4183,8 @@ class Activity {
 
                 container.style.width = windowWidth + "px";
                 container.style.height = windowHeight + "px";
-                canvas.width = windowWidth;
-                canvas.height = windowHeight;
                 overCanvas.width = canvas.width;
-                overCanvas.height = canvas.width;
+                overCanvas.height = canvas.height;
                 canvasHolder.width = canvas.width;
                 canvasHolder.height = canvas.height;
             }


### PR DESCRIPTION
Fixes #6326

### PR Category
- [x] Bug Fix

### Summary
Fixed incorrect assignment of overlay canvas height during resize.

### Changes
- Replaced canvas.width with canvas.height for overCanvas height

### Testing
- Resized browser window
- Verified proper alignment