### PR TITLE
fix: improve error message formatting in setSynthVolume

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,5 @@ module.exports = {
         "!planet/js/__tests__/**"
     ],
     coverageReporters: ["text-summary", "text", "lcov"],
-    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    setupFilesAfterEnv: ["<rootDir>/jest.setup.js"]
 };

--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -257,7 +257,7 @@ function setupVolumeActions(activity) {
             }
 
             if (synth === null) {
-                activity.errorMsg(synth + "not found");
+                activity.errorMsg(synthname + " " + _("not found"));
                 synth = DEFAULTVOICE;
             }
 

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -431,7 +431,7 @@ describe("setupVolumeActions", () => {
 
         it("should handle invalid synth name", () => {
             Singer.VolumeActions.setSynthVolume("invalidSynth", 70, 0, "testBlock");
-            expect(activity.errorMsg).toHaveBeenCalledWith("nullnot found");
+            expect(activity.errorMsg).toHaveBeenCalledWith("invalidSynth not found");
             expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
         });
 


### PR DESCRIPTION
# Description

This PR fixes a malformed error message in the `setSynthVolume` method within `js/turtleactions/VolumeActions.js`.

## The Problem
When the `setSynthVolume` function fails to identify a synthesizer or instrument name, it attempts to display an error message to the user. However, the existing code was using the `synth` variable—which is explicitly `null` at that point in the logic—instead of the actual input string (`synthname`). Additionally, the message lacked a space and proper localization support.

**Original Buggy Output**: `nullnot found`

## Changes
- Updated the error message to use `synthname` (the actual user-provided input).
- Added a space for readability.
- Wrapped the "not found" text in the `_()` translation helper to ensure it is correctly localized for all users.

## Testing
- Verified that unrecognized instrument names now trigger a readable and properly formatted error alert identifying exactly which input was not found.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

closes #6697 