### PR TITLE
perf: enforce Core Web Vitals budgets and add resource size limits in Lighthouse CI

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -23,19 +23,23 @@ module.exports = {
             }
         },
         assert: {
-            // Assertions for performance budgets
-            // These will warn but not fail the build initially
             assertions: {
-                "categories:performance": ["warn", { minScore: 0.5 }],
+                // Category scores — error on performance, warn on the rest
+                "categories:performance": ["error", { minScore: 0.4 }],
                 "categories:accessibility": ["warn", { minScore: 0.8 }],
                 "categories:best-practices": ["warn", { minScore: 0.8 }],
                 "categories:seo": ["warn", { minScore: 0.8 }],
-                // Specific metrics to track
-                "first-contentful-paint": ["warn", { maxNumericValue: 4000 }],
-                "largest-contentful-paint": ["warn", { maxNumericValue: 6000 }],
-                "cumulative-layout-shift": ["warn", { maxNumericValue: 0.25 }],
-                "total-blocking-time": ["warn", { maxNumericValue: 600 }],
-                "speed-index": ["warn", { maxNumericValue: 5000 }]
+                // Core Web Vitals — fail CI if any regress past these ceilings
+                "first-contentful-paint": ["error", { maxNumericValue: 4000 }],
+                "largest-contentful-paint": ["error", { maxNumericValue: 6000 }],
+                "cumulative-layout-shift": ["error", { maxNumericValue: 0.25 }],
+                "total-blocking-time": ["error", { maxNumericValue: 600 }],
+                "speed-index": ["warn", { maxNumericValue: 5000 }],
+                // Resource size budgets (bytes) — catch bundle bloat early
+                "resource-summary:script:size": ["error", { maxNumericValue: 5242880 }],
+                "resource-summary:stylesheet:size": ["warn", { maxNumericValue: 1048576 }],
+                "resource-summary:image:size": ["warn", { maxNumericValue: 2097152 }],
+                "resource-summary:total:size": ["error", { maxNumericValue: 10485760 }]
             }
         },
         upload: {


### PR DESCRIPTION
# perf: enforce Core Web Vitals budgets and add resource size limits in Lighthouse CI

## Category

-[x] Performance

---

## Summary

Upgrade Core Web Vitals assertions (FCP, LCP, CLS, TBT) from warn to error so CI actually blocks PRs that regress load performance  
Add resource size budgets for scripts (5 MB), stylesheets (1 MB), images (2 MB), and total page weight (10 MB) to catch bundle bloat early  
Keep speed-index and non-performance categories as warn since they are volatile across CI environments  

---

## Problem

All Lighthouse assertions were set to warn, meaning performance regressions were silently logged but never blocked a merge. Contributors could land PRs that significantly degraded load times without any CI signal.

---

## Fix

Promote the most actionable metrics to error level so they gate merges, and add resource size budgets that flag when new dependencies or assets push the bundle past safe limits.

---

## Test Plan

- Open a PR and verify Lighthouse CI runs and reports scores in the PR comment  
- Confirm CI fails if a test PR intentionally exceeds the TBT or total size budget  
- Confirm non-performance categories still warn without blocking