### PR TITLE
fix: resolve widget double-click issue by ensuring async loading comp…

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -86,6 +86,32 @@ function setupWidgetBlocks(activity) {
     }
 
     /**
+     * Ensures that a widget is loaded and initialized before executing block logic.
+     * If the widget is null, it initiates a lazy load and returns an interruption signal.
+     *
+     * @param {object} logo - The logo object.
+     * @param {string} widgetKey - The key for the widget in the logo object.
+     * @param {string[]} modules - The modules to require.
+     * @param {Function} initFn - Callback to initialize the widget instance.
+     * @param {object} turtle - The turtle object.
+     * @param {object} blk - The block object.
+     * @param {any} receivedArg - The received argument.
+     * @returns {[null, number, boolean]|null} - Interruption signal or null if already loaded.
+     */
+    function _ensureWidget(logo, widgetKey, modules, initFn, turtle, blk, receivedArg) {
+        if (logo[widgetKey] === null) {
+            _lazyRequire(modules, function () {
+                logo[widgetKey] = initFn();
+                if (typeof logo.runFromBlockNow === "function") {
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
+                }
+            });
+            return [null, 0, true];
+        }
+        return null;
+    }
+
+    /**
      * Represents a block for controlling sound envelope (ADSR).
      * @extends FlowBlock
      */
@@ -298,13 +324,16 @@ function setupWidgetBlocks(activity) {
          * @param {any} receivedArg - The argument received from the previous block.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.temperament === null) {
-                _lazyRequire(["widgets/temperament"], function () {
-                    logo.temperament = new TemperamentWidget();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "temperament",
+                ["widgets/temperament"],
+                () => new TemperamentWidget(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.insideTemperament = true;
             logo.temperament.inTemperament = args[0];
@@ -460,13 +489,16 @@ function setupWidgetBlocks(activity) {
          * @returns {number[]} - The output values.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.timbre === null) {
-                _lazyRequire(["widgets/timbre"], function () {
-                    logo.timbre = new TimbreWidget();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "timbre",
+                ["widgets/timbre"],
+                () => new TimbreWidget(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inTimbre = true;
 
@@ -756,13 +788,16 @@ function setupWidgetBlocks(activity) {
          * @returns {number[]} - The output values.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.tempo === null) {
-                _lazyRequire(["widgets/tempo"], function () {
-                    logo.tempo = new Tempo();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "tempo",
+                ["widgets/tempo"],
+                () => new Tempo(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inTempo = true;
             logo.tempo.BPMBlocks = [];
@@ -830,13 +865,16 @@ function setupWidgetBlocks(activity) {
          * @returns {number[]} - The output values.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.arpeggio === null) {
-                _lazyRequire(["widgets/arpeggio"], function () {
-                    logo.arpeggio = new Arpeggio();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "arpeggio",
+                ["widgets/arpeggio"],
+                () => new Arpeggio(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inArpeggio = true;
 
@@ -909,13 +947,16 @@ function setupWidgetBlocks(activity) {
          * @param {any} receivedArg - The argument received from the previous block.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.pitchDrumMatrix === null) {
-                _lazyRequire(["widgets/pitchdrummatrix"], function () {
-                    logo.pitchDrumMatrix = new PitchDrumMatrix();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "pitchDrumMatrix",
+                ["widgets/pitchdrummatrix"],
+                () => new PitchDrumMatrix(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inPitchDrumMatrix = true;
             logo.pitchDrumMatrix.rowLabels = [];
@@ -987,13 +1028,16 @@ function setupWidgetBlocks(activity) {
          * @returns {array} - The output array.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.pitchSlider === null) {
-                _lazyRequire(["widgets/pitchslider"], function () {
-                    logo.pitchSlider = new PitchSlider();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "pitchSlider",
+                ["widgets/pitchslider"],
+                () => new PitchSlider(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inPitchSlider = true;
             logo.pitchSlider.frequencies = [];
@@ -1143,13 +1187,16 @@ function setupWidgetBlocks(activity) {
          * @returns {any[]} - Returns an array of arguments.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.musicKeyboard === null) {
-                _lazyRequire(["widgets/musickeyboard"], function () {
-                    logo.musicKeyboard = new MusicKeyboard(activity);
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "musicKeyboard",
+                ["widgets/musickeyboard"],
+                () => new MusicKeyboard(activity),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.inMusicKeyboard = true;
             logo.musicKeyboard.blockNo = blk;
@@ -1212,13 +1259,16 @@ function setupWidgetBlocks(activity) {
          * @returns {any[]} - Returns an array of arguments.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.pitchStaircase === null) {
-                _lazyRequire(["widgets/pitchstaircase"], function () {
-                    logo.pitchStaircase = new PitchStaircase();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "pitchStaircase",
+                ["widgets/pitchstaircase"],
+                () => new PitchStaircase(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.pitchStaircase.Stairs = [];
             logo.pitchStaircase.stairPitchBlocks = [];
@@ -1324,13 +1374,16 @@ function setupWidgetBlocks(activity) {
          * @returns {any[]} - Returns an array of arguments.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.rhythmRuler === null) {
-                _lazyRequire(["widgets/rhythmruler"], function () {
-                    logo.rhythmRuler = new RhythmRuler();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "rhythmRuler",
+                ["widgets/rhythmruler"],
+                () => new RhythmRuler(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.rhythmRuler.Rulers = [];
             logo.rhythmRuler.Drums = [];
@@ -1529,58 +1582,61 @@ function setupWidgetBlocks(activity) {
         flow(args, logo, turtle, blk, receivedArg) {
             logo.inMatrix = true;
 
-            if (logo.phraseMaker === null) {
-                _lazyRequire(
-                    [
-                        "widgets/PhraseMakerUtils",
-                        "widgets/PhraseMakerGrid",
-                        "widgets/PhraseMakerUI",
-                        "widgets/PhraseMakerAudio",
-                        "widgets/phrasemaker"
-                    ],
-                    function () {
-                        // Create explicit dependency object for PhraseMaker
-                        const phraseMakerDeps = {
-                            activity: activity,
-                            _: _,
-                            platformColor: platformColor,
-                            docById: docById,
-                            docBySelector: docBySelector,
-                            MATRIXSOLFEHEIGHT: MATRIXSOLFEHEIGHT,
-                            MATRIXSOLFEWIDTH: MATRIXSOLFEWIDTH,
-                            toFraction: toFraction,
-                            Singer: Singer,
-                            SOLFEGECONVERSIONTABLE: SOLFEGECONVERSIONTABLE,
-                            slicePath: slicePath,
-                            wheelnav: wheelnav,
-                            delayExecution: delayExecution,
-                            DEFAULTVOICE: DEFAULTVOICE,
-                            getDrumName: getDrumName,
-                            getDrumIcon: getDrumIcon,
-                            noteIsSolfege: noteIsSolfege,
-                            isCustomTemperament: isCustomTemperament,
-                            i18nSolfege: i18nSolfege,
-                            getNote: getNote,
-                            DEFAULTDRUM: DEFAULTDRUM,
-                            last: last,
-                            DRUMS: DRUMS,
-                            SHARP: SHARP,
-                            FLAT: FLAT,
-                            PREVIEWVOLUME: PREVIEWVOLUME,
-                            DEFAULTVOLUME: DEFAULTVOLUME,
-                            noteToFrequency: noteToFrequency,
-                            LCD: LCD,
-                            calcNoteValueToDisplay: calcNoteValueToDisplay,
-                            NOTESYMBOLS: NOTESYMBOLS,
-                            EIGHTHNOTEWIDTH: EIGHTHNOTEWIDTH,
-                            getTemperament: getTemperament
-                        };
-                        logo.phraseMaker = new PhraseMaker(phraseMakerDeps);
-                        logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                    }
-                );
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "phraseMaker",
+                [
+                    "widgets/PhraseMakerUtils",
+                    "widgets/PhraseMakerGrid",
+                    "widgets/PhraseMakerUI",
+                    "widgets/PhraseMakerAudio",
+                    "widgets/phrasemaker"
+                ],
+                () => {
+                    // Create explicit dependency object for PhraseMaker
+                    const phraseMakerDeps = {
+                        activity: activity,
+                        _: _,
+                        platformColor: platformColor,
+                        docById: docById,
+                        docBySelector: docBySelector,
+                        MATRIXSOLFEHEIGHT: MATRIXSOLFEHEIGHT,
+                        MATRIXSOLFEWIDTH: MATRIXSOLFEWIDTH,
+                        toFraction: toFraction,
+                        Singer: Singer,
+                        SOLFEGECONVERSIONTABLE: SOLFEGECONVERSIONTABLE,
+                        slicePath: slicePath,
+                        wheelnav: wheelnav,
+                        delayExecution: delayExecution,
+                        DEFAULTVOICE: DEFAULTVOICE,
+                        getDrumName: getDrumName,
+                        getDrumIcon: getDrumIcon,
+                        noteIsSolfege: noteIsSolfege,
+                        isCustomTemperament: isCustomTemperament,
+                        i18nSolfege: i18nSolfege,
+                        getNote: getNote,
+                        DEFAULTDRUM: DEFAULTDRUM,
+                        last: last,
+                        DRUMS: DRUMS,
+                        SHARP: SHARP,
+                        FLAT: FLAT,
+                        PREVIEWVOLUME: PREVIEWVOLUME,
+                        DEFAULTVOLUME: DEFAULTVOLUME,
+                        noteToFrequency: noteToFrequency,
+                        LCD: LCD,
+                        calcNoteValueToDisplay: calcNoteValueToDisplay,
+                        NOTESYMBOLS: NOTESYMBOLS,
+                        EIGHTHNOTEWIDTH: EIGHTHNOTEWIDTH,
+                        getTemperament: getTemperament
+                    };
+                    return new PhraseMaker(phraseMakerDeps);
+                },
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
+
             logo.phraseMaker.blockNo = blk;
 
             logo.phraseMaker._instrumentName = DEFAULTVOICE;
@@ -1790,13 +1846,16 @@ function setupWidgetBlocks(activity) {
          * @param {any} receivedArg - The argument received from the previous block.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            if (logo.reflection === null) {
-                _lazyRequire(["widgets/reflection"], function () {
-                    logo.reflection = new ReflectionMatrix();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "reflection",
+                ["widgets/reflection"],
+                () => new ReflectionMatrix(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
             logo.reflection.init(activity);
             logo.statusFields = [];
@@ -1872,13 +1931,17 @@ function setupWidgetBlocks(activity) {
         flow(args, logo, turtle, blk, receivedArg) {
             logo.inLegoWidget = true;
 
-            if (logo.legoWidget === null) {
-                _lazyRequire(["widgets/legobricks"], function () {
-                    logo.legoWidget = new LegoWidget();
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                });
-                return [null, 0, true];
-            }
+            const interruption = _ensureWidget(
+                logo,
+                "legoWidget",
+                ["widgets/legobricks"],
+                () => new LegoWidget(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
+
             logo.legoWidget.blockNo = blk;
 
             logo.legoWidget.rowLabels = [];

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -153,7 +153,7 @@ function setupWidgetBlocks(activity) {
                 logo.timbre.synthVals["envelope"]["sustain"] = last(tur.singer.sustain);
                 logo.timbre.synthVals["envelope"]["release"] = last(tur.singer.release);
 
-                if (logo.timbre.env.length != 0) {
+                if (logo.timbre.env.length !== 0) {
                     activity.errorMsg(_("You are adding multiple envelope blocks."));
                 } else {
                     // Create the synth for the instrument.
@@ -295,12 +295,15 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.temperament === null) {
                 _lazyRequire(["widgets/temperament"], function () {
                     logo.temperament = new TemperamentWidget();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.insideTemperament = true;
@@ -453,13 +456,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.timbre === null) {
                 _lazyRequire(["widgets/timbre"], function () {
                     logo.timbre = new TimbreWidget();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inTimbre = true;
@@ -609,7 +615,7 @@ function setupWidgetBlocks(activity) {
                             blocks,
                             turtle,
                             Math.max(0, blocks.length - 2),
-                            turtle ==
+                            turtle ===
                                 activity.turtles.getTurtle(activity.turtles.getTurtleCount() - 1)
                         );
                 }
@@ -746,13 +752,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.tempo === null) {
                 _lazyRequire(["widgets/tempo"], function () {
                     logo.tempo = new Tempo();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inTempo = true;
@@ -817,13 +826,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.arpeggio === null) {
                 _lazyRequire(["widgets/arpeggio"], function () {
                     logo.arpeggio = new Arpeggio();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inArpeggio = true;
@@ -894,12 +906,15 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.pitchDrumMatrix === null) {
                 _lazyRequire(["widgets/pitchdrummatrix"], function () {
                     logo.pitchDrumMatrix = new PitchDrumMatrix();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inPitchDrumMatrix = true;
@@ -968,13 +983,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {array} - The output array.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.pitchSlider === null) {
                 _lazyRequire(["widgets/pitchslider"], function () {
                     logo.pitchSlider = new PitchSlider();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inPitchSlider = true;
@@ -1121,13 +1139,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {any[]} - Returns an array of arguments.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.musicKeyboard === null) {
                 _lazyRequire(["widgets/musickeyboard"], function () {
                     logo.musicKeyboard = new MusicKeyboard(activity);
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.inMusicKeyboard = true;
@@ -1187,13 +1208,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {any[]} - Returns an array of arguments.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.pitchStaircase === null) {
                 _lazyRequire(["widgets/pitchstaircase"], function () {
                     logo.pitchStaircase = new PitchStaircase();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.pitchStaircase.Stairs = [];
@@ -1296,13 +1320,16 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {any[]} - Returns an array of arguments.
          */
-        flow(args, logo, turtle, blk) {
-            if (logo.rhythmRuler == null) {
+        flow(args, logo, turtle, blk, receivedArg) {
+            if (logo.rhythmRuler === null) {
                 _lazyRequire(["widgets/rhythmruler"], function () {
                     logo.rhythmRuler = new RhythmRuler();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.rhythmRuler.Rulers = [];
@@ -1497,8 +1524,9 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             logo.inMatrix = true;
 
             if (logo.phraseMaker === null) {
@@ -1548,8 +1576,10 @@ function setupWidgetBlocks(activity) {
                             getTemperament: getTemperament
                         };
                         logo.phraseMaker = new PhraseMaker(phraseMakerDeps);
+                        logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                     }
                 );
+                return [null, 0, true];
             }
             logo.phraseMaker.blockNo = blk;
 
@@ -1757,12 +1787,15 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             if (logo.reflection === null) {
                 _lazyRequire(["widgets/reflection"], function () {
                     logo.reflection = new ReflectionMatrix();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
 
             logo.reflection.init(activity);
@@ -1833,15 +1866,18 @@ function setupWidgetBlocks(activity) {
          * @param {object} logo - The logo object.
          * @param {object} turtle - The turtle object.
          * @param {object} blk - The block object.
+         * @param {any} receivedArg - The argument received from the previous block.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
             logo.inLegoWidget = true;
 
             if (logo.legoWidget === null) {
                 _lazyRequire(["widgets/legobricks"], function () {
                     logo.legoWidget = new LegoWidget();
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
                 });
+                return [null, 0, true];
             }
             logo.legoWidget.blockNo = blk;
 

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -100,6 +100,7 @@ function setupWidgetBlocks(activity) {
      */
     function _ensureWidget(logo, widgetKey, modules, initFn, turtle, blk, receivedArg) {
         if (logo[widgetKey] === null) {
+            logo[widgetKey] = "loading"; // Guard against multiple simultaneous loads
             _lazyRequire(modules, function () {
                 logo[widgetKey] = initFn();
                 if (typeof logo.runFromBlockNow === "function") {
@@ -107,6 +108,8 @@ function setupWidgetBlocks(activity) {
                 }
             });
             return [null, 0, true];
+        } else if (logo[widgetKey] === "loading") {
+            return [null, 0, true]; // Still loading, continue to interrupt
         }
         return null;
     }

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -124,6 +124,46 @@ global.TemperamentWidget = jest.fn(() => ({
     init: jest.fn()
 }));
 
+global.MusicKeyboard = jest.fn();
+global.PhraseMaker = jest.fn();
+global.Arpeggio = jest.fn();
+global.PitchDrumMatrix = jest.fn();
+global.PitchSlider = jest.fn();
+global.PitchStaircase = jest.fn();
+global.RhythmRuler = jest.fn();
+global.ReflectionMatrix = jest.fn();
+global.LegoWidget = jest.fn();
+
+global.platformColor = jest.fn();
+global.docById = jest.fn();
+global.docBySelector = jest.fn();
+global.MATRIXSOLFEHEIGHT = 10;
+global.MATRIXSOLFEWIDTH = 10;
+global.toFraction = jest.fn();
+global.Singer = jest.fn();
+global.SOLFEGECONVERSIONTABLE = {};
+global.slicePath = jest.fn();
+global.wheelnav = jest.fn();
+global.delayExecution = jest.fn();
+global.getDrumName = jest.fn();
+global.getDrumIcon = jest.fn();
+global.noteIsSolfege = jest.fn();
+global.isCustomTemperament = jest.fn();
+global.i18nSolfege = jest.fn();
+global.getNote = jest.fn();
+global.DEFAULTDRUM = "drum";
+global.DRUMS = [];
+global.SHARP = "#";
+global.FLAT = "b";
+global.PREVIEWVOLUME = 0.5;
+global.DEFAULTVOLUME = 0.8;
+global.noteToFrequency = jest.fn();
+global.LCD = jest.fn();
+global.calcNoteValueToDisplay = jest.fn();
+global.NOTESYMBOLS = [];
+global.EIGHTHNOTEWIDTH = 20;
+global.getTemperament = jest.fn();
+
 global.instrumentsEffects = {};
 global.instrumentsFilters = {};
 
@@ -178,7 +218,8 @@ const createMockLogo = () => {
             startingPitch: null
         },
         setDispatchBlock: jest.fn(),
-        setTurtleListener: jest.fn()
+        setTurtleListener: jest.fn(),
+        runFromBlockNow: jest.fn()
     };
 };
 
@@ -275,6 +316,17 @@ describe("setupWidgetBlocks", () => {
     describe("TimbreBlock", () => {
         it("initializes with string instrument name", () => {
             const timbre = getBlock("timbre");
+            // First call: returns interruption while loading widget
+            const interruption = timbre.flow(
+                ["customInstrument", "childBlk"],
+                logo,
+                0,
+                "timbreBlk"
+            );
+            expect(interruption).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalled();
+
+            // Second call: widget is loaded, so it proceeds
             const result = timbre.flow(["customInstrument", "childBlk"], logo, 0, "timbreBlk");
             expect(logo.inTimbre).toBe(true);
             expect(logo.timbre.instrumentName).toBe("customInstrument");
@@ -283,6 +335,10 @@ describe("setupWidgetBlocks", () => {
 
         it("uses default voice and shows error for non-string", () => {
             const timbre = getBlock("timbre");
+            // First call: interruption
+            timbre.flow([123, "childBlk"], logo, 0, "timbreBlk");
+
+            // Second call: actual logic
             timbre.flow([123, "childBlk"], logo, 0, "timbreBlk");
             expect(activity.errorMsg).toHaveBeenCalledWith("No input error", "timbreBlk");
             expect(logo.timbre.instrumentName).toBe(global.DEFAULTVOICE);
@@ -292,6 +348,10 @@ describe("setupWidgetBlocks", () => {
     describe("TempoBlock", () => {
         it("initializes tempo widget and returns child block", () => {
             const tempo = getBlock("tempo");
+            // First call: interruption
+            tempo.flow(["childBlk"], logo, 0, "tempoBlk");
+
+            // Second call: proceeds
             const result = tempo.flow(["childBlk"], logo, 0, "tempoBlk");
             expect(logo.inTempo).toBe(true);
             expect(logo.tempo).toBeDefined();
@@ -300,6 +360,10 @@ describe("setupWidgetBlocks", () => {
 
         it("sets dispatch block and turtle listener", () => {
             const tempo = getBlock("tempo");
+            // First call: interruption
+            tempo.flow(["childBlk"], logo, 0, "tempoBlk");
+
+            // Second call: proceeds
             tempo.flow(["childBlk"], logo, 0, "tempoBlk");
             expect(logo.setDispatchBlock).toHaveBeenCalledWith("tempoBlk", 0, "_tempo_0");
             expect(logo.setTurtleListener).toHaveBeenCalled();
@@ -347,6 +411,38 @@ describe("setupWidgetBlocks", () => {
             expect(logo.inSample).toBe(true);
             expect(logo.sample).toBeDefined();
             expect(result).toEqual(["childBlk", 1]);
+        });
+    });
+
+    describe("First-Click Flow (Lazy Loading)", () => {
+        it("returns interruption and triggers runFromBlockNow for TemperamentBlock", () => {
+            const temperament = getBlock("temperament");
+            logo.temperament = null;
+            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "tempBlk", true, "received");
+        });
+
+        it("returns interruption and triggers runFromBlockNow for MusicKeyboardBlock", () => {
+            const keyboard = getBlock("musickeyboard");
+            logo.musicKeyboard = null;
+            const res = keyboard.flow(["childBlk"], logo, 0, "kbdBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "kbdBlk", true, "received");
+        });
+
+        it("returns interruption and triggers runFromBlockNow for MatrixBlock (PhraseMaker)", () => {
+            const matrix = getBlock("matrix");
+            logo.phraseMaker = null;
+            const res = matrix.flow(["childBlk"], logo, 0, "matrixBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
+                logo,
+                0,
+                "matrixBlk",
+                true,
+                "received"
+            );
         });
     });
 });

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -444,5 +444,14 @@ describe("setupWidgetBlocks", () => {
                 "received"
             );
         });
+
+        it("returns interruption if widget is already loading (guard check)", () => {
+            const temperament = getBlock("temperament");
+            logo.temperament = "loading";
+            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            // Should not trigger another runFromBlockNow or lazy load callback
+            expect(logo.runFromBlockNow).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
# Fix: Resolve Widget Double-Click Requirement

## Description
This PR resolves a long-standing issue where widgets in Music Blocks (e.g., Phrase Maker, Music Keyboard, Tempo, etc.) required two clicks to open instead of one. 

## The Bug
The root cause was a race condition in `js/blocks/WidgetBlocks.js`. Most widget blocks used the `_lazyRequire` pattern to load their respective modules asynchronously. However, the `flow` method of these blocks attempted to access properties of the widget (like `logo.phraseMaker.blockNo`) immediately after initiating the load, but before the module had finished loading and the widget was instantiated. 

This resulted in a `TypeError: logo.<widget> is null` on the first attempt. The second attempt succeeded because the module was already cached and the widget was initialized from the previous (failed) attempt.

## The Fix
I implemented a robust re-execution pattern across all affected blocks:
1. **Deferred Execution**: If the widget is not yet initialized (`null`), the `flow` method triggers `_lazyRequire` and returns `[null, 0, true]`. This tells the Logo engine to stop the current execution path cleanly.
2. **Asynchronous Callback**: Inside the `_lazyRequire` callback, once the module is loaded and the widget instance is created, `logo.runFromBlockNow(...)` is called to re-trigger the block automatically.
3. **Synchronous Fallback**: On the second (automatic) call, the widget is already present, so the block proceeds to initialize the widget and open its UI without further user interaction.

## Affected Blocks
The following blocks in `WidgetBlocks.js` have been updated:
- `MatrixBlock` (Phrase Maker) - *Primary reported issue*
- `TemperamentBlock`
- `TimbreBlock`
- `ArpeggioMatrixBlock`
- `PitchDrumMatrixBlock`
- `PitchSliderBlock`
- `MusicKeyboardBlock`
- `PitchStaircaseBlock`
- `RhythmRuler2Block`
- `ReflectionBlock`
- `LegoBricksBlock`
- `TempoBlock`

## Additional Improvements
- **JSDoc Updates**: All modified `flow` methods now have updated JSDoc documentation including the `receivedArg` parameter.
- **Lint Fixes**: Resolved existing and introduced `eqeqeq` (strict equality) warnings in `WidgetBlocks.js` to ensure the file is lint-clean.
- **Formatting**: The file has been formatted using `prettier` to match project standards.

## How to Test
1. Select any widget from the **Widget palette** (e.g., Phrase Maker or Rhythm Ruler).
2. Drag it onto the workspace.
3. Click the block once.
4. **Expected**: The widget should open its window/UI immediately on the first click.
5. **Verify**: Check the browser console to ensure no `TypeError` occurs during the process.

Fixes #6564 
- [x] Bug fix

https://github.com/user-attachments/assets/3b566cd8-b273-44f9-bcfc-ec9dd048550b

