### PR TITLE
Fix PhraseMaker default snare drum preview

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -272,6 +272,35 @@ describe("PhraseMaker Widget", () => {
             expect(Object.keys(phraseMaker._blockMap)).toHaveLength(2);
         });
 
+        test("loads default drum row synths before grid preview playback", () => {
+            const loadSynth = jest.fn();
+            const setSynthVolume = jest.fn();
+            const instrumentNames = [];
+            const pm = new PhraseMaker({
+                getDrumName: jest.fn(label => (label === "snare drum" ? "snare drum" : null)),
+                Singer: { setSynthVolume }
+            });
+
+            pm.activity = {
+                logo: {
+                    synth: { loadSynth }
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({
+                        singer: { instrumentNames }
+                    }))
+                }
+            };
+            pm.rowLabels = ["snare drum", "sol", "snare drum"];
+
+            pm._loadDrumSynthsForRows();
+
+            expect(instrumentNames).toEqual(["snare drum"]);
+            expect(loadSynth).toHaveBeenCalledTimes(1);
+            expect(loadSynth).toHaveBeenCalledWith(0, "snare drum");
+            expect(setSynthVolume).toHaveBeenCalledWith(pm.activity.logo, 0, "snare drum", 50);
+        });
+
         test("should track lyrics", () => {
             phraseMaker._lyrics.push("do");
             phraseMaker._lyrics.push("re");

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -306,6 +306,39 @@ class PhraseMaker {
     }
 
     /**
+     * Loads drum synths used by existing PhraseMaker rows before cell preview playback.
+     * @private
+     * @param {number} [turtleIndex=0] - Index of the turtle that triggered this widget.
+     */
+    _loadDrumSynthsForRows(turtleIndex = 0) {
+        if (!this.activity?.logo?.synth) {
+            return;
+        }
+
+        const tur = this.activity.turtles?.ithTurtle?.(turtleIndex);
+        const instrumentNames = tur?.singer?.instrumentNames;
+        const loadedDrums = new Set();
+
+        for (let i = 0; i < this.rowLabels.length; i++) {
+            const drumName = this._deps.getDrumName(this.rowLabels[i]);
+            if (drumName === null || loadedDrums.has(drumName)) {
+                continue;
+            }
+
+            loadedDrums.add(drumName);
+
+            if (Array.isArray(instrumentNames) && !instrumentNames.includes(drumName)) {
+                instrumentNames.push(drumName);
+                this.activity.logo.synth.loadSynth(0, drumName);
+            } else if (!Array.isArray(instrumentNames)) {
+                this.activity.logo.synth.loadSynth(0, drumName);
+            }
+
+            this._deps.Singer?.setSynthVolume?.(this.activity.logo, 0, drumName, DEFAULTVOLUME);
+        }
+    }
+
+    /**
      * Adds a node to the PhraseMaker matrix.
      * This method is used to preserve and restore the state of a cell in the matrix.
      * @param {number} rowBlock - The pitch or drum block associated with the node.
@@ -382,6 +415,7 @@ class PhraseMaker {
 
         this._notesToPlay = [];
         this._matrixHasTuplets = false;
+        this._loadDrumSynthsForRows(turtleIndex);
 
         // Add the buttons to the top row.
 


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation


## Summary

- Preload drum synths for existing PhraseMaker drum rows during widget initialization
- Keep drum row synth volume initialized before grid-cell preview playback
- Add a regression test for the default snare drum row so duplicate rows load once

## Root Cause

The drum pie menu loads the selected drum synth before previewing it, but default PhraseMaker drum rows could be clicked before their synth had been loaded. That made the default snare row play the wrong sound until the user opened or reselected it in the drum pie menu.

Fixes #6548.

## Validation

- `npm test -- js/widgets/__tests__/phrasemaker.test.js --runInBand`
- `npx prettier --check js/widgets/phrasemaker.js js/widgets/__tests__/phrasemaker.test.js`
- `npx eslint js/widgets/phrasemaker.js js/widgets/__tests__/phrasemaker.test.js`
- `npm test -- --runInBand`



@walterbender Could you please review this PR when you have a chance?

