### PR TITLE
fix(phrasemaker): read meter from triggering turtle, not always turtle 0

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -1580,7 +1580,7 @@ function setupWidgetBlocks(activity) {
                     // Process queued up rhythms.
                     logo.phraseMaker.blockNo = blk;
                     logo.phraseMaker.sorted = false;
-                    logo.phraseMaker.init(activity);
+                    logo.phraseMaker.init(activity, turtle);
 
                     for (let i = 0; i < logo.tupletRhythms.length; i++) {
                         // We have two cases: (1) notes in a tuplet;

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -339,6 +339,80 @@ describe("PhraseMaker Widget", () => {
         });
     });
 
+    describe("init() turtleIndex parameter", () => {
+        /**
+         * Builds a minimal activity mock. ithTurtle() returns singer data for
+         * turtles defined in meterByIndex; omitted turtles return undefined
+         * beats/noteValue, which exercises the `|| 4` fallback in init().
+         */
+        function makeActivity(meterByIndex) {
+            return {
+                turtles: {
+                    ithTurtle: jest.fn(i => ({
+                        singer: {
+                            beatsPerMeasure: meterByIndex[i]?.beats,
+                            noteValuePerBeat: meterByIndex[i]?.noteValue,
+                            keySignature: "C major"
+                        }
+                    }))
+                }
+            };
+        }
+
+        /**
+         * Invoke init() and absorb any downstream errors thrown once the DOM
+         * setup begins (after _measureLimit has already been set). This lets us
+         * assert on _measureLimit without providing full DOM stubs for the rest
+         * of the 400-line init() method.
+         */
+        function callInitPartial(pm, activity, turtleIndex) {
+            try {
+                pm.init(activity, turtleIndex);
+            } catch (_) {
+                // Tolerated: errors from un-stubbed DOM APIs further in init().
+                // _measureLimit is computed before any DOM access.
+            }
+        }
+
+        test("defaults to turtle 0 when turtleIndex is omitted", () => {
+            const pm = new PhraseMaker(mockDeps);
+            const activity = makeActivity({ 0: { beats: 4, noteValue: 4 } });
+            callInitPartial(pm, activity, undefined);
+            // 4/4: 4 / 4 = 1.0
+            expect(pm._measureLimit).toBeCloseTo(1.0);
+            expect(activity.turtles.ithTurtle).toHaveBeenCalledWith(0);
+        });
+
+        test("uses turtleIndex 0 explicitly to read 4/4 meter", () => {
+            const pm = new PhraseMaker(mockDeps);
+            const activity = makeActivity({ 0: { beats: 4, noteValue: 4 } });
+            callInitPartial(pm, activity, 0);
+            expect(pm._measureLimit).toBeCloseTo(1.0);
+            expect(activity.turtles.ithTurtle).toHaveBeenCalledWith(0);
+        });
+
+        test("uses turtleIndex 1 to read 3/4 meter from turtle 1", () => {
+            const pm = new PhraseMaker(mockDeps);
+            const activity = makeActivity({
+                0: { beats: 4, noteValue: 4 },
+                1: { beats: 3, noteValue: 4 }
+            });
+            callInitPartial(pm, activity, 1);
+            // 3/4: 3 / 4 = 0.75
+            expect(pm._measureLimit).toBeCloseTo(0.75);
+            expect(activity.turtles.ithTurtle).toHaveBeenCalledWith(1);
+        });
+
+        test("falls back to 4/4 when singer meter is not yet initialized", () => {
+            const pm = new PhraseMaker(mockDeps);
+            // meterByIndex is empty: beats/noteValue are undefined, || 4 applies
+            const activity = makeActivity({});
+            callInitPartial(pm, activity, 0);
+            // undefined || 4 = 4; 4 / 4 = 1.0
+            expect(pm._measureLimit).toBeCloseTo(1.0);
+        });
+    });
+
     describe("dependency injection", () => {
         test("should use injected deps", () => {
             const customDeps = {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -343,8 +343,9 @@ class PhraseMaker {
      * Initializes the PhraseMaker matrix widget.
      * This method sets up the PhraseMaker matrix in the DOM (Document Object Model) and initializes its functionality.
      * @param {Activity} activity - The activity instance associated with the PhraseMaker widget.
+     * @param {number} [turtleIndex=0] - Index of the turtle that triggered this widget.
      */
-    init(activity) {
+    init(activity, turtleIndex = 0) {
         // Initializes the matrix. First removes the previous matrix
         // and then make another one in DOM (document object model)
         let tempTable;
@@ -352,15 +353,14 @@ class PhraseMaker {
 
         this._currentMusicalTime = 0; // Tracks duration used in the current bar
 
-        // Get the meter from the turtle's singer (Meter Block sets this)
-        const turtle = activity.turtles.ithTurtle(0); // Get turtle 0
-        const beatsPerMeasure = turtle.singer.beatsPerMeasure || 4; // Default to 4
-        const noteValuePerBeat = turtle.singer.noteValuePerBeat || 4; // Default to 4
+        // Read the meter from the turtle that triggered this widget so that
+        // bar-line separators reflect the correct time signature.
+        const turtle = activity.turtles.ithTurtle(turtleIndex);
+        const beatsPerMeasure = turtle.singer.beatsPerMeasure || 4;
+        const noteValuePerBeat = turtle.singer.noteValuePerBeat || 4;
 
-        // Calculate the duration of ONE measure
-        // beatsPerMeasure is the number of beats (e.g., 3 for 3/4)
-        // noteValuePerBeat is the note type that gets one beat (e.g., 4 for quarter note)
-        // For 3/4: 3 beats * (1/4) = 0.75
+        // Calculate the duration of ONE measure.
+        // For 3/4: 3 beats × (1/4) = 0.75
         this._measureLimit = beatsPerMeasure / noteValuePerBeat;
 
         this._noteStored = [];


### PR DESCRIPTION
The Phrase Maker widget computed _measureLimit (used for bar-line placement) from turtle 0's singer unconditionally. In multi-turtle programs where turtle 0 uses a different time signature than the turtle whose action block opened the widget, bar-lines appeared at incorrect column positions.

Fix: add a turtleIndex parameter (default 0) to init(). MatrixBlock.flow() already has the originating turtle index in scope and now passes it through, so the correct turtle's beatsPerMeasure and noteValuePerBeat are used.

Also adds four unit tests covering:
- default turtle 0 behaviour when index is omitted
- explicit turtle 0 (4/4)
- turtle 1 with 3/4 meter (verifies _measureLimit = 0.75)
- fallback to 4/4 when meter is uninitialized

- [x] Bug Fix