### PR TITLE
fix: correct off-by-one error in nth modal pitch block

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -2640,8 +2640,8 @@ class Block {
                 if (this.blocks.blockList[c2].name === "number") {
                     if (this.blocks.blockList[c1].name === "number") {
                         const degrees = DEGREES.split(" ");
-                        const i = this.blocks.blockList[c1].value - 1;
-                        if (i > 0 && i < degrees.length) {
+                        const i = this.blocks.blockList[c1].value;
+                        if (i >= 0 && i < degrees.length) {
                             return degrees[i] + " " + this.blocks.blockList[c2].value;
                         } else {
                             return (

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -174,8 +174,8 @@ function setupPitchActions(activity) {
         static playNthModalPitch(number, octave, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
 
-            //  (0, 4) --> ti 3; (-1, 4) --> la 3, (-6, 4) --> do 3
-            //  (1, 4) --> do 4; ( 2, 4) --> re 4; ( 8, 4) --> do 5
+            //  (0, 4) --> do 4; ( 1, 4) --> re 4; ( 7, 4) --> do 5
+            //  (-1, 4) --> ti 3; (-2, 4) --> la 3, (-7, 4) --> do 3
 
             // If number is a float value then round-off to the nearest integer
             number = Math.round(number);
@@ -185,7 +185,7 @@ function setupPitchActions(activity) {
 
             const obj = keySignatureToMode(tur.singer.keySignature);
             const modeLength = MUSICALMODES[obj[1]].length;
-            let scaleDegree = (Math.floor(number - 1) % modeLength) + 1;
+            let scaleDegree;
 
             // Choose a reference based on the key selected.
             // This is based on the position of a note on the circle of fifths e.g C --> 1, G-->8.
@@ -218,17 +218,21 @@ function setupPitchActions(activity) {
             deltaOctave doesn't directly affect the octave that will play; instead it changes what we say is the reference octave i.e the value connected to the octave argument of this block.
 
             You may see this as a cyclical process:
-            e.g Repeat the scale degree block 14 times while in G major starting from note value --> 1 and octave arg --> 4
-            Till we reach B --> Both deltaOctave and deltaSemi are {0,0}
-            As we cross B and reach C --> no. of semitones < ref, deltaSemi = 1, deltaOctave = 0 and this causes note C to play in octave 5
-            This behavious continues till E, as we reach F# (or Gb) --> deltaOctave becomes 1 and deltaSemi goes back to zero since we've traversed
+            e.g Repeat the scale degree block 14 times while in G major starting from note value --> 0 and octave arg --> 4
+            Till we reach B (note value 2) --> Both deltaOctave and deltaSemi are {0,0}
+            As we cross B and reach C (note value 3) --> no. of semitones < ref, deltaSemi = 1, deltaOctave = 0 and this causes note C to play in octave 5
+            This continues till F# (note value 6), as we reach G (note value 7) --> deltaOctave becomes 1 and deltaSemi goes back to zero since we've traversed
             our modeLength ( 7 ) once.
             Again on C deltaSemi will be 1, deltaOctave was already 1 and thus a total change of 2 octaves --> C6. Thus, deltaOctave brings a change
             to the reference octave.
             So this process can continue indefinitely producing our desired results.
             */
 
-            scaleDegree = isNegativeArg ? modeLength - scaleDegree : scaleDegree;
+            if (isNegativeArg) {
+                scaleDegree = modeLength - ((number - 1) % modeLength);
+            } else {
+                scaleDegree = (number % modeLength) + 1;
+            }
 
             const [note, offset] = nthDegreeToPitch(tur.singer.keySignature, scaleDegree);
             let semitones = ref;


### PR DESCRIPTION
# Fixes #6433 

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

Fixes an off-by-one error in `playNthModalPitch` where the function used 1-based indexing internally, but the block documentation and example projects expect 0-based indexing (`0` = first scale degree). This caused every note to be shifted down by one scale degree, breaking the "Circle of Fifths (Nth Modal Pitch)" example project.

## Problem

The `NthModalPitchBlock` help text explicitly states:
> "0 is the first position, 1 is the second, -1 is the note before the first"

However, the `playNthModalPitch` function in `PitchActions.js` treated the input as 1-based (`1` = first position). This meant:
- Input `0` produced **B** (7th degree) instead of **C** (1st degree) in C major
- Every note in every key was shifted down by one scale degree
- The "12 Keys Circles and Nth" example project (which sends values 0–7) produced incomprehensible output

### Buggy Lilypond output (before fix):
<img width="977" height="400" alt="image" src="https://github.com/user-attachments/assets/66fda962-52f8-4cec-9a03-6508b7869bc3" />

```
 \key c \major
b'16 c'16 d'16 e'16 f'16 g'16 a'16 b''16  \key g \major

fis''16 g'16 a'16 b'16 c''16 d''16 e''16 fis'''16  \key d \major

cis''16 d'16 e'16 fis'16 g'16 a'16 b'16 cis'''16  \key a \major

gis''16 a'16 b'16 cis''16 d''16 e''16 fis''16 gis'''16  \key e \major

dis''16 e'16 fis'16 gis'16 a'16 b'16 cis''16 dis'''16  \key b \major

ais''16 b'16 cis''16 dis''16 e''16 fis''16 gis''16 ais'''16  \key ges \major

f''16 ges'16 aes'16 bes'16 b'16 des''16 ees''16 f'''16  \key des \major

c''16 des'16 ees'16 f'16 ges'16 aes'16 bes'16 c'''16  \key aes \major

g''16 aes'16 bes'16 c''16 des''16 ees''16 f''16 g'''16  \key ees \major

d''16 ees'16 f'16 g'16 aes'16 bes'16 c''16 d'''16  \key bes \major

a''16 bes'16 c''16 d''16 ees''16 f''16 g''16 a'''16  \key f \major

e''16 f'16 g'16 a'16 bes'16 c''16 d''16 e'''16  \key c \major

b'16 c'16 d'16 e'16 f'16 g'16 a'16 b''16 
```

Each scale starts on the **wrong note** (one degree too low).

### Fixed Lilypond output (after fix):
<img width="970" height="398" alt="image" src="https://github.com/user-attachments/assets/608115d9-a835-43d1-bc49-b1e96c5d69b2" />

```
 \key c \major
c'16 d'16 e'16 f'16 g'16 a'16 b'16 c''16  \key g \major

g'16 a'16 b'16 c''16 d''16 e''16 fis''16 g''16  \key d \major

d'16 e'16 fis'16 g'16 a'16 b'16 cis''16 d''16  \key a \major

a'16 b'16 cis''16 d''16 e''16 fis''16 gis''16 a''16  \key e \major

e'16 fis'16 gis'16 a'16 b'16 cis''16 dis''16 e''16  \key b \major

b'16 cis''16 dis''16 e''16 fis''16 gis''16 ais''16 b''16  \key ges \major

ges'16 aes'16 bes'16 b'16 des''16 ees''16 f''16 ges''16  \key des \major

des'16 ees'16 f'16 ges'16 aes'16 bes'16 c''16 des''16  \key aes \major

aes'16 bes'16 c''16 des''16 ees''16 f''16 g''16 aes''16  \key ees \major

ees'16 f'16 g'16 aes'16 bes'16 c''16 d''16 ees''16  \key bes \major

bes'16 c''16 d''16 ees''16 f''16 g''16 a''16 bes''16  \key f \major

f'16 g'16 a'16 bes'16 c''16 d''16 e''16 f''16  \key c \major

c'16 d'16 e'16 f'16 g'16 a'16 b'16 c''16 
```

Each scale now correctly starts on the **tonic** of the key.

Test plan

- [x] All 3967 existing tests pass across 124 test suites
- [x] Loaded "12-Keys-Circles-and-Nth" example project and verified Lilypond output matches expected output from issue - all 12 keys start on the correct tonic note
- [x] Generated before/after sheet music PDFs via LilyPond to visually confirm the fix
- [ ] Manually test nth modal pitch block with inputs 0–7 in C major → should play C, D, E, F, G, A, B, C
- [ ] Manually test with negative inputs (−1 should play the note below the tonic)
- [ ] Test with non-major modes (e.g., minor, dorian)