### PR TITLE
fix: sanitize built-in plugin name prompt (Related to CVE-14)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6792,7 +6792,11 @@ class Activity {
                 // Validate: only allow safe characters (alphanumeric and hyphens)
                 // This prevents path traversal attacks like "../../secrets"
                 if (!/^[a-z0-9\-]+$/.test(name)) {
-                    alert(_("Invalid plugin name. Only alphanumeric characters and hyphens are allowed."));
+                    alert(
+                        _(
+                            "Invalid plugin name. Only alphanumeric characters and hyphens are allowed."
+                        )
+                    );
                     return;
                 }
                 this._loadBuiltInPlugin(name);

--- a/js/activity.js
+++ b/js/activity.js
@@ -6780,14 +6780,22 @@ class Activity {
 
         this._doOpenPlugin = () => {
             this.toolbar.closeAuxToolbar(showHideAuxMenu);
-            const name = prompt(
+            const rawName = prompt(
                 _("Enter the name of a built-in plugin, or leave blank to upload a plugin file:")
             );
-            if (name === null) {
+            if (rawName === null) {
                 return; // User cancelled the operation
             }
-            if (name.trim() !== "") {
-                this._loadBuiltInPlugin(name.trim().toLowerCase());
+
+            const name = rawName.trim().toLowerCase();
+            if (name !== "") {
+                // Validate: only allow safe characters (alphanumeric and hyphens)
+                // This prevents path traversal attacks like "../../secrets"
+                if (!/^[a-z0-9\-]+$/.test(name)) {
+                    alert(_("Invalid plugin name. Only alphanumeric characters and hyphens are allowed."));
+                    return;
+                }
+                this._loadBuiltInPlugin(name);
             } else {
                 this.pluginChooser.focus();
                 this.pluginChooser.click();

--- a/js/activity.js
+++ b/js/activity.js
@@ -6789,12 +6789,12 @@ class Activity {
 
             const name = rawName.trim().toLowerCase();
             if (name !== "") {
-                // Validate: only allow safe characters (alphanumeric and hyphens)
+                // Validate: only allow safe characters (alphanumeric, hyphens, and underscores)
                 // This prevents path traversal attacks like "../../secrets"
-                if (!/^[a-z0-9\-]+$/.test(name)) {
+                if (!/^[a-z0-9\-_]+$/.test(name)) {
                     alert(
                         _(
-                            "Invalid plugin name. Only alphanumeric characters and hyphens are allowed."
+                            "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
                         )
                     );
                     return;


### PR DESCRIPTION
- [x] Bug Fix ; #6620 
fixes a potential directory traversal vulnerability in the plugin loader. Previously, the prompt() input was used directly to build a file path, which could be exploited with inputs like ../../.