### PR TITLE
fix: lazy-load HelpWidget in aux pie menu context

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3853,7 +3853,15 @@ const piemenuBlockContext = block => {
     if (helpButton !== null) {
         wheel.navItems[helpButton].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
-            new HelpWidget(that, true);
+            if (typeof HelpWidget === "undefined") {
+                if (typeof require !== "undefined") {
+                    require(["widgets/help"], function () {
+                        new HelpWidget(that, true);
+                    });
+                }
+            } else {
+                new HelpWidget(that, true);
+            }
             docById("contextWheelDiv").style.display = "none";
         };
     }


### PR DESCRIPTION
## Fix: Block help does not open from aux pie menu

Fixes #6563

### Problem

When invoking help from the right-click aux pie menu on a block, the help widget fails to open with:

```
Uncaught ReferenceError: HelpWidget is not defined
    at navigateFunction (piemenus.js:3856)
```

The `HelpWidget` class lives in `widgets/help.js`, which is not part of the eagerly loaded module list. It is loaded on demand via `lazyLoad("widgets/help")` when the toolbar help button is clicked (`activity.js`). However, the aux pie menu in `piemenus.js` references `HelpWidget` directly without ensuring the module is loaded first.

If the user opens help from the toolbar first, `HelpWidget` becomes available globally and the pie menu works — confirming the issue is strictly about missing lazy loading.

### Fix

Added a `typeof HelpWidget === "undefined"` guard in the pie menu help button handler. When the class is not yet available, it dynamically loads `widgets/help` via RequireJS `require()` before constructing the widget. If already loaded, it constructs immediately — no redundant loading.

This matches the same lazy-loading pattern used in `activity.js` for the toolbar help button.

### Changes

- **`js/piemenus.js`** — Lazy-load `widgets/help` before constructing `HelpWidget` in the aux pie menu context handler.

### Testing

1. Open Music Blocks without clicking the toolbar help button.
2. Right-click on any block to open the aux pie menu.
3. Click the `?` (help) button.
4. **Expected:** The help widget opens to the help page for that block.
5. **Before fix:** `ReferenceError: HelpWidget is not defined` in the console.



- [x] Bug fix