### PR TITLE
perf: mark wheel event listeners as passive to fix scroll-blocking violations (fixes #6597)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3115,7 +3115,7 @@ class Activity {
             this.addEventListener(window, "mousedown", this._resetIdleTimer);
             this.addEventListener(window, "keydown", this._resetIdleTimer);
             this.addEventListener(window, "touchstart", this._resetIdleTimer);
-            this.addEventListener(window, "wheel", this._resetIdleTimer);
+            this.addEventListener(window, "wheel", this._resetIdleTimer, { passive: true });
 
             // Periodic check for idle state - store interval ID for cleanup
             this._idleWatcherInterval = setInterval(() => {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -265,8 +265,8 @@ class WidgetWindow {
         };
 
         this._widget = this._create("div", "wfbWidget", this._body);
-        this._widget.addEventListener("wheel", disableScroll, false);
-        this._widget.addEventListener("DOMMouseScroll", disableScroll, false);
+        this._widget.addEventListener("wheel", disableScroll, { passive: true });
+        this._widget.addEventListener("DOMMouseScroll", disableScroll, { passive: true });
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes #6597 — Non-passive wheel event listeners causing scroll-blocking performance warnings.

## PR Category

- [x] Performance

## Problem

On every page load, Chrome DevTools reported two `[Violation]` warnings:

```
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event.
Consider marking event handler as 'passive' to make the page more responsive.
```

The browser had to wait to check if `preventDefault()` would be called before allowing scroll to proceed, causing potential scroll lag.

## Changes Made

- **`js/activity.js`** — Added `{ passive: true }` to the `wheel` listener used for idle timer reset
- **`js/widgets/widgetWindows.js`** — Added `{ passive: true }` to the `wheel` and `DOMMouseScroll` listeners in `disableScroll`

Neither handler calls `preventDefault()`, so marking them passive is safe with no behavior change.

## Testing Performed

- ✅ Loaded the app locally — zero `[Violation]` warnings in the console
- ✅ Scrolling behavior unchanged
- ✅ Widget scroll lock still works correctly

## Checklist

- [x] I have tested these changes locally and they work as expected
- [x] I have run `npm run lint` with no errors
- [x] I have run `npx prettier --check .` with no errors

### Before (violations present)
<img width="819" height="588" alt="Screenshot 2026-04-14 at 3 27 35 PM" src="https://github.com/user-attachments/assets/6da674e6-798a-477d-8ca3-fbccb85d9947" />


### After (violations resolved)
<!-- Add screenshot showing clean console with no [Violation] warnings -->
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 3 37 35 PM" src="https://github.com/user-attachments/assets/20c5bd94-7058-481f-8a6e-61e37a16f702" />

