### PR TITLE
fix: resolve aggressive letter stripping in getArticulation

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -854,9 +854,9 @@ describe("getArticulation", () => {
         expect(getArticulation("do")).toBe("");
         expect(getArticulation("re")).toBe("");
     });
-    it("should handle combinations of articulations", () => {
-        expect(getArticulation("do^")).toBe("");
-        expect(getArticulation("C^^")).toBe("");
+    it("should extract articulation symbols (extract from do^ or C^^)", () => {
+        expect(getArticulation("do^")).toBe("^");
+        expect(getArticulation("C^^")).toBe("^^");
     });
     it("should preserve non-articulation characters", () => {
         expect(getArticulation("X")).toBe("X");
@@ -864,7 +864,13 @@ describe("getArticulation", () => {
     });
     it("should handle empty and special cases", () => {
         expect(getArticulation("")).toBe("");
-        expect(getArticulation("doremifa")).toBe("");
+        expect(getArticulation("doremifa")).toBe("remifa"); // Only strips the first prefix
+    });
+    it("should handle custom note names like BAGPIPE_D correctly", () => {
+        // "BAGPIPE_D" should not have internal letters stripped.
+        // If "B" is seen as a note name prefix, it extracts "AGPIPE_D".
+        // Crucially, it no longer removes A, G, E, or D from the middle.
+        expect(getArticulation("BAGPIPE_D")).toBe("AGPIPE_D");
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2963,31 +2963,26 @@ const frequencyToPitch = hz => {
 };
 
 /**
- * Get the articulation symbols from a note string.
+ * Get the articulation (accidental/direction) suffix from a note string by
+ * stripping the leading note-name prefix.
+ *
+ * Valid prefixes are the seven solfege syllables (do, re, mi, fa, sol, la, ti)
+ * and the seven letter note names (A–G). The prefix is matched only at the
+ * start of the string so that custom note names that happen to contain these
+ * letters elsewhere are not mangled.
+ *
  * @function
- * @param {string} note - The note string.
- * @returns {string} The note string without articulation symbols.
+ * @param {string} note - The note string (e.g. "C♯", "sol♭", "A^^").
+ * @returns {string} Whatever follows the note-name prefix (the articulation),
+ *     or the full string unchanged if no recognised prefix is found.
  */
 const getArticulation = note => {
-    return note
-        .replace("do", "")
-        .replace("re", "")
-        .replace("mi", "")
-        .replace("fa", "")
-        .replace("sol", "")
-        .replace("la", "")
-        .replace("ti", "")
-        .replace("A", "")
-        .replace("B", "")
-        .replace("C", "")
-        .replace("D", "")
-        .replace("E", "")
-        .replace("F", "")
-        .replace("G", "")
-        .replace("^^", "") // up/down from custom notes
-        .replace("vv", "")
-        .replace("^", "")
-        .replace("v", "");
+    // Match solfege names (longest first to avoid "sol" being shadowed by
+    // a later "la" replacement) or a single letter note name, anchored at
+    // the very start of the string.  Everything after the prefix is the
+    // articulation we want.
+    const match = note.match(/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/);
+    return match ? match[1] : note;
 };
 
 /**

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4292,6 +4292,7 @@ function getNote(
             case FLAT + SHARP:
             case SHARP + FLAT:
             default:
+                noteArg += articulation;
                 break;
         }
 
@@ -4742,6 +4743,7 @@ function getNote(
             case FLAT + SHARP:
             case SHARP + FLAT:
             default:
+                noteArg += articulation;
                 break;
         }
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1369,7 +1369,7 @@ function Synth() {
             attr = 0;
         }
 
-        const fragment = solfege.replace(attr, "");
+        const fragment = solfege.replace(getArticulation(solfege), "");
         let chromaticNumber = 0;
         if (fragment in solfegeDict) {
             chromaticNumber = solfegeDict[fragment];


### PR DESCRIPTION
- [x] Bug fix : #6713 

## Description
Refactored getArticulation in musicutils.js to resolve a bug where note names and solfege syllables were being stripped globally from note strings. This was causing corruption in custom note names and temperaments (e.g., "BAGPIPE_D" being mangled into "PI_").

## Changes
Refactored getArticulation: Replaced sequential string replacements with an anchored Regular Expression (/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/). This ensures that only the note-name prefix is matched at the start of the string, correctly isolating the articulation suffix without affecting internal characters.
**Fixed synthutils.js**: Corrected a bug in _parseSampleCenterNo that incorrectly used a numeric value for string replacement; it now properly handles the articulation string before conversion.
