### PR TITLE
Security: Add rel="noopener noreferrer" to external link in Planet module

### DIFF
--- a/planet/js/StringHelper.js
+++ b/planet/js/StringHelper.js
@@ -67,7 +67,7 @@ class StringHelper {
             [
                 "projectviewer-report-conduct",
                 _(
-                    'Report projects which violate the <a href="https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md" target="_blank">Sugar Labs Code of Conduct</a>.'
+                    'Report projects which violate the <a href="https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md" target="_blank" rel="noopener noreferrer">Sugar Labs Code of Conduct</a>.'
                 )
             ],
             ["projectviewer-report-reason", _("Reason for reporting project")],


### PR DESCRIPTION
## Description
This PR adds `rel="noopener noreferrer"` to the external Code of Conduct link in the Planet module's reporting dialog.

## Why it matters
- **Security:** Prevents "tabnabbing" attacks where the opened page could redirect the original tab to a phishing site via `window.opener`.
- **Performance:** Ensures the new tab runs in a separate process, preventing it from slowing down the main application.
- **Best Practice:** Aligns with modern web security standards (OWASP, Google Lighthouse).

## Changes Made
- Updated `planet/js/StringHelper.js` to include `rel="noopener noreferrer"` on the dynamically rendered external link.

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation
- [x] Security
- [x] Refactor / Maintenance

## Testing
- [x] Link still opens correctly in a new tab
- [x] Follows standard HTML5 security practices