### PR TITLE
Security: Adding rel attribute to external help links

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -381,7 +381,7 @@ class HelpWidget {
         if (HELPCONTENT[page].length > 3) {
             const link = HELPCONTENT[page][3];
             // console.debug(page + " " + link);
-            body += `<p><a href="${link}" target="_blank">${HELPCONTENT[page][4]}</a></p>`;
+            body += `<p><a href="${link}" target="_blank" rel="noopener noreferrer">${HELPCONTENT[page][4]}</a></p>`;
         }
 
         if ([_("Congratulations.")].includes(HELPCONTENT[page][0])) {


### PR DESCRIPTION
## Description
This PR adds `rel="noopener noreferrer"` to the external guide link in the Help widget.

## Why it matters
- **Security:** Prevents "tabnabbing" attacks where the opened page could redirect the original tab to a phishing site via `window.opener`.
- **Performance:** Ensures the new tab runs in a separate process, preventing it from slowing down Music Blocks.
- **Best Practice:** Aligns with modern web security standards (e.g. Google Lighthouse).

## Changes Made
- Updated `js/widgets/help.js` to include `rel="noopener noreferrer"` on dynamically generated external links.

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation
- [x] Security
- [x] Refactor / Maintenance

## Testing
- [x] Link still opens correctly in a new tab
- [x] Follows standard HTML5 security practices