### PR TITLE
fix: main to master branch in security scan workflow (Related to #6452)

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,27 +1,28 @@
 name: Security Scans
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+    push:
+        branches:
+            - master
+    pull_request:
+    workflow_dispatch:
 
 jobs:
-  security-scans:
-    runs-on: ubuntu-latest
+    security-scans:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+                  cache: "npm"
 
-      - name: Install Dependencies
-        run: npm ci
+            - name: Install Dependencies
+              run: npm ci
 
-      - name: Run npm Audit
-        run: npm audit --omit=dev --audit-level=high
+            - name: Run npm Audit
+              run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
What was wrong (push trigger to main which doesn't exist)

What was changed (main → master)
Related to #6452