### PR TITLE
perf(utils): add retry limit to autocomplete setup polling

### DIFF
--- a/js/utils/jquery-setup.js
+++ b/js/utils/jquery-setup.js
@@ -29,6 +29,9 @@ jQuery(document).ready(function () {
 
 // Fix autocomplete dropdown position to stay anchored to the search input.
 jQuery(document).ready(function () {
+    let retries = 0;
+    const MAX_RETRIES = 20;
+
     const fixAutocompletePosition = function () {
         const $search = jQuery("#search");
         if ($search.length && $search.data("ui-autocomplete")) {
@@ -50,7 +53,8 @@ jQuery(document).ready(function () {
                     }, 0);
                 };
             }
-        } else {
+        } else if (retries < MAX_RETRIES) {
+            retries++;
             setTimeout(fixAutocompletePosition, 500);
         }
     };

--- a/js/utils/jquery-setup.js
+++ b/js/utils/jquery-setup.js
@@ -56,6 +56,10 @@ jQuery(document).ready(function () {
         } else if (retries < MAX_RETRIES) {
             retries++;
             setTimeout(fixAutocompletePosition, 500);
+        } else {
+            console.error(
+                `Autocomplete setup failed: Could not initialize ui-autocomplete on #search after ${MAX_RETRIES} retries.`
+            );
         }
     };
     setTimeout(fixAutocompletePosition, 1000);


### PR DESCRIPTION
## Description
This pull request fixes a performance bug where `jquery-setup.js` would keep polling the DOM forever if the `#search` UI autocomplete didn't start up or if the element wasn't on the current page layout. 

The script safely backs off after 10 seconds of polling by adding a retry upper bound (`MAX_RETRIES = 20`). This stops the background from looping forever and saves the user's CPU and memory cycles.

## Related Issues
Fixes #6634 

## Changes
* `js/utils/jquery-setup.js`: Introduced a `retries` tracking variable and a `MAX_RETRIES` constant.
* Modified the recursive `else` block to only execute `setTimeout` if `retries < MAX_RETRIES`.

## How Has This Been Tested?
* Verified that when the element initializes locally, the DOM rendering intercepts perfectly.
* Simulated an autocomplete failure and verified via the javascript profiler that the function safely terminates and ceases execution after the maximum number of retries is hit, instead of endlessly looping.

## Checklist
- [x] I have read and followed the project's code of conduct.
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] My code follows the project's code style and passes `npm run lint`.
- [x] I have tested my changes locally.

## PR Category
- [x] Performance