### PR TITLE
fix: guarantee lock release in DuplicateBlock and ArpeggioBlock criti…

### DIFF
--- a/js/blocks/FlowBlocks.js
+++ b/js/blocks/FlowBlocks.js
@@ -257,93 +257,91 @@ function setupFlowBlocks(activity) {
                 // Set the turtle listener
                 logo.setTurtleListener(turtle, listenerName, __listener);
 
-                // Acquire lock synchronously for the main flow
-                // Note: This section runs synchronously, so we use a simple spin-wait
-                // with a maximum iteration count to prevent infinite loops
-                let lockAttempts = 0;
-                const maxLockAttempts = 1000;
-                while (logo.connectionStoreLock && lockAttempts < maxLockAttempts) {
-                    lockAttempts++;
-                }
-                if (lockAttempts >= maxLockAttempts) {
+                // Acquire lock for the main flow
+                // JavaScript is single-threaded, so if the lock is held here it means
+                // a previous critical section did not release it (likely due to an error).
+                // We warn and force-acquire since no spin-wait can help in a single thread.
+                if (logo.connectionStoreLock) {
                     console.warn(
-                        "connectionStoreLock: Max attempts reached in DuplicateBlock flow"
+                        "connectionStoreLock: Lock already held in DuplicateBlock flow, forcing acquisition"
                     );
                 }
                 logo.connectionStoreLock = true;
 
-                // Check to see if another turtle has already disconnected these blocks
-                const otherTurtle = __lookForOtherTurtles(blk, turtle);
-                if (otherTurtle != null) {
-                    // Copy the connections and queue the blocks
-                    logo.connectionStore[turtle][blk] = [];
-                    for (let i = logo.connectionStore[otherTurtle][blk].length; i > 0; i--) {
-                        const obj = [
-                            logo.connectionStore[otherTurtle][blk][i - 1][0],
-                            logo.connectionStore[otherTurtle][blk][i - 1][1],
-                            logo.connectionStore[otherTurtle][blk][i - 1][2]
-                        ];
-                        logo.connectionStore[turtle][blk].push(obj);
-                        let child = obj[0];
-                        if (activity.blocks.blockList[child].name === "hidden") {
-                            child = activity.blocks.blockList[child].connections[0];
-                        }
+                try {
+                    // Check to see if another turtle has already disconnected these blocks
+                    const otherTurtle = __lookForOtherTurtles(blk, turtle);
+                    if (otherTurtle != null) {
+                        // Copy the connections and queue the blocks
+                        logo.connectionStore[turtle][blk] = [];
+                        for (let i = logo.connectionStore[otherTurtle][blk].length; i > 0; i--) {
+                            const obj = [
+                                logo.connectionStore[otherTurtle][blk][i - 1][0],
+                                logo.connectionStore[otherTurtle][blk][i - 1][1],
+                                logo.connectionStore[otherTurtle][blk][i - 1][2]
+                            ];
+                            logo.connectionStore[turtle][blk].push(obj);
+                            let child = obj[0];
+                            if (activity.blocks.blockList[child].name === "hidden") {
+                                child = activity.blocks.blockList[child].connections[0];
+                            }
 
-                        const queueBlock = new Queue(child, factor, blk, receivedArg);
-                        tur.parentFlowQueue.push(blk);
-                        tur.queue.push(queueBlock);
-                    }
-                } else {
-                    let child = activity.blocks.findBottomBlock(args[1]);
-                    while (child != blk) {
-                        if (activity.blocks.blockList[child].name !== "hidden") {
                             const queueBlock = new Queue(child, factor, blk, receivedArg);
                             tur.parentFlowQueue.push(blk);
                             tur.queue.push(queueBlock);
                         }
+                    } else {
+                        let child = activity.blocks.findBottomBlock(args[1]);
+                        while (child != blk) {
+                            if (activity.blocks.blockList[child].name !== "hidden") {
+                                const queueBlock = new Queue(child, factor, blk, receivedArg);
+                                tur.parentFlowQueue.push(blk);
+                                tur.queue.push(queueBlock);
+                            }
 
-                        child = activity.blocks.blockList[child].connections[0];
-                    }
-
-                    // Break the connections between blocks in the clamp so
-                    // that when we run the queues, only the individual blocks
-                    // run
-                    logo.connectionStore[turtle][blk] = [];
-                    child = args[1];
-                    while (child != null) {
-                        const lastConnection =
-                            activity.blocks.blockList[child].connections.length - 1;
-                        const nextBlk =
-                            activity.blocks.blockList[child].connections[lastConnection];
-                        // Don't disconnect a hidden block from its parent
-                        if (
-                            nextBlk != null &&
-                            activity.blocks.blockList[nextBlk].name === "hidden"
-                        ) {
-                            logo.connectionStore[turtle][blk].push([
-                                nextBlk,
-                                1,
-                                activity.blocks.blockList[nextBlk].connections[1]
-                            ]);
-                            child = activity.blocks.blockList[nextBlk].connections[1];
-                            activity.blocks.blockList[nextBlk].connections[1] = null;
-                        } else {
-                            logo.connectionStore[turtle][blk].push([
-                                child,
-                                lastConnection,
-                                nextBlk
-                            ]);
-                            activity.blocks.blockList[child].connections[lastConnection] = null;
-                            child = nextBlk;
+                            child = activity.blocks.blockList[child].connections[0];
                         }
 
-                        if (child != null) {
-                            activity.blocks.blockList[child].connections[0] = null;
+                        // Break the connections between blocks in the clamp so
+                        // that when we run the queues, only the individual blocks
+                        // run
+                        logo.connectionStore[turtle][blk] = [];
+                        child = args[1];
+                        while (child != null) {
+                            const lastConnection =
+                                activity.blocks.blockList[child].connections.length - 1;
+                            const nextBlk =
+                                activity.blocks.blockList[child].connections[lastConnection];
+                            // Don't disconnect a hidden block from its parent
+                            if (
+                                nextBlk != null &&
+                                activity.blocks.blockList[nextBlk].name === "hidden"
+                            ) {
+                                logo.connectionStore[turtle][blk].push([
+                                    nextBlk,
+                                    1,
+                                    activity.blocks.blockList[nextBlk].connections[1]
+                                ]);
+                                child = activity.blocks.blockList[nextBlk].connections[1];
+                                activity.blocks.blockList[nextBlk].connections[1] = null;
+                            } else {
+                                logo.connectionStore[turtle][blk].push([
+                                    child,
+                                    lastConnection,
+                                    nextBlk
+                                ]);
+                                activity.blocks.blockList[child].connections[lastConnection] = null;
+                                child = nextBlk;
+                            }
+
+                            if (child != null) {
+                                activity.blocks.blockList[child].connections[0] = null;
+                            }
                         }
                     }
+                } finally {
+                    logo.connectionStoreLock = false;
                 }
-
-                logo.connectionStoreLock = false;
             }
         }
     }

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -865,81 +865,90 @@ function setupIntervalsBlocks(activity) {
 
             logo.setTurtleListener(turtle, listenerName, __listener);
 
-            // Acquire lock synchronously for the main flow
-            // Note: This section runs synchronously, so we use a simple spin-wait
-            // with a maximum iteration count to prevent infinite loops
-            let lockAttempts = 0;
-            const maxLockAttempts = 1000;
-            while (logo.connectionStoreLock && lockAttempts < maxLockAttempts) {
-                lockAttempts++;
-            }
-            if (lockAttempts >= maxLockAttempts) {
-                console.warn("connectionStoreLock: Max attempts reached in ArpeggioBlock flow");
+            // Acquire lock for the main flow
+            // JavaScript is single-threaded, so if the lock is held here it means
+            // a previous critical section did not release it (likely due to an error).
+            // We warn and force-acquire since no spin-wait can help in a single thread.
+            if (logo.connectionStoreLock) {
+                console.warn(
+                    "connectionStoreLock: Lock already held in ArpeggioBlock flow, forcing acquisition"
+                );
             }
             logo.connectionStoreLock = true;
 
-            // Check to see if another turtle has already disconnected these blocks
-            const otherTurtle = __lookForOtherTurtles(blk, turtle);
-            if (otherTurtle != null) {
-                // Copy the connections and queue the blocks.
-                logo.connectionStore[turtle][blk] = [];
-                for (let i = logo.connectionStore[otherTurtle][blk].length; i > 0; i--) {
-                    const obj = [
-                        logo.connectionStore[otherTurtle][blk][i - 1][0],
-                        logo.connectionStore[otherTurtle][blk][i - 1][1],
-                        logo.connectionStore[otherTurtle][blk][i - 1][2]
-                    ];
-                    logo.connectionStore[turtle][blk].push(obj);
-                    let child = obj[0];
-                    if (activity.blocks.blockList[child].name === "hidden") {
-                        child = activity.blocks.blockList[child].connections[0];
-                    }
+            try {
+                // Check to see if another turtle has already disconnected these blocks
+                const otherTurtle = __lookForOtherTurtles(blk, turtle);
+                if (otherTurtle != null) {
+                    // Copy the connections and queue the blocks.
+                    logo.connectionStore[turtle][blk] = [];
+                    for (let i = logo.connectionStore[otherTurtle][blk].length; i > 0; i--) {
+                        const obj = [
+                            logo.connectionStore[otherTurtle][blk][i - 1][0],
+                            logo.connectionStore[otherTurtle][blk][i - 1][1],
+                            logo.connectionStore[otherTurtle][blk][i - 1][2]
+                        ];
+                        logo.connectionStore[turtle][blk].push(obj);
+                        let child = obj[0];
+                        if (activity.blocks.blockList[child].name === "hidden") {
+                            child = activity.blocks.blockList[child].connections[0];
+                        }
 
-                    const queueBlock = new Queue(child, factor, blk, receivedArg);
-                    tur.parentFlowQueue.push(blk);
-                    tur.queue.push(queueBlock);
-                }
-            } else {
-                let child = activity.blocks.findBottomBlock(args[1]);
-                while (child != blk) {
-                    if (activity.blocks.blockList[child].name !== "hidden") {
                         const queueBlock = new Queue(child, factor, blk, receivedArg);
                         tur.parentFlowQueue.push(blk);
                         tur.queue.push(queueBlock);
                     }
-                    child = activity.blocks.blockList[child].connections[0];
-                }
-
-                // Break the connections between blocks in the clamp so
-                // that when we run the queues, only the individual blocks,
-                // each inserted into a semitoneinterval block, run.
-                logo.connectionStore[turtle][blk] = [];
-                child = args[1];
-                while (child != null) {
-                    const lastConnection = activity.blocks.blockList[child].connections.length - 1;
-                    const nextBlk = activity.blocks.blockList[child].connections[lastConnection];
-                    // Don't disconnect a hidden block from its parent.
-                    if (nextBlk != null && activity.blocks.blockList[nextBlk].name === "hidden") {
-                        logo.connectionStore[turtle][blk].push([
-                            nextBlk,
-                            1,
-                            activity.blocks.blockList[nextBlk].connections[1]
-                        ]);
-                        child = activity.blocks.blockList[nextBlk].connections[1];
-                        activity.blocks.blockList[nextBlk].connections[1] = null;
-                    } else {
-                        logo.connectionStore[turtle][blk].push([child, lastConnection, nextBlk]);
-                        activity.blocks.blockList[child].connections[lastConnection] = null;
-                        child = nextBlk;
+                } else {
+                    let child = activity.blocks.findBottomBlock(args[1]);
+                    while (child != blk) {
+                        if (activity.blocks.blockList[child].name !== "hidden") {
+                            const queueBlock = new Queue(child, factor, blk, receivedArg);
+                            tur.parentFlowQueue.push(blk);
+                            tur.queue.push(queueBlock);
+                        }
+                        child = activity.blocks.blockList[child].connections[0];
                     }
 
-                    if (child != null) {
-                        activity.blocks.blockList[child].connections[0] = null;
+                    // Break the connections between blocks in the clamp so
+                    // that when we run the queues, only the individual blocks,
+                    // each inserted into a semitoneinterval block, run.
+                    logo.connectionStore[turtle][blk] = [];
+                    child = args[1];
+                    while (child != null) {
+                        const lastConnection =
+                            activity.blocks.blockList[child].connections.length - 1;
+                        const nextBlk =
+                            activity.blocks.blockList[child].connections[lastConnection];
+                        // Don't disconnect a hidden block from its parent.
+                        if (
+                            nextBlk != null &&
+                            activity.blocks.blockList[nextBlk].name === "hidden"
+                        ) {
+                            logo.connectionStore[turtle][blk].push([
+                                nextBlk,
+                                1,
+                                activity.blocks.blockList[nextBlk].connections[1]
+                            ]);
+                            child = activity.blocks.blockList[nextBlk].connections[1];
+                            activity.blocks.blockList[nextBlk].connections[1] = null;
+                        } else {
+                            logo.connectionStore[turtle][blk].push([
+                                child,
+                                lastConnection,
+                                nextBlk
+                            ]);
+                            activity.blocks.blockList[child].connections[lastConnection] = null;
+                            child = nextBlk;
+                        }
+
+                        if (child != null) {
+                            activity.blocks.blockList[child].connections[0] = null;
+                        }
                     }
                 }
+            } finally {
+                logo.connectionStoreLock = false;
             }
-
-            logo.connectionStoreLock = false;
         }
     }
 

--- a/js/blocks/__tests__/FlowBlocks.test.js
+++ b/js/blocks/__tests__/FlowBlocks.test.js
@@ -279,6 +279,31 @@ describe("FlowBlocks integration", () => {
         expect(activity.errorMsg).toHaveBeenCalledWith(NOINPUTERRORMSG, blk);
     });
 
+    test("DuplicateBlock releases lock even when critical section throws", () => {
+        const block = getBlock("duplicatenotes");
+        const blk = 0;
+
+        // Set up a minimal blockList that will cause an error during
+        // the connection-breaking loop (accessing undefined block)
+        activity.blocks.blockList = {
+            0: { name: "duplicatenotes", connections: [null, 1, null, 2] },
+            1: { name: "visibleA", connections: [0, 99] }
+        };
+        activity.blocks.findBottomBlock = jest.fn(() => 1);
+        // Block 99 doesn't exist, so accessing blockList[99].name will throw
+        logo.connectionStore = { 0: {} };
+        logo.connectionStoreLock = false;
+
+        // The flow should not propagate the error (try/finally handles it)
+        // but the lock MUST be released afterward
+        expect(() => {
+            block.flow([2, 1], logo, 0, blk, ["arg"]);
+        }).toThrow();
+
+        // The critical guarantee: lock is released even after an error
+        expect(logo.connectionStoreLock).toBe(false);
+    });
+
     test("DefaultCaseBlock validates switch context", () => {
         const block = getBlock("defaultcase");
         const blk = 2;


### PR DESCRIPTION
while i was looking at the existing lock mechanism( which already has retries via_acquirelock) i saw two issue that could cause problem during multi-turtle duplicate/arpeggio excution

-lock leak on exception - the main flow() method acquire connection storelock but the criticial section betweem acquire and realease had no try/finally if any of the block threw( eg accessin a missing block ) the lock would never get released. the async listener_ acquirelock would then spin for 1 second before force-requiring.

-dead spin wait loop the synchronous  spin-wait ( while ( lock && attempts< 10000)) can never actually work in single threaded javscript so no other code can run while the loop is excuting so the flag can never change  , so i replaced it with an honesh check and warn that does the same thing without pretending to wait

Related to #5155



- [x] Bug Fix`