### PR TITLE
Fix: Palette layout issues and reinitialization logic redundancy

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -2404,46 +2404,46 @@ describe("Palettes Class", () => {
         });
     });
 
-    describe("clear method", () => {
-        test("clears dict and resets state", () => {
-            // Setup document mock for clear method
-            global.document = {
-                createElement: jest.fn(() => ({
-                    id: "",
-                    setAttribute: jest.fn(),
-                    classList: { add: jest.fn() },
-                    innerHTML: "",
-                    childNodes: [{ style: {} }]
-                })),
-                body: { appendChild: jest.fn() }
+    describe("reinitialize method", () => {
+        test("hides existing menus, removes old palette element, and reinitialize palettes", () => {
+            const hideMenu1 = jest.fn();
+            const hideMenu2 = jest.fn();
+            const paletteElement = {
+                parentNode: {
+                    removeChild: jest.fn()
+                },
+                style: {}
             };
-            global.docById = jest.fn(id => {
-                if (id === "palette") {
-                    return { parentNode: { removeChild: jest.fn() } };
-                }
-                return null;
-            });
 
-            palettes.dict = { test: { hideMenu: jest.fn() } };
+            palettes.dict = {
+                rhythm: { hideMenu: hideMenu1 },
+                pitch: { hideMenu: hideMenu2 }
+            };
             palettes.visible = true;
-            palettes.activePalette = "test";
+            palettes.activePalette = "rhythm";
+            palettes.paletteObject = { id: "old" };
+            palettes.collapsed = true;
 
-            palettes.clear();
+            global.BUILTINPALETTES = [];
+            global.docById = jest.fn(id => (id === "palette" ? paletteElement : null));
 
+            const mockInitTarget = {
+                add: jest.fn().mockReturnThis(),
+                init_selectors: jest.fn(),
+                makePalettes: jest.fn(),
+                show: jest.fn()
+            };
+
+            palettes.reinitialize(mockInitTarget);
+
+            expect(hideMenu1).toHaveBeenCalled();
+            expect(hideMenu2).toHaveBeenCalled();
+            expect(paletteElement.parentNode.removeChild).toHaveBeenCalledWith(paletteElement);
             expect(palettes.dict).toEqual({});
             expect(palettes.visible).toBe(false);
             expect(palettes.activePalette).toBeNull();
-        });
-
-        test("handles errors gracefully", () => {
-            // Make docById throw to test error handling
-            global.docById = jest.fn(() => {
-                throw new Error("Test error");
-            });
-            palettes.dict = {};
-
-            // Should not throw due to try-catch
-            expect(() => palettes.clear()).not.toThrow();
+            expect(palettes.paletteObject).toBeNull();
+            expect(palettes.collapsed).toBe(false);
         });
     });
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -9010,19 +9010,11 @@ class Activity {
                 this.palettes.hide();
             }
 
-            if (typeof this.palettes.clear !== "function") {
-                console.warn("Palettes clear method not available");
-                // Fallback clear implementation
-                this.palettes.dict = {};
-                this.palettes.visible = false;
-                this.palettes.activePalette = null;
-                this.palettes.paletteObject = null;
-            } else {
-                this.palettes.clear();
-            }
+            this.palettes.reinitialize(this.palettes);
 
-            // Reinitialize palettes
-            initPalettes(this.palettes);
+            // Increase palette element style.top value for correct alignment
+            const element = docById("palette");
+            element.style.top = `${60 + this.palettes.top}px`;
 
             // Reinitialize blocks
             if (this.blocks) {

--- a/js/palette.js
+++ b/js/palette.js
@@ -981,87 +981,34 @@ class Palettes {
         docById("palette").style.visibility = "visible";
     }
 
-    clear() {
-        try {
-            // First hide all palettes
-            for (const name in this.dict) {
-                if (Object.prototype.hasOwnProperty.call(this.dict, name)) {
-                    const palette = this.dict[name];
-                    if (palette && typeof palette.hideMenu === "function") {
-                        palette.hideMenu();
-                    }
+    reinitialize(palettes) {
+        // First hide all palettes
+        for (const name in this.dict) {
+            if (Object.prototype.hasOwnProperty.call(this.dict, name)) {
+                const palette = this.dict[name];
+                if (palette && typeof palette.hideMenu === "function") {
+                    palette.hideMenu();
                 }
             }
-
-            // Remove the palette DOM element if it exists
-            const paletteElement = docById("palette");
-            if (paletteElement) {
-                paletteElement.parentNode.removeChild(paletteElement);
-            }
-
-            // Clear the dictionary and reset state
-            this.dict = {};
-            this.visible = false;
-            this.activePalette = null;
-            this.paletteObject = null;
-
-            // Recreate the palette using the original initialization code
-            const element = document.createElement("div");
-            element.id = "palette";
-            element.setAttribute("class", "disable_highlighting");
-            element.classList.add("flex-palette");
-            element.setAttribute(
-                "style",
-                `position: fixed; z-index: 1000; left: 0px; top: ${
-                    60 + this.top
-                }px; overflow-y: auto;`
-            );
-            element.innerHTML = `<div style="height:fit-content">
-                    <table width="${1.5 * this.cellSize}" bgcolor="white">
-                        <thead>
-                            <tr></tr>
-                        </thead>
-                    </table>
-                    <table width="${4.5 * this.cellSize}" bgcolor="white">
-                        <thead>
-                            <tr>
-                                <td style= "width:28px"></td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        </tbody>
-                    </table>
-                </div>`;
-            element.childNodes[0].style.border = `1px solid ${platformColor.selectorSelected}`;
-            document.body.appendChild(element);
-
-            const toggleBtn = document.createElement("div");
-            toggleBtn.innerHTML = "◀";
-            toggleBtn.id = "paletteToggle";
-
-            toggleBtn.style.position = "absolute";
-            toggleBtn.style.top = "12px";
-            toggleBtn.style.right = "-18px";
-            toggleBtn.style.width = "22px";
-            toggleBtn.style.height = "40px";
-            toggleBtn.style.display = "flex";
-            toggleBtn.style.alignItems = "center";
-            toggleBtn.style.justifyContent = "center";
-            toggleBtn.style.cursor = "pointer";
-            toggleBtn.style.background = platformColor.selectorSelected;
-            toggleBtn.style.color = "white";
-
-            toggleBtn.style.borderRadius = "0 6px 6px 0";
-            toggleBtn.style.boxShadow = "0 2px 4px rgba(0,0,0,0.15)";
-            toggleBtn.style.fontWeight = "bold";
-            toggleBtn.style.fontSize = "14px";
-
-            toggleBtn.onclick = () => this.toggleCollapse();
-
-            element.appendChild(toggleBtn);
-        } catch (e) {
-            console.error("Error clearing palettes:", e);
         }
+
+        // Remove the palette DOM element if it exists
+        const paletteElement = docById("palette");
+        if (paletteElement) {
+            paletteElement.parentNode.removeChild(paletteElement);
+        }
+
+        // Clear the dictionary and reset state
+        this.dict = {};
+        this.visible = false;
+        this.activePalette = null;
+        this.paletteObject = null;
+
+        // Initialize palettes
+        initPalettes(palettes);
+
+        // Reset palette collapsed state
+        this.collapsed = false;
     }
 
     setBlocks(blocks) {


### PR DESCRIPTION
This PR resolves [#6706](https://github.com/sugarlabs/musicblocks/issues/6706)

### Issues Addressed

- Palette layout regression and toggle button bug when MB mode switch occurs [#6706](https://github.com/sugarlabs/musicblocks/issues/6706)
- Redundant logic for reinitialization of palettes at mode switch
---
### Solution

- Removed redundant and incorrect palette logic for reinitialization, and replaced it with `reinitialize()` method
- Updated mode switch handler in `js/activity.js` to use the new `palette.reinitialize()` method
- Updated the tests to align with the changes
---
### Changes
- `js/activity.js` <br>
  - Replaced `this.palettes.clear()` and `initPalettes()` calls with single `this.palettes.reinitialize()` during mode switch.
  - Updates `element.style.top` attribute of palette element for correct UI alignment at mode switch.
 
- `js/palette.js`<br>
  - Replaced `clear()` method with `reinitialize()` method.
    - Removes the old palette element from DOM
    - Resets palette internal state
    - calls initPalettes() function for initializing palette
    - Resets Palette collapsed state
  
- `js/__tests__/palette.js`
  - Removed `clear()` method tests
  - Added tests for `reinitialize()` method

---
### Screen Recording
[Screencast from 2026-04-18 20-46-53.webm](https://github.com/user-attachments/assets/bcf3bf7d-0e43-43fc-adb3-64148fc552bc)

---
### Testing/ verification performed
- Browser testing passes
- Palette toggle works as intended
- Palette layout remains consistant
- Palette and search functionality works as intended
- All jest tests pass

---
### PR Category

- [x] Bug Fix