### PR TITLE
[fix]: guard doForward against non-finite steps to prevent infinite loop

### DIFF
--- a/js/__tests__/turtle-painter-infinity.bug.test.js
+++ b/js/__tests__/turtle-painter-infinity.bug.test.js
@@ -62,7 +62,7 @@ describe("BUG: TurtlePainter.doForward with Infinity hangs the main thread", () 
         spy.mockRestore();
     });
 
-    test("doForward(Infinity) treats step as zero — no movement, no infinite loop", () => {
+    test("doForward(Infinity) normalizes to 1 — executes normally, no infinite loop", () => {
         const painter = new Painter(createMockTurtle());
         const ABORT_AT = 5000;
         let iterations = 0;
@@ -71,9 +71,10 @@ describe("BUG: TurtlePainter.doForward with Infinity hangs the main thread", () 
             if (iterations >= ABORT_AT) throw new Error("ABORT_INFINITE_LOOP");
         });
 
-        // Must not throw and must not loop — steps is clamped to 0 so _move
-        // is called at most once (the straight-line path, zero distance).
+        // Non-finite steps clamped to 1 — function runs its full pipeline,
+        // _move is called a small finite number of times, no runaway loop.
         expect(() => painter.doForward(Infinity)).not.toThrow();
+        expect(iterations).toBeGreaterThan(0);
         expect(iterations).toBeLessThan(ABORT_AT);
         spy.mockRestore();
     });

--- a/js/__tests__/turtle-painter-infinity.bug.test.js
+++ b/js/__tests__/turtle-painter-infinity.bug.test.js
@@ -62,15 +62,19 @@ describe("BUG: TurtlePainter.doForward with Infinity hangs the main thread", () 
         spy.mockRestore();
     });
 
-    test("doForward(Infinity) returns immediately without entering the loop (fix)", () => {
+    test("doForward(Infinity) treats step as zero — no movement, no infinite loop", () => {
         const painter = new Painter(createMockTurtle());
+        const ABORT_AT = 5000;
         let iterations = 0;
         const spy = jest.spyOn(painter, "_move").mockImplementation(() => {
             iterations++;
+            if (iterations >= ABORT_AT) throw new Error("ABORT_INFINITE_LOOP");
         });
 
-        painter.doForward(Infinity);
-        expect(iterations).toBe(0);
+        // Must not throw and must not loop — steps is clamped to 0 so _move
+        // is called at most once (the straight-line path, zero distance).
+        expect(() => painter.doForward(Infinity)).not.toThrow();
+        expect(iterations).toBeLessThan(ABORT_AT);
         spy.mockRestore();
     });
 });

--- a/js/__tests__/turtle-painter-infinity.bug.test.js
+++ b/js/__tests__/turtle-painter-infinity.bug.test.js
@@ -5,6 +5,7 @@
 const Painter = require("../turtle-painter");
 
 global.WRAP = true;
+global.NANERRORMSG = "Not a number.";
 global.getcolor = jest.fn(() => [50, 100, "rgba(255,0,49,1)"]);
 global.getMunsellColor = jest.fn(() => "rgba(128,64,32,1)");
 global.hex2rgb = jest.fn(() => "rgba(255,0,49,1)");
@@ -15,7 +16,8 @@ const createMockTurtle = () => ({
         screenY2turtleY: y => y,
         turtleX2screenX: x => x,
         turtleY2screenY: y => y,
-        scale: 1
+        scale: 1,
+        activity: { errorMsg: jest.fn() }
     },
     activity: { refreshCanvas: jest.fn() },
     container: { x: 0, y: 0, rotation: 0 },
@@ -62,20 +64,17 @@ describe("BUG: TurtlePainter.doForward with Infinity hangs the main thread", () 
         spy.mockRestore();
     });
 
-    test("doForward(Infinity) normalizes to 1 — executes normally, no infinite loop", () => {
-        const painter = new Painter(createMockTurtle());
-        const ABORT_AT = 5000;
+    test("doForward(Infinity) shows error and returns early — no movement, no infinite loop", () => {
+        const mockTurtle = createMockTurtle();
+        const painter = new Painter(mockTurtle);
         let iterations = 0;
         const spy = jest.spyOn(painter, "_move").mockImplementation(() => {
             iterations++;
-            if (iterations >= ABORT_AT) throw new Error("ABORT_INFINITE_LOOP");
         });
 
-        // Non-finite steps clamped to 1 — function runs its full pipeline,
-        // _move is called a small finite number of times, no runaway loop.
-        expect(() => painter.doForward(Infinity)).not.toThrow();
-        expect(iterations).toBeGreaterThan(0);
-        expect(iterations).toBeLessThan(ABORT_AT);
+        painter.doForward(Infinity);
+        expect(iterations).toBe(0);
+        expect(mockTurtle.turtles.activity.errorMsg).toHaveBeenCalledWith(global.NANERRORMSG);
         spy.mockRestore();
     });
 });

--- a/js/__tests__/turtle-painter-infinity.bug.test.js
+++ b/js/__tests__/turtle-painter-infinity.bug.test.js
@@ -1,0 +1,76 @@
+// Minimal repro: doForward(Infinity) never terminates under wrap mode
+// because the wrap loop's only exit condition is `steps -= 5` and
+// `Infinity - 5 === Infinity`.
+
+const Painter = require("../turtle-painter");
+
+global.WRAP = true;
+global.getcolor = jest.fn(() => [50, 100, "rgba(255,0,49,1)"]);
+global.getMunsellColor = jest.fn(() => "rgba(128,64,32,1)");
+global.hex2rgb = jest.fn(() => "rgba(255,0,49,1)");
+
+const createMockTurtle = () => ({
+    turtles: {
+        screenX2turtleX: x => x,
+        screenY2turtleY: y => y,
+        turtleX2screenX: x => x,
+        turtleY2screenY: y => y,
+        scale: 1
+    },
+    activity: { refreshCanvas: jest.fn() },
+    container: { x: 0, y: 0, rotation: 0 },
+    ctx: {
+        beginPath: jest.fn(),
+        clearRect: jest.fn(),
+        stroke: jest.fn(),
+        closePath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        arc: jest.fn(),
+        fill: jest.fn(),
+        canvas: { width: 800, height: 600 },
+        strokeStyle: "",
+        fillStyle: "",
+        lineWidth: 1,
+        lineCap: ""
+    },
+    penstrokes: { image: null },
+    orientation: 0,
+    updateCache: jest.fn(),
+    blinking: jest.fn().mockReturnValue(false)
+});
+
+describe("BUG: TurtlePainter.doForward with Infinity hangs the main thread", () => {
+    beforeEach(() => {
+        jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+    });
+    afterEach(() => {
+        window.requestAnimationFrame.mockRestore();
+    });
+
+    test("doForward(10) completes quickly in wrap mode (sanity check)", () => {
+        const painter = new Painter(createMockTurtle());
+        let iterations = 0;
+        const spy = jest.spyOn(painter, "_move").mockImplementation(() => {
+            iterations++;
+            if (iterations > 1000) throw new Error("UNEXPECTED_RUNAWAY");
+        });
+        painter.doForward(10);
+        // Only one _move call is expected because the new point
+        // stays in bounds (0 + 10 < 600), so we skip the wrap branch.
+        expect(iterations).toBeLessThan(10);
+        spy.mockRestore();
+    });
+
+    test("doForward(Infinity) returns immediately without entering the loop (fix)", () => {
+        const painter = new Painter(createMockTurtle());
+        let iterations = 0;
+        const spy = jest.spyOn(painter, "_move").mockImplementation(() => {
+            iterations++;
+        });
+
+        painter.doForward(Infinity);
+        expect(iterations).toBe(0);
+        spy.mockRestore();
+    });
+});

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -793,7 +793,10 @@ class Painter {
      */
     doForward(steps, linePart) {
         steps = Number(steps);
-        if (!Number.isFinite(steps)) steps = 1;
+        if (!Number.isFinite(steps)) {
+            this.turtles.activity.errorMsg(NANERRORMSG);
+            return;
+        }
 
         this._processColor();
 

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -792,7 +792,8 @@ class Painter {
      * @param steps - the number of steps the turtle goes forward by
      */
     doForward(steps, linePart) {
-        if (!Number.isFinite(Number(steps))) steps = 0;
+        steps = Number(steps);
+        if (!Number.isFinite(steps)) steps = 1;
 
         this._processColor();
 

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -792,6 +792,8 @@ class Painter {
      * @param steps - the number of steps the turtle goes forward by
      */
     doForward(steps, linePart) {
+        if (!Number.isFinite(Number(steps))) return;
+
         this._processColor();
 
         if (!this._fillState) {
@@ -1336,7 +1338,7 @@ class Painter {
         this.turtle.penstrokes.image = null;
         this.turtle.ctx.beginPath();
         this.turtle.ctx.clearRect(0, 0, this.turtle.canvas.width, this.turtle.canvas.height);
-        if (turtles.c1ctx != null) {
+        if (turtles.c1ctx !== null) {
             turtles.c1ctx.beginPath();
             turtles.c1ctx.clearRect(
                 0,
@@ -1366,7 +1368,7 @@ class Painter {
         );
 
         const turtles = this.turtles;
-        if (turtles.canvas1 == null) {
+        if (turtles.canvas1 === null) {
             turtles.gx = this.turtle.ctx.canvas.width;
             turtles.gy = this.turtle.ctx.canvas.height;
             turtles.canvas1 = document.createElement("canvas");

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -792,7 +792,7 @@ class Painter {
      * @param steps - the number of steps the turtle goes forward by
      */
     doForward(steps, linePart) {
-        if (!Number.isFinite(Number(steps))) return;
+        if (!Number.isFinite(Number(steps))) steps = 0;
 
         this._processColor();
 

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -1339,7 +1339,7 @@ class Painter {
         this.turtle.penstrokes.image = null;
         this.turtle.ctx.beginPath();
         this.turtle.ctx.clearRect(0, 0, this.turtle.canvas.width, this.turtle.canvas.height);
-        if (turtles.c1ctx !== null) {
+        if (turtles.c1ctx) {
             turtles.c1ctx.beginPath();
             turtles.c1ctx.clearRect(
                 0,
@@ -1369,7 +1369,7 @@ class Painter {
         );
 
         const turtles = this.turtles;
-        if (turtles.canvas1 === null) {
+        if (!turtles.canvas1) {
             turtles.gx = this.turtle.ctx.canvas.width;
             turtles.gy = this.turtle.ctx.canvas.height;
             turtles.canvas1 = document.createElement("canvas");


### PR DESCRIPTION
- [x] Bug Fix

## Summary

This fixes an infinite loop in `TurtlePainter.doForward()` when `steps` becomes non-finite (like Infinity).

---

## Impact

Right now if `steps === Infinity`, the loop inside doForward never ends and the whole tab freezes. Stop button doesn’t work, canvas stops updating, and user may lose work.

This is easy to hit because math blocks like power (2 ^ 2000) return Infinity and there is no check before using it.

---

## Steps to Reproduce

1. Add a `forward` block  
2. Put `2 ^ 2000` inside it  
3. Click Run  

Result: browser freezes  

---

## Root Cause

The loop assumes steps is finite:

// before
while (steps >= 0) {
    steps -= stepUnit;
}

But:

Infinity - 5 === Infinity

So condition is always true → infinite loop.

---

## Fix

Added a simple guard at the top of `doForward()`:

if (!Number.isFinite(Number(steps))) return;

This normalizes input and exits early for Infinity / NaN / invalid values.

---

## Notes

- No change to existing behavior for valid inputs  
- Wrap logic, drawing, and movement stay unchanged  
- Just prevents bad values from entering the loop  