### PR TITLE
fix: catch errors from malformed MIDI files on import

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -8341,10 +8341,16 @@ class Activity {
                     };
 
                     midiReader.onload = e => {
-                        const midi = new Midi(e.target.result);
-
-                        console.debug(midi);
-                        midiImportBlocks(midi);
+                        try {
+                            const midi = new Midi(e.target.result);
+                            console.debug(midi);
+                            midiImportBlocks(midi);
+                        } catch (err) {
+                            console.error(err);
+                            that.errorMsg(
+                                _("Cannot load project from the file. Please check the file type.")
+                            );
+                        }
                     };
 
                     const file = that.fileChooser.files[0];
@@ -8438,10 +8444,16 @@ class Activity {
                     }, 200);
                 };
                 midiReader.onload = e => {
-                    const midi = new Midi(e.target.result);
-
-                    console.debug(midi);
-                    midiImportBlocks(midi);
+                    try {
+                        const midi = new Midi(e.target.result);
+                        console.debug(midi);
+                        midiImportBlocks(midi);
+                    } catch (err) {
+                        console.error(err);
+                        that.errorMsg(
+                            _("Cannot load project from the file. Please check the file type.")
+                        );
+                    }
                 };
 
                 // Music Block Parser from abc to MB

--- a/js/activity.js
+++ b/js/activity.js
@@ -8346,10 +8346,14 @@ class Activity {
                             console.debug(midi);
                             midiImportBlocks(midi);
                         } catch (err) {
-                            console.error(err);
-                            that.errorMsg(
-                                _("Cannot load project from the file. Please check the file type.")
-                            );
+                            console.error("MIDI import failed:", err);
+                            if (that && typeof that.errorMsg === "function") {
+                                that.errorMsg(
+                                    _(
+                                        "Cannot load project from the file. Please check the file type."
+                                    )
+                                );
+                            }
                         }
                     };
 
@@ -8449,10 +8453,12 @@ class Activity {
                         console.debug(midi);
                         midiImportBlocks(midi);
                     } catch (err) {
-                        console.error(err);
-                        that.errorMsg(
-                            _("Cannot load project from the file. Please check the file type.")
-                        );
+                        console.error("MIDI import failed:", err);
+                        if (that && typeof that.errorMsg === "function") {
+                            that.errorMsg(
+                                _("Cannot load project from the file. Please check the file type.")
+                            );
+                        }
                     }
                 };
 


### PR DESCRIPTION
- [x] Bug Fix

## Summary

Fixes a silent failure in the MIDI import flow where malformed or invalid `.mid` files caused an uncaught exception and no user feedback.

---

## Impact

- Importing a broken or non-MIDI file previously resulted in no visible response  
- From the user’s perspective, the app looked frozen (no modal, no error)  
- This affects both file chooser and drag-and-drop flows  
- Makes it hard for students/teachers to understand what went wrong  

Now:
- The error is caught properly  
- A clear message is shown to the user  
- Behavior matches other file import paths  

---

## Fix:

Wrapped both MIDI load handlers in try/catch and reused the existing error message:
```js
midiReader.onload = e => {
    try {
        const midi = new Midi(e.target.result);
        midiImportBlocks(midi);
    } catch (err) {
        console.error(err);
        that.errorMsg(_("Cannot load project from the file. Please check the file type."));
    }
};
```