### PR TITLE
fix: restore previous onkeydown handler when HelpWidget closes

### DIFF
--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -226,13 +226,15 @@ describe("HelpWidget", () => {
             expect(mockWidgetWindow.destroy).toHaveBeenCalled();
         });
 
-        test("onclose restores document.onkeydown", () => {
+        test("onclose restores document.onkeydown to the handler active before Help opened", () => {
             const activity = createMockActivity();
-            new HelpWidget(activity, false);
+            const prevHandler = jest.fn();
+            document.onkeydown = prevHandler;
 
+            new HelpWidget(activity, false);
             mockWidgetWindow.onclose();
 
-            expect(document.onkeydown).toBe(activity.__keyPressed);
+            expect(document.onkeydown).toBe(prevHandler);
         });
 
         test("calls windowFor with correct arguments", () => {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -41,6 +41,7 @@ class HelpWidget {
         this.appendedBlockList = [];
         this.index = 0;
         this.isOpen = true;
+        this._prevKeyHandler = document.onkeydown;
 
         const widgetWindow = window.widgetWindows.windowFor(this, "help", "help", false);
         //widgetWindow.getWidgetBody().style.overflowY = "auto";
@@ -51,7 +52,7 @@ class HelpWidget {
         widgetWindow.show();
         widgetWindow.onclose = () => {
             this.isOpen = false;
-            document.onkeydown = activity.__keyPressed;
+            document.onkeydown = this._prevKeyHandler;
             widgetWindow.destroy();
             // Trigger the hint only if they were on the first page of the tour
             if (this.index === 0 && typeof this.activity.textMsg === "function") {


### PR DESCRIPTION
## Description

Closing the Help widget was unconditionally resetting `document.onkeydown`
to `activity.__keyPressed`, which clobbered any keyboard handler installed
by another widget (e.g. Music Keyboard) that was active before Help opened.

The fix snapshots `document.onkeydown` in the constructor before Help takes
over arrow-key navigation, then restores that exact snapshot on close.

## Related Issue

This PR fixes #6631

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   `js/widgets/help.js` — snapshot `document.onkeydown` into `this._prevKeyHandler` in the constructor; restore it on close instead of hardcoding `activity.__keyPressed`
-   `js/widgets/__tests__/help.test.js` — updated existing `onclose` test to assert the correct restore behavior

## Testing Performed

-   `npm run lint` — no errors
-   `npx prettier --check js/widgets/help.js` — clean
-   `npm test` — 4571/4571 tests pass

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes for Reviewers

The snapshot is taken once in the constructor — the earliest reliable moment before Help touches `document.onkeydown`. This covers both the tour flow (`_setup`) and the block-help flow (`_blockHelp`), since both are triggered after construction.
