### PR TITLE
Fix interval number wraparound for B# and Cb. Fixes #6629

### DIFF
--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -82,6 +82,26 @@ function setupIntervalsActions(activity) {
         }
 
         /**
+         * Returns the zero-based semitone step for a note name.
+         * `B#` and `Cb` both map to 0 in ALLNOTESTEP, but they sit on opposite
+         * sides of the octave boundary and must be distinguished here.
+         *
+         * @static
+         * @param {string} note
+         * @param {number} temperamentLength
+         * @returns {number}
+         */
+        static getNoteStep(note, temperamentLength) {
+            const step = ALLNOTESTEP[note];
+
+            if (step === 0) {
+                return note.startsWith("C") ? temperamentLength - 1 : 0;
+            }
+
+            return step - 1;
+        }
+
+        /**
          * @static
          * @param {number} turtle
          * @returns {String}
@@ -89,25 +109,13 @@ function setupIntervalsActions(activity) {
         static GetIntervalNumber(turtle) {
             const tur = activity.turtles.ithTurtle(turtle);
             let { firstNote, secondNote, octave } = GetNotesForInterval(tur);
-            let totalIntervals = Math.abs(ALLNOTESTEP[firstNote] - ALLNOTESTEP[secondNote]);
 
             // Use dynamic temperament length for custom tunings
             const temperamentLength = this.getTemperamentLength();
+            const firstStep = this.getNoteStep(firstNote, temperamentLength);
+            const secondStep = this.getNoteStep(secondNote, temperamentLength);
 
-            if (ALLNOTESTEP[secondNote] < ALLNOTESTEP[firstNote] && octave !== 0)
-                totalIntervals = temperamentLength - totalIntervals;
-
-            if (octave < 0 && totalIntervals !== 0 && totalIntervals !== temperamentLength)
-                totalIntervals = temperamentLength - totalIntervals;
-
-            if (octave < -1 || totalIntervals === 0) octave = Math.abs(octave);
-
-            while (octave > 0) {
-                totalIntervals += temperamentLength;
-                octave--;
-            }
-
-            return totalIntervals;
+            return Math.abs(octave * temperamentLength + (secondStep - firstStep));
         }
 
         /**

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -38,7 +38,17 @@ describe("setupIntervalsActions", () => {
             minor: [2, 1, 2, 2, 1, 2, 2]
         };
 
-        global.ALLNOTESTEP = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+        global.ALLNOTESTEP = {
+            "Cb": 0,
+            "C": 1,
+            "D": 3,
+            "E": 5,
+            "F": 6,
+            "G": 8,
+            "A": 10,
+            "B": 12,
+            "B#": 0
+        };
         global.NOTENAMES = ["C", "D", "E", "F", "G", "A", "B"];
 
         global.SEMITONETOINTERVALMAP = Array(13)
@@ -177,6 +187,26 @@ describe("setupIntervalsActions", () => {
             octave: -3
         });
         expect(typeof Singer.IntervalsActions.GetIntervalNumber(0)).toBe("number");
+    });
+
+    test("GetIntervalNumber treats B to B# as one semitone across the octave boundary", () => {
+        GetNotesForInterval.mockReturnValueOnce({
+            firstNote: "B",
+            secondNote: "B#",
+            octave: 1
+        });
+
+        expect(Singer.IntervalsActions.GetIntervalNumber(0)).toBe(1);
+    });
+
+    test("GetIntervalNumber treats B to Cb as a unison", () => {
+        GetNotesForInterval.mockReturnValueOnce({
+            firstNote: "B",
+            secondNote: "Cb",
+            octave: 0
+        });
+
+        expect(Singer.IntervalsActions.GetIntervalNumber(0)).toBe(0);
     });
 
     test("GetCurrentInterval normal", () => {


### PR DESCRIPTION
Description
Fixes #6629

The Interval Number block was overcounting enharmonic wraparound cases such as B to B#. The note-step table stores both B# and Cb at the octave boundary, so the old calculation could add an extra octave on top of the wrapped semitone distance.

PR Category
Bug Fix - Fixes a bug or incorrect behavior
Tests - Adds or updates test coverage

Root Cause
GetIntervalNumber() mixed folded note-step values from ALLNOTESTEP with a separate octave delta from GetNotesForInterval(). For wrapped enharmonic spellings, especially B# and Cb, that combined two representations of the same octave crossing and produced incorrect interval numbers.

Solution
Normalize note names to zero-based semitone steps before applying the octave delta, and treat wrapped enharmonics according to their spelling at the octave boundary. Added regression tests for B to B# and B to Cb so the bug stays fixed.

Checklist
- I have tested these changes locally and they work as expected.
- I have added/updated tests that prove the effectiveness of these changes.
- I have followed the project's coding style guidelines.
- I have run the relevant local checks with no errors.

Validation
npx jest js/turtleactions/__tests__/IntervalsActions.test.js js/blocks/__tests__/IntervalsBlocks.test.js js/js-export/API/__tests__/IntervalsBlocksAPI.test.js --runInBand --coverage=false
