### PR TITLE
Fix #6562: Release webcam stream tracks in doStopVideoCam

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1338,7 +1338,16 @@ function doStopVideoCam(cameraID, setCameraID) {
     }
 
     setCameraID(null);
-    document.querySelector("#camVideo").pause();
+    const video = document.querySelector("#camVideo");
+    if (video) {
+        video.pause();
+        if (video.srcObject) {
+            const tracks = video.srcObject.getTracks();
+            tracks.forEach(track => track.stop());
+            video.srcObject = null;
+        }
+    }
+    CameraManager.reset();
 }
 
 /**


### PR DESCRIPTION
Fixes #6562

## PR Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README

## Description
The camera stop helper previously paused the `#camVideo` element but left the underlying `MediaStream` tracks running. This resulted in the webcam remaining active and the privacy indicator light staying on. This PR ensures all tracks are explicitly stopped and the hardware is released.

## Changes Made
- **js/utils/utils.js**: Updated `doStopVideoCam()` to stop all `MediaStream` tracks and clear the `srcObject`.
- **js/utils/utils.js**: Added a call to `CameraManager.reset()` to synchronize the internal setup state.

## Testing Performed
- **Automated Tests**: Ran `npm test` and verified all tests passed.
- **Manual Test**: Verified in the browser that the hardware activity light turns off immediately upon stopping.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.