### PR TITLE
fix: correct error message in setSynthVolume when synth is not found

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -257,7 +257,7 @@ function setupVolumeActions(activity) {
             }
 
             if (synth === null) {
-                activity.errorMsg(synth + "not found");
+                activity.errorMsg(_(`${synthname} not found`));
                 synth = DEFAULTVOICE;
             }
 

--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -257,7 +257,7 @@ function setupVolumeActions(activity) {
             }
 
             if (synth === null) {
-                activity.errorMsg(_(`${synthname} not found`));
+                activity.errorMsg(_("Synth not found") + ": " + synthname);
                 synth = DEFAULTVOICE;
             }
 

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -431,7 +431,7 @@ describe("setupVolumeActions", () => {
 
         it("should handle invalid synth name", () => {
             Singer.VolumeActions.setSynthVolume("invalidSynth", 70, 0, "testBlock");
-            expect(activity.errorMsg).toHaveBeenCalledWith("invalidSynth not found");
+            expect(activity.errorMsg).toHaveBeenCalledWith("Synth not found: invalidSynth");
             expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
         });
 

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -431,7 +431,7 @@ describe("setupVolumeActions", () => {
 
         it("should handle invalid synth name", () => {
             Singer.VolumeActions.setSynthVolume("invalidSynth", 70, 0, "testBlock");
-            expect(activity.errorMsg).toHaveBeenCalledWith("nullnot found");
+            expect(activity.errorMsg).toHaveBeenCalledWith("invalidSynth not found");
             expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
         });
 


### PR DESCRIPTION
## Summary

Fixes a broken error message in `Singer.VolumeActions.setSynthVolume` where an unresolved synth name displayed `nullnot found` instead of a meaningful message.

## Problem

When `setSynthVolume` could not match `synthname` to any known voice or drum, it fell through to the error branch with `synth` still set to `null`:

```js
activity.errorMsg(synth + "not found");  // → "nullnot found"
```

Three issues in one line:
- Used `synth` (which is `null`) instead of the unresolved `synthname`
- Missing space before `"not found"`
- Not wrapped in `_()` for translation

## Fix

```js
activity.errorMsg(_(`${synthname} not found`));
```

- Replaced `synth` with `synthname` to display the actual unresolved value
- Added the missing space
- Wrapped in `_()` consistent with other error messages in the same file (e.g. `setMasterVolume`)

Updated the corresponding Jest test expectation from `"nullnot found"` to `"invalidSynth not found"`.

## Files Changed

- `js/turtleactions/VolumeActions.js` — fix error message (1 line)
- `js/turtleactions/__tests__/VolumeActions.test.js` — sync test expectation (1 line)

## Testing

- Existing Jest test for the invalid synth case now passes with the corrected expectation
- No other tests affected

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

closes #6697 