### PR TITLE
Fix #6593: Resolve Promise being passed to project loading in Planet close flow

### DIFF
--- a/planet/js/LocalPlanet.js
+++ b/planet/js/LocalPlanet.js
@@ -48,8 +48,7 @@ class LocalPlanet {
         this.projects = [];
 
         for (const project in this.ProjectTable) {
-            // eslint-disable-next-line no-prototype-builtins
-            if (this.ProjectTable.hasOwnProperty(project)) {
+            if (Object.prototype.hasOwnProperty.call(this.ProjectTable, project)) {
                 this.projects.push([project, null]);
             }
         }
@@ -78,7 +77,7 @@ class LocalPlanet {
             if (this.projects[i][0] === this.currentProjectID) index = i;
         }
 
-        if (index != -1) {
+        if (index !== -1) {
             const id = `local-project-image-${this.projects[index][0]}`;
 
             const cardimg = document.getElementById(id);
@@ -116,12 +115,12 @@ class LocalPlanet {
         Planet.loadProjectFromData(this.ProjectTable[id].ProjectData);
     }
 
-    mergeProject(id) {
+    async mergeProject(id) {
         const Planet = this.Planet;
-        const d = this.ProjectStorage.getCurrentProjectData();
+        const d = await Planet.ProjectStorage.getCurrentProjectData();
 
         if (d === null) {
-            this.ProjectStorage.initialiseNewProject();
+            await Planet.ProjectStorage.initialiseNewProject();
             Planet.loadProjectFromData(this.ProjectTable[id].ProjectData);
         } else Planet.loadProjectFromData(this.ProjectTable[id].ProjectData, true);
     }

--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -123,9 +123,9 @@ class Planet {
         );
     }
 
-    closeButton() {
+    async closeButton() {
         if (this.ProjectStorage.getCurrentProjectID() !== this.oldCurrentProjectID) {
-            const data = this.ProjectStorage.getCurrentProjectData();
+            const data = await this.ProjectStorage.getCurrentProjectData();
             !data ? this.loadNewProject() : this.loadProjectFromData(data);
         } else this.planetClose();
     }


### PR DESCRIPTION
Fixes #6593

## PR Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README

## Description
Since the migration of `ProjectStorage.getCurrentProjectData()` to an `async` function (utilizing `localforage`), several synchronous callers were inadvertently passing the resulting `Promise` to `loadProjectFromData()` instead of the resolved project JSON. This was most noticeable when closing the "Planet" (cloud) subsystem immediately after switching projects, leading to a crash or failed load.

This PR ensures these calls are properly `await`ed and also corrects a reference error discovered in `LocalPlanet.js`.

## Changes Made
- **planet/js/Planet.js**: Updated `closeButton()` to be `async` and `await` the project data.
- **planet/js/LocalPlanet.js**: Updated `mergeProject()` to be `async` and added `await` for project data.
- **planet/js/LocalPlanet.js**: Fixed a reference error where `this.ProjectStorage` was used instead of `this.Planet.ProjectStorage`.
- **planet/js/LocalPlanet.js**: Fixed minor linting issues (`eqeqeq` and unused `eslint-disable`) identified during pre-commit checks.

## Testing Performed
- **Automated Tests**: Ran `npm test js/__tests__/planetInterface.test.js` and verified all 21 tests passed.
- **Manual Test**: Verified in the browser that switching projects and then closing the Planet modal correctly loads the new project without console errors.
- **Manual Test**: Verified the "Merge" functionality in the "Local" tab.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.