### PR TITLE
feat: add touch handlers to musickeyboard and rhythmruler widgets (Related to #6603)

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1454,6 +1454,11 @@ function MusicKeyboard(activity) {
                     }
                 };
 
+                cell.ontouchstart = e => {
+                    e.preventDefault();
+                    cell.onmousedown(e.touches[0]);
+                };
+
                 cell.onmouseover = () => {
                     // let obj, i, j;
                     // obj = cell.id.split(":");
@@ -1471,6 +1476,11 @@ function MusicKeyboard(activity) {
                 };
 
                 cell.onmouseup = function () {
+                    isMouseDown = false;
+                };
+
+                cell.ontouchend = function (e) {
+                    e.preventDefault();
                     isMouseDown = false;
                 };
             }

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -1260,6 +1260,12 @@ class RhythmRuler {
         cell.removeEventListener("mouseup", __mouseUpHandler);
         cell.addEventListener("mouseup", __mouseUpHandler);
 
+        cell.removeEventListener("touchstart", __mouseDownHandler);
+        cell.addEventListener("touchstart", __mouseDownHandler, { passive: true });
+
+        cell.removeEventListener("touchend", __mouseUpHandler);
+        cell.addEventListener("touchend", __mouseUpHandler, { passive: true });
+
         cell.removeEventListener("click", __clickHandler);
         cell.addEventListener("click", __clickHandler);
     }


### PR DESCRIPTION
Adds touch event handlers to widget grid cells that previously only responded to mouse events.

## Changes
- `js/widgets/musickeyboard.js`: add ontouchstart/ontouchend to note grid cells
- `js/widgets/rhythmruler.js`: mirror mousedown/mouseup with touchstart/touchend (passive) on rhythm cells

## Testing
- ✅ All tests pass (25/25)
- ✅ Music keyboard grid cells respond to touch
- ✅ Rhythm ruler cells respond to touch
- ✅ Desktop mouse behavior unchanged

## Demo

https://github.com/user-attachments/assets/aedbe128-1c01-4d60-92d6-6e49391aedaa



## Category
- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Related
Part of #6603. Companion PRs: pinch-to-zoom, mobile-scaling, mobile-editing-layout, mobile-palette-drawer, touch-drag-threshold.
