### PR TITLE
fix: avoid nodemon EMFILE in dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,5 +95,12 @@
             "eslint --max-warnings=0 --fix",
             "prettier --write"
         ]
+    },
+    "nodemonConfig": {
+        "watch": [
+            "index.js",
+            "package.json"
+        ],
+        "ext": "js,mjs,cjs,json"
     }
 }


### PR DESCRIPTION
## Summary

Fixes the local dev workflow so `npm run dev` no longer crashes with:

`EMFILE: too many open files, watch`

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## What changed

- Added a `nodemonConfig` in `package.json`
- Limited nodemon watching to:
  - `index.js`
  - `package.json`

This avoids recursive watching across the whole repo, which was causing the file watcher limit to be exceeded.

## Why this works

The dev server here is just the Node/Express entrypoint serving static files. Restarting Node is only needed when the server entry file or package config changes, not when every frontend file changes.

## Verification

- Reproduced the original `npm run dev` failure before the fix
- Confirmed `npm run dev` starts successfully after the change
- Confirmed nodemon now watches `index.js` and `package.json`
- Touched `index.js` and verified nodemon restarted correctly
- Ran `npx prettier --check package.json`

## Related

Fixes #6455 
