### PR TITLE
Fix sampler and AI debugger widget opening

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -87,7 +87,7 @@ function setupWidgetBlocks(activity) {
 
     /**
      * Ensures that a widget is loaded and initialized before executing block logic.
-     * If the widget is null, it initiates a lazy load and returns an interruption signal.
+     * If the widget is missing, it initiates a lazy load and returns an interruption signal.
      *
      * @param {object} logo - The logo object.
      * @param {string} widgetKey - The key for the widget in the logo object.
@@ -99,7 +99,7 @@ function setupWidgetBlocks(activity) {
      * @returns {[null, number, boolean]|null} - Interruption signal or null if already loaded.
      */
     function _ensureWidget(logo, widgetKey, modules, initFn, turtle, blk, receivedArg) {
-        if (logo[widgetKey] === null) {
+        if (logo[widgetKey] === null || logo[widgetKey] === undefined) {
             logo[widgetKey] = "loading"; // Guard against multiple simultaneous loads
             _lazyRequire(modules, function () {
                 logo[widgetKey] = initFn();
@@ -412,7 +412,18 @@ function setupWidgetBlocks(activity) {
          * @param {object} blk - The block object.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
+        flow(args, logo, turtle, blk, receivedArg) {
+            const interruption = _ensureWidget(
+                logo,
+                "sample",
+                ["widgets/sampler"],
+                () => new SampleWidget(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
+
             logo.inSample = true;
 
             const listenerName = "_sampler_" + turtle;
@@ -2013,14 +2024,23 @@ function setupWidgetBlocks(activity) {
          * @param {object} blk - The block object.
          * @returns {number[]} - The output values.
          */
-        flow(args, logo, turtle, blk) {
-            logo.inSample = true;
+        flow(args, logo, turtle, blk, receivedArg) {
+            const interruption = _ensureWidget(
+                logo,
+                "aiDebugger",
+                ["widgets/aidebugger"],
+                () => new AIDebuggerWidget(),
+                turtle,
+                blk,
+                receivedArg
+            );
+            if (interruption) return interruption;
 
-            const listenerName = "_sampler_" + turtle;
+            const listenerName = "_aidebugger_" + turtle;
             logo.setDispatchBlock(blk, turtle, listenerName);
 
             const __listener = event => {
-                logo.sample.init(activity);
+                logo.aiDebugger.init(activity);
             };
 
             logo.setTurtleListener(turtle, listenerName, __listener);

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -118,6 +118,7 @@ global.TimbreWidget = jest.fn(() => ({
     init: jest.fn()
 }));
 global.SampleWidget = jest.fn(() => ({ init: jest.fn() }));
+global.AIDebuggerWidget = jest.fn(() => ({ init: jest.fn() }));
 global.TemperamentWidget = jest.fn(() => ({
     inTemperament: null,
     scale: null,
@@ -208,6 +209,7 @@ const createMockLogo = () => {
         tempo: null,
         timbre: null,
         sample: null,
+        aiDebugger: null,
         temperament: null,
         meterWidget: null,
         modeWidget: null,
@@ -232,6 +234,8 @@ describe("setupWidgetBlocks", () => {
     beforeEach(() => {
         activity = createMockActivity();
         logo = createMockLogo();
+        global.SampleWidget.mockClear();
+        global.AIDebuggerWidget.mockClear();
         global.instrumentsEffects[0] = {};
         global.instrumentsFilters[0] = {};
         setupWidgetBlocks(activity);
@@ -405,12 +409,69 @@ describe("setupWidgetBlocks", () => {
     });
 
     describe("SamplerBlock", () => {
-        it("initializes sample widget and returns child block", () => {
+        it("lazy-loads sample widget and returns child block on replay", () => {
             const sampler = getBlock("sampler");
+
+            const interruption = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
+            expect(interruption).toEqual([null, 0, true]);
+            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
+                logo,
+                0,
+                "samplerBlk",
+                true,
+                "received"
+            );
+
             const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk");
             expect(logo.inSample).toBe(true);
             expect(logo.sample).toBeDefined();
             expect(result).toEqual(["childBlk", 1]);
+        });
+
+        it("lazy-loads sample widget when logo.sample is undefined", () => {
+            const sampler = getBlock("sampler");
+            delete logo.sample;
+
+            const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
+
+            expect(result).toEqual([null, 0, true]);
+            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
+            expect(logo.sample).toBeDefined();
+        });
+    });
+
+    describe("AIDebuggerBlock", () => {
+        it("uses its own widget instance instead of sampler state", () => {
+            const sampler = getBlock("sampler");
+            const aiDebugger = getBlock("aidebugger");
+
+            sampler.flow(["childBlk"], logo, 0, "samplerBlk");
+            sampler.flow(["childBlk"], logo, 0, "samplerBlk");
+            aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk");
+            aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk");
+
+            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
+            expect(global.AIDebuggerWidget).toHaveBeenCalledTimes(1);
+            expect(logo.sample).toBeDefined();
+            expect(logo.aiDebugger).toBeDefined();
+            expect(logo.sample).not.toBe(logo.aiDebugger);
+            expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
+        });
+
+        it("does not depend on sampler state being initialized", () => {
+            const aiDebugger = getBlock("aidebugger");
+
+            const interruption = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk", "received");
+            expect(interruption).toEqual([null, 0, true]);
+            expect(global.AIDebuggerWidget).toHaveBeenCalledTimes(1);
+            expect(logo.aiDebugger).toBeDefined();
+            expect(logo.sample).toBeNull();
+            expect(logo.inSample).toBe(false);
+
+            const result = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk");
+            expect(result).toEqual(["childBlk", 1]);
+            expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
         });
     });
 


### PR DESCRIPTION
### Description
Fix sampler and AI debugger widget not opening issue by giving each widget its own lazy-loaded runtime state.

### Changes

- Treat missing widget state as unloaded in shared widget setup.
- Lazy-load sampler through logo.sample.
- Lazy-load AI debugger through logo.aiDebugger instead of sampler state.
- Add regression tests for sampler opening and sampler/debugger state separation.

### Verification
npx lint-staged
npm test -- --runTestsByPath js/blocks/__tests__/WidgetBlocks.test.js

**Before:**

https://github.com/user-attachments/assets/5db9fc83-fff9-4da4-a44d-8682a08b3eaf


**After:**

https://github.com/user-attachments/assets/2a531aa5-fdf2-4f4c-a87d-5616eb3776e5




- [x] Bug fix