### PR TITLE
fix: remove duplicate escapeHTML method in reflection.js

### DIFF
--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -67,31 +67,16 @@ class ReflectionMatrix {
         this.code = "";
     }
 
-    escapeHTML(text) {
-        const escapeMap = {
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            '"': '&quot;',
-            "'": '&#39;'
-        };
-
-        return text.replace(/[&<>"']/g, char => escapeMap[char]);
-    }
-
     sanitizeLinks(html) {
-        return html.replace(
-            /<a\s+[^>]*href\s*=\s*(['"]?)([^'">\s]+)\1/gi,
-            (match, quote, url) => {
-                const unsafeSchemes = /^(javascript|data|vbscript):/i;
+        return html.replace(/<a\s+[^>]*href\s*=\s*(['"]?)([^'">\s]+)\1/gi, (match, quote, url) => {
+            const unsafeSchemes = /^(javascript|data|vbscript):/i;
 
-                if (unsafeSchemes.test(url.trim())) {
-                    return match.replace(url, "#");
-                }
-
-                return match;
+            if (unsafeSchemes.test(url.trim())) {
+                return match.replace(url, "#");
             }
-        );
+
+            return match;
+        });
     }
 
     /**


### PR DESCRIPTION
reflection.js has two definitions of escapeHTML (line 70 and line 654). 
The first uses &#39; for single quotes, the second uses &#x27;. Removed 
the one at line 70 as the implementation at line 654 matches what the 
tests expect.

Fixes ESLint error: no-dupe-class-members

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation