### PR TITLE
Optimize dragging performance with requestAnimationFrame

### DIFF
--- a/js/utils/mb-dialog.js
+++ b/js/utils/mb-dialog.js
@@ -203,15 +203,26 @@
         let dragDx = 0;
         let dragDy = 0;
         let dragRafId = null;
+        let latestClientX = 0;
+        let latestClientY = 0;
 
         const onMouseMove = event => {
             if (!dragging) return;
+
+            latestClientX = event.clientX;
+            latestClientY = event.clientY;
+
             if (dragRafId) return;
 
-            const clientX = event.clientX;
-            const clientY = event.clientY;
-
             dragRafId = requestAnimationFrame(() => {
+                if (!dragging) {
+                    dragRafId = null;
+                    return;
+                }
+
+                const clientX = latestClientX;
+                const clientY = latestClientY;
+
                 const x = clientX - dragDx;
                 const y = clientY - dragDy;
                 const maxLeft = Math.max(window.innerWidth - frame.offsetWidth, 8);

--- a/js/utils/mb-dialog.js
+++ b/js/utils/mb-dialog.js
@@ -202,19 +202,32 @@
         let dragging = false;
         let dragDx = 0;
         let dragDy = 0;
+        let dragRafId = null;
 
         const onMouseMove = event => {
             if (!dragging) return;
-            const x = event.clientX - dragDx;
-            const y = event.clientY - dragDy;
-            const maxLeft = Math.max(window.innerWidth - frame.offsetWidth, 8);
-            const maxTop = Math.max(window.innerHeight - frame.offsetHeight, 64);
-            frame.style.left = `${Math.min(Math.max(x, 8), maxLeft)}px`;
-            frame.style.top = `${Math.min(Math.max(y, 64), maxTop)}px`;
+            if (dragRafId) return;
+
+            const clientX = event.clientX;
+            const clientY = event.clientY;
+
+            dragRafId = requestAnimationFrame(() => {
+                const x = clientX - dragDx;
+                const y = clientY - dragDy;
+                const maxLeft = Math.max(window.innerWidth - frame.offsetWidth, 8);
+                const maxTop = Math.max(window.innerHeight - frame.offsetHeight, 64);
+                frame.style.left = `${Math.min(Math.max(x, 8), maxLeft)}px`;
+                frame.style.top = `${Math.min(Math.max(y, 64), maxTop)}px`;
+                dragRafId = null;
+            });
         };
 
         const onMouseUp = () => {
             dragging = false;
+            if (dragRafId) {
+                cancelAnimationFrame(dragRafId);
+                dragRafId = null;
+            }
         };
 
         topBar.addEventListener("mousedown", event => {

--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -124,6 +124,7 @@ afterEach(() => {
 function createMockActivity(options = {}) {
     return {
         __keyPressed: jest.fn(),
+        textMsg: jest.fn(),
         blocks: {
             activeBlock: options.activeBlock || null,
             blockList: options.blockList || {},

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -624,26 +624,39 @@ class JSEditor {
      */
     _setupDividerResize(divider, editorContainer, editorconsole, consolelabel) {
         let isResizing = false;
+        let resizeRafId = null;
 
         const onMouseMove = e => {
             if (!isResizing) return;
-            const parentRect = this._editor.getBoundingClientRect();
-            const menubarHeight = this._menubar ? this._menubar.offsetHeight : 0;
-            const availableHeight = this._editor.clientHeight - menubarHeight;
-            const dynamicTop = parentRect.top + menubarHeight;
+            if (resizeRafId) return;
 
-            const newEditorHeight = e.clientY - dynamicTop;
-            const dividerHeight = divider.offsetHeight;
-            const consoleHeaderHeight = consolelabel.offsetHeight;
-            const newConsoleHeight =
-                availableHeight - newEditorHeight - dividerHeight - consoleHeaderHeight;
+            const clientY = e.clientY;
 
-            editorContainer.style.flexBasis = `${newEditorHeight}px`;
-            editorconsole.style.flexBasis = `${newConsoleHeight}px`;
+            resizeRafId = requestAnimationFrame(() => {
+                const parentRect = this._editor.getBoundingClientRect();
+                const menubarHeight = this._menubar ? this._menubar.offsetHeight : 0;
+                const availableHeight = this._editor.clientHeight - menubarHeight;
+                const dynamicTop = parentRect.top + menubarHeight;
+
+                const newEditorHeight = clientY - dynamicTop;
+                const dividerHeight = divider.offsetHeight;
+                const consoleHeaderHeight = consolelabel.offsetHeight;
+                const newConsoleHeight =
+                    availableHeight - newEditorHeight - dividerHeight - consoleHeaderHeight;
+
+                editorContainer.style.flexBasis = `${newEditorHeight}px`;
+                editorconsole.style.flexBasis = `${newConsoleHeight}px`;
+                
+                resizeRafId = null;
+            });
         };
 
         const onMouseUp = () => {
             isResizing = false;
+            if (resizeRafId) {
+                cancelAnimationFrame(resizeRafId);
+                resizeRafId = null;
+            }
             document.removeEventListener("mousemove", onMouseMove);
             document.removeEventListener("mouseup", onMouseUp);
         };
@@ -741,6 +754,7 @@ class JSEditor {
         let isResizing = false;
         let resizeDirection = null;
         let startX, startY, startWidth, startHeight, startLeft, startTop;
+        let resizeRafId = null;
 
         const startResize = (e, direction) => {
             if (this.widgetWindow._maximized) return; // Don't resize when maximized
@@ -762,49 +776,61 @@ class JSEditor {
 
         const doResize = e => {
             if (!isResizing) return;
+            if (resizeRafId) return;
 
-            const deltaX = e.clientX - startX;
-            const deltaY = e.clientY - startY;
+            const clientX = e.clientX;
+            const clientY = e.clientY;
 
-            let newWidth = startWidth;
-            let newHeight = startHeight;
-            let newLeft = startLeft;
+            resizeRafId = requestAnimationFrame(() => {
+                const deltaX = clientX - startX;
+                const deltaY = clientY - startY;
 
-            // Calculate new dimensions based on direction
-            if (resizeDirection.includes("right")) {
-                newWidth = Math.max(400, startWidth + deltaX);
-            }
-            if (resizeDirection.includes("left")) {
-                const widthDelta = startWidth - deltaX;
-                if (widthDelta >= 400) {
-                    newWidth = widthDelta;
-                    newLeft = startLeft + deltaX;
+                let newWidth = startWidth;
+                let newHeight = startHeight;
+                let newLeft = startLeft;
+
+                // Calculate new dimensions based on direction
+                if (resizeDirection.includes("right")) {
+                    newWidth = Math.max(400, startWidth + deltaX);
                 }
-            }
-            if (resizeDirection.includes("bottom")) {
-                newHeight = Math.max(300, startHeight + deltaY);
-            }
+                if (resizeDirection.includes("left")) {
+                    const widthDelta = startWidth - deltaX;
+                    if (widthDelta >= 400) {
+                        newWidth = widthDelta;
+                        newLeft = startLeft + deltaX;
+                    }
+                }
+                if (resizeDirection.includes("bottom")) {
+                    newHeight = Math.max(300, startHeight + deltaY);
+                }
 
-            // Apply new dimensions
-            windowFrame.style.width = newWidth + "px";
-            windowFrame.style.height = newHeight + "px";
+                // Apply new dimensions
+                windowFrame.style.width = newWidth + "px";
+                windowFrame.style.height = newHeight + "px";
 
-            if (resizeDirection.includes("left")) {
-                windowFrame.style.left = newLeft + "px";
-            }
+                if (resizeDirection.includes("left")) {
+                    windowFrame.style.left = newLeft + "px";
+                }
 
-            // Update editor content size
-            const editorDiv = this._editor;
-            if (editorDiv) {
-                editorDiv.style.width = newWidth + "px";
-                editorDiv.style.height = newHeight - 32 + "px"; // Subtract title bar height
-            }
+                // Update editor content size
+                const editorDiv = this._editor;
+                if (editorDiv) {
+                    editorDiv.style.width = newWidth + "px";
+                    editorDiv.style.height = newHeight - 32 + "px"; // Subtract title bar height
+                }
+                
+                resizeRafId = null;
+            });
         };
 
         const stopResize = () => {
             if (!isResizing) return;
             isResizing = false;
             resizeDirection = null;
+            if (resizeRafId) {
+                cancelAnimationFrame(resizeRafId);
+                resizeRafId = null;
+            }
         };
 
         // Attach event listeners

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -625,14 +625,23 @@ class JSEditor {
     _setupDividerResize(divider, editorContainer, editorconsole, consolelabel) {
         let isResizing = false;
         let resizeRafId = null;
+        let latestClientY = 0;
 
         const onMouseMove = e => {
             if (!isResizing) return;
+
+            latestClientY = e.clientY;
+
             if (resizeRafId) return;
 
-            const clientY = e.clientY;
-
             resizeRafId = requestAnimationFrame(() => {
+                if (!isResizing) {
+                    resizeRafId = null;
+                    return;
+                }
+
+                const clientY = latestClientY;
+
                 const parentRect = this._editor.getBoundingClientRect();
                 const menubarHeight = this._menubar ? this._menubar.offsetHeight : 0;
                 const availableHeight = this._editor.clientHeight - menubarHeight;
@@ -755,6 +764,8 @@ class JSEditor {
         let resizeDirection = null;
         let startX, startY, startWidth, startHeight, startLeft, startTop;
         let resizeRafId = null;
+        let latestClientX = 0;
+        let latestClientY = 0;
 
         const startResize = (e, direction) => {
             if (this.widgetWindow._maximized) return; // Don't resize when maximized
@@ -776,12 +787,21 @@ class JSEditor {
 
         const doResize = e => {
             if (!isResizing) return;
+
+            latestClientX = e.clientX;
+            latestClientY = e.clientY;
+
             if (resizeRafId) return;
 
-            const clientX = e.clientX;
-            const clientY = e.clientY;
-
             resizeRafId = requestAnimationFrame(() => {
+                if (!isResizing || !resizeDirection) {
+                    resizeRafId = null;
+                    return;
+                }
+
+                const clientX = latestClientX;
+                const clientY = latestClientY;
+
                 const deltaX = clientX - startX;
                 const deltaY = clientY - startY;
 

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -646,7 +646,7 @@ class JSEditor {
 
                 editorContainer.style.flexBasis = `${newEditorHeight}px`;
                 editorconsole.style.flexBasis = `${newConsoleHeight}px`;
-                
+
                 resizeRafId = null;
             });
         };
@@ -818,7 +818,7 @@ class JSEditor {
                     editorDiv.style.width = newWidth + "px";
                     editorDiv.style.height = newHeight - 32 + "px"; // Subtract title bar height
                 }
-                
+
                 resizeRafId = null;
             });
         };


### PR DESCRIPTION
### **Summary**

This PR improves performance when resizing dialogs (e.g., JS Editor and resizable widgets) by throttling `mousemove`-based resize logic using `requestAnimationFrame`.

Currently, resize logic is executed directly inside a `mousemove` event handler, which can trigger hundreds of DOM updates per second. This leads to unnecessary layout recalculations and increased CPU usage during drag operations.

---

### **Changes**

* Wrapped `doResize` logic inside a `requestAnimationFrame` loop
* Ensured only one resize update runs per frame
* Reduced excessive DOM writes during continuous mouse movement
* Applied changes to:

  * `js/widgets/jseditor.js`
  * `js/utils/mb-dialog.js`

---

### **Before**

* Resize handler executed on every `mousemove` event
* Frequent layout recalculations
* Noticeable lag/jank during resizing
* Higher CPU usage

---

### **After**

* Resize updates aligned with browser render cycle (~60fps)
* Reduced layout thrashing
* Smoother resizing experience
* Lower CPU usage

---

### **Implementation Details**

A simple RAF-based throttle was introduced:

* Store latest mouse position
* Schedule resize using `requestAnimationFrame`
* Prevent multiple RAF calls from stacking

This approach is consistent with existing optimizations used for block dragging.

---
### **Notes**

This change focuses on improving performance without altering existing behavior or UI logic.

---

### **Checklist**

* [x] Code follows project guidelines
* [x] No breaking changes introduced
* [x] Tested manually for resizing interactions
* [x] Ready for review

---
- [x] Performance
