### PR TITLE
fix: correct ActionBlocks.test.js mock and assertion after textMsg refactor

### DIFF
--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -140,6 +140,7 @@ describe("ActionBlocks", () => {
                 }))
             },
             errorMsg: jest.fn(),
+            textMsg: jest.fn(),
             refreshCanvas: jest.fn(),
             stage: {
                 dispatchEvent: jest.fn()
@@ -442,7 +443,7 @@ describe("ActionBlocks", () => {
             jest.spyOn(block, "getURL").mockReturnValue("http://localhost?outurl=http://cb");
             block.flow([100]);
             if (onReadyCallback) onReadyCallback();
-            expect(global.alert).toHaveBeenCalledWith("ok");
+            expect(activity.textMsg).toHaveBeenCalledWith("ok");
         });
 
         test("does not post when args length is not 1", () => {


### PR DESCRIPTION
ActionBlocks.test.js was failing on master after #6278 merged. Two issues:

- `activity.textMsg` was missing from the activity mock, causing a TypeError
- Test assertion was checking `global.alert` instead of `activity.textMsg`

All 60 tests pass after this fix.

## PR Category
- [ ] Bug Fix
- [ ] Performance
- [ ] Feature
- [x] Tests
- [ ] Documentation