### PR TITLE
# fix(phrasemaker): prevent listener accumulation in makeClickable

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -3897,10 +3897,17 @@ class PhraseMaker {
                     };
                 }
             } else {
-                cell.removeEventListener("mousedown", __mouseDownHandler);
-                cell.addEventListener("mousedown", __mouseDownHandler);
+                // Remove previously stored handlers to prevent listener accumulation
+                if (cell._pmMouseDown) {
+                    cell.removeEventListener("mousedown", cell._pmMouseDown);
+                }
+                if (cell._pmMouseUp) {
+                    cell.removeEventListener("mouseup", cell._pmMouseUp);
+                }
 
-                cell.removeEventListener("mouseup", __mouseUpHandler);
+                cell._pmMouseDown = __mouseDownHandler;
+                cell._pmMouseUp = __mouseUpHandler;
+                cell.addEventListener("mousedown", __mouseDownHandler);
                 cell.addEventListener("mouseup", __mouseUpHandler);
             }
         }


### PR DESCRIPTION
## Category

-[x] Bug fix

---

## Summary

Fix ineffective `removeEventListener` calls in `makeClickable()` that failed to remove old handlers because new function references were created each invocation.  
Store handler references on the cell element itself (`cell._pmMouseDown`, `cell._pmMouseUp`) so the correct reference is available for removal on subsequent calls.

---

## Problem

`makeClickable()` is called multiple times (on init, after adding notes, after sorting). Each call creates new `__mouseDownHandler` and `__mouseUpHandler` closures and attempts `removeEventListener` with the new reference — but `removeEventListener` only works with the same function reference used in `addEventListener`.

As a result, the old listeners were never removed, causing duplicate handlers to stack on every cell with each call.

---

## Fix

Before adding new listeners, check if the cell has previously stored handler references and remove those. Then store the new handler on the element for future cleanup.

---

