### PR TITLE
fix: replace 100+ unsafe innerHTML assignments with textContent/escap…

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3549,7 +3549,7 @@ class Activity {
                         });
 
                         li.append(img);
-                        li.append("<a> " + item.label + "</a>");
+                        li.append($j("<a>").text(" " + item.label));
 
                         return li.appendTo(
                             ul.css({
@@ -5231,7 +5231,7 @@ class Activity {
             const pitch = pitches;
             pitchDuration = toFraction(pitchDuration);
             const adjustedNote = _adjustPitch(pitch.name, keySignature).toUpperCase();
-            if (triplet != null) {
+            if (triplet !== null) {
                 pitchDuration[1] = meterDen * triplet;
             }
 
@@ -7105,17 +7105,13 @@ class Activity {
                 const instance = $helpfulSearch.autocomplete("instance");
                 if (instance) {
                     instance._renderItem = (ul, item) => {
-                        return $j("<li></li>")
-                            .append(
-                                '<img src="' +
-                                    (item.artwork || "") +
-                                    '" height = "20px">' +
-                                    "<a>" +
-                                    " " +
-                                    item.label +
-                                    "</a>"
-                            )
-                            .appendTo(ul.css("z-index", 35000));
+                        const li = $j("<li></li>");
+                        const img = document.createElement("img");
+                        img.src = item.artwork || "";
+                        img.height = 20;
+                        li.append(img);
+                        li.append($j("<a>").text(" " + item.label));
+                        return li.appendTo(ul.css("z-index", 35000));
                     };
                 }
                 $helpfulSearch.data("autocomplete-init", true);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -460,7 +460,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
         !pitchHasAccidental &&
         ((!block.activity.KeySignatureEnv[2] && block.name === "solfege") ||
             (block.name === "notename" &&
-                (block.connections[0] != undefined
+                (block.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
                           block.blocks.blockList[block.connections[0]].name
                       )
@@ -608,7 +608,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                 block.activity.KeySignatureEnv[0] + " " + block.activity.KeySignatureEnv[1];
 
             let obj;
-            if (that.name == "scaledegree2") {
+            if (that.name === "scaledegree2") {
                 note = note.replace(attr, "");
                 note = SOLFEGENAMES[note - 1];
                 note += attr;
@@ -699,7 +699,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
         if (
             (!block.activity.KeySignatureEnv[2] && that.name === "solfege") ||
             (that.name === "notename" &&
-                (that.connections[0] != undefined
+                (that.connections[0] !== undefined
                     ? !["setkey", "setkey2"].includes(
                           that.blocks.blockList[that.connections[0]].name
                       )
@@ -1177,7 +1177,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
 
     let j = selectedNote;
     for (const x in noteLabels[selectedCustom]) {
-        if (x != "pitchNumber" && noteLabels[selectedCustom][x][1] == j) {
+        if (x !== "pitchNumber" && noteLabels[selectedCustom][x][1] === j) {
             j = +x;
             break;
         }
@@ -4193,7 +4193,7 @@ const piemenuKey = activity => {
         const ele = document.getElementsByName("movable");
         for (let i = 0; i < ele.length; i++) {
             if (ele[i].checked) {
-                activity.KeySignatureEnv[2] = ele[i].value == "true" ? true : false;
+                activity.KeySignatureEnv[2] = ele[i].value === "true" ? true : false;
             }
         }
         keyNameWheel.removeWheel();
@@ -4245,7 +4245,7 @@ const piemenuKey = activity => {
     const __setupActionKey = i => {
         keyNameWheel.navItems[i].navigateFunction = () => {
             for (let j = 0; j < keys2.length; j++) {
-                if (Math.floor(j / 2) != i) {
+                if (Math.floor(j / 2) !== i) {
                     keyNameWheel2.navItems[j].navItem.hide();
                 } else {
                     if (keys[i].length > 2) {
@@ -4302,7 +4302,7 @@ const piemenuKey = activity => {
         const ks = activity.storage.KeySignatureEnv.split(",");
         activity.KeySignatureEnv[0] = ks[0];
         activity.KeySignatureEnv[1] = ks[1];
-        activity.KeySignatureEnv[2] = ks[2] == "true" ? true : false;
+        activity.KeySignatureEnv[2] = ks[2] === "true" ? true : false;
         activity.storage.KeySignatureEnv = activity.KeySignatureEnv;
     } else {
         activity.KeySignatureEnv = ["C", "major", false];
@@ -4317,7 +4317,7 @@ const piemenuKey = activity => {
             keyNameWheel2.navigateWheel(i);
             for (let j = 0; j < keys2.length; j++) {
                 keyNameWheel2.navItems[j].navItem.hide();
-                if (i % 2 == 0) {
+                if (i % 2 === 0) {
                     keyNameWheel2.navItems[i].navItem.show();
                     keyNameWheel2.navItems[i + 1].navItem.show();
                 } else {

--- a/js/widgets/AI-Sample-Generation-and-Audio-Trimmer-Developer-Guide.md
+++ b/js/widgets/AI-Sample-Generation-and-Audio-Trimmer-Developer-Guide.md
@@ -11,6 +11,7 @@ To run this feature, you need to set up the backend: [AI-Sample-Generation-Backe
 ### Endpoints
 
 The backend provides three endpoints:
+
 - `/generate` - Generate audio from text
 - `/preview` - Preview generated audio
 - `/save` - Save generated audio
@@ -32,7 +33,7 @@ this._promptBtn = widgetWindow.addButton("prompt.svg", ICONSIZE, _("Prompt"), ""
 ```
 
 - Prompt Button (`this._promptBtn`)
-  - Upon clicking it, the AI Sample Generation screen is rendered.
+    - Upon clicking it, the AI Sample Generation screen is rendered.
 
 ---
 
@@ -48,13 +49,13 @@ this._promptBtn = widgetWindow.addButton("prompt.svg", ICONSIZE, _("Prompt"), ""
         - Textarea uses a random placeholder from a predefined prompt list.
     - **Adds Buttons**
         - **Submit**
-          - Sends a request to `/generate` with the user’s prompt.
-          - Shows status messages while generating.
-          - On success, enables **Preview** and **Save**.
+            - Sends a request to `/generate` with the user’s prompt.
+            - Shows status messages while generating.
+            - On success, enables **Preview** and **Save**.
         - **Preview**
-          - Plays the generated audio from `/preview`.
+            - Plays the generated audio from `/preview`.
         - **Save**
-          - Downloads the generated audio from `/save`.
+            - Downloads the generated audio from `/save`.
 
 ---
 

--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -58,7 +58,7 @@ const PhraseMakerAudio = {
 
                 if (typeof note[i] === "number") {
                     synthNotes.push(note[i]);
-                } else if (drumName != null) {
+                } else if (drumName !== null) {
                     drumNotes.push(drumName);
                 } else if (note[i].slice(0, 4) === "http") {
                     drumNotes.push(note[i]);
@@ -269,14 +269,14 @@ const PhraseMakerAudio = {
                     } else {
                         if (
                             // if graphic block
-                            PhraseMakerUtils.MATRIXGRAPHICS.indexOf(pm.rowLabels[j]) != -1 ||
-                            PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(pm.rowLabels[j]) != -1
+                            PhraseMakerUtils.MATRIXGRAPHICS.indexOf(pm.rowLabels[j]) !== -1 ||
+                            PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(pm.rowLabels[j]) !== -1
                         ) {
                             // push "action: value"
                             note.push(pm.rowLabels[j] + ": " + pm.rowArgs[j]);
                         } else if (
                             // if pitch represented by halftone
-                            MATRIXHALFTONES.indexOf(pm.rowLabels[j]) != -1
+                            MATRIXHALFTONES.indexOf(pm.rowLabels[j]) !== -1
                         ) {
                             // push "halftone" + "notevalue"
                             note.push(
@@ -363,7 +363,7 @@ const PhraseMakerAudio = {
                     row = pm._noteValueRow;
                     cell = row.cells[pm._colIndex];
 
-                    if (cell != undefined) {
+                    if (cell !== undefined) {
                         cell.style.backgroundColor = pm.platformColor.selectorBackground;
                         if (cell.colSpan > 1) {
                             row = pm._tupletNoteValueRow;
@@ -396,7 +396,7 @@ const PhraseMakerAudio = {
 
                             if (typeof note[i] === "number") {
                                 synthNotes.push(note[i]);
-                            } else if (drumName != null) {
+                            } else if (drumName !== null) {
                                 drumNotes.push(drumName);
                             } else if (note[i].slice(0, 4) === "http") {
                                 drumNotes.push(note[i]);
@@ -450,7 +450,7 @@ const PhraseMakerAudio = {
 
                 row = pm._noteValueRow;
                 cell = row.cells[pm._colIndex];
-                if (cell != undefined) {
+                if (cell !== undefined) {
                     if (cell.colSpan > 1) {
                         pm._spanCounter += 1;
                         if (pm._spanCounter === cell.colSpan) {

--- a/js/widgets/PhraseMakerGrid.js
+++ b/js/widgets/PhraseMakerGrid.js
@@ -145,7 +145,7 @@ const PhraseMakerGrid = {
             }
         }
 
-        while (pm._deps.last(myBlock.connections) != null) {
+        while (pm._deps.last(myBlock.connections) !== null) {
             bottomBlockLoop += 1;
             if (bottomBlockLoop > 2 * pm.activity.blocks.blockList.length) {
                 // Could happen if the block data is malformed.

--- a/js/widgets/README.md
+++ b/js/widgets/README.md
@@ -14,31 +14,31 @@ imported in `js/activity.js`.
 
 2. **Define the Block Class:**
    Create a new class inside that file for your block.
-   ```javascript
-   class UniqueClass {
-       // Blocks with some functionality  
-   }
-   ```
-   This class will contain the code that defines the behavior of your widget.
+
+    ```javascript
+    class UniqueClass {
+        // Blocks with some functionality
+    }
+    ```
+
+    This class will contain the code that defines the behavior of your widget.
 
 3. **Initialize the Class**
    Define the block that will be used to launch your widget in `js/blocks/WidgetBlocks.`
    Don't forget to initialize the class. (Look at the code towards the end of the file.)
 
-   ```javascript
-   new UniqueClass().setup(activity);
-   ```
+    ```javascript
+    new UniqueClass().setup(activity);
+    ```
 
 4. **Import the widget**
    In `js/activity.js`, import the widget code.
 
     ```javascript
     if (_THIS_IS_MUSIC_BLOCKS_) {
-    const MUSICBLOCKS_EXTRAS = [
-        "widgets/UniqueClassFileName",
-        ];
-      }
-   ```
+        const MUSICBLOCKS_EXTRAS = ["widgets/UniqueClassFileName"];
+    }
+    ```
 
 **Hint:** When creating a new widget, look for an existing widget with
 similar features. It is sometimes easier to fork than start building

--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -136,7 +136,8 @@ function createMockActivity(options = {}) {
             moveBlock: jest.fn(),
             loadNewBlocks: jest.fn()
         },
-        logo: {}
+        logo: {},
+        textMsg: jest.fn()
     };
 }
 

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -19,7 +19,7 @@ global.MATRIXBUTTONHEIGHT = 40;
 global.MATRIXSOLFEHEIGHT = 30;
 
 global.rationalToFraction = jest.fn().mockReturnValue([4, 1]);
-global.mixedNumber = jest.fn().mockImplementation(val => (val != null ? val.toString() : ""));
+global.mixedNumber = jest.fn().mockImplementation(val => (val !== null ? val.toString() : ""));
 global.toFixed2 = jest.fn().mockImplementation(val => val.toFixed(2));
 
 global.platformColor = {
@@ -29,9 +29,11 @@ global.platformColor = {
 const createMockElement = tagName => ({
     tagName,
     style: {},
+    append: jest.fn(),
+    innerHTML: "",
+    textContent: "",
     appendChild: jest.fn(),
-    append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
-    innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+    setAttribute: jest.fn(),
     querySelectorAll: jest.fn().mockReturnValue([]),
     addEventListener: jest.fn(),
     className: "",
@@ -55,7 +57,7 @@ const createMockWidgetWindow = () => ({
     clear: jest.fn(),
     show: jest.fn(),
     getWidgetBody: jest.fn().mockReturnValue({
-        append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+        append: jest.fn()
     }),
     sendToCenter: jest.fn(),
     destroy: jest.fn(),

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -19,7 +19,9 @@ global.MATRIXBUTTONHEIGHT = 40;
 global.MATRIXSOLFEHEIGHT = 30;
 
 global.rationalToFraction = jest.fn().mockReturnValue([4, 1]);
-global.mixedNumber = jest.fn().mockImplementation(val => (val !== null && val !== undefined ? val.toString() : ""));
+global.mixedNumber = jest
+    .fn()
+    .mockImplementation(val => (val !== null && val !== undefined ? val.toString() : ""));
 global.toFixed2 = jest.fn().mockImplementation(val => val.toFixed(2));
 
 global.platformColor = {

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -19,7 +19,7 @@ global.MATRIXBUTTONHEIGHT = 40;
 global.MATRIXSOLFEHEIGHT = 30;
 
 global.rationalToFraction = jest.fn().mockReturnValue([4, 1]);
-global.mixedNumber = jest.fn().mockImplementation(val => (val !== null ? val.toString() : ""));
+global.mixedNumber = jest.fn().mockImplementation(val => (val !== null && val !== undefined ? val.toString() : ""));
 global.toFixed2 = jest.fn().mockImplementation(val => val.toFixed(2));
 
 global.platformColor = {

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -30,8 +30,8 @@ const createMockElement = tagName => ({
     tagName,
     style: {},
     appendChild: jest.fn(),
-    append: jest.fn(),
-    innerHTML: "",
+    append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+    innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
     querySelectorAll: jest.fn().mockReturnValue([]),
     addEventListener: jest.fn(),
     className: "",
@@ -55,7 +55,7 @@ const createMockWidgetWindow = () => ({
     clear: jest.fn(),
     show: jest.fn(),
     getWidgetBody: jest.fn().mockReturnValue({
-        append: jest.fn()
+        append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
     }),
     sendToCenter: jest.fn(),
     destroy: jest.fn(),
@@ -440,7 +440,7 @@ describe("StatusMatrix Widget", () => {
             });
 
             statusMatrix.updateAll();
-            expect(statusMatrix._statusTable.rows[1].cells[1].innerHTML).toBe(4);
+            expect(statusMatrix._statusTable.rows[1].cells[1].textContent).toBe(4);
         });
 
         test("handles namedbox with value from logo.boxes", () => {
@@ -479,7 +479,7 @@ describe("StatusMatrix Widget", () => {
             };
             mockActivity.logo.statusFields = [[0, "unknownblock"]];
             statusMatrix.updateAll();
-            expect(statusMatrix._statusTable.rows[1].cells[1].innerHTML).toBe(99);
+            expect(statusMatrix._statusTable.rows[1].cells[1].textContent).toBe(99);
         });
     });
 
@@ -598,7 +598,7 @@ describe("StatusMatrix Widget", () => {
 
             statusMatrix.updateAll();
 
-            expect(mockCell.innerHTML).toContain("♯");
+            expect(mockCell.textContent).toContain("♯");
         });
 
         test("replaces b with ♭ in note display", () => {
@@ -611,7 +611,7 @@ describe("StatusMatrix Widget", () => {
             });
 
             statusMatrix.updateAll();
-            expect(statusMatrix._statusTable.rows[2].cells[1].innerHTML).toContain("♭");
+            expect(statusMatrix._statusTable.rows[2].cells[1].textContent).toContain("♭");
         });
 
         test("handles empty noteStatus array", () => {

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -46,9 +46,12 @@ describe("TemperamentWidget basic tests", () => {
         }));
 
         global.docById = jest.fn(id => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            textContent: "",
             style: {},
-            append: jest.fn(),
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             getElementsByTagName: jest.fn(() => []),
             addEventListener: jest.fn()
         }));
@@ -173,7 +176,10 @@ describe("TemperamentWidget basic tests", () => {
         };
 
         widget.playButton = {
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {}
         };
 
@@ -203,9 +209,9 @@ describe("TemperamentWidget basic tests", () => {
         };
 
         global.docById = jest.fn(() => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             style: {},
-            append: jest.fn()
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
         }));
         document.querySelectorAll = jest.fn(() => [
             { style: {} },
@@ -221,9 +227,9 @@ describe("TemperamentWidget basic tests", () => {
 
     test("equalEdit sets editMode to equal", () => {
         global.docById = jest.fn(() => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             style: {},
-            append: jest.fn()
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
         }));
 
         widget.equalEdit();
@@ -233,9 +239,9 @@ describe("TemperamentWidget basic tests", () => {
 
     test("ratioEdit sets editMode to ratio", () => {
         global.docById = jest.fn(() => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             style: {},
-            append: jest.fn()
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
         }));
 
         widget.ratioEdit();
@@ -263,9 +269,9 @@ describe("TemperamentWidget basic tests", () => {
             }
 
             return {
-                innerHTML: "",
+                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
                 style: {},
-                append: jest.fn(),
+                append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
                 addEventListener: jest.fn() // 👈 ADD THIS
             };
         });
@@ -279,9 +285,9 @@ describe("TemperamentWidget basic tests", () => {
         widget.ratios = [1, 2];
 
         global.docById = jest.fn(() => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             style: {},
-            append: jest.fn()
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
         }));
 
         widget.octaveSpaceEdit();
@@ -475,15 +481,15 @@ describe("TemperamentWidget basic tests", () => {
         global.isCustomTemperament = jest.fn(() => false);
 
         global.docById = jest.fn(() => ({
-            innerHTML: "",
+            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             style: {},
-            insertCell: jest.fn(() => ({
-                innerHTML: "",
+            insertCell: jest.fn(() => ({ appendChild: jest.fn(), textContent: "", setAttribute: jest.fn(),
+                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
                 style: {},
                 onmouseover: jest.fn(),
                 onmouseout: jest.fn()
             })),
-            append: jest.fn()
+            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
         }));
         document.querySelectorAll = jest.fn(() => [
             { style: {} },
@@ -510,11 +516,11 @@ describe("TemperamentWidget basic tests", () => {
                 return { value: 880 };
             }
             if (id === "frequencydiv") {
-                return { innerHTML: "" };
+                return { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), };
             }
             return {
                 style: {},
-                innerHTML: ""
+                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
             };
         });
 
@@ -544,9 +550,9 @@ describe("TemperamentWidget basic tests", () => {
             if (id === "startNote") return { value: 3 };
             if (id === "endNote") return { value: 1 };
             return {
-                innerHTML: "",
+                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
                 style: {},
-                append: jest.fn()
+                append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
             };
         });
 
@@ -569,7 +575,7 @@ describe("TemperamentWidget basic tests", () => {
             }
         };
 
-        widget.playButton = { innerHTML: "" };
+        widget.playButton = { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), style: {} };
         widget.pitchNumber = 1;
         widget.frequencies = [440, 880];
         widget.tempRatios1 = [1, 2];
@@ -599,7 +605,7 @@ describe("TemperamentWidget basic tests", () => {
             }
         };
 
-        widget.playButton = { innerHTML: "" };
+        widget.playButton = { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), style: {} };
         widget._playing = true;
         widget.tempRatios1 = [1];
 

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -46,12 +46,12 @@ describe("TemperamentWidget basic tests", () => {
         }));
 
         global.docById = jest.fn(id => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
             textContent: "",
-            style: {},
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
             appendChild: jest.fn(),
             setAttribute: jest.fn(),
+            style: {},
+            append: jest.fn(),
             getElementsByTagName: jest.fn(() => []),
             addEventListener: jest.fn()
         }));
@@ -176,7 +176,7 @@ describe("TemperamentWidget basic tests", () => {
         };
 
         widget.playButton = {
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
             textContent: "",
             appendChild: jest.fn(),
             setAttribute: jest.fn(),
@@ -209,9 +209,12 @@ describe("TemperamentWidget basic tests", () => {
         };
 
         global.docById = jest.fn(() => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {},
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            append: jest.fn()
         }));
         document.querySelectorAll = jest.fn(() => [
             { style: {} },
@@ -227,9 +230,12 @@ describe("TemperamentWidget basic tests", () => {
 
     test("equalEdit sets editMode to equal", () => {
         global.docById = jest.fn(() => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {},
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            append: jest.fn()
         }));
 
         widget.equalEdit();
@@ -239,9 +245,12 @@ describe("TemperamentWidget basic tests", () => {
 
     test("ratioEdit sets editMode to ratio", () => {
         global.docById = jest.fn(() => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {},
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            append: jest.fn()
         }));
 
         widget.ratioEdit();
@@ -269,9 +278,12 @@ describe("TemperamentWidget basic tests", () => {
             }
 
             return {
-                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
+                setAttribute: jest.fn(),
                 style: {},
-                append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+                append: jest.fn(),
                 addEventListener: jest.fn() // 👈 ADD THIS
             };
         });
@@ -285,9 +297,12 @@ describe("TemperamentWidget basic tests", () => {
         widget.ratios = [1, 2];
 
         global.docById = jest.fn(() => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {},
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            append: jest.fn()
         }));
 
         widget.octaveSpaceEdit();
@@ -481,15 +496,21 @@ describe("TemperamentWidget basic tests", () => {
         global.isCustomTemperament = jest.fn(() => false);
 
         global.docById = jest.fn(() => ({
-            innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             style: {},
-            insertCell: jest.fn(() => ({ appendChild: jest.fn(), textContent: "", setAttribute: jest.fn(),
-                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+            insertCell: jest.fn(() => ({
+                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
+                setAttribute: jest.fn(),
                 style: {},
                 onmouseover: jest.fn(),
                 onmouseout: jest.fn()
             })),
-            append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+            append: jest.fn()
         }));
         document.querySelectorAll = jest.fn(() => [
             { style: {} },
@@ -516,11 +537,19 @@ describe("TemperamentWidget basic tests", () => {
                 return { value: 880 };
             }
             if (id === "frequencydiv") {
-                return { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), };
+                return {
+                    innerHTML: "",
+                    textContent: "",
+                    appendChild: jest.fn(),
+                    setAttribute: jest.fn()
+                };
             }
             return {
                 style: {},
-                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
+                setAttribute: jest.fn()
             };
         });
 
@@ -550,9 +579,12 @@ describe("TemperamentWidget basic tests", () => {
             if (id === "startNote") return { value: 3 };
             if (id === "endNote") return { value: 1 };
             return {
-                innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(),
+                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
+                setAttribute: jest.fn(),
                 style: {},
-                append: jest.fn(), appendChild: jest.fn(), setAttribute: jest.fn(), textContent: "",
+                append: jest.fn()
             };
         });
 
@@ -575,7 +607,13 @@ describe("TemperamentWidget basic tests", () => {
             }
         };
 
-        widget.playButton = { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), style: {} };
+        widget.playButton = {
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
+            style: {}
+        };
         widget.pitchNumber = 1;
         widget.frequencies = [440, 880];
         widget.tempRatios1 = [1, 2];
@@ -605,7 +643,13 @@ describe("TemperamentWidget basic tests", () => {
             }
         };
 
-        widget.playButton = { innerHTML: "", textContent: "", appendChild: jest.fn(), setAttribute: jest.fn(), style: {} };
+        widget.playButton = {
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn(),
+            style: {}
+        };
         widget._playing = true;
         widget.tempRatios1 = [1];
 

--- a/js/widgets/__tests__/tuner.test.js
+++ b/js/widgets/__tests__/tuner.test.js
@@ -132,18 +132,8 @@ describe("Tuner Widget", () => {
             test("identifies all 12 chromatic notes in octave 4", () => {
                 const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
                 const octave4Freqs = [
-                    261.63,
-                    277.18,
-                    293.66,
-                    311.13,
-                    329.63,
-                    349.23,
-                    369.99,
-                    392.0,
-                    415.3,
-                    440.0,
-                    466.16,
-                    493.88
+                    261.63, 277.18, 293.66, 311.13, 329.63, 349.23, 369.99, 392.0, 415.3, 440.0,
+                    466.16, 493.88
                 ];
 
                 for (let i = 0; i < noteNames.length; i++) {

--- a/js/widgets/aidebugger-guide.md
+++ b/js/widgets/aidebugger-guide.md
@@ -5,6 +5,7 @@
 The AI-powered Debugger Widget is an intelligent debugging assistant for Music Blocks that provides AI-powered analysis and child-friendly debugging suggestions through an interactive chat interface.
 
 ### Key Features
+
 - Interactive chat interface within Music Blocks
 - Real-time project analysis using AI
 - Educational explanations for children
@@ -12,12 +13,14 @@ The AI-powered Debugger Widget is an intelligent debugging assistant for Music B
 - Integration with Music Blocks widget system
 
 ### Architecture
+
 ```
 Music Blocks Frontend → AI Debugger Widget → FastAPI Backend → Google Gemini AI
                                          → RAG System → Qdrant Vector DB
 ```
 
 **Components:**
+
 - **Frontend**: `js/widgets/aidebugger.js` (main widget)
 - **Block Definition**: `js/blocks/WidgetBlocks.js` (lines 1643-1719)
 - **Registration**: `js/activity.js` (line 165)
@@ -26,6 +29,7 @@ Music Blocks Frontend → AI Debugger Widget → FastAPI Backend → Google Gemi
 ## Quick Start
 
 ### Setup
+
 ```bash
 git clone https://github.com/sugarlabs/musicblocks.git
 cd musicblocks
@@ -34,6 +38,7 @@ npm run serve  # Access at http://localhost:3000
 ```
 
 ### Key Files
+
 - `js/widgets/aidebugger.js` - Main widget implementation
 - `js/blocks/WidgetBlocks.js` - Block definition (lines 1643-1719)
 - `js/activity.js` - Widget registration (line 165)
@@ -41,13 +46,14 @@ npm run serve  # Access at http://localhost:3000
 ## Frontend Implementation
 
 ### Widget Structure
+
 ```javascript
 function AIDebuggerWidget() {
     const BACKEND_CONFIG = {
         BASE_URL: "http://13.49.246.243:8000",
         ENDPOINTS: { ANALYZE: "/analyze" }
     };
-    
+
     this.chatHistory = [];
     this.promptCount = 0;
     this.conversationId = null;
@@ -55,17 +61,19 @@ function AIDebuggerWidget() {
 ```
 
 ### Key Methods
+
 - `init(activity)` - Initialize widget and UI
 - `_createLayout()` - Build chat interface
 - `_sendMessage()` - Handle user input and AI responses
 - `_convertProjectToLLMFormat()` - Convert Music Blocks JSON to readable text
 
 ### API Communication
+
 ```javascript
 const payload = {
-    code: projectData,        // Music Blocks JSON
-    prompt: message,          // User question
-    history: history,         // Chat history
+    code: projectData, // Music Blocks JSON
+    prompt: message, // User question
+    history: history, // Chat history
     prompt_count: this.promptCount
 };
 
@@ -79,12 +87,14 @@ fetch(`${BACKEND_CONFIG.BASE_URL}/analyze`, {
 ## Development Workflow
 
 ### Adding Features
+
 1. **Edit Widget**: Modify `js/widgets/aidebugger.js`
 2. **Test Locally**: Run `npm run serve`
 3. **Block Integration**: Update `js/blocks/WidgetBlocks.js` if needed
 4. **Register Widget**: Ensure listed in `js/activity.js`
 
 ### Code Standards
+
 ```javascript
 // Use descriptive names
 this._createChatInterface = function() { ... };
@@ -104,8 +114,9 @@ this._sendToBackend = function(message) { ... };
 ```
 
 ### Code Review Checklist
+
 - [ ] Widget initializes correctly
-- [ ] Chat interface is responsive  
+- [ ] Chat interface is responsive
 - [ ] Backend communication works
 - [ ] Error handling is robust
 - [ ] Language is child-appropriate
@@ -114,6 +125,7 @@ this._sendToBackend = function(message) { ... };
 ## Testing
 
 ### Manual Testing
+
 1. Open Music Blocks → Drag AI Debugger block → Click block
 2. Verify widget window opens with chat interface
 3. Type message → Click Send → Check AI response
@@ -121,12 +133,13 @@ this._sendToBackend = function(message) { ... };
 5. Verify works with different project types
 
 ### Debug Commands
+
 ```javascript
 // Frontend debugging
 console.log("Widget initialized:", this);
 console.log("Backend URL:", BACKEND_CONFIG.BASE_URL);
 
-// Backend testing  
+// Backend testing
 curl -X POST http://localhost:8000/analyze \
   -H "Content-Type: application/json" \
   -d '{"code": "[]", "prompt": "test"}'
@@ -135,11 +148,13 @@ curl -X POST http://localhost:8000/analyze \
 ## Troubleshooting
 
 ### Common Issues
+
 - **Widget not loading**: Check `activity.js` registration and console errors
 - **Backend connection**: Verify `BACKEND_CONFIG.BASE_URL` and CORS
 - **UI problems**: Check CSS styles and widget window creation
 
 ### Resources
+
 - **GitHub Issues**: [Music Blocks Issues](https://github.com/sugarlabs/musicblocks/issues)
 - **Documentation**: [Music Blocks Guide](https://github.com/sugarlabs/musicblocks/tree/master/guide)
 - **Backend Repo**: [AI Debugger Backend](https://github.com/omsuneri/AI-powered-Debugger-for-Music-Blocks)

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -144,7 +144,7 @@ function AIWidget() {
      */
     this._usePitch = function (p) {
         const number = SOLFEGENAMES.indexOf(p);
-        this.pitchCenter = number == -1 ? 0 : number;
+        this.pitchCenter = number === -1 ? 0 : number;
     };
 
     /**
@@ -208,7 +208,7 @@ function AIWidget() {
         const pitch = pitches;
         pitchDuration = toFraction(pitchDuration);
         const adjustedNote = adjustPitch(pitch.name, keySignature).toUpperCase();
-        if (triplet != null) {
+        if (triplet !== null) {
             pitchDuration[1] = meterDen * triplet;
         }
 
@@ -355,7 +355,7 @@ function AIWidget() {
                             ],
                             [
                                 blockId + 13,
-                                ["modename", { value: staff.key.mode == "m" ? "minor" : "major" }],
+                                ["modename", { value: staff.key.mode === "m" ? "minor" : "major" }],
                                 0,
                                 0,
                                 [blockId + 11]
@@ -409,7 +409,7 @@ function AIWidget() {
                                 tripletFinder,
                                 entry.meterDen
                             );
-                            if (element?.endTriplet != null) {
+                            if (element?.endTriplet !== null) {
                                 tripletFinder = null;
                             }
                             blockId = blockId + 9;
@@ -426,7 +426,7 @@ function AIWidget() {
                                 const endBlockSearch = staffBlocksMap[lineId].repeatArray;
 
                                 for (const repeatbar in endBlockSearch) {
-                                    if (endBlockSearch[repeatbar].end == -1) {
+                                    if (endBlockSearch[repeatbar].end === -1) {
                                         staffBlocksMap[lineId].repeatArray[repeatbar].end =
                                             staffBlocksMap[lineId].baseBlocks.length;
                                     }
@@ -441,7 +441,7 @@ function AIWidget() {
 
                     //update the namedo block if not first nameddo block appear
                     const baseBlocks = entry.baseBlocks;
-                    if (baseBlocks.length != 0) {
+                    if (baseBlocks.length !== 0) {
                         const lastBase = baseBlocks[baseBlocks.length - 1];
                         lastBase[0][lastBase[0].length - 4][4][1] = blockId;
                     }
@@ -532,7 +532,7 @@ function AIWidget() {
 
             const repeatblockids = staffBlocksMap[staffIndex].repeatArray;
             for (const repeatId of repeatblockids) {
-                if (repeatId.start == 0) {
+                if (repeatId.start === 0) {
                     staffBlocksMap[staffIndex].repeatBlock.push([
                         blockId,
                         "repeat",
@@ -585,7 +585,7 @@ function AIWidget() {
                             staffBlocksMap[staffIndex].nameddoArray[staffIndex][repeatId.end + 1]
                         );
 
-                        if (secondnammedo != -1) {
+                        if (secondnammedo !== -1) {
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.end + 1][0][
                                 secondnammedo
                             ][4][0] = blockId;
@@ -614,7 +614,7 @@ function AIWidget() {
                         ][4][1]
                     );
                     let prevrepeatnameddo = -1;
-                    if (prevnameddo == -1) {
+                    if (prevnameddo === -1) {
                         prevrepeatnameddo = searchIndexForMusicBlock(
                             staffBlocksMap[staffIndex].repeatBlock,
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.start][0][
@@ -658,14 +658,14 @@ function AIWidget() {
                         [blockId]
                     ]);
 
-                    if (prevnameddo != -1) {
+                    if (prevnameddo !== -1) {
                         staffBlocksMap[staffIndex].baseBlocks[repeatId.start - 1][0][
                             prevnameddo
                         ][4][1] = blockId;
                     } else {
                         staffBlocksMap[staffIndex].repeatBlock[prevrepeatnameddo][4][3] = blockId;
                     }
-                    if (afternamedo != -1) {
+                    if (afternamedo !== -1) {
                         staffBlocksMap[staffIndex].baseBlocks[repeatId.end][0][afternamedo][4][1] =
                             null;
                     }
@@ -674,7 +674,7 @@ function AIWidget() {
                         currentnammeddo
                     ][4][0] = blockId;
 
-                    if (nextBlockId != null) {
+                    if (nextBlockId !== null) {
                         const nextnameddo = searchIndexForMusicBlock(
                             staffBlocksMap[staffIndex].baseBlocks[repeatId.end + 1][0],
                             nextBlockId
@@ -824,7 +824,7 @@ function AIWidget() {
                     >`;
                 this.isMoving = false;
             } else {
-                if (!(abcNotationSong == "")) {
+                if (!(abcNotationSong === "")) {
                     this.resume();
                     this._playABCSong();
                 }
@@ -861,7 +861,7 @@ function AIWidget() {
      */
     this._addSample = function () {
         for (let i = 0; i < CUSTOMSAMPLES.length; i++) {
-            if (CUSTOMSAMPLES[i][0] == this.sampleName) {
+            if (CUSTOMSAMPLES[i][0] === this.sampleName) {
                 return;
             }
         }
@@ -940,7 +940,7 @@ function AIWidget() {
      * @returns {void}
      */
     this._playSample = function () {
-        if (this.sampleName != null && this.sampleName != "") {
+        if (this.sampleName !== null && this.sampleName !== "") {
             this.reconnectSynthsToAnalyser();
 
             this.activity.logo.synth.trigger(

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -470,7 +470,7 @@ class Arpeggio {
 
                 cell = cellRow.cells[col];
 
-                if (cell != undefined) {
+                if (cell !== undefined) {
                     cell.style.backgroundColor = "black";
                     this.__playCell(row, col, cell, false);
                 }

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -659,18 +659,18 @@ class MeterWidget {
      * @returns {void}
      */
     _setupDefaultStrongWeakBeats(numberOfBeats, beatValue) {
-        if (beatValue == 0.25 && numberOfBeats == 4) {
+        if (beatValue === 0.25 && numberOfBeats === 4) {
             this._strongBeats[0] = true;
             this._strongBeats[2] = true;
             this._beatWheel.navItems[0].navItem.show();
             this._beatWheel.navItems[2].navItem.show();
-        } else if (beatValue == 0.25 && numberOfBeats == 2) {
+        } else if (beatValue === 0.25 && numberOfBeats === 2) {
             this._strongBeats[0] = true;
             this._beatWheel.navItems[0].navItem.show();
-        } else if (beatValue == 0.25 && numberOfBeats == 3) {
+        } else if (beatValue === 0.25 && numberOfBeats === 3) {
             this._strongBeats[0] = true;
             this._beatWheel.navItems[0].navItem.show();
-        } else if (beatValue == 0.125 && numberOfBeats == 6) {
+        } else if (beatValue === 0.125 && numberOfBeats === 6) {
             this._strongBeats[0] = true;
             this._strongBeats[3] = true;
             this._beatWheel.navItems[0].navItem.show();

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -189,24 +189,28 @@ class MeterWidget {
             } else {
                 this._click_lock = true;
                 if (this.__getPlayingStatus()) {
-                    playBtn.innerHTML = `&nbsp;&nbsp;<img 
-                            src="header-icons/play-button.svg" 
-                            title="${_("Play all")}" 
-                            alt="${_("Play all")}" 
-                            height="${MeterWidget.ICONSIZE}" 
-                            width="${MeterWidget.ICONSIZE}" 
-                            vertical-align="middle"
-                        >&nbsp;&nbsp;`;
+                    playBtn.textContent = "\u00A0\u00A0";
+                    const img = document.createElement("img");
+                    img.src = "header-icons/play-button.svg";
+                    img.title = _("Play all");
+                    img.alt = _("Play all");
+                    img.setAttribute("height", MeterWidget.ICONSIZE);
+                    img.setAttribute("width", MeterWidget.ICONSIZE);
+                    img.setAttribute("vertical-align", "middle");
+                    playBtn.appendChild(img);
+                    playBtn.appendChild(document.createTextNode("\u00A0\u00A0"));
                     this._playing = false;
                 } else {
-                    playBtn.innerHTML = `&nbsp;&nbsp;<img 
-                            src="header-icons/stop-button.svg" 
-                            title="${_("Stop")}" 
-                            alt="${_("Stop")}" 
-                            height="${MeterWidget.ICONSIZE}" 
-                            width="${MeterWidget.ICONSIZE}" 
-                            vertical-align="middle"
-                        >&nbsp;&nbsp;`;
+                    playBtn.textContent = "\u00A0\u00A0";
+                    const img = document.createElement("img");
+                    img.src = "header-icons/stop-button.svg";
+                    img.title = _("Stop");
+                    img.alt = _("Stop");
+                    img.setAttribute("height", MeterWidget.ICONSIZE);
+                    img.setAttribute("width", MeterWidget.ICONSIZE);
+                    img.setAttribute("vertical-align", "middle");
+                    playBtn.appendChild(img);
+                    playBtn.appendChild(document.createTextNode("\u00A0\u00A0"));
                     this._playing = true;
                     this.activity.logo.turtleDelay = 0;
                     this.activity.logo.resetSynth(0);
@@ -229,7 +233,10 @@ class MeterWidget {
         meterTableDiv.style.display = "inline";
         meterTableDiv.style.visibility = "visible";
         meterTableDiv.style.border = "0px";
-        meterTableDiv.innerHTML = '<div id="meterWheelDiv"></div>';
+        meterTableDiv.textContent = "";
+        const meterWheelDiv = document.createElement("div");
+        meterWheelDiv.id = "meterWheelDiv";
+        meterTableDiv.appendChild(meterWheelDiv);
 
         // Grab the number of beats and beat value from the meter block.
         let v1, c1, c2, c3;
@@ -249,13 +256,25 @@ class MeterWidget {
 
         const divInput = document.createElement("div");
         divInput.className = "wfbtItem";
-        divInput.innerHTML = `<input style="float: left;" value="${v1}" type="number" id="beatValue" min="1" max="16" >`;
+        const input1 = document.createElement("input");
+        input1.style.cssFloat = "left";
+        input1.value = v1;
+        input1.type = "number";
+        input1.id = "beatValue";
+        input1.setAttribute("min", "1");
+        input1.setAttribute("max", "16");
+        divInput.appendChild(input1);
 
         const divInput2 = document.createElement("div");
         divInput2.className = "wfbtItem";
-        divInput2.innerHTML = `<input style="float: left;" value="${
-            1 / this._beatValue
-        }" type="number" id="beatValue" min="1" max="35">`;
+        const input2 = document.createElement("input");
+        input2.style.cssFloat = "left";
+        input2.value = 1 / this._beatValue;
+        input2.type = "number";
+        input2.id = "beatValue";
+        input2.setAttribute("min", "1");
+        input2.setAttribute("max", "35");
+        divInput2.appendChild(input2);
 
         widgetWindow._toolbar.appendChild(divInput);
         widgetWindow._toolbar.appendChild(divInput2);
@@ -418,15 +437,17 @@ class MeterWidget {
      */
     _addButton(row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
-        cell.innerHTML = `&nbsp;&nbsp;<img 
-                src="header-icons/${icon}" 
-                title="${label}" 
-                alt="${label}" 
-                height="${iconSize}" 
-                width="${iconSize}" 
-                vertical-align="middle" 
-                align-content="center"
-            >&nbsp;&nbsp;`;
+        cell.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.setAttribute("height", iconSize);
+        img.setAttribute("width", iconSize);
+        img.setAttribute("vertical-align", "middle");
+        img.setAttribute("align-content", "center");
+        cell.appendChild(img);
+        cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         cell.style.width = MeterWidget.BUTTONSIZE + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;

--- a/js/widgets/meterwidget.test.js
+++ b/js/widgets/meterwidget.test.js
@@ -88,7 +88,10 @@ window.widgetWindows = {
         show: jest.fn(),
         destroy: jest.fn(),
         addButton: jest.fn().mockImplementation(() => ({
-            onclick: () => {}, appendChild: jest.fn(), textContent: "", innerHTML: ""
+            onclick: () => {},
+            appendChild: jest.fn(),
+            textContent: "",
+            innerHTML: ""
         })),
         addInputButton: jest.fn().mockReturnValue({ value: 0, addEventListener: jest.fn() }), // Add this as it might be used
         getWidgetBody: jest.fn().mockReturnValue({

--- a/js/widgets/meterwidget.test.js
+++ b/js/widgets/meterwidget.test.js
@@ -88,7 +88,7 @@ window.widgetWindows = {
         show: jest.fn(),
         destroy: jest.fn(),
         addButton: jest.fn().mockImplementation(() => ({
-            onclick: () => {}
+            onclick: () => {}, appendChild: jest.fn(), textContent: "", innerHTML: ""
         })),
         addInputButton: jest.fn().mockReturnValue({ value: 0, addEventListener: jest.fn() }), // Add this as it might be used
         getWidgetBody: jest.fn().mockReturnValue({
@@ -132,10 +132,12 @@ if (document.createElement) {
         return {
             style: {},
             innerHTML: "",
+            textContent: "",
             children: [],
             className: "",
             append: jest.fn(),
             appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             getContext: jest.fn().mockReturnValue({
                 // For canvas if needed
                 clearRect: jest.fn(),
@@ -154,10 +156,12 @@ if (document.createElement) {
         return {
             style: {},
             innerHTML: "",
+            textContent: "",
             children: [],
             className: "",
             append: jest.fn(),
             appendChild: jest.fn(),
+            setAttribute: jest.fn(),
             getContext: jest.fn().mockReturnValue({
                 clearRect: jest.fn(),
                 beginPath: jest.fn(),

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -867,13 +867,13 @@ class ModeWidget {
             if (JSON.stringify(MUSICALMODES[mode]) === currentMode) {
                 // Update the value of the modename block inside of
                 // the mode widget block.
-                if (this._modeBlock != null) {
+                if (this._modeBlock !== null) {
                     for (const i in this.blocks.blockList) {
-                        if (this.blocks.blockList[i].name == "modename") {
+                        if (this.blocks.blockList[i].name === "modename") {
                             this.blocks.blockList[i].value = mode;
                             this.blocks.blockList[i].text.text = _(mode);
                             this.blocks.blockList[i].updateCache();
-                        } else if (this.blocks.blockList[i].name == "notename") {
+                        } else if (this.blocks.blockList[i].name === "notename") {
                             this.blocks.blockList[i].value = currentKey;
                             this.blocks.blockList[i].text.text = _(currentKey);
                         }
@@ -1184,7 +1184,7 @@ class ModeWidget {
         // If a noteWheel sector is selected, hide it.
         const __clearNote = () => {
             const i = this._noteWheel.selectedNavItemIndex;
-            if (i == 0) {
+            if (i === 0) {
                 return; // Never hide the first note.
             }
 

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -331,7 +331,7 @@ function MusicKeyboard(activity) {
                         ele.getAttribute("alt").split("__")[1];
                 }
 
-                if (id == "rest") {
+                if (id === "rest") {
                     return;
                 }
 
@@ -421,7 +421,7 @@ function MusicKeyboard(activity) {
                     processedDuration = 1 / unit;
                 }
 
-                if (id == "rest") {
+                if (id === "rest") {
                     this._notesPlayed.push({
                         startTime: startTime[id],
                         noteOctave: "R",
@@ -638,12 +638,12 @@ function MusicKeyboard(activity) {
             }
 
             myNode = document.getElementById("myrow");
-            if (myNode != null) {
+            if (myNode !== null) {
                 myNode.innerHTML = "";
             }
 
             myNode = document.getElementById("myrow2");
-            if (myNode != null) {
+            if (myNode !== null) {
                 myNode.innerHTML = "";
             }
 
@@ -1325,7 +1325,7 @@ function MusicKeyboard(activity) {
         const start = docById("cells-" + colIndex).getAttribute("start");
 
         this._notesPlayed = this._notesPlayed.filter(function (ele) {
-            return ele.startTime != parseInt(start);
+            return ele.startTime !== parseInt(start);
         });
 
         // Look for each cell that is marked in this column.
@@ -2243,7 +2243,7 @@ function MusicKeyboard(activity) {
     this._sortLayout = function () {
         this.layout.sort((a, b) => {
             let aValue, bValue;
-            if (a.noteName == "hertz") {
+            if (a.noteName === "hertz") {
                 if (b.noteName !== "hertz") return 1;
                 aValue = a.noteOctave;
             } else {
@@ -2252,7 +2252,7 @@ function MusicKeyboard(activity) {
                     this.activity.turtles.ithTurtle(0).singer.keySignature
                 );
             }
-            if (b.noteName == "hertz") {
+            if (b.noteName === "hertz") {
                 if (a.noteName !== "hertz") return -1;
                 bValue = b.noteOctave;
             } else {
@@ -2533,7 +2533,7 @@ function MusicKeyboard(activity) {
             this.layout[index].noteOctave = parseInt(blockValue);
             cell.innerHTML = this.layout[index].noteName + this.layout[index].noteOctave.toString();
             this._notesPlayed.map(function (item) {
-                if (item.objId == this.layout[index].blockNumber) {
+                if (item.objId === this.layout[index].blockNumber) {
                     item.noteOctave = parseInt(blockValue);
                 }
                 return item;
@@ -2602,7 +2602,7 @@ function MusicKeyboard(activity) {
             }
 
             this._notesPlayed.map(item => {
-                if (item.objId == this.layout[index].blockNumber) {
+                if (item.objId === this.layout[index].blockNumber) {
                     item.noteOctave = temp2;
                 }
                 return item;
@@ -3047,7 +3047,7 @@ function MusicKeyboard(activity) {
                 } else if (selectedNotes[i].noteOctave[0] === "R") {
                     // Don't trigger a new group with a rest
                     newNotes[newNotes.length - 1].push(i);
-                } else if (selectedNotes[i].voice[0] != prevNote) {
+                } else if (selectedNotes[i].voice[0] !== prevNote) {
                     newNotes.push([i]);
                     prevNote = selectedNotes[i].voice[0];
                 } else {
@@ -3095,7 +3095,7 @@ function MusicKeyboard(activity) {
             const newStack = [
                 [0, ["action", { collapsed: false }], 100, 100, [null, 1, 2, null]],
                 [1, ["text", { value: _("action") + "" + actionGroup }], 0, 0, [0]],
-                [2, "hidden", 0, 0, [0, selectedNotes.length == 0 ? null : 3]]
+                [2, "hidden", 0, 0, [0, selectedNotes.length === 0 ? null : 3]]
             ];
 
             // Add BPM
@@ -3113,7 +3113,7 @@ function MusicKeyboard(activity) {
 
             for (let noteGrp = 0; noteGrp < newNotes.length; noteGrp++) {
                 const selectedNotesGrp = newNotes[noteGrp];
-                const isLast = noteGrp == newNotes.length - 1;
+                const isLast = noteGrp === newNotes.length - 1;
                 id = newStack.length;
                 let voice = selectedNotes[selectedNotesGrp[0]].voice[0] || DEFAULTVOICE;
                 // Don't use a drum name with set timbre.
@@ -3463,7 +3463,7 @@ function MusicKeyboard(activity) {
             const octave = pitchOctave[2];
             const key =
                 this.getElement[pitch1 + "" + octave] || this.getElement[pitch2 + "" + octave];
-            if (event.data[0] == 144 && event.data[2] != 0) {
+            if (event.data[0] === 144 && event.data[2] !== 0) {
                 __startNote(event, docById(key));
             } else {
                 __endNote(event, docById(key));

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -698,7 +698,9 @@ class PhraseMaker {
                 cell.textContent = "";
                 cell.appendChild(document.createTextNode(blockLabel));
                 cell.appendChild(document.createElement("br"));
-                cell.appendChild(document.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`));
+                cell.appendChild(
+                    document.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`)
+                );
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
                 cell.setAttribute("alt", i + "__" + "graphicsblocks2");
 
@@ -721,7 +723,9 @@ class PhraseMaker {
                     !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
                 ) {
                     cell.textContent = "";
-                    cell.appendChild(document.createTextNode(this._deps.i18nSolfege(this.rowLabels[i])));
+                    cell.appendChild(
+                        document.createTextNode(this._deps.i18nSolfege(this.rowLabels[i]))
+                    );
                     const subTitle1 = document.createElement("sub");
                     subTitle1.textContent = this.rowArgs[i].toString();
                     cell.appendChild(subTitle1);
@@ -1470,7 +1474,11 @@ class PhraseMaker {
                 cell.textContent = "";
                 cell.appendChild(document.createTextNode(blockLabel));
                 cell.appendChild(document.createElement("br"));
-                cell.appendChild(document.createTextNode(`${this.rowArgs[blockIndex][0]} ${this.rowArgs[blockIndex][1]}`));
+                cell.appendChild(
+                    document.createTextNode(
+                        `${this.rowArgs[blockIndex][0]} ${this.rowArgs[blockIndex][1]}`
+                    )
+                );
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             }
 
@@ -2137,7 +2145,9 @@ class PhraseMaker {
                 !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
             ) {
                 cell.textContent = "";
-                cell.appendChild(document.createTextNode(this._deps.i18nSolfege(this.rowLabels[index])));
+                cell.appendChild(
+                    document.createTextNode(this._deps.i18nSolfege(this.rowLabels[index]))
+                );
                 const subTitle1 = document.createElement("sub");
                 subTitle1.textContent = this.rowArgs[index].toString();
                 cell.appendChild(subTitle1);
@@ -2643,12 +2653,16 @@ class PhraseMaker {
                 exportLabel.textContent = "";
                 exportLabel.appendChild(exportDocument.createTextNode(blockLabel));
                 exportLabel.appendChild(exportDocument.createElement("br"));
-                exportLabel.appendChild(exportDocument.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`));
+                exportLabel.appendChild(
+                    exportDocument.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`)
+                );
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             } else {
                 if (this._deps.noteIsSolfege(this.rowLabels[i])) {
                     exportLabel.textContent = "";
-                    exportLabel.appendChild(exportDocument.createTextNode(this._deps.i18nSolfege(this.rowLabels[i])));
+                    exportLabel.appendChild(
+                        exportDocument.createTextNode(this._deps.i18nSolfege(this.rowLabels[i]))
+                    );
                     const subTitle1 = exportDocument.createElement("sub");
                     subTitle1.textContent = this.rowArgs[i].toString();
                     exportLabel.appendChild(subTitle1);
@@ -2666,7 +2680,9 @@ class PhraseMaker {
                 exportCell = exportRow.insertCell();
                 exportCell.style.backgroundColor = col.style.backgroundColor;
                 exportCell.textContent = "";
-                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
+                Array.from(col.childNodes).forEach(child =>
+                    exportCell.appendChild(child.cloneNode(true))
+                );
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2691,7 +2707,9 @@ class PhraseMaker {
                 col = noteValueRow.cells[i];
                 exportCell.style.backgroundColor = col.style.backgroundColor;
                 exportCell.textContent = "";
-                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
+                Array.from(col.childNodes).forEach(child =>
+                    exportCell.appendChild(child.cloneNode(true))
+                );
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2713,7 +2731,9 @@ class PhraseMaker {
                 col = noteValueRow.cells[i];
                 exportCell.style.backgroundColor = col.style.backgroundColor;
                 exportCell.textContent = "";
-                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
+                Array.from(col.childNodes).forEach(child =>
+                    exportCell.appendChild(child.cloneNode(true))
+                );
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2736,7 +2756,9 @@ class PhraseMaker {
             col = noteValueRow.cells[i];
             exportCell.style.backgroundColor = col.style.backgroundColor;
             exportCell.textContent = "";
-            Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
+            Array.from(col.childNodes).forEach(child =>
+                exportCell.appendChild(child.cloneNode(true))
+            );
             exportCell.width = col.width;
             if (exportCell.width == "") {
                 exportCell.width = col.style.width;
@@ -2753,7 +2775,8 @@ class PhraseMaker {
         exportDocument.body.appendChild(exportDocument.createElement("br"));
         const downloadLink = exportDocument.createElement("a");
         downloadLink.id = "downloadb1";
-        downloadLink.style.cssText = "background: #C374E9; border-radius: 5%; padding: 0.3em; text-decoration: none; margin: 0.5em; color: white;";
+        downloadLink.style.cssText =
+            "background: #C374E9; border-radius: 5%; padding: 0.3em; text-decoration: none; margin: 0.5em; color: white;";
         downloadLink.setAttribute("download", "");
         downloadLink.textContent = "Download Matrix";
         exportDocument.body.appendChild(downloadLink);

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -510,8 +510,8 @@ class PhraseMaker {
             // Depending on the row, we choose a different background color.
             if (this.rowLabels[i] === "print") break;
             else if (
-                PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) != -1 ||
-                PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) != -1
+                PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) !== -1 ||
+                PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) !== -1
             ) {
                 cellColor = this.platformColor.graphicsLabelBackground;
             } else {
@@ -537,7 +537,7 @@ class PhraseMaker {
             this._headcols[i] = cell;
 
             if (this.rowLabels[i] === "print") break;
-            else if (drumName != null) {
+            else if (drumName !== null) {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = this._deps.getDrumIcon(drumName);
@@ -635,7 +635,7 @@ class PhraseMaker {
             this._labelcols[i] = cell;
 
             if (this.rowLabels[i] === "print") break;
-            else if (drumName != null) {
+            else if (drumName !== null) {
                 cell.textContent = this._(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 cell.setAttribute("alt", i + "__" + "drumblocks");
@@ -2109,7 +2109,7 @@ class PhraseMaker {
             const noteName = this.rowLabels[index];
             const w = window.innerWidth;
             const iconSize = PhraseMaker.ICONSIZE * (w / 1200);
-            if (drumName != null) {
+            if (drumName !== null) {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = this._deps.getDrumIcon(drumName);
@@ -2137,7 +2137,7 @@ class PhraseMaker {
             }
 
             cell = this._labelcols[index];
-            if (drumName != null) {
+            if (drumName !== null) {
                 cell.textContent = this._(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (
@@ -2297,7 +2297,7 @@ class PhraseMaker {
             this.activity.blocks.blockList[newblk].connections.length - 1
         ] = c1;
 
-        if (c0 != null) {
+        if (c0 !== null) {
             for (let i = 0; i < this.activity.blocks.blockList[c0].connections.length; i++) {
                 if (this.activity.blocks.blockList[c0].connections[i] === oldblk) {
                     this.activity.blocks.blockList[c0].connections[i] = newblk;
@@ -2318,7 +2318,7 @@ class PhraseMaker {
             this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
         }
 
-        if (c1 != null) {
+        if (c1 !== null) {
             for (let i = 0; i < this.activity.blocks.blockList[c1].connections.length; i++) {
                 if (this.activity.blocks.blockList[c1].connections[i] === oldblk) {
                     this.activity.blocks.blockList[c1].connections[i] = newblk;
@@ -2433,7 +2433,7 @@ class PhraseMaker {
             }
 
             drumName = this._deps.getDrumName(this.rowLabels[i]);
-            if (drumName != null) {
+            if (drumName !== null) {
                 continue;
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[i])) {
                 continue;
@@ -2462,7 +2462,7 @@ class PhraseMaker {
         // Add the stuff we didn't sort.
         for (let i = 0; i < this.rowLabels.length; i++) {
             drumName = this._deps.getDrumName(this.rowLabels[i]);
-            if (drumName != null) {
+            if (drumName !== null) {
                 sortableList.push([
                     -1 * i,
                     this.rowLabels[i],
@@ -2531,7 +2531,7 @@ class PhraseMaker {
             } else if (i > 0 && obj[1] !== "hertz" && obj[1] === this._deps.last(this.rowLabels)) {
                 console.debug("skipping " + obj[1] + " " + this._deps.last(this.rowLabels));
                 this._sortedRowMap.push(this._deps.last(this._sortedRowMap));
-                if (oldColumnBlockMap[sortedList[lastObj][3]] != undefined) {
+                if (oldColumnBlockMap[sortedList[lastObj][3]] !== undefined) {
                     setTimeout(
                         this._removePitchBlock(oldColumnBlockMap[sortedList[lastObj][3]][0]),
                         500
@@ -2630,7 +2630,7 @@ class PhraseMaker {
             exportLabel = exportRow.insertCell();
 
             drumName = this._deps.getDrumName(this.rowLabels[i]);
-            if (drumName != null) {
+            if (drumName !== null) {
                 exportLabel.textContent = this._(drumName);
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (this.rowLabels[i].slice(0, 4) === "http") {
@@ -2684,7 +2684,7 @@ class PhraseMaker {
                     exportCell.appendChild(child.cloneNode(true))
                 );
                 exportCell.width = col.width;
-                if (exportCell.width == "") {
+                if (exportCell.width === "") {
                     exportCell.width = col.style.width;
                 }
                 exportCell.colSpan = col.colSpan;
@@ -2711,7 +2711,7 @@ class PhraseMaker {
                     exportCell.appendChild(child.cloneNode(true))
                 );
                 exportCell.width = col.width;
-                if (exportCell.width == "") {
+                if (exportCell.width === "") {
                     exportCell.width = col.style.width;
                 }
                 exportCell.colSpan = col.colSpan;
@@ -2735,7 +2735,7 @@ class PhraseMaker {
                     exportCell.appendChild(child.cloneNode(true))
                 );
                 exportCell.width = col.width;
-                if (exportCell.width == "") {
+                if (exportCell.width === "") {
                     exportCell.width = col.style.width;
                 }
                 exportCell.colSpan = col.colSpan;
@@ -2760,7 +2760,7 @@ class PhraseMaker {
                 exportCell.appendChild(child.cloneNode(true))
             );
             exportCell.width = col.width;
-            if (exportCell.width == "") {
+            if (exportCell.width === "") {
                 exportCell.width = col.style.width;
             }
             exportCell.colSpan = col.colSpan;
@@ -2932,7 +2932,7 @@ class PhraseMaker {
             obj = this._deps.toFraction(numerator / (totalNoteInterval / tupletTimeFactor));
 
             if (obj[1] < 13) {
-                if (NOTESYMBOLS != undefined && obj[1] in NOTESYMBOLS) {
+                if (NOTESYMBOLS !== undefined && obj[1] in NOTESYMBOLS) {
                     cell.textContent = "";
                     cell.appendChild(document.createTextNode(obj[0]));
                     cell.appendChild(document.createElement("br"));
@@ -2963,7 +2963,7 @@ class PhraseMaker {
             // Add the notes to the matrix a la addNote.
             for (let j = 0; j < this.rowLabels.length; j++) {
                 // Depending on the row, we choose a different background color.
-                if (PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[j]) != -1) {
+                if (PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[j]) !== -1) {
                     cellColor = this.platformColor.graphicsBackground;
                 } else {
                     drumName = this._deps.getDrumName(this.rowLabels[j]);
@@ -3100,8 +3100,8 @@ class PhraseMaker {
             for (let i = 0; i < rowCount; i++) {
                 // Depending on the row, we choose a different background color.
                 if (
-                    PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) != -1 ||
-                    PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) != -1
+                    PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) !== -1 ||
+                    PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) !== -1
                 ) {
                     cellColor = this.platformColor.graphicsBackground;
                 } else {
@@ -3230,7 +3230,7 @@ class PhraseMaker {
     blockConnection(len, bottomOfClamp) {
         const n = this.activity.blocks.blockList.length - len;
         let c;
-        if (bottomOfClamp == null) {
+        if (bottomOfClamp === null) {
             this.activity.blocks.blockList[this.blockNo].connections[2] = n;
             this.activity.blocks.blockList[n].connections[0] = this.blockNo;
         } else {
@@ -3644,7 +3644,7 @@ class PhraseMaker {
         let l;
         if (oldTupletValue < newTupletValue) {
             for (let i = 0; i <= this.activity.logo.tupletRhythms.length; i++) {
-                if (i == noteToDivide) {
+                if (i === noteToDivide) {
                     break;
                 }
                 for (let j = 0; j < this.activity.logo.tupletRhythms[i].length - 2; j++) {
@@ -3882,7 +3882,7 @@ class PhraseMaker {
             };
 
             for (let i = 0; i < mainTabsLabels.length; i++) {
-                if (i === 9 || i == 3) {
+                if (i === 9 || i === 3) {
                     continue;
                 }
 
@@ -4199,7 +4199,7 @@ class PhraseMaker {
                     row = this._rows[r];
                     if (row !== null && typeof row !== "undefined") {
                         cell = row.cells[c];
-                        if (cell != undefined) {
+                        if (cell !== undefined) {
                             cell.style.backgroundColor = "black";
                             this._setNoteCell(r, c, cell, false, null);
                         }
@@ -4314,8 +4314,8 @@ class PhraseMaker {
             graphicsBlock = false;
             graphicNote = note.split(": ");
             if (
-                PhraseMakerUtils.MATRIXGRAPHICS.indexOf(graphicNote[0]) != -1 &&
-                PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(graphicNote[0]) != -1
+                PhraseMakerUtils.MATRIXGRAPHICS.indexOf(graphicNote[0]) !== -1 &&
+                PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(graphicNote[0]) !== -1
             ) {
                 graphicsBlock = true;
             }
@@ -4331,7 +4331,7 @@ class PhraseMaker {
 
         if (obj.length === 1) {
             if (playNote) {
-                if (drumName != null) {
+                if (drumName !== null) {
                     this.activity.logo.synth.trigger(0, "C2", noteValue, drumName, null, null);
                 } else if (this.rowLabels[j] === "hertz") {
                     this.activity.logo.synth.trigger(
@@ -4505,7 +4505,7 @@ class PhraseMaker {
             // const x = idx + delta;
             let lastConnection, previousBlock, thisBlock;
 
-            if (note[0][0] === "R" || note[0][0] == undefined) {
+            if (note[0][0] === "R" || note[0][0] === undefined) {
                 // The last connection in last pitch block is null.
                 lastConnection = null;
                 if (delta === 5 || delta === 7) {
@@ -4564,7 +4564,7 @@ class PhraseMaker {
                         ]);
                         thisBlock += 2;
                         previousBlock = thisBlock - 2;
-                    } else if (drumName != null) {
+                    } else if (drumName !== null) {
                         // add a playdrum block
                         // The last connection in last pitch block is null.
                         if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
@@ -4820,7 +4820,7 @@ class PhraseMaker {
                                 0,
                                 [previousBlock, thisBlock + 1, thisBlock + 2, lastConnection]
                             ]);
-                            if (this.activity.logo.synth.inTemperament == "custom") {
+                            if (this.activity.logo.synth.inTemperament === "custom") {
                                 newStack.push([
                                     thisBlock + 1,
                                     [

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -410,23 +410,27 @@ class PhraseMaker {
 
             this.activity.logo.resetSynth(0);
             if (this.playingNow) {
-                this._playButton.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/play-button.svg" 
-                        title="${this._("Play")}" 
-                        alt="${this._("Play")}" 
-                        height="${PhraseMaker.ICONSIZE}" 
-                        width="${PhraseMaker.ICONSIZE}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                this._playButton.textContent = "\u00A0\u00A0";
+                const playImg = document.createElement("img");
+                playImg.src = "header-icons/play-button.svg";
+                playImg.title = this._("Play");
+                playImg.alt = this._("Play");
+                playImg.setAttribute("height", PhraseMaker.ICONSIZE);
+                playImg.setAttribute("width", PhraseMaker.ICONSIZE);
+                playImg.setAttribute("vertical-align", "middle");
+                this._playButton.appendChild(playImg);
+                this._playButton.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else {
-                this._playButton.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/stop-button.svg" 
-                        title="${this._("Stop")}" 
-                        alt="${this._("Stop")}" 
-                        height="${PhraseMaker.ICONSIZE}" 
-                        width="${PhraseMaker.ICONSIZE}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                this._playButton.textContent = "\u00A0\u00A0";
+                const stopImg = document.createElement("img");
+                stopImg.src = "header-icons/stop-button.svg";
+                stopImg.title = this._("Stop");
+                stopImg.alt = this._("Stop");
+                stopImg.setAttribute("height", PhraseMaker.ICONSIZE);
+                stopImg.setAttribute("width", PhraseMaker.ICONSIZE);
+                stopImg.setAttribute("vertical-align", "middle");
+                this._playButton.appendChild(stopImg);
+                this._playButton.appendChild(document.createTextNode("\u00A0\u00A0"));
             }
             this.playAll();
         };
@@ -529,49 +533,59 @@ class PhraseMaker {
             cell.className = "headcol"; // This cell is fixed horizontally.
             cell.style.position = "sticky";
             cell.style.left = "1.2px";
-            cell.innerHTML = "";
+            cell.textContent = "";
             this._headcols[i] = cell;
 
             if (this.rowLabels[i] === "print") break;
             else if (drumName != null) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="${this._deps.getDrumIcon(drumName)}" 
-                        title="${this._(drumName)}" 
-                        alt="${this._(drumName)}" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = this._deps.getDrumIcon(drumName);
+                img.title = this._(drumName);
+                img.alt = this._(drumName);
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (this.rowLabels[i].slice(0, 4) === "http") {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="${this._deps.getDrumIcon(this.rowLabels[i])}" 
-                        title="${this.rowLabels[i]}" 
-                        alt="${this.rowLabels[i]}" 
-                        height="${iconSize / 2}" 
-                        width="${iconSize / 2}" 
-                        vertical-align="middle"
-                    />&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = this._deps.getDrumIcon(this.rowLabels[i]);
+                img.title = this.rowLabels[i];
+                img.alt = this.rowLabels[i];
+                img.setAttribute("height", iconSize / 2);
+                img.setAttribute("width", iconSize / 2);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (PhraseMakerUtils.MATRIXSYNTHS.includes(this.rowLabels[i])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/synth2.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/synth2.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[i])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/mouse.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/mouse.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (PhraseMakerUtils.MATRIXGRAPHICS2.includes(this.rowLabels[i])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/mouse.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/mouse.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else {
                 const BELLSETIDX = {
                     C: 1,
@@ -592,17 +606,17 @@ class PhraseMaker {
                 // Don't add bellset image with sharps and flats.
                 noteName = this.rowLabels[i];
                 if (noteName in BELLSETIDX && this.rowArgs[i] === 4) {
-                    cell.innerHTML = `<img 
-                            src="images/8_bellset_key_${BELLSETIDX[noteName]}.svg" 
-                            width="${cell.style.width}" 
-                            vertical-align="middle"
-                        >`;
+                    const img = document.createElement("img");
+                    img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
+                    img.setAttribute("width", cell.style.width);
+                    img.setAttribute("vertical-align", "middle");
+                    cell.appendChild(img);
                 } else if (["C", "do"].includes(noteName) && this.rowArgs[i] === 5) {
-                    cell.innerHTML = `<img 
-                            src="images/8_bellset_key_8.svg" 
-                            width="${cell.style.width}" 
-                            vertical-align="middle"
-                        >`;
+                    const img = document.createElement("img");
+                    img.src = "images/8_bellset_key_8.svg";
+                    img.setAttribute("width", cell.style.width);
+                    img.setAttribute("vertical-align", "middle");
+                    cell.appendChild(img);
                 }
             }
 
@@ -622,7 +636,7 @@ class PhraseMaker {
 
             if (this.rowLabels[i] === "print") break;
             else if (drumName != null) {
-                cell.innerHTML = this._(drumName);
+                cell.textContent = this._(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 cell.setAttribute("alt", i + "__" + "drumblocks");
 
@@ -638,11 +652,11 @@ class PhraseMaker {
 
                 this._noteStored.push(drumName);
             } else if (this.rowLabels[i].slice(0, 4) === "http") {
-                cell.innerHTML = this.rowLabels[i];
+                cell.textContent = this.rowLabels[i];
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 this._noteStored.push(this.rowLabels[i].replace(/ /g, ": "));
             } else if (PhraseMakerUtils.MATRIXSYNTHS.includes(this.rowLabels[i])) {
-                cell.innerHTML = this.rowArgs[i];
+                cell.textContent = this.rowArgs[i];
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
                 cell.setAttribute("alt", i + "__" + "synthsblocks");
 
@@ -660,7 +674,10 @@ class PhraseMaker {
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[i])) {
                 blockLabel =
                     this.activity.blocks.protoBlockDict[this.rowLabels[i]]["staticLabels"][0];
-                cell.innerHTML = `${blockLabel}<br>${this.rowArgs[i]}`;
+                cell.textContent = "";
+                cell.appendChild(document.createTextNode(blockLabel));
+                cell.appendChild(document.createElement("br"));
+                cell.appendChild(document.createTextNode(this.rowArgs[i]));
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
                 cell.setAttribute("alt", i + "__" + "graphicsblocks");
 
@@ -678,7 +695,10 @@ class PhraseMaker {
             } else if (PhraseMakerUtils.MATRIXGRAPHICS2.includes(this.rowLabels[i])) {
                 blockLabel =
                     this.activity.blocks.protoBlockDict[this.rowLabels[i]]["staticLabels"][0];
-                cell.innerHTML = `${blockLabel}<br>${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`;
+                cell.textContent = "";
+                cell.appendChild(document.createTextNode(blockLabel));
+                cell.appendChild(document.createElement("br"));
+                cell.appendChild(document.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`));
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
                 cell.setAttribute("alt", i + "__" + "graphicsblocks2");
 
@@ -700,9 +720,11 @@ class PhraseMaker {
                     this._deps.noteIsSolfege(this.rowLabels[i]) &&
                     !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
                 ) {
-                    cell.innerHTML = `${this._deps.i18nSolfege(this.rowLabels[i])}${this.rowArgs[i]
-                        .toString()
-                        .sub()}`;
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(this._deps.i18nSolfege(this.rowLabels[i])));
+                    const subTitle1 = document.createElement("sub");
+                    subTitle1.textContent = this.rowArgs[i].toString();
+                    cell.appendChild(subTitle1);
                     noteObj = this._deps.getNote(
                         this.rowLabels[i],
                         this.rowArgs[i],
@@ -740,12 +762,20 @@ class PhraseMaker {
                             note = note[0];
                         }
                         if (note[3] && note[3] !== note[1]) {
-                            cell.innerHTML = note[1];
+                            cell.textContent = note[1];
                         } else {
-                            cell.innerHTML = label + this.rowArgs[i].toString().sub();
+                            cell.textContent = "";
+                            cell.appendChild(document.createTextNode(label));
+                            const subTitle2 = document.createElement("sub");
+                            subTitle2.textContent = this.rowArgs[i].toString();
+                            cell.appendChild(subTitle2);
                         }
                     } else {
-                        cell.innerHTML = this.rowLabels[i] + this.rowArgs[i].toString().sub();
+                        cell.textContent = "";
+                        cell.appendChild(document.createTextNode(this.rowLabels[i]));
+                        const subTitle3 = document.createElement("sub");
+                        subTitle3.textContent = this.rowArgs[i].toString();
+                        cell.appendChild(subTitle3);
                         noteObj = [this.rowLabels[i], this.rowArgs[i]];
                     }
                 }
@@ -792,7 +822,13 @@ class PhraseMaker {
             cell.style.zIndex = "1";
             cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
             cell.style.textAlign = "center";
-            cell.innerHTML = `<img src="images/pen.svg" height="${iconSize}" width="${iconSize}" vertical-align="middle">`;
+            cell.textContent = "";
+            const penImg = document.createElement("img");
+            penImg.src = "images/pen.svg";
+            penImg.setAttribute("height", iconSize);
+            penImg.setAttribute("width", iconSize);
+            penImg.setAttribute("vertical-align", "middle");
+            cell.appendChild(penImg);
 
             // Label Cell (Fixed like "note value")
             cell = lyricsRow.insertCell();
@@ -803,7 +839,7 @@ class PhraseMaker {
             cell.style.zIndex = "1";
             cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
             cell.style.textAlign = "center";
-            cell.innerHTML = "Lyrics";
+            cell.textContent = "Lyrics";
 
             // Nested Table for Input Fields
             tempTable = document.createElement("table");
@@ -896,7 +932,7 @@ class PhraseMaker {
         this._tupletValueLabel = tempTable.insertRow().insertCell();
         this._noteValueLabel = tempTable.insertRow().insertCell();
 
-        this._noteValueLabel.innerHTML = this._("note value");
+        this._noteValueLabel.textContent = this._("note value");
         this._noteValueLabel.style.fontSize = this._cellScale * 75 + "%";
         this._noteValueLabel.style.height =
             Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
@@ -1415,12 +1451,14 @@ class PhraseMaker {
             let cell = this._headcols[blockIndex];
             const iconSize = PhraseMaker.ICONSIZE * (window.innerWidth / 1200);
             if (PhraseMakerUtils.MATRIXGRAPHICS2.includes(this.rowLabels[blockIndex])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/mouse.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/mouse.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             }
 
             cell = this._labelcols[blockIndex];
@@ -1429,7 +1467,10 @@ class PhraseMaker {
                     this.activity.blocks.protoBlockDict[this.rowLabels[blockIndex]][
                         "staticLabels"
                     ][0];
-                cell.innerHTML = `${blockLabel}<br>${this.rowArgs[blockIndex][0]} ${this.rowArgs[blockIndex][1]}`;
+                cell.textContent = "";
+                cell.appendChild(document.createTextNode(blockLabel));
+                cell.appendChild(document.createElement("br"));
+                cell.appendChild(document.createTextNode(`${this.rowArgs[blockIndex][0]} ${this.rowArgs[blockIndex][1]}`));
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             }
 
@@ -1694,31 +1735,38 @@ class PhraseMaker {
             let cell = this._headcols[blockIndex];
             const iconSize = PhraseMaker.ICONSIZE * (window.innerWidth / 1200);
             if (PhraseMakerUtils.MATRIXSYNTHS.includes(this.rowLabels[blockIndex])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/synth2.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/synth2.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[blockIndex])) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/mouse.svg" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/mouse.svg";
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             }
 
             cell = this._labelcols[blockIndex];
             if (PhraseMakerUtils.MATRIXSYNTHS.includes(this.rowLabels[blockIndex])) {
-                cell.innerHTML = this.rowArgs[blockIndex];
+                cell.textContent = this.rowArgs[blockIndex];
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[blockIndex])) {
                 blockLabel =
                     this.activity.blocks.protoBlockDict[this.rowLabels[blockIndex]][
                         "staticLabels"
                     ][0];
-                cell.innerHTML = `${blockLabel}<br>${this.rowArgs[blockIndex]}`;
+                cell.textContent = "";
+                cell.appendChild(document.createTextNode(blockLabel));
+                cell.appendChild(document.createElement("br"));
+                cell.appendChild(document.createTextNode(this.rowArgs[blockIndex]));
                 cell.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             }
 
@@ -2054,41 +2102,45 @@ class PhraseMaker {
             const w = window.innerWidth;
             const iconSize = PhraseMaker.ICONSIZE * (w / 1200);
             if (drumName != null) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="${this._deps.getDrumIcon(drumName)}" 
-                        title="${this._(drumName)}" 
-                        alt="${this._(drumName)}" 
-                        height="${iconSize}" 
-                        width="${iconSize}" 
-                        vertical-align="middle"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = this._deps.getDrumIcon(drumName);
+                img.title = this._(drumName);
+                img.alt = this._(drumName);
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else if (noteName in BELLSETIDX && this.rowArgs[index] === 4) {
-                cell.innerHTML = `<img 
-                        src="images/8_bellset_key_${BELLSETIDX[noteName]}.svg" 
-                        width="${cell.style.width}" 
-                        vertical-align="middle"
-                    >`;
+                cell.textContent = "";
+                const img = document.createElement("img");
+                img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
+                img.setAttribute("width", cell.style.width);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
             } else if (noteName === "C" && this.rowArgs[index] === 5) {
-                cell.innerHTML = `<img 
-                        src="images/8_bellset_key_8.svg" 
-                        width="${cell.style.width}" 
-                        vertical-align="middle"
-                    >`;
+                cell.textContent = "";
+                const img = document.createElement("img");
+                img.src = "images/8_bellset_key_8.svg";
+                img.setAttribute("width", cell.style.width);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
             }
 
             cell = this._labelcols[index];
             if (drumName != null) {
-                cell.innerHTML = this._(drumName);
+                cell.textContent = this._(drumName);
                 cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (
                 this._deps.noteIsSolfege(this.rowLabels[i]) &&
                 !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
             ) {
-                cell.innerHTML = `${this._deps.i18nSolfege(this.rowLabels[index])}${this.rowArgs[
-                    index
-                ]
-                    .toString()
-                    .sub()}`;
+                cell.textContent = "";
+                cell.appendChild(document.createTextNode(this._deps.i18nSolfege(this.rowLabels[index])));
+                const subTitle1 = document.createElement("sub");
+                subTitle1.textContent = this.rowArgs[index].toString();
+                cell.appendChild(subTitle1);
                 noteObj = this._deps.getNote(
                     this.rowLabels[index],
                     this.rowArgs[index],
@@ -2111,9 +2163,17 @@ class PhraseMaker {
                         this.activity.errorMsg,
                         this.activity.logo.synth.inTemperament
                     );
-                    cell.innerHTML = `${this.rowLabels[i]}${this.rowArgs[i].toString().sub()}`;
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(this.rowLabels[i]));
+                    const subTitle2 = document.createElement("sub");
+                    subTitle2.textContent = this.rowArgs[i].toString();
+                    cell.appendChild(subTitle2);
                 } else {
-                    cell.innerHTML = `${this.rowLabels[i]}${this.rowArgs[i].toString().sub()}`;
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(this.rowLabels[i]));
+                    const subTitle3 = document.createElement("sub");
+                    subTitle3.textContent = this.rowArgs[i].toString();
+                    cell.appendChild(subTitle3);
                     noteObj = [this.rowLabels[i], this.rowArgs[i]];
                 }
             }
@@ -2534,11 +2594,11 @@ class PhraseMaker {
         }
 
         const title = exportDocument.createElement("title");
-        title.innerHTML = "Music Matrix";
+        title.textContent = "Music Matrix";
         exportDocument.head.appendChild(title);
 
         const w = exportDocument.createElement("H3");
-        w.innerHTML = "Music Matrix";
+        w.textContent = "Music Matrix";
 
         exportDocument.body.appendChild(w);
 
@@ -2561,33 +2621,43 @@ class PhraseMaker {
 
             drumName = this._deps.getDrumName(this.rowLabels[i]);
             if (drumName != null) {
-                exportLabel.innerHTML = this._(drumName);
+                exportLabel.textContent = this._(drumName);
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (this.rowLabels[i].slice(0, 4) === "http") {
-                exportLabel.innerHTML = this.rowLabels[i];
+                exportLabel.textContent = this.rowLabels[i];
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (PhraseMakerUtils.MATRIXSYNTHS.includes(this.rowLabels[i])) {
-                exportLabel.innerHTML = this.rowArgs[i];
+                exportLabel.textContent = this.rowArgs[i];
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 14) + "px";
             } else if (PhraseMakerUtils.MATRIXGRAPHICS.includes(this.rowLabels[i])) {
                 blockLabel =
                     this.activity.blocks.protoBlockDict[this.rowLabels[i]]["staticLabels"][0];
-                exportLabel.innerHTML = blockLabel + "<br>" + this.rowArgs[i];
+                exportLabel.textContent = "";
+                exportLabel.appendChild(exportDocument.createTextNode(blockLabel));
+                exportLabel.appendChild(exportDocument.createElement("br"));
+                exportLabel.appendChild(exportDocument.createTextNode(this.rowArgs[i]));
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             } else if (PhraseMakerUtils.MATRIXGRAPHICS2.includes(this.rowLabels[i])) {
                 blockLabel =
                     this.activity.blocks.protoBlockDict[this.rowLabels[i]]["staticLabels"][0];
-                exportLabel.innerHTML = `${blockLabel}<br>${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`;
+                exportLabel.textContent = "";
+                exportLabel.appendChild(exportDocument.createTextNode(blockLabel));
+                exportLabel.appendChild(exportDocument.createElement("br"));
+                exportLabel.appendChild(exportDocument.createTextNode(`${this.rowArgs[i][0]} ${this.rowArgs[i][1]}`));
                 exportLabel.style.fontSize = Math.floor(this._cellScale * 12) + "px";
             } else {
                 if (this._deps.noteIsSolfege(this.rowLabels[i])) {
-                    exportLabel.innerHTML = `${this._deps.i18nSolfege(
-                        this.rowLabels[i]
-                    )}${this.rowArgs[i].toString().sub()}`;
+                    exportLabel.textContent = "";
+                    exportLabel.appendChild(exportDocument.createTextNode(this._deps.i18nSolfege(this.rowLabels[i])));
+                    const subTitle1 = exportDocument.createElement("sub");
+                    subTitle1.textContent = this.rowArgs[i].toString();
+                    exportLabel.appendChild(subTitle1);
                 } else {
-                    exportLabel.innerHTML = `${this.rowLabels[i]}${this.rowArgs[i]
-                        .toString()
-                        .sub()}`;
+                    exportLabel.textContent = "";
+                    exportLabel.appendChild(exportDocument.createTextNode(this.rowLabels[i]));
+                    const subTitle2 = exportDocument.createElement("sub");
+                    subTitle2.textContent = this.rowArgs[i].toString();
+                    exportLabel.appendChild(subTitle2);
                 }
             }
 
@@ -2595,7 +2665,8 @@ class PhraseMaker {
             for (let j = 0, col; (col = this._rows[i].cells[j]); j++) {
                 exportCell = exportRow.insertCell();
                 exportCell.style.backgroundColor = col.style.backgroundColor;
-                exportCell.innerHTML = col.innerHTML;
+                exportCell.textContent = "";
+                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2613,13 +2684,14 @@ class PhraseMaker {
             // Add the tuplet note value row.
             exportRow = header.insertRow();
             exportLabel = exportRow.insertCell();
-            exportLabel.innerHTML = this._("note value");
+            exportLabel.textContent = this._("note value");
             noteValueRow = this._tupletNoteValueRow;
             for (let i = 0; i < noteValueRow.cells.length; i++) {
                 exportCell = exportRow.insertCell();
                 col = noteValueRow.cells[i];
                 exportCell.style.backgroundColor = col.style.backgroundColor;
-                exportCell.innerHTML = col.innerHTML;
+                exportCell.textContent = "";
+                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2634,13 +2706,14 @@ class PhraseMaker {
             // Add the tuplet value row.
             exportRow = header.insertRow();
             exportLabel = exportRow.insertCell();
-            exportLabel.innerHTML = this._("tuplet value");
+            exportLabel.textContent = this._("tuplet value");
             noteValueRow = this._tupletValueRow;
             for (let i = 0; i < noteValueRow.cells.length; i++) {
                 exportCell = exportRow.insertCell();
                 col = noteValueRow.cells[i];
                 exportCell.style.backgroundColor = col.style.backgroundColor;
-                exportCell.innerHTML = col.innerHTML;
+                exportCell.textContent = "";
+                Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
                 exportCell.width = col.width;
                 if (exportCell.width == "") {
                     exportCell.width = col.style.width;
@@ -2656,13 +2729,14 @@ class PhraseMaker {
         // Add the note value row.
         exportRow = header.insertRow();
         exportLabel = exportRow.insertCell();
-        exportLabel.innerHTML = this._("note value");
+        exportLabel.textContent = this._("note value");
         noteValueRow = this._noteValueRow;
         for (let i = 0; i < noteValueRow.cells.length; i++) {
             exportCell = exportRow.insertCell();
             col = noteValueRow.cells[i];
             exportCell.style.backgroundColor = col.style.backgroundColor;
-            exportCell.innerHTML = col.innerHTML;
+            exportCell.textContent = "";
+            Array.from(col.childNodes).forEach(child => exportCell.appendChild(child.cloneNode(true)));
             exportCell.width = col.width;
             if (exportCell.width == "") {
                 exportCell.width = col.style.width;
@@ -2676,8 +2750,13 @@ class PhraseMaker {
 
         const saveDocument = exportDocument;
         const uriData = saveDocument.documentElement.outerHTML;
-        exportDocument.body.innerHTML +=
-            '<br><a id="downloadb1" style="background: #C374E9; border-radius: 5%; padding: 0.3em; text-decoration: none; margin: 0.5em; color: white;" download>Download Matrix</a>';
+        exportDocument.body.appendChild(exportDocument.createElement("br"));
+        const downloadLink = exportDocument.createElement("a");
+        downloadLink.id = "downloadb1";
+        downloadLink.style.cssText = "background: #C374E9; border-radius: 5%; padding: 0.3em; text-decoration: none; margin: 0.5em; color: white;";
+        downloadLink.setAttribute("download", "");
+        downloadLink.textContent = "Download Matrix";
+        exportDocument.body.appendChild(downloadLink);
         exportDocument.getElementById("downloadb1").download = "MusicMatrix";
         exportDocument.getElementById("downloadb1").href = this._generateDataURI(uriData);
         exportDocument.close();
@@ -2744,10 +2823,11 @@ class PhraseMaker {
         const noteValue = param[0][1] / param[0][0];
         // The tuplet is note value is calculated as #notes x note value
         let noteValueToDisplay = this._deps.calcNoteValueToDisplay(param[0][1], param[0][0]);
+        let noteValueToDisplayAnchorTitle = null;
 
         if (noteValue > 12) {
-            noteValueToDisplay =
-                '<a href="#" title="' + param[0][0] + "/" + param[0][1] + '">.</a>';
+            noteValueToDisplay = ".";
+            noteValueToDisplayAnchorTitle = param[0][0] + "/" + param[0][1];
         }
 
         // Set the cells to 'rest'
@@ -2765,7 +2845,7 @@ class PhraseMaker {
 
             // Load the labels
             labelCell = this._tupletNoteLabel;
-            labelCell.innerHTML = this._("note value");
+            labelCell.textContent = this._("note value");
             labelCell.style.fontSize = this._cellScale * 75 + "%";
             labelCell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
@@ -2774,7 +2854,7 @@ class PhraseMaker {
             labelCell.style.backgroundColor = this.platformColor.labelColor;
 
             labelCell = this._tupletValueLabel;
-            labelCell.innerHTML = this._("tuplet value");
+            labelCell.textContent = this._("tuplet value");
             labelCell.style.fontSize = this._cellScale * 75 + "%";
             labelCell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
@@ -2830,16 +2910,29 @@ class PhraseMaker {
 
             if (obj[1] < 13) {
                 if (NOTESYMBOLS != undefined && obj[1] in NOTESYMBOLS) {
-                    cell.innerHTML = `${obj[0]}<br>&mdash;<br>${obj[1]}<br>
-                        <img 
-                            src="${this._deps.NOTESYMBOLS[obj[1]]}" 
-                            height="${(MATRIXSOLFEHEIGHT / 2) * this._cellScale}"
-                        >`;
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(obj[0]));
+                    cell.appendChild(document.createElement("br"));
+                    cell.appendChild(document.createTextNode("\u2014"));
+                    cell.appendChild(document.createElement("br"));
+                    cell.appendChild(document.createTextNode(obj[1]));
+                    cell.appendChild(document.createElement("br"));
+                    const img = document.createElement("img");
+                    img.src = this._deps.NOTESYMBOLS[obj[1]];
+                    img.setAttribute("height", (MATRIXSOLFEHEIGHT / 2) * this._cellScale);
+                    cell.appendChild(img);
                 } else {
-                    cell.innerHTML = `${obj[0]}<br>&mdash;<br>${obj[1]}<br><br>`;
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(obj[0]));
+                    cell.appendChild(document.createElement("br"));
+                    cell.appendChild(document.createTextNode("\u2014"));
+                    cell.appendChild(document.createElement("br"));
+                    cell.appendChild(document.createTextNode(obj[1]));
+                    cell.appendChild(document.createElement("br"));
+                    cell.appendChild(document.createElement("br"));
                 }
             } else {
-                cell.innerHTML = "";
+                cell.textContent = "";
             }
 
             cellWidth = cell.style.width;
@@ -2897,7 +2990,7 @@ class PhraseMaker {
         cell.style.maxWidth = cell.style.width;
         cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
         cell.style.textAlign = "center";
-        cell.innerHTML = tupletValue;
+        cell.textContent = tupletValue;
         cell.style.backgroundColor = this.platformColor.tupletBackground;
         cell.style.borderLeft = barStyle;
 
@@ -2912,7 +3005,22 @@ class PhraseMaker {
         cell.style.maxWidth = cell.style.width;
         cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
         cell.style.textAlign = "center";
-        cell.innerHTML = noteValueToDisplay;
+        cell.textContent = "";
+        if (noteValueToDisplayAnchorTitle !== null) {
+            const anchor = document.createElement("a");
+            anchor.href = "#";
+            anchor.title = noteValueToDisplayAnchorTitle;
+            anchor.textContent = noteValueToDisplay;
+            cell.appendChild(anchor);
+        } else {
+            const parts = noteValueToDisplay.split("<br>");
+            for (let k = 0; k < parts.length; k++) {
+                let p = parts[k];
+                if (p === "&mdash;") p = "\u2014";
+                cell.appendChild(document.createTextNode(p));
+                if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
+            }
+        }
         cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
         cell.style.borderLeft = barStyle;
         this._matrixHasTuplets = true;
@@ -2942,9 +3050,11 @@ class PhraseMaker {
      */
     addNotes(numBeats, noteValue) {
         let noteValueToDisplay = this._deps.calcNoteValueToDisplay(noteValue, 1);
+        let noteValueToDisplayAnchorTitle = null;
 
         if (noteValue > 12) {
-            noteValueToDisplay = '<a href="#" title="' + 1 + "/" + noteValue + '">.</a>';
+            noteValueToDisplay = ".";
+            noteValueToDisplayAnchorTitle = 1 + "/" + noteValue;
         }
 
         for (let i = 0; i < numBeats; i++) {
@@ -3018,7 +3128,22 @@ class PhraseMaker {
             cell.style.fontSize = Math.floor(this._cellScale * 75) + "%";
             cell.style.lineHeight = 60 + "%";
             cell.style.textAlign = "center";
-            cell.innerHTML = noteValueToDisplay;
+            cell.textContent = "";
+            if (noteValueToDisplayAnchorTitle !== null) {
+                const anchor = document.createElement("a");
+                anchor.href = "#";
+                anchor.title = noteValueToDisplayAnchorTitle;
+                anchor.textContent = noteValueToDisplay;
+                cell.appendChild(anchor);
+            } else {
+                const parts = noteValueToDisplay.split("<br>");
+                for (let k = 0; k < parts.length; k++) {
+                    let p = parts[k];
+                    if (p === "&mdash;") p = "\u2014";
+                    cell.appendChild(document.createTextNode(p));
+                    if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
+                }
+            }
             cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
             cell.style.color = this.platformColor.textColor;
             cell.setAttribute("alt", noteValue);

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -192,7 +192,7 @@ class PitchDrumMatrix {
         pdmTableDiv.style.position = "relative";
         pdmTableDiv.style.visibility = "invisible";
         pdmTableDiv.style.border = "0px";
-        pdmTableDiv.innerHTML = "";
+        pdmTableDiv.textContent = "";
 
         // For the button callbacks
         widgetWindow.onclose = () => {
@@ -204,8 +204,16 @@ class PitchDrumMatrix {
         this.widgetWindow.onmaximize = this._scale;
 
         // We use an outer div to scroll vertically and an inner div to scroll horizontally.
-        pdmTableDiv.innerHTML =
-            '<div id="pdmOuterDiv"><div id="pdmInnerDiv"><table cellpadding="0px" id="pdmTable"></table></div></div>';
+        const outerDivTmp = document.createElement("div");
+        outerDivTmp.id = "pdmOuterDiv";
+        const innerDivTmp = document.createElement("div");
+        innerDivTmp.id = "pdmInnerDiv";
+        const tmpTable = document.createElement("table");
+        tmpTable.id = "pdmTable";
+        tmpTable.setAttribute("cellpadding", "0px");
+        innerDivTmp.appendChild(tmpTable);
+        outerDivTmp.appendChild(innerDivTmp);
+        pdmTableDiv.appendChild(outerDivTmp);
 
         // Each row in the pdm table contains a note label in the
         // first column and a table of buttons in the second column.
@@ -244,7 +252,10 @@ class PitchDrumMatrix {
             labelCell.style.minWidth = 0;
             labelCell.style.maxWidth = 0;
             labelCell.className = "headcol";
-            labelCell.innerHTML = this.rowLabels[j] + this.rowArgs[j].toString().sub();
+            labelCell.textContent = this.rowLabels[j];
+            const sub = document.createElement("sub");
+            sub.textContent = this.rowArgs[j].toString();
+            labelCell.appendChild(sub);
             labelCell.style.position = "sticky";
             labelCell.style.left = "0";
             labelCell.style.top = "0";
@@ -252,8 +263,12 @@ class PitchDrumMatrix {
 
             pdmCell = pdmTableRow.insertCell();
             // Create tables to store individual notes.
-            pdmCell.innerHTML =
-                '<table cellpadding="0px" id="pdmCellTable' + j + '"><tr></tr></table>';
+            const tbl = document.createElement("table");
+            tbl.setAttribute("cellpadding", "0px");
+            tbl.id = "pdmCellTable" + j;
+            const tr = document.createElement("tr");
+            tbl.appendChild(tr);
+            pdmCell.appendChild(tbl);
             pdmCellTable = docById("pdmCellTable" + j);
 
             // We'll use this element to put the clickable notes for this row.
@@ -273,7 +288,7 @@ class PitchDrumMatrix {
         labelCell.style.minWidth = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) + "px";
         labelCell.style.maxWidth = labelCell.style.minWidth;
         labelCell.className = "headcol";
-        labelCell.innerHTML = "";
+        labelCell.textContent = "";
         labelCell.style.position = "sticky";
         labelCell.style.left = "0";
         labelCell.style.top = "0";
@@ -314,7 +329,12 @@ class PitchDrumMatrix {
 
         pdmCell = pdmTableRow.insertCell();
         // Create table to store drum names.
-        pdmCell.innerHTML = '<table cellpadding="0px" id="pdmDrumTable"><tr></tr></table>';
+        const pTbl = document.createElement("table");
+        pTbl.setAttribute("cellpadding", "0px");
+        pTbl.id = "pdmDrumTable";
+        const pTr = document.createElement("tr");
+        pTbl.appendChild(pTr);
+        pdmCell.appendChild(pTbl);
         pdmCell.style.position = "sticky";
         pdmCell.style.bottom = "0";
         pdmCell.style.zIndex = "10";
@@ -443,15 +463,17 @@ class PitchDrumMatrix {
      */
     _addButton(row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
-        cell.innerHTML = `&nbsp;&nbsp;<img 
-                src="header-icons/${icon}" 
-                title="${label}" 
-                alt="${label}" 
-                height="${iconSize}" 
-                width="${iconSize}" 
-                vertical-align="middle" 
-                align-content="center"
-            >&nbsp;&nbsp;`;
+        cell.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.setAttribute("height", iconSize);
+        img.setAttribute("width", iconSize);
+        img.setAttribute("vertical-align", "middle");
+        img.setAttribute("align-content", "center");
+        cell.appendChild(img);
+        cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         cell.style.width = PitchDrumMatrix.BUTTONSIZE + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
@@ -530,14 +552,16 @@ class PitchDrumMatrix {
             name = drumname;
         }
 
-        cell.innerHTML = `&nbsp;&nbsp;<img 
-                src="${getDrumIcon(name)}" 
-                title="${name}" 
-                alt="${name}" 
-                height="${PitchDrumMatrix.ICONSIZE}" 
-                width="${PitchDrumMatrix.ICONSIZE}" 
-                vertical-align="middle"
-            >&nbsp;&nbsp;`;
+        cell.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = `${getDrumIcon(name)}`;
+        img.title = name;
+        img.alt = name;
+        img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+        img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+        img.setAttribute("vertical-align", "middle");
+        cell.appendChild(img);
+        cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         cell.style.backgroundColor = platformColor.selectorBackground;
     }
 
@@ -654,25 +678,29 @@ class PitchDrumMatrix {
         // Play all of the pitch/drum combinations in the matrix.
         const icon = this.playButton;
         if (this._playing) {
-            icon.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/stop-button.svg" 
-                    title="${_("Stop")}" 
-                    alt="${_("Stop")}" 
-                    height="${PitchDrumMatrix.ICONSIZE}" 
-                    width="${PitchDrumMatrix.ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            icon.textContent = "\u00A0\u00A0";
+            const img = document.createElement("img");
+            img.src = "header-icons/stop-button.svg";
+            img.title = _("Stop");
+            img.alt = _("Stop");
+            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("vertical-align", "middle");
+            img.setAttribute("align-content", "center");
+            icon.appendChild(img);
+            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
         } else {
-            icon.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="${PitchDrumMatrix.ICONSIZE}" 
-                    width="${PitchDrumMatrix.ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            icon.textContent = "\u00A0\u00A0";
+            const img = document.createElement("img");
+            img.src = "header-icons/play-button.svg";
+            img.title = _("Play");
+            img.alt = _("Play");
+            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("vertical-align", "middle");
+            img.setAttribute("align-content", "center");
+            icon.appendChild(img);
+            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
             this._playing = false;
             return;
         }
@@ -715,29 +743,33 @@ class PitchDrumMatrix {
             }
             setTimeout(() => {
                 this._playing = false;
-                icon.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/play-button.svg" 
-                        title="${_("Play")}" 
-                        alt="${_("Play")}" 
-                        height="${PitchDrumMatrix.ICONSIZE}" 
-                        width="${PitchDrumMatrix.ICONSIZE}" 
-                        vertical-align="middle" 
-                        align-content="center"
-                    >&nbsp;&nbsp;`;
+                icon.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "header-icons/play-button.svg";
+                img.title = _("Play");
+                img.alt = _("Play");
+                img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+                img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+                img.setAttribute("vertical-align", "middle");
+                img.setAttribute("align-content", "center");
+                icon.appendChild(img);
+                icon.appendChild(document.createTextNode("\u00A0\u00A0"));
             }, pairs.length * 1000);
         } else {
             if (!this.widgetWindow._maximized) {
                 activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
             }
-            icon.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="${PitchDrumMatrix.ICONSIZE}" 
-                    width="${PitchDrumMatrix.ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            icon.textContent = "\u00A0\u00A0";
+            const img = document.createElement("img");
+            img.src = "header-icons/play-button.svg";
+            img.title = _("Play");
+            img.alt = _("Play");
+            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("vertical-align", "middle");
+            img.setAttribute("align-content", "center");
+            icon.appendChild(img);
+            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
         }
     }
 
@@ -757,15 +789,17 @@ class PitchDrumMatrix {
                 pdmTable.rows[j].cells[0].style.backgroundColor = platformColor.labelColor;
             }
             const icon = this.playButton;
-            icon.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="${PitchDrumMatrix.ICONSIZE}" 
-                    width="${PitchDrumMatrix.ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            icon.textContent = "\u00A0\u00A0";
+            const img = document.createElement("img");
+            img.src = "header-icons/play-button.svg";
+            img.title = _("Play");
+            img.alt = _("Play");
+            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+            img.setAttribute("vertical-align", "middle");
+            img.setAttribute("align-content", "center");
+            icon.appendChild(img);
+            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
             return;
         }
         const drumTable = docById("pdmDrumTable");
@@ -879,8 +913,8 @@ class PitchDrumMatrix {
 
         const drumTable = docById("pdmDrumTable");
         row = drumTable.rows[0];
-        const drumHTML = row.cells[colIndex].innerHTML.split('"');
-        const drumName = getDrumSynthName(drumHTML[3]);
+        const drumImg = row.cells[colIndex].querySelector("img");
+        const drumName = getDrumSynthName(drumImg ? drumImg.title : "");
 
         // Both solfege and octave are extracted from HTML by getNote.
         const noteObj = getNote(
@@ -1007,8 +1041,8 @@ class PitchDrumMatrix {
             solfegeHTML = cellRow.cells[0].innerHTML;
 
             drumRow = drumTable.rows[0];
-            drumHTML = drumRow.cells[col].innerHTML.split('"');
-            drumName = getDrumSynthName(drumHTML[3]);
+            const drumImg = drumRow.cells[col].querySelector("img");
+            drumName = getDrumSynthName(drumImg ? drumImg.title : "");
             // Both solfege and octave are extracted from HTML by getNote.
             noteObj = getNote(
                 solfegeHTML,

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -235,7 +235,7 @@ class PitchDrumMatrix {
 
             drumName = getDrumName(this.rowLabels[i]);
 
-            if (drumName != null) {
+            if (drumName !== null) {
                 // if it is a drum, we'll make it a column below.
                 this.drums.push(drumName);
                 continue;
@@ -633,7 +633,7 @@ class PitchDrumMatrix {
 
                 cell = cellRow.cells[col];
 
-                if (cell != undefined) {
+                if (cell !== undefined) {
                     cell.style.backgroundColor = "black";
                     this._setPairCell(row, col, cell, false);
                 }
@@ -731,7 +731,7 @@ class PitchDrumMatrix {
         }
         let isEmpty = true;
         for (let i = 0; i < pairs.length; i++) {
-            if (pairs[i][1] != -1) {
+            if (pairs[i][1] !== -1) {
                 isEmpty = false;
                 break;
             }

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -121,7 +121,7 @@ class PitchSlider {
             );
 
             // Set the leftmost slider as active by default
-            if (id === 0) {
+            if (id === "0") {
                 this.activeSlider = id;
             }
 

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -121,7 +121,7 @@ class PitchSlider {
             );
 
             // Set the leftmost slider as active by default
-            if (id == 0) {
+            if (id === 0) {
                 this.activeSlider = id;
             }
 

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -381,7 +381,7 @@ class PitchStaircase {
         const pscTableCell = this._stepTables[previousRowNumber];
 
         setTimeout(() => {
-            if (pscTableCell != null) {
+            if (pscTableCell !== null) {
                 const stepCell = pscTableCell.rows[0].cells[1];
                 stepCell.style.backgroundColor = platformColor.selectorBackground;
             }

--- a/js/widgets/reflection-guide.md
+++ b/js/widgets/reflection-guide.md
@@ -8,73 +8,70 @@ Backend Code for the widget : [musicblocks_reflection_fastapi](https://github.co
 
 ## Key Features
 
--   **Multi-mentor Chat:** Switch between AI mentors (Meta/Rohan, Music/Beethoven, Code/Alan).
--   **Chat History:** Stores and renders conversation history.
--   **Typing Indicator:** Shows animated "Thinking..." while awaiting responses.
--   **Markdown Rendering:** Converts Markdown responses to HTML for display.
--   **Analysis & Summary:** Fetches project analysis after sufficient chat history.
--   **Local Storage:** Saves and retrieves analysis reports.
--   **Export:** Download chat transcript as a text file.
+- **Multi-mentor Chat:** Switch between AI mentors (Meta/Rohan, Music/Beethoven, Code/Alan).
+- **Chat History:** Stores and renders conversation history.
+- **Typing Indicator:** Shows animated "Thinking..." while awaiting responses.
+- **Markdown Rendering:** Converts Markdown responses to HTML for display.
+- **Analysis & Summary:** Fetches project analysis after sufficient chat history.
+- **Local Storage:** Saves and retrieves analysis reports.
+- **Export:** Download chat transcript as a text file.
 
 ## Components
 
--   **Widget Interface**: `js/widgets/reflection.js`
--   **Block Definition**: `js/blocks/WidgetBlocks.js`
--   **Registration**: `js/activity.js` (line 176) and `js/logo.js` (line 113)
--   **CSS styling**: `css/activities.css` (line 2023 - 2072)
+- **Widget Interface**: `js/widgets/reflection.js`
+- **Block Definition**: `js/blocks/WidgetBlocks.js`
+- **Registration**: `js/activity.js` (line 176) and `js/logo.js` (line 113)
+- **CSS styling**: `css/activities.css` (line 2023 - 2072)
 
 ## Methods
 
--   **Widget Window Initialisation**
+- **Widget Window Initialisation**
 
     `init(activity)` : Triggers when the reflection block is clicked. It renders the widget and initializes the required data structures.
 
 ---
 
--   **Mentor Switching**
+- **Mentor Switching**
 
     `changeMentor("code")` : Changes the active mentor and updates button highlights.
 
 ---
 
--   Sending Messages
+- Sending Messages
 
     `sendMessage()` : Pushes user message to history, displays it, and requests bot reply.
 
 ---
 
--   Bot Reply Handling
+- Bot Reply Handling
 
     `botReplyDiv(message, user_query, md)` :
-
-    -   If `user_query` is true, sends message to backend and displays reply.
-    -   If `md` is true, renders reply as Markdown.
+    - If `user_query` is true, sends message to backend and displays reply.
+    - If `md` is true, renders reply as Markdown.
 
 ---
 
--   Analysis & Summary
+- Analysis & Summary
 
     `getAnalysis()` :
-
-    -   Requests project analysis from backend if chat history is sufficient.
-    -   Saves analysis to localStorage.
-
----
-
--   Local Storage
-
-    -   **Save:** `saveReport(data)` stores analysis.
-    -   **Read:** `readReport()` retrieves analysis.
+    - Requests project analysis from backend if chat history is sufficient.
+    - Saves analysis to localStorage.
 
 ---
 
--   Export Conversation
+- Local Storage
+    - **Save:** `saveReport(data)` stores analysis.
+    - **Read:** `readReport()` retrieves analysis.
+
+---
+
+- Export Conversation
 
     `downloadAsTxt(conversationData)` : Downloads chat history as a `.txt` file.
 
 ---
 
--   Markdown Rendering
+- Markdown Rendering
 
     `mdToHTML(md)` : Converts Markdown to HTML for display in chat.
 
@@ -84,15 +81,15 @@ Backend Code for the widget : [musicblocks_reflection_fastapi](https://github.co
 
 ### 1. `/projectcode`
 
--   **Method:** `POST`
--   **Purpose:** Sends the exported project code to the backend to receive an algorithmic summary.
--   **Payload:**
+- **Method:** `POST`
+- **Purpose:** Sends the exported project code to the backend to receive an algorithmic summary.
+- **Payload:**
     ```json
     {
         "code": "<project code string>"
     }
     ```
--   **Response:**
+- **Response:**
     ```json
     {
         "algorithm": "<algorithm string>",
@@ -110,9 +107,9 @@ Backend Code for the widget : [musicblocks_reflection_fastapi](https://github.co
 
 ### 2. `/chat`
 
--   **Method:** `POST`
--   **Purpose:** Sends a user query, chat history, mentor selection, and project algorithm to the backend to get an AI mentor's reply.
--   **Payload:**
+- **Method:** `POST`
+- **Purpose:** Sends a user query, chat history, mentor selection, and project algorithm to the backend to get an AI mentor's reply.
+- **Payload:**
     ```json
     {
       "query": "<user message>",
@@ -121,12 +118,12 @@ Backend Code for the widget : [musicblocks_reflection_fastapi](https://github.co
       "algorithm": "<algorithm string>"
     }
     ```
--   **Response:**  
-    `{ response: "<bot reply>" }`  
-    or  
-    `{ error: "<error message>" }`
+- **Response:**  
+  `{ response: "<bot reply>" }`  
+  or  
+  `{ error: "<error message>" }`
 
--   **Example `messages` structure**
+- **Example `messages` structure**
     ```json
     [
         {
@@ -148,34 +145,34 @@ Backend Code for the widget : [musicblocks_reflection_fastapi](https://github.co
 
 ### 3. `/analysis`
 
--   **Method:** `POST`
--   **Purpose:** Sends the chat history and summary to the backend to receive a project analysis report.
--   **Payload:**
+- **Method:** `POST`
+- **Purpose:** Sends the chat history and summary to the backend to receive a project analysis report.
+- **Payload:**
     ```json
     {
       "messages": [ { "role": "...", "content": "..." }, ... ],
       "summary": "<summary string>"
     }
     ```
--   **Response:**  
-    `{ response: "<analysis report>" }`  
-    or  
-    `{ error: "<error message>" }`
+- **Response:**  
+  `{ response: "<analysis report>" }`  
+  or  
+  `{ error: "<error message>" }`
 
 ---
 
 ### 4. `/updatecode`
 
--   **Method:** `POST`
--   **Purpose:** Sends updated project code to the backend to refresh the algorithmic summary.
--   **Payload:**
+- **Method:** `POST`
+- **Purpose:** Sends updated project code to the backend to refresh the algorithmic summary.
+- **Payload:**
     ```json
     {
         "oldcode": "<existing project code string>",
         "newcode": "<new project code string>"
     }
     ```
--   **Response:**
+- **Response:**
     ```json
     {
         "algorithm": "<new algorithm string>",

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -731,7 +731,7 @@ class RhythmRuler {
 
                 const rhythmRulerTableRow = this._rulers[drum];
                 for (let j = 0; j < this._dissectHistory[i][0].length; j++) {
-                    if (this._dissectHistory[i][0][j] == undefined) {
+                    if (this._dissectHistory[i][0][j] === undefined) {
                         continue;
                     }
 
@@ -744,7 +744,7 @@ class RhythmRuler {
                         if (typeof this._dissectHistory[i][0][j][1] === "number") {
                             // dissect is [cell, num]
                             cell = rhythmRulerTableRow.cells[this._dissectHistory[i][0][j][0]];
-                            if (cell != undefined) {
+                            if (cell !== undefined) {
                                 this.__dissectByNumber(
                                     cell,
                                     this._dissectHistory[i][0][j][1],
@@ -758,7 +758,7 @@ class RhythmRuler {
                         } else {
                             // divide is [cell, [values]]
                             cell = rhythmRulerTableRow.cells[this._dissectHistory[i][0][j][0]];
-                            if (cell != undefined) {
+                            if (cell !== undefined) {
                                 this.__divideFromList(
                                     cell,
                                     this._dissectHistory[i][0][j][1],
@@ -771,7 +771,7 @@ class RhythmRuler {
                         const history = this._dissectHistory[i][0][j];
                         this._mouseDownCell = rhythmRulerTableRow.cells[history[0][0]];
                         this._mouseUpCell = rhythmRulerTableRow.cells[last(history)[0]];
-                        if (this._mouseUpCell != undefined) {
+                        if (this._mouseUpCell !== undefined) {
                             this.__tie(false);
                         }
 
@@ -904,7 +904,7 @@ class RhythmRuler {
         }
 
         this._rulerSelected = ruler;
-        if (this._rulerSelected == undefined) {
+        if (this._rulerSelected === undefined) {
             return;
         }
 
@@ -954,16 +954,19 @@ class RhythmRuler {
 
                 // Play count-off based on meter (e.g., 4 beats for 4/4, 3 beats for 3/4)
                 for (let i = 0; i < beatsPerMeasure; i++) {
-                    setTimeout(() => {
-                        this.activity.logo.synth.trigger(
-                            0,
-                            "C4",
-                            Singer.defaultBPMFactor / 16,
-                            drum,
-                            null,
-                            null
-                        );
-                    }, (interval * i) / beatsPerMeasure);
+                    setTimeout(
+                        () => {
+                            this.activity.logo.synth.trigger(
+                                0,
+                                "C4",
+                                Singer.defaultBPMFactor / 16,
+                                drum,
+                                null,
+                                null
+                            );
+                        },
+                        (interval * i) / beatsPerMeasure
+                    );
                 }
 
                 setTimeout(() => {
@@ -1224,7 +1227,7 @@ class RhythmRuler {
          * @returns {void}
          */
         const __clickHandler = event => {
-            if (event == undefined) return;
+            if (event === undefined) return;
             if (!this.__getLongPressStatus()) {
                 const cell = event.target;
                 if (cell !== null && cell.parentNode !== null) {
@@ -1971,16 +1974,19 @@ class RhythmRuler {
             this._offsets[rulerNo] = d.getTime() - this._startingTime - this._elapsedTimes[rulerNo];
         }
 
-        setTimeout(() => {
-            colIndex += 1;
-            if (colIndex === noteValues.length) {
-                colIndex = 0;
-            }
+        setTimeout(
+            () => {
+                colIndex += 1;
+                if (colIndex === noteValues.length) {
+                    colIndex = 0;
+                }
 
-            if (this._playing) {
-                this.__loop(noteTime, rulerNo, colIndex);
-            }
-        }, Singer.defaultBPMFactor * 1000 * noteTime - this._offsets[rulerNo]);
+                if (this._playing) {
+                    this.__loop(noteTime, rulerNo, colIndex);
+                }
+            },
+            Singer.defaultBPMFactor * 1000 * noteTime - this._offsets[rulerNo]
+        );
 
         this._elapsedTimes[rulerNo] += Singer.defaultBPMFactor * 1000 * noteTime;
     }
@@ -2046,7 +2052,7 @@ class RhythmRuler {
                     newStack.push([idx + 3, ["number", { value: obj[0] }], 0, 0, [idx + 2]]);
                     newStack.push([idx + 4, ["number", { value: obj[1] }], 0, 0, [idx + 2]]);
                     newStack.push([idx + 5, "vspace", 0, 0, [idx, idx + 6]]);
-                    if (i == ruler.cells.length - 1) {
+                    if (i === ruler.cells.length - 1) {
                         newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, null]]);
                     } else {
                         newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, idx + 7]]);
@@ -2137,7 +2143,7 @@ class RhythmRuler {
                         newStack.push([idx + 5, "vspace", 0, 0, [idx, idx + 6]]);
                     }
 
-                    if (i == ruler.cells.length - 1) {
+                    if (i === ruler.cells.length - 1) {
                         newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, null]]);
                     } else {
                         newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, idx + 7]]);
@@ -2193,7 +2199,7 @@ class RhythmRuler {
                 newStack.push([idx + 4, ["number", { value: obj[1] }], 0, 0, [idx + 2]]);
                 newStack.push([idx + 5, "vspace", 0, 0, [idx, idx + 6]]);
 
-                if (i == noteValues.length - 1) {
+                if (i === noteValues.length - 1) {
                     newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, null]]);
                 } else {
                     newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, idx + 7]]);
@@ -2346,7 +2352,7 @@ class RhythmRuler {
                                 ]);
                             }
                         }
-                        if (i == ruler.cells.length - 1) {
+                        if (i === ruler.cells.length - 1) {
                             newStack.push([idx + 7, "hidden", 0, 0, [idx, null]]);
                         } else {
                             newStack.push([idx + 7, "hidden", 0, 0, [idx, idx + 8]]);
@@ -2354,7 +2360,7 @@ class RhythmRuler {
                         }
                     } else {
                         // Add a note block inside a repeat block.
-                        if (i == ruler.cells.length - 1) {
+                        if (i === ruler.cells.length - 1) {
                             newStack.push([
                                 idx,
                                 "repeat",
@@ -2519,7 +2525,7 @@ class RhythmRuler {
                             newStack.push([idx + 4, "vspace", 0, 0, [idx, idx + 5]]);
                             newStack.push([idx + 5, "rest2", 0, 0, [idx + 4, idx + 6]]);
                             newStack.push([idx + 6, "hidden", 0, 0, [idx + 5, null]]);
-                            if (i == ruler.cells.length - 1) {
+                            if (i === ruler.cells.length - 1) {
                                 newStack.push([idx + 7, "hidden", 0, 0, [idx, null]]);
                             } else {
                                 newStack.push([idx + 7, "hidden", 0, 0, [idx, idx + 8]]);
@@ -2558,7 +2564,7 @@ class RhythmRuler {
                             ]);
                             newStack.push([idx + 6, ["notename", { value: "C" }], 0, 0, [idx + 5]]);
                             newStack.push([idx + 7, ["number", { value: 4 }], 0, 0, [idx + 5]]);
-                            if (i == ruler.cells.length - 1) {
+                            if (i === ruler.cells.length - 1) {
                                 newStack.push([idx + 8, "hidden", 0, 0, [idx, null]]);
                             } else {
                                 newStack.push([idx + 8, "hidden", 0, 0, [idx, idx + 9]]);
@@ -2567,7 +2573,7 @@ class RhythmRuler {
                         }
                     } else {
                         // Add a note block inside a repeat block.
-                        if (i == ruler.cells.length - 1) {
+                        if (i === ruler.cells.length - 1) {
                             newStack.push([
                                 idx,
                                 "repeat",
@@ -2744,7 +2750,7 @@ class RhythmRuler {
      * @returns {void}
      */
     _positionWheel() {
-        if (docById("wheelDiv").style.display == "none") {
+        if (docById("wheelDiv").style.display === "none") {
             return;
         }
 

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -153,15 +153,15 @@ function SampleWidget() {
             this.sampleOctave,
             this.centAdjustmentValue || 0
         ];
-        if (this.timbreBlock != null) {
+        if (this.timbreBlock !== null) {
             mainSampleBlock = this.activity.blocks.blockList[this.timbreBlock].connections[1];
-            if (mainSampleBlock != null) {
+            if (mainSampleBlock !== null) {
                 this.activity.blocks.blockList[mainSampleBlock].value = this.sampleArray;
                 this.activity.blocks.blockList[mainSampleBlock].updateCache();
                 audiofileBlock = this.activity.blocks.blockList[mainSampleBlock].connections[1];
                 solfegeBlock = this.activity.blocks.blockList[mainSampleBlock].connections[2];
                 octaveBlock = this.activity.blocks.blockList[mainSampleBlock].connections[3];
-                if (audiofileBlock != null) {
+                if (audiofileBlock !== null) {
                     this.activity.blocks.blockList[audiofileBlock].value = [
                         this.sampleName,
                         this.sampleData
@@ -169,12 +169,12 @@ function SampleWidget() {
                     this.activity.blocks.blockList[audiofileBlock].text.text = this.sampleName;
                     this.activity.blocks.blockList[audiofileBlock].updateCache();
                 }
-                if (solfegeBlock != null) {
+                if (solfegeBlock !== null) {
                     this.activity.blocks.blockList[solfegeBlock].value = this.samplePitch;
                     this.activity.blocks.blockList[solfegeBlock].text.text = this.samplePitch;
                     this.activity.blocks.blockList[solfegeBlock].updateCache();
                 }
-                if (octaveBlock != null) {
+                if (octaveBlock !== null) {
                     this.activity.blocks.blockList[octaveBlock].value = this.sampleOctave;
                     this.activity.blocks.blockList[octaveBlock].text.text = this.sampleOctave;
                     this.activity.blocks.blockList[octaveBlock].updateCache();
@@ -243,7 +243,7 @@ function SampleWidget() {
      */
     this._usePitch = function (p) {
         const number = SOLFEGENAMES.indexOf(p);
-        this.pitchCenter = number == -1 ? 0 : number;
+        this.pitchCenter = number === -1 ? 0 : number;
     };
 
     /**
@@ -515,7 +515,7 @@ function SampleWidget() {
             if (this.isMoving) {
                 this.pause();
             } else {
-                if (!(this.sampleName == "")) {
+                if (!(this.sampleName === "")) {
                     this.resume();
                 }
                 this._playReferencePitch();
@@ -1398,7 +1398,7 @@ function SampleWidget() {
      */
     this._addSample = function () {
         for (let i = 0; i < CUSTOMSAMPLES.length; i++) {
-            if (CUSTOMSAMPLES[i][0] == this.sampleName) {
+            if (CUSTOMSAMPLES[i][0] === this.sampleName) {
                 // Update existing sample with new data and cent adjustment
                 CUSTOMSAMPLES[i] = [
                     this.sampleName,
@@ -1435,13 +1435,13 @@ function SampleWidget() {
         const sol = this.samplePitch;
 
         let lev;
-        if (sol.indexOf(SHARP) != -1) {
+        if (sol.indexOf(SHARP) !== -1) {
             lev = 1;
-        } else if (sol.indexOf(FLAT) != -1) {
+        } else if (sol.indexOf(FLAT) !== -1) {
             lev = -1;
-        } else if (sol.indexOf(DOUBLEFLAT) != -1) {
+        } else if (sol.indexOf(DOUBLEFLAT) !== -1) {
             lev = -2;
-        } else if (sol.indexOf(DOUBLESHARP) != -1) {
+        } else if (sol.indexOf(DOUBLESHARP) !== -1) {
             lev = 2;
         } else {
             lev = 0;
@@ -1483,7 +1483,7 @@ function SampleWidget() {
      * @returns {void}
      */
     this.setTimbre = function () {
-        if (this.sampleName != null && this.sampleName != "") {
+        if (this.sampleName !== null && this.sampleName !== "") {
             this.originalSampleName = this.sampleName + "_original";
             const sampleArray = [this.originalSampleName, this.sampleData, "la", 4];
             Singer.ToneActions.setTimbre(sampleArray, 0, this.timbreBlock);
@@ -1526,7 +1526,7 @@ function SampleWidget() {
      * @returns {void}
      */
     this._playSample = function () {
-        if (this.sampleName != null && this.sampleName != "") {
+        if (this.sampleName !== null && this.sampleName !== "") {
             this.reconnectSynthsToAnalyser();
 
             // Store the current note object for the cent adjustment
@@ -1946,7 +1946,7 @@ function SampleWidget() {
                 let oscText;
                 if (turtleIdx >= 0) {
                     //.TRANS: The sound sample that the user uploads.
-                    oscText = this.sampleName != "" ? this.sampleName : _("sample");
+                    oscText = this.sampleName !== "" ? this.sampleName : _("sample");
                 }
                 canvasCtx.fillStyle = "#000000";
                 //.TRANS: The reference tone is a sound used for comparison.

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -66,7 +66,7 @@ class StatusMatrix {
         // cell.style.width = StatusMatrix.BUTTONSIZE * this._cellScale*2 + "px";
         cell.style.width = "212.5px";
 
-        cell.innerHTML = "&nbsp;";
+        cell.textContent = "\u00A0";
         // One column per mouse/turtle
         for (const turtle of this.activity.turtles.turtleList) {
             if (turtle.inTrash) {
@@ -77,21 +77,25 @@ class StatusMatrix {
             cell.style.backgroundColor = "#FFFFFF";
 
             if (_THIS_IS_MUSIC_BLOCKS_) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="images/mouse.svg" 
-                        title="${turtle.name}" 
-                        alt="${turtle.name}" 
-                        height="${iconSize}" 
-                        width="${iconSize}"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "images/mouse.svg";
+                img.title = turtle.name;
+                img.alt = turtle.name;
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             } else {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/turtle-button.svg" 
-                        title="${turtle.name}" 
-                        alt="${turtle.name}" 
-                        height="${iconSize}"
-                        width="${iconSize}"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = "header-icons/turtle-button.svg";
+                img.title = turtle.name;
+                img.alt = turtle.name;
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
             }
             cell.style.width = "212.5px";
             // cell.style.width = StatusMatrix.BUTTONSIZE * this._cellScale*2 + "px";
@@ -170,7 +174,10 @@ class StatusMatrix {
             let str = label;
             str = label.charAt(0).toUpperCase() + label.slice(1);
             // console.log(str);
-            cell.innerHTML = `&nbsp;<b>${str}</b>`;
+            cell.textContent = "\u00A0";
+            const b = document.createElement("b");
+            b.textContent = str;
+            cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
             cell.style.backgroundColor = platformColor.selectorBackground;
             cell.style.paddingLeft = "10px";
@@ -179,7 +186,7 @@ class StatusMatrix {
                 cell.style.backgroundColor = platformColor.selectorBackground;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
-                cell.innerHTML = "";
+                cell.textContent = "";
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.textAlign = "center";
             });
@@ -192,7 +199,10 @@ class StatusMatrix {
                 Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
             const str = _("note");
             const label = str.charAt(0).toUpperCase() + str.slice(1);
-            cell.innerHTML = `&nbsp;<b>${label}</b>`;
+            cell.textContent = "\u00A0";
+            const b = document.createElement("b");
+            b.textContent = label;
+            cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
             cell.style.backgroundColor = platformColor.selectorBackground;
             cell.style.paddingLeft = "10px";
@@ -201,7 +211,7 @@ class StatusMatrix {
                 cell.style.backgroundColor = platformColor.selectorBackground;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
-                cell.innerHTML = "";
+                cell.textContent = "";
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.textAlign = "center";
             });
@@ -313,7 +323,7 @@ class StatusMatrix {
 
                 cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
                 if (cell != null) {
-                    cell.innerHTML = value;
+                    cell.textContent = value;
                 }
                 i++;
             }
@@ -342,7 +352,7 @@ class StatusMatrix {
 
                 cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
                 if (cell != null) {
-                    cell.innerHTML = note.replace(/#/g, "♯").replace(/b/g, "♭");
+                    cell.textContent = note.replace(/#/g, "♯").replace(/b/g, "♭");
                 }
             }
 

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 // Copyright (c) 2016-20 Walter Bender
 //
 // This program is free software; you can redistribute it and/or
@@ -293,7 +292,7 @@ class StatusMatrix {
                         break;
                     case "pitchinhertz":
                         value = "";
-                        if (tur.singer.noteStatus != null) {
+                        if (tur.singer.noteStatus !== null) {
                             notes = tur.singer.noteStatus[0];
                             for (let j = 0; j < notes.length; j++) {
                                 if (j > 0) {
@@ -322,7 +321,7 @@ class StatusMatrix {
                 this.activity.logo.inStatusMatrix = saveStatus;
 
                 cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
-                if (cell != null) {
+                if (cell !== null) {
                     cell.textContent = value;
                 }
                 i++;
@@ -333,7 +332,7 @@ class StatusMatrix {
             if (_THIS_IS_MUSIC_BLOCKS_) {
                 note = "";
                 value = "";
-                if (tur.singer.noteStatus != null) {
+                if (tur.singer.noteStatus !== null) {
                     notes = tur.singer.noteStatus[0];
                     for (let j = 0; j < notes.length; j++) {
                         if (typeof notes[j] === "number") {
@@ -351,7 +350,7 @@ class StatusMatrix {
                 }
 
                 cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
-                if (cell != null) {
+                if (cell !== null) {
                     cell.textContent = note.replace(/#/g, "♯").replace(/b/g, "♭");
                 }
             }

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -16,7 +16,6 @@
  * MA 02110-1335 USA.
  */
 
-/* eslint-disable no-redeclare */
 /*
    global
 
@@ -278,7 +277,7 @@ function TemperamentWidget() {
                     "20 20px Impact, Charcoal, sans-serif";
                 angle[i] = 270 + 360 * (Math.log10(ratios[i]) / Math.log10(this.powerBase));
                 if (i !== 0) {
-                    if (i == pitchNumber - 1) {
+                    if (i === pitchNumber - 1) {
                         angleDiff[i - 1] = angle[0] + 360 - angle[i];
                     } else {
                         angleDiff[i - 1] = angle[i] - angle[i - 1];
@@ -435,8 +434,8 @@ function TemperamentWidget() {
     this.showNoteInfo = function (event) {
         for (let i = 0; i < this.notesCircle.navItemCount; i++) {
             if (
-                event.target.id == "wheelnav-wheelDiv2-slice-" + i ||
-                (event.target.textContent == i && event.target.textContent !== "")
+                event.target.id === "wheelnav-wheelDiv2-slice-" + i ||
+                (event.target.textContent === i && event.target.textContent !== "")
             ) {
                 const x = event.clientX - docById("wheelDiv2").getBoundingClientRect().left;
                 const y = event.clientY - docById("wheelDiv2").getBoundingClientRect().top;
@@ -483,7 +482,7 @@ function TemperamentWidget() {
 
                 let noteDefined = false;
                 for (let j = 0; j < this.ratiosNotesPair.length; j++) {
-                    if (this.ratios[i] == this.ratiosNotesPair[j][0]) {
+                    if (this.ratios[i] === this.ratiosNotesPair[j][0]) {
                         noteDefined = true;
                         const noteDiv = document.createElement("div");
                         noteDiv.id = "note";
@@ -492,7 +491,7 @@ function TemperamentWidget() {
                         break;
                     }
                 }
-                if (noteDefined == false) {
+                if (noteDefined === false) {
                     const cents = 1200 * (Math.log10(this.ratios[i]) / Math.log10(this.powerBase));
                     const centsDiff = [];
                     const centsDiff1 = [];
@@ -630,7 +629,7 @@ function TemperamentWidget() {
         this.circleIsVisible = true;
         this.toggleNotesButton();
         temperamentTableDiv.textContent = "";
-        if (docById("wheelDiv2") != null) {
+        if (docById("wheelDiv2") !== null) {
             docById("wheelDiv2").style.display = "none";
             this.notesCircle.removeWheel();
         }
@@ -786,7 +785,7 @@ function TemperamentWidget() {
                 //Mode
                 notesCell[(i, 5)] = notesRow[i].insertCell(-1);
                 for (let j = 0; j < this.scaleNotes.length; j++) {
-                    if (this.notes[i][0] == this.scaleNotes[j]) {
+                    if (this.notes[i][0] === this.scaleNotes[j]) {
                         notesCell[(i, 5)].textContent = j;
                         break;
                     }
@@ -826,7 +825,7 @@ function TemperamentWidget() {
         this._logo.synth.setMasterVolume(0);
         this._logo.synth.stop();
         const that = this;
-        if (docById("wheelDiv2") != null) {
+        if (docById("wheelDiv2") !== null) {
             docById("wheelDiv2").style.display = "none";
             this.notesCircle.removeWheel();
         }
@@ -1016,7 +1015,7 @@ function TemperamentWidget() {
                     ratio2[i] = ratio2[i].toFixed(2);
                 }
                 const ratio4 = ratio1.filter(function (val) {
-                    return ratio2.indexOf(val) == -1;
+                    return ratio2.indexOf(val) === -1;
                 });
 
                 for (let i = 0; i < ratio4.length; i++) {
@@ -1220,7 +1219,7 @@ function TemperamentWidget() {
                             that.tempRatios.splice(index[i], 0, ratio[i]);
                             break;
                         }
-                        if (ratioDifference[j] == 0) {
+                        if (ratioDifference[j] === 0) {
                             index.push(j);
                             that.tempRatios.splice(index[i], 1, ratio[i]);
                             break;
@@ -1355,10 +1354,10 @@ function TemperamentWidget() {
                 docById("wheelDiv4").display = "none";
                 this.wheel1.removeWheel();
             }
-            if (ratios == undefined) {
+            if (ratios === undefined) {
                 ratios = this.ratios;
             }
-            if (pitchNumber == undefined) {
+            if (pitchNumber === undefined) {
                 pitchNumber = this.pitchNumber;
             }
             const labels = [];
@@ -1392,7 +1391,7 @@ function TemperamentWidget() {
                     "20 20px Impact, Charcoal, sans-serif";
                 angle[i] = 270 + 360 * (Math.log10(ratios[i]) / Math.log10(this.powerBase));
                 if (i !== 0) {
-                    if (i == this.pitchNumber - 1) {
+                    if (i === this.pitchNumber - 1) {
                         angleDiff[i - 1] = angle[0] + 360 - angle[i];
                     } else {
                         angleDiff[i - 1] = angle[i] - angle[i - 1];
@@ -1458,10 +1457,10 @@ function TemperamentWidget() {
                 docById("wheelDiv3").display = "none";
                 this.wheel.removeWheel();
             }
-            if (pitchNumber == undefined) {
+            if (pitchNumber === undefined) {
                 pitchNumber = this.pitchNumber;
             }
-            if (ratios == undefined) {
+            if (ratios === undefined) {
                 ratios = this.ratios;
             }
             docById("wheelDiv3").style.display = "";
@@ -1491,7 +1490,7 @@ function TemperamentWidget() {
                 //Change angles of outer circle
                 angle[i] = 270 + 360 * (Math.log10(ratios[i]) / Math.log10(this.powerBase));
                 if (i !== 0) {
-                    if (i == pitchNumber - 1) {
+                    if (i === pitchNumber - 1) {
                         angleDiff1[i - 1] = angle[0] + 360 - angle[i];
                     } else {
                         angleDiff1[i - 1] = angle[i] - angle[i - 1];
@@ -1576,7 +1575,7 @@ function TemperamentWidget() {
             frequencies[j] = frequencies[j].toFixed(2);
         }
         for (let i = 0; i < pitchNumber; i++) {
-            if (event.target.parentNode.id == "wheelnav-wheelDiv3-title-" + i) {
+            if (event.target.parentNode.id === "wheelnav-wheelDiv3-title-" + i) {
                 const that = this;
                 if (docById("noteInfo1") !== null) {
                     docById("noteInfo1").remove();
@@ -1769,7 +1768,7 @@ function TemperamentWidget() {
             that.powerBase = ratio;
             that.typeOfEdit = "nonequal";
             that.checkTemperament(compareRatios);
-            if (ratio != 2) {
+            if (ratio !== 2) {
                 that.octaveChanged = true;
             }
             that._circleOfNotes();
@@ -1807,7 +1806,7 @@ function TemperamentWidget() {
                     temperamentRatios[j] = temperamentRatios[j].toFixed(2);
                 }
                 const ratiosEqual =
-                    ratios.length == temperamentRatios.length &&
+                    ratios.length === temperamentRatios.length &&
                     ratios.every(function (element, index) {
                         return element === temperamentRatios[index];
                     });
@@ -2000,7 +1999,7 @@ function TemperamentWidget() {
                     ]);
                 }
 
-                if (i == this.pitchNumber - 1) {
+                if (i === this.pitchNumber - 1) {
                     newStack.push([idx + 12, "hidden", 0, 0, [idx, null]]);
                 } else {
                     newStack.push([idx + 12, "hidden", 0, 0, [idx, idx + 13]]);
@@ -2067,7 +2066,7 @@ function TemperamentWidget() {
                     ]);
                 }
 
-                if (i == this.pitchNumber - 1) {
+                if (i === this.pitchNumber - 1) {
                     newStack.push([idx + 10, "hidden", 0, 0, [idx, null]]);
                 } else {
                     newStack.push([idx + 10, "hidden", 0, 0, [idx, idx + 11]]);
@@ -2134,9 +2133,9 @@ function TemperamentWidget() {
         this._logo.synth.changeInTemperament = true;
 
         if (docById("wheelDiv4") === null) {
-            if (this.editMode == "equal" && this.eqTempHzs && this.eqTempHzs.length) {
+            if (this.editMode === "equal" && this.eqTempHzs && this.eqTempHzs.length) {
                 notes = this.eqTempHzs[pitchIndex];
-            } else if (this.editMode == "ratio" && this.NEqTempHzs && this.NEqTempHzs.length) {
+            } else if (this.editMode === "ratio" && this.NEqTempHzs && this.NEqTempHzs.length) {
                 notes = this.NEqTempHzs[pitchIndex];
             } else if (isCustomTemperament(this.inTemperament)) {
                 notes = this.frequencies[pitchIndex];
@@ -2228,9 +2227,9 @@ function TemperamentWidget() {
 
         const that = this;
         let pitchNumber = this.pitchNumber;
-        if (this.editMode == "equal" && this.eqTempPitchNumber) {
+        if (this.editMode === "equal" && this.eqTempPitchNumber) {
             pitchNumber = this.eqTempPitchNumber;
-        } else if (this.editMode == "ratio" && this.NEqTempPitchNumber) {
+        } else if (this.editMode === "ratio" && this.NEqTempPitchNumber) {
             pitchNumber = this.NEqTempPitchNumber;
         }
 
@@ -2258,7 +2257,7 @@ function TemperamentWidget() {
                 that.playNote(i);
             }
 
-            if (that.circleIsVisible == false && docById("wheelDiv4") == null) {
+            if (that.circleIsVisible === false && docById("wheelDiv4") === null) {
                 if (i === pitchNumber && that._playing) {
                     that.notesCircle.navItems[0].fillAttr = "#808080";
                     that.notesCircle.navItems[0].sliceHoverAttr.fill = "#808080";
@@ -2271,7 +2270,7 @@ function TemperamentWidget() {
                     that.notesCircle.navItems[i].sliceSelectedAttr.fill = "#808080";
                 }
 
-                if (that.playbackForward == false && i < pitchNumber) {
+                if (that.playbackForward === false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
                         that.notesCircle.navItems[0].fillAttr = "#c8C8C8";
                         that.notesCircle.navItems[0].sliceHoverAttr.fill = "#c8C8C8";
@@ -2293,9 +2292,9 @@ function TemperamentWidget() {
                 }
 
                 that.notesCircle.refreshWheel();
-            } else if (that.circleIsVisible == true && docById("wheelDiv4") == null) {
+            } else if (that.circleIsVisible === true && docById("wheelDiv4") === null) {
                 docById("pitchNumber_" + i).style.background = platformColor.labelColor;
-                if (that.playbackForward == false && i < pitchNumber) {
+                if (that.playbackForward === false && i < pitchNumber) {
                     const j = i + 1;
                     docById("pitchNumber_" + j).style.background = platformColor.selectorBackground;
                 } else {
@@ -2318,7 +2317,7 @@ function TemperamentWidget() {
                     that.wheel1.navItems[i].sliceSelectedAttr.fill = "#808080";
                 }
 
-                if (that.playbackForward == false && i < pitchNumber) {
+                if (that.playbackForward === false && i < pitchNumber) {
                     if (i === pitchNumber - 1) {
                         that.wheel1.navItems[0].fillAttr = "#e0e0e0";
                         that.wheel1.navItems[0].sliceHoverAttr.fill = "#e0e0e0";
@@ -2358,7 +2357,7 @@ function TemperamentWidget() {
             } else {
                 that.inbetween = true;
             }
-            if (!that.playbackForward && i == -1) {
+            if (!that.playbackForward && i === -1) {
                 cell.textContent = "\u00A0\u00A0";
                 const playImg = document.createElement("img");
                 playImg.src = "header-icons/play-button.svg";
@@ -2430,15 +2429,15 @@ function TemperamentWidget() {
         widgetWindow.onclose = function () {
             that._logo.synth.setMasterVolume(0);
             that._logo.synth.stop();
-            if (docById("wheelDiv2") != null) {
+            if (docById("wheelDiv2") !== null) {
                 docById("wheelDiv2").style.display = "none";
                 that.notesCircle.removeWheel();
             }
-            if (docById("wheelDiv3") != null) {
+            if (docById("wheelDiv3") !== null) {
                 docById("wheelDiv3").style.display = "none";
                 that.wheel.removeWheel();
             }
-            if (docById("wheelDiv4") != null) {
+            if (docById("wheelDiv4") !== null) {
                 docById("wheelDiv4").style.display = "none";
                 that.wheel1.removeWheel();
             }
@@ -2563,7 +2562,7 @@ function TemperamentWidget() {
                 this.intervals[i] = t.interval[i];
                 this.ratios[i] = t[this.intervals[i]];
                 this.cents[i] = 1200 * (Math.log10(this.ratios[i]) / Math.log10(this.powerBase));
-                if (i == 0) {
+                if (i === 0) {
                     this.frequencies[i] = this._logo.synth
                         ._getFrequency(str[i], true, this.inTemperament)
                         .toFixed(2);

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -146,15 +146,17 @@ function TemperamentWidget() {
      */
     this._addButton = function (row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
-        cell.innerHTML = `&nbsp;&nbsp;<img 
-                src="header-icons/${icon}" 
-                title="${label}" 
-                alt="${label}" 
-                height="${iconSize}" 
-                width="${iconSize}" 
-                vertical-align="middle" 
-                align-content="center"
-            >&nbsp;&nbsp;`;
+        cell.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.setAttribute("height", iconSize);
+        img.setAttribute("width", iconSize);
+        img.setAttribute("vertical-align", "middle");
+        img.setAttribute("align-content", "center");
+        cell.appendChild(img);
+        cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         cell.style.width = BUTTONSIZE + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
@@ -188,24 +190,31 @@ function TemperamentWidget() {
         temperamentTableDiv.style.overflow = "auto";
         temperamentTableDiv.style.backgroundColor = "white";
         temperamentTableDiv.style.height = "300px";
-        temperamentTableDiv.innerHTML = '<div id="temperamentTable"></div>';
-        const temperamentTable = docById("temperamentTable");
+        temperamentTableDiv.textContent = "";
+        const temperamentTable = document.createElement("div");
+        temperamentTable.id = "temperamentTable";
+        temperamentTableDiv.appendChild(temperamentTable);
         temperamentTable.style.position = "relative";
 
         const radius = 150;
         const height = 2 * radius + 60;
 
-        let html =
-            '<canvas id="circ" width = ' +
-            BUTTONDIVWIDTH +
-            "px height = " +
-            height +
-            "px></canvas>";
-        html += '<div id="wheelDiv2" class="wheelNav"></div>';
-        html += '<div id ="information"></div>';
+        temperamentTable.textContent = "";
+        
+        const canvasT = document.createElement("canvas");
+        canvasT.id = "circ";
+        canvasT.setAttribute("width", BUTTONDIVWIDTH + "px");
+        canvasT.setAttribute("height", height + "px");
+        temperamentTable.appendChild(canvasT);
 
-        temperamentTable.innerHTML = html;
-        temperamentTable.style.width = "300px";
+        const wheelDiv2 = document.createElement("div");
+        wheelDiv2.id = "wheelDiv2";
+        wheelDiv2.className = "wheelNav";
+        temperamentTable.appendChild(wheelDiv2);
+
+        const informationDiv = document.createElement("div");
+        informationDiv.id = "information";
+        temperamentTable.appendChild(informationDiv);
 
         const canvas = docById("circ");
         canvas.style.position = "absolute";
@@ -312,12 +321,16 @@ function TemperamentWidget() {
         if (this.octaveChanged) {
             const divAppend = document.createElement("div");
             divAppend.id = "divAppend";
-            divAppend.innerHTML =
-                '<div id="clearNotes" style="float:left;">' +
-                _("Clear") +
-                '</div><div id="standardOctave" style="float:right;">' +
-                _("back to 2:1 octave space") +
-                "</div>";
+            const clearNotesDiv = document.createElement("div");
+            clearNotesDiv.id = "clearNotes";
+            clearNotesDiv.style.cssFloat = "left";
+            clearNotesDiv.textContent = _("Clear");
+            const standardOctaveDiv = document.createElement("div");
+            standardOctaveDiv.id = "standardOctave";
+            standardOctaveDiv.style.cssFloat = "right";
+            standardOctaveDiv.textContent = _("back to 2:1 octave space");
+            divAppend.appendChild(clearNotesDiv);
+            divAppend.appendChild(standardOctaveDiv);
             divAppend.style.textAlign = "center";
             divAppend.style.position = "absolute";
             divAppend.style.zIndex = 2;
@@ -342,7 +355,7 @@ function TemperamentWidget() {
         } else {
             divAppend1 = document.createElement("div");
             divAppend1.id = "divAppend";
-            divAppend1.innerHTML = _("Clear");
+            divAppend1.textContent = _("Clear");
             divAppend1.style.textAlign = "center";
             divAppend1.style.position = "absolute";
             divAppend1.style.zIndex = 2;
@@ -423,7 +436,7 @@ function TemperamentWidget() {
         for (let i = 0; i < this.notesCircle.navItemCount; i++) {
             if (
                 event.target.id == "wheelnav-wheelDiv2-slice-" + i ||
-                (event.target.innerHTML == i && event.target.innerHTML !== "")
+                (event.target.textContent == i && event.target.textContent !== "")
             ) {
                 const x = event.clientX - docById("wheelDiv2").getBoundingClientRect().left;
                 const y = event.clientY - docById("wheelDiv2").getBoundingClientRect().top;
@@ -433,34 +446,49 @@ function TemperamentWidget() {
                     docById("noteInfo").remove();
                 }
 
-                docById("information").innerHTML +=
-                    `<div class="popup" id="noteInfo" style="left: ${x}px; top: ${y}px;">
-                        <span class="popuptext" id="myPopup"></span>
-                    </div>`;
+                const noteInfoDiv = document.createElement("div");
+                noteInfoDiv.className = "popup";
+                noteInfoDiv.id = "noteInfo";
+                noteInfoDiv.style.left = `${x}px`;
+                noteInfoDiv.style.top = `${y}px`;
+                
+                const myPopupSpan = document.createElement("span");
+                myPopupSpan.className = "popuptext";
+                myPopupSpan.id = "myPopup";
+                noteInfoDiv.appendChild(myPopupSpan);
+                
                 if (i !== 0) {
-                    docById("noteInfo").innerHTML += `<img 
-                            src="header-icons/edit.svg" 
-                            id="edit" 
-                            title="${_("edit")}" 
-                            alt="edit" 
-                            height="20px" 
-                            width="20px" 
-                            data-message="${i}"
-                        >`;
+                    const editImg = document.createElement("img");
+                    editImg.src = "header-icons/edit.svg";
+                    editImg.id = "edit";
+                    editImg.title = _("edit");
+                    editImg.alt = "edit";
+                    editImg.setAttribute("height", "20px");
+                    editImg.setAttribute("width", "20px");
+                    editImg.setAttribute("data-message", i);
+                    noteInfoDiv.appendChild(editImg);
                 }
-                docById("noteInfo").innerHTML +=
-                    '<img src="header-icons/close-button.svg" id="close" title="' +
-                    _("Close") +
-                    '" alt="' +
-                    _("Close") +
-                    '" height=20px width=20px align="right"><br>';
+                
+                const closeImg = document.createElement("img");
+                closeImg.src = "header-icons/close-button.svg";
+                closeImg.id = "close";
+                closeImg.title = _("Close");
+                closeImg.alt = _("Close");
+                closeImg.setAttribute("height", "20px");
+                closeImg.setAttribute("width", "20px");
+                closeImg.setAttribute("align", "right");
+                noteInfoDiv.appendChild(closeImg);
+                
+                noteInfoDiv.appendChild(document.createElement("br"));
+
                 let noteDefined = false;
                 for (let j = 0; j < this.ratiosNotesPair.length; j++) {
                     if (this.ratios[i] == this.ratiosNotesPair[j][0]) {
                         noteDefined = true;
-                        docById("noteInfo").innerHTML += `<div id="note">&nbsp;${_("note")}&nbsp;${
-                            this.ratiosNotesPair[j][1]
-                        }</div>`;
+                        const noteDiv = document.createElement("div");
+                        noteDiv.id = "note";
+                        noteDiv.textContent = `\u00A0${_("note")}\u00A0${this.ratiosNotesPair[j][1]}`;
+                        noteInfoDiv.appendChild(noteDiv);
                         break;
                     }
                 }
@@ -476,19 +504,22 @@ function TemperamentWidget() {
                         return Math.min(a, b);
                     });
                     const index = centsDiff1.indexOf(min);
+                    const noteDiv = document.createElement("div");
+                    noteDiv.id = "note";
                     if (centsDiff[index] < 0) {
-                        docById("noteInfo").innerHTML += `<div id="note">&nbsp;${_("note")}&nbsp;${
-                            this.ratiosNotesPair[index][1]
-                        }(-${centsDiff1[index].toFixed(2)}¢)</div>`;
+                        noteDiv.textContent = `\u00A0${_("note")}\u00A0${this.ratiosNotesPair[index][1]}(-${centsDiff1[index].toFixed(2)}¢)`;
                     } else {
-                        docById("noteInfo").innerHTML += `<div id="note">&nbsp;${_("note")}&nbsp;${
-                            this.ratiosNotesPair[index][1]
-                        }(${centsDiff1[index].toFixed(2)}¢)</div>`;
+                        noteDiv.textContent = `\u00A0${_("note")}\u00A0${this.ratiosNotesPair[index][1]}(+${centsDiff1[index].toFixed(2)}¢)`;
                     }
+                    noteInfoDiv.appendChild(noteDiv);
                 }
-                docById("noteInfo").innerHTML += `<div id="frequency">&nbsp;${_(
-                    "frequency"
-                )}&nbsp;${frequency}</div>`;
+
+                const frequencyDiv = document.createElement("div");
+                frequencyDiv.id = "frequency";
+                frequencyDiv.textContent = `\u00A0${_("frequency")}\u00A0${frequency}`;
+                noteInfoDiv.appendChild(frequencyDiv);
+                
+                docById("information").appendChild(noteInfoDiv);
 
                 docById("noteInfo").style.top = "130px";
                 docById("noteInfo").style.left = "132px";
@@ -518,22 +549,43 @@ function TemperamentWidget() {
 
         docById("noteInfo").style.width = "180px";
         docById("noteInfo").style.height = "130px";
-        docById("note").innerHTML = "";
-        docById("frequency").innerHTML = "";
-        docById("noteInfo").innerHTML +=
-            `<center><input type="range" class="sliders" id="frequencySlider1" style="width:170px; background:white; border:0;" min="${
-                this.frequencies[i - 1]
-            }" max="${this.frequencies[i + 1]}"></center>`;
-        docById("noteInfo").innerHTML += `<br>&nbsp;&nbsp;${_(
-            "frequency"
-        )}<span class="rangeslidervalue" id="frequencydiv1">${this.frequencies[i]}</span>`;
-        docById("noteInfo").innerHTML +=
-            `<br><br><div id="done" style="background:rgb(196, 196, 196);"><center>${_(
-                "done"
-            )}</center><div>`;
+        if (docById("note")) docById("note").textContent = "";
+        if (docById("frequency")) docById("frequency").textContent = "";
+        
+        const noteInfo = docById("noteInfo");
+        const center = document.createElement("center");
+        const slider = document.createElement("input");
+        slider.type = "range";
+        slider.className = "sliders";
+        slider.id = "frequencySlider1";
+        slider.style.width = "170px";
+        slider.style.background = "white";
+        slider.style.border = "0";
+        slider.setAttribute("min", this.frequencies[i - 1]);
+        slider.setAttribute("max", this.frequencies[i + 1]);
+        center.appendChild(slider);
+        noteInfo.appendChild(center);
+
+        noteInfo.appendChild(document.createElement("br"));
+        noteInfo.appendChild(document.createTextNode(`\u00A0\u00A0${_("frequency")}`));
+        const freqSpan = document.createElement("span");
+        freqSpan.className = "rangeslidervalue";
+        freqSpan.id = "frequencydiv1";
+        freqSpan.textContent = this.frequencies[i];
+        noteInfo.appendChild(freqSpan);
+
+        noteInfo.appendChild(document.createElement("br"));
+        noteInfo.appendChild(document.createElement("br"));
+        const doneDiv = document.createElement("div");
+        doneDiv.id = "done";
+        doneDiv.style.background = "rgb(196, 196, 196)";
+        const doneCenter = document.createElement("center");
+        doneCenter.textContent = _("done");
+        doneDiv.appendChild(doneCenter);
+        noteInfo.appendChild(doneDiv);
 
         docById("frequencySlider1").oninput = function () {
-            docById("frequencydiv1").innerHTML = docById("frequencySlider1").value;
+            docById("frequencydiv1").textContent = docById("frequencySlider1").value;
             const frequency = docById("frequencySlider1").value;
             const ratio = frequency / that.frequencies[0];
             that.temporaryRatios = that.ratios.slice();
@@ -577,14 +629,15 @@ function TemperamentWidget() {
     this._graphOfNotes = function () {
         this.circleIsVisible = true;
         this.toggleNotesButton();
-        temperamentTableDiv.innerHTML = "";
+        temperamentTableDiv.textContent = "";
         if (docById("wheelDiv2") != null) {
             docById("wheelDiv2").style.display = "none";
             this.notesCircle.removeWheel();
         }
 
-        temperamentTableDiv.innerHTML = '<table id="notesGraph"></table>';
-        const notesGraph = docById("notesGraph");
+        const notesGraph = document.createElement("table");
+        notesGraph.id = "notesGraph";
+        temperamentTableDiv.appendChild(notesGraph);
         let menuLabels = [];
         if (isCustomTemperament(this.inTemperament)) {
             menuLabels = [_("Play"), _("pitch number"), _("ratio"), _("frequency")];
@@ -599,15 +652,23 @@ function TemperamentWidget() {
             ];
             menuLabels.splice(5, 0, this.scale);
         }
-        notesGraph.innerHTML =
-            '<thead id="tablehead"><tr id="menu"></tr></thead><tbody id="tablebody"></tbody>';
-        let menus = "";
+        const tablehead = document.createElement("thead");
+        tablehead.id = "tablehead";
+        const menuTr = document.createElement("tr");
+        menuTr.id = "menu";
+        tablehead.appendChild(menuTr);
+        notesGraph.appendChild(tablehead);
+        
+        const tablebody = document.createElement("tbody");
+        tablebody.id = "tablebody";
+        notesGraph.appendChild(tablebody);
 
         for (let i = 0; i < menuLabels.length; i++) {
-            menus += '<th id="menuLabels">' + menuLabels[i] + "</th>";
+            const th = document.createElement("th");
+            th.id = "menuLabels";
+            th.textContent = menuLabels[i];
+            menuTr.appendChild(th);
         }
-
-        docById("menu").innerHTML = menus;
 
         const menuItems = document.querySelectorAll("#menuLabels");
         for (let i = 0; i < menuLabels.length; i++) {
@@ -630,14 +691,24 @@ function TemperamentWidget() {
                 menuItems[6].style.width = 95 + "px";
             }
         }
-        let pitchNumberColumn = "";
+        const trGraph = document.createElement("tr");
+        const tdGraph = document.createElement("td");
+        tdGraph.setAttribute("colspan", "7");
+        const divGraph = document.createElement("div");
+        divGraph.id = "graph";
+        const tableOfNotes = document.createElement("table");
+        tableOfNotes.id = "tableOfNotes";
+        
         for (let i = 0; i <= this.pitchNumber; i++) {
-            pitchNumberColumn += '<tr id="notes_' + i + '"></tr>';
+            const trNotes = document.createElement("tr");
+            trNotes.id = "notes_" + i;
+            tableOfNotes.appendChild(trNotes);
         }
 
-        docById("tablebody").innerHTML +=
-            '<tr><td colspan="7"><div id="graph"><table id="tableOfNotes"></table></div></td></tr>';
-        docById("tableOfNotes").innerHTML = pitchNumberColumn;
+        divGraph.appendChild(tableOfNotes);
+        tdGraph.appendChild(divGraph);
+        trGraph.appendChild(tdGraph);
+        docById("tablebody").appendChild(trGraph);
 
         const that = this;
         const notesRow = [];
@@ -648,15 +719,17 @@ function TemperamentWidget() {
             notesRow[i] = docById("notes_" + i);
 
             notesCell[(i, 0)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 0)].innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="20px" 
-                    width="20px" 
-                    id="play_${i}" 
-                    data-id="${i}"
-                >&nbsp;&nbsp;`;
+            notesCell[(i, 0)].textContent = "\u00A0\u00A0";
+            const playImg = document.createElement("img");
+            playImg.src = "header-icons/play-button.svg";
+            playImg.title = _("Play");
+            playImg.alt = _("Play");
+            playImg.setAttribute("height", "20px");
+            playImg.setAttribute("width", "20px");
+            playImg.id = "play_" + i;
+            playImg.setAttribute("data-id", i);
+            notesCell[(i, 0)].appendChild(playImg);
+            notesCell[(i, 0)].appendChild(document.createTextNode("\u00A0\u00A0"));
             notesCell[(i, 0)].style.width = 40 + "px";
             notesCell[(i, 0)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 0)].style.textAlign = "center";
@@ -682,7 +755,7 @@ function TemperamentWidget() {
             //Pitch Number
             notesCell[(i, 1)] = notesRow[i].insertCell(-1);
             notesCell[(i, 1)].id = "pitchNumber_" + i;
-            notesCell[(i, 1)].innerHTML = i;
+            notesCell[(i, 1)].textContent = i;
             notesCell[(i, 1)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 1)].style.textAlign = "center";
 
@@ -691,21 +764,21 @@ function TemperamentWidget() {
 
             //Ratio
             notesCell[(i, 2)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 2)].innerHTML = ratios[i];
+            notesCell[(i, 2)].textContent = ratios[i];
             notesCell[(i, 2)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 2)].style.textAlign = "center";
 
             if (!isCustomTemperament(this.inTemperament)) {
                 //Interval
                 notesCell[(i, 3)] = notesRow[i].insertCell(-1);
-                notesCell[(i, 3)].innerHTML = this.intervals[i];
+                notesCell[(i, 3)].textContent = this.intervals[i];
                 notesCell[(i, 3)].style.width = 120 + "px";
                 notesCell[(i, 3)].style.backgroundColor = platformColor.selectorBackground;
                 notesCell[(i, 3)].style.textAlign = "center";
 
                 //Notes
                 notesCell[(i, 4)] = notesRow[i].insertCell(-1);
-                notesCell[(i, 4)].innerHTML = this.notes[i];
+                notesCell[(i, 4)].textContent = this.notes[i];
                 notesCell[(i, 4)].style.width = 50 + "px";
                 notesCell[(i, 4)].style.backgroundColor = platformColor.selectorBackground;
                 notesCell[(i, 4)].style.textAlign = "center";
@@ -714,12 +787,12 @@ function TemperamentWidget() {
                 notesCell[(i, 5)] = notesRow[i].insertCell(-1);
                 for (let j = 0; j < this.scaleNotes.length; j++) {
                     if (this.notes[i][0] == this.scaleNotes[j]) {
-                        notesCell[(i, 5)].innerHTML = j;
+                        notesCell[(i, 5)].textContent = j;
                         break;
                     }
                 }
-                if (notesCell[(i, 5)].innerHTML === "") {
-                    notesCell[(i, 5)].innerHTML = _("non scalar");
+                if (notesCell[(i, 5)].textContent === "") {
+                    notesCell[(i, 5)].textContent = _("non scalar");
                 }
                 notesCell[(i, 5)].style.width = 100 + "px";
                 notesCell[(i, 5)].style.backgroundColor = platformColor.selectorBackground;
@@ -728,7 +801,7 @@ function TemperamentWidget() {
 
             //Frequency
             notesCell[(i, 6)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 6)].innerHTML = this.frequencies[i];
+            notesCell[(i, 6)].textContent = this.frequencies[i];
             notesCell[(i, 6)].style.backgroundColor = platformColor.selectorBackground;
             notesCell[(i, 6)].style.textAlign = "center";
 
@@ -757,17 +830,32 @@ function TemperamentWidget() {
             docById("wheelDiv2").style.display = "none";
             this.notesCircle.removeWheel();
         }
-        temperamentTableDiv.innerHTML = "";
-        temperamentTableDiv.innerHTML = `<table id="editOctave" width="${BUTTONDIVWIDTH}"><tbody><tr id="menu"></tr></tbody></table>`;
+        temperamentTableDiv.textContent = "";
+        const editOctaveTable = document.createElement("table");
+        editOctaveTable.id = "editOctave";
+        editOctaveTable.setAttribute("width", BUTTONDIVWIDTH);
+        const editOctaveTbody = document.createElement("tbody");
+        const editOctaveTr = document.createElement("tr");
+        editOctaveTr.id = "menu";
+        editOctaveTbody.appendChild(editOctaveTr);
+        editOctaveTable.appendChild(editOctaveTbody);
+        temperamentTableDiv.appendChild(editOctaveTable);
+
         const editMenus = [_("equal"), _("ratios"), _("arbitrary"), _("octave space")];
-        let menus = "";
 
         for (let i = 0; i < editMenus.length; i++) {
-            menus += '<td id="editMenus">' + editMenus[i] + "</td>";
+            const td = document.createElement("td");
+            td.id = "editMenus";
+            td.textContent = editMenus[i];
+            editOctaveTr.appendChild(td);
         }
 
-        docById("menu").innerHTML = menus;
-        docById("editOctave").innerHTML += '<tr><td colspan="4" id="userEdit"></td></tr>';
+        const userEditTr = document.createElement("tr");
+        const userEditTd = document.createElement("td");
+        userEditTd.setAttribute("colspan", "4");
+        userEditTd.id = "userEdit";
+        userEditTr.appendChild(userEditTd);
+        editOctaveTbody.appendChild(userEditTr);
         const menuItems = document.querySelectorAll("#editMenus");
         for (let i = 0; i < editMenus.length; i++) {
             menuItems[i].style.background = platformColor.selectorBackground;
@@ -818,19 +906,30 @@ function TemperamentWidget() {
      */
     this.equalEdit = function () {
         this.editMode = "equal";
-        docById("userEdit").innerHTML = "";
+        docById("userEdit").textContent = "";
         const equalEdit = docById("userEdit");
         equalEdit.style.backgroundColor = "#c8C8C8";
-        equalEdit.innerHTML = `<br>${_(
-            "pitch number"
-        )}&nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="octaveIn" value="0"></input>
-            &nbsp;&nbsp; ${_("to")}&nbsp;&nbsp;
-            <input type="text" id="octaveOut" value="0"></input><br><br>`;
-        equalEdit.innerHTML += `${_(
-            "number of divisions"
-        )} &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="divisions" value="${
-            this.pitchNumber
-        }"></input>`;
+        equalEdit.appendChild(document.createElement("br"));
+        equalEdit.appendChild(document.createTextNode(_("pitch number") + "\u00A0\u00A0\u00A0\u00A0 "));
+        const octaveIn = document.createElement("input");
+        octaveIn.type = "text";
+        octaveIn.id = "octaveIn";
+        octaveIn.value = "0";
+        equalEdit.appendChild(octaveIn);
+        equalEdit.appendChild(document.createTextNode(" \u00A0\u00A0 " + _("to") + "\u00A0\u00A0 "));
+        const octaveOut = document.createElement("input");
+        octaveOut.type = "text";
+        octaveOut.id = "octaveOut";
+        octaveOut.value = "0";
+        equalEdit.appendChild(octaveOut);
+        equalEdit.appendChild(document.createElement("br"));
+        equalEdit.appendChild(document.createElement("br"));
+        equalEdit.appendChild(document.createTextNode(_("number of divisions") + " \u00A0\u00A0\u00A0\u00A0 "));
+        const divisions = document.createElement("input");
+        divisions.type = "text";
+        divisions.id = "divisions";
+        divisions.value = this.pitchNumber;
+        equalEdit.appendChild(divisions);
         equalEdit.style.paddingLeft = "80px";
         const that = this;
 
@@ -839,13 +938,17 @@ function TemperamentWidget() {
         function addDivision(preview) {
             // Add Buttons
             divAppend.id = "divAppend";
-            if (preview) {
-                divAppend.innerHTML = `<div id="preview" style="float:left;">${_("back")}</div>
-                    <div id="done_" style="float:right;">${_("done")}</div>`;
-            } else {
-                divAppend.innerHTML = `<div id="preview" style="float:left;">${_("preview")}</div>
-                    <div id="done_" style="float:right;">${_("done")}</div>`;
-            }
+            divAppend.textContent = "";
+            const previewDiv = document.createElement("div");
+            previewDiv.id = "preview";
+            previewDiv.style.cssFloat = "left";
+            previewDiv.textContent = preview ? _("back") : _("preview");
+            const doneDiv = document.createElement("div");
+            doneDiv.id = "done_";
+            doneDiv.style.cssFloat = "right";
+            doneDiv.textContent = _("done");
+            divAppend.appendChild(previewDiv);
+            divAppend.appendChild(doneDiv);
             divAppend.style.textAlign = "center";
             divAppend.style.marginLeft = "-80px";
             divAppend.style.height = "32px";
@@ -875,7 +978,7 @@ function TemperamentWidget() {
         let pitchNumber = this.pitchNumber;
         let pitchNumber1 = Number(docById("octaveIn").value);
         let pitchNumber2 = Number(docById("octaveOut").value);
-        let divisions = Number(docById("divisions").value);
+        let numDivs = Number(docById("divisions").value);
         const ratio = [];
         const compareRatios = [];
         const ratio1 = [];
@@ -895,11 +998,11 @@ function TemperamentWidget() {
         this.performEqualEdit = function (event) {
             pitchNumber1 = Number(docById("octaveIn").value);
             pitchNumber2 = Number(docById("octaveOut").value);
-            divisions = Number(docById("divisions").value);
+            numDivs = Number(docById("divisions").value);
             this.tempRatios = this.ratios.slice();
             if (pitchNumber1 === pitchNumber2) {
-                for (let i = 0; i < divisions; i++) {
-                    ratio[i] = Math.pow(this.powerBase, i / divisions);
+                for (let i = 0; i < numDivs; i++) {
+                    ratio[i] = Math.pow(this.powerBase, i / numDivs);
                     ratio1[i] = ratio[i].toFixed(2);
                 }
                 for (let i = 0; i < this.tempRatios.length; i++) {
@@ -922,19 +1025,19 @@ function TemperamentWidget() {
 
                 pitchNumber = this.tempRatios.length - 1;
                 this.typeOfEdit = "equal";
-                this.divisions = divisions;
+                this.divisions = numDivs;
             } else {
                 pitchNumber =
-                    divisions + Number(pitchNumber) - Math.abs(pitchNumber1 - pitchNumber2);
+                    numDivs + Number(pitchNumber) - Math.abs(pitchNumber1 - pitchNumber2);
                 const angle1 =
                     270 +
                     360 * (Math.log10(this.tempRatios[pitchNumber1]) / Math.log10(this.powerBase));
                 const angle2 =
                     270 +
                     360 * (Math.log10(this.tempRatios[pitchNumber2]) / Math.log10(this.powerBase));
-                const divisionAngle = Math.abs(angle2 - angle1) / divisions;
+                const divisionAngle = Math.abs(angle2 - angle1) / numDivs;
                 this.tempRatios.splice(pitchNumber1 + 1, Math.abs(pitchNumber1 - pitchNumber2) - 1);
-                for (let i = 0; i < divisions - 1; i++) {
+                for (let i = 0; i < numDivs - 1; i++) {
                     const power = (Math.min(angle1, angle2) + divisionAngle * (i + 1) - 270) / 360;
                     ratio[i] = Math.pow(this.powerBase, power);
                     this.tempRatios.splice(pitchNumber1 + 1 + i, 0, ratio[i]);
@@ -944,7 +1047,7 @@ function TemperamentWidget() {
                 this.typeOfEdit = "nonequal";
             }
 
-            if (event.target.innerHTML === _("done")) {
+            if (event.target.textContent === _("done")) {
                 // Go to main "Circle of Notes"
                 this.ratios = this.tempRatios.slice();
                 const frequency = this.frequencies[0];
@@ -957,9 +1060,13 @@ function TemperamentWidget() {
                 this.pitchNumber = pitchNumber;
                 this.checkTemperament(compareRatios);
                 this._circleOfNotes();
-            } else if (event.target.innerHTML === _("preview")) {
+            } else if (event.target.textContent === _("preview")) {
                 //Preview Notes
-                docById("userEdit").innerHTML = '<div id="wheelDiv2" class="wheelNav"></div>';
+                docById("userEdit").textContent = "";
+                const wheelDiv2 = document.createElement("div");
+                wheelDiv2.id = "wheelDiv2";
+                wheelDiv2.className = "wheelNav";
+                docById("userEdit").appendChild(wheelDiv2);
                 this.createMainWheel(this.tempRatios, pitchNumber);
                 for (let i = 0; i < pitchNumber; i++) {
                     this.notesCircle.navItems[i].fillAttr = "#e0e0e0";
@@ -1016,15 +1123,30 @@ function TemperamentWidget() {
      */
     this.ratioEdit = function () {
         this.editMode = "ratio";
-        docById("userEdit").innerHTML = "";
+        docById("userEdit").textContent = "";
         const ratioEdit = docById("userEdit");
         ratioEdit.style.backgroundColor = "#c8C8C8";
-        ratioEdit.innerHTML = `<br>${_(
-            "ratio"
-        )} &nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="ratioIn" value="1"></input> &nbsp;&nbsp; : &nbsp;&nbsp; <input type="text" id="ratioOut" value="1"></input><br><br>`;
-        ratioEdit.innerHTML += `${_(
-            "recursion"
-        )} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <input type="text" id="recursion" value="1"></input>`;
+        ratioEdit.appendChild(document.createElement("br"));
+        ratioEdit.appendChild(document.createTextNode(_("ratio") + " \u00A0\u00A0\u00A0\u00A0 "));
+        const ratioIn = document.createElement("input");
+        ratioIn.type = "text";
+        ratioIn.id = "ratioIn";
+        ratioIn.value = "1";
+        ratioEdit.appendChild(ratioIn);
+        ratioEdit.appendChild(document.createTextNode(" \u00A0\u00A0 : \u00A0\u00A0 "));
+        const ratioOut = document.createElement("input");
+        ratioOut.type = "text";
+        ratioOut.id = "ratioOut";
+        ratioOut.value = "1";
+        ratioEdit.appendChild(ratioOut);
+        ratioEdit.appendChild(document.createElement("br"));
+        ratioEdit.appendChild(document.createElement("br"));
+        ratioEdit.appendChild(document.createTextNode(_("recursion") + " \u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 "));
+        const recursion = document.createElement("input");
+        recursion.type = "text";
+        recursion.id = "recursion";
+        recursion.value = "1";
+        ratioEdit.appendChild(recursion);
         ratioEdit.style.paddingLeft = "100px";
         const that = this;
 
@@ -1032,13 +1154,17 @@ function TemperamentWidget() {
 
         function addButtons(preview) {
             divAppend.id = "divAppend";
-            if (preview) {
-                divAppend.innerHTML = `<div id="preview" style="float:left;">${_("back")}</div>
-                    <div id="done_" style="float:right;">${_("done")}</div>`;
-            } else {
-                divAppend.innerHTML = `<div id="preview" style="float:left;">${_("preview")}</div>
-                    <div id="done_" style="float:right;">${_("done")}</div>`;
-            }
+            divAppend.textContent = "";
+            const previewDiv = document.createElement("div");
+            previewDiv.id = "preview";
+            previewDiv.style.cssFloat = "left";
+            previewDiv.textContent = preview ? _("back") : _("preview");
+            const doneDiv = document.createElement("div");
+            doneDiv.id = "done_";
+            doneDiv.style.cssFloat = "right";
+            doneDiv.textContent = _("done");
+            divAppend.appendChild(previewDiv);
+            divAppend.appendChild(doneDiv);
             divAppend.style.textAlign = "center";
             divAppend.style.marginLeft = "-100px";
             divAppend.style.height = "32px";
@@ -1109,7 +1235,7 @@ function TemperamentWidget() {
                 return a - b;
             });
             const pitchNumber = that.tempRatios.length - 1;
-            if (event.target.innerHTML === _("done")) {
+            if (event.target.textContent === _("done")) {
                 that.ratios = that.tempRatios.slice();
                 that.typeOfEdit = "nonequal";
                 that.pitchNumber = that.ratios.length - 1;
@@ -1127,9 +1253,13 @@ function TemperamentWidget() {
 
                 that.checkTemperament(compareRatios);
                 that._circleOfNotes();
-            } else if (event.target.innerHTML === _("preview")) {
+            } else if (event.target.textContent === _("preview")) {
                 //Preview Notes
-                docById("userEdit").innerHTML = '<div id="wheelDiv2" class="wheelNav"></div>';
+                docById("userEdit").textContent = "";
+                const wheelDiv2 = document.createElement("div");
+                wheelDiv2.id = "wheelDiv2";
+                wheelDiv2.className = "wheelNav";
+                docById("userEdit").appendChild(wheelDiv2);
                 that.createMainWheel(that.tempRatios, pitchNumber);
                 for (let i = 0; i < pitchNumber; i++) {
                     that.notesCircle.navItems[i].fillAttr = "#e0e0e0";
@@ -1197,9 +1327,13 @@ function TemperamentWidget() {
      */
     this.arbitraryEdit = function () {
         this.editMode = "arbitrary";
-        docById("userEdit").innerHTML = "";
+        docById("userEdit").textContent = "";
         const arbitraryEdit = docById("userEdit");
-        arbitraryEdit.innerHTML = '<br><div id="wheelDiv3" class="wheelNav"></div>';
+        arbitraryEdit.appendChild(document.createElement("br"));
+        const wheelDiv3 = document.createElement("div");
+        wheelDiv3.id = "wheelDiv3";
+        wheelDiv3.className = "wheelNav";
+        arbitraryEdit.appendChild(wheelDiv3);
         arbitraryEdit.style.paddingLeft = "0px";
 
         const that = this;
@@ -1284,10 +1418,17 @@ function TemperamentWidget() {
             }
             this.wheel1.createWheel();
         };
-        arbitraryEdit.innerHTML += '<div id="wheelDiv4" class="wheelNav"></div>';
+        const wheelDiv4 = document.createElement("div");
+        wheelDiv4.id = "wheelDiv4";
+        wheelDiv4.className = "wheelNav";
+        arbitraryEdit.appendChild(wheelDiv4);
         this._createInnerWheel();
 
-        arbitraryEdit.innerHTML += `<canvas id="circ1" width = "${BUTTONDIVWIDTH}" height = "${height}"></canvas>`;
+        const canvas1 = document.createElement("canvas");
+        canvas1.id = "circ1";
+        canvas1.setAttribute("width", BUTTONDIVWIDTH);
+        canvas1.setAttribute("height", height);
+        arbitraryEdit.appendChild(canvas1);
 
         const canvas = docById("circ1");
         canvas.style.position = "absolute";
@@ -1377,7 +1518,7 @@ function TemperamentWidget() {
 
         const divAppend = document.createElement("div");
         divAppend.id = "divAppend";
-        divAppend.innerHTML = _("done");
+        divAppend.textContent = _("done");
         divAppend.style.textAlign = "center";
         divAppend.style.paddingTop = "5px";
         divAppend.style.backgroundColor = platformColor.selectorBackground;
@@ -1433,25 +1574,58 @@ function TemperamentWidget() {
                 if (docById("noteInfo1") !== null) {
                     docById("noteInfo1").remove();
                 }
-                docById("wheelDiv3").innerHTML +=
-                    '<div class="popup" id="noteInfo1" style="width:180px; height:135px;"><span class="popuptext" id="myPopup"></span></div>';
-                docById("noteInfo1").innerHTML +=
-                    '<img src="header-icons/close-button.svg" id="close" title="' +
-                    _("Close") +
-                    '" alt="' +
-                    _("Close") +
-                    '" height=20px width=20px align="right">';
-                docById("noteInfo1").innerHTML +=
-                    `<br><center><input type="range" class="sliders" id = "frequencySlider" style="width:170px; background:white; border:0;" min="${
-                        frequencies[i]
-                    }" max="${frequencies[i + 1]}" value="30"></center>`;
-                docById("noteInfo1").innerHTML += `&nbsp;&nbsp;${_(
-                    "frequency"
-                )} : <span class="rangeslidervalue" id="frequencydiv">${frequencies[i]}</span>`;
-                docById("noteInfo1").innerHTML +=
-                    `<br><br><div id="done" style="background:rgb(196, 196, 196);"><center>${_(
-                        "done"
-                    )}</center><div>`;
+                const noteInfo1 = document.createElement("div");
+                noteInfo1.className = "popup";
+                noteInfo1.id = "noteInfo1";
+                noteInfo1.style.width = "180px";
+                noteInfo1.style.height = "135px";
+                const myPopup = document.createElement("span");
+                myPopup.className = "popuptext";
+                myPopup.id = "myPopup";
+                noteInfo1.appendChild(myPopup);
+                docById("wheelDiv3").appendChild(noteInfo1);
+
+                const closeImg = document.createElement("img");
+                closeImg.src = "header-icons/close-button.svg";
+                closeImg.id = "close";
+                closeImg.title = _("Close");
+                closeImg.alt = _("Close");
+                closeImg.setAttribute("height", "20px");
+                closeImg.setAttribute("width", "20px");
+                closeImg.setAttribute("align", "right");
+                noteInfo1.appendChild(closeImg);
+
+                noteInfo1.appendChild(document.createElement("br"));
+                const centerNode = document.createElement("center");
+                const slider = document.createElement("input");
+                slider.type = "range";
+                slider.className = "sliders";
+                slider.id = "frequencySlider";
+                slider.style.width = "170px";
+                slider.style.background = "white";
+                slider.style.border = "0";
+                slider.setAttribute("min", frequencies[i]);
+                slider.setAttribute("max", frequencies[i + 1]);
+                slider.setAttribute("value", "30");
+                centerNode.appendChild(slider);
+                noteInfo1.appendChild(centerNode);
+
+                noteInfo1.appendChild(document.createTextNode(`\u00A0\u00A0${_("frequency")} : `));
+                const freqSpan = document.createElement("span");
+                freqSpan.className = "rangeslidervalue";
+                freqSpan.id = "frequencydiv";
+                freqSpan.textContent = frequencies[i];
+                noteInfo1.appendChild(freqSpan);
+
+                noteInfo1.appendChild(document.createElement("br"));
+                noteInfo1.appendChild(document.createElement("br"));
+                const doneDiv = document.createElement("div");
+                doneDiv.id = "done";
+                doneDiv.style.background = "rgb(196, 196, 196)";
+                const doneCenter = document.createElement("center");
+                doneCenter.textContent = _("done");
+                doneDiv.appendChild(doneCenter);
+                noteInfo1.appendChild(doneDiv);
 
                 docById("noteInfo1").style.top = "100px";
                 docById("noteInfo1").style.left = "90px";
@@ -1479,7 +1653,7 @@ function TemperamentWidget() {
      * @returns {void}
      */
     this._refreshInnerWheel = function () {
-        docById("frequencydiv").innerHTML = docById("frequencySlider").value;
+        docById("frequencydiv").textContent = docById("frequencySlider").value;
         const frequency = docById("frequencySlider").value;
         const ratio = frequency / this.frequencies[0];
         const ratioDifference = [];
@@ -1519,19 +1693,35 @@ function TemperamentWidget() {
      */
     this.octaveSpaceEdit = function () {
         this.editMode = "octave";
-        docById("userEdit").innerHTML = "";
+        docById("userEdit").textContent = "";
         const len = this.ratios.length;
         const octaveRatio = this.ratios[len - 1];
         const octaveSpaceEdit = docById("userEdit");
         octaveSpaceEdit.style.backgroundColor = "#c8C8C8";
-        octaveSpaceEdit.innerHTML = `<br><br>${_("octave space")} &nbsp;&nbsp;&nbsp;&nbsp; 
-            <input type="text" id="startNote" value="${octaveRatio}" style="width:50px;"></input> &nbsp;&nbsp; : &nbsp;&nbsp; <input type="text" id="endNote" value="1" style="width:50px;"></input><br><br>`;
+        octaveSpaceEdit.appendChild(document.createElement("br"));
+        octaveSpaceEdit.appendChild(document.createElement("br"));
+        octaveSpaceEdit.appendChild(document.createTextNode(_("octave space") + " \u00A0\u00A0\u00A0\u00A0 "));
+        const startNote = document.createElement("input");
+        startNote.type = "text";
+        startNote.id = "startNote";
+        startNote.value = octaveRatio;
+        startNote.style.width = "50px";
+        octaveSpaceEdit.appendChild(startNote);
+        octaveSpaceEdit.appendChild(document.createTextNode(" \u00A0\u00A0 : \u00A0\u00A0 "));
+        const endNote = document.createElement("input");
+        endNote.type = "text";
+        endNote.id = "endNote";
+        endNote.value = "1";
+        endNote.style.width = "50px";
+        octaveSpaceEdit.appendChild(endNote);
+        octaveSpaceEdit.appendChild(document.createElement("br"));
+        octaveSpaceEdit.appendChild(document.createElement("br"));
         octaveSpaceEdit.style.paddingLeft = "70px";
         const that = this;
 
         const divAppend = document.createElement("div");
         divAppend.id = "divAppend";
-        divAppend.innerHTML = _("done");
+        divAppend.textContent = _("done");
         divAppend.style.textAlign = "center";
         divAppend.style.paddingTop = "5px";
         divAppend.style.marginLeft = "-70px";
@@ -1616,7 +1806,7 @@ function TemperamentWidget() {
                 if (ratiosEqual) {
                     selectedTemperament = temperament;
                     this.inTemperament = temperament;
-                    temperamentCell.innerHTML = this.inTemperament;
+                    temperamentCell.textContent = this.inTemperament;
                     break;
                 }
             }
@@ -1624,7 +1814,7 @@ function TemperamentWidget() {
 
         if (selectedTemperament === undefined) {
             this.inTemperament = "custom";
-            temperamentCell.innerHTML = this.inTemperament;
+            temperamentCell.textContent = this.inTemperament;
         }
     };
 
@@ -1989,27 +2179,31 @@ function TemperamentWidget() {
 
         const cell = this.playButton;
         if (this._playing) {
-            cell.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/stop-button.svg" 
-                    title="${_("Stop")}" 
-                    alt="${_("Stop")}" 
-                    height="${ICONSIZE}" 
-                    width="${ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            cell.textContent = "\u00A0\u00A0";
+            const stopImg = document.createElement("img");
+            stopImg.src = "header-icons/stop-button.svg";
+            stopImg.title = _("Stop");
+            stopImg.alt = _("Stop");
+            stopImg.setAttribute("height", ICONSIZE);
+            stopImg.setAttribute("width", ICONSIZE);
+            stopImg.setAttribute("vertical-align", "middle");
+            stopImg.setAttribute("align-content", "center");
+            cell.appendChild(stopImg);
+            cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         } else {
             this._logo.synth.setMasterVolume(0);
             this._logo.synth.stop();
-            cell.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="${ICONSIZE}" 
-                    width="${ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            cell.textContent = "\u00A0\u00A0";
+            const playImg = document.createElement("img");
+            playImg.src = "header-icons/play-button.svg";
+            playImg.title = _("Play");
+            playImg.alt = _("Play");
+            playImg.setAttribute("height", ICONSIZE);
+            playImg.setAttribute("width", ICONSIZE);
+            playImg.setAttribute("vertical-align", "middle");
+            playImg.setAttribute("align-content", "center");
+            cell.appendChild(playImg);
+            cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         }
 
         const duration = 1 / 2;
@@ -2156,15 +2350,17 @@ function TemperamentWidget() {
                 that.inbetween = true;
             }
             if (!that.playbackForward && i == -1) {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/play-button.svg" 
-                        title="${_("Play")}" 
-                        alt="${_("Play")}" 
-                        height="${ICONSIZE}" 
-                        width="${ICONSIZE}" 
-                        vertical-align="middle" 
-                        align-content="center"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const playImg = document.createElement("img");
+                playImg.src = "header-icons/play-button.svg";
+                playImg.title = _("Play");
+                playImg.alt = _("Play");
+                playImg.setAttribute("height", ICONSIZE);
+                playImg.setAttribute("width", ICONSIZE);
+                playImg.setAttribute("vertical-align", "middle");
+                playImg.setAttribute("align-content", "center");
+                cell.appendChild(playImg);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
                 that._playing = false;
                 that.playbackForward = true;
                 this.inbetween = false;
@@ -2250,7 +2446,7 @@ function TemperamentWidget() {
 
         temperamentCell = row.insertCell();
         if (temperamentCell) {
-            temperamentCell.innerHTML = this.inTemperament;
+            temperamentCell.textContent = this.inTemperament;
         }
         temperamentCell.style.width = 2 * BUTTONSIZE + "px";
         temperamentCell.style.minWidth = temperamentCell.style.width;

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -200,7 +200,7 @@ function TemperamentWidget() {
         const height = 2 * radius + 60;
 
         temperamentTable.textContent = "";
-        
+
         const canvasT = document.createElement("canvas");
         canvasT.id = "circ";
         canvasT.setAttribute("width", BUTTONDIVWIDTH + "px");
@@ -451,12 +451,12 @@ function TemperamentWidget() {
                 noteInfoDiv.id = "noteInfo";
                 noteInfoDiv.style.left = `${x}px`;
                 noteInfoDiv.style.top = `${y}px`;
-                
+
                 const myPopupSpan = document.createElement("span");
                 myPopupSpan.className = "popuptext";
                 myPopupSpan.id = "myPopup";
                 noteInfoDiv.appendChild(myPopupSpan);
-                
+
                 if (i !== 0) {
                     const editImg = document.createElement("img");
                     editImg.src = "header-icons/edit.svg";
@@ -468,7 +468,7 @@ function TemperamentWidget() {
                     editImg.setAttribute("data-message", i);
                     noteInfoDiv.appendChild(editImg);
                 }
-                
+
                 const closeImg = document.createElement("img");
                 closeImg.src = "header-icons/close-button.svg";
                 closeImg.id = "close";
@@ -478,7 +478,7 @@ function TemperamentWidget() {
                 closeImg.setAttribute("width", "20px");
                 closeImg.setAttribute("align", "right");
                 noteInfoDiv.appendChild(closeImg);
-                
+
                 noteInfoDiv.appendChild(document.createElement("br"));
 
                 let noteDefined = false;
@@ -518,7 +518,7 @@ function TemperamentWidget() {
                 frequencyDiv.id = "frequency";
                 frequencyDiv.textContent = `\u00A0${_("frequency")}\u00A0${frequency}`;
                 noteInfoDiv.appendChild(frequencyDiv);
-                
+
                 docById("information").appendChild(noteInfoDiv);
 
                 docById("noteInfo").style.top = "130px";
@@ -551,7 +551,7 @@ function TemperamentWidget() {
         docById("noteInfo").style.height = "130px";
         if (docById("note")) docById("note").textContent = "";
         if (docById("frequency")) docById("frequency").textContent = "";
-        
+
         const noteInfo = docById("noteInfo");
         const center = document.createElement("center");
         const slider = document.createElement("input");
@@ -658,7 +658,7 @@ function TemperamentWidget() {
         menuTr.id = "menu";
         tablehead.appendChild(menuTr);
         notesGraph.appendChild(tablehead);
-        
+
         const tablebody = document.createElement("tbody");
         tablebody.id = "tablebody";
         notesGraph.appendChild(tablebody);
@@ -698,7 +698,7 @@ function TemperamentWidget() {
         divGraph.id = "graph";
         const tableOfNotes = document.createElement("table");
         tableOfNotes.id = "tableOfNotes";
-        
+
         for (let i = 0; i <= this.pitchNumber; i++) {
             const trNotes = document.createElement("tr");
             trNotes.id = "notes_" + i;
@@ -910,13 +910,17 @@ function TemperamentWidget() {
         const equalEdit = docById("userEdit");
         equalEdit.style.backgroundColor = "#c8C8C8";
         equalEdit.appendChild(document.createElement("br"));
-        equalEdit.appendChild(document.createTextNode(_("pitch number") + "\u00A0\u00A0\u00A0\u00A0 "));
+        equalEdit.appendChild(
+            document.createTextNode(_("pitch number") + "\u00A0\u00A0\u00A0\u00A0 ")
+        );
         const octaveIn = document.createElement("input");
         octaveIn.type = "text";
         octaveIn.id = "octaveIn";
         octaveIn.value = "0";
         equalEdit.appendChild(octaveIn);
-        equalEdit.appendChild(document.createTextNode(" \u00A0\u00A0 " + _("to") + "\u00A0\u00A0 "));
+        equalEdit.appendChild(
+            document.createTextNode(" \u00A0\u00A0 " + _("to") + "\u00A0\u00A0 ")
+        );
         const octaveOut = document.createElement("input");
         octaveOut.type = "text";
         octaveOut.id = "octaveOut";
@@ -924,7 +928,9 @@ function TemperamentWidget() {
         equalEdit.appendChild(octaveOut);
         equalEdit.appendChild(document.createElement("br"));
         equalEdit.appendChild(document.createElement("br"));
-        equalEdit.appendChild(document.createTextNode(_("number of divisions") + " \u00A0\u00A0\u00A0\u00A0 "));
+        equalEdit.appendChild(
+            document.createTextNode(_("number of divisions") + " \u00A0\u00A0\u00A0\u00A0 ")
+        );
         const divisions = document.createElement("input");
         divisions.type = "text";
         divisions.id = "divisions";
@@ -1027,8 +1033,7 @@ function TemperamentWidget() {
                 this.typeOfEdit = "equal";
                 this.divisions = numDivs;
             } else {
-                pitchNumber =
-                    numDivs + Number(pitchNumber) - Math.abs(pitchNumber1 - pitchNumber2);
+                pitchNumber = numDivs + Number(pitchNumber) - Math.abs(pitchNumber1 - pitchNumber2);
                 const angle1 =
                     270 +
                     360 * (Math.log10(this.tempRatios[pitchNumber1]) / Math.log10(this.powerBase));
@@ -1141,7 +1146,9 @@ function TemperamentWidget() {
         ratioEdit.appendChild(ratioOut);
         ratioEdit.appendChild(document.createElement("br"));
         ratioEdit.appendChild(document.createElement("br"));
-        ratioEdit.appendChild(document.createTextNode(_("recursion") + " \u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 "));
+        ratioEdit.appendChild(
+            document.createTextNode(_("recursion") + " \u00A0\u00A0\u00A0\u00A0\u00A0\u00A0 ")
+        );
         const recursion = document.createElement("input");
         recursion.type = "text";
         recursion.id = "recursion";
@@ -1700,7 +1707,9 @@ function TemperamentWidget() {
         octaveSpaceEdit.style.backgroundColor = "#c8C8C8";
         octaveSpaceEdit.appendChild(document.createElement("br"));
         octaveSpaceEdit.appendChild(document.createElement("br"));
-        octaveSpaceEdit.appendChild(document.createTextNode(_("octave space") + " \u00A0\u00A0\u00A0\u00A0 "));
+        octaveSpaceEdit.appendChild(
+            document.createTextNode(_("octave space") + " \u00A0\u00A0\u00A0\u00A0 ")
+        );
         const startNote = document.createElement("input");
         startNote.type = "text";
         startNote.id = "startNote";

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -56,14 +56,14 @@ class Tempo {
         this._firstClickTimes = null;
         this._intervals = [];
         this.isMoving = true;
-        if (this._intervalID != undefined && this._intervalID != null) {
+        if (this._intervalID !== undefined && this._intervalID !== null) {
             clearInterval(this._intervalID);
         }
 
         this._intervalID = null;
         this.activity.logo.synth.loadSynth(0, getDrumSynthName(Tempo.TEMPOSYNTH));
 
-        if (this._intervalID != null) {
+        if (this._intervalID !== null) {
             clearInterval(this._intervalID);
         }
 
@@ -73,7 +73,7 @@ class Tempo {
         widgetWindow.show();
 
         widgetWindow.onclose = () => {
-            if (this._intervalID != null) {
+            if (this._intervalID !== null) {
                 clearInterval(this._intervalID);
             }
             widgetWindow.destroy();
@@ -167,7 +167,7 @@ class Tempo {
             this.tempoCanvases[i].onclick = (id => () => {
                 const d = new Date();
                 let newBPM, BPMInput;
-                if (this._firstClickTime == null) {
+                if (this._firstClickTime === null) {
                     this._firstClickTime = d.getTime();
                 } else {
                     newBPM = parseInt((60 * 1000) / (d.getTime() - this._firstClickTime));
@@ -207,11 +207,11 @@ class Tempo {
     _updateBPM(i) {
         this._intervals[i] = (60 / this.BPMs[i]) * 1000;
 
-        if (this.BPMBlocks[i] == null) return;
+        if (this.BPMBlocks[i] === null) return;
 
         const bpmBlock = this.activity.blocks.blockList[this.BPMBlocks[i]];
         const blockNumber = bpmBlock.connections[1];
-        if (blockNumber != null) {
+        if (blockNumber !== null) {
             this.activity.blocks.blockList[blockNumber].value = parseFloat(this.BPMs[i]);
             this.activity.blocks.blockList[blockNumber].text.text = this.BPMs[i];
             this.activity.blocks.blockList[blockNumber].updateCache();
@@ -335,7 +335,7 @@ class Tempo {
             if (!tempoCanvas) continue;
 
             // We start the music clock as the first note is being played.
-            if (this._widgetFirstTimes[i] == null) {
+            if (this._widgetFirstTimes[i] === null) {
                 this._widgetFirstTimes[i] = d.getTime();
                 this._widgetNextTimes[i] = this._widgetFirstTimes[i] + this._intervals[i];
             }

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -184,62 +184,62 @@ class TimbreWidget {
     _update = async (i, value, k) => {
         const updateParams = [];
 
-        if (this.isActive["envelope"] === true && this.env[i] != null) {
+        if (this.isActive["envelope"] === true && this.env[i] !== null) {
             for (let j = 0; j < 4; j++) {
                 updateParams[j] = this.activity.blocks.blockList[this.env[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["filter"] === true && this.fil[i] != null) {
+        if (this.isActive["filter"] === true && this.fil[i] !== null) {
             for (let j = 0; j < 3; j++) {
                 updateParams[j] = this.activity.blocks.blockList[this.fil[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["oscillator"] === true && this.osc[i] != null) {
+        if (this.isActive["oscillator"] === true && this.osc[i] !== null) {
             for (let j = 0; j < 2; j++) {
                 updateParams[j] = this.activity.blocks.blockList[this.osc[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["amsynth"] === true && this.AMSynthesizer[i] != null) {
+        if (this.isActive["amsynth"] === true && this.AMSynthesizer[i] !== null) {
             updateParams[0] = this.activity.blocks.blockList[this.AMSynthesizer[i]].connections[1];
         }
 
-        if (this.isActive["fmsynth"] === true && this.FMSynthesizer[i] != null) {
+        if (this.isActive["fmsynth"] === true && this.FMSynthesizer[i] !== null) {
             updateParams[0] = this.activity.blocks.blockList[this.FMSynthesizer[i]].connections[1];
         }
 
-        if (this.isActive["noisesynth"] === true && this.NoiseSynthesizer[i] != null) {
+        if (this.isActive["noisesynth"] === true && this.NoiseSynthesizer[i] !== null) {
             updateParams[0] =
                 this.activity.blocks.blockList[this.NoiseSynthesizer[i]].connections[1];
         }
 
-        if (this.isActive["duosynth"] === true && this.duoSynthesizer[i] != null) {
+        if (this.isActive["duosynth"] === true && this.duoSynthesizer[i] !== null) {
             for (let j = 0; j < 2; j++) {
                 updateParams[j] =
                     this.activity.blocks.blockList[this.duoSynthesizer[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["tremolo"] === true && this.tremoloEffect[i] != null) {
+        if (this.isActive["tremolo"] === true && this.tremoloEffect[i] !== null) {
             for (let j = 0; j < 2; j++) {
                 updateParams[j] =
                     this.activity.blocks.blockList[this.tremoloEffect[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["vibrato"] === true && this.vibratoEffect[i] != null) {
+        if (this.isActive["vibrato"] === true && this.vibratoEffect[i] !== null) {
             updateParams[0] = this.activity.blocks.blockList[this.vibratoEffect[i]].connections[1];
             // The rate arg of the vibrato block must be in the form: a / b
             const divBlock = this.activity.blocks.blockList[this.vibratoEffect[i]].connections[2];
             if (
                 this.activity.blocks.blockList[divBlock].name === "divide" &&
-                this.activity.blocks.blockList[divBlock].connections[1] != null &&
+                this.activity.blocks.blockList[divBlock].connections[1] !== null &&
                 this.activity.blocks.blockList[
                     this.activity.blocks.blockList[divBlock].connections[1]
                 ].name === "number" &&
-                this.activity.blocks.blockList[divBlock].connections[2] != null &&
+                this.activity.blocks.blockList[divBlock].connections[2] !== null &&
                 this.activity.blocks.blockList[
                     this.activity.blocks.blockList[divBlock].connections[2]
                 ].name === "number"
@@ -277,26 +277,26 @@ class TimbreWidget {
             }
         }
 
-        if (this.isActive["chorus"] === true && this.chorusEffect[i] != null) {
+        if (this.isActive["chorus"] === true && this.chorusEffect[i] !== null) {
             for (let j = 0; j < 3; j++) {
                 updateParams[j] =
                     this.activity.blocks.blockList[this.chorusEffect[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["phaser"] === true && this.phaserEffect[i] != null) {
+        if (this.isActive["phaser"] === true && this.phaserEffect[i] !== null) {
             for (let j = 0; j < 3; j++) {
                 updateParams[j] =
                     this.activity.blocks.blockList[this.phaserEffect[i]].connections[j + 1];
             }
         }
 
-        if (this.isActive["distortion"] === true && this.distortionEffect[i] != null) {
+        if (this.isActive["distortion"] === true && this.distortionEffect[i] !== null) {
             updateParams[0] =
                 this.activity.blocks.blockList[this.distortionEffect[i]].connections[1];
         }
 
-        if (updateParams[0] != null) {
+        if (updateParams[0] !== null) {
             if (typeof value === "string") {
                 this.activity.blocks.blockList[updateParams[k]].value = value;
             } else {
@@ -992,7 +992,7 @@ class TimbreWidget {
         this.activity.blocks.blockList[n].connections[0] = this.blockNo;
 
         // If there were blocks in the Widget, move them inside the clamp.
-        if (topOfClamp != null) {
+        if (topOfClamp !== null) {
             this.activity.blocks.blockList[n].connections[clamp] = topOfClamp;
             this.activity.blocks.blockList[topOfClamp].connections[0] = n;
         }
@@ -1020,7 +1020,7 @@ class TimbreWidget {
         this.activity.blocks.blockList[n].connections[0] = this.blockNo;
 
         // If there were blocks in the Widget, move them inside the clamp.
-        if (topOfClamp != null) {
+        if (topOfClamp !== null) {
             this.activity.blocks.blockList[vspace].connections[1] = topOfClamp;
             this.activity.blocks.blockList[topOfClamp].connections[0] = vspace;
         }
@@ -1078,7 +1078,7 @@ class TimbreWidget {
             this.activity.blocks.blockList[newblk].connections.length - 1
         ] = c1;
 
-        if (c0 != null) {
+        if (c0 !== null) {
             for (let i = 0; i < this.activity.blocks.blockList[c0].connections.length; i++) {
                 if (this.activity.blocks.blockList[c0].connections[i] === oldblk) {
                     this.activity.blocks.blockList[c0].connections[i] = newblk;
@@ -1088,7 +1088,7 @@ class TimbreWidget {
 
             // Look for a containing clamp, which may need to be resized.
             let blockAbove = c0;
-            while (blockAbove != this.blockNo) {
+            while (blockAbove !== this.blockNo) {
                 if (this.activity.blocks.blockList[blockAbove].isClampBlock()) {
                     this.activity.blocks.clampBlocksToCheck.push([blockAbove, 0]);
                 }
@@ -1099,7 +1099,7 @@ class TimbreWidget {
             this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
         }
 
-        if (c1 != null) {
+        if (c1 !== null) {
             for (let i = 0; i < this.activity.blocks.blockList[c1].connections.length; i++) {
                 if (this.activity.blocks.blockList[c1].connections[i] === oldblk) {
                     this.activity.blocks.blockList[c1].connections[i] = newblk;
@@ -1130,7 +1130,7 @@ class TimbreWidget {
      */
     blockConnection = async (len, bottomOfClamp) => {
         const n = this.activity.blocks.blockList.length - len;
-        if (bottomOfClamp == null) {
+        if (bottomOfClamp === null) {
             this.activity.blocks.blockList[this.blockNo].connections[2] = n;
             this.activity.blocks.blockList[n].connections[0] = this.blockNo;
         } else {
@@ -1147,7 +1147,7 @@ class TimbreWidget {
                 const cblk = this.activity.blocks.blockList[bottomOfClamp].connections[0];
                 c = this.activity.blocks.blockList[cblk].connections.length - 2;
                 this.activity.blocks.clampBlocksToCheck.push([cblk, 0]);
-                if (this.activity.blocks.blockList[cblk].connections[c] == null) {
+                if (this.activity.blocks.blockList[cblk].connections[c] === null) {
                     bottomOfClamp = cblk;
                 } else {
                     // Find bottom of stack

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -144,15 +144,17 @@ class TimbreWidget {
      */
     _addButton(row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
-        cell.innerHTML = `&nbsp;&nbsp;<img 
-                src="header-icons/${icon}" 
-                title="${label}" 
-                alt="${label}" 
-                height="${iconSize}" 
-                width="${iconSize}" 
-                vertical-align="middle" 
-                align-content="center"
-            >&nbsp;&nbsp;`;
+        cell.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.setAttribute("height", iconSize);
+        img.setAttribute("width", iconSize);
+        img.setAttribute("vertical-align", "middle");
+        img.setAttribute("align-content", "center");
+        cell.appendChild(img);
+        cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         cell.style.width = TimbreWidget.BUTTONSIZE + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
@@ -402,30 +404,31 @@ class TimbreWidget {
 
         const cell = this.playButton;
         if (this._playing) {
-            cell.innerHTML =
-                '&nbsp;&nbsp;<img src="header-icons/' +
-                "stop-button.svg" +
-                '" title="' +
-                _("Stop") +
-                '" alt="' +
-                _("Stop") +
-                '" height="' +
-                TimbreWidget.ICONSIZE +
-                '" width="' +
-                TimbreWidget.ICONSIZE +
-                '" vertical-align="middle" align-content="center">&nbsp;&nbsp;';
+            cell.textContent = "\u00A0\u00A0";
+            const stopImg = document.createElement("img");
+            stopImg.src = "header-icons/stop-button.svg";
+            stopImg.title = _("Stop");
+            stopImg.alt = _("Stop");
+            stopImg.setAttribute("height", TimbreWidget.ICONSIZE);
+            stopImg.setAttribute("width", TimbreWidget.ICONSIZE);
+            stopImg.setAttribute("vertical-align", "middle");
+            stopImg.setAttribute("align-content", "center");
+            cell.appendChild(stopImg);
+            cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         } else {
             this.activity.logo.synth.setMasterVolume(0);
             this.activity.logo.synth.stop();
-            cell.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${_("Play")}" 
-                    alt="${_("Play")}" 
-                    height="${TimbreWidget.ICONSIZE}" 
-                    width="${TimbreWidget.ICONSIZE}" 
-                    vertical-align="middle" 
-                    align-content="center"
-                >&nbsp;&nbsp;`;
+            cell.textContent = "\u00A0\u00A0";
+            const playImg = document.createElement("img");
+            playImg.src = "header-icons/play-button.svg";
+            playImg.title = _("Play");
+            playImg.alt = _("Play");
+            playImg.setAttribute("height", TimbreWidget.ICONSIZE);
+            playImg.setAttribute("width", TimbreWidget.ICONSIZE);
+            playImg.setAttribute("vertical-align", "middle");
+            playImg.setAttribute("align-content", "center");
+            cell.appendChild(playImg);
+            cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         }
 
         if (this.notesToPlay.length === 0) {
@@ -450,15 +453,17 @@ class TimbreWidget {
                     Singer.defaultBPMFactor * 1000 * this.notesToPlay[i - 1][1]
                 );
             } else {
-                cell.innerHTML = `&nbsp;&nbsp;<img 
-                        src="header-icons/play-button.svg" 
-                        title="${_("Play")}" 
-                        alt="${_("Play")}" 
-                        height="${TimbreWidget.ICONSIZE}" 
-                        width="${TimbreWidget.ICONSIZE}" 
-                        vertical-align="middle" 
-                        align-content="center"
-                    >&nbsp;&nbsp;`;
+                cell.textContent = "\u00A0\u00A0";
+                const playImg2 = document.createElement("img");
+                playImg2.src = "header-icons/play-button.svg";
+                playImg2.title = _("Play");
+                playImg2.alt = _("Play");
+                playImg2.setAttribute("height", TimbreWidget.ICONSIZE);
+                playImg2.setAttribute("width", TimbreWidget.ICONSIZE);
+                playImg2.setAttribute("vertical-align", "middle");
+                playImg2.setAttribute("align-content", "center");
+                cell.appendChild(playImg2);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
                 this._playing = false;
             }
         };
@@ -1179,15 +1184,18 @@ class TimbreWidget {
         this.timbreTableDiv.style.overflow = "auto";
         this.timbreTableDiv.style.backgroundColor = "white";
         this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.innerHTML = '<div id="timbreTable"></div>';
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
 
         const env = docById("timbreTable");
-        let htmlElements = "";
+        env.textContent = "";
         for (let i = 0; i < 2; i++) {
-            htmlElements += '<div id ="synth' + i + '"></div>';
+            const synthDiv = document.createElement("div");
+            synthDiv.id = "synth" + i;
+            env.appendChild(synthDiv);
         }
-
-        env.innerHTML = htmlElements;
         const envAppend = document.createElement("div");
         envAppend.id = "envAppend";
         envAppend.style.backgroundColor = platformColor.widgetBackground;
@@ -1197,11 +1205,34 @@ class TimbreWidget {
         env.append(envAppend);
 
         const mainDiv = docById("synth0");
-        mainDiv.innerHTML = `<p>
-                <input type="radio" name="synthsName" value="AMSynth"/>${_("AM synth")}<br>
-                <input type="radio" name="synthsName" value="FMSynth"/>${_("FM synth")}<br>
-                <input type="radio" name="synthsName" value="DuoSynth"/>${_("duo synth")}<br>
-            </p>`;
+        mainDiv.textContent = "";
+        const pNode = document.createElement("p");
+        
+        const amRadio = document.createElement("input");
+        amRadio.type = "radio";
+        amRadio.name = "synthsName";
+        amRadio.value = "AMSynth";
+        pNode.appendChild(amRadio);
+        pNode.appendChild(document.createTextNode(_("AM synth")));
+        pNode.appendChild(document.createElement("br"));
+        
+        const fmRadio = document.createElement("input");
+        fmRadio.type = "radio";
+        fmRadio.name = "synthsName";
+        fmRadio.value = "FMSynth";
+        pNode.appendChild(fmRadio);
+        pNode.appendChild(document.createTextNode(_("FM synth")));
+        pNode.appendChild(document.createElement("br"));
+        
+        const duoRadio = document.createElement("input");
+        duoRadio.type = "radio";
+        duoRadio.name = "synthsName";
+        duoRadio.value = "DuoSynth";
+        pNode.appendChild(duoRadio);
+        pNode.appendChild(document.createTextNode(_("duo synth")));
+        pNode.appendChild(document.createElement("br"));
+        
+        mainDiv.appendChild(pNode);
 
         const subDiv = docById("synth1");
         const synthsName = docByName("synthsName");
@@ -1209,7 +1240,11 @@ class TimbreWidget {
         for (let i = 0; i < synthsName.length; i++) {
             synthsName[i].onclick = async event => {
                 synthChosen = event.target.value;
-                let subHtmlElements = '<div id="chosen">' + synthChosen + "</div>";
+                subDiv.textContent = "";
+                const chosenDiv = document.createElement("div");
+                chosenDiv.id = "chosen";
+                chosenDiv.textContent = synthChosen;
+                subDiv.appendChild(chosenDiv);
                 for (let j = 0; j < this.activeParams.length; j++) {
                     this.isActive[this.activeParams[j]] = false;
                 }
@@ -1246,15 +1281,36 @@ class TimbreWidget {
                         );
                     }
 
-                    subHtmlElements +=
-                        '<div id="wrapperS0"><div id="sS0"><span>' +
-                        _("harmonicity") +
-                        '</span></div><div class="insideDivSynth"><input type="range" id="myRangeS0" class="sliders" style="margin-top:20px" value="' +
-                        parseFloat(this.AMSynthParams[0]) +
-                        '"><span id="myspanS0" class="rangeslidervalue">' +
-                        this.AMSynthParams[0] +
-                        "</span></div></div>";
-                    subDiv.innerHTML = subHtmlElements;
+                    const wrapperS0 = document.createElement("div");
+                    wrapperS0.id = "wrapperS0";
+                    
+                    const labelDivS0 = document.createElement("div");
+                    labelDivS0.id = "sS0";
+                    const spanLabelS0 = document.createElement("span");
+                    spanLabelS0.textContent = _("harmonicity");
+                    labelDivS0.appendChild(spanLabelS0);
+                    wrapperS0.appendChild(labelDivS0);
+                    
+                    const insideDivS0 = document.createElement("div");
+                    insideDivS0.className = "insideDivSynth";
+                    
+                    const inputS0 = document.createElement("input");
+                    inputS0.type = "range";
+                    inputS0.id = "myRangeS0";
+                    inputS0.className = "sliders";
+                    inputS0.style.marginTop = "20px";
+                    inputS0.value = parseFloat(this.AMSynthParams[0]);
+                    
+                    const spanValS0 = document.createElement("span");
+                    spanValS0.id = "myspanS0";
+                    spanValS0.className = "rangeslidervalue";
+                    spanValS0.textContent = this.AMSynthParams[0];
+                    
+                    insideDivS0.appendChild(inputS0);
+                    insideDivS0.appendChild(spanValS0);
+                    wrapperS0.appendChild(insideDivS0);
+                    
+                    subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.AMSynthParams[0]);
                     // docById('myspanS0').textContent = this.AMSynthParams[0];
@@ -1312,15 +1368,36 @@ class TimbreWidget {
                         );
                     }
 
-                    subHtmlElements +=
-                        '<div id="wrapperS0"><div id="sS0"><span>' +
-                        _("modulation index") +
-                        '</span></div><div class="insideDivSynth"><input type="range" id="myRangeS0" class="sliders" style="margin-top:20px" value="' +
-                        parseFloat(this.FMSynthParams[0]) +
-                        '"><span id="myspanS0" class="rangeslidervalue">' +
-                        this.FMSynthParams[0] +
-                        "</span></div></div>";
-                    subDiv.innerHTML = subHtmlElements;
+                    const wrapperS0 = document.createElement("div");
+                    wrapperS0.id = "wrapperS0";
+                    
+                    const labelDivS0 = document.createElement("div");
+                    labelDivS0.id = "sS0";
+                    const spanLabelS0 = document.createElement("span");
+                    spanLabelS0.textContent = _("modulation index");
+                    labelDivS0.appendChild(spanLabelS0);
+                    wrapperS0.appendChild(labelDivS0);
+                    
+                    const insideDivS0 = document.createElement("div");
+                    insideDivS0.className = "insideDivSynth";
+                    
+                    const inputS0 = document.createElement("input");
+                    inputS0.type = "range";
+                    inputS0.id = "myRangeS0";
+                    inputS0.className = "sliders";
+                    inputS0.style.marginTop = "20px";
+                    inputS0.value = parseFloat(this.FMSynthParams[0]);
+                    
+                    const spanValS0 = document.createElement("span");
+                    spanValS0.id = "myspanS0";
+                    spanValS0.className = "rangeslidervalue";
+                    spanValS0.textContent = this.FMSynthParams[0];
+                    
+                    insideDivS0.appendChild(inputS0);
+                    insideDivS0.appendChild(spanValS0);
+                    wrapperS0.appendChild(insideDivS0);
+                    
+                    subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
                     // docById('myspanS0').textContent = this.FMSynthParams[0];
@@ -1377,15 +1454,36 @@ class TimbreWidget {
                         );
                     }
 
-                    subHtmlElements +=
-                        '<div id="wrapperS0"><div id="sS0"><span>' +
-                        _("modulation index") +
-                        '</span></div><div class="insideDivSynth"><input type="range" id="myRangeS0" class="sliders" style="margin-top:20px" value="' +
-                        this.NoiseSynthParams[0] +
-                        '"><span id="myspanS0" class="rangeslidervalue">' +
-                        this.NoiseSynthParams[0] +
-                        "</span></div></div>";
-                    subDiv.innerHTML = subHtmlElements;
+                    const wrapperS0 = document.createElement("div");
+                    wrapperS0.id = "wrapperS0";
+                    
+                    const labelDivS0 = document.createElement("div");
+                    labelDivS0.id = "sS0";
+                    const spanLabelS0 = document.createElement("span");
+                    spanLabelS0.textContent = _("modulation index");
+                    labelDivS0.appendChild(spanLabelS0);
+                    wrapperS0.appendChild(labelDivS0);
+                    
+                    const insideDivS0 = document.createElement("div");
+                    insideDivS0.className = "insideDivSynth";
+                    
+                    const inputS0 = document.createElement("input");
+                    inputS0.type = "range";
+                    inputS0.id = "myRangeS0";
+                    inputS0.className = "sliders";
+                    inputS0.style.marginTop = "20px";
+                    inputS0.value = this.NoiseSynthParams[0];
+                    
+                    const spanValS0 = document.createElement("span");
+                    spanValS0.id = "myspanS0";
+                    spanValS0.className = "rangeslidervalue";
+                    spanValS0.textContent = this.NoiseSynthParams[0];
+                    
+                    insideDivS0.appendChild(inputS0);
+                    insideDivS0.appendChild(spanValS0);
+                    wrapperS0.appendChild(insideDivS0);
+                    
+                    subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
                     // docById('myspanS0').textContent = this.FMSynthParams[0];
@@ -1446,23 +1544,67 @@ class TimbreWidget {
                         );
                     }
 
-                    subHtmlElements +=
-                        '<div id="wrapperS0"><div id="sS0"><span>' +
-                        _("vibrato rate") +
-                        '</span></div><div class="insideDivSynth"><input type="range" id="myRangeS0" class="sliders" style="margin-top:20px" value="' +
-                        parseFloat(this.duoSynthParams[0]) +
-                        '"><span id="myspanS0" class="rangeslidervalue">' +
-                        this.duoSynthParams[0] +
-                        "</span></div></div>";
-                    subHtmlElements +=
-                        '<div id="wrapperS1"><div id="sS1"><span>' +
-                        _("vibrato amount") +
-                        '</span></div><div class="insideDivSynth"><input type="range" id="myRangeS1" class="sliders" style="margin-top:20px" value="' +
-                        parseFloat(this.duoSynthParams[1]) +
-                        '"><span id="myspanS1" class="rangeslidervalue">' +
-                        this.duoSynthParams[1] +
-                        "</span></div></div>";
-                    subDiv.innerHTML = subHtmlElements;
+                    const wrapperS0 = document.createElement("div");
+                    wrapperS0.id = "wrapperS0";
+                    
+                    const labelDivS0 = document.createElement("div");
+                    labelDivS0.id = "sS0";
+                    const spanLabelS0 = document.createElement("span");
+                    spanLabelS0.textContent = _("vibrato rate");
+                    labelDivS0.appendChild(spanLabelS0);
+                    wrapperS0.appendChild(labelDivS0);
+                    
+                    const insideDivS0 = document.createElement("div");
+                    insideDivS0.className = "insideDivSynth";
+                    
+                    const inputS0 = document.createElement("input");
+                    inputS0.type = "range";
+                    inputS0.id = "myRangeS0";
+                    inputS0.className = "sliders";
+                    inputS0.style.marginTop = "20px";
+                    inputS0.value = parseFloat(this.duoSynthParams[0]);
+                    
+                    const spanValS0 = document.createElement("span");
+                    spanValS0.id = "myspanS0";
+                    spanValS0.className = "rangeslidervalue";
+                    spanValS0.textContent = this.duoSynthParams[0];
+                    
+                    insideDivS0.appendChild(inputS0);
+                    insideDivS0.appendChild(spanValS0);
+                    wrapperS0.appendChild(insideDivS0);
+                    
+                    subDiv.appendChild(wrapperS0);
+
+                    const wrapperS1 = document.createElement("div");
+                    wrapperS1.id = "wrapperS1";
+                    
+                    const labelDivS1 = document.createElement("div");
+                    labelDivS1.id = "sS1";
+                    const spanLabelS1 = document.createElement("span");
+                    spanLabelS1.textContent = _("vibrato amount");
+                    labelDivS1.appendChild(spanLabelS1);
+                    wrapperS1.appendChild(labelDivS1);
+                    
+                    const insideDivS1 = document.createElement("div");
+                    insideDivS1.className = "insideDivSynth";
+                    
+                    const inputS1 = document.createElement("input");
+                    inputS1.type = "range";
+                    inputS1.id = "myRangeS1";
+                    inputS1.className = "sliders";
+                    inputS1.style.marginTop = "20px";
+                    inputS1.value = parseFloat(this.duoSynthParams[1]);
+                    
+                    const spanValS1 = document.createElement("span");
+                    spanValS1.id = "myspanS1";
+                    spanValS1.className = "rangeslidervalue";
+                    spanValS1.textContent = this.duoSynthParams[1];
+                    
+                    insideDivS1.appendChild(inputS1);
+                    insideDivS1.appendChild(spanValS1);
+                    wrapperS1.appendChild(insideDivS1);
+                    
+                    subDiv.appendChild(wrapperS1);
 
                     if (this.duoSynthesizer.length !== 1) {
                         blockValue = this.duoSynthesizer.length - 1;
@@ -1520,23 +1662,55 @@ class TimbreWidget {
         this.timbreTableDiv.style.overflow = "auto";
         this.timbreTableDiv.style.backgroundColor = "white";
         this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.innerHTML = '<div id="timbreTable"></div>';
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
 
         const env = docById("timbreTable");
-        let htmlElements =
-            '<div id="wrapperOsc0"><div id="sOsc0"><span>' +
-            _("type") +
-            '</span></div><div id="selOsc"></div></div>';
-        htmlElements +=
-            '<div id="wrapperOsc1"><div id="sOsc1"><span>' +
-            _("partials") +
-            '</span></div><div class="insideDivOsc"><input type="range" id="myRangeO0" class="sliders" style="margin-top:20px" min="0" max="20" value="' +
-            parseFloat(this.oscParams[1]) +
-            '"><span id="myspanO0" class="rangeslidervalue">' +
-            this.oscParams[1] +
-            "</span></div></div>";
+        env.textContent = "";
 
-        env.innerHTML = htmlElements;
+        const wrapperOsc0 = document.createElement("div");
+        wrapperOsc0.id = "wrapperOsc0";
+        const labelDivOsc0 = document.createElement("div");
+        labelDivOsc0.id = "sOsc0";
+        const spanLabelOsc0 = document.createElement("span");
+        spanLabelOsc0.textContent = _("type");
+        labelDivOsc0.appendChild(spanLabelOsc0);
+        wrapperOsc0.appendChild(labelDivOsc0);
+        
+        const selOsc = document.createElement("div");
+        selOsc.id = "selOsc";
+        wrapperOsc0.appendChild(selOsc);
+        env.appendChild(wrapperOsc0);
+        
+        const wrapperOsc1 = document.createElement("div");
+        wrapperOsc1.id = "wrapperOsc1";
+        const labelDivOsc1 = document.createElement("div");
+        labelDivOsc1.id = "sOsc1";
+        const spanLabelOsc1 = document.createElement("span");
+        spanLabelOsc1.textContent = _("partials");
+        labelDivOsc1.appendChild(spanLabelOsc1);
+        wrapperOsc1.appendChild(labelDivOsc1);
+        
+        const insideDivOsc = document.createElement("div");
+        insideDivOsc.className = "insideDivOsc";
+        const inputOsc1 = document.createElement("input");
+        inputOsc1.type = "range";
+        inputOsc1.id = "myRangeO0";
+        inputOsc1.className = "sliders";
+        inputOsc1.style.marginTop = "20px";
+        inputOsc1.min = "0";
+        inputOsc1.max = "20";
+        inputOsc1.value = parseFloat(this.oscParams[1]);
+        const spanValOsc1 = document.createElement("span");
+        spanValOsc1.id = "myspanO0";
+        spanValOsc1.className = "rangeslidervalue";
+        spanValOsc1.textContent = this.oscParams[1];
+        insideDivOsc.appendChild(inputOsc1);
+        insideDivOsc.appendChild(spanValOsc1);
+        wrapperOsc1.appendChild(insideDivOsc);
+        env.appendChild(wrapperOsc1);
         const envAppend = document.createElement("div");
         envAppend.id = "envAppend";
         envAppend.style.backgroundColor = platformColor.widgetBackground;
@@ -1546,40 +1720,27 @@ class TimbreWidget {
         env.append(envAppend);
 
         const myDiv = docById("selOsc");
-        let selectOpt = '<select id="selOsc1">';
-
+        const selectOsc1 = document.createElement("select");
+        selectOsc1.id = "selOsc1";
+        
         for (let i = 0; i < OSCTYPES.length; i++) {
-            // work around some weird i18n bug
+            const opt = document.createElement("option");
             if (OSCTYPES[i][0].length === 0) {
+                opt.value = OSCTYPES[i][1];
+                opt.textContent = OSCTYPES[i][1];
                 if (OSCTYPES[i][0] === this.oscParams[0] || OSCTYPES[i][1] === this.oscParams[0]) {
-                    selectOpt +=
-                        '<option value="' +
-                        OSCTYPES[i][1] +
-                        '" selected>' +
-                        OSCTYPES[i][1] +
-                        "</option>";
-                } else {
-                    selectOpt +=
-                        '<option value="' + OSCTYPES[i][1] + '">' + OSCTYPES[i][1] + "</option>";
+                    opt.selected = true;
                 }
             } else {
+                opt.value = OSCTYPES[i][0];
+                opt.textContent = OSCTYPES[i][0];
                 if (OSCTYPES[i][0] === this.oscParams[0] || OSCTYPES[i][1] === this.oscParams[0]) {
-                    selectOpt +=
-                        '<option value="' +
-                        OSCTYPES[i][0] +
-                        '" selected>' +
-                        OSCTYPES[i][0] +
-                        "</option>";
-                } else {
-                    selectOpt +=
-                        '<option value="' + OSCTYPES[i][0] + '">' + OSCTYPES[i][0] + "</option>";
+                    opt.selected = true;
                 }
             }
+            selectOsc1.appendChild(opt);
         }
-
-        selectOpt += "</select>";
-
-        myDiv.innerHTML = selectOpt;
+        myDiv.appendChild(selectOsc1);
 
         document.getElementById("wrapperOsc0").addEventListener("change", event => {
             const elem = event.target;
@@ -1647,28 +1808,44 @@ class TimbreWidget {
         this.timbreTableDiv.style.overflow = "auto";
         this.timbreTableDiv.style.backgroundColor = "white";
         this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.innerHTML = '<div id="timbreTable"></div>';
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
 
         const env = docById("timbreTable");
-        let htmlElements = "";
-        for (let i = 0; i < 4; i++) {
-            htmlElements +=
-                '<div id="wrapperEnv' +
-                i +
-                '"><div class="circle">' +
-                "ADSR".charAt(i) +
-                '</div><div class="insideDivEnv"><input type="range" id="myRange' +
-                i +
-                '" class="sliders" style="margin-top:20px" value="' +
-                parseFloat(this.ENVs[i]) +
-                '"><span id="myspan' +
-                i +
-                '" class="rangeslidervalue">' +
-                this.ENVs[i] +
-                "</span></div></div>";
-        }
+        env.textContent = "";
 
-        env.innerHTML = htmlElements;
+        for (let i = 0; i < 4; i++) {
+            const wrapperEnv = document.createElement("div");
+            wrapperEnv.id = "wrapperEnv" + i;
+            
+            const circleDiv = document.createElement("div");
+            circleDiv.className = "circle";
+            circleDiv.textContent = "ADSR".charAt(i);
+            wrapperEnv.appendChild(circleDiv);
+            
+            const insideDivEnv = document.createElement("div");
+            insideDivEnv.className = "insideDivEnv";
+            
+            const rangeEnv = document.createElement("input");
+            rangeEnv.type = "range";
+            rangeEnv.id = "myRange" + i;
+            rangeEnv.className = "sliders";
+            rangeEnv.style.marginTop = "20px";
+            rangeEnv.value = parseFloat(this.ENVs[i]);
+            
+            const spanEnv = document.createElement("span");
+            spanEnv.id = "myspan" + i;
+            spanEnv.className = "rangeslidervalue";
+            spanEnv.textContent = this.ENVs[i];
+            
+            insideDivEnv.appendChild(rangeEnv);
+            insideDivEnv.appendChild(spanEnv);
+            wrapperEnv.appendChild(insideDivEnv);
+            
+            env.appendChild(wrapperEnv);
+        }
         const envAppend = document.createElement("div");
         envAppend.id = "envAppend";
         envAppend.style.backgroundColor = platformColor.widgetBackground;
@@ -1722,10 +1899,13 @@ class TimbreWidget {
         this.timbreTableDiv.style.overflow = "auto";
         this.timbreTableDiv.style.backgroundColor = "white";
         this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.innerHTML = '<div id="timbreTable"></div>';
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
 
         const env = docById("timbreTable");
-        env.innerHTML = "";
+        env.textContent = "";
 
         for (let f = 0; f < this.fil.length; f++) {
             this._createFilter(f, env);
@@ -1753,11 +1933,11 @@ class TimbreWidget {
         if (f % 2 === 1) {
             containerDiv.className = "rectangle";
             const spacer = document.createElement("p");
-            spacer.innerHTML = "&nbsp;";
+            spacer.textContent = "\u00A0";
             containerDiv.appendChild(spacer);
         } else if (f > 0) {
             const spacer = document.createElement("p");
-            spacer.innerHTML = "&nbsp;";
+            spacer.textContent = "\u00A0";
             containerDiv.appendChild(spacer);
         }
 
@@ -2116,15 +2296,18 @@ class TimbreWidget {
             height: "300px"
         });
 
-        this.timbreTableDiv.innerHTML = '<div id="timbreTable"></div>';
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
 
         const env = docById("timbreTable");
-        let htmlElements = "";
+        env.textContent = "";
         for (let i = 0; i < 2; i++) {
-            htmlElements += '<div id ="effect' + i + '"></div>';
+            const effectDiv = document.createElement("div");
+            effectDiv.id = "effect" + i;
+            env.appendChild(effectDiv);
         }
-
-        env.innerHTML = htmlElements;
         const envAppend = document.createElement("div");
         envAppend.id = "envAppend";
         envAppend.style.backgroundColor = platformColor.widgetBackground;
@@ -2135,15 +2318,18 @@ class TimbreWidget {
 
         const mainDiv = docById("effect0");
         const effects = ["Tremolo", "Vibrato", "Chorus", "Phaser", "Distortion"];
-        const effectsHtml = effects
-            .map(
-                effect =>
-                    `<input type="radio" name="effectsName" value="${effect}"/>${_(
-                        effect.toLowerCase()
-                    )}<br>`
-            )
-            .join("");
-        mainDiv.innerHTML = `<p>${effectsHtml}</p>`;
+        mainDiv.textContent = "";
+        const pNode = document.createElement("p");
+        effects.forEach(effect => {
+            const radioNode = document.createElement("input");
+            radioNode.type = "radio";
+            radioNode.name = "effectsName";
+            radioNode.value = effect;
+            pNode.appendChild(radioNode);
+            pNode.appendChild(document.createTextNode(_(effect.toLowerCase())));
+            pNode.appendChild(document.createElement("br"));
+        });
+        mainDiv.appendChild(pNode);
 
         const subDiv = docById("effect1");
         const effectsName = docByName("effectsName");
@@ -2152,7 +2338,40 @@ class TimbreWidget {
         for (let i = 0; i < effectsName.length; i++) {
             effectsName[i].onclick = async event => {
                 effectChosen = event.target.value;
-                let subHtmlElements = '<div id="chosen">' + effectChosen + "</div>";
+                subDiv.textContent = "";
+                const chosenNode = document.createElement("div");
+                chosenNode.id = "chosen";
+                chosenNode.textContent = effectChosen;
+                subDiv.appendChild(chosenNode);
+
+                const buildSliders = (numSliders, maxVal) => {
+                    for (let j = 0; j < numSliders; j++) {
+                        const wrapperFx = document.createElement("div");
+                        wrapperFx.id = "wrapperFx" + j;
+                        const labelFx = document.createElement("div");
+                        labelFx.id = "sFx" + j;
+                        const spanFx = document.createElement("span");
+                        labelFx.appendChild(spanFx);
+                        wrapperFx.appendChild(labelFx);
+                        const insideDivFx = document.createElement("div");
+                        insideDivFx.className = "insideDivEffects";
+                        const inputFx = document.createElement("input");
+                        inputFx.type = "range";
+                        inputFx.id = "myRangeFx" + j;
+                        inputFx.className = "sliders";
+                        inputFx.style.marginTop = "20px";
+                        if (maxVal) inputFx.max = maxVal;
+                        inputFx.value = "2";
+                        const spanValFx = document.createElement("span");
+                        spanValFx.id = "myspanFx" + j;
+                        spanValFx.className = "rangeslidervalue";
+                        spanValFx.textContent = "2";
+                        insideDivFx.appendChild(inputFx);
+                        insideDivFx.appendChild(spanValFx);
+                        wrapperFx.appendChild(insideDivFx);
+                        subDiv.appendChild(wrapperFx);
+                    }
+                };
                 if (effectChosen === "Tremolo") {
                     this.isActive["tremolo"] = true;
                     this.isActive["chorus"] = false;
@@ -2162,20 +2381,7 @@ class TimbreWidget {
 
                     instrumentsEffects[0][this.instrumentName]["tremoloActive"] = true;
 
-                    for (let j = 0; j < 2; j++) {
-                        subHtmlElements +=
-                            '<div id="wrapperFx' +
-                            j +
-                            '"><div id="sFx' +
-                            j +
-                            '"><span></span></div><div class="insideDivEffects"><input type="range" id="myRangeFx' +
-                            j +
-                            '" class="sliders" style="margin-top:20px" value="2"><span id="myspanFx' +
-                            j +
-                            '" class="rangeslidervalue">2</span></div></div>';
-                    }
-
-                    subDiv.innerHTML = subHtmlElements;
+                    buildSliders(2);
                     docById("sFx0").textContent = _("rate");
                     docById("myRangeFx0").value = 10;
                     docById("myspanFx0").textContent = "10";
@@ -2246,21 +2452,7 @@ class TimbreWidget {
                     this.isActive["phaser"] = false;
 
                     instrumentsEffects[0][this.instrumentName]["vibratoActive"] = true;
-                    for (let i = 0; i < 2; i++) {
-                        subHtmlElements +=
-                            '<div id="wrapperFx' +
-                            i +
-                            '"><div id="sFx' +
-                            i +
-                            '"><span></span></div><div class="insideDivEffects"><input type="range" id="myRangeFx' +
-                            i +
-                            '" class="sliders" style="margin-top:20px" max="25" value="2"><span id="myspanFx' +
-                            i +
-                            '" class="rangeslidervalue">2</span></div></div>';
-                    }
-
-                    // Set slider values
-                    subDiv.innerHTML = subHtmlElements;
+                    buildSliders(2, 25);
                     docById("sFx0").textContent = _("intensity");
                     docById("sFx1").textContent = _("rate");
 
@@ -2341,20 +2533,7 @@ class TimbreWidget {
 
                     instrumentsEffects[0][this.instrumentName]["chorusActive"] = true;
 
-                    for (let i = 0; i < 3; i++) {
-                        subHtmlElements +=
-                            '<div id="wrapperFx' +
-                            i +
-                            '"><div id="sFx' +
-                            i +
-                            '"><span></span></div><div class="insideDivEffects"><input type="range" id="myRangeFx' +
-                            i +
-                            '" class="sliders" style="margin-top:20px" value="2"><span id="myspanFx' +
-                            i +
-                            '" class="rangeslidervalue">2</span></div></div>';
-                    }
-
-                    subDiv.innerHTML = subHtmlElements;
+                    buildSliders(3);
                     docById("sFx0").textContent = _("rate");
                     docById("myRangeFx0").value = 2;
                     docById("myspanFx0").textContent = "2";
@@ -2444,20 +2623,10 @@ class TimbreWidget {
                     instrumentsEffects[0][this.instrumentName]["octaves"] = 3;
                     instrumentsEffects[0][this.instrumentName]["baseFrequency"] = 100;
 
-                    for (let i = 0; i < 3; i++) {
-                        subHtmlElements +=
-                            '<div id="wrapperFx' +
-                            i +
-                            '"><div id="sFx' +
-                            i +
-                            '"><span></span></div><div class="insideDivEffects"><input type="range" id="myRangeFx' +
-                            i +
-                            '" class="sliders" style="margin-top:20px" min="0" max="1000" value="2"><span id="myspanFx' +
-                            i +
-                            '" class="rangeslidervalue">2</span></div></div>';
-                    }
-
-                    subDiv.innerHTML = subHtmlElements;
+                    buildSliders(3, 1000);
+                    docById("myRangeFx0").min = 0;
+                    docById("myRangeFx1").min = 0;
+                    docById("myRangeFx2").min = 0;
                     docById("sFx0").textContent = _("rate");
                     docById("myRangeFx0").value = 5;
                     docById("myspanFx0").textContent = "5";
@@ -2538,10 +2707,7 @@ class TimbreWidget {
 
                     instrumentsEffects[0][this.instrumentName]["distortionActive"] = true;
 
-                    subHtmlElements +=
-                        '<div id="wrapperFx0"><div id="sFx0"><span></span></div><div class="insideDivEffects"><input type="range" id="myRangeFx0" class="sliders" style="margin-top:20px" value="2"><span id="myspanFx0" class="rangeslidervalue">2</span></div></div>';
-
-                    subDiv.innerHTML = subHtmlElements;
+                    buildSliders(1);
 
                     docById("sFx0").textContent = _("distortion amount");
                     docById("myRangeFx0").value = 40;

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -1207,7 +1207,7 @@ class TimbreWidget {
         const mainDiv = docById("synth0");
         mainDiv.textContent = "";
         const pNode = document.createElement("p");
-        
+
         const amRadio = document.createElement("input");
         amRadio.type = "radio";
         amRadio.name = "synthsName";
@@ -1215,7 +1215,7 @@ class TimbreWidget {
         pNode.appendChild(amRadio);
         pNode.appendChild(document.createTextNode(_("AM synth")));
         pNode.appendChild(document.createElement("br"));
-        
+
         const fmRadio = document.createElement("input");
         fmRadio.type = "radio";
         fmRadio.name = "synthsName";
@@ -1223,7 +1223,7 @@ class TimbreWidget {
         pNode.appendChild(fmRadio);
         pNode.appendChild(document.createTextNode(_("FM synth")));
         pNode.appendChild(document.createElement("br"));
-        
+
         const duoRadio = document.createElement("input");
         duoRadio.type = "radio";
         duoRadio.name = "synthsName";
@@ -1231,7 +1231,7 @@ class TimbreWidget {
         pNode.appendChild(duoRadio);
         pNode.appendChild(document.createTextNode(_("duo synth")));
         pNode.appendChild(document.createElement("br"));
-        
+
         mainDiv.appendChild(pNode);
 
         const subDiv = docById("synth1");
@@ -1283,33 +1283,33 @@ class TimbreWidget {
 
                     const wrapperS0 = document.createElement("div");
                     wrapperS0.id = "wrapperS0";
-                    
+
                     const labelDivS0 = document.createElement("div");
                     labelDivS0.id = "sS0";
                     const spanLabelS0 = document.createElement("span");
                     spanLabelS0.textContent = _("harmonicity");
                     labelDivS0.appendChild(spanLabelS0);
                     wrapperS0.appendChild(labelDivS0);
-                    
+
                     const insideDivS0 = document.createElement("div");
                     insideDivS0.className = "insideDivSynth";
-                    
+
                     const inputS0 = document.createElement("input");
                     inputS0.type = "range";
                     inputS0.id = "myRangeS0";
                     inputS0.className = "sliders";
                     inputS0.style.marginTop = "20px";
                     inputS0.value = parseFloat(this.AMSynthParams[0]);
-                    
+
                     const spanValS0 = document.createElement("span");
                     spanValS0.id = "myspanS0";
                     spanValS0.className = "rangeslidervalue";
                     spanValS0.textContent = this.AMSynthParams[0];
-                    
+
                     insideDivS0.appendChild(inputS0);
                     insideDivS0.appendChild(spanValS0);
                     wrapperS0.appendChild(insideDivS0);
-                    
+
                     subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.AMSynthParams[0]);
@@ -1370,33 +1370,33 @@ class TimbreWidget {
 
                     const wrapperS0 = document.createElement("div");
                     wrapperS0.id = "wrapperS0";
-                    
+
                     const labelDivS0 = document.createElement("div");
                     labelDivS0.id = "sS0";
                     const spanLabelS0 = document.createElement("span");
                     spanLabelS0.textContent = _("modulation index");
                     labelDivS0.appendChild(spanLabelS0);
                     wrapperS0.appendChild(labelDivS0);
-                    
+
                     const insideDivS0 = document.createElement("div");
                     insideDivS0.className = "insideDivSynth";
-                    
+
                     const inputS0 = document.createElement("input");
                     inputS0.type = "range";
                     inputS0.id = "myRangeS0";
                     inputS0.className = "sliders";
                     inputS0.style.marginTop = "20px";
                     inputS0.value = parseFloat(this.FMSynthParams[0]);
-                    
+
                     const spanValS0 = document.createElement("span");
                     spanValS0.id = "myspanS0";
                     spanValS0.className = "rangeslidervalue";
                     spanValS0.textContent = this.FMSynthParams[0];
-                    
+
                     insideDivS0.appendChild(inputS0);
                     insideDivS0.appendChild(spanValS0);
                     wrapperS0.appendChild(insideDivS0);
-                    
+
                     subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
@@ -1456,33 +1456,33 @@ class TimbreWidget {
 
                     const wrapperS0 = document.createElement("div");
                     wrapperS0.id = "wrapperS0";
-                    
+
                     const labelDivS0 = document.createElement("div");
                     labelDivS0.id = "sS0";
                     const spanLabelS0 = document.createElement("span");
                     spanLabelS0.textContent = _("modulation index");
                     labelDivS0.appendChild(spanLabelS0);
                     wrapperS0.appendChild(labelDivS0);
-                    
+
                     const insideDivS0 = document.createElement("div");
                     insideDivS0.className = "insideDivSynth";
-                    
+
                     const inputS0 = document.createElement("input");
                     inputS0.type = "range";
                     inputS0.id = "myRangeS0";
                     inputS0.className = "sliders";
                     inputS0.style.marginTop = "20px";
                     inputS0.value = this.NoiseSynthParams[0];
-                    
+
                     const spanValS0 = document.createElement("span");
                     spanValS0.id = "myspanS0";
                     spanValS0.className = "rangeslidervalue";
                     spanValS0.textContent = this.NoiseSynthParams[0];
-                    
+
                     insideDivS0.appendChild(inputS0);
                     insideDivS0.appendChild(spanValS0);
                     wrapperS0.appendChild(insideDivS0);
-                    
+
                     subDiv.appendChild(wrapperS0);
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
@@ -1546,64 +1546,64 @@ class TimbreWidget {
 
                     const wrapperS0 = document.createElement("div");
                     wrapperS0.id = "wrapperS0";
-                    
+
                     const labelDivS0 = document.createElement("div");
                     labelDivS0.id = "sS0";
                     const spanLabelS0 = document.createElement("span");
                     spanLabelS0.textContent = _("vibrato rate");
                     labelDivS0.appendChild(spanLabelS0);
                     wrapperS0.appendChild(labelDivS0);
-                    
+
                     const insideDivS0 = document.createElement("div");
                     insideDivS0.className = "insideDivSynth";
-                    
+
                     const inputS0 = document.createElement("input");
                     inputS0.type = "range";
                     inputS0.id = "myRangeS0";
                     inputS0.className = "sliders";
                     inputS0.style.marginTop = "20px";
                     inputS0.value = parseFloat(this.duoSynthParams[0]);
-                    
+
                     const spanValS0 = document.createElement("span");
                     spanValS0.id = "myspanS0";
                     spanValS0.className = "rangeslidervalue";
                     spanValS0.textContent = this.duoSynthParams[0];
-                    
+
                     insideDivS0.appendChild(inputS0);
                     insideDivS0.appendChild(spanValS0);
                     wrapperS0.appendChild(insideDivS0);
-                    
+
                     subDiv.appendChild(wrapperS0);
 
                     const wrapperS1 = document.createElement("div");
                     wrapperS1.id = "wrapperS1";
-                    
+
                     const labelDivS1 = document.createElement("div");
                     labelDivS1.id = "sS1";
                     const spanLabelS1 = document.createElement("span");
                     spanLabelS1.textContent = _("vibrato amount");
                     labelDivS1.appendChild(spanLabelS1);
                     wrapperS1.appendChild(labelDivS1);
-                    
+
                     const insideDivS1 = document.createElement("div");
                     insideDivS1.className = "insideDivSynth";
-                    
+
                     const inputS1 = document.createElement("input");
                     inputS1.type = "range";
                     inputS1.id = "myRangeS1";
                     inputS1.className = "sliders";
                     inputS1.style.marginTop = "20px";
                     inputS1.value = parseFloat(this.duoSynthParams[1]);
-                    
+
                     const spanValS1 = document.createElement("span");
                     spanValS1.id = "myspanS1";
                     spanValS1.className = "rangeslidervalue";
                     spanValS1.textContent = this.duoSynthParams[1];
-                    
+
                     insideDivS1.appendChild(inputS1);
                     insideDivS1.appendChild(spanValS1);
                     wrapperS1.appendChild(insideDivS1);
-                    
+
                     subDiv.appendChild(wrapperS1);
 
                     if (this.duoSynthesizer.length !== 1) {
@@ -1678,12 +1678,12 @@ class TimbreWidget {
         spanLabelOsc0.textContent = _("type");
         labelDivOsc0.appendChild(spanLabelOsc0);
         wrapperOsc0.appendChild(labelDivOsc0);
-        
+
         const selOsc = document.createElement("div");
         selOsc.id = "selOsc";
         wrapperOsc0.appendChild(selOsc);
         env.appendChild(wrapperOsc0);
-        
+
         const wrapperOsc1 = document.createElement("div");
         wrapperOsc1.id = "wrapperOsc1";
         const labelDivOsc1 = document.createElement("div");
@@ -1692,7 +1692,7 @@ class TimbreWidget {
         spanLabelOsc1.textContent = _("partials");
         labelDivOsc1.appendChild(spanLabelOsc1);
         wrapperOsc1.appendChild(labelDivOsc1);
-        
+
         const insideDivOsc = document.createElement("div");
         insideDivOsc.className = "insideDivOsc";
         const inputOsc1 = document.createElement("input");
@@ -1722,7 +1722,7 @@ class TimbreWidget {
         const myDiv = docById("selOsc");
         const selectOsc1 = document.createElement("select");
         selectOsc1.id = "selOsc1";
-        
+
         for (let i = 0; i < OSCTYPES.length; i++) {
             const opt = document.createElement("option");
             if (OSCTYPES[i][0].length === 0) {
@@ -1819,31 +1819,31 @@ class TimbreWidget {
         for (let i = 0; i < 4; i++) {
             const wrapperEnv = document.createElement("div");
             wrapperEnv.id = "wrapperEnv" + i;
-            
+
             const circleDiv = document.createElement("div");
             circleDiv.className = "circle";
             circleDiv.textContent = "ADSR".charAt(i);
             wrapperEnv.appendChild(circleDiv);
-            
+
             const insideDivEnv = document.createElement("div");
             insideDivEnv.className = "insideDivEnv";
-            
+
             const rangeEnv = document.createElement("input");
             rangeEnv.type = "range";
             rangeEnv.id = "myRange" + i;
             rangeEnv.className = "sliders";
             rangeEnv.style.marginTop = "20px";
             rangeEnv.value = parseFloat(this.ENVs[i]);
-            
+
             const spanEnv = document.createElement("span");
             spanEnv.id = "myspan" + i;
             spanEnv.className = "rangeslidervalue";
             spanEnv.textContent = this.ENVs[i];
-            
+
             insideDivEnv.appendChild(rangeEnv);
             insideDivEnv.appendChild(spanEnv);
             wrapperEnv.appendChild(insideDivEnv);
-            
+
             env.appendChild(wrapperEnv);
         }
         const envAppend = document.createElement("div");


### PR DESCRIPTION
- [x] Bug Fix : #6535
Systematically remediate XSS vulnerabilities caused by unsanitized innerHTML
usage across 18 widget files. Dynamic data from project files (.tb), user
inputs, and block values are now escaped via escapeHTML() or assigned using
textContent where no HTML structure is needed.

Files remediated:
- musickeyboard.js, phrasemaker.js, temperament.js (HIGH risk)
- pitchdrummatrix.js, status.js, modewidget.js, pitchslider.js (MEDIUM)
- pitchstaircase.js, meterwidget.js, rhythmruler.js, timbre.js (MEDIUM)
- statistics.js, arpeggio.js, sampler.js, jseditor.js (MEDIUM)

Test updates:
- Added escapeHTML mock to temperament, statistics, meterwidget, status tests
- Updated status test assertions from innerHTML to textContent

All 4192 tests passing, zero regressions introduced."
