### PR TITLE
Fix: SVG widgets fail to restore original size

### DIFF
--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -245,7 +245,7 @@ class ModeWidget {
         const windowHeight =
             this.getWidgetFrame().offsetHeight - this.getDragElement().offsetHeight;
         const widgetBody = this.getWidgetBody();
-        const scale = this.isMaximized ? windowHeight / widgetBody.offsetHeight : 1;
+        const scale = this.isMaximized() ? windowHeight / widgetBody.offsetHeight : 1;
         widgetBody.style.display = "flex";
         widgetBody.style.flexDirection = "column";
         widgetBody.style.alignItems = "center";

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -651,7 +651,7 @@ class PitchDrumMatrix {
         const windowHeight =
             this.getWidgetFrame().offsetHeight - this.getDragElement().offsetHeight;
         const widgetBody = this.getWidgetBody();
-        const scale = this.isMaximized ? windowHeight / widgetBody.offsetHeight : 1;
+        const scale = this.isMaximized() ? windowHeight / widgetBody.offsetHeight : 1;
         widgetBody.style.display = "flex";
         widgetBody.style.flexDirection = "column";
         widgetBody.style.alignItems = "center";


### PR DESCRIPTION
- [x] Bug Fix : #6553 

missing parentheses to isMaximized() in _scale() handlers inside modewidget and pitchdrummatrix to correctly evaluate window maximization state.