### PR TITLE
Fix Music Keyboard restoring stale global key handlers on close. Fixes #6628

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -1,0 +1,78 @@
+global.localStorage = {
+    beginnerMode: "false"
+};
+
+const MusicKeyboard = require("../musickeyboard.js");
+
+describe("MusicKeyboard document key handler lifecycle", () => {
+    let originalOnKeyDown;
+    let originalOnKeyUp;
+
+    beforeEach(() => {
+        originalOnKeyDown = document.onkeydown;
+        originalOnKeyUp = document.onkeyup;
+        document.onkeydown = null;
+        document.onkeyup = null;
+    });
+
+    afterEach(() => {
+        document.onkeydown = originalOnKeyDown;
+        document.onkeyup = originalOnKeyUp;
+    });
+
+    test("captures the handlers active when the keyboard is opened", () => {
+        const firstHandler = jest.fn();
+        const newerHandler = jest.fn();
+        const newerKeyUpHandler = jest.fn();
+
+        document.onkeydown = firstHandler;
+        const keyboard = new MusicKeyboard({});
+
+        document.onkeydown = newerHandler;
+        document.onkeyup = newerKeyUpHandler;
+
+        keyboard._cacheDocumentKeyHandlers();
+
+        document.onkeydown = jest.fn();
+        document.onkeyup = jest.fn();
+        keyboard._restoreDocumentKeyHandlers();
+
+        expect(document.onkeydown).toBe(newerHandler);
+        expect(document.onkeyup).toBe(newerKeyUpHandler);
+    });
+
+    test("does not overwrite the saved handlers after the first snapshot", () => {
+        const preservedOnKeyDown = jest.fn();
+        const preservedOnKeyUp = jest.fn();
+
+        document.onkeydown = preservedOnKeyDown;
+        document.onkeyup = preservedOnKeyUp;
+
+        const keyboard = new MusicKeyboard({});
+
+        keyboard._cacheDocumentKeyHandlers();
+        document.onkeydown = null;
+        document.onkeyup = jest.fn();
+        keyboard._cacheDocumentKeyHandlers();
+        keyboard._restoreDocumentKeyHandlers();
+
+        expect(document.onkeydown).toBe(preservedOnKeyDown);
+        expect(document.onkeyup).toBe(preservedOnKeyUp);
+    });
+
+    test("clears the saved snapshot after restoring handlers", () => {
+        const previousOnKeyDown = jest.fn();
+        const previousOnKeyUp = jest.fn();
+
+        document.onkeydown = previousOnKeyDown;
+        document.onkeyup = previousOnKeyUp;
+
+        const keyboard = new MusicKeyboard({});
+
+        keyboard._cacheDocumentKeyHandlers();
+        keyboard._restoreDocumentKeyHandlers();
+
+        expect(keyboard._savedDocumentOnKeyDown).toBeUndefined();
+        expect(keyboard._savedDocumentOnKeyUp).toBeUndefined();
+    });
+});

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -57,9 +57,6 @@ function MusicKeyboard(activity) {
     const WHITEKEYS = [65, 83, 68, 70, 71, 72, 74, 75, 76];
     const SPACE = 32;
 
-    const saveOnKeyDown = document.onkeydown;
-    const saveOnKeyUp = document.onkeyup;
-
     const w = window.innerWidth;
     /**
      * Reference to the activity associated with the keyboard.
@@ -91,11 +88,40 @@ function MusicKeyboard(activity) {
      */
     this._stopOrCloseClicked = false;
 
+    this._savedDocumentOnKeyDown = undefined;
+    this._savedDocumentOnKeyUp = undefined;
+
     /**
      * Flag indicating whether playback is currently active.
      * @type {boolean}
      */
     this.playingNow = false;
+
+    this._cacheDocumentKeyHandlers = function () {
+        if (
+            this._savedDocumentOnKeyDown !== undefined ||
+            this._savedDocumentOnKeyUp !== undefined
+        ) {
+            return;
+        }
+
+        this._savedDocumentOnKeyDown = document.onkeydown;
+        this._savedDocumentOnKeyUp = document.onkeyup;
+    };
+
+    this._restoreDocumentKeyHandlers = function () {
+        if (
+            this._savedDocumentOnKeyDown === undefined &&
+            this._savedDocumentOnKeyUp === undefined
+        ) {
+            return;
+        }
+
+        document.onkeydown = this._savedDocumentOnKeyDown;
+        document.onkeyup = this._savedDocumentOnKeyUp;
+        this._savedDocumentOnKeyDown = undefined;
+        this._savedDocumentOnKeyUp = undefined;
+    };
 
     /**
      * Array of instruments.
@@ -480,6 +506,7 @@ function MusicKeyboard(activity) {
             //event.preventDefault();
         };
 
+        this._cacheDocumentKeyHandlers();
         document.onkeydown = __keyboarddown;
         document.onkeyup = __keyboardup;
     };
@@ -630,8 +657,7 @@ function MusicKeyboard(activity) {
          */
         widgetWindow.onclose = () => {
             let myNode;
-            document.onkeydown = saveOnKeyDown;
-            document.onkeyup = saveOnKeyUp;
+            this._restoreDocumentKeyHandlers();
 
             if (document.getElementById("keyboardHolder2")) {
                 document.getElementById("keyboardHolder2").style.display = "none";
@@ -2666,6 +2692,7 @@ function MusicKeyboard(activity) {
      * It sets up event handling for key presses on the keyboard.
      */
     this._createKeyboard = function () {
+        this._cacheDocumentKeyHandlers();
         document.onkeydown = null;
         const mkbKeyboardDiv = this.keyboardDiv;
         mkbKeyboardDiv.style.display = "flex";
@@ -3512,4 +3539,8 @@ function MusicKeyboard(activity) {
          */
         navigator.requestMIDIAccess({ sysex: true }).then(onMIDISuccess, onMIDIFailure);
     };
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = MusicKeyboard;
 }


### PR DESCRIPTION
## Description

Fixes #6628

Closing the Music Keyboard widget could restore stale global keyboard handlers and break keyboard behavior in other widgets that were still open. The problem came from snapshotting `document.onkeydown` and `document.onkeyup` too early, at construction time, and then restoring that stale snapshot later on close.

## PR Category

-   [x] Bug Fix - Fixes a bug or incorrect behavior
-   [ ] Feature - Adds new functionality
-   [ ] Performance - Improves performance (load time, memory, rendering, etc.)
-   [x] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README

## Root Cause

`MusicKeyboard` saved `document.onkeydown` and `document.onkeyup` once in the constructor, before the widget actually took over keyboard input. If another widget changed the global keyboard handlers afterward, closing Music Keyboard restored the older constructor-time snapshot and overwrote the newer handlers.

## Solution

Replaced the constructor-time snapshot with per-open handler caching. Music Keyboard now stores the current `document.onkeydown` and `document.onkeyup` handlers right before it overrides them, restores that snapshot on close, and clears the saved snapshot after restoration. Added focused regression tests to cover snapshot timing, stale-handler protection, and cleanup after restore.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run the relevant local checks with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Validation

-   `npx jest js/widgets/__tests__/musickeyboard.test.js --runInBand --coverage=false`
