### PR TITLE
Add circular view to Rhythm Maker widget

### DIFF
--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -621,14 +621,101 @@ describe("RhythmRuler Widget", () => {
             expect(() => rhythmRuler._drawCircularView()).not.toThrow();
         });
 
-        test("_onCircularClick should not act while playing", () => {
+        test("_onCircularMouseDown should not record a hit while playing", () => {
             rhythmRuler._playing = true;
             rhythmRuler._circularCanvas = createMockCanvas();
             rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
 
-            const spy = jest.spyOn(rhythmRuler, "__dissectByNumber").mockImplementation();
-            rhythmRuler._onCircularClick({ clientX: 100, clientY: 100 });
-            expect(spy).not.toHaveBeenCalled();
+            rhythmRuler._onCircularMouseDown({ clientX: 100, clientY: 100 });
+            expect(rhythmRuler._circularDownHit).toBeNull();
+        });
+
+        test("_onCircularMouseUp should not act while playing", () => {
+            rhythmRuler._playing = true;
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+
+            const dissectSpy = jest.spyOn(rhythmRuler, "__dissectByNumber").mockImplementation();
+            const tieSpy = jest.spyOn(rhythmRuler, "__tie").mockImplementation();
+            rhythmRuler._onCircularMouseUp({ clientX: 100, clientY: 100 });
+            expect(dissectSpy).not.toHaveBeenCalled();
+            expect(tieSpy).not.toHaveBeenCalled();
+        });
+
+        test("same-slice mousedown+mouseup should trigger dissect", () => {
+            rhythmRuler._playing = false;
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+            rhythmRuler._rulers = [
+                { cells: [{ style: {} }, { style: {} }, { style: {} }, { style: {} }] }
+            ];
+            rhythmRuler._dissectNumber = { value: "2" };
+
+            // Pretend both events landed on the same slice.
+            jest.spyOn(rhythmRuler, "_hitTestCircular").mockReturnValue({
+                rulerIndex: 0,
+                cellIndex: 1
+            });
+            const dissectSpy = jest.spyOn(rhythmRuler, "__dissectByNumber").mockImplementation();
+            jest.spyOn(rhythmRuler, "saveDissectHistory").mockImplementation();
+            jest.spyOn(rhythmRuler, "_drawCircularView").mockImplementation();
+
+            rhythmRuler._onCircularMouseDown({});
+            rhythmRuler._onCircularMouseUp({});
+
+            expect(dissectSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test("cross-slice swipe on same ruler should trigger __tie", () => {
+            rhythmRuler._playing = false;
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+            rhythmRuler._rulers = [
+                { cells: [{ style: {} }, { style: {} }, { style: {} }, { style: {} }] }
+            ];
+
+            const hitSpy = jest.spyOn(rhythmRuler, "_hitTestCircular");
+            hitSpy.mockReturnValueOnce({ rulerIndex: 0, cellIndex: 0 });
+            hitSpy.mockReturnValueOnce({ rulerIndex: 0, cellIndex: 2 });
+
+            const tieSpy = jest.spyOn(rhythmRuler, "__tie").mockImplementation();
+            jest.spyOn(rhythmRuler, "saveDissectHistory").mockImplementation();
+            jest.spyOn(rhythmRuler, "_drawCircularView").mockImplementation();
+
+            rhythmRuler._onCircularMouseDown({});
+            rhythmRuler._onCircularMouseUp({});
+
+            expect(tieSpy).toHaveBeenCalledTimes(1);
+            expect(rhythmRuler._rulerSelected).toBe(0);
+        });
+
+        test("cross-ruler swipe should NOT tie (falls through to dissect)", () => {
+            rhythmRuler._playing = false;
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler.Rulers = [
+                [[4, 4, 4, 4], []],
+                [[4, 4, 4, 4], []]
+            ];
+            rhythmRuler._rulers = [
+                { cells: [{ style: {} }, { style: {} }, { style: {} }, { style: {} }] },
+                { cells: [{ style: {} }, { style: {} }, { style: {} }, { style: {} }] }
+            ];
+            rhythmRuler._dissectNumber = { value: "2" };
+
+            const hitSpy = jest.spyOn(rhythmRuler, "_hitTestCircular");
+            hitSpy.mockReturnValueOnce({ rulerIndex: 0, cellIndex: 1 });
+            hitSpy.mockReturnValueOnce({ rulerIndex: 1, cellIndex: 2 });
+
+            const tieSpy = jest.spyOn(rhythmRuler, "__tie").mockImplementation();
+            const dissectSpy = jest.spyOn(rhythmRuler, "__dissectByNumber").mockImplementation();
+            jest.spyOn(rhythmRuler, "saveDissectHistory").mockImplementation();
+            jest.spyOn(rhythmRuler, "_drawCircularView").mockImplementation();
+
+            rhythmRuler._onCircularMouseDown({});
+            rhythmRuler._onCircularMouseUp({});
+
+            expect(tieSpy).not.toHaveBeenCalled();
+            expect(dissectSpy).toHaveBeenCalledTimes(1);
         });
 
         test("__pause should clear circular highlights", () => {

--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -57,6 +57,7 @@ global.platformColor = {
 global.DRUMNAMES = [];
 global.VOICENAMES = [];
 global.EFFECTSNAMES = [];
+global.getComputedStyle = jest.fn().mockReturnValue({ backgroundColor: "#303030" });
 
 // Mock Window Manager
 
@@ -78,6 +79,8 @@ const mockWindow = {
                 onblur: null
             })),
             getWidgetBody: jest.fn().mockReturnValue({
+                clientWidth: 500,
+                clientHeight: 400,
                 appendChild: jest.fn(),
                 append: jest.fn(),
                 insertRow: jest.fn().mockReturnValue({
@@ -125,12 +128,21 @@ global.document = {
         }),
         deleteCell: jest.fn(),
         classList: { add: jest.fn(), remove: jest.fn() },
+        parentNode: { style: { backgroundColor: "#303030" } },
         getContext: jest.fn().mockReturnValue({
             clearRect: jest.fn(),
             beginPath: jest.fn(),
+            arc: jest.fn(),
             fillStyle: "",
+            strokeStyle: "",
+            lineWidth: 1,
+            font: "",
+            textAlign: "",
+            textBaseline: "",
             fill: jest.fn(),
-            closePath: jest.fn()
+            stroke: jest.fn(),
+            closePath: jest.fn(),
+            fillText: jest.fn()
         })
     })),
     getElementById: jest.fn().mockReturnValue({
@@ -481,6 +493,157 @@ describe("RhythmRuler Widget", () => {
 
             rhythmRuler._fullscreenScaleFactor = 5;
             expect(rhythmRuler._fullscreenScaleFactor).toBe(5);
+        });
+    });
+
+    // =========================================================================
+    // CIRCULAR VIEW TESTS
+    // =========================================================================
+    describe("Circular View", () => {
+        function createMockCanvas() {
+            return {
+                width: 0,
+                height: 0,
+                style: { display: "", margin: "" },
+                parentNode: { style: { backgroundColor: "#303030" } },
+                addEventListener: jest.fn(),
+                getBoundingClientRect: jest.fn().mockReturnValue({ left: 0, top: 0 }),
+                getContext: jest.fn().mockReturnValue({
+                    clearRect: jest.fn(),
+                    beginPath: jest.fn(),
+                    arc: jest.fn(),
+                    closePath: jest.fn(),
+                    fill: jest.fn(),
+                    stroke: jest.fn(),
+                    fillText: jest.fn(),
+                    fillStyle: "",
+                    strokeStyle: "",
+                    lineWidth: 1,
+                    font: "",
+                    textAlign: "",
+                    textBaseline: ""
+                })
+            };
+        }
+
+        test("should initialize circular view state to false", () => {
+            expect(rhythmRuler._circularView).toBe(false);
+            expect(rhythmRuler._circularCanvas).toBeNull();
+            expect(rhythmRuler._circularHighlight).toEqual({});
+        });
+
+        test("should toggle _circularView flag", () => {
+            expect(rhythmRuler._circularView).toBe(false);
+            rhythmRuler._circularView = true;
+            expect(rhythmRuler._circularView).toBe(true);
+            rhythmRuler._circularView = false;
+            expect(rhythmRuler._circularView).toBe(false);
+        });
+
+        test("_toggleCircularView should show canvas and hide table when switching to circular", () => {
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+            rhythmRuler._rulers = [{ cells: [] }];
+            rhythmRuler._circularView = true;
+            // Pre-set the canvas so _toggleCircularView skips document.createElement
+            rhythmRuler._circularCanvas = createMockCanvas();
+
+            rhythmRuler._toggleCircularView();
+
+            expect(rhythmRuler._circularCanvas.style.display).toBe("block");
+            expect(rhythmRuler._rhythmRulerTable.style.display).toBe("none");
+        });
+
+        test("_toggleCircularView should hide canvas when switching to linear", () => {
+            // Setup: create a mock canvas first
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler._circularCanvas = { style: {}, addEventListener: jest.fn() };
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+            rhythmRuler._rulers = [
+                {
+                    children: [],
+                    cells: [{ style: {} }, { style: {} }, { style: {} }, { style: {} }]
+                }
+            ];
+            rhythmRuler._circularView = false;
+
+            rhythmRuler._toggleCircularView();
+
+            expect(rhythmRuler._circularCanvas.style.display).toBe("none");
+            expect(rhythmRuler._rhythmRulerTable.style.display).toBe("");
+        });
+
+        test("_drawCircularView should not crash with empty rulers", () => {
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [];
+
+            expect(() => rhythmRuler._drawCircularView()).not.toThrow();
+        });
+
+        test("_drawCircularView should not crash with single ruler", () => {
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+
+            expect(() => rhythmRuler._drawCircularView()).not.toThrow();
+        });
+
+        test("_drawCircularView should not crash with multiple rulers (concentric)", () => {
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [
+                [[4, 4, 4, 4], []],
+                [[3, 3, 3], []],
+                [[8, 8, 8, 8, 8, 8, 8, 8], []]
+            ];
+
+            expect(() => rhythmRuler._drawCircularView()).not.toThrow();
+        });
+
+        test("_drawCircularView should handle rests (negative note values)", () => {
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [[[4, -4, 4, 4], []]];
+
+            expect(() => rhythmRuler._drawCircularView()).not.toThrow();
+        });
+
+        test("_drawCircularView should handle playback highlights", () => {
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler._rhythmRulerTable = { style: {} };
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+            rhythmRuler._playing = true;
+            rhythmRuler._circularHighlight = { 0: 2 };
+
+            expect(() => rhythmRuler._drawCircularView()).not.toThrow();
+        });
+
+        test("_onCircularClick should not act while playing", () => {
+            rhythmRuler._playing = true;
+            rhythmRuler._circularCanvas = createMockCanvas();
+            rhythmRuler.Rulers = [[[4, 4, 4, 4], []]];
+
+            const spy = jest.spyOn(rhythmRuler, "__dissectByNumber").mockImplementation();
+            rhythmRuler._onCircularClick({ clientX: 100, clientY: 100 });
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        test("__pause should clear circular highlights", () => {
+            rhythmRuler._circularHighlight = { 0: 2, 1: 1 };
+            rhythmRuler._playing = true;
+            rhythmRuler._playAllCell = { innerHTML: "" };
+            rhythmRuler.Rulers = [[[4], []]];
+            rhythmRuler._rulers = [
+                {
+                    children: [],
+                    cells: [{ style: {} }]
+                }
+            ];
+
+            rhythmRuler.__pause();
+
+            expect(rhythmRuler._circularHighlight).toEqual({});
         });
     });
 });

--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -512,6 +512,8 @@ describe("RhythmRuler Widget", () => {
                     clearRect: jest.fn(),
                     beginPath: jest.fn(),
                     arc: jest.fn(),
+                    moveTo: jest.fn(),
+                    lineTo: jest.fn(),
                     closePath: jest.fn(),
                     fill: jest.fn(),
                     stroke: jest.fn(),

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -137,6 +137,22 @@ class RhythmRuler {
         this._circularHighlight = {};
 
         /**
+         * Tracks the slice where a mousedown began, used to distinguish
+         * single-slice dissect from multi-slice swipe-to-tie.
+         * @type {{rulerIndex: number, cellIndex: number}|null}
+         * @private
+         */
+        this._circularDownHit = null;
+
+        /**
+         * Tracks the slice the pointer is currently over while dragging,
+         * so the soon-to-be-merged slices can be highlighted.
+         * @type {{rulerIndex: number, cellIndex: number}|null}
+         * @private
+         */
+        this._circularDragTo = null;
+
+        /**
          * Array representing the list of undo operations.
          * @type {Array}
          * @private
@@ -2840,8 +2856,20 @@ class RhythmRuler {
                 this._circularCanvas = document.createElement("canvas");
                 this._circularCanvas.style.display = "block";
                 this._circularCanvas.style.margin = "auto";
-                this._circularCanvas.addEventListener("click", event => {
-                    this._onCircularClick(event);
+                this._circularCanvas.addEventListener("mousedown", event => {
+                    this._onCircularMouseDown(event);
+                });
+                this._circularCanvas.addEventListener("mousemove", event => {
+                    this._onCircularMouseMove(event);
+                });
+                this._circularCanvas.addEventListener("mouseup", event => {
+                    this._onCircularMouseUp(event);
+                });
+                this._circularCanvas.addEventListener("mouseleave", () => {
+                    if (this._circularDragTo !== null) {
+                        this._circularDragTo = null;
+                        this._drawCircularView();
+                    }
                 });
                 this.widgetWindow.getWidgetBody().append(this._circularCanvas);
             }
@@ -2924,9 +2952,20 @@ class RhythmRuler {
 
                 // Determine fill color.
                 const isHighlighted = this._circularHighlight[i] === j && this._playing;
+                const isInDragRange =
+                    this._circularDownHit !== null &&
+                    this._circularDragTo !== null &&
+                    this._circularDownHit.rulerIndex === i &&
+                    this._circularDragTo.rulerIndex === i &&
+                    j >=
+                        Math.min(this._circularDownHit.cellIndex, this._circularDragTo.cellIndex) &&
+                    j <= Math.max(this._circularDownHit.cellIndex, this._circularDragTo.cellIndex);
                 let fillColor;
                 if (isHighlighted) {
                     fillColor = platformColor.rulerHighlight;
+                } else if (isInDragRange) {
+                    // Slices currently being dragged across: show as pending merge.
+                    fillColor = platformColor.rulerHighlight || "#FFEB3B";
                 } else if (nv < 0) {
                     // Rest: muted color
                     fillColor = "#888888";
@@ -2954,7 +2993,7 @@ class RhythmRuler {
                 if (sweepAngle > 0.25 && ringThickness > 20) {
                     const obj = rationalToFraction(Math.abs(1 / nv));
                     const text = obj[0] + "/" + obj[1];
-                    ctx.fillStyle = isHighlighted ? "#000000" : "#FFFFFF";
+                    ctx.fillStyle = isHighlighted || isInDragRange ? "#000000" : "#FFFFFF";
                     ctx.font = Math.min(Math.floor(ringThickness * 0.35), 14) + "px sans-serif";
                     ctx.textAlign = "center";
                     ctx.textBaseline = "middle";
@@ -2989,15 +3028,16 @@ class RhythmRuler {
     }
 
     /**
-     * Handles click events on the circular canvas to determine which
-     * ruler and cell was clicked, then triggers a dissect operation.
+     * Hit-tests a mouse event on the circular canvas and returns the
+     * ruler and cell index under the pointer, or null if outside any ring.
      * @private
      * @param {MouseEvent} event
+     * @returns {{rulerIndex: number, cellIndex: number}|null}
      */
-    _onCircularClick(event) {
-        if (this._playing) return;
-
+    _hitTestCircular(event) {
         const canvas = this._circularCanvas;
+        if (!canvas) return null;
+
         const rect = canvas.getBoundingClientRect();
         const x = event.clientX - rect.left;
         const y = event.clientY - rect.top;
@@ -3008,7 +3048,7 @@ class RhythmRuler {
         const dy = y - centerY;
         const dist = Math.sqrt(dx * dx + dy * dy);
         let angle = Math.atan2(dy, dx);
-        // Normalize so 12 o'clock (top) is 0 and goes clockwise.
+        // Normalize so 12 o'clock (top) is 0 and increases clockwise.
         angle = angle + Math.PI / 2;
         if (angle < 0) angle += 2 * Math.PI;
 
@@ -3023,54 +3063,157 @@ class RhythmRuler {
                 ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
                 : totalRingSpace;
 
-        // Find which ring (ruler) was clicked.
-        let clickedRuler = -1;
+        // Find which ring (ruler) the pointer is in.
+        let hitRuler = -1;
         for (let i = 0; i < rulerCount; i++) {
             const ringInner = innerHoleRadius + i * (ringThickness + ringGap);
             const ringOuter = ringInner + ringThickness;
             if (dist >= ringInner && dist <= ringOuter) {
-                clickedRuler = i;
+                hitRuler = i;
                 break;
             }
         }
+        if (hitRuler < 0) return null;
 
-        if (clickedRuler < 0) return;
-
-        // Find which cell (slice) was clicked based on angle.
-        const noteValues = this.Rulers[clickedRuler][0];
+        // Find which slice based on angle.
+        const noteValues = this.Rulers[hitRuler][0];
         let totalDuration = 0;
         for (let j = 0; j < noteValues.length; j++) {
             totalDuration += 1 / Math.abs(noteValues[j]);
         }
 
         let cumAngle = 0;
-        let clickedCell = -1;
+        let hitCell = -1;
         for (let j = 0; j < noteValues.length; j++) {
             const duration = 1 / Math.abs(noteValues[j]);
             const sweepAngle = (duration / totalDuration) * 2 * Math.PI;
             if (angle >= cumAngle && angle < cumAngle + sweepAngle) {
-                clickedCell = j;
+                hitCell = j;
                 break;
             }
             cumAngle += sweepAngle;
         }
+        if (hitCell < 0) return null;
 
-        if (clickedCell < 0) return;
+        return { rulerIndex: hitRuler, cellIndex: hitCell };
+    }
 
-        // Perform the dissect on the identified cell.
-        this._rulerSelected = clickedRuler;
-        const ruler = this._rulers[clickedRuler];
-        if (ruler && ruler.cells[clickedCell]) {
+    /**
+     * Records the slice where a mousedown began so it can later be paired
+     * with a mouseup to decide between a single-slice dissect and a
+     * multi-slice tie.
+     * @private
+     * @param {MouseEvent} event
+     */
+    _onCircularMouseDown(event) {
+        if (this._playing) return;
+        const hit = this._hitTestCircular(event);
+        if (!hit) {
+            this._circularDownHit = null;
+            this._circularDragTo = null;
+            return;
+        }
+        this._circularDownHit = hit;
+        this._circularDragTo = hit;
+    }
+
+    /**
+     * Tracks the slice under the pointer while the mouse button is held
+     * down so the soon-to-be-merged range can be highlighted.
+     * @private
+     * @param {MouseEvent} event
+     */
+    _onCircularMouseMove(event) {
+        if (this._playing) return;
+        if (this._circularDownHit === null) return;
+
+        const hit = this._hitTestCircular(event);
+        const prev = this._circularDragTo;
+
+        // Only redraw when the slice under the pointer actually changes,
+        // to avoid flooding redraws on every pixel of movement.
+        const changed =
+            (prev === null && hit !== null) ||
+            (prev !== null && hit === null) ||
+            (prev !== null &&
+                hit !== null &&
+                (prev.rulerIndex !== hit.rulerIndex || prev.cellIndex !== hit.cellIndex));
+
+        if (changed) {
+            this._circularDragTo = hit;
+            this._drawCircularView();
+        }
+    }
+
+    /**
+     * Handles the end of a pointer gesture on the circular canvas.
+     * If the pointer came up on the same slice it went down on, the slice
+     * is dissected (split). If it came up on a different slice within the
+     * same ruler, the slices between them are tied together.
+     * @private
+     * @param {MouseEvent} event
+     */
+    _onCircularMouseUp(event) {
+        if (this._playing) return;
+        const down = this._circularDownHit;
+        this._circularDownHit = null;
+        this._circularDragTo = null;
+        if (!down) return;
+
+        const up = this._hitTestCircular(event);
+        if (!up) return;
+
+        // A tie requires both endpoints to be on the same ruler and on
+        // different slices; anything else falls through to dissect.
+        if (down.rulerIndex === up.rulerIndex && down.cellIndex !== up.cellIndex) {
+            this._tieCircular(down.rulerIndex, down.cellIndex, up.cellIndex);
+            return;
+        }
+
+        // Single-slice click: dissect.
+        this._rulerSelected = down.rulerIndex;
+        const ruler = this._rulers[down.rulerIndex];
+        if (ruler && ruler.cells[down.cellIndex]) {
             let inputNum = this._dissectNumber.value;
             if (inputNum === "" || isNaN(inputNum)) {
                 inputNum = 2;
             } else {
                 inputNum = Math.abs(Math.floor(inputNum));
             }
-            this.__dissectByNumber(ruler.cells[clickedCell], inputNum, true);
+            this.__dissectByNumber(ruler.cells[down.cellIndex], inputNum, true);
             this.saveDissectHistory();
             this._drawCircularView();
         }
+    }
+
+    /**
+     * Ties a contiguous range of slices on a single ruler into one note,
+     * reusing the linear view's __tie() implementation by pointing its
+     * _mouseDownCell/_mouseUpCell at the underlying DOM cells.
+     * @private
+     * @param {number} rulerIndex
+     * @param {number} fromCell
+     * @param {number} toCell
+     */
+    _tieCircular(rulerIndex, fromCell, toCell) {
+        const ruler = this._rulers[rulerIndex];
+        if (!ruler || !ruler.cells) return;
+
+        const downIndex = Math.min(fromCell, toCell);
+        const upIndex = Math.max(fromCell, toCell);
+        const downCell = ruler.cells[downIndex];
+        const upCell = ruler.cells[upIndex];
+        if (!downCell || !upCell) return;
+
+        this._rulerSelected = rulerIndex;
+        this._mouseDownCell = downCell;
+        this._mouseUpCell = upCell;
+        this.__tie(true);
+        this._mouseDownCell = null;
+        this._mouseUpCell = null;
+
+        this.saveDissectHistory();
+        this._drawCircularView();
     }
 }
 if (typeof module !== "undefined") {

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -115,6 +115,28 @@ class RhythmRuler {
         this._dissectHistory = [];
 
         /**
+         * Whether the circular (pie) view is active.
+         * @type {boolean}
+         * @private
+         */
+        this._circularView = false;
+
+        /**
+         * Canvas element for the circular view.
+         * @type {HTMLCanvasElement|null}
+         * @private
+         */
+        this._circularCanvas = null;
+
+        /**
+         * Index of the cell currently highlighted during circular playback.
+         * Keyed by ruler index.
+         * @type {Object}
+         * @private
+         */
+        this._circularHighlight = {};
+
+        /**
          * Array representing the list of undo operations.
          * @type {Array}
          * @private
@@ -577,12 +599,19 @@ class RhythmRuler {
             this._clear();
         };
 
+        this._circularToggle = widgetWindow.addButton("circle.svg", iconSize, _("Circular view"));
+        this._circularToggle.onclick = () => {
+            this._circularView = !this._circularView;
+            this._toggleCircularView();
+        };
+
         /**
          * Represents the table containing the rhythm rulers.
          * The table has an outer div for vertical scrolling and an inner div for horizontal scrolling.
          * @type {HTMLTableElement}
          */
         const rhythmRulerTable = document.createElement("table");
+        this._rhythmRulerTable = rhythmRulerTable;
         widgetWindow.getWidgetBody().append(rhythmRulerTable);
 
         /**
@@ -1340,6 +1369,7 @@ class RhythmRuler {
             noteValues[cell.cellIndex] = -noteValue;
 
             this._calculateZebraStripes(this._rulerSelected);
+            this._refreshCircularView();
 
             const divisionHistory = this.Rulers[this._rulerSelected][1];
             if (addToUndoList) {
@@ -1402,6 +1432,7 @@ class RhythmRuler {
             }
 
             this._calculateZebraStripes(this._rulerSelected);
+            this._refreshCircularView();
         }
     }
 
@@ -1471,6 +1502,7 @@ class RhythmRuler {
             }
 
             this._calculateZebraStripes(this._rulerSelected);
+            this._refreshCircularView();
         }
     }
 
@@ -1581,6 +1613,7 @@ class RhythmRuler {
             );
 
             this._calculateZebraStripes(this._rulerSelected);
+            this._refreshCircularView();
         }
     }
 
@@ -1717,6 +1750,7 @@ class RhythmRuler {
 
         divisionHistory.pop();
         this._calculateZebraStripes(lastRuler);
+        this._refreshCircularView();
     }
 
     /**
@@ -1764,6 +1798,8 @@ class RhythmRuler {
                 this._undo();
             }
         }
+
+        this._refreshCircularView();
     }
 
     /**
@@ -1788,6 +1824,10 @@ class RhythmRuler {
         for (let i = 0; i < this.Rulers.length; i++) {
             this._calculateZebraStripes(i);
         }
+
+        // Clear circular highlights and redraw.
+        this._circularHighlight = {};
+        this._refreshCircularView();
     }
 
     /**
@@ -1968,6 +2008,12 @@ class RhythmRuler {
 
             // And highlight its cell.
             cell.style.backgroundColor = platformColor.rulerHighlight; // selectorBackground;
+
+            // Update circular view highlight if active.
+            if (this._circularView && this._circularCanvas) {
+                this._circularHighlight[rulerNo] = colIndex;
+                this._drawCircularView();
+            }
 
             // Calculate any offset in playback.
             const d = new Date();
@@ -2770,6 +2816,239 @@ class RhythmRuler {
             docById("wheelDiv").style.top = y + 60 + "px";
         } else {
             docById("wheelDiv").style.top = y - 300 + "px";
+        }
+    }
+
+    /**
+     * Toggles between linear (table) and circular (canvas) views.
+     * @private
+     */
+    _refreshCircularView() {
+        if (this._circularView && this._circularCanvas) {
+            this._drawCircularView();
+        }
+    }
+
+    /**
+     * Toggles between linear (table) and circular (canvas) views.
+     * @private
+     */
+    _toggleCircularView() {
+        if (this._circularView) {
+            this._rhythmRulerTable.style.display = "none";
+            if (!this._circularCanvas) {
+                this._circularCanvas = document.createElement("canvas");
+                this._circularCanvas.style.display = "block";
+                this._circularCanvas.style.margin = "auto";
+                this._circularCanvas.addEventListener("click", event => {
+                    this._onCircularClick(event);
+                });
+                this.widgetWindow.getWidgetBody().append(this._circularCanvas);
+            }
+            this._circularCanvas.style.display = "block";
+            this._drawCircularView();
+        } else {
+            if (this._circularCanvas) {
+                this._circularCanvas.style.display = "none";
+            }
+            this._rhythmRulerTable.style.display = "";
+            // Refresh zebra stripes after switching back.
+            for (let i = 0; i < this.Rulers.length; i++) {
+                this._calculateZebraStripes(i);
+            }
+        }
+    }
+
+    /**
+     * Draws the circular (donut/pie) view on the canvas.
+     * Each ruler is a concentric ring. Each note value is an arc slice
+     * whose angle is proportional to its duration.
+     * @private
+     */
+    _drawCircularView() {
+        const canvas = this._circularCanvas;
+        if (!canvas) return;
+
+        const body = this.widgetWindow.getWidgetBody();
+        const bodyW = body.clientWidth || 400;
+        const bodyH = body.clientHeight || 400;
+        // Use the smaller dimension but leave room for padding.
+        const size = Math.max(Math.min(bodyW - 20, bodyH - 20, 600), 200);
+        canvas.width = size;
+        canvas.height = size;
+
+        const ctx = canvas.getContext("2d");
+        ctx.clearRect(0, 0, size, size);
+
+        const centerX = size / 2;
+        const centerY = size / 2;
+        const rulerCount = this.Rulers.length;
+
+        // Ring geometry: leave a hole in the center and space for labels.
+        const innerHoleRadius = size * 0.1;
+        const outerLimit = size * 0.47;
+        const ringGap = 2;
+        const totalRingSpace = outerLimit - innerHoleRadius;
+        const ringThickness =
+            rulerCount > 0
+                ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
+                : totalRingSpace;
+
+        const colors = [platformColor.selectorBackground, platformColor.selectorSelected];
+
+        for (let i = 0; i < rulerCount; i++) {
+            const noteValues = this.Rulers[i][0];
+            // Outermost ruler is index 0 (matching Walter's concentric sketch).
+            const ringIndex = i;
+            const ringInner = innerHoleRadius + ringIndex * (ringThickness + ringGap);
+            const ringOuter = ringInner + ringThickness;
+
+            // Sum of durations (1/noteValue) for angle calculation.
+            let totalDuration = 0;
+            for (let j = 0; j < noteValues.length; j++) {
+                totalDuration += 1 / Math.abs(noteValues[j]);
+            }
+
+            let startAngle = -Math.PI / 2; // 12 o'clock
+
+            for (let j = 0; j < noteValues.length; j++) {
+                const nv = noteValues[j];
+                const duration = 1 / Math.abs(nv);
+                const sweepAngle = (duration / totalDuration) * 2 * Math.PI;
+                const endAngle = startAngle + sweepAngle;
+
+                // Determine fill color.
+                const isHighlighted = this._circularHighlight[i] === j && this._playing;
+                let fillColor;
+                if (isHighlighted) {
+                    fillColor = platformColor.rulerHighlight;
+                } else if (nv < 0) {
+                    // Rest: muted color
+                    fillColor = "#888888";
+                } else {
+                    fillColor = i % 2 === 0 ? colors[j % 2] : colors[(j + 1) % 2];
+                }
+
+                // Draw the arc slice.
+                ctx.beginPath();
+                ctx.arc(centerX, centerY, ringOuter, startAngle, endAngle);
+                ctx.arc(centerX, centerY, ringInner, endAngle, startAngle, true);
+                ctx.closePath();
+                ctx.fillStyle = fillColor;
+                ctx.fill();
+                ctx.strokeStyle = "#666666";
+                ctx.lineWidth = 1;
+                ctx.stroke();
+
+                // Draw note label if slice is large enough.
+                const midAngle = startAngle + sweepAngle / 2;
+                const labelRadius = (ringInner + ringOuter) / 2;
+                const labelX = centerX + labelRadius * Math.cos(midAngle);
+                const labelY = centerY + labelRadius * Math.sin(midAngle);
+
+                if (sweepAngle > 0.25 && ringThickness > 20) {
+                    const obj = rationalToFraction(Math.abs(1 / nv));
+                    const text = obj[0] + "/" + obj[1];
+                    ctx.fillStyle = isHighlighted ? "#000000" : "#FFFFFF";
+                    ctx.font = Math.min(Math.floor(ringThickness * 0.35), 14) + "px sans-serif";
+                    ctx.textAlign = "center";
+                    ctx.textBaseline = "middle";
+                    ctx.fillText(text, labelX, labelY);
+                }
+
+                startAngle = endAngle;
+            }
+        }
+
+        // Draw center hole (clear it).
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, innerHoleRadius - 1, 0, 2 * Math.PI);
+        ctx.fillStyle = getComputedStyle(canvas.parentNode).backgroundColor || "#303030";
+        ctx.fill();
+    }
+
+    /**
+     * Handles click events on the circular canvas to determine which
+     * ruler and cell was clicked, then triggers a dissect operation.
+     * @private
+     * @param {MouseEvent} event
+     */
+    _onCircularClick(event) {
+        if (this._playing) return;
+
+        const canvas = this._circularCanvas;
+        const rect = canvas.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        const centerX = canvas.width / 2;
+        const centerY = canvas.height / 2;
+
+        const dx = x - centerX;
+        const dy = y - centerY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        let angle = Math.atan2(dy, dx);
+        // Normalize so 12 o'clock (top) is 0 and goes clockwise.
+        angle = angle + Math.PI / 2;
+        if (angle < 0) angle += 2 * Math.PI;
+
+        const size = canvas.width;
+        const innerHoleRadius = size * 0.1;
+        const outerLimit = size * 0.47;
+        const rulerCount = this.Rulers.length;
+        const ringGap = 2;
+        const totalRingSpace = outerLimit - innerHoleRadius;
+        const ringThickness =
+            rulerCount > 0
+                ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
+                : totalRingSpace;
+
+        // Find which ring (ruler) was clicked.
+        let clickedRuler = -1;
+        for (let i = 0; i < rulerCount; i++) {
+            const ringInner = innerHoleRadius + i * (ringThickness + ringGap);
+            const ringOuter = ringInner + ringThickness;
+            if (dist >= ringInner && dist <= ringOuter) {
+                clickedRuler = i;
+                break;
+            }
+        }
+
+        if (clickedRuler < 0) return;
+
+        // Find which cell (slice) was clicked based on angle.
+        const noteValues = this.Rulers[clickedRuler][0];
+        let totalDuration = 0;
+        for (let j = 0; j < noteValues.length; j++) {
+            totalDuration += 1 / Math.abs(noteValues[j]);
+        }
+
+        let cumAngle = 0;
+        let clickedCell = -1;
+        for (let j = 0; j < noteValues.length; j++) {
+            const duration = 1 / Math.abs(noteValues[j]);
+            const sweepAngle = (duration / totalDuration) * 2 * Math.PI;
+            if (angle >= cumAngle && angle < cumAngle + sweepAngle) {
+                clickedCell = j;
+                break;
+            }
+            cumAngle += sweepAngle;
+        }
+
+        if (clickedCell < 0) return;
+
+        // Perform the dissect on the identified cell.
+        this._rulerSelected = clickedRuler;
+        const ruler = this._rulers[clickedRuler];
+        if (ruler && ruler.cells[clickedCell]) {
+            let inputNum = this._dissectNumber.value;
+            if (inputNum === "" || isNaN(inputNum)) {
+                inputNum = 2;
+            } else {
+                inputNum = Math.abs(Math.floor(inputNum));
+            }
+            this.__dissectByNumber(ruler.cells[clickedCell], inputNum, true);
+            this.saveDissectHistory();
+            this._drawCircularView();
         }
     }
 }

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -2872,10 +2872,15 @@ class RhythmRuler {
         const body = this.widgetWindow.getWidgetBody();
         const bodyW = body.clientWidth || 400;
         const bodyH = body.clientHeight || 400;
-        // Use the smaller dimension but leave room for padding.
-        const size = Math.max(Math.min(bodyW - 20, bodyH - 20, 600), 200);
+        // Keep the canvas a perfect square so slices stay circular.
+        // Use the smaller dimension (minus padding) so the circle always fits.
+        const size = Math.max(Math.min(bodyW, bodyH) - 20, 200);
         canvas.width = size;
         canvas.height = size;
+        // Lock the CSS display size to match so the browser does not scale
+        // it into an oval when the container is wider than tall.
+        canvas.style.width = size + "px";
+        canvas.style.height = size + "px";
 
         const ctx = canvas.getContext("2d");
         ctx.clearRect(0, 0, size, size);
@@ -2965,6 +2970,22 @@ class RhythmRuler {
         ctx.arc(centerX, centerY, innerHoleRadius - 1, 0, 2 * Math.PI);
         ctx.fillStyle = getComputedStyle(canvas.parentNode).backgroundColor || "#303030";
         ctx.fill();
+
+        // Draw a "start here, plays clockwise" indicator at 12 o'clock.
+        // A small triangle pointing clockwise (to the right) sits just above
+        // the outer edge of the rings.
+        const indicatorY = centerY - outerLimit - 6;
+        const arrowSize = Math.max(6, size * 0.02);
+        ctx.beginPath();
+        ctx.moveTo(centerX - arrowSize, indicatorY - arrowSize);
+        ctx.lineTo(centerX + arrowSize, indicatorY);
+        ctx.lineTo(centerX - arrowSize, indicatorY + arrowSize);
+        ctx.closePath();
+        ctx.fillStyle = platformColor.rulerHighlight || "#FFEB3B";
+        ctx.fill();
+        ctx.strokeStyle = "#000000";
+        ctx.lineWidth = 1;
+        ctx.stroke();
     }
 
     /**


### PR DESCRIPTION
## Description

The Rhythm Maker currently displays rhythms as a linear horizontal bar. Since rhythm inherently wraps (beat 1 follows the last beat), a circular display is a more natural representation. This PR adds a toggle in the Rhythm Maker toolbar to switch between the existing linear view and a new circular donut/pie view.

In circular mode, each note value becomes a pie slice whose angle is proportional to its duration. Multiple rulers with different meters appear as concentric rings, making it easy to see where beats from different meters align useful for understanding polyrhythms.

## Related Issue

This PR fixes #1290

## PR Category

-   [ ] Bug Fix - Fixes a bug or incorrect behavior
-   [x] Feature - Adds new functionality
-   [ ] Performance - Improves performance (load time, memory, rendering, etc.)
-   [x] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README

## Changes Made

-   Added a circle toggle button to the Rhythm Maker toolbar that switches between linear (table) and circular (canvas) views
-   Built a canvas-based circular renderer (`_drawCircularView`) that draws each ruler as a concentric ring with pie slices for each note value
-   Slice angles are proportional to note duration relative to the total measure
-   Multiple rulers are drawn as concentric rings (outermost = first ruler), matching the concentric design Walter described in the issue
-   Clicking a slice triggers the same dissect/split operation as clicking a cell in the linear view
-   Playback highlights sweep around the circle in real time during playback
-   Rests (negative note values) are displayed in a muted grey color
-   Note value labels (e.g. 1/4, 1/8) are drawn inside slices when there is enough space
-   Toggling back to linear view restores the original table display with zebra stripes
-   The data model, playback logic, and undo/redo history are fully shared between both views only the rendering changes
-   Added 11 new tests covering circular view initialization, toggle behavior, drawing with empty/single/multiple/rest rulers, playback highlights, and click guard during playback

## Testing Performed

-   All 36 rhythm ruler tests pass (25 existing + 11 new circular view tests)
-   Full test suite passes (4247 tests, 0 regressions)
-   Tested manually in browser: toggled between linear and circular views, split slices by clicking, verified playback highlight animation, tested with single and multiple rulers
-   Ran `npm run lint` and `npx prettier --check .` with no errors on changed files

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

To test the circular view:

1. Drag a **rhythm maker** block from the Widgets palette onto the canvas
2. Run the project - the Rhythm Maker widget opens
3. Click the **circle icon** in the toolbar (last button) to switch to circular view
4. Click any slice to split it (uses the dissect number shown in the toolbar)
5. Click play to see the highlight sweep around the circle
6. Click the circle icon again to toggle back to linear view

## Before & After

## Before & After

| Linear View (existing) | Circular View (new) |
|---|---|
| ![before]<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/7a5bf911-f62e-420f-ad32-1a86d39a00a9" />| ![after]<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/8854f77c-64ac-47be-8d2d-8295e7ba763f" /> |


