### PR TITLE
fix: lazy-load HelpWidget in aux pie menu context

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3853,8 +3853,17 @@ const piemenuBlockContext = block => {
     if (helpButton !== null) {
         wheel.navItems[helpButton].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
-            new HelpWidget(that, true);
-            docById("contextWheelDiv").style.display = "none";
+
+            const launchHelp = () => {
+                new HelpWidget(that, true);
+                docById("contextWheelDiv").style.display = "none";
+            };
+
+            if (typeof HelpWidget === "undefined" && typeof window.require === "function") {
+                window.require(["widgets/help"], launchHelp);
+            } else {
+                launchHelp();
+            }
         };
     }
 


### PR DESCRIPTION
- [x] Bug Fix : #6563 
This fixes where clicking the help (?) icon from a block's right-click pie menu crashes the app with a HelpWidget is not defined error.
The HelpWidget was already being lazy-loaded correctly for the main toolbar, but that logic was missing for the aux pie menu. I've updated the pie menu's click handler to safely lazy-load the widget on demand using window.require, which fixes the console error and correctly opens the block's help page.