### PR TITLE
Fix palette auto-closing after mouse clicks on toolbar/workspace

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -105,6 +105,7 @@ class Palettes {
         // Tracks whether the palette was collapsed before Tab focus entered,
         // so we can restore its state when focus leaves.
         this._wasCollapsedBeforeFocus = false;
+        this._expandedForKeyboardFocus = false;
     }
 
     init() {
@@ -256,11 +257,22 @@ class Palettes {
         // Auto-expand the palette when it receives Tab focus (if it was collapsed),
         // and restore the previous state when focus leaves.
         palette.addEventListener("focus", () => {
+            // Mouse clicks can also focus the palette container. Only auto-expand
+            // when focus was entered via keyboard navigation.
+            if (!this._keyboardNavActive) {
+                this._wasCollapsedBeforeFocus = false;
+                this._expandedForKeyboardFocus = false;
+                return;
+            }
+
             // Record the state at the moment Tab focus enters.
             this._wasCollapsedBeforeFocus = this.collapsed;
+            this._expandedForKeyboardFocus = false;
+
             // If the palette is collapsed, open it so the user can see it.
             if (this.collapsed) {
                 this.toggleCollapse();
+                this._expandedForKeyboardFocus = true;
             }
         });
 
@@ -269,10 +281,15 @@ class Palettes {
             // If it's still inside the palette, do nothing.
             if (palette.contains(event.relatedTarget)) return;
             // Restore the palette to the state it was in before Tab focus entered.
-            if (this._wasCollapsedBeforeFocus) {
+            if (
+                this._expandedForKeyboardFocus &&
+                this._wasCollapsedBeforeFocus &&
+                !this.collapsed
+            ) {
                 this.toggleCollapse();
             }
             this._wasCollapsedBeforeFocus = false;
+            this._expandedForKeyboardFocus = false;
         });
 
         // Clear keyboard nav highlight on mouse movement and restore mouse hover


### PR DESCRIPTION
This fixes a bug where the left palette would close itself after being reopened, especially when the user clicked the toolbar, the collapse button, or the workspace.

**Issue**:

The palette would pick on mouse clicks on workspace and toolbar, which caused the palette to collapse/expand depending upon the state it was left. 

**Reproduction Steps:**

1. collapse palette
2. click on workspace/ toolbar
3. Expand palette
4. click again on workspace / toolbar 
5. Now you will be able to see the palette automatically closing. 

**Issue Video:** 

https://github.com/user-attachments/assets/fd139242-afb6-4291-a1e1-4681cbfe891b

**Fix**

Updated the palette focus handling so the auto-expand/auto-restore behavior only runs when the palette is entered through keyboard navigation.

In practice, the fix does this:

- ignore palette focus events unless keyboard navigation is active
- track whether the palette was expanded specifically because of keyboard focus
- only restore the collapsed state on focusout if that keyboard-driven expansion actually happened

This keeps the keyboard accessibility behavior intact, while stopping mouse clicks on the toolbar, collapse handle, or workspace from closing the palette unexpectedly.

- [x] Bug fix