### PR TITLE
Load performance tracker on demand

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -109,7 +109,6 @@ let MYDEFINES = [
     "utils/musicutils",
     "utils/synthutils",
     "utils/mathutils",
-    "utils/performanceTracker",
     "activity/pastebox",
     "prefixfree.min",
     "Tone",

--- a/js/logo.js
+++ b/js/logo.js
@@ -18,7 +18,7 @@
    instrumentsEffects, Singer, Tone, CAMERAVALUE, doUseCamera,
    VIDEOVALUE, last, getIntervalDirection, getIntervalNumber,
    mixedNumber, rationalToFraction, doStopVideoCam, StatusMatrix,
-   getStatsFromNotation, delayExecution, DEFAULTVOICE, performanceTracker, window
+   getStatsFromNotation, delayExecution, DEFAULTVOICE, performanceTracker, requirejs, window
  */
 
 /*
@@ -1116,12 +1116,31 @@ class Logo {
      * @returns {void}
      */
     runLogoCommands(startHere, env) {
+        const performanceModeEnabled =
+            typeof window !== "undefined" &&
+            (window.DEBUG_PERFORMANCE === true ||
+                (window.location && window.location.search.includes("performance=true")));
+
+        if (
+            performanceModeEnabled &&
+            typeof performanceTracker === "undefined" &&
+            typeof requirejs === "function" &&
+            !this._performanceTrackerLoadFailed
+        ) {
+            requirejs(
+                ["utils/performanceTracker"],
+                () => this.runLogoCommands(startHere, env),
+                () => {
+                    this._performanceTrackerLoadFailed = true;
+                    this.runLogoCommands(startHere, env);
+                }
+            );
+            return;
+        }
+
         // Performance instrumentation: enable/disable based on URL flag
         if (typeof performanceTracker !== "undefined") {
-            if (
-                typeof window !== "undefined" &&
-                window.location.search.includes("performance=true")
-            ) {
+            if (performanceModeEnabled) {
                 performanceTracker.enable();
             } else {
                 performanceTracker.disable();


### PR DESCRIPTION
Fixes #6417 

### Summary

This PR optimizes startup performance by loading `performanceTracker` only when performance mode is enabled, instead of during initial application load.

### Problem

Currently, `performanceTracker` is included during startup (`js/activity.js`) for all users, even though it is only used when performance mode is enabled (`js/logo.js`). This introduces unnecessary overhead during normal application load.

### Changes / Fixes

- Replaced eager loading with conditional loading using `requirejs`
- Introduced `performanceModeEnabled` flag and reused it to avoid duplicate condition checks
- Ensured `performanceTracker` loads only when performance mode is active
- Added safeguard (`_performanceTrackerLoadFailed`) to prevent repeated failed load attempts
- Improved readability by centralizing performance mode logic

### Behavior

- If performance mode is enabled → `performanceTracker` is loaded and used  
- If still loading → execution retries safely  
- If loading fails → execution continues without breaking  
- If performance mode is disabled → module is not loaded  

### Impact

- Reduces unnecessary startup work for most users  
- Improves initial load performance  
- Keeps existing functionality unchanged  

### Notes

- Recursive call to `runLogoCommands` is controlled and only triggered after load attempt  
- No changes to behavior outside performance mode  

---

- [x] Performance