### PR TITLE
Docs: Fix typo 'refernce' to 'reference' in comment

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -70,7 +70,7 @@ class WidgetWindow {
      * @param {boolean} fullscreen
      */
     constructor(key, title, fullscreen = true) {
-        // Keep a refernce to the object within handlers
+        // Keep a reference to the object within handlers
         this._key = key;
         this._buttons = [];
         this._first = true;


### PR DESCRIPTION
## Description
Fixed a minor typo in a comment: "refernce" → "reference"

## File Changed
- `js/widgets/widgetWindows.js` (line 73)

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation
- [ ] Security
- [x] Refactor / Maintenance

## Testing
- [x] No functional changes
- [x] Comment is now correctly spelled