### PR TITLE
Fix UI hang by resolving stalled callback when project downloads fail

### DIFF
--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -283,10 +283,13 @@ class GlobalPlanet {
         if (data.success) {
             this.cache[id] = data.data;
             this.cache[id].ProjectData = null;
-            this.loadCount -= 1;
+        } else {
+            this.throwOfflineError();
+        }
 
-            if (this.loadCount <= 0) callback();
-        } else this.throwOfflineError();
+        this.loadCount -= 1;
+
+        if (this.loadCount <= 0) callback();
     }
 
     forceAddToCache(id, callback) {


### PR DESCRIPTION
Previously, when caching global projects using `downloadProjectsToCache()`, if any project failed to load (`data.success === false`), `loadCount` was not decremented. As a result, when mixed with successful downloads, `loadCount` never reached 0.

This caused the final callback to never fire, leaving the frontend stuck indefinitely.

## Changes Proposed

* Updated the `addProjectToCache()` method in `planet/js/GlobalPlanet.js`
* Moved `this.loadCount -= 1` and the condition `if (this.loadCount <= 0) callback();` outside the `if (data.success)` block to ensure it executes for both success and failure cases
* `throwOfflineError()` continues to be triggered appropriately on failures

## Result

* `loadCount` now correctly decrements in all scenarios
* The callback reliably fires once all requests (successful or failed) are completed
* Prevents the application from getting stuck in a loading state

## Testing

* Verified behavior with a mix of successful and failed project loads
* Confirmed callback execution when `loadCount` reaches 0
fixes #6472 

## PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior