### PR TITLE
fix: cancel delayed reflection typing indicator

### DIFF
--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -66,11 +66,7 @@ class ReflectionMatrix {
          */
         this.code = "";
 
-        /**
-         * Timeout id for delayed typing indicators
-         * @type {number|null}
-         */
-        this.typingIndicatorTimeout = null;
+        this.startChatTypingTimeout = null;
     }
 
     sanitizeLinks(html) {
@@ -106,7 +102,13 @@ class ReflectionMatrix {
         widgetWindow.onclose = () => {
             this.isOpen = false;
             this.activity.isInputON = false;
-            this.hideTypingIndicator();
+            if (this.startChatTypingTimeout) {
+                clearTimeout(this.startChatTypingTimeout);
+                this.startChatTypingTimeout = null;
+            }
+            if (this.dotsInterval) {
+                clearInterval(this.dotsInterval);
+            }
             widgetWindow.destroy();
         };
 
@@ -219,8 +221,6 @@ class ReflectionMatrix {
     showTypingIndicator(action) {
         if (this.typingDiv) return;
 
-        this.clearPendingTypingIndicator();
-
         this.typingDiv = document.createElement("div");
         this.typingDiv.className = "typing-indicator";
 
@@ -248,45 +248,15 @@ class ReflectionMatrix {
      * @returns {void}
      */
     hideTypingIndicator() {
-        this.clearPendingTypingIndicator();
+        if (this.startChatTypingTimeout) {
+            clearTimeout(this.startChatTypingTimeout);
+            this.startChatTypingTimeout = null;
+        }
 
         if (this.typingDiv) {
             clearInterval(this.dotsInterval);
             this.typingDiv.remove();
             this.typingDiv = null;
-        }
-    }
-
-    /**
-     * Schedules a typing indicator after an optional delay.
-     * @param {string} action - Status text to show in the indicator.
-     * @param {number} delay - Delay before showing the indicator.
-     * @returns {void}
-     */
-    scheduleTypingIndicator(action, delay = 0) {
-        this.clearPendingTypingIndicator();
-
-        if (delay <= 0) {
-            this.showTypingIndicator(action);
-            return;
-        }
-
-        this.typingIndicatorTimeout = setTimeout(() => {
-            this.typingIndicatorTimeout = null;
-            if (this.isOpen) {
-                this.showTypingIndicator(action);
-            }
-        }, delay);
-    }
-
-    /**
-     * Clears any delayed typing indicator that has not rendered yet.
-     * @returns {void}
-     */
-    clearPendingTypingIndicator() {
-        if (this.typingIndicatorTimeout) {
-            clearTimeout(this.typingIndicatorTimeout);
-            this.typingIndicatorTimeout = null;
         }
     }
 
@@ -324,7 +294,12 @@ class ReflectionMatrix {
         if (this.triggerFirst === true) return;
 
         this.triggerFirst = true;
-        this.scheduleTypingIndicator("Reading code", 1000);
+        this.startChatTypingTimeout = setTimeout(() => {
+            this.startChatTypingTimeout = null;
+            if (this.isOpen) {
+                this.showTypingIndicator("Reading code");
+            }
+        }, 1000);
 
         const code = await this.activity.prepareExport();
         const data = await this.generateAlgorithm(code);

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -65,6 +65,12 @@ class ReflectionMatrix {
          * @type {string}
          */
         this.code = "";
+
+        /**
+         * Timeout id for delayed typing indicators
+         * @type {number|null}
+         */
+        this.typingIndicatorTimeout = null;
     }
 
     sanitizeLinks(html) {
@@ -100,9 +106,7 @@ class ReflectionMatrix {
         widgetWindow.onclose = () => {
             this.isOpen = false;
             this.activity.isInputON = false;
-            if (this.dotsInterval) {
-                clearInterval(this.dotsInterval);
-            }
+            this.hideTypingIndicator();
             widgetWindow.destroy();
         };
 
@@ -215,6 +219,8 @@ class ReflectionMatrix {
     showTypingIndicator(action) {
         if (this.typingDiv) return;
 
+        this.clearPendingTypingIndicator();
+
         this.typingDiv = document.createElement("div");
         this.typingDiv.className = "typing-indicator";
 
@@ -242,10 +248,45 @@ class ReflectionMatrix {
      * @returns {void}
      */
     hideTypingIndicator() {
+        this.clearPendingTypingIndicator();
+
         if (this.typingDiv) {
             clearInterval(this.dotsInterval);
             this.typingDiv.remove();
             this.typingDiv = null;
+        }
+    }
+
+    /**
+     * Schedules a typing indicator after an optional delay.
+     * @param {string} action - Status text to show in the indicator.
+     * @param {number} delay - Delay before showing the indicator.
+     * @returns {void}
+     */
+    scheduleTypingIndicator(action, delay = 0) {
+        this.clearPendingTypingIndicator();
+
+        if (delay <= 0) {
+            this.showTypingIndicator(action);
+            return;
+        }
+
+        this.typingIndicatorTimeout = setTimeout(() => {
+            this.typingIndicatorTimeout = null;
+            if (this.isOpen) {
+                this.showTypingIndicator(action);
+            }
+        }, delay);
+    }
+
+    /**
+     * Clears any delayed typing indicator that has not rendered yet.
+     * @returns {void}
+     */
+    clearPendingTypingIndicator() {
+        if (this.typingIndicatorTimeout) {
+            clearTimeout(this.typingIndicatorTimeout);
+            this.typingIndicatorTimeout = null;
         }
     }
 
@@ -283,9 +324,7 @@ class ReflectionMatrix {
         if (this.triggerFirst === true) return;
 
         this.triggerFirst = true;
-        setTimeout(() => {
-            this.showTypingIndicator("Reading code");
-        }, 1000);
+        this.scheduleTypingIndicator("Reading code", 1000);
 
         const code = await this.activity.prepareExport();
         const data = await this.generateAlgorithm(code);


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
This fixes a Reflection Widget startup bug where the delayed "Reading code" typing indicator could appear after the initial export/backend request had already completed.

## What changed
- added tracked timeout management for delayed typing indicators
- cleared any pending delayed indicator before rendering or hiding the indicator
- reused the same cleanup path when the widget closes
- replaced the raw startup `setTimeout()` call with a helper that can be cancelled safely

## Root cause
`startChatSession()` scheduled the startup typing indicator with a delayed `setTimeout()`, but that timeout was never cleared if startup finished in under 1 second. In that case, `hideTypingIndicator()` ran before the indicator existed, and the delayed callback could still fire later and leave a stale "Reading code" indicator on screen.

## User impact
Users no longer see a late or stuck startup typing indicator after the first reflection response has already appeared.

## Validation
- `node --check js/widgets/reflection.js`
- manual code inspection of the startup and close paths


#6550 