### PR TITLE
Issue 4724

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1129,14 +1129,14 @@ class Blocks {
                 if (!foundMatch) {
                     console.debug(
                         "Did not find match for " +
-                        myBlock.name +
-                        " (" +
-                        blk +
-                        ") and " +
-                        this.blockList[cblk].name +
-                        " (" +
-                        cblk +
-                        ")"
+                            myBlock.name +
+                            " (" +
+                            blk +
+                            ") and " +
+                            this.blockList[cblk].name +
+                            " (" +
+                            cblk +
+                            ")"
                     );
 
                     console.debug(myBlock.connections);
@@ -2146,7 +2146,7 @@ class Blocks {
                                     if (
                                         protoblock.name === "nameddo" &&
                                         protoblock.staticLabels[0] ===
-                                        this.blockList[connection].value
+                                            this.blockList[connection].value
                                     ) {
                                         await delayExecution(50);
                                         blockPalette.remove(
@@ -2868,14 +2868,14 @@ class Blocks {
             ) {
                 console.debug(
                     "WARNING: CORRUPTED BLOCK DATA. Block " +
-                    myBlock.name +
-                    " (" +
-                    blk +
-                    ") is connected to the same block " +
-                    this.blockList[myBlock.connections[0]].name +
-                    " (" +
-                    myBlock.connections[0] +
-                    ") twice."
+                        myBlock.name +
+                        " (" +
+                        blk +
+                        ") is connected to the same block " +
+                        this.blockList[myBlock.connections[0]].name +
+                        " (" +
+                        myBlock.connections[0] +
+                        ") twice."
                 );
                 return blk;
             }
@@ -3614,7 +3614,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, arg];
             } else if (name === "newnote") {
-                postProcess = () => { };
+                postProcess = () => {};
                 postProcessArg = [thisBlock, null];
             } else {
                 postProcess = null;
@@ -4362,7 +4362,7 @@ class Blocks {
                 const block = actionsPalette.protoList[blockId];
                 if (
                     ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].indexOf(block.name) !==
-                    -1 /** && block.defaults[0] !== _('action') */ &&
+                        -1 /** && block.defaults[0] !== _('action') */ &&
                     block.defaults[0] === oldName
                 ) {
                     block.defaults[0] = newName;
@@ -5887,10 +5887,10 @@ class Blocks {
                             if (nextName !== "hidden") {
                                 console.debug(
                                     "last connection of " +
-                                    name +
-                                    " is " +
-                                    nextName +
-                                    ": adding hidden block"
+                                        name +
+                                        " is " +
+                                        nextName +
+                                        ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][len - 1] = blockObjsLength + extraBlocksLength;
@@ -6024,10 +6024,10 @@ class Blocks {
                             if (nextName !== "hidden") {
                                 console.debug(
                                     "last connection of " +
-                                    name +
-                                    " is " +
-                                    nextName +
-                                    ": adding hidden block"
+                                        name +
+                                        " is " +
+                                        nextName +
+                                        ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][2] = blockObjsLength + extraBlocksLength;
@@ -6817,7 +6817,7 @@ class Blocks {
                                     if (this.protoBlockDict[blockObjs[c][1][0]] !== undefined) {
                                         if (
                                             this.protoBlockDict[blockObjs[c][1][0]].dockTypes[
-                                            cc
+                                                cc
                                             ] !== "in"
                                         ) {
                                             flowBlock = false;
@@ -6833,7 +6833,7 @@ class Blocks {
                                         if (this.protoBlockDict[blockObjs[c][1]] !== undefined) {
                                             if (
                                                 this.protoBlockDict[blockObjs[c][1]].dockTypes[
-                                                cc
+                                                    cc
                                                 ] !== "out"
                                             ) {
                                                 flowBlock = false;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1129,14 +1129,14 @@ class Blocks {
                 if (!foundMatch) {
                     console.debug(
                         "Did not find match for " +
-                            myBlock.name +
-                            " (" +
-                            blk +
-                            ") and " +
-                            this.blockList[cblk].name +
-                            " (" +
-                            cblk +
-                            ")"
+                        myBlock.name +
+                        " (" +
+                        blk +
+                        ") and " +
+                        this.blockList[cblk].name +
+                        " (" +
+                        cblk +
+                        ")"
                     );
 
                     console.debug(myBlock.connections);
@@ -1385,6 +1385,10 @@ class Blocks {
                     let newBlockName = "solfege";
                     let newBlockValue = "sol";
                     switch (this.blockList[oldBlock].name) {
+                        case "customNote":
+                            newBlockName = "customNote";
+                            newBlockValue = "C(+0¢)";
+                            break;
                         case "eastindiansolfege":
                             newBlockName = this.blockList[oldBlock].name;
                             newBlockValue = "sol";
@@ -2142,7 +2146,7 @@ class Blocks {
                                     if (
                                         protoblock.name === "nameddo" &&
                                         protoblock.staticLabels[0] ===
-                                            this.blockList[connection].value
+                                        this.blockList[connection].value
                                     ) {
                                         await delayExecution(50);
                                         blockPalette.remove(
@@ -2864,14 +2868,14 @@ class Blocks {
             ) {
                 console.debug(
                     "WARNING: CORRUPTED BLOCK DATA. Block " +
-                        myBlock.name +
-                        " (" +
-                        blk +
-                        ") is connected to the same block " +
-                        this.blockList[myBlock.connections[0]].name +
-                        " (" +
-                        myBlock.connections[0] +
-                        ") twice."
+                    myBlock.name +
+                    " (" +
+                    blk +
+                    ") is connected to the same block " +
+                    this.blockList[myBlock.connections[0]].name +
+                    " (" +
+                    myBlock.connections[0] +
+                    ") twice."
                 );
                 return blk;
             }
@@ -3610,7 +3614,7 @@ class Blocks {
 
                 postProcessArg = [thisBlock, arg];
             } else if (name === "newnote") {
-                postProcess = () => {};
+                postProcess = () => { };
                 postProcessArg = [thisBlock, null];
             } else {
                 postProcess = null;
@@ -4358,7 +4362,7 @@ class Blocks {
                 const block = actionsPalette.protoList[blockId];
                 if (
                     ["nameddo", "namedcalc", "nameddoArg", "namedcalcArg"].indexOf(block.name) !==
-                        -1 /** && block.defaults[0] !== _('action') */ &&
+                    -1 /** && block.defaults[0] !== _('action') */ &&
                     block.defaults[0] === oldName
                 ) {
                     block.defaults[0] = newName;
@@ -5883,10 +5887,10 @@ class Blocks {
                             if (nextName !== "hidden") {
                                 console.debug(
                                     "last connection of " +
-                                        name +
-                                        " is " +
-                                        nextName +
-                                        ": adding hidden block"
+                                    name +
+                                    " is " +
+                                    nextName +
+                                    ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][len - 1] = blockObjsLength + extraBlocksLength;
@@ -6020,10 +6024,10 @@ class Blocks {
                             if (nextName !== "hidden") {
                                 console.debug(
                                     "last connection of " +
-                                        name +
-                                        " is " +
-                                        nextName +
-                                        ": adding hidden block"
+                                    name +
+                                    " is " +
+                                    nextName +
+                                    ": adding hidden block"
                                 );
                                 /** If the next block is not a hidden block, add one. */
                                 blockObjs[b][4][2] = blockObjsLength + extraBlocksLength;
@@ -6813,7 +6817,7 @@ class Blocks {
                                     if (this.protoBlockDict[blockObjs[c][1][0]] !== undefined) {
                                         if (
                                             this.protoBlockDict[blockObjs[c][1][0]].dockTypes[
-                                                cc
+                                            cc
                                             ] !== "in"
                                         ) {
                                             flowBlock = false;
@@ -6829,7 +6833,7 @@ class Blocks {
                                         if (this.protoBlockDict[blockObjs[c][1]] !== undefined) {
                                             if (
                                                 this.protoBlockDict[blockObjs[c][1]].dockTypes[
-                                                    cc
+                                                cc
                                                 ] !== "out"
                                             ) {
                                                 flowBlock = false;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -413,7 +413,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - halfWheelSize
             )
         ) + "px";
@@ -424,7 +424,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - halfWheelSize
             )
         ) + "px";
@@ -488,8 +488,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (block.name === "notename" &&
                 (block.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
-                          block.blocks.blockList[block.connections[0]].name
-                      )
+                        block.blocks.blockList[block.connections[0]].name
+                    )
                     : true)))
     ) {
         if (scale[6 - i][0] === FIXEDSOLFEGE[note] || scale[6 - i][0] === note) {
@@ -724,8 +724,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (that.name === "notename" &&
                 (that.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
-                          that.blocks.blockList[that.connections[0]].name
-                      )
+                        that.blocks.blockList[that.connections[0]].name
+                    )
                     : true))
         ) {
             let i = scale.indexOf(selection["note"]);
@@ -1120,7 +1120,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1131,7 +1131,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -1236,109 +1236,34 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
 
+        // Ensure audio context is started (required by modern browsers).
         try {
-            // Ensure audio context is started (required by modern browsers)
             await Tone.start();
         } catch (e) {
             console.debug("Tone.start() skipped or failed", e);
         }
 
-        // Ensure synth is initialized before proceeding
-        if (!that.activity.logo.synth) {
-            return;
+        const tur = that.activity.turtles.ithTurtle(0);
+
+        if (!tur.singer.instrumentNames.includes(DEFAULTVOICE)) {
+            that.activity.logo.synth.createDefaultSynth(0);
+            that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
         }
 
-        // Always ensure tone is initialized
-        if (!that.activity.logo.synth.tone) {
-            that.activity.logo.synth.newTone();
-        }
+        that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
+        that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
 
-        // Create and load synth if needed
-        if (!instruments[0] || !instruments[0][DEFAULTVOICE]) {
-            try {
-                that.activity.logo.synth.createDefaultSynth(0);
-                await that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
-            } catch (e) {
-                return;
-            }
-        }
-
-        // Set volume
-        try {
-            that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
-            that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
-        } catch (e) {
-            return;
-        }
-
-        // Trigger note with proper error handling
         if (!that._triggerLock) {
             that._triggerLock = true;
-            try {
-                const customID = that.customID || label;
-                let freq = null;
-
-                // Try to compute frequency from the temperament data directly.
-                // noteLabels[customID] contains the temperament data. Entries can be:
-                //   - Plain numbers (ratios) when no custom notes are defined
-                //   - Arrays [ratio, noteName, octave] when custom notes are saved
-                const tempData = noteLabels[customID];
-                if (tempData) {
-                    // Find the entry that matches the displayed note label.
-                    for (const pitchNum in tempData) {
-                        if (pitchNum === "pitchNumber" || pitchNum === "interval") continue;
-                        const entry = tempData[pitchNum];
-                        let entryLabel, entryRatio, entryOctave;
-
-                        if (typeof entry === "number") {
-                            // Equal-style format: key is the label, value is the ratio
-                            entryLabel = pitchNum;
-                            entryRatio = entry;
-                            entryOctave = 4; // default octave
-                        } else if (Array.isArray(entry) && entry.length >= 3) {
-                            // Custom format: [ratio, noteName, octave]
-                            entryLabel = entry[1];
-                            entryRatio = entry[0];
-                            entryOctave = Number(entry[2]);
-                        }
-
-                        if (entryLabel === note && entryRatio != null) {
-                            // Compute frequency: ratio * startingPitchFrequency * octaveOffset
-                            const startPitch = that.activity.logo.synth.startingPitch;
-                            const startFreq = Tone.Frequency(startPitch).toFrequency();
-                            const octaveDiff = octave - entryOctave;
-                            freq = entryRatio * startFreq * Math.pow(2, octaveDiff);
-                            break;
-                        }
-                    }
-                }
-
-                // If direct computation failed, try getCustomFrequency
-                if (freq === null || isNaN(freq)) {
-                    const noteWithOctave = note + octave;
-                    const result = that.activity.logo.synth.getCustomFrequency(
-                        noteWithOctave,
-                        customID
-                    );
-                    if (typeof result === "number" && !isNaN(result)) {
-                        freq = result;
-                    }
-                }
-
-                if (freq !== null && typeof freq === "number" && !isNaN(freq)) {
-                    // Play the frequency directly via synth.trigger
-                    await that.activity.logo.synth.trigger(
-                        0,
-                        freq,
-                        1 / 8,
-                        DEFAULTVOICE,
-                        null,
-                        null,
-                        false
-                    );
-                }
-            } catch (e) {
-                console.error("Error in custom pitch preview:", e);
+            const customID = that.customID || label;
+            // Pass note + octave directly to getCustomFrequency (bypass getNote
+            // which cannot parse custom note names like "C(+0¢)").
+            const no = that.activity.logo.synth.getCustomFrequency(
+                [note + octave],
+                customID
+            );
+            if (no !== undefined && no !== "undefined") {
+                instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
             }
         }
 
@@ -1729,7 +1654,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1740,7 +1665,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2663,7 +2588,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2674,7 +2599,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2777,7 +2702,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2788,7 +2713,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2912,7 +2837,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2923,7 +2848,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3103,7 +3028,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3114,7 +3039,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3249,7 +3174,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3260,7 +3185,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3745,7 +3670,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                        canvasLeft
+                    canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3756,7 +3681,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                        canvasTop
+                    canvasTop
                 ) - 200
             )
         ) + "px";
@@ -4315,9 +4240,9 @@ const piemenuKey = activity => {
                         activity.KeySignatureEnv[1];
                     activity.textMsg(
                         _("You have chosen key for your pitch preview.") +
-                            activity.KeySignatureEnv[0] +
-                            " " +
-                            activity.KeySignatureEnv[1]
+                        activity.KeySignatureEnv[0] +
+                        " " +
+                        activity.KeySignatureEnv[1]
                     );
                 }
             }

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1217,7 +1217,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         hideWheelDiv();
     };
 
-    const __selectionChanged = () => {
+    const __selectionChanged = async () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
         that.value = note;
@@ -1236,23 +1236,109 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
 
-        const obj = getNote(note, octave, 0, "C major", false, null, that.activity.errorMsg, label);
-        const tur = that.activity.turtles.ithTurtle(0);
-
-        if (!tur.singer.instrumentNames.includes(DEFAULTVOICE)) {
-            that.activity.logo.synth.createDefaultSynth(0);
-            that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+        try {
+            // Ensure audio context is started (required by modern browsers)
+            await Tone.start();
+        } catch (e) {
+            console.debug("Tone.start() skipped or failed", e);
         }
 
-        that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
-        that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+        // Ensure synth is initialized before proceeding
+        if (!that.activity.logo.synth) {
+            return;
+        }
 
+        // Always ensure tone is initialized
+        if (!that.activity.logo.synth.tone) {
+            that.activity.logo.synth.newTone();
+        }
+
+        // Create and load synth if needed
+        if (!instruments[0] || !instruments[0][DEFAULTVOICE]) {
+            try {
+                that.activity.logo.synth.createDefaultSynth(0);
+                await that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+            } catch (e) {
+                return;
+            }
+        }
+
+        // Set volume
+        try {
+            that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
+            that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+        } catch (e) {
+            return;
+        }
+
+        // Trigger note with proper error handling
         if (!that._triggerLock) {
             that._triggerLock = true;
-            // Get the frequency of the custom note for the preview.
-            const no = that.activity.logo.synth.getCustomFrequency([note + obj[1]], that.customID);
-            if (no !== undefined && no !== "undefined") {
-                instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
+            try {
+                const customID = that.customID || label;
+                let freq = null;
+
+                // Try to compute frequency from the temperament data directly.
+                // noteLabels[customID] contains the temperament data. Entries can be:
+                //   - Plain numbers (ratios) when no custom notes are defined
+                //   - Arrays [ratio, noteName, octave] when custom notes are saved
+                const tempData = noteLabels[customID];
+                if (tempData) {
+                    // Find the entry that matches the displayed note label.
+                    for (const pitchNum in tempData) {
+                        if (pitchNum === "pitchNumber" || pitchNum === "interval") continue;
+                        const entry = tempData[pitchNum];
+                        let entryLabel, entryRatio, entryOctave;
+
+                        if (typeof entry === "number") {
+                            // Equal-style format: key is the label, value is the ratio
+                            entryLabel = pitchNum;
+                            entryRatio = entry;
+                            entryOctave = 4; // default octave
+                        } else if (Array.isArray(entry) && entry.length >= 3) {
+                            // Custom format: [ratio, noteName, octave]
+                            entryLabel = entry[1];
+                            entryRatio = entry[0];
+                            entryOctave = Number(entry[2]);
+                        }
+
+                        if (entryLabel === note && entryRatio != null) {
+                            // Compute frequency: ratio * startingPitchFrequency * octaveOffset
+                            const startPitch = that.activity.logo.synth.startingPitch;
+                            const startFreq = Tone.Frequency(startPitch).toFrequency();
+                            const octaveDiff = octave - entryOctave;
+                            freq = entryRatio * startFreq * Math.pow(2, octaveDiff);
+                            break;
+                        }
+                    }
+                }
+
+                // If direct computation failed, try getCustomFrequency
+                if (freq === null || isNaN(freq)) {
+                    const noteWithOctave = note + octave;
+                    const result = that.activity.logo.synth.getCustomFrequency(
+                        noteWithOctave,
+                        customID
+                    );
+                    if (typeof result === "number" && !isNaN(result)) {
+                        freq = result;
+                    }
+                }
+
+                if (freq !== null && typeof freq === "number" && !isNaN(freq)) {
+                    // Play the frequency directly via synth.trigger
+                    await that.activity.logo.synth.trigger(
+                        0,
+                        freq,
+                        1 / 8,
+                        DEFAULTVOICE,
+                        null,
+                        null,
+                        false
+                    );
+                }
+            } catch (e) {
+                console.error("Error in custom pitch preview:", e);
             }
         }
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -413,7 +413,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - halfWheelSize
             )
         ) + "px";
@@ -424,7 +424,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - halfWheelSize
             )
         ) + "px";
@@ -488,8 +488,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (block.name === "notename" &&
                 (block.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
-                        block.blocks.blockList[block.connections[0]].name
-                    )
+                          block.blocks.blockList[block.connections[0]].name
+                      )
                     : true)))
     ) {
         if (scale[6 - i][0] === FIXEDSOLFEGE[note] || scale[6 - i][0] === note) {
@@ -724,8 +724,8 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             (that.name === "notename" &&
                 (that.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
-                        that.blocks.blockList[that.connections[0]].name
-                    )
+                          that.blocks.blockList[that.connections[0]].name
+                      )
                     : true))
         ) {
             let i = scale.indexOf(selection["note"]);
@@ -1120,7 +1120,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1131,7 +1131,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -1258,10 +1258,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
             const customID = that.customID || label;
             // Pass note + octave directly to getCustomFrequency (bypass getNote
             // which cannot parse custom note names like "C(+0¢)").
-            const no = that.activity.logo.synth.getCustomFrequency(
-                [note + octave],
-                customID
-            );
+            const no = that.activity.logo.synth.getCustomFrequency([note + octave], customID);
             if (no !== undefined && no !== "undefined") {
                 instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
             }
@@ -1654,7 +1651,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -1665,7 +1662,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2588,7 +2585,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2599,7 +2596,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2702,7 +2699,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2713,7 +2710,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -2837,7 +2834,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -2848,7 +2845,7 @@ const piemenuChords = (block, selectedChord) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3028,7 +3025,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3039,7 +3036,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3174,7 +3171,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3185,7 +3182,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -3636,18 +3633,15 @@ const piemenuModes = (block, selectedMode) => {
         docById("wheelnav-_exitWheel-title-1").style.fill = platformColor.textColor || "#ffffff";
         docById("wheelnav-_exitWheel-title-1").style.pointerEvents = "none";
         docById("wheelnav-_exitWheel-slice-1").style.pointerEvents = "none";
-        setTimeout(
-            () => {
-                const playButtonTitle = docById("wheelnav-_exitWheel-title-1");
-                const playButtonSlice = docById("wheelnav-_exitWheel-slice-1");
-                if (playButtonTitle && playButtonSlice) {
-                    playButtonTitle.style.fill = platformColor.textColor || "#000000";
-                    playButtonTitle.style.pointerEvents = "auto";
-                    playButtonSlice.style.pointerEvents = "auto";
-                }
-            },
-            (20 * 1000) / 10
-        );
+        setTimeout(() => {
+            const playButtonTitle = docById("wheelnav-_exitWheel-title-1");
+            const playButtonSlice = docById("wheelnav-_exitWheel-slice-1");
+            if (playButtonTitle && playButtonSlice) {
+                playButtonTitle.style.fill = platformColor.textColor || "#000000";
+                playButtonTitle.style.pointerEvents = "auto";
+                playButtonSlice.style.pointerEvents = "auto";
+            }
+        }, (20 * 1000) / 10);
 
         __playScale(activeTabs, 0);
     };
@@ -3670,7 +3664,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (x + block.activity.blocksContainer.x) * block.activity.getStageScale() +
-                    canvasLeft
+                        canvasLeft
                 ) - 200
             )
         ) + "px";
@@ -3681,7 +3675,7 @@ const piemenuModes = (block, selectedMode) => {
                 0,
                 Math.round(
                     (y + block.activity.blocksContainer.y) * block.activity.getStageScale() +
-                    canvasTop
+                        canvasTop
                 ) - 200
             )
         ) + "px";
@@ -4240,9 +4234,9 @@ const piemenuKey = activity => {
                         activity.KeySignatureEnv[1];
                     activity.textMsg(
                         _("You have chosen key for your pitch preview.") +
-                        activity.KeySignatureEnv[0] +
-                        " " +
-                        activity.KeySignatureEnv[1]
+                            activity.KeySignatureEnv[0] +
+                            " " +
+                            activity.KeySignatureEnv[1]
                     );
                 }
             }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -782,7 +782,7 @@ function Synth() {
 
                 // Fallback: handle pitch-index keys (e.g., "0", "1")
                 // for equal-style temperament data where entries are
-                // plain numbers (ratios) instead of [ratio, name, octave] arrays.
+                // plain number (ratios) instead of [ratio, name, octave] arrays.
                 if (thisTemperament[oneNote] !== undefined) {
                     const entry = thisTemperament[oneNote];
                     const ratio = typeof entry === "number" ? entry : entry[0];

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -773,8 +773,8 @@ function Synth() {
                             const octaveDiff = octave - thisTemperament[pitchNumber][2];
                             return Number(
                                 thisTemperament[pitchNumber][0] *
-                                startPitchFrequency *
-                                Math.pow(getOctaveRatio(), octaveDiff)
+                                    startPitchFrequency *
+                                    Math.pow(getOctaveRatio(), octaveDiff)
                             );
                         }
                     }
@@ -2840,10 +2840,10 @@ function Synth() {
                                 // Prepare a non-mutating activity proxy with a local logo fallback
                                 const defaultLogo = {
                                     synth: {
-                                        createDefaultSynth: () => { },
-                                        loadSynth: () => { },
-                                        setMasterVolume: () => { },
-                                        trigger: () => { },
+                                        createDefaultSynth: () => {},
+                                        loadSynth: () => {},
+                                        setMasterVolume: () => {},
+                                        trigger: () => {},
                                         inTemperament: "equal"
                                     },
                                     errorMsg: msg => {
@@ -2874,7 +2874,7 @@ function Synth() {
                                             }
                                         ],
                                         stageClick: false,
-                                        setPitchOctave: () => { },
+                                        setPitchOctave: () => {},
                                         findPitchOctave: () => 4,
                                         turtles: {
                                             _canvas: {
@@ -2891,7 +2891,7 @@ function Synth() {
                                     connections: [0], // Connect to the pitch block
                                     value: targetPitch.note,
                                     text: { text: targetPitch.note },
-                                    updateCache: () => { },
+                                    updateCache: () => {},
                                     _exitWheel: null,
                                     _pitchWheel: null,
                                     _accidentalsWheel: null,
@@ -2901,7 +2901,7 @@ function Synth() {
                                     container: {
                                         x: targetNoteSelector.offsetLeft,
                                         y: targetNoteSelector.offsetTop,
-                                        setChildIndex: () => { }
+                                        setChildIndex: () => {}
                                     },
                                     prevAccidental: "♮",
                                     name: "pitch", // This is needed for pitch preview
@@ -3361,7 +3361,7 @@ function Synth() {
                             const shouldLight =
                                 centsFromTarget < 0
                                     ? segmentCents <= 0 &&
-                                    Math.abs(segmentCents) <= Math.abs(centsFromTarget) // Flat side
+                                      Math.abs(segmentCents) <= Math.abs(centsFromTarget) // Flat side
                                     : segmentCents >= 0 && segmentCents <= centsFromTarget; // Sharp side
 
                             if (shouldLight || Math.abs(centsFromTarget - segmentCents) <= 5) {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -773,11 +773,24 @@ function Synth() {
                             const octaveDiff = octave - thisTemperament[pitchNumber][2];
                             return Number(
                                 thisTemperament[pitchNumber][0] *
-                                    startPitchFrequency *
-                                    Math.pow(getOctaveRatio(), octaveDiff)
+                                startPitchFrequency *
+                                Math.pow(getOctaveRatio(), octaveDiff)
                             );
                         }
                     }
+                }
+
+                // Fallback: handle pitch-index keys (e.g., "0", "1")
+                // for equal-style temperament data where entries are
+                // plain numbers (ratios) instead of [ratio, name, octave] arrays.
+                if (thisTemperament[oneNote] !== undefined) {
+                    const entry = thisTemperament[oneNote];
+                    const ratio = typeof entry === "number" ? entry : entry[0];
+                    const entryOctave = typeof entry === "number" ? 4 : Number(entry[2]);
+                    const octaveDiff = octave - entryOctave;
+                    return Number(
+                        ratio * startPitchFrequency * Math.pow(getOctaveRatio(), octaveDiff)
+                    );
                 }
             }
             return oneNote;
@@ -2830,10 +2843,10 @@ function Synth() {
                                 // Prepare a non-mutating activity proxy with a local logo fallback
                                 const defaultLogo = {
                                     synth: {
-                                        createDefaultSynth: () => {},
-                                        loadSynth: () => {},
-                                        setMasterVolume: () => {},
-                                        trigger: () => {},
+                                        createDefaultSynth: () => { },
+                                        loadSynth: () => { },
+                                        setMasterVolume: () => { },
+                                        trigger: () => { },
                                         inTemperament: "equal"
                                     },
                                     errorMsg: msg => {
@@ -2864,7 +2877,7 @@ function Synth() {
                                             }
                                         ],
                                         stageClick: false,
-                                        setPitchOctave: () => {},
+                                        setPitchOctave: () => { },
                                         findPitchOctave: () => 4,
                                         turtles: {
                                             _canvas: {
@@ -2881,7 +2894,7 @@ function Synth() {
                                     connections: [0], // Connect to the pitch block
                                     value: targetPitch.note,
                                     text: { text: targetPitch.note },
-                                    updateCache: () => {},
+                                    updateCache: () => { },
                                     _exitWheel: null,
                                     _pitchWheel: null,
                                     _accidentalsWheel: null,
@@ -2891,7 +2904,7 @@ function Synth() {
                                     container: {
                                         x: targetNoteSelector.offsetLeft,
                                         y: targetNoteSelector.offsetTop,
-                                        setChildIndex: () => {}
+                                        setChildIndex: () => { }
                                     },
                                     prevAccidental: "♮",
                                     name: "pitch", // This is needed for pitch preview
@@ -3351,7 +3364,7 @@ function Synth() {
                             const shouldLight =
                                 centsFromTarget < 0
                                     ? segmentCents <= 0 &&
-                                      Math.abs(segmentCents) <= Math.abs(centsFromTarget) // Flat side
+                                    Math.abs(segmentCents) <= Math.abs(centsFromTarget) // Flat side
                                     : segmentCents >= 0 && segmentCents <= centsFromTarget; // Sharp side
 
                             if (shouldLight || Math.abs(centsFromTarget - segmentCents) <= 5) {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1968,30 +1968,27 @@ function Synth() {
                 // A 500 ms safety buffer is added beyond the note duration to prevent
                 // premature disposal caused by audio-clock drift or scheduler jitter,
                 // which would otherwise produce crackling artefacts in long sessions.
-                setTimeout(
-                    () => {
-                        try {
-                            // Dispose of effects
-                            effectsToDispose.forEach(effect => {
-                                if (effect && typeof effect.dispose === "function") {
-                                    effect.dispose();
+                setTimeout(() => {
+                    try {
+                        // Dispose of effects
+                        effectsToDispose.forEach(effect => {
+                            if (effect && typeof effect.dispose === "function") {
+                                effect.dispose();
+                            }
+                        });
+
+                        // Dispose of filters
+                        if (temp_filters.length > 0) {
+                            temp_filters.forEach(filter => {
+                                if (filter && typeof filter.dispose === "function") {
+                                    filter.dispose();
                                 }
                             });
-
-                            // Dispose of filters
-                            if (temp_filters.length > 0) {
-                                temp_filters.forEach(filter => {
-                                    if (filter && typeof filter.dispose === "function") {
-                                        filter.dispose();
-                                    }
-                                });
-                            }
-                        } catch (e) {
-                            console.debug("Error disposing effects:", e);
                         }
-                    },
-                    beatValue * 1000 + 500
-                );
+                    } catch (e) {
+                        console.debug("Error disposing effects:", e);
+                    }
+                }, beatValue * 1000 + 500);
             }
         } catch (e) {
             console.error("Error in _performNotes:", e);


### PR DESCRIPTION
## Description

This PR fully addresses **#4724** — fixing both issues with Custom Pitch Blocks:

1. **Identity Loss:** Custom Pitch Blocks were reverting to regular Pitch Blocks when dragged from the palette.
2. **Missing Preview Sound:** Clicking on notes in the Custom Pitch Block's pie menu produced static noise or silence instead of a pitch preview.

## Root Cause

### Identity Loss ([js/blocks.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/blocks.js:0:0-0:0))

The switch statement that handles block replacement when dragging from the palette had no `case` for `"customNote"`. Without it, custom pitch blocks fell through to the default behavior and were replaced with regular pitch blocks.

### Missing Preview Sound ([js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0) + [js/utils/synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0))

The [__selectionChanged](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:2028:4-2035:6) handler in [piemenuCustomNotes](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:913:0-1262:2) ([js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0)) had two problems:

1. **No audio context initialization** — `Tone.start()` was never called. Modern browsers require this after user interaction before audio can play.

2. **[getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1) can't parse custom note names** — Custom notes like [C(+0¢)](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/block.js:2025:4-2031:5) were passed through [getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1), which only understands standard note names (C, D, E...), producing invalid output that caused the frequency lookup to fail.

Additionally, [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6) in [synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0) could not handle **pitch-index labels** (e.g., `"0"`, `"1"`) — when custom temperament data stores entries as plain ratio numbers instead of `[ratio, name, octave]` arrays, the function failed to find a match and returned a string instead of a frequency.

## Changes

### [js/blocks.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/blocks.js:0:0-0:0)
- Added `case "customNote"` to the block replacement switch statement so Custom Pitch Blocks retain their identity when dragged from the palette.

### [js/utils/synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0) — [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6)
- Added a fallback after the existing note-name matching loop: when no match is found, it checks if the note is a **pitch-index key** (e.g., `"0"`) in the temperament data and computes the frequency directly from the ratio.

### [js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0) — `piemenuCustomNotes.__selectionChanged()`
- Made the handler `async` and added `Tone.start()` for proper audio context initialization.
- Replaced [getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1) (which can't parse custom note names) with direct `note + octave` passed to [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6).

## Testing

- All existing tests pass (3861 tests, 123 suites)
- Manually verified:
  - Custom Pitch Blocks retain their identity when dragged from the palette
  - Pie menu plays clean preview sounds for both regular and Define Temperament workflows

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
