### PR TITLE
fix: guard doArc against non-finite angle and radius

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -972,11 +972,18 @@ class Painter {
      * @param radius - radius of arc
      */
     doArc(angle, radius) {
+        angle = Number(angle);
+        radius = Number(radius);
+        if (!Number.isFinite(angle) || !Number.isFinite(radius)) {
+            this.turtles.activity.errorMsg(NANERRORMSG);
+            return;
+        }
+
         if (radius < 0) {
             radius = -radius;
         }
 
-        let adeg = Number(angle),
+        let adeg = angle,
             factor;
         if (adeg < 0) {
             factor = -1;


### PR DESCRIPTION
- [x] Bug Fix

## Summary
Fixes an infinite loop in doArc when angle or radius becomes non-finite (Infinity/NaN). This is the same bug pattern as doForward (already fixed earlier), but was missed here.

---

## Impact
If a student passes something like 1/0 or a very large value:
- doArc enters infinite loop
- browser tab freezes (main thread blocked)
- stop button doesn’t work
- user may lose unsaved work

Arc is commonly used, so this is a real classroom issue.

---

## Fix
Added finite checks at the top of doArc (same approach as doForward):
```js
angle = Number(angle);
radius = Number(radius);

if (!Number.isFinite(angle) || !Number.isFinite(radius)) {
this.turtles.activity.errorMsg(NANERRORMSG);
return;
}
```