### PR TITLE
test: fix PhraseMaker mocks and failing tests

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -257,7 +257,7 @@ function setupVolumeActions(activity) {
             }
 
             if (synth === null) {
-                activity.errorMsg(synth + "not found");
+                activity.errorMsg(synthname + " " + _("not found"));
                 synth = DEFAULTVOICE;
             }
 

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -431,7 +431,7 @@ describe("setupVolumeActions", () => {
 
         it("should handle invalid synth name", () => {
             Singer.VolumeActions.setSynthVolume("invalidSynth", 70, 0, "testBlock");
-            expect(activity.errorMsg).toHaveBeenCalledWith("nullnot found");
+            expect(activity.errorMsg).toHaveBeenCalledWith("invalidSynth not found");
             expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
         });
 

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -194,6 +194,7 @@ describe("PhraseMaker Widget", () => {
             wheelnav: jest.fn(),
             slicePath: jest.fn(),
             DEFAULTVOICE: "electronic synth",
+            Singer: { setSynthVolume: jest.fn() },
 
             last: arr => arr[arr.length - 1],
             LCD: (a, b) => (a * b) / (b === 0 ? 1 : 1), // simple stub
@@ -1173,7 +1174,8 @@ describe("PhraseMaker Widget", () => {
                 synth: {
                     inTemperament: "equal",
                     stopSound: jest.fn(),
-                    stop: jest.fn()
+                    stop: jest.fn(),
+                    loadSynth: jest.fn()
                 }
             },
             blocks: {

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -180,6 +180,8 @@ global.document = {
     createTextNode: jest.fn(t => t)
 };
 
+global.normalizeNoteAccidentals = jest.fn(note => note);
+
 describe("PhraseMaker Widget", () => {
     let phraseMaker;
     let mockDeps;
@@ -198,7 +200,7 @@ describe("PhraseMaker Widget", () => {
 
             last: arr => arr[arr.length - 1],
             LCD: (a, b) => (a * b) / (b === 0 ? 1 : 1), // simple stub
-            calcNoteValueToDisplay: jest.fn(() => ["1/4", "♩"]),
+            calcNoteValueToDisplay: jest.fn(() => "1<br>&mdash;<br>4<br>♩"),
             getDrumName: jest.fn(() => null),
             getDrumIcon: jest.fn(() => ""),
             getDrumSynthName: jest.fn(() => "kick"),
@@ -545,12 +547,17 @@ describe("PhraseMaker Widget", () => {
                 insertCell: jest.fn(() => ({
                     style: {},
                     setAttribute: jest.fn(),
-                    addEventListener: jest.fn()
+                    addEventListener: jest.fn(),
+                    appendChild: jest.fn()
                 }))
             }
         ];
         phraseMaker._noteValueRow = {
-            insertCell: jest.fn(() => ({ style: {}, setAttribute: jest.fn() }))
+            insertCell: jest.fn(() => ({
+                style: {},
+                setAttribute: jest.fn(),
+                appendChild: jest.fn()
+            }))
         };
 
         phraseMaker.addNotes(2, 4);
@@ -562,7 +569,8 @@ describe("PhraseMaker Widget", () => {
             style: {},
             innerHTML: "",
             setAttribute: jest.fn(),
-            addEventListener: jest.fn()
+            addEventListener: jest.fn(),
+            appendChild: jest.fn()
         });
 
         phraseMaker._rows = [
@@ -673,7 +681,7 @@ describe("PhraseMaker Widget", () => {
             }
         };
 
-        phraseMaker.blockConnection(1);
+        phraseMaker.blockConnection(1, null);
 
         expect(phraseMaker.activity.blocks.clampBlocksToCheck.length).toBe(1);
     });


### PR DESCRIPTION
## Summary
This PR fixes failing Jest tests related to the PhraseMaker widget by correcting incomplete mocks and updating test expectations.

## The Problem
Some PhraseMaker tests were failing due to:
- Incomplete or incorrect mocks
- Mismatch between expected and actual behavior in tests

These issues caused Jest failures unrelated to other functional changes.

## Changes
- Fixed incomplete PhraseMaker mocks
- Updated test expectations to align with actual behavior
- Ensured all Jest tests pass consistently

## Testing
- Verified that all Jest test suites now pass successfully
- Specifically validated PhraseMaker-related tests

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Split from #6698  to isolate PhraseMaker-related test fixes.