### PR TITLE
fix: Restore palette TAB auto-open when collapsed

### DIFF
--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -2510,14 +2510,25 @@ class FocusCycleManager {
             const palette = document.getElementById("palette");
             if (!palette) return;
             if (container) container.classList.add("focus-zone-active");
-            // Give native focus to the palette container (it has tabindex).
-            palette.focus({ preventScroll: true });
 
             // Sync palette.js's internal state so arrow keys work immediately.
+            let p = null;
             try {
-                const p = this._getActivity()?.palettes;
+                p = this._getActivity()?.palettes;
                 if (p) {
                     p._keyboardNavActive = true;
+                }
+            } catch {
+                // Palette keyboard state sync is best-effort.
+            }
+
+            // Give native focus to the palette container (it has tabindex).
+            // This must happen after palette.js knows we arrived via keyboard,
+            // otherwise the collapsed palette will not auto-expand on Tab.
+            palette.focus({ preventScroll: true });
+
+            try {
+                if (p) {
                     // Only set to blocks section if there are rows and nothing is already focused.
                     const listBody = palette.children[0]?.children[1]?.children[1];
                     const rows = listBody ? Array.from(listBody.children) : [];


### PR DESCRIPTION
This PR fixes the regression introduced in the PR #6510 (check comments)

Summary: 
The palette already ignored mouse-triggered focus so it would not auto-close when clicking the toolbar or workspace, but Tab navigation stopped reopening the palette when it was collapsed. The issue was that the toolbar focus manager called palette.focus() before marking the palette as keyboard-active, so the palette treated the focus event like a normal mouse focus.

This PR sets palette keyboard mode before focusing the palette, restoring the expected Tab behavior while keeping the original mouse auto-close fix intact.

Video: 

https://github.com/user-attachments/assets/3bcc4bc3-5a3b-4335-9bae-4fbff727d649

- [x] Bug fix
