### PR TITLE
test: mock requestAnimationFrame to fix mb-dialog.test.js failures

### DIFF
--- a/js/utils/__tests__/mb-dialog.test.js
+++ b/js/utils/__tests__/mb-dialog.test.js
@@ -51,6 +51,13 @@ describe("MBDialog", () => {
             clear: jest.fn()
         };
         Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+        // Mock requestAnimationFrame and cancelAnimationFrame
+        window.requestAnimationFrame = jest.fn().mockImplementation(cb => {
+            cb();
+            return 1;
+        });
+        window.cancelAnimationFrame = jest.fn();
     });
 
     afterEach(() => {


### PR DESCRIPTION
# Fix mb-dialog.test.js failures due to async dragging optimization

## Description
This PR addresses failing Jest tests in the `js/utils/__tests__/mb-dialog.test.js` file. These failures were a side effect of recent optimizations that introduced `requestAnimationFrame` (RAF) to the dragging logic.

## Rationale
The `mb-dialog.js` implementation was recently updated to use `requestAnimationFrame` for smoother dragging performance. However, because JSDOM/Jest handles RAF asynchronously, the synchronous assertions in the unit tests were executing before the browser frame could update the element's style. This caused coordinate mismatches where the test expected the new drag position but received the initial centered position (`512px` in the test environment).

## Changes
- **Mocked `requestAnimationFrame`**: Added a synchronous mock for `window.requestAnimationFrame` in the test's `beforeEach` block.
- **Mocked `cancelAnimationFrame`**: Added a mock for `window.cancelAnimationFrame` to ensure full compatibility with the implementation's cleanup logic.

## Verification Results

### Unit Tests
Ran the specific test suite to confirm the fix:
```text
Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        0.226 s
```

- [x] Bug fix
