### PR TITLE
fix: correct typo in Set-heap block help string

### DIFF
--- a/js/blocks/HeapBlocks.js
+++ b/js/blocks/HeapBlocks.js
@@ -520,7 +520,7 @@ function setupHeapBlocks(activity) {
              * @param {string[]} [] - An array with help string information.
              */
             this.setHelpString([
-                _("The Set-heap entry block sets a value in he heap at the specified location."),
+                _("The Set-heap entry block sets a value in the heap at the specified location."),
                 "documentation",
                 ""
             ]);

--- a/locales/af.json
+++ b/locales/af.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/agr.json
+++ b/locales/agr.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/am.json
+++ b/locales/am.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -625,7 +625,7 @@
   "index heap": "قيمة (مؤشر) الكومة",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "حدد القيمة المدخلة إلى الكومة",
   "index": "مؤشر",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ayc.json
+++ b/locales/ayc.json
@@ -625,7 +625,7 @@
   "index heap": "nayrïri qutu",
   "Index must be > 0.": "Wakichata > 0 chimputa jilañapawa",
   "Maximum heap size is 1000.": "El tamaño máximo de pilas es 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "Qutu kutichiy",
   "index": "wakichatanaka",
   "The Pop block removes the value at the top of the heap.": "El bloque Pop elimina el valor en la parte superior del pila.",

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/bi.json
+++ b/locales/bi.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -626,7 +626,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/br.json
+++ b/locales/br.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/da.json
+++ b/locales/da.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -625,7 +625,7 @@
   "index heap": "Stapel abrufen",
   "Index must be > 0.": "Index muss > 0 sein",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "Stapel bestimmen",
   "index": "Index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/dev.json
+++ b/locales/dev.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/dz.json
+++ b/locales/dz.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/el.json
+++ b/locales/el.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/en_GB.json
+++ b/locales/en_GB.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -625,7 +625,7 @@
   "index heap": "valor en la pila",
   "Index must be > 0.": "El índice debe ser > 0.",
   "Maximum heap size is 1000.": "El tamaño máximo de pilas es 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.",
   "set heap": "fijar pila",
   "index": "posición en la pila",
   "The Pop block removes the value at the top of the heap.": "El bloque Pop elimina el valor en la parte superior del pila.",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ff.json
+++ b/locales/ff.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/fil.json
+++ b/locales/fil.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -625,7 +625,7 @@
   "index heap": "indexer le tas",
   "Index must be > 0.": "L'index doit être > 0.",
   "Maximum heap size is 1000.": "La taille maximale du tas est de 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "Le bloc Set-heap entry définit une valeur dans le tas à l'emplacement spécifié.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "Le bloc Set-heap entry définit une valeur dans le tas à l'emplacement spécifié.",
   "set heap": "définir le tas",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "Le bloc Pop supprime la valeur en haut du tas.",

--- a/locales/gn.json
+++ b/locales/gn.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/gug.json
+++ b/locales/gug.json
@@ -625,7 +625,7 @@
   "index heap": "tepy aty pe",
   "Index must be > 0.": "Rysýi tuichave vaerã mba’evegui",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "omoambue aty repy",
   "index": "henda aty pe",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ha.json
+++ b/locales/ha.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/he.json
+++ b/locales/he.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -834,7 +834,7 @@
   "reverse heap": "हीप उलटें",
   "The Index-heap block returns a value in the heap at a specified location.": "इंडेक्स-हीप ब्लॉक निर्दिष्ट स्थान पर हीप में एक मूल्य लौटाता है।",
   "index heap": "हीप में स्थिति में से मूल्य प्राप्त करें",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "सेट-हीप एंट्री ब्लॉक निर्दिष्ट स्थान पर हीप में मूल्य सेट करता है।",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "सेट-हीप एंट्री ब्लॉक निर्दिष्ट स्थान पर हीप में मूल्य सेट करता है।",
   "set heap": "ढेर लगाओ",
   "The Pop block removes the value at the top of the heap.": "पॉप ब्लॉक हीप के शीर्ष पर मूल्य को हटा देता है।",
   "pop": "पॉप",

--- a/locales/ht.json
+++ b/locales/ht.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/hus.json
+++ b/locales/hus.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/hy.json
+++ b/locales/hy.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ibo.json
+++ b/locales/ibo.json
@@ -625,7 +625,7 @@
   "index heap": "ndeksi obo",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "setịpụụrụ obo",
   "index": "ndeksi",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/id.json
+++ b/locales/id.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/is.json
+++ b/locales/is.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ja-kana.json
+++ b/locales/ja-kana.json
@@ -625,7 +625,7 @@
   "index heap": "ヒープに ばんごうを ふる",
   "Index must be > 0.": "インデクス ばんごうは 0 より おおきい ひつようが あります。",
   "Maximum heap size is 1000.": "ヒープの おおきさは、 さいだい 1000です。",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "ヒープを せってい する",
   "index": "インデックス",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -2355,9 +2355,9 @@
     "kanji": "音階的",
     "kana": "おんかいてき"
   },
-  "The Set-heap entry block sets a value in he heap at the specified location.": {
+  "The Set-heap entry block sets a value in the heap at the specified location.": {
     "kanji": "Set-heapエントリーブロックは指定された位置のヒープに値を設定します。",
-    "kana": "The Set-heap entry block sets a value in he heap at the specified location."
+    "kana": "The Set-heap entry block sets a value in the heap at the specified location."
   },
   "heap": {
     "kanji": "ヒープ",

--- a/locales/km.json
+++ b/locales/km.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/kos.json
+++ b/locales/kos.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mg.json
+++ b/locales/mg.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mi.json
+++ b/locales/mi.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ml.json
+++ b/locales/ml.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mn.json
+++ b/locales/mn.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mr.json
+++ b/locales/mr.json
@@ -625,7 +625,7 @@
   "index heap": "इंडेक्स हीप",
   "Index must be > 0.": "इंडेक्स > 0 असावा.",
   "Maximum heap size is 1000.": "कमाल हीप आकार 1000 आहे.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "सेट-हीप एंट्री ब्लॉक दिलेल्या स्थानावर हीपमध्ये मूल्य सेट करतो.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "सेट-हीप एंट्री ब्लॉक दिलेल्या स्थानावर हीपमध्ये मूल्य सेट करतो.",
   "set heap": "सेट हीप",
   "index": "इंडेक्स",
   "The Pop block removes the value at the top of the heap.": "पॉप ब्लॉक हीपच्या शीर्षस्थानील मूल्य काढून टाकतो.",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/mvo.json
+++ b/locales/mvo.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ne.json
+++ b/locales/ne.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/pa.json
+++ b/locales/pa.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/pap.json
+++ b/locales/pap.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/pbs.json
+++ b/locales/pbs.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -623,7 +623,7 @@
   "index heap": "pilha índice",
   "Index must be > 0.": "O índice deve ser > 0.",
   "Maximum heap size is 1000.": "O tamanho máximo da pilha é 1.000",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "O bloco de entrada Definir-pilha define um valor na pilha na localização especificada.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "O bloco de entrada Definir-pilha define um valor na pilha na localização especificada.",
   "set heap": "definir pilha",
   "index": "índice",
   "The Pop block removes the value at the top of the heap.": "O bloco Pop remove o valor do topo da pilha.",

--- a/locales/quz.json
+++ b/locales/quz.json
@@ -625,7 +625,7 @@
   "index heap": "valor en la pila",
   "Index must be > 0.": "El índice debe ser > 0.",
   "Maximum heap size is 1000.": "El tamaño máximo de pilas es 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "Qutu kutichiy",
   "index": "posición",
   "The Pop block removes the value at the top of the heap.": "El bloque Pop elimina el valor en la parte superior del pila.",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/rw.json
+++ b/locales/rw.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sd.json
+++ b/locales/sd.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/si.json
+++ b/locales/si.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ta.json
+++ b/locales/ta.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/te.json
+++ b/locales/te.json
@@ -626,7 +626,7 @@
   "index heap": "ఇండెక్స్ హీప్",
   "Index must be > 0.": "సూచి ఉచితంగా ఉండాలి.",
   "Maximum heap size is 1000.": "అత్యధిక హీప్ పరిమాణం 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "సెట్-హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్ట ప్రదేశంలో హీప్‌లో ఒక విలువను సెట్ చేస్తుంది.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "సెట్-హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్ట ప్రదేశంలో హీప్‌లో ఒక విలువను సెట్ చేస్తుంది.",
   "set heap": "హీప్‌ను లోడ్ చేయండి",
   "index": "సూచి",
   "The Pop block removes the value at the top of the heap.": "పాప్ బ్లాక్ హీప్ చేతిన విలువను తీసేస్తుంది.",

--- a/locales/th.json
+++ b/locales/th.json
@@ -625,7 +625,7 @@
   "index heap": "ดัชนีฮีป",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "ตั้งค่าฮีป",
   "index": "ดัชนี",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -625,7 +625,7 @@
   "index heap": "dizin yığını",
   "Index must be > 0.": "indeks &gt",
   "Maximum heap size is 1000.": "maksimum yığın boyutu 1000'dir",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "yığın ayarla",
   "index": "dizin",
   "The Pop block removes the value at the top of the heap.": "pop bloğu yığının en üstündeki değeri kaldırır",

--- a/locales/tvl.json
+++ b/locales/tvl.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/tzo.json
+++ b/locales/tzo.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ug.json
+++ b/locales/ug.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/ur.json
+++ b/locales/ur.json
@@ -625,7 +625,7 @@
   "index heap": "انڈیکس ہیپ",
   "Index must be > 0.": "انڈیکس > 0 ہونا چاہئے۔",
   "Maximum heap size is 1000.": "زیادہ سے زیادہ ڈھیر کا سائز 1000 ہے۔",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "سیٹ ہیپ انٹری بلاک مخصوص جگہ پر ڈھیر میں ایک قیمت طے کرتا ہے۔",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "سیٹ ہیپ انٹری بلاک مخصوص جگہ پر ڈھیر میں ایک قیمت طے کرتا ہے۔",
   "set heap": "ڈھیر طے کریں",
   "index": "انڈیکس",
   "The Pop block removes the value at the top of the heap.": "پاپ بلاک ڈھیر کے اوپری حصے میں قیمت کو دور کرتا ہے۔",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/wa.json
+++ b/locales/wa.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/yo.json
+++ b/locales/yo.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -625,7 +625,7 @@
   "index heap": "堆索引",
   "Index must be > 0.": "索引必须大于0。",
   "Maximum heap size is 1000.": "堆的最大大小为1000。",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "Set-heap entry 块在指定位置设置堆中的值。",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "Set-heap entry 块在指定位置设置堆中的值。",
   "set heap": "设置堆",
   "index": "索引",
   "The Pop block removes the value at the top of the heap.": "Pop 块移除堆顶的值。",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -625,7 +625,7 @@
   "index heap": "index heap",
   "Index must be > 0.": "Index must be > 0.",
   "Maximum heap size is 1000.": "Maximum heap size is 1000.",
-  "The Set-heap entry block sets a value in he heap at the specified location.": "The Set-heap entry block sets a value in he heap at the specified location.",
+  "The Set-heap entry block sets a value in the heap at the specified location.": "The Set-heap entry block sets a value in the heap at the specified location.",
   "set heap": "set heap",
   "index": "index",
   "The Pop block removes the value at the top of the heap.": "The Pop block removes the value at the top of the heap.",

--- a/po/MusicBlocks.pot
+++ b/po/MusicBlocks.pot
@@ -4607,7 +4607,7 @@ msgid "index heap"
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:521
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:537

--- a/po/af.po
+++ b/po/af.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/agr.po
+++ b/po/agr.po
@@ -5738,7 +5738,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13323,7 +13323,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14743,7 +14743,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/am.po
+++ b/po/am.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ar.po
+++ b/po/ar.po
@@ -3627,7 +3627,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11215,7 +11215,7 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12635,7 +12635,7 @@ msgstr "حرّك"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ayc.po
+++ b/po/ayc.po
@@ -4221,7 +4221,7 @@ msgstr "El tamaño máximo de pilas es 1000."
 
 #: js/blocks/HeapBlocks.js:523
 #. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539

--- a/po/bg.po
+++ b/po/bg.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/bi.po
+++ b/po/bi.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/bn.po
+++ b/po/bn.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/br.po
+++ b/po/br.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ca.po
+++ b/po/ca.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/cs.po
+++ b/po/cs.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/da.po
+++ b/po/da.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/de.po
+++ b/po/de.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13310,7 +13310,7 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14715,7 +14715,7 @@ msgstr "Roboter bewegen"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/dz.po
+++ b/po/dz.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/el.po
+++ b/po/el.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/en.po
+++ b/po/en.po
@@ -5745,7 +5745,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13330,7 +13330,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4295,7 +4295,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11880,7 +11880,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -13300,7 +13300,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/es.po
+++ b/po/es.po
@@ -3634,7 +3634,7 @@ msgid "Maximum heap size is 1000."
 msgstr "El tamaño máximo de pilas es 1000."
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada."
 
 #: js/blocks/HeapBlocks.js:539

--- a/po/fa.po
+++ b/po/fa.po
@@ -5739,7 +5739,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13324,7 +13324,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14744,7 +14744,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ff.po
+++ b/po/ff.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/fi.po
+++ b/po/fi.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/fil.po
+++ b/po/fil.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/fr.po
+++ b/po/fr.po
@@ -3636,7 +3636,7 @@ msgid "Maximum heap size is 1000."
 msgstr "La taille maximale du tas est de 1000."
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "Le bloc Set-heap entry définit une valeur dans le tas à l'emplacement spécifié."
 
 #: js/blocks/HeapBlocks.js:539
@@ -11221,7 +11221,7 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr "Le bloc <em>Setheapentry</em> définit une valeur dans le tas à l'emplacement spécifié."
 
 #: js/turtledefs.js:29
@@ -12638,7 +12638,7 @@ msgstr "mouvement"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr "Le bloc Setheapentry définit une valeur dans le tas à l'emplacement spécifié."
 
 #: js/utilitybox.js:281

--- a/po/gn.po
+++ b/po/gn.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/gug.po
+++ b/po/gug.po
@@ -4226,7 +4226,7 @@ msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
 #. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -12510,7 +12510,7 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -13766,7 +13766,7 @@ msgstr "mongu’e"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ha.po
+++ b/po/ha.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/he.po
+++ b/po/he.po
@@ -3624,7 +3624,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11209,7 +11209,7 @@ msgstr "זוז"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12629,7 +12629,7 @@ msgstr "זוז"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/hi.po
+++ b/po/hi.po
@@ -4696,7 +4696,7 @@ msgid "index heap"
 msgstr "हीप में स्थिति में से मूल्य प्राप्त करें"
 
 #: js/blocks/HeapBlocks.js:521
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "सेट-हीप एंट्री ब्लॉक निर्दिष्ट स्थान पर हीप में मूल्य सेट करता है।"
 
 #: js/blocks/HeapBlocks.js:537

--- a/po/ht.po
+++ b/po/ht.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/hu.po
+++ b/po/hu.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/hus.po
+++ b/po/hus.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/hy.po
+++ b/po/hy.po
@@ -5738,7 +5738,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13323,7 +13323,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14743,7 +14743,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ibo.po
+++ b/po/ibo.po
@@ -3629,7 +3629,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11210,7 +11210,7 @@ msgstr "ije"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12610,7 +12610,7 @@ msgstr "ije"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/id.po
+++ b/po/id.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/is.po
+++ b/po/is.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/it.po
+++ b/po/it.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr "muovere"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr "muovere"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -3626,7 +3626,7 @@ msgid "Maximum heap size is 1000."
 msgstr "ヒープの おおきさは、 さいだい 1000です。"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539

--- a/po/ja.po
+++ b/po/ja.po
@@ -3708,7 +3708,7 @@ msgid "Maximum heap size is 1000."
 msgstr "ヒープの大きさは、最大1000です。"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 # TRANS: machine translation
 msgstr "Set-heapエントリーブロックは指定された位置のヒープに値を設定します。"
 

--- a/po/km.po
+++ b/po/km.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/kn.po
+++ b/po/kn.po
@@ -5738,7 +5738,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13323,7 +13323,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14743,7 +14743,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ko.po
+++ b/po/ko.po
@@ -3627,7 +3627,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11215,7 +11215,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12635,7 +12635,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/kos.po
+++ b/po/kos.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mg.po
+++ b/po/mg.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mi.po
+++ b/po/mi.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mk.po
+++ b/po/mk.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ml.po
+++ b/po/ml.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mn.po
+++ b/po/mn.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mr.po
+++ b/po/mr.po
@@ -3627,7 +3627,7 @@ msgid "Maximum heap size is 1000."
 msgstr "कमाल हीप आकार 1000 आहे."
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "सेट-हीप एंट्री ब्लॉक दिलेल्या स्थानावर हीपमध्ये मूल्य सेट करतो."
 
 #: js/blocks/HeapBlocks.js:539
@@ -11212,7 +11212,7 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr "<em>Setheapentry</em> ब्लॉक निर्दिष्ट ठिकाणी हीपमध्ये एक मूल्य सेट करतो."
 
 #: js/turtledefs.js:29
@@ -12622,7 +12622,7 @@ msgstr "हलवा"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr "सेटहीपएंट्री ब्लॉक निर्दिष्ट ठिकाणी हिपमध्ये एक मूल्य सेट करतो."
 
 #: js/utilitybox.js:281

--- a/po/ms.po
+++ b/po/ms.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/mvo.po
+++ b/po/mvo.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/nb.po
+++ b/po/nb.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ne.po
+++ b/po/ne.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/nl.po
+++ b/po/nl.po
@@ -5739,7 +5739,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13324,7 +13324,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14744,7 +14744,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/pa.po
+++ b/po/pa.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/pap.po
+++ b/po/pap.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/pbs.po
+++ b/po/pbs.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/pl.po
+++ b/po/pl.po
@@ -5742,7 +5742,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13327,7 +13327,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14747,7 +14747,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/pt.po
+++ b/po/pt.po
@@ -3623,7 +3623,7 @@ msgid "Maximum heap size is 1000."
 msgstr "O tamanho máximo da pilha é 1.000"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "O bloco de entrada Definir-pilha define um valor na pilha na localização especificada."
 
 #: js/blocks/HeapBlocks.js:539

--- a/po/quz.po
+++ b/po/quz.po
@@ -4624,7 +4624,7 @@ msgstr "El tamaño máximo de pilas es 1000."
 
 #: js/blocks/HeapBlocks.js:523
 #. TRANS: El bloque Fijar entrada de pila establece un valor en la pila en la ubicación especificada.
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539

--- a/po/ro.po
+++ b/po/ro.po
@@ -5742,7 +5742,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13327,7 +13327,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14747,7 +14747,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ru.po
+++ b/po/ru.po
@@ -5742,7 +5742,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13327,7 +13327,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14747,7 +14747,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/rw.po
+++ b/po/rw.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sd.po
+++ b/po/sd.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/si.po
+++ b/po/si.po
@@ -5744,7 +5744,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13329,7 +13329,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14749,7 +14749,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sk.po
+++ b/po/sk.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sl.po
+++ b/po/sl.po
@@ -5742,7 +5742,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13327,7 +13327,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14747,7 +14747,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sq.po
+++ b/po/sq.po
@@ -5738,7 +5738,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13323,7 +13323,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14743,7 +14743,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sv.po
+++ b/po/sv.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/sw.po
+++ b/po/sw.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ta.po
+++ b/po/ta.po
@@ -3626,7 +3626,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11214,7 +11214,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12634,7 +12634,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/te.po
+++ b/po/te.po
@@ -3631,7 +3631,7 @@ msgid "Maximum heap size is 1000."
 msgstr "అత్యధిక హీప్ పరిమాణం 1000."
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "సెట్-హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్ట ప్రదేశంలో హీప్‌లో ఒక విలువను సెట్ చేస్తుంది."
 
 #: js/blocks/HeapBlocks.js:539
@@ -11266,7 +11266,7 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr "<em>సెట్‌హీప్‌ఎంట్రీ</em> బ్లాక్ నిర్దిష్ట స్థానంలో హీప్‌లో ఒక విలువ నిర్ధారిస్తుంది."
 
 #: js/turtledefs.js:29
@@ -12540,7 +12540,7 @@ msgstr "చలింపు"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr "సెట్హీప్ ఎంట్రీ బ్లాక్ నిర్దిష్టమైన స్థానంలో హీప్‌లో ఒక విలువ సెట్ చేస్తుంది."
 
 #: js/utilitybox.js:281

--- a/po/th.po
+++ b/po/th.po
@@ -3627,7 +3627,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11205,7 +11205,7 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12602,7 +12602,7 @@ msgstr "ย้าย"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/tr.po
+++ b/po/tr.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr "maksimum yığın boyutu 1000'dir"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14741,7 +14741,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/tvl.po
+++ b/po/tvl.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/tzo.po
+++ b/po/tzo.po
@@ -5740,7 +5740,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13325,7 +13325,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14745,7 +14745,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ug.po
+++ b/po/ug.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/ur.po
+++ b/po/ur.po
@@ -3136,7 +3136,7 @@ msgid "Maximum heap size is 1000."
 msgstr "زیادہ سے زیادہ ڈھیر کا سائز 1000 ہے۔"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "سیٹ ہیپ انٹری بلاک مخصوص جگہ پر ڈھیر میں ایک قیمت طے کرتا ہے۔"
 
 #. TRANS: load the heap from a JSON encoding

--- a/po/vi.po
+++ b/po/vi.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/wa.po
+++ b/po/wa.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/yo.po
+++ b/po/yo.po
@@ -5741,7 +5741,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -13326,7 +13326,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14746,7 +14746,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4254,7 +4254,7 @@ msgid "Maximum heap size is 1000."
 msgstr "堆的最大大小为1000。"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 # TRANS: machine translation
 msgstr "Set-heap entry 块在指定位置设置堆中的值。"
 
@@ -12695,7 +12695,7 @@ msgstr "移动"
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -14115,7 +14115,7 @@ msgstr "移动"
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3627,7 +3627,7 @@ msgid "Maximum heap size is 1000."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in he heap at the specified location."
+msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr ""
 
 #: js/blocks/HeapBlocks.js:539
@@ -11215,7 +11215,7 @@ msgstr ""
 
 #: js/turtledefs.js:413
 
-#~ msgid "The <em>Setheapentry</em> block sets a value in he heap at the specified location."
+#~ msgid "The <em>Setheapentry</em> block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/turtledefs.js:29
@@ -12635,7 +12635,7 @@ msgstr ""
 
 #: js/turtledefs.js:421
 
-#~ msgid "The Setheapentry block sets a value in he heap at the specified location."
+#~ msgid "The Setheapentry block sets a value in the heap at the specified location."
 #~ msgstr ""
 
 #: js/utilitybox.js:281


### PR DESCRIPTION
## Overview
Fixes a typo in the Set-heap entry block help string where "the" was misspelled as "he".

- Changed: "The Set-heap entry block sets a value in he heap at the specified location."
- To: "The Set-heap entry block sets a value in the heap at the specified location."

## Related Issue
Closes #6685

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Only the typo is fixed — no unrelated changes
- [x] Translation key updated in locales/en.json and all locale JSON files
- [x] msgid updated in po/MusicBlocks.pot and all .po files
- [x] Prettier check passes
- [x] Jest tests pass
