### PR TITLE
fix(security): sanitize plugin name to prevent path traversal in _loadBuiltInPlugin

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6783,7 +6783,17 @@ class Activity {
         };
 
         this._loadBuiltInPlugin = name => {
-            const url = "plugins/" + name + ".json";
+            // Sanitize the plugin name to prevent path-traversal attacks
+            // (e.g. "../../sensitive-file").  Only allow alphanumeric
+            // characters, hyphens, and underscores — the characters that
+            // appear in legitimate plugin basenames.
+            const safeName = name.replace(/[^a-z0-9_-]/g, "");
+            if (safeName.length === 0) {
+                console.error("Invalid plugin name: " + name);
+                return;
+            }
+
+            const url = "plugins/" + safeName + ".json";
             const xhr = new XMLHttpRequest();
             xhr.open("GET", url, true);
             const that = this;


### PR DESCRIPTION
Closes #6620

## Summary

The `_loadBuiltInPlugin` method in `js/activity.js` constructs a fetch URL directly from unsanitized user input obtained via `prompt()`. An attacker or malicious script could supply a path-traversal payload like `../../sensitive-file` to force the application to request files outside the intended `plugins/` directory.

## Root Cause

```javascript
// BEFORE — user input used directly in URL construction
this._loadBuiltInPlugin = name => {
    const url = "plugins/" + name + ".json";  // ❌ No sanitization
    // ...
};
```

An input of `../../etc/passwd` would produce the URL `plugins/../../etc/passwd.json`, escaping the `plugins/` directory entirely.

## Fix

Added an allowlist regex that strips all characters except `[a-z0-9_-]` from the plugin name before constructing the URL. This ensures the path can never escape the `plugins/` directory. An empty result after sanitization is rejected with an error log.

```javascript
// AFTER — only safe characters survive
this._loadBuiltInPlugin = name => {
    const safeName = name.replace(/[^a-z0-9_-]/g, "");
    if (safeName.length === 0) {
        console.error("Invalid plugin name: " + name);
        return;
    }
    const url = "plugins/" + safeName + ".json";  // ✅ Safe
    // ...
};
```

### Why this approach
- **Allowlist > blocklist**: Rather than trying to detect `..` or `/` (which can be bypassed via encoding tricks), we only permit the characters that legitimate plugin names use.
- **Minimal change**: The fix is 10 lines in a single function — no behavioral changes for valid plugin names.
- The caller (`_doOpenPlugin`) already calls `.trim().toLowerCase()`, so by the time the name reaches `_loadBuiltInPlugin`, the regex `[a-z0-9_-]` covers all valid inputs.

## PR Category
- [x] Bug Fix
- [x] Security
- [ ] Feature
- [ ] Tests
- [ ] Documentation

## Impact

| Input | Before | After |
|---|---|---|
| `my-plugin` | ✅ `plugins/my-plugin.json` | ✅ `plugins/my-plugin.json` |
| `../../etc/passwd` | 🔴 `plugins/../../etc/passwd.json` | ✅ `plugins/etcpasswd.json` |
| `../secret` | 🔴 `plugins/../secret.json` | ✅ `plugins/secret.json` |
| ` ` (empty) | 🔴 `plugins/.json` | ✅ Rejected with error log |

## Files Changed
- `js/activity.js` — `_loadBuiltInPlugin()`: added input sanitization via allowlist regex
