### PR TITLE
fix: add RequireJS errback to _loadSample to prevent hung promise

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -888,6 +888,9 @@ function Synth() {
                     console.error(`Error processing sample ${sampleName}:`, e);
                     reject(e);
                 }
+            }, err => {
+                console.error(`Failed to load sample module for ${sampleName}:`, err);
+                reject(err);
             });
         });
     };


### PR DESCRIPTION
- [x] Bug Fix

## Summary

Fixes a hang in sample loading where `_loadSample` never settled if a RequireJS module failed to load. This caused project preload and synth creation to silently stall with no error.

---

## Impact

- Projects could hang during sample preload (no “samples loaded” state)
- Instruments (voice/drum) might never be created → silent playback
- UI appears stuck with no feedback or recovery
- Common in real environments (flaky Wi-Fi, blocked scripts, 404s)

Now:
- Failed sample loads reject properly
- Preload completes (no deadlock)
- Synth creation either proceeds or fails gracefully
- No change to successful load behavior

---

## Fix

Add the RequireJS errback (third argument) and reject on failure:
```js
return new Promise((resolve, reject) => {
    require(
        [sampleInfo.path],
        () => {
            // existing success logic (unchanged)
            resolve();
        },
        (err) => {
            console.error(`Failed to load sample module for ${sampleName}:`, err);
            reject(err);
        }
    );
});
```