### PR TITLE
fix: remediate prototype pollution via __proto__ in generate

### DIFF
--- a/js/js-export/__tests__/generate.test.js
+++ b/js/js-export/__tests__/generate.test.js
@@ -261,12 +261,11 @@ describe("JSGenerate Class", () => {
             "background: greenyellow; color: midnightblue; font-weight: bold"
         );
     });
-  
+
     test("should generate stack trees with various block types and arguments", () => {
         globalActivity.blocks.stackList = [1, 20];
-        const booleanGrandParent = { constructor: { name: "BooleanBlock" } };
-        const booleanParent = Object.create(booleanGrandParent);
-        const booleanProtoblock = Object.create(booleanParent);
+        window.BooleanBlock = class BooleanBlock {};
+        const booleanProtoblock = new window.BooleanBlock();
         booleanProtoblock.style = "value";
         const standardGrandParent = { constructor: { name: "StandardBlock" } };
         const standardParent = Object.create(standardGrandParent);

--- a/js/js-export/generate.js
+++ b/js/js-export/generate.js
@@ -132,7 +132,8 @@ class JSGenerate {
                         if (JSInterface.isGetter(arg.name)) {
                             args.push([arg.name, null]);
                         } else if (
-                            Object.getPrototypeOf(Object.getPrototypeOf(arg.protoblock)).constructor.name === "BooleanBlock"
+                            window.BooleanBlock &&
+                            arg.protoblock instanceof window.BooleanBlock
                         ) {
                             if (arg.name === "boolean") {
                                 args.push("bool_" + arg.value);

--- a/js/js-export/generate.js
+++ b/js/js-export/generate.js
@@ -132,7 +132,7 @@ class JSGenerate {
                         if (JSInterface.isGetter(arg.name)) {
                             args.push([arg.name, null]);
                         } else if (
-                            arg.protoblock.__proto__.__proto__.constructor.name === "BooleanBlock"
+                            Object.getPrototypeOf(Object.getPrototypeOf(arg.protoblock)).constructor.name === "BooleanBlock"
                         ) {
                             if (arg.name === "boolean") {
                                 args.push("bool_" + arg.value);


### PR DESCRIPTION
- [x] Bug fix : #6587 

replaces direct proto traversal in generate.js with the much safer Object.getPrototypeOf() method. Relying on proto is discouraged and often flagged by security scanners as a prototype pollution risk . Our type-checking logic remains exactly the same, but it is now secure.
