### PR TITLE
fix(jseditor): close button (X) not working in JavaScript editor widget

### DIFF
--- a/js/widgets/__tests__/jseditor.test.js
+++ b/js/widgets/__tests__/jseditor.test.js
@@ -79,7 +79,7 @@ function createMockWidgetWindow() {
     return {
         clear: jest.fn(),
         show: jest.fn(),
-        onclose: null,
+        onclose: jest.fn(),
         onmaximize: null,
         addButton: jest.fn(() => {
             const btn = document.createElement("div");
@@ -295,6 +295,26 @@ describe("JSEditor", () => {
             const editor = createEditor();
 
             expect(mockWidgetWindow.getWidgetBody().contains(editor._editor)).toBe(true);
+        });
+
+        test("calls onclose and updates editor state", () => {
+            const editor = createEditor();
+
+            editor._resizeHandlers = {
+                doResize: jest.fn(),
+                stopResize: jest.fn()
+            };
+
+            const removeEventListener = jest.spyOn(document, "removeEventListener");
+            const onclose = jest.spyOn(mockWidgetWindow, "onclose");
+            editor.widgetWindow.onclose();
+            expect(removeEventListener).toHaveBeenCalledWith("mousemove", expect.any(Function));
+            expect(removeEventListener).toHaveBeenCalledWith("mouseup", expect.any(Function));
+            expect(editor._resizeHandlers).toBeNull();
+            expect(editor.isOpen).toBe(false);
+            expect(onclose).toHaveBeenCalled();
+
+            removeEventListener.mockRestore();
         });
     });
 

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -282,6 +282,7 @@ class JSEditor {
      */
 
     _setup() {
+        const defaultOnClose = this.widgetWindow.onclose.bind(this.widgetWindow);
         this.widgetWindow.onclose = () => {
             if (this._resizeHandlers) {
                 document.removeEventListener("mousemove", this._resizeHandlers.doResize);
@@ -289,6 +290,7 @@ class JSEditor {
                 this._resizeHandlers = null;
             }
             this.isOpen = false;
+            defaultOnClose();
         };
 
         this.widgetWindow.onmaximize = () => {


### PR DESCRIPTION
### Summary
Fixes: #6642 
Fixes a regression where the "X" (close button) in the JavaScript Editor widget did not close the widget.
The issue occurred because `widgetWindow.onclose` was being overridden, which prevented the default close behavior from executing.

### PR Category
- [x] Bug Fix - Fixes widget close regression
- [ ] Feature
- [ ] Performance
- [x] Tests - Adds coverage for onclose behavior
- [ ] Documentation 

https://github.com/user-attachments/assets/6c4a4799-d816-4b1b-b05d-c7c1166917b2

<img width="547" height="145" alt="Screenshot 2026-04-16 at 12 48 15 AM" src="https://github.com/user-attachments/assets/f09d9e00-c1c2-4427-94d8-72a0f2928de3" />

### Key Changes
- Fixed `onclose` override by calling the original handler.
- Ensured proper cleanup of resize handlers
- Added test to verify:
  - resize listeners are removed
  - editor state is updated

### Checklist
- [x] I have tested these changes locally (Chrome + Firefox)
- [x] The close button now works as expected
- [x] I have added/updated tests to cover this fix
- [x] I have followed the project's coding style guidelines