### PR TITLE
fix: safeguard search widget outside-click handler against missing palette rows

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3414,7 +3414,10 @@ class Activity {
                             document.getElementById("ui-id-1").contains(e.target))
                     ) {
                         //do nothing when clicked on the menu
-                    } else if (document.getElementsByTagName("tr")[2].contains(e.target)) {
+                    } else if (
+                        document.querySelector("#palette tbody tr") &&
+                        document.querySelector("#palette tbody tr").contains(e.target)
+                    ) {
                         //do nothing when clicked on the search row
                     } else {
                         // this will hide the search bar if someone clicks on menu items


### PR DESCRIPTION
## Summary
This PR fixes a `TypeError` that occurred when clicking outside the palette search widget during startup or in states where the palette DOM was partially reconstructed.

## The Problem
The outside-click handler for the search widget in `js/activity.js` relied on a hard-coded global DOM lookup:
`document.getElementsByTagName("tr")[2].contains(e.target)`

This assumed that there were always at least three `<tr>` elements on the page. In scenarios where the palette wasn't fully loaded or was being rebuilt, this indexed lookup returned `undefined`, causing a crash when calling `.contains()`.

## The Fix
- Replaced the hard-coded `tr[2]` lookup with a scoped query: `document.querySelector("#palette tbody tr")`.
- Added a guard (`&&`) to ensure the row exists before performing the containment check.

This improvement makes the search widget more robust during early loading phases and ensures it identifies the correct "search row" element relative to the palette container.

## Verification
- Verified that the new selector accurately targets the search button row within the `#palette` structure.
- Confirmed that the added guard prevents the `TypeError` when the row is absent from the DOM.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

closes #6691 
