### PR TITLE
fix: guard against undefined piemenuValues on plugin blocks (#6501)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014-21 Walter Bender
+// Copyright (c) 2014-21 Walter Bender
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the The GNU Affero General Public
@@ -3480,7 +3480,10 @@ class Block {
             return false;
         }
 
-        if (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC1.length === 0) {
+        if (
+            (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC1?.length ?? 0) ===
+            0
+        ) {
             return false;
         }
 
@@ -3502,7 +3505,10 @@ class Block {
             return false;
         }
 
-        if (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC2.length === 0) {
+        if (
+            (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC2?.length ?? 0) ===
+            0
+        ) {
             return false;
         }
 
@@ -3524,7 +3530,10 @@ class Block {
             return false;
         }
 
-        if (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC3.length === 0) {
+        if (
+            (this.blocks.blockList[this.connections[0]].protoblock.piemenuValuesC3?.length ?? 0) ===
+            0
+        ) {
             return false;
         }
 


### PR DESCRIPTION

Fixes #6501

Plugin blocks (like Floor from the Maths plugin) crash with a TypeError when you try to edit their input values. This happens because plugin blocks use ProtoBlock directly, which doesn't initialize piemenuValuesC1/C2/C3 — unlike BaseBlock which sets them to empty arrays.

When _usePieNumberC1/C2/C3() tries to check .length on these undefined properties, it blows up.

Fix: Added optional chaining (?.) so it safely skips the pie menu for blocks that don't define custom values, instead of crashing.

- [x] Bug Fix