### PR TITLE
Added getting started section to documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -6,9 +6,15 @@ labels: "Issue-Documentation"
 assignees: ""
 ---
 
+#### Getting started
+1. Open music blocks.
+2. Drag blocks from the palette.
+3. Connect blocks together.
+4. Click run button to play music.
+
 #### Current State
 
-<!-- A brief description of what the current circumstance is. -->
+<!-- A brief description of the current situation -->
 
 #### Desired State
 


### PR DESCRIPTION
This PR adds a Getting started section to the documentation to help new users understand how to begin using Music Blocks.
This is a documentation improvement under the awareness label.