### PR TITLE
fix: resolve shifted arguments in SawtoothBlock flow method

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -122,7 +122,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            Singer.playSynthBlock(args, logo, turtle, blk);
+            Singer.playSynthBlock(args, activity, logo, turtle, blk);
         }
     }
 


### PR DESCRIPTION
# Summary

This PR fixes a runtime bug in the `SawtoothBlock` implementation where the `activity` context was omitted from the `Singer.playSynthBlock` call.

## The Problem
The function signature for `Singer.playSynthBlock` expects five arguments:
`playSynthBlock(args, activity, logo, turtle, blk)`

In `js/blocks/PitchBlocks.js`, the `SawtoothBlock` was incorrectly calling it with only four:
`Singer.playSynthBlock(args, logo, turtle, blk)`

Because the `activity` argument was missing, the `logo` object was shifted into the `activity` position, `turtle` into `logo`, and so on. This resulted in the block failing to execute correctly, often leading to silent output or background errors when the sawtooth waveform was used.

## Changes
- Corrected the method call in `SawtoothBlock.flow` within `js/blocks/PitchBlocks.js` to include the `activity` argument in the correct position.

## Testing
- Verified that the `SawtoothBlock` now matches the correct implementation pattern used by the `SineBlock`, `SquareBlock`, and `TriangleBlock`.
- Manual verification: The sawtooth block now correctly triggers audio through the synthesizer engine without argument misalignment errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

closes #6695 