### PR TITLE
Fix search widget outside-click crash when palette row is missing. Fixes #6691

### DIFF
--- a/js/__tests__/activity_listeners.test.js
+++ b/js/__tests__/activity_listeners.test.js
@@ -87,6 +87,8 @@ describe("Activity Event Listener Management", () => {
             throw new Error("Could not load Activity class");
         }
 
+        document.body.innerHTML = "";
+
         // Instantiate lightly - might need to mock constructor calls
         // Constructor does: this._listeners = []; this.prepSearchWidget(); ...
         // We might need to mock prototype methods that run in constructor to avoid side effects
@@ -157,5 +159,29 @@ describe("Activity Event Listener Management", () => {
         activity.removeEventListener(target, "click", listener, { capture: true });
 
         expect(activity._listeners).toHaveLength(0);
+    });
+
+    test("returns false when the palette search row is missing", () => {
+        expect(activity._isSearchWidgetPaletteTarget(target)).toBe(false);
+    });
+
+    test("matches the rendered palette search row instead of a global tr index", () => {
+        const unrelatedTable = document.createElement("table");
+        unrelatedTable.innerHTML = "<tbody><tr></tr><tr></tr><tr><td id='wrong-row'></td></tr></tbody>";
+        document.body.appendChild(unrelatedTable);
+
+        const palette = document.createElement("div");
+        palette.id = "palette";
+        palette.innerHTML =
+            "<table><tbody><tr id='search-row'><td><span id='search-target'></span></td></tr></tbody></table>";
+        document.body.appendChild(palette);
+
+        const searchTarget = document.getElementById("search-target");
+
+        expect(activity._getSearchWidgetPaletteRow().id).toBe("search-row");
+        expect(activity._isSearchWidgetPaletteTarget(searchTarget)).toBe(true);
+        expect(activity._isSearchWidgetPaletteTarget(document.getElementById("wrong-row"))).toBe(
+            false
+        );
     });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -3414,7 +3414,7 @@ class Activity {
                             document.getElementById("ui-id-1").contains(e.target))
                     ) {
                         //do nothing when clicked on the menu
-                    } else if (document.getElementsByTagName("tr")[2].contains(e.target)) {
+                    } else if (that._isSearchWidgetPaletteTarget(e.target)) {
                         //do nothing when clicked on the search row
                     } else {
                         // this will hide the search bar if someone clicks on menu items
@@ -8811,6 +8811,24 @@ class Activity {
         const end = window.__mbPerf.marks[endMark];
         if (typeof start !== "number" || typeof end !== "number") return;
         window.__mbPerf.measures[measureName] = +(end - start).toFixed(2);
+    }
+
+    /**
+     * Returns the palette search row, if it is currently rendered.
+     * @returns {HTMLTableRowElement|null}
+     */
+    _getSearchWidgetPaletteRow() {
+        return document.getElementById("palette")?.querySelector("tbody > tr") ?? null;
+    }
+
+    /**
+     * Checks whether an event target is inside the palette search row.
+     * @param {EventTarget|null} target - Event target to match.
+     * @returns {boolean} True when the target is the search row or a descendant.
+     */
+    _isSearchWidgetPaletteTarget(target) {
+        const searchRow = this._getSearchWidgetPaletteRow();
+        return !!(searchRow && target && (target === searchRow || searchRow.contains(target)));
     }
 
     /**


### PR DESCRIPTION
Description
This fixes a crash path in the search widget outside-click handler. The previous code assumed document.getElementsByTagName("tr")[2] was always the palette search row, so outside clicks could throw a TypeError when that row was missing or when unrelated table rows existed elsewhere in the page.

Related Issue
Fixes #6691

PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [x] Tests - Adds or updates test coverage
- [ ] Documentation - Updates to docs, comments, or README

Changes Made
- Replaced the hard-coded global tr index check in the search widget close handler with a scoped helper that finds the rendered search row inside the palette.
- Guarded the row containment check so outside clicks stay safe even when the palette row is not present.
- Added regression tests for both the missing-row case and the case where unrelated tr elements exist elsewhere in the document.

Testing Performed
- npx jest js/__tests__/activity_listeners.test.js --runInBand --coverage=false
- npx eslint js/activity.js js/__tests__/activity_listeners.test.js

Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run npm run lint and npx prettier --check . with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled "Allow edits from maintainers" (required for auto-rebase; this only affects the PR branch, not your fork).

Additional Notes for Reviewers
- Validation here is focused on the touched activity search-row logic and its regression coverage. I did not run the full repo-wide lint or prettier checks for this small fix.
