### PR TITLE
test: add initial unit tests for legobricks core logic

### DIFF
--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -20,13 +20,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-const fs = require("fs");
-const path = require("path");
-
-const source = fs.readFileSync(path.resolve(__dirname, "../legobricks.js"), "utf-8");
-new Function(source + "\nif (typeof global !== 'undefined') { global.LegoWidget = LegoWidget; }")();
-
 global._ = str => str;
+const LegoWidget = require("../legobricks");
 
 describe("LegoWidget core logic", () => {
     let widget;

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -3065,3 +3065,7 @@ function LegoWidget() {
         });
     };
 }
+
+if (typeof module !== "undefined") {
+    module.exports = LegoWidget;
+}


### PR DESCRIPTION
This PR covers deterministic non-UI logic only for the LEGO Bricks widget.
It is an intentionally small first step toward broader widget coverage.

## Related Issue

Partially addresses #6344

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made
-   Add an initial Jest test file for `js/widgets/legobricks.js`.
-   Cover `_calculateFallbackFrequency()`, `addRowBlock()`, and `clearBlocks()`.
-   Limit the scope to deterministic core logic without expanding into widget UI behavior.

## Testing Performed
-   Ran `npx npm@10 ci` to match the repository CI install flow more closely than the local system npm 11.
-   Ran changed-file checks equivalent to the PR linter workflow:
    - `npx eslint js/widgets/__tests__/legobricks.test.js`
    - `npx prettier --check js/widgets/__tests__/legobricks.test.js`
-   Ran `npm run build --if-present`.
-   Ran the targeted test:
    - `npm test -- js/widgets/__tests__/legobricks.test.js`
-   Ran the full Jest suite:
    - `npm test -- --json --outputFile=jest-results.json`
    - Result: 125 suites passed, 3973 tests passed.
-   Ran the Cypress E2E suite in headless Chrome against the local app server:
    - `npx cypress run --browser chrome --config video=false`
    - Result: 17 tests passed.

## Checklist
-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
-   This PR intentionally covers deterministic non-UI logic only.
-   Repo-wide `npx prettier --check .` is not currently clean due to unrelated pre-existing files; the changed-file Prettier check for this PR passed.