### PR TITLE
Fix ReferenceError: HelpWidget is not defined in piemenuBlockContext

### DIFF
--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -969,14 +969,6 @@ class SVG {
             "bb|" +
             this._scale +
             "|" +
-            this._fill +
-            "|" +
-            this._stroke +
-            "|" +
-            this._strokeWidth +
-            "|" +
-            platformColor.blockText +
-            "|" +
             this._expandX +
             "|" +
             this._expandY +
@@ -1352,14 +1344,6 @@ class SVG {
             "boolcmp|" +
             this._scale +
             "|" +
-            this._fill +
-            "|" +
-            this._stroke +
-            "|" +
-            this._strokeWidth +
-            "|" +
-            platformColor.blockText +
-            "|" +
             this._expandX +
             "|" +
             this._expandY +
@@ -1484,14 +1468,6 @@ class SVG {
         const cacheKey =
             "bc|" +
             this._scale +
-            "|" +
-            this._fill +
-            "|" +
-            this._stroke +
-            "|" +
-            this._strokeWidth +
-            "|" +
-            platformColor.blockText +
             "|" +
             this._expandX +
             "|" +
@@ -1732,14 +1708,6 @@ class SVG {
         const cacheKey =
             "ac|" +
             this._scale +
-            "|" +
-            this._fill +
-            "|" +
-            this._stroke +
-            "|" +
-            this._strokeWidth +
-            "|" +
-            platformColor.blockText +
             "|" +
             this._expandX +
             "|" +

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -969,6 +969,14 @@ class SVG {
             "bb|" +
             this._scale +
             "|" +
+            this._fill +
+            "|" +
+            this._stroke +
+            "|" +
+            this._strokeWidth +
+            "|" +
+            platformColor.blockText +
+            "|" +
             this._expandX +
             "|" +
             this._expandY +
@@ -1344,6 +1352,14 @@ class SVG {
             "boolcmp|" +
             this._scale +
             "|" +
+            this._fill +
+            "|" +
+            this._stroke +
+            "|" +
+            this._strokeWidth +
+            "|" +
+            platformColor.blockText +
+            "|" +
             this._expandX +
             "|" +
             this._expandY +
@@ -1468,6 +1484,14 @@ class SVG {
         const cacheKey =
             "bc|" +
             this._scale +
+            "|" +
+            this._fill +
+            "|" +
+            this._stroke +
+            "|" +
+            this._strokeWidth +
+            "|" +
+            platformColor.blockText +
             "|" +
             this._expandX +
             "|" +
@@ -1708,6 +1732,14 @@ class SVG {
         const cacheKey =
             "ac|" +
             this._scale +
+            "|" +
+            this._fill +
+            "|" +
+            this._stroke +
+            "|" +
+            this._strokeWidth +
+            "|" +
+            platformColor.blockText +
             "|" +
             this._expandX +
             "|" +

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3853,9 +3853,13 @@ const piemenuBlockContext = block => {
     if (helpButton !== null) {
         wheel.navItems[helpButton].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
-            require(["widgets/help"], () => {
+            if (typeof HelpWidget !== "undefined") {
                 new HelpWidget(that, true);
-            });
+            } else {
+                require(["widgets/help"], () => {
+                    new HelpWidget(that, true);
+                });
+            }
             docById("contextWheelDiv").style.display = "none";
         };
     }

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3853,7 +3853,9 @@ const piemenuBlockContext = block => {
     if (helpButton !== null) {
         wheel.navItems[helpButton].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
-            new HelpWidget(that, true);
+            require(["widgets/help"], () => {
+                new HelpWidget(that, true);
+            });
             docById("contextWheelDiv").style.display = "none";
         };
     }


### PR DESCRIPTION
### Fix ReferenceError: HelpWidget is not defined in piemenuBlockContext

#### Summary
This PR resolves a `ReferenceError` that occurred when attempting to open the Help Widget from the block context menu before the global help system had been initialized.

#### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Others

#### Problem
In `js/piemenus.js`, the `HelpWidget` was instantiated directly inside the `navigateFunction` of the block pie menu. Because `widgets/help` is a lazy-loaded module, it was not guaranteed to be defined in the global scope when a user right-clicked a block on a fresh page load. This led to a "HelpWidget is not defined" console error and the widget failing to open.

#### Solution
Updated `js/piemenus.js` to wrap the `new HelpWidget(that, true)` call inside a RequireJS `require(["widgets/help"], ...)` callback. This ensures that the module is correctly loaded and the `HelpWidget` global is available before instantiation.

#### Category Checks
- [x] **Universal Availability**: Verified that the fix applies to all blocks across all palettes (Pitch, Rhythm, Flow, etc.).
- [x] **Independence of Palette State**: Confirmed that the fix works regardless of the specific block's category or palette state.

#### Verification
- Manually confirmed that right-clicking a block and selecting the '?' icon now correctly loads the module and opens the Help Widget on the first attempt.
- Verified that subsequent clicks are instantaneous due to module caching.

Fixes #6563
