### PR TITLE
fix(security): remove eval() from JS export class 

### DIFF
--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -24,6 +24,10 @@
  * @class
  * @classdesc pertains to the Mouse (corresponding to Turtle) in JavaScript based Music Blocks programs.
  */
+const resolvePath = path =>
+    path
+        .split(".")
+        .reduce((obj, key) => obj?.[key], typeof window !== "undefined" ? window : globalThis);
 class Mouse {
     /** Mouse objects in program */
     static MouseList = [];
@@ -159,7 +163,7 @@ class MusicBlocks {
             ].forEach(path => {
                 MusicBlocks._methodList[path] = [];
 
-                const classObj = path.split(".").reduce((obj, key) => obj?.[key], window);
+                const classObj = resolvePath(path);
 
                 if (!classObj) {
                     console.warn(`Class path "${path}" not found`);
@@ -258,7 +262,7 @@ class MusicBlocks {
                     throw new Error(`Class ${cname} not found`);
                 }
 
-                const classRef = cname === "Painter" ? this.turtle.painter : window[cname];
+                const classRef = cname === "Painter" ? this.turtle.painter : resolvePath(cname);
                 if (!classRef) {
                     throw new Error(`Class ${cname} not found`);
                 }

--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -156,22 +156,28 @@ class MusicBlocks {
                 "Singer.VolumeActions",
                 "Singer.DrumActions",
                 "Turtle.DictActions"
-            ].forEach(className => {
-                MusicBlocks._methodList[className] = [];
+            ].forEach(path => {
+                MusicBlocks._methodList[path] = [];
 
-                if (className === "Painter") {
-                    for (const methodName of Object.getOwnPropertyNames(
-                        eval(className + ".prototype")
-                    )) {
-                        if (methodName !== "constructor" && !methodName.startsWith("_"))
-                            MusicBlocks._methodList[className].push(methodName);
-                    }
+                const classObj = path.split(".").reduce((obj, key) => obj?.[key], window);
+
+                if (!classObj) {
+                    console.warn(`Class path "${path}" not found`);
                     return;
                 }
 
-                for (const methodName of Object.getOwnPropertyNames(eval(className))) {
-                    if (methodName !== "length" && methodName !== "prototype")
-                        MusicBlocks._methodList[className].push(methodName);
+                if (path === "Painter") {
+                    for (const methodName of Object.getOwnPropertyNames(classObj.prototype)) {
+                        if (methodName !== "constructor" && !methodName.startsWith("_")) {
+                            MusicBlocks._methodList[path].push(methodName);
+                        }
+                    }
+                } else {
+                    for (const methodName of Object.getOwnPropertyNames(classObj)) {
+                        if (methodName !== "length" && methodName !== "prototype") {
+                            MusicBlocks._methodList[path].push(methodName);
+                        }
+                    }
                 }
             });
         }
@@ -248,13 +254,19 @@ class MusicBlocks {
                         break;
                     }
                 }
+                if (!cname) {
+                    throw new Error(`Class ${cname} not found`);
+                }
 
-                cname = cname === "Painter" ? this.turtle.painter : eval(cname);
+                const classRef = cname === "Painter" ? this.turtle.painter : window[cname];
+                if (!classRef) {
+                    throw new Error(`Class ${cname} not found`);
+                }
 
                 returnVal =
                     args === undefined || (Array.isArray(args) && args.length === 0)
-                        ? cname[command]()
-                        : cname[command](...args);
+                        ? classRef[command]()
+                        : classRef[command](...args);
             }
 
             const delay = this.turtle.waitTime;

--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -259,12 +259,19 @@ class MusicBlocks {
                     }
                 }
                 if (!cname) {
-                    throw new Error(`Class ${cname} not found`);
+                    throw new Error(`Command "${command}" not found in any class`);
                 }
 
                 const classRef = cname === "Painter" ? this.turtle.painter : resolvePath(cname);
+
                 if (!classRef) {
-                    throw new Error(`Class ${cname} not found`);
+                    throw new Error(
+                        `Class "${cname}" could not be resolved for command "${command}"`
+                    );
+                }
+
+                if (typeof classRef[command] !== "function") {
+                    throw new Error(`Command "${command}" not found on class "${cname}"`);
                 }
 
                 returnVal =


### PR DESCRIPTION
### Summary
This PR removes eval() from the JavaScript execution engine and replaces it with  direct class resolution. This improves security and ensure compatibility with CSP.

### Problem
The export logic builds and executes commands based on class names like "Singer.PitchActions". Earlier this was done using eval(), which means strings were executed as code at runtime.
This is not ideal because:
- it can execute unintended code if the input is not fully controlled
- it requires 'unsafe-eval' in CSP, which weakens security

Key changes
- replaced eval(...) with accessing the class directly
- resolved nested class names (like "Singer.PitchActions") without using eval
- added explicit msg to throw errors if a class or command is missing

This change only affects how classes are accessed and does not modify any API classes

### PR category 
- [x] Bug fix

### Checklist
- [x] I have tested these changes locally and verified that the JavaScript Editor executes commands correctly across all API categories.
- [x] I have followed the project's coding style guidelines.
- [x] I have run npm run lint, npm run test, and npx prettier --write . with no errors.
