### PR TITLE
fix: use dynamic blueButtonText color in Clear Workspace confirm dialog

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1605,7 +1605,7 @@ class Activity {
             confirmBtn.classList.add("confirm-button");
             confirmBtn.textContent = _("Confirm");
             confirmBtn.style.backgroundColor = platformColor.blueButton;
-            confirmBtn.style.color = "white";
+            confirmBtn.style.color = platformColor.blueButtonText;
             confirmBtn.style.border = "none";
             confirmBtn.style.borderRadius = "4px";
             confirmBtn.style.padding = "8px 16px";


### PR DESCRIPTION
Follow-up to #6681

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Summary

Applies dynamic theme colors to the `Clear Workspace` confirmation dialog to fix text visibility issues in High Contrast mode.

### Before the fix:

<img width="1918" height="965" alt="Screenshot 2026-04-18 181252" src="https://github.com/user-attachments/assets/954f7e66-0ec3-48fa-a2da-f9803a27d707" />

### After the fix:

<img width="1897" height="838" alt="image" src="https://github.com/user-attachments/assets/e83ab7f4-c493-4af0-abbe-942774f931dd" />


### What changed

- Replaced the hardcoded `"white"` text color with `platformColor.blueButtonText` in `js/activity.js` (`renderClearConfirmation`).
- Ensures the confirmation button remains fully readable (black text on cyan background) when the application is running in High Contrast mode.

### Addresses review concerns from #6681

- Fulfills the mentor request to adjust the unreadable white-on-cyan button colors "across the board" in the application's existing dialogs.
- Leverages the new `blueButtonText` property added to `platformstyle.js` in PR #6681.

### Verification

- [x] `npm run lint` 0 errors (401 pre-existing warnings, none new)
- [x] `npm test` 141 suites, 4630 tests all passing

### Browser testing

1. `npm run serve:dev` then open http://127.0.0.1:3000
2. Open Settings, switch theme to `High Contrast`
3. Click the `Clear Workspace` (trash can) icon in the toolbar
4. Confirm the text is now perfectly readable (black text on the bright cyan button)
5. Switch theme back to `Light` or `Dark` and verify the text reverts to white on blue.
