### PR TITLE
fix: add missing textMsg and errorMsg mocks to help.test.js

### DIFF
--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -136,7 +136,9 @@ function createMockActivity(options = {}) {
             moveBlock: jest.fn(),
             loadNewBlocks: jest.fn()
         },
-        logo: {}
+        logo: {},
+        textMsg: jest.fn(),
+        errorMsg: jest.fn()
     };
 }
 


### PR DESCRIPTION
help.test.js was failing on master. The createMockActivity function was 
missing textMsg and errorMsg, causing a TypeError when the onclose handler 
was triggered.

All 39 tests pass after this fix.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation