### PR TITLE
Fix dark mode text contrast on sidebar blocks. Fixes #6590

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1260,11 +1260,13 @@ class Block {
                 artwork = that.artwork
                     .replace(/fill_color/g, DISABLEDFILLCOLOR)
                     .replace(/stroke_color/g, DISABLEDSTROKECOLOR)
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             } else {
                 artwork = that.artwork
                     .replace(/fill_color/g, PALETTEHIGHLIGHTCOLORS[that.protoblock.palette.name])
                     .replace(/stroke_color/g, HIGHLIGHTSTROKECOLORS[that.protoblock.palette.name])
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             }
 
@@ -1300,6 +1302,7 @@ class Block {
                 artwork = that.artwork
                     .replace(/fill_color/g, DISABLEDFILLCOLOR)
                     .replace(/stroke_color/g, DISABLEDSTROKECOLOR)
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             } else {
                 artwork = that.artwork
@@ -1308,6 +1311,7 @@ class Block {
                         platformColor.paletteColors[that.protoblock.palette.name][3]
                     )
                     .replace(/stroke_color/g, HIGHLIGHTSTROKECOLORS[that.protoblock.palette.name])
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             }
 
@@ -1340,11 +1344,13 @@ class Block {
                 artwork = that.artwork
                     .replace(/fill_color/g, DISABLEDFILLCOLOR)
                     .replace(/stroke_color/g, DISABLEDSTROKECOLOR)
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             } else {
                 artwork = that.artwork
                     .replace(/fill_color/g, platformColor.disconnected)
                     .replace(/stroke_color/g, HIGHLIGHTSTROKECOLORS[that.protoblock.palette.name])
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", safeSVG(block_label));
             }
 
@@ -1405,11 +1411,13 @@ class Block {
             artwork = this.artwork
                 .replace(/fill_color/g, DISABLEDFILLCOLOR)
                 .replace(/stroke_color/g, DISABLEDSTROKECOLOR)
+                .replace(/block_text_color/g, platformColor.blockText)
                 .replace("block_label", safeSVG(block_label));
         } else {
             artwork = this.artwork
                 .replace(/fill_color/g, PALETTEFILLCOLORS[this.protoblock.palette.name])
                 .replace(/stroke_color/g, PALETTESTROKECOLORS[this.protoblock.palette.name])
+                .replace(/block_text_color/g, platformColor.blockText)
                 .replace("block_label", safeSVG(block_label));
         }
 
@@ -1879,6 +1887,7 @@ class Block {
             that.blocks.blockCollapseArt[that.blockIndex] = that.collapseArtwork
                 .replace(/fill_color/g, PALETTEFILLCOLORS[that.protoblock.palette.name])
                 .replace(/stroke_color/g, PALETTESTROKECOLORS[that.protoblock.palette.name])
+                .replace(/block_text_color/g, platformColor.blockText)
                 .replace("block_label", safeSVG(that.collapseText.text));
 
             __processExpandButton(that);
@@ -1903,6 +1912,7 @@ class Block {
                 artwork
                     .replace(/fill_color/g, PALETTEHIGHLIGHTCOLORS[that.protoblock.palette.name])
                     .replace(/stroke_color/g, HIGHLIGHTSTROKECOLORS[that.protoblock.palette.name])
+                    .replace(/block_text_color/g, platformColor.blockText)
                     .replace("block_label", ""),
                 __processHighlightCollapseBitmap,
                 that
@@ -1912,6 +1922,7 @@ class Block {
         const artwork = this.collapseArtwork
             .replace(/fill_color/g, PALETTEFILLCOLORS[this.protoblock.palette.name])
             .replace(/stroke_color/g, PALETTESTROKECOLORS[this.protoblock.palette.name])
+            .replace(/block_text_color/g, platformColor.blockText)
             .replace("block_label", "");
         _blockMakeBitmap(artwork, __processCollapseBitmap, this);
     }

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -512,7 +512,7 @@ class SVG {
             '<text style="font-size:' +
             fontSize +
             "px;fill:" +
-            platformColor.blockText +
+            "block_text_color" +
             ";font-family:sans-serif;text-anchor:" +
             align +
             '">';

--- a/js/palette.js
+++ b/js/palette.js
@@ -1409,11 +1409,13 @@ class PaletteModel {
             artwork = artwork
                 .replace(/fill_color/g, DISABLEDFILLCOLOR)
                 .replace(/stroke_color/g, DISABLEDSTROKECOLOR)
+                .replace(/block_text_color/g, platformColor.blockText)
                 .replace("block_label", safeSVG(label));
         } else {
             artwork = artwork
                 .replace(/fill_color/g, PALETTEFILLCOLORS[protoBlock.palette.name])
                 .replace(/stroke_color/g, PALETTESTROKECOLORS[protoBlock.palette.name])
+                .replace(/block_text_color/g, platformColor.blockText)
                 .replace("block_label", safeSVG(label));
         }
 

--- a/js/themebox.js
+++ b/js/themebox.js
@@ -339,7 +339,6 @@ class ThemeBox {
                 if (block && block.protoblock && block.protoblock.palette) {
                     // Redraw block to update other colors
                     if (typeof block.regenerateArtwork === "function") {
-                        // Ensure blockfactory uses the correct theme information
                         block.regenerateArtwork(false);
                     }
                     // Update text color
@@ -458,6 +457,14 @@ class ThemeBox {
                             row.style.backgroundColor = platformColor.paletteBackground;
                         }
                     }
+                }
+
+                // Refresh the currently open palette menu so block artwork
+                // SVGs are regenerated with the updated blockText color.
+                const activeName = this.activity.palettes.activePalette;
+                if (activeName && this.activity.palettes.dict[activeName]) {
+                    this.activity.palettes.dict[activeName].hideMenu();
+                    this.activity.palettes.showPalette(activeName);
                 }
             } catch (e) {
                 console.debug("Could not refresh palette:", e);


### PR DESCRIPTION
## Description

Fixes #6590
Fixes #6566 

When toggling between light/dark/high-contrast themes, the **block text labels** (e.g., `repeat`, `forever`, `note`, `pitch`) did not update their color dynamically. The block backgrounds changed correctly, but the text remained the color from the previous theme, making it nearly invisible on dark block backgrounds. A manual browser refresh was the only way to see the correct text color.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README


## Root Cause

Block shapes use placeholder tokens (`fill_color`, `stroke_color`) in their SVG strings that get replaced with actual theme colors at render time. However, the text fill color in `blockfactory.js`'s `text()` method was resolving `platformColor.blockText` directly at SVG generation time, baking the color (e.g., `#282828`) into the SVG string. When the theme changed, the block background placeholders were correctly replaced with new colors, but the text color was already a hardcoded hex value — not a placeholder — so it was never updated.

## Solution

Replaced the hardcoded `platformColor.blockText` in `blockfactory.js`'s `text()` method with a placeholder string `"block_text_color"`, matching the existing pattern used by `fill_color` and `stroke_color`. Then added `.replace(/block_text_color/g, platformColor.blockText)` alongside every existing `fill_color`/`stroke_color` replacement in `block.js` and `palette.js`, so the text color is always resolved from the current theme at render time. Also added a palette menu refresh in `themebox.js` so any open palette sidebar regenerates its block previews with the updated color on theme switch.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
