### PR TITLE
fix: resolve crash in MeterBlocks when missing inputs in tempo clamp …

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,5 @@ module.exports = {
         "!planet/js/__tests__/**"
     ],
     coverageReporters: ["text-summary", "text", "lcov"],
-    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    setupFilesAfterEnv: ["<rootDir>/jest.setup.js"]
 };

--- a/js/blocks/MeterBlocks.js
+++ b/js/blocks/MeterBlocks.js
@@ -1006,6 +1006,12 @@ function setupMeterBlocks(activity) {
          * @param {string} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
+            if (bpmnumberblock === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return;
+            }
+
             if (args.length === 2 && typeof args[0] === "number" && typeof args[1] === "number") {
                 Singer.MeterActions.setMasterBPM(args[0], args[1], blk);
 
@@ -1014,12 +1020,7 @@ function setupMeterBlocks(activity) {
 
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
-                const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                const bpmValue =
-                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
-                        ? activity.blocks.blockList[bpmnumberblock].text.text
-                        : args[0].toString();
-                logo.tempo.BPMs.push(bpmValue);
+                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
             }
         }
     }
@@ -1058,6 +1059,12 @@ function setupMeterBlocks(activity) {
          * @param {string} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
+            if (bpmnumberblock === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return;
+            }
+
             if (args.length === 1 && typeof args[0] === "number") {
                 if (args[0] < 30) {
                     activity.errorMsg(_("Beats per minute must be > 30."), blk);
@@ -1074,12 +1081,7 @@ function setupMeterBlocks(activity) {
 
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
-                const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                const bpmValue =
-                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
-                        ? activity.blocks.blockList[bpmnumberblock].text.text
-                        : args[0].toString();
-                logo.tempo.BPMs.push(bpmValue);
+                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
             }
         }
     }
@@ -1140,6 +1142,12 @@ function setupMeterBlocks(activity) {
          * @param {string} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
+            if (bpmnumberblock === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return;
+            }
+
             if (args.length === 2 && typeof args[0] === "number" && typeof args[1] === "number") {
                 Singer.MeterActions.setBPM(args[0], args[1], turtle, blk);
 
@@ -1148,12 +1156,7 @@ function setupMeterBlocks(activity) {
 
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
-                const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                const bpmValue =
-                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
-                        ? activity.blocks.blockList[bpmnumberblock].text.text
-                        : args[0].toString();
-                logo.tempo.BPMs.push(bpmValue);
+                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
             }
         }
     }

--- a/js/blocks/MeterBlocks.js
+++ b/js/blocks/MeterBlocks.js
@@ -1015,7 +1015,11 @@ function setupMeterBlocks(activity) {
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
                 const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
+                const bpmValue =
+                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
+                        ? activity.blocks.blockList[bpmnumberblock].text.text
+                        : args[0].toString();
+                logo.tempo.BPMs.push(bpmValue);
             }
         }
     }
@@ -1071,7 +1075,11 @@ function setupMeterBlocks(activity) {
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
                 const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
+                const bpmValue =
+                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
+                        ? activity.blocks.blockList[bpmnumberblock].text.text
+                        : args[0].toString();
+                logo.tempo.BPMs.push(bpmValue);
             }
         }
     }
@@ -1141,7 +1149,11 @@ function setupMeterBlocks(activity) {
             if (logo.inTempo) {
                 logo.tempo.BPMBlocks.push(blk);
                 const bpmnumberblock = activity.blocks.blockList[blk].connections[1];
-                logo.tempo.BPMs.push(activity.blocks.blockList[bpmnumberblock].text.text);
+                const bpmValue =
+                    bpmnumberblock !== null && activity.blocks.blockList[bpmnumberblock]
+                        ? activity.blocks.blockList[bpmnumberblock].text.text
+                        : args[0].toString();
+                logo.tempo.BPMs.push(bpmValue);
             }
         }
     }


### PR DESCRIPTION
### Summary
This PR fixes a `TypeError` that causes a hard crash of the Logo engine when certain BPM blocks (`setmasterbpm2`, `setmasterbpm`, and `setbpm3`) are executed inside a `tempo` clamp with missing input connections.

### Changes
- Added null guards in `js/blocks/MeterBlocks.js` for `bpmnumberblock` connections.
- Implemented fallback logic: if a visually connected block is missing, the code now uses the current/default BPM value (`args[0]`) instead of attempting to dereference a null pointer.

### Screenshots

#### **Before (Engine Crash)**
<img width="2940" height="1538" alt="image" src="https://github.com/user-attachments/assets/4eb9ac81-6f05-496c-af5e-2e52ca5eab7a" />


#### **After (Fixed Behavior)**
<img width="1470" height="769" alt="image" src="https://github.com/user-attachments/assets/d18194ad-281a-4e69-a406-3ba523141836" />


### Verification
- [x] Reproduction test passed.
- [x] All 31 existing `MeterBlocks` unit tests passed.
- [x] Full project test suite (4692 tests) passed without regression.

### PR Category
- [x] Bug Fix

fixes: #6699 
