### PR TITLE
FIX: Cleanup visibilitychange listener in Oscilloscope widget

### DIFF
--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -65,8 +65,10 @@ class Oscilloscope {
         widgetWindow.show();
 
         widgetWindow.onclose = () => {
-            this.close();
-        };
+        // Cleanup document event listener
+        document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        this.close();
+    };
         widgetWindow.onmaximize = this._scale.bind(this);
 
         // UI state


### PR DESCRIPTION
## Description
This PR adds cleanup for the document-level `visibilitychange` event listener in the Oscilloscope widget (`js/widgets/oscilloscope.js`).

## Problem
The Oscilloscope widget registers a `visibilitychange` listener on `document` when it is initialized, but the listener is not removed when the widget is closed.

This can lead to:
- Memory leaks
- Unnecessary event handling after widget closure
- Potential duplicate listeners if the widget is reopened multiple times

## Changes Made
- Removed the `visibilitychange` listener inside the widget `onclose` handler
- Ensured that the listener is properly cleaned up before calling `this.close()`

## PR Category

- [x] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation
- [ ] Security
- [x] Refactor / Maintenance