### PR TITLE
fix: remove redundant duplicate line in MusicKeyboard.onclose

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -685,7 +685,6 @@ function MusicKeyboard(activity) {
 
             selectedNotes = [];
             docById("wheelDivptm").style.display = "none";
-            docById("wheelDivptm").style.display = "none";
             if (this._menuWheel) this._menuWheel.removeWheel();
             if (this._pitchWheel) this._pitchWheel.removeWheel();
             if (this._tabsWheel) this._tabsWheel.removeWheel();


### PR DESCRIPTION
## Overview
Removes a duplicate line in the onclose handler of the Music Keyboard widget 
where wheelDivptm was being set to display = "none" twice consecutively.

// Before
docById("wheelDivptm").style.display = "none";
docById("wheelDivptm").style.display = "none"; // removed

// After
docById("wheelDivptm").style.display = "none";

## Related Issue
Closes #6687

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Only the duplicate line is removed — no unrelated changes
- [x] 1 file changed, 1 deletion
- [x] Prettier check passes
- [x] Jest tests pass
