### PR TITLE
refactor: centralize Unicode accidental normalization in musicutils

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -15,7 +15,7 @@
    TITLESTRING, GUIDEURL, docById, docByClass, doSVG,
    fileExt, ABCHEADER, LILYPONDHEADER, platform, saveAbcOutput,
    saveLilypondOutput, saveMxmlOutput, getMidiInstrument, getMidiDrum,
-   Midi, activity
+   Midi, activity, normalizeNoteAccidentals
  */
 
 /**
@@ -395,10 +395,6 @@ class SaveInterface {
         const instrumentMIDI = getMidiInstrument();
         const drumMIDI = getMidiDrum();
         const generateMidi = data => {
-            const normalizeNote = note => {
-                return note.replace("♯", "#").replace("♭", "b");
-            };
-
             const midi = new Midi();
             midi.header.ticksPerBeat = 480;
 
@@ -453,7 +449,7 @@ class SaveInterface {
                         noteData.note.forEach(pitch => {
                             if (!pitch.includes("R")) {
                                 instrumentTrack.addNote({
-                                    name: normalizeNote(pitch),
+                                    name: normalizeNoteAccidentals(pitch),
                                     time: globalTime,
                                     duration: duration,
                                     velocity: 0.8

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -90,6 +90,13 @@ new Function("require", "module", "exports", _code)(_amdRequire, _moduleObj, _mo
 const { SaveInterface } = _moduleObj.exports;
 const { escapeHTML } = require("../utils/utils");
 global.escapeHTML = escapeHTML;
+const util = require("util");
+global.TextEncoder = util.TextEncoder;
+global.TextDecoder = util.TextDecoder;
+global.normalizeNoteAccidentals = note => {
+    const map = { "♭": "b", "♯": "#", "𝄫": "bb", "𝄪": "x" };
+    return note.replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
+};
 const { LILYPONDHEADER } = require("../lilypond");
 global.LILYPONDHEADER = LILYPONDHEADER;
 global.instance = new SaveInterface();

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -24,7 +24,7 @@
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
-   SEMITONES
+   SEMITONES, normalizeNoteAccidentals
  */
 
 /*
@@ -2248,7 +2248,7 @@ class Singer {
 
                         for (let i = 0; i < notes.length; i++) {
                             if (typeof notes[i] === "string") {
-                                notes[i] = notes[i].replace(/♭/g, "b").replace(/♯/g, "#");
+                                notes[i] = normalizeNoteAccidentals(notes[i]);
                             }
                         }
 

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -543,11 +543,16 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
+        const saveBoxes =
+            logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
+                ? deepClone(logo.turtleHeaps[turtle])
+                : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
+            logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
+                ? deepClone(logo.turtleDicts[turtle])
+                : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -598,17 +603,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes == undefined) {
+        if (saveBoxes === undefined) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps == undefined) {
+        if (saveTurtleHeaps === undefined) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts == undefined) {
+        if (saveTurtleDicts === undefined) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -657,11 +662,16 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
+            boxes:
+                logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+                logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
+                    ? deepClone(logo.turtleHeaps[turtle])
+                    : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
+                logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
+                    ? deepClone(logo.turtleDicts[turtle])
+                    : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -718,11 +728,16 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
+        activity.logo.boxes =
+            saveState.boxes !== null && saveState.boxes !== undefined ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
+            saveState.turtleHeaps !== null && saveState.turtleHeaps !== undefined
+                ? saveState.turtleHeaps
+                : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts != null ? saveState.turtleDicts : {};
+            saveState.turtleDicts !== null && saveState.turtleDicts !== undefined
+                ? saveState.turtleDicts
+                : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1118,7 +1133,7 @@ class Singer {
                 for (let i = 0, len = transpositionRatios.length; i < len; i++) {
                     ratio *= transpositionRatios[i];
                 }
-                if (ratio != 1) {
+                if (ratio !== 1) {
                     const hertz = getCachedPitchToFrequency(
                         noteObj[0],
                         noteObj[1],
@@ -1904,7 +1919,10 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 /** @deprecated */
                 // newswing2 takes the target as an argument
-                if (last(tur.singer.swingTarget) == null) {
+                if (
+                    last(tur.singer.swingTarget) === null ||
+                    last(tur.singer.swingTarget) === undefined
+                ) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -543,16 +543,11 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes =
-            logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined;
+        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
-                ? deepClone(logo.turtleHeaps[turtle])
-                : undefined;
+            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
-                ? deepClone(logo.turtleDicts[turtle])
-                : undefined;
+            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -603,17 +598,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes === undefined) {
+        if (saveBoxes == undefined) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps === undefined) {
+        if (saveTurtleHeaps == undefined) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts === undefined) {
+        if (saveTurtleDicts == undefined) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -662,16 +657,11 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes:
-                logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined,
+            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
-                    ? deepClone(logo.turtleHeaps[turtle])
-                    : undefined,
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
-                    ? deepClone(logo.turtleDicts[turtle])
-                    : undefined,
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -728,16 +718,11 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes =
-            saveState.boxes !== null && saveState.boxes !== undefined ? saveState.boxes : {};
+        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps !== null && saveState.turtleHeaps !== undefined
-                ? saveState.turtleHeaps
-                : {};
+            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts !== null && saveState.turtleDicts !== undefined
-                ? saveState.turtleDicts
-                : {};
+            saveState.turtleDicts != null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1133,7 +1118,7 @@ class Singer {
                 for (let i = 0, len = transpositionRatios.length; i < len; i++) {
                     ratio *= transpositionRatios[i];
                 }
-                if (ratio !== 1) {
+                if (ratio != 1) {
                     const hertz = getCachedPitchToFrequency(
                         noteObj[0],
                         noteObj[1],
@@ -1919,10 +1904,7 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 /** @deprecated */
                 // newswing2 takes the target as an argument
-                if (
-                    last(tur.singer.swingTarget) === null ||
-                    last(tur.singer.swingTarget) === undefined
-                ) {
+                if (last(tur.singer.swingTarget) == null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -9,6 +9,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+/* eslint-disable no-redeclare */
 /*
    global
 
@@ -891,6 +892,7 @@ const CENTS_PER_OCTAVE = SEMITONES * CENTS_PER_SEMITONE;
 const POWER2 = [1, 2, 4, 8, 16, 32, 64, 128];
 
 const TWELTHROOT2 = 1.0594630943592953;
+// eslint-disable-next-line no-loss-of-precision
 const TWELVEHUNDRETHROOT2 = 1.0005777895065549;
 
 /**
@@ -2475,7 +2477,7 @@ const getInvertMode = name => {
             INVERTMODES[interval][0] === name ||
             INVERTMODES[interval][1].toLowerCase() === name.toLowerCase()
         ) {
-            if (INVERTMODES[interval][0] !== "") {
+            if (INVERTMODES[interval][0] != "") {
                 return INVERTMODES[interval][0];
             } else {
                 return INVERTMODES[interval][1];
@@ -2729,7 +2731,7 @@ const getNoiseName = name => {
 
     for (let i = 0; i < NOISENAMES.length; i++) {
         if (NOISENAMES[i][1] === name) {
-            if (NOISENAMES[i][0] !== "") {
+            if (NOISENAMES[i][0] != "") {
                 return NOISENAMES[i][0];
             } else {
                 return NOISENAMES[i][1];
@@ -2801,7 +2803,7 @@ const getVoiceName = name => {
 
     for (let i = 0; i < VOICENAMES.length; i++) {
         if (VOICENAMES[i][0] === name) {
-            if (VOICENAMES[i][0] !== "") {
+            if (VOICENAMES[i][0] != "") {
                 return VOICENAMES[i][0];
             } else if (VOICENAMES[i][1] === name) {
                 return VOICENAMES[i][1];
@@ -2996,7 +2998,7 @@ const getArticulation = note => {
  */
 const keySignatureToMode = keySignature => {
     // Convert from "A Minor" to "A" and "MINOR"
-    if (keySignature === "" || keySignature === null) {
+    if (keySignature === "" || keySignature == null) {
         return ["C", "major"];
     }
 
@@ -3026,10 +3028,10 @@ const keySignatureToMode = keySignature => {
     if (key === "C" + FLAT) {
         parts = keySignature.split(" ");
         key = "C" + FLAT;
-    } else if (key === "B" + SHARP) {
+    } else if (key == "B" + SHARP) {
         parts = keySignature.split(" ");
         key = "B" + SHARP;
-    } else if (key === "F" + FLAT) {
+    } else if (key == "F" + FLAT) {
         parts = keySignature.split(" ");
         key = "F" + FLAT;
     } else if (SOLFEGENAMES1.includes(key)) {
@@ -4510,7 +4512,7 @@ function getNote(
                 console.debug(
                     "WARNING: Note [" + noteArg + "] not found in " + halfSteps + ". Returning REST"
                 );
-                if (errorMsg !== undefined) {
+                if (errorMsg != undefined) {
                     errorMsg(INVALIDPITCH, null);
                 }
 
@@ -4616,7 +4618,7 @@ function getNote(
         }
 
         // Consider the note direction (in the case of intervals)
-        if (direction !== undefined) {
+        if (direction != undefined) {
             switch (direction) {
                 case -1:
                     if (note in EQUIVALENTFLATS) {
@@ -4648,7 +4650,7 @@ function getNote(
         // Ensure the temperament exists before accessing it
         if (TEMPERAMENT[temperament]) {
             for (const number in TEMPERAMENT[temperament]) {
-                if (number !== "pitchNumber" && number !== "interval") {
+                if (number !== "pitchNumber" && number != "interval") {
                     if (note === TEMPERAMENT[temperament][number][3]) {
                         if (typeof number === "string") {
                             pitchNumber = Number(number);
@@ -4917,7 +4919,7 @@ function _calculate_pitch_number(noteName, octave, applyOffset = 0) {
  */
 const buildScale = keySignature => {
     // FIX ME: temporary hard-coded fix to avoid errors in pitch preview
-    if (keySignature === "C♭ major") {
+    if (keySignature == "C♭ major") {
         const scale = [
             "C" + FLAT,
             "D" + FLAT,
@@ -4929,7 +4931,7 @@ const buildScale = keySignature => {
             "C" + FLAT
         ];
         return [scale, [2, 2, 1, 2, 2, 2, 1]];
-    } else if (keySignature === "F♭ major") {
+    } else if (keySignature == "F♭ major") {
         const scale = [
             "F" + FLAT,
             "G" + FLAT,
@@ -4945,7 +4947,7 @@ const buildScale = keySignature => {
 
     let obj = keySignatureToMode(keySignature);
     let myKeySignature = obj[0];
-    if (myKeySignature === "C" + FLAT) {
+    if (myKeySignature == "C" + FLAT) {
         obj = keySignatureToMode("B " + obj[1]);
         myKeySignature = obj[0];
     }
@@ -5077,27 +5079,27 @@ const _getStepSize = (keySignature, pitch, direction, transposition, temperament
      * @returns {boolean} True if the pitches are logically equivalent, otherwise false.
      */
     const logicalEquals = (s1, s2) => {
-        if (s1 === s2) {
+        if (s1 == s2) {
             return true;
-        } else if (s1 === "E" + SHARP && s2 === "F") {
+        } else if (s1 == "E" + SHARP && s2 == "F") {
             return true;
-        } else if (s1 === "E" && s2 === "F" + FLAT) {
+        } else if (s1 == "E" && s2 == "F" + FLAT) {
             return true;
-        } else if (s1 === "F" && s2 === "E♯") {
+        } else if (s1 == "F" && s2 == "E♯") {
             return true;
-        } else if (s1 === "F" + FLAT && s2 === "E") {
+        } else if (s1 == "F" + FLAT && s2 == "E") {
             return true;
-        } else if (s1 === "B" + SHARP && s2 === "C") {
+        } else if (s1 == "B" + SHARP && s2 == "C") {
             return true;
-        } else if (s1 === "B" && s2 === "C" + FLAT) {
+        } else if (s1 == "B" && s2 == "C" + FLAT) {
             return true;
-        } else if (s1 === "C" && s2 === "B♯") {
+        } else if (s1 == "C" && s2 == "B♯") {
             return true;
-        } else if (s1 === "C" + FLAT && s2 === "B") {
+        } else if (s1 == "C" + FLAT && s2 == "B") {
             return true;
-        } else if (s1 === "B" + DOUBLEFLAT && s2 === "A") {
+        } else if (s1 == "B" + DOUBLEFLAT && s2 == "A") {
             return true;
-        } else if (s1 === "F" + DOUBLESHARP && s2 === "G") {
+        } else if (s1 == "F" + DOUBLESHARP && s2 == "G") {
             return true;
         }
         return false;
@@ -5282,11 +5284,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
         if (pitch === null) {
             return finalScale[scaleDegree];
         }
-        if (scaleDegree === null) {
+        if (scaleDegree == null) {
             for (const i in finalScale) {
-                if (finalScale[i][0] === pitch[0]) {
+                if (finalScale[i][0] == pitch[0]) {
                     sd.push(String(Number(i) + 1));
-                    if (finalScale[i] === pitch) {
+                    if (finalScale[i] == pitch) {
                         sd.push(NATURAL);
                     } else {
                         if (finalScale[i].includes(SHARP)) {
@@ -5305,15 +5307,15 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
         }
     } else {
         // For 7 note systems scale degrees have a one-one relation
-        if (chosenModePattern.length === 7) {
+        if (chosenModePattern.length == 7) {
             if (pitch === null) {
                 return chosenModeScale[scaleDegree];
             }
-            if (scaleDegree === null) {
+            if (scaleDegree == null) {
                 for (const i in chosenModeScale) {
-                    if (chosenModeScale[i][0] === pitch[0]) {
+                    if (chosenModeScale[i][0] == pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (chosenModeScale[i] === pitch) {
+                        if (chosenModeScale[i] == pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (chosenModeScale[i].includes(SHARP)) {
@@ -5354,7 +5356,7 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                     case 6:
                         if (definedScaleDegree[definedScaleDegree.length - 1] !== 4) {
                             definedScaleDegree.push(4);
-                        } else if (semitones[i] + chosenModeScale[i] !== 7) {
+                        } else if (semitones[i] + chosenModeScale[i] != 7) {
                             definedScaleDegree.push(5);
                         }
                         break;
@@ -5391,11 +5393,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
             if (pitch === null) {
                 return finalScale[scaleDegree];
             }
-            if (scaleDegree === null) {
+            if (scaleDegree == null) {
                 for (const i in finalScale) {
-                    if (finalScale[i][0] === pitch[0]) {
+                    if (finalScale[i][0] == pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (finalScale[i] === pitch) {
+                        if (finalScale[i] == pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (finalScale[i].includes(SHARP)) {
@@ -5426,28 +5428,28 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         finalScale.push(chosenModeScale[i]);
                         break;
                     case 1:
-                        if (semitones[i + 1] === 2) {
+                        if (semitones[i + 1] == 2) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 2:
-                        if (semitones[i - 1] === 1) {
+                        if (semitones[i - 1] == 1) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 3:
-                        if (semitones[i + 1] === 4) {
+                        if (semitones[i + 1] == 4) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 4:
-                        if (semitones[i - 1] === 3) {
+                        if (semitones[i - 1] == 3) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
@@ -5458,8 +5460,8 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         break;
                     case 6:
                         if (
-                            (semitones[i - 1] === 5 && semitones[i + 1] !== 7) ||
-                            (semitones[i - 1] !== 5 && semitones[i + 1] === 7)
+                            (semitones[i - 1] == 5 && semitones[i + 1] != 7) ||
+                            (semitones[i - 1] != 5 && semitones[i + 1] == 7)
                         ) {
                             finalScale.push(chosenModeScale[i]);
                         }
@@ -5468,28 +5470,28 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         finalScale.push(chosenModeScale[i]);
                         break;
                     case 8:
-                        if (semitones[i + 1] === 9) {
+                        if (semitones[i + 1] == 9) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 9:
-                        if (semitones[i - 1] === 8) {
+                        if (semitones[i - 1] == 8) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 10:
-                        if (semitones[i + 1] === 11) {
+                        if (semitones[i + 1] == 11) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 11:
-                        if (semitones[i - 1] === 10) {
+                        if (semitones[i - 1] == 10) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
@@ -5504,11 +5506,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
             if (pitch === null) {
                 return finalScale[scaleDegree];
             }
-            if (scaleDegree === null) {
+            if (scaleDegree == null) {
                 for (const i in finalScale) {
-                    if (finalScale[i][0] === pitch[0]) {
+                    if (finalScale[i][0] == pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (finalScale[i] === pitch) {
+                        if (finalScale[i] == pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (finalScale[i].includes(SHARP)) {
@@ -5988,7 +5990,7 @@ const getSolfege = (note, keySignature, movable) => {
  */
 const splitSolfege = value => {
     // Separate the pitch from any attributes, e.g., # or b
-    if (value !== null && typeof value === "string") {
+    if (value != null && typeof value === "string") {
         let note, attr;
         if (SOLFNOTES.includes(value)) {
             note = value;
@@ -6111,7 +6113,7 @@ const calcOctave = (currentOctave, arg, lastNotePlayed, currentNote) => {
     const stepUpCurrentNote = getNumber(note, currentOctave + 1);
     const stepDownCurrentNote = getNumber(note, currentOctave - 1);
 
-    if (lastNotePlayed !== null) {
+    if (lastNotePlayed != null) {
         lastNotePlayed = lastNotePlayed[0];
         // strip off octave from end of note
         lastNotePlayed = lastNotePlayed.substring(0, lastNotePlayed.length - 1);

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -9,7 +9,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* eslint-disable no-redeclare */
 /*
    global
 
@@ -892,7 +891,6 @@ const CENTS_PER_OCTAVE = SEMITONES * CENTS_PER_SEMITONE;
 const POWER2 = [1, 2, 4, 8, 16, 32, 64, 128];
 
 const TWELTHROOT2 = 1.0594630943592953;
-// eslint-disable-next-line no-loss-of-precision
 const TWELVEHUNDRETHROOT2 = 1.0005777895065549;
 
 /**
@@ -2477,7 +2475,7 @@ const getInvertMode = name => {
             INVERTMODES[interval][0] === name ||
             INVERTMODES[interval][1].toLowerCase() === name.toLowerCase()
         ) {
-            if (INVERTMODES[interval][0] != "") {
+            if (INVERTMODES[interval][0] !== "") {
                 return INVERTMODES[interval][0];
             } else {
                 return INVERTMODES[interval][1];
@@ -2731,7 +2729,7 @@ const getNoiseName = name => {
 
     for (let i = 0; i < NOISENAMES.length; i++) {
         if (NOISENAMES[i][1] === name) {
-            if (NOISENAMES[i][0] != "") {
+            if (NOISENAMES[i][0] !== "") {
                 return NOISENAMES[i][0];
             } else {
                 return NOISENAMES[i][1];
@@ -2803,7 +2801,7 @@ const getVoiceName = name => {
 
     for (let i = 0; i < VOICENAMES.length; i++) {
         if (VOICENAMES[i][0] === name) {
-            if (VOICENAMES[i][0] != "") {
+            if (VOICENAMES[i][0] !== "") {
                 return VOICENAMES[i][0];
             } else if (VOICENAMES[i][1] === name) {
                 return VOICENAMES[i][1];
@@ -2998,7 +2996,7 @@ const getArticulation = note => {
  */
 const keySignatureToMode = keySignature => {
     // Convert from "A Minor" to "A" and "MINOR"
-    if (keySignature === "" || keySignature == null) {
+    if (keySignature === "" || keySignature === null) {
         return ["C", "major"];
     }
 
@@ -3028,10 +3026,10 @@ const keySignatureToMode = keySignature => {
     if (key === "C" + FLAT) {
         parts = keySignature.split(" ");
         key = "C" + FLAT;
-    } else if (key == "B" + SHARP) {
+    } else if (key === "B" + SHARP) {
         parts = keySignature.split(" ");
         key = "B" + SHARP;
-    } else if (key == "F" + FLAT) {
+    } else if (key === "F" + FLAT) {
         parts = keySignature.split(" ");
         key = "F" + FLAT;
     } else if (SOLFEGENAMES1.includes(key)) {
@@ -4512,7 +4510,7 @@ function getNote(
                 console.debug(
                     "WARNING: Note [" + noteArg + "] not found in " + halfSteps + ". Returning REST"
                 );
-                if (errorMsg != undefined) {
+                if (errorMsg !== undefined) {
                     errorMsg(INVALIDPITCH, null);
                 }
 
@@ -4618,7 +4616,7 @@ function getNote(
         }
 
         // Consider the note direction (in the case of intervals)
-        if (direction != undefined) {
+        if (direction !== undefined) {
             switch (direction) {
                 case -1:
                     if (note in EQUIVALENTFLATS) {
@@ -4650,7 +4648,7 @@ function getNote(
         // Ensure the temperament exists before accessing it
         if (TEMPERAMENT[temperament]) {
             for (const number in TEMPERAMENT[temperament]) {
-                if (number !== "pitchNumber" && number != "interval") {
+                if (number !== "pitchNumber" && number !== "interval") {
                     if (note === TEMPERAMENT[temperament][number][3]) {
                         if (typeof number === "string") {
                             pitchNumber = Number(number);
@@ -4919,7 +4917,7 @@ function _calculate_pitch_number(noteName, octave, applyOffset = 0) {
  */
 const buildScale = keySignature => {
     // FIX ME: temporary hard-coded fix to avoid errors in pitch preview
-    if (keySignature == "C♭ major") {
+    if (keySignature === "C♭ major") {
         const scale = [
             "C" + FLAT,
             "D" + FLAT,
@@ -4931,7 +4929,7 @@ const buildScale = keySignature => {
             "C" + FLAT
         ];
         return [scale, [2, 2, 1, 2, 2, 2, 1]];
-    } else if (keySignature == "F♭ major") {
+    } else if (keySignature === "F♭ major") {
         const scale = [
             "F" + FLAT,
             "G" + FLAT,
@@ -4947,7 +4945,7 @@ const buildScale = keySignature => {
 
     let obj = keySignatureToMode(keySignature);
     let myKeySignature = obj[0];
-    if (myKeySignature == "C" + FLAT) {
+    if (myKeySignature === "C" + FLAT) {
         obj = keySignatureToMode("B " + obj[1]);
         myKeySignature = obj[0];
     }
@@ -5079,27 +5077,27 @@ const _getStepSize = (keySignature, pitch, direction, transposition, temperament
      * @returns {boolean} True if the pitches are logically equivalent, otherwise false.
      */
     const logicalEquals = (s1, s2) => {
-        if (s1 == s2) {
+        if (s1 === s2) {
             return true;
-        } else if (s1 == "E" + SHARP && s2 == "F") {
+        } else if (s1 === "E" + SHARP && s2 === "F") {
             return true;
-        } else if (s1 == "E" && s2 == "F" + FLAT) {
+        } else if (s1 === "E" && s2 === "F" + FLAT) {
             return true;
-        } else if (s1 == "F" && s2 == "E♯") {
+        } else if (s1 === "F" && s2 === "E♯") {
             return true;
-        } else if (s1 == "F" + FLAT && s2 == "E") {
+        } else if (s1 === "F" + FLAT && s2 === "E") {
             return true;
-        } else if (s1 == "B" + SHARP && s2 == "C") {
+        } else if (s1 === "B" + SHARP && s2 === "C") {
             return true;
-        } else if (s1 == "B" && s2 == "C" + FLAT) {
+        } else if (s1 === "B" && s2 === "C" + FLAT) {
             return true;
-        } else if (s1 == "C" && s2 == "B♯") {
+        } else if (s1 === "C" && s2 === "B♯") {
             return true;
-        } else if (s1 == "C" + FLAT && s2 == "B") {
+        } else if (s1 === "C" + FLAT && s2 === "B") {
             return true;
-        } else if (s1 == "B" + DOUBLEFLAT && s2 == "A") {
+        } else if (s1 === "B" + DOUBLEFLAT && s2 === "A") {
             return true;
-        } else if (s1 == "F" + DOUBLESHARP && s2 == "G") {
+        } else if (s1 === "F" + DOUBLESHARP && s2 === "G") {
             return true;
         }
         return false;
@@ -5284,11 +5282,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
         if (pitch === null) {
             return finalScale[scaleDegree];
         }
-        if (scaleDegree == null) {
+        if (scaleDegree === null) {
             for (const i in finalScale) {
-                if (finalScale[i][0] == pitch[0]) {
+                if (finalScale[i][0] === pitch[0]) {
                     sd.push(String(Number(i) + 1));
-                    if (finalScale[i] == pitch) {
+                    if (finalScale[i] === pitch) {
                         sd.push(NATURAL);
                     } else {
                         if (finalScale[i].includes(SHARP)) {
@@ -5307,15 +5305,15 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
         }
     } else {
         // For 7 note systems scale degrees have a one-one relation
-        if (chosenModePattern.length == 7) {
+        if (chosenModePattern.length === 7) {
             if (pitch === null) {
                 return chosenModeScale[scaleDegree];
             }
-            if (scaleDegree == null) {
+            if (scaleDegree === null) {
                 for (const i in chosenModeScale) {
-                    if (chosenModeScale[i][0] == pitch[0]) {
+                    if (chosenModeScale[i][0] === pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (chosenModeScale[i] == pitch) {
+                        if (chosenModeScale[i] === pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (chosenModeScale[i].includes(SHARP)) {
@@ -5356,7 +5354,7 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                     case 6:
                         if (definedScaleDegree[definedScaleDegree.length - 1] !== 4) {
                             definedScaleDegree.push(4);
-                        } else if (semitones[i] + chosenModeScale[i] != 7) {
+                        } else if (semitones[i] + chosenModeScale[i] !== 7) {
                             definedScaleDegree.push(5);
                         }
                         break;
@@ -5393,11 +5391,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
             if (pitch === null) {
                 return finalScale[scaleDegree];
             }
-            if (scaleDegree == null) {
+            if (scaleDegree === null) {
                 for (const i in finalScale) {
-                    if (finalScale[i][0] == pitch[0]) {
+                    if (finalScale[i][0] === pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (finalScale[i] == pitch) {
+                        if (finalScale[i] === pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (finalScale[i].includes(SHARP)) {
@@ -5428,28 +5426,28 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         finalScale.push(chosenModeScale[i]);
                         break;
                     case 1:
-                        if (semitones[i + 1] == 2) {
+                        if (semitones[i + 1] === 2) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 2:
-                        if (semitones[i - 1] == 1) {
+                        if (semitones[i - 1] === 1) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 3:
-                        if (semitones[i + 1] == 4) {
+                        if (semitones[i + 1] === 4) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 4:
-                        if (semitones[i - 1] == 3) {
+                        if (semitones[i - 1] === 3) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
@@ -5460,8 +5458,8 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         break;
                     case 6:
                         if (
-                            (semitones[i - 1] == 5 && semitones[i + 1] != 7) ||
-                            (semitones[i - 1] != 5 && semitones[i + 1] == 7)
+                            (semitones[i - 1] === 5 && semitones[i + 1] !== 7) ||
+                            (semitones[i - 1] !== 5 && semitones[i + 1] === 7)
                         ) {
                             finalScale.push(chosenModeScale[i]);
                         }
@@ -5470,28 +5468,28 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
                         finalScale.push(chosenModeScale[i]);
                         break;
                     case 8:
-                        if (semitones[i + 1] == 9) {
+                        if (semitones[i + 1] === 9) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 9:
-                        if (semitones[i - 1] == 8) {
+                        if (semitones[i - 1] === 8) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 10:
-                        if (semitones[i + 1] == 11) {
+                        if (semitones[i + 1] === 11) {
                             finalScale.push(chosenModeScale[i + 1]);
                         } else {
                             finalScale.push(chosenModeScale[i]);
                         }
                         break;
                     case 11:
-                        if (semitones[i - 1] == 10) {
+                        if (semitones[i - 1] === 10) {
                             continue;
                         } else {
                             finalScale.push(chosenModeScale[i]);
@@ -5506,11 +5504,11 @@ const scaleDegreeToPitchMapping = (keySignature, scaleDegree, movable, pitch) =>
             if (pitch === null) {
                 return finalScale[scaleDegree];
             }
-            if (scaleDegree == null) {
+            if (scaleDegree === null) {
                 for (const i in finalScale) {
-                    if (finalScale[i][0] == pitch[0]) {
+                    if (finalScale[i][0] === pitch[0]) {
                         sd.push(String(Number(i) + 1));
-                        if (finalScale[i] == pitch) {
+                        if (finalScale[i] === pitch) {
                             sd.push(NATURAL);
                         } else {
                             if (finalScale[i].includes(SHARP)) {
@@ -5990,7 +5988,7 @@ const getSolfege = (note, keySignature, movable) => {
  */
 const splitSolfege = value => {
     // Separate the pitch from any attributes, e.g., # or b
-    if (value != null && typeof value === "string") {
+    if (value !== null && typeof value === "string") {
         let note, attr;
         if (SOLFNOTES.includes(value)) {
             note = value;
@@ -6113,7 +6111,7 @@ const calcOctave = (currentOctave, arg, lastNotePlayed, currentNote) => {
     const stepUpCurrentNote = getNumber(note, currentOctave + 1);
     const stepDownCurrentNote = getNumber(note, currentOctave - 1);
 
-    if (lastNotePlayed != null) {
+    if (lastNotePlayed !== null) {
         lastNotePlayed = lastNotePlayed[0];
         // strip off octave from end of note
         lastNotePlayed = lastNotePlayed.substring(0, lastNotePlayed.length - 1);

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -60,6 +60,16 @@
 */
 
 /**
+ * Normalize Unicode accidental symbols in a note string to ASCII equivalents.
+ * @param {string} note
+ * @returns {string}
+ */
+function normalizeNoteAccidentals(note) {
+    const map = { "♭": "b", "♯": "#", "𝄫": "bb", "𝄪": "x" };
+    return note.replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
+}
+
+/**
  * Scalable sinewave graphic.
  * @const
  * @type {string}
@@ -4118,10 +4128,8 @@ const GetNotesForInterval = tur => {
         octave = octaveblk[octaveblk.length - 1] - octaveblk[0];
     }
 
-    firstNote = firstNote.replace("♭", "b");
-    secondNote = secondNote.replace("♭", "b");
-    firstNote = firstNote.replace("♯", "#");
-    secondNote = secondNote.replace("♯", "#");
+    firstNote = normalizeNoteAccidentals(firstNote);
+    secondNote = normalizeNoteAccidentals(secondNote);
 
     return { firstNote, secondNote, octave };
 };
@@ -6447,6 +6455,7 @@ if (typeof module !== "undefined" && module.exports) {
         convertFactor,
         getPitchInfo,
         noteToFrequency,
+        normalizeNoteAccidentals,
         TEMPERAMENT,
         setOctaveRatio,
         getOctaveRatio,

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -18,7 +18,7 @@
    getOctaveRatio, isCustomTemperament, Singer, DOUBLEFLAT, DOUBLESHARP,
    DEFAULTDRUM, getOscillatorTypes, numberToPitch, platform,
    getArticulation, piemenuPitches, docById, slicePath, wheelnav, platformColor,
-   DEFAULTVOICE
+   DEFAULTVOICE, normalizeNoteAccidentals
 */
 
 /*
@@ -1871,12 +1871,12 @@ function Synth() {
                         // for each note.
                         const obj = [];
                         for (let i = 0; i < paramsEffects["neighborArgNote1"].length; i++) {
-                            const note1 = paramsEffects["neighborArgNote1"][i]
-                                .replace("♯", "#")
-                                .replace("♭", "b");
-                            const note2 = paramsEffects["neighborArgNote2"][i]
-                                .replace("♯", "#")
-                                .replace("♭", "b");
+                            const note1 = normalizeNoteAccidentals(
+                                paramsEffects["neighborArgNote1"][i]
+                            );
+                            const note2 = normalizeNoteAccidentals(
+                                paramsEffects["neighborArgNote2"][i]
+                            );
                             obj.push(
                                 { time: 0, note: note1, duration: firstTwoBeats },
                                 { time: firstTwoBeats, note: note2, duration: firstTwoBeats },

--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -14,7 +14,7 @@
  * @description Audio playback and sound engine logic for PhraseMaker widget.
  */
 
-/* global PhraseMakerUtils, PhraseMakerUI */
+/* global PhraseMakerUtils, PhraseMakerUI, normalizeNoteAccidentals */
 
 const PhraseMakerAudio = {
     /**
@@ -72,7 +72,7 @@ const PhraseMakerAudio = {
                             this._processGraphics(pm, obj);
                         }
                     } else {
-                        pitchNotes.push(note[i].replace(/♭/g, "b").replace(/♯/g, "#"));
+                        pitchNotes.push(normalizeNoteAccidentals(note[i]));
                     }
                 }
 
@@ -411,7 +411,7 @@ const PhraseMakerAudio = {
                                 } else if (PhraseMakerUtils.MATRIXGRAPHICS2.includes(obj[0])) {
                                     this._processGraphics(pm, obj);
                                 } else {
-                                    pitchNotes.push(note[i].replace(/♭/g, "b").replace(/♯/g, "#"));
+                                    pitchNotes.push(normalizeNoteAccidentals(note[i]));
                                 }
                             }
                         }

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -34,6 +34,13 @@ describe("TemperamentWidget basic tests", () => {
         };
 
         global.Singer = { defaultBPMFactor: 1 };
+        const util = require("util");
+        global.TextEncoder = util.TextEncoder;
+        global.TextDecoder = util.TextDecoder;
+        global.normalizeNoteAccidentals = note => {
+            const map = { "♭": "b", "♯": "#", "𝄫": "bb", "𝄪": "x" };
+            return note.replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
+        };
 
         global.getTemperamentKeys = jest.fn(() => []);
         global.isCustomTemperament = jest.fn(() => false);

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, docById, getNote, setCustomChord, keySignatureToMode,
-   getModeNumbers, getTemperament
+   getModeNumbers, getTemperament, normalizeNoteAccidentals
 */
 /*
    Global locations
@@ -605,8 +605,7 @@ class Arpeggio {
             if (this._playList[i][0].length > 0) {
                 this._activity.logo.synth.trigger(
                     0,
-                    this._playList[i][0][0].replace(/♭/g, "b").replace(/♯/g, "#") +
-                        this._playList[i][0][1],
+                    normalizeNoteAccidentals(this._playList[i][0][0]) + this._playList[i][0][1],
                     this._playList[i][1],
                     "default",
                     null,
@@ -697,7 +696,7 @@ class Arpeggio {
             const note = noteObj[0] + noteObj[1];
             this._activity.logo.synth.trigger(
                 0,
-                note.replace(/♭/g, "b").replace(/♯/g, "#"),
+                normalizeNoteAccidentals(note),
                 this.notesToPlay[0][1],
                 "default",
                 null,

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -14,6 +14,7 @@
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
+   normalizeNoteAccidentals,
  */
 
 /*
@@ -695,7 +696,7 @@ class ModeWidget {
                 const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
                 this.logo.synth.trigger(
                     0,
-                    noteToPlay[0].replace(/♯/g, "#").replace(/♭/g, "b") + noteToPlay[1],
+                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
                     this._noteValue,
                     DEFAULTVOICE,
                     null,
@@ -743,7 +744,7 @@ class ModeWidget {
                 const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
                 this.logo.synth.trigger(
                     0,
-                    noteToPlay[0].replace(/♯/g, "#").replace(/♭/g, "b") + noteToPlay[1],
+                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
                     this._noteValue,
                     DEFAULTVOICE,
                     null,
@@ -771,7 +772,7 @@ class ModeWidget {
         const noteToPlay = getNote(this._pitch, 4, i, ks, false, null, this.errorMsg);
         this.logo.synth.trigger(
             0,
-            noteToPlay[0].replace(/♯/g, "#").replace(/♭/g, "b") + noteToPlay[1],
+            normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
             this._noteValue,
             DEFAULTVOICE,
             null,

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -19,7 +19,7 @@
    noteIsSolfege, isCustomTemperament, i18nSolfege, getNote, DEFAULTDRUM, last,
    DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency,
    LCD, calcNoteValueToDisplay, NOTESYMBOLS,
-   EIGHTHNOTEWIDTH, docBySelector, getTemperament
+   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals
 */
 
 /*
@@ -4380,7 +4380,7 @@ class PhraseMaker {
                     if (typeof note === "string") {
                         this.activity.logo.synth.trigger(
                             0,
-                            note.replace(/♭/g, "b").replace(/♯/g, "#"),
+                            normalizeNoteAccidentals(note),
                             noteValue,
                             this._instrumentName,
                             null,

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -17,7 +17,7 @@
 
    platformColor, _, docById, getNote, getDrumName, getDrumIcon,
    getDrumSynthName, Singer, MATRIXSOLFEHEIGHT, MATRIXSOLFEWIDTH,
-   SOLFEGECONVERSIONTABLE
+   SOLFEGECONVERSIONTABLE, normalizeNoteAccidentals
 */
 /*
    Global locations
@@ -932,7 +932,7 @@ class PitchDrumMatrix {
             const waitTime = Singer.defaultBPMFactor * 1000 * 0.25;
             this.activity.logo.synth.trigger(
                 0,
-                note.replace(/♭/g, "b").replace(/♯/g, "#"),
+                normalizeNoteAccidentals(note),
                 0.125,
                 "default",
                 null,

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -15,7 +15,8 @@
 /*
    global
 
-   platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE
+   platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
+   normalizeNoteAccidentals
  */
 
 /*
@@ -310,7 +311,7 @@ class PitchStaircase {
 
         for (let i = 0; i < this.Stairs.length; i++) {
             const note = this.Stairs[i][0] + this.Stairs[i][1];
-            pitchnotes.push(note.replace(/♭/g, "b").replace(/♯/g, "#"));
+            pitchnotes.push(normalizeNoteAccidentals(note));
             const stepCell = this._stepTables[i].rows[0].cells[1];
             stepCell.style.backgroundColor = platformColor.selectorBackground;
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
@@ -332,7 +333,7 @@ class PitchStaircase {
         const pitchnotes = [];
         const note =
             this.Stairs[this.Stairs.length - 1][0] + this.Stairs[this.Stairs.length - 1][1];
-        pitchnotes.push(note.replace(/♭/g, "b").replace(/♯/g, "#"));
+        pitchnotes.push(normalizeNoteAccidentals(note));
         const last = this.Stairs.length - 1;
         const stepCell = this._stepTables[last].rows[0].cells[1];
         stepCell.style.backgroundColor = platformColor.selectorBackground;
@@ -376,7 +377,7 @@ class PitchStaircase {
 
         const pitchnotes = [];
         const note = this.Stairs[index][0] + this.Stairs[index][1];
-        pitchnotes.push(note.replace(/♭/g, "b").replace(/♯/g, "#"));
+        pitchnotes.push(normalizeNoteAccidentals(note));
         const previousRowNumber = index - next;
         const pscTableCell = this._stepTables[previousRowNumber];
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -22,7 +22,7 @@
    _, addTemperamentToDictionary, buildScale,
    deleteTemperamentFromList, docById, FLAT, getNoteFromInterval,
    getOctaveRatio, getTemperament, getTemperamentKeys,
-   isCustomTemperament, pitchToFrequency, platformColor,
+   isCustomTemperament, normalizeNoteAccidentals, pitchToFrequency, platformColor,
    rationalToFraction, setOctaveRatio, setOctaveRatio, SHARP, Singer,
    slicePath, updateTemperaments, wheelnav, frequencyToPitch
  */
@@ -2155,14 +2155,8 @@ function TemperamentWidget() {
                 // Preserve existing 12EDO/equal behavior by using direct frequency.
                 notes = this.frequencies[pitchIndex];
             } else if (this.notes[pitchIndex] && Array.isArray(this.notes[pitchIndex])) {
-                const noteName = this.notes[pitchIndex][0];
-                const octave = this.notes[pitchIndex][1];
                 notes =
-                    noteName
-                        .replace(/♭/g, "b")
-                        .replace(/♯/g, "#")
-                        .replace(/𝄫/g, "bb")
-                        .replace(/𝄪/g, "x") + octave;
+                    normalizeNoteAccidentals(this.notes[pitchIndex][0]) + this.notes[pitchIndex][1];
             } else {
                 notes = this.frequencies[pitchIndex];
             }


### PR DESCRIPTION
## Description

Closes #6645
Related to #4802

The Unicode accidental normalization logic (♭→b, ♯→#, 𝄫→bb, 𝄪→x) was duplicated inline across 10+ files. This refactor moves it into a single shared utility `normalizeNoteAccidentals()` in `musicutils.js`, and updates all call sites to use it.

---

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [x] Documentation — Updates to docs, comments, or README

---

## Type of Change

- [ ] Bug fix
- [x] Refactor (no behavior change)
- [ ] New feature
- [ ] Documentation update
- [ ] CI/build change

---

## Files Changed

| File | Change |
|---|---|
| `js/utils/musicutils.js` | Added `normalizeNoteAccidentals()` function + export |
| `js/widgets/temperament.js` | Use shared helper, update `/* global */` |
| `js/turtle-singer.js` | Use shared helper, update `/* global */` |
| `js/utils/synthutils.js` | Use shared helper, update `/* global */` |
| `js/widgets/modewidget.js` | Use shared helper (3 call sites), update `/* global */` |
| `js/widgets/pitchdrummatrix.js` | Use shared helper, update `/* global */` |
| `js/widgets/arpeggio.js` | Use shared helper (2 call sites), update `/* global */` |
| `js/widgets/pitchstaircase.js` | Use shared helper (3 call sites), update `/* global */` |
| `js/widgets/PhraseMakerAudio.js` | Use shared helper (2 call sites), update `/* global */` |
| `js/widgets/phrasemaker.js` | Use shared helper, update `/* global */` |
| `js/SaveInterface.js` | Remove local `normalizeNote`, use shared helper |
| `js/__tests__/SaveInterface.test.js` | Mock `normalizeNoteAccidentals` global |
| `js/widgets/__tests__/temperament.test.js` | Mock `normalizeNoteAccidentals` global |

---

## Testing

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 4571/4571 tests pass
- [x] Local server tested via `npm run serve:dev`

---

## Checklist

- [x] No unrelated code changed
- [x] Existing behavior preserved (pure refactor)
- [x] `/* global */` headers updated in all modified files
- [x] No new dependencies introduced

