### PR TITLE
ci: replace hard-coded coverage thresholds with base-branch delta check

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -34,12 +34,43 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run Jest Tests
+      - name: Run Jest Tests (PR)
         id: jest
         run: |
           npm test -- --coverage --json --outputFile=jest-results.json || echo "TESTS_FAILED=true" >> $GITHUB_ENV
-          COVERAGE=$(node -e "const s=require('./coverage/coverage-summary.json').total;console.log('Statements: '+s.statements.pct+'% | Branches: '+s.branches.pct+'% | Functions: '+s.functions.pct+'% | Lines: '+s.lines.pct+'%');" 2>/dev/null || echo "Coverage summary unavailable")
-          echo "COVERAGE_SUMMARY=$COVERAGE" >> $GITHUB_ENV
+          cp coverage/coverage-summary.json pr-coverage.json 2>/dev/null || echo "{}" > pr-coverage.json
+
+      - name: Run Jest Tests (base branch)
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}:base-branch
+          git worktree add base-copy base-branch
+          cd base-copy
+          npm ci
+          npm test -- --coverage || true
+          cp coverage/coverage-summary.json ../base-coverage.json 2>/dev/null || echo "{}" > ../base-coverage.json
+          cd ..
+
+      - name: Compare coverage (delta check)
+        run: |
+          node -e "
+            const fs = require('fs');
+            const readJson = (p) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')).total || {}; } catch (e) { return {}; } };
+            const pr = readJson('pr-coverage.json');
+            const base = readJson('base-coverage.json');
+            let dropped = false;
+            const lines = [];
+            for (const metric of ['statements','branches','functions','lines']) {
+              const prPct = (pr[metric] && pr[metric].pct) || 0;
+              const basePct = (base[metric] && base[metric].pct) || 0;
+              const delta = (prPct - basePct).toFixed(2);
+              let arrow = '→';
+              if (prPct < basePct) { dropped = true; arrow = '↓'; }
+              else if (prPct > basePct) { arrow = '↑'; }
+              lines.push('- **' + metric + '**: ' + basePct + '% ' + arrow + ' ' + prPct + '% (Δ ' + delta + '%)');
+            }
+            fs.appendFileSync(process.env.GITHUB_ENV, 'COVERAGE_DROPPED=' + dropped + '\n');
+            fs.appendFileSync(process.env.GITHUB_ENV, 'DELTA_REPORT<<EOF\n' + lines.join('\n') + '\nEOF\n');
+          "
 
       - name: Read Jest Results
         id: results
@@ -77,13 +108,13 @@ jobs:
           # Generate content for the comment file
           {
             if [ "$TESTS_PASSED" = "true" ]; then
-              echo "✅ All Jest tests passed! This PR is ready to merge."
-              echo ""
-              echo "**Coverage:** $COVERAGE_SUMMARY"
+              if [ "$COVERAGE_DROPPED" = "true" ]; then
+                echo "❌ Coverage dropped compared to \`${{ github.event.pull_request.base.ref }}\`. Please add tests for new code."
+              else
+                echo "✅ All Jest tests passed and coverage did not drop."
+              fi
             else
               echo "❌ Some Jest tests failed. Please check the logs and fix the issues before merging."
-              echo ""
-              echo "**Coverage:** $COVERAGE_SUMMARY"
               echo ""
               echo "**Failed Tests:**"
               echo ""
@@ -91,6 +122,9 @@ jobs:
               echo "$FAILED_TESTS"
               echo '```'
             fi
+            echo ""
+            echo "### 📊 Coverage vs \`${{ github.event.pull_request.base.ref }}\`"
+            echo "$DELTA_REPORT"
           } > "$COMMENT_FILE"
 
       - name: PR comment
@@ -99,3 +133,9 @@ jobs:
           file-path: ${{ steps.results.outputs.COMMENT_FILE }}
           pr-number: ${{ steps.results.outputs.PR_NUMBER }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if coverage dropped
+        if: env.COVERAGE_DROPPED == 'true'
+        run: |
+          echo "::error::Coverage dropped compared to the base branch. See PR comment for details."
+          exit 1

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,13 +11,5 @@ module.exports = {
         "!planet/js/__tests__/**"
     ],
     coverageReporters: ["text-summary", "text", "lcov", "json-summary"],
-    coverageThreshold: {
-        global: {
-            statements: 34,
-            branches: 29,
-            functions: 41,
-            lines: 34
-        }
-    },
     setupFilesAfterEnv: ["<rootDir>/jest.setup.js"]
 };


### PR DESCRIPTION
## Description

Follow-up to #6694 implementing @walterbender review suggestion: instead of hard-coded thresholds (which would need manual bumps as coverage improves), compare PR coverage against the base branch and fail if any metric decreased. This self-tracks as coverage grows no manual threshold maintenance ever needed.

## Related Issue

Follow-up to #6694.

## PR Category

-   [x] Bug Fix - Fixes a bug or incorrect behavior (manual-maintenance issue in prior PR)
-   [ ] Feature - Adds new functionality
-   [ ] Performance - Improves performance
-   [ ] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README

## Changes Made

-   Remove the hard-coded `coverageThreshold` block from `jest.config.js`
-   Update `.github/workflows/pr-jest-tests.yml` to:
    1. Run Jest with `--coverage` on the PR head (as before)
    2. Check out the base branch via `git worktree`, install deps, and run Jest with `--coverage` there to produce a baseline `coverage-summary.json`
    3. Compare the two summaries on `statements`, `branches`, `functions`, and `lines` using a small Node script (no `jq`/`awk` dependency)
    4. Post a delta report in the PR comment showing `base% → PR% (Δ ±X%)` with up/down/flat arrows for each metric so reviewers see movement at a glance
    5. Fail the job with a clear error message if any metric dropped

## Testing Performed

Verified locally against the actual repo:
-   `npx jest --coverage` produces `coverage/coverage-summary.json` with the expected `total.<metric>.pct` structure
-   The Node delta script correctly detected a simulated drop (functions 48.13% → 46.55%) and set `COVERAGE_DROPPED=true`
-   Arrow rendering is correct for up (↑), down (↓), and flat (→) cases
-   `$GITHUB_ENV` heredoc syntax writes a clean multi-line `DELTA_REPORT` block

Will be validated on CI on the first run (can't test `pull_request_target` + `git worktree` locally).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes 
@walterbender  this implements the delta approach you suggested on #6694. The downside is that CI runs Jest twice per PR (once on PR head, once on base branch). On average Music Blocks Jest runs take ~45 seconds, so the total added cost is roughly one additional minute per PR. If that's too much, we could cache the base-branch coverage per commit SHA to avoid redundant re-runs.

The first run of this workflow will compute a baseline on `master` automatically - no manual setup needed.
