### PR TITLE
Handle missing textMsg in HelpWidget on close

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -54,7 +54,7 @@ class HelpWidget {
             document.onkeydown = activity.__keyPressed;
             widgetWindow.destroy();
             // Trigger the hint only if they were on the first page of the tour
-            if (this.index === 0) {
+            if (this.index === 0 && typeof this.activity.textMsg === "function") {
                 this.activity.textMsg(
                     _(
                         "Start by dragging a block from the left panel and connect it to the Start block."


### PR DESCRIPTION
## Description

Guard the Help widget close handler so it only calls `activity.textMsg` when that function exists.

Fixes #6560.

## PR Category

- [x] Bug Fix - Fixes a bug or incorrect behavior
- [ ] Tests - Adds or updates test coverage
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [ ] Documentation - Updates to docs, comments, or README

## Changes Made

- Added a defensive check before calling `activity.textMsg` in the Help widget close handler.

## Testing Performed

- `npx jest js/widgets/__tests__/help.test.js --runInBand --no-coverage`
- `npm test -- --runInBand`

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
