### PR TITLE
fix: add array bounds validation for staffBlocksMap to prevent crashes

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5620,8 +5620,25 @@ class Activity {
             }
 
             const finalBlock = [];
-            // Some Error are here need to be fixed
             for (const staffIndex in staffBlocksMap) {
+                // Validate that the staff has sufficient block data for linking.
+                // Staves with no notes or incomplete structures from certain
+                // ABC notation inputs can cause crashes when accessing nested
+                // array elements without bounds checking.
+                if (
+                    !staffBlocksMap[staffIndex].baseBlocks ||
+                    staffBlocksMap[staffIndex].baseBlocks.length === 0 ||
+                    !staffBlocksMap[staffIndex].baseBlocks[0] ||
+                    !staffBlocksMap[staffIndex].baseBlocks[0][0] ||
+                    staffBlocksMap[staffIndex].baseBlocks[0][0].length < 4 ||
+                    staffBlocksMap[staffIndex].startBlock.length < 3 ||
+                    !staffBlocksMap[staffIndex].nameddoArray ||
+                    !staffBlocksMap[staffIndex].nameddoArray[staffIndex] ||
+                    staffBlocksMap[staffIndex].nameddoArray[staffIndex].length === 0
+                ) {
+                    finalBlock.push(...staffBlocksMap[staffIndex].startBlock);
+                    continue;
+                }
                 staffBlocksMap[staffIndex].startBlock[
                     staffBlocksMap[staffIndex].startBlock.length - 3
                 ][4][2] =
@@ -5637,6 +5654,16 @@ class Activity {
                     ][0];
                 const repeatblockids = staffBlocksMap[staffIndex].repeatArray;
                 for (const repeatId of repeatblockids) {
+                    // Skip repeat entries with out-of-bounds block indices
+                    if (
+                        repeatId.start < 0 ||
+                        repeatId.end < 0 ||
+                        repeatId.start >= staffBlocksMap[staffIndex].baseBlocks.length ||
+                        repeatId.end >= staffBlocksMap[staffIndex].baseBlocks.length
+                    ) {
+                        continue;
+                    }
+
                     if (repeatId.start === 0) {
                         staffBlocksMap[staffIndex].repeatBlock.push([
                             blockId,

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -517,22 +517,47 @@ function AIWidget() {
             const startBlockArray = staffBlocksMap[staffIndex].startBlock;
             const baseBlocks = staffBlocksMap[staffIndex].baseBlocks;
 
-            if (baseBlocks.length > 0 && baseBlocks[0].length > 0) {
-                const firstNoteBlockId = baseBlocks[0][0][0];
+            // Validate that the staff has sufficient block data for linking.
+            // Staves with no notes or incomplete structures from certain
+            // ABC notation inputs can cause crashes when accessing nested
+            // array elements without bounds checking.
+            if (
+                !baseBlocks ||
+                baseBlocks.length === 0 ||
+                !baseBlocks[0] ||
+                !baseBlocks[0][0] ||
+                baseBlocks[0][0].length < 4 ||
+                startBlockArray.length < 3 ||
+                !staffBlocksMap[staffIndex].nameddoArray ||
+                !staffBlocksMap[staffIndex].nameddoArray[staffIndex] ||
+                staffBlocksMap[staffIndex].nameddoArray[staffIndex].length === 0
+            ) {
+                finalBlock.push(...startBlockArray);
+                continue;
+            }
 
-                // Find the meter block to connect it to the first note
-                const meterBlock = startBlockArray.find(
-                    b => b[1] === "meter" || b[1][0] === "meter"
-                );
-                if (meterBlock) {
-                    meterBlock[4][3] = firstNoteBlockId;
-                }
+            const firstNoteBlockId = baseBlocks[0][0][0];
+
+            // Find the meter block to connect it to the first note
+            const meterBlock = startBlockArray.find(b => b[1] === "meter" || b[1][0] === "meter");
+            if (meterBlock) {
+                meterBlock[4][3] = firstNoteBlockId;
             }
 
             const repeatBlock = [];
 
             const repeatblockids = staffBlocksMap[staffIndex].repeatArray;
             for (const repeatId of repeatblockids) {
+                // Skip repeat entries with out-of-bounds block indices
+                if (
+                    repeatId.start < 0 ||
+                    repeatId.end < 0 ||
+                    repeatId.start >= baseBlocks.length ||
+                    repeatId.end >= baseBlocks.length
+                ) {
+                    continue;
+                }
+
                 if (repeatId.start === 0) {
                     staffBlocksMap[staffIndex].repeatBlock.push([
                         blockId,


### PR DESCRIPTION
The parseABC function crashes with TypeError: Cannot read property of undefined when ABC notation produces staves with no notes or incomplete repeat structures. The code was accessing deeply nested arrays (baseBlocks[0][0], nameddoArray[staffIndex][repeatId.end+1], etc.) without checking if they existed first.

Fix: Added bounds validation before the linking loop empty/malformed staves are skipped gracefully. Also added repeat index bounds checking to prevent out-of-range access. Applied to both js/activity.js and js/widgets/aiwidget.js.
- [x] Bug Fix