### PR TITLE
fix: add missing blk argument to errorMsg calls in ProgramBlocks

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -83,7 +83,7 @@ function setupProgramBlocks(activity) {
 
             // Use async fetch to avoid blocking the UI
             if (!isSafeUrl(url)) {
-                activity.errorMsg(_("Invalid URL"));
+                activity.errorMsg(_("Invalid URL"), blk);
                 return;
             }
 
@@ -91,7 +91,7 @@ function setupProgramBlocks(activity) {
                 .then(response => {
                     if (!response.ok) {
                         console.debug("fetched the wrong page or network error...");
-                        activity.errorMsg(_("404: Page not found"));
+                        activity.errorMsg(_("404: Page not found"), blk);
                         throw new Error("Network response was not ok");
                     }
                     return response.text();
@@ -103,7 +103,7 @@ function setupProgramBlocks(activity) {
                         logo.turtleHeaps[name] = data;
                     } catch (e) {
                         console.debug(e);
-                        activity.errorMsg(_("Error parsing JSON data:") + e);
+                        activity.errorMsg(_("Error parsing JSON data:") + e, blk);
                         logo.turtleHeaps[name] = oldHeap;
                     }
                 })
@@ -178,7 +178,7 @@ function setupProgramBlocks(activity) {
             if (name in logo.turtleHeaps) {
                 const data = JSON.stringify(logo.turtleHeaps[name]);
                 if (!isSafeUrl(url)) {
-                    activity.errorMsg(_("Invalid URL"));
+                    activity.errorMsg(_("Invalid URL"), blk);
                     return;
                 }
 
@@ -187,7 +187,7 @@ function setupProgramBlocks(activity) {
                 xmlHttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
                 xmlHttp.send(data);
             } else {
-                activity.errorMsg(_("Cannot find a valid heap for") + " " + name);
+                activity.errorMsg(_("Cannot find a valid heap for") + " " + name, blk);
             }
         }
     }
@@ -256,7 +256,7 @@ function setupProgramBlocks(activity) {
             const c = block.connections[1];
             if (c !== null && activity.blocks.blockList[c].name === "loadFile") {
                 if (args.length !== 1) {
-                    activity.errorMsg(_("You must select a file."));
+                    activity.errorMsg(_("You must select a file."), blk);
                 } else {
                     try {
                         logo.turtleHeaps[turtle] = JSON.parse(
@@ -268,12 +268,13 @@ function setupProgramBlocks(activity) {
                     } catch (e) {
                         logo.turtleHeaps[turtle] = oldHeap;
                         activity.errorMsg(
-                            _("The file you selected does not contain a valid heap.")
+                            _("The file you selected does not contain a valid heap."),
+                            blk
                         );
                     }
                 }
             } else {
-                activity.errorMsg(_("The loadHeap block needs a loadFile block."));
+                activity.errorMsg(_("The loadHeap block needs a loadFile block."), blk);
             }
         }
     }

--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -339,10 +339,13 @@ function setupProgramBlocks(activity) {
                     }
                 } catch (e) {
                     logo.turtleHeaps[turtle] = oldHeap;
-                    activity.errorMsg(_("The block you selected does not contain a valid heap."));
+                    activity.errorMsg(
+                        _("The block you selected does not contain a valid heap."),
+                        blk
+                    );
                 }
             } else {
-                activity.errorMsg(_("The Set heap block needs a heap."));
+                activity.errorMsg(_("The Set heap block needs a heap."), blk);
             }
         }
     }
@@ -425,7 +428,7 @@ function setupProgramBlocks(activity) {
             const c = block.connections[2];
             if (c !== null && activity.blocks.blockList[c].name === "loadFile") {
                 if (args.length !== 2) {
-                    activity.errorMsg(_("You must select a file."));
+                    activity.errorMsg(_("You must select a file."), blk);
                 } else {
                     try {
                         const d = JSON.parse(activity.blocks.blockList[c].value[1]);
@@ -442,12 +445,13 @@ function setupProgramBlocks(activity) {
                         }
                     } catch (e) {
                         activity.errorMsg(
-                            _("The file you selected does not contain a valid dictionary.")
+                            _("The file you selected does not contain a valid dictionary."),
+                            blk
                         );
                     }
                 }
             } else {
-                activity.errorMsg(_("The load dictionary block needs a load file block."));
+                activity.errorMsg(_("The load dictionary block needs a load file block."), blk);
             }
         }
     }
@@ -544,11 +548,12 @@ function setupProgramBlocks(activity) {
                     }
                 } catch (e) {
                     activity.errorMsg(
-                        _("The block you selected does not contain a valid dictionary.")
+                        _("The block you selected does not contain a valid dictionary."),
+                        blk
                     );
                 }
             } else {
-                activity.errorMsg(_("The set dictionary block needs a dictionary."));
+                activity.errorMsg(_("The set dictionary block needs a dictionary."), blk);
             }
         }
     }
@@ -1325,7 +1330,7 @@ function setupProgramBlocks(activity) {
                 const protoblk = obj[0];
                 const protoName = obj[2];
                 if (protoblk === null) {
-                    activity.errorMsg(_("Cannot find block") + " " + name);
+                    activity.errorMsg(_("Cannot find block") + " " + name, blk);
 
                     console.debug("Cannot find block " + name);
                     return 0;
@@ -1343,25 +1348,35 @@ function setupProgramBlocks(activity) {
 
                             if (typeof arg === "number") {
                                 if (!["anyin", "numberin"].includes(dockType)) {
-                                    activity.errorMsg(_("Warning: block argument type mismatch"));
+                                    activity.errorMsg(
+                                        _("Warning: block argument type mismatch"),
+                                        blk
+                                    );
                                 }
                                 newBlock.push([i, ["number", { value: arg }], 0, 0, [0]]);
                                 newBlock[0][4].push(i);
                             } else if (typeof arg === "string") {
                                 if (!["anyin", "textin"].includes(dockType)) {
-                                    activity.errorMsg(_("Warning: block argument type mismatch"));
+                                    activity.errorMsg(
+                                        _("Warning: block argument type mismatch"),
+                                        blk
+                                    );
                                 }
                                 newBlock.push([i, ["string", { value: arg }], 0, 0, [0]]);
                                 newBlock[0][4].push(i);
                             } else if (typeof arg === "boolean") {
                                 if (!["anyin", "booleanin"].includes(dockType)) {
-                                    activity.errorMsg(_("Warning: block argument type mismatch"));
+                                    activity.errorMsg(
+                                        _("Warning: block argument type mismatch"),
+                                        blk
+                                    );
                                 }
                                 newBlock.push([i, ["boolean", { value: arg }], 0, 0, [0]]);
                                 newBlock[0][4].push(i);
                             } else {
                                 activity.errorMsg(
-                                    _("Warning: block argument type unhandled: ") + typeof arg
+                                    _("Warning: block argument type unhandled: ") + typeof arg,
+                                    blk
                                 );
 
                                 console.warn("Unhandled argument type", arg);
@@ -1444,7 +1459,7 @@ function setupProgramBlocks(activity) {
             // only http: and https: protocols, preventing open redirect attacks
             // via javascript:, data:, vbscript:, or other dangerous URI schemes.
             if (!isSafeUrl(url)) {
-                activity.errorMsg(_("Please enter a valid URL."));
+                activity.errorMsg(_("Please enter a valid URL."), blk);
                 return;
             }
 

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -217,7 +217,7 @@ describe("ProgramBlocks", () => {
             // Wait for the async fetch to complete
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            expect(activity.errorMsg).toHaveBeenCalledWith("404: Page not found");
+            expect(activity.errorMsg).toHaveBeenCalledWith("404: Page not found", 1);
         });
 
         test("handles JSON parse error", async () => {
@@ -282,7 +282,8 @@ describe("ProgramBlocks", () => {
             block.flow(["nonexistent", "http://test.com"], logo, 0, 1);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "Cannot find a valid heap for nonexistent"
+                "Cannot find a valid heap for nonexistent",
+                1
             );
         });
     });
@@ -318,7 +319,8 @@ describe("ProgramBlocks", () => {
             block.flow([[null, null]], logo, 0, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The file you selected does not contain a valid heap."
+                "The file you selected does not contain a valid heap.",
+                blk
             );
         });
 
@@ -336,7 +338,8 @@ describe("ProgramBlocks", () => {
             block.flow([[null, null]], logo, 0, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The file you selected does not contain a valid heap."
+                "The file you selected does not contain a valid heap.",
+                blk
             );
         });
 
@@ -353,7 +356,8 @@ describe("ProgramBlocks", () => {
             block.flow([[null, null]], logo, 0, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The loadHeap block needs a loadFile block."
+                "The loadHeap block needs a loadFile block.",
+                blk
             );
         });
     });
@@ -387,7 +391,8 @@ describe("ProgramBlocks", () => {
             block.flow([null], logo, 0, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The block you selected does not contain a valid heap."
+                "The block you selected does not contain a valid heap.",
+                blk
             );
         });
 
@@ -400,7 +405,7 @@ describe("ProgramBlocks", () => {
             const block = getBlock("setHeap");
             block.flow([null], logo, 0, blk);
 
-            expect(activity.errorMsg).toHaveBeenCalledWith("The Set heap block needs a heap.");
+            expect(activity.errorMsg).toHaveBeenCalledWith("The Set heap block needs a heap.", blk);
         });
     });
 
@@ -476,7 +481,8 @@ describe("ProgramBlocks", () => {
             block.flow(["MyDict", [null, null]], logo, 0, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The load dictionary block needs a load file block."
+                "The load dictionary block needs a load file block.",
+                blk
             );
         });
 
@@ -497,7 +503,8 @@ describe("ProgramBlocks", () => {
             block.flow(["MyDict", [null, null]], logo, turtle, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The file you selected does not contain a valid dictionary."
+                "The file you selected does not contain a valid dictionary.",
+                blk
             );
         });
     });
@@ -545,7 +552,8 @@ describe("ProgramBlocks", () => {
             block.flow(["MyDict", {}], logo, turtle, blk);
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "The block you selected does not contain a valid dictionary."
+                "The block you selected does not contain a valid dictionary.",
+                blk
             );
         });
     });
@@ -808,7 +816,7 @@ describe("ProgramBlocks", () => {
             block.flow(["javascript:alert(document.cookie)"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.");
+            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
         });
 
         test("blocks data: URI scheme", () => {
@@ -816,7 +824,7 @@ describe("ProgramBlocks", () => {
             block.flow(["data:text/html,<script>alert(1)</script>"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.");
+            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
         });
 
         test("blocks vbscript: protocol", () => {
@@ -824,7 +832,7 @@ describe("ProgramBlocks", () => {
             block.flow(["vbscript:MsgBox('xss')"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.");
+            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
         });
 
         test("rejects bare domain without protocol", () => {
@@ -832,7 +840,7 @@ describe("ProgramBlocks", () => {
             block.flow(["evil.com"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.");
+            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
         });
 
         test("rejects null input", () => {
@@ -970,7 +978,7 @@ describe("ProgramBlocks", () => {
             ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
-            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
+            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"), 0);
         });
 
         test("handles string arg with dock type mismatch", () => {
@@ -982,7 +990,7 @@ describe("ProgramBlocks", () => {
             ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "numberin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
-            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
+            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"), 0);
         });
 
         test("handles boolean arg with dock type mismatch", () => {
@@ -994,7 +1002,7 @@ describe("ProgramBlocks", () => {
             ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
-            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
+            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"), 0);
         });
 
         test("handles unhandled arg type (object)", () => {
@@ -1006,7 +1014,7 @@ describe("ProgramBlocks", () => {
             ]);
             activity.blocks.protoBlockDict["proto1"] = { dockTypes: [null, "textin"] };
             getBlock("makeblock").arg(logo, 0, 0, null);
-            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"));
+            expect(activity.errorMsg).toHaveBeenCalledWith(expect.stringContaining("Warning"), 0);
         });
     });
 });


### PR DESCRIPTION
## Overview
Several blocks in the Program palette were calling `activity.errorMsg()` without the `blk` argument. In Music Blocks, passing `blk` triggers a visual highlight on the failing block. Without it, users see an error message but have no visual indication of which block caused it.

## Changes
Added the missing `blk` argument to all `errorMsg` calls in `js/blocks/ProgramBlocks.js`:

| Block | Error |
|-------|-------|
| `LoadHeapFromAppBlock` | `"Invalid URL"` |
| `LoadHeapFromAppBlock` | `"404: Page not found"` |
| `LoadHeapFromAppBlock` | `"Error parsing JSON data:"` |
| `SaveHeapToAppBlock` | `"Invalid URL"` |
| `SaveHeapToAppBlock` | `"Cannot find a valid heap for"` |
| `LoadHeapBlock` | `"You must select a file."` |
| `LoadHeapBlock` | `"The file you selected does not contain a valid heap."` |
| `LoadHeapBlock` | `"The loadHeap block needs a loadFile block."` |
| `SetHeapBlock` | `"The block you selected does not contain a valid heap."` |
| `SetHeapBlock` | `"The Set heap block needs a heap."` |
| `LoadDictBlock` | `"You must select a file."` |
| `LoadDictBlock` | `"The file you selected does not contain a valid dictionary."` |
| `LoadDictBlock` | `"The load dictionary block needs a load file block."` |
| `SetDictBlock` | `"The block you selected does not contain a valid dictionary."` |
| `SetDictBlock` | `"The set dictionary block needs a dictionary."` |
| `MakeBlockBlock` | `"Cannot find block"` |
| `MakeBlockBlock` | `"Warning: block argument type mismatch"` (3 instances) |
| `MakeBlockBlock` | `"Warning: block argument type unhandled:"` |
| `OpenProjectBlock` | `"Please enter a valid URL."` |

Updated corresponding test assertions in `js/blocks/__tests__/ProgramBlocks.test.js` to expect the `blk` parameter.

## Related Issue
Closes #6689

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Only `blk` argument added to existing `errorMsg` calls — no unrelated changes
- [x] 2 files changed (source + tests)
- [x] Prettier check passes
- [x] All Jest tests pass (70/70)
