### PR TITLE
Fix incorrect this binding in global search input handler

### DIFF
--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -131,7 +131,7 @@ $(document).ready(() => {
 
     document.getElementById("global-search").addEventListener("input", evt => {
         document.getElementById("search-close").style.display =
-            this.value === "" ? "none" : "initial";
+            evt.target.value === "" ? "none" : "initial";
     });
 
     document.getElementById("local-tab").addEventListener("click", evt => {


### PR DESCRIPTION
### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

---

This PR fixes an issue in the global search input event handler where `this.value` was used inside an arrow function.

Since arrow functions do not bind their own `this`, it may not correctly refer to the input element, leading to unreliable behavior.

###  Changes:
- Replaced `this.value` with `evt.target.value` to correctly access the input value

###  Impact:
- Ensures consistent behavior of the search input
- Correctly toggles visibility of the search close button based on input value
- No functional regressions introduced

---

This is a small fix to improve reliability of the search UI behavior.