### PR TITLE
Fix utils.js global window.onload overwrite during IE check. Fixes #6721

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -29,6 +29,7 @@ global.window = {
     },
     server: "http://localhost/",
     onload: null,
+    addEventListener: jest.fn(),
     setInterval: jest.fn(),
     clearInterval: jest.fn()
 };
@@ -95,6 +96,27 @@ const {
 } = require("../utils.js");
 
 describe("Utility Functions (logic-only)", () => {
+    describe("load handler registration", () => {
+        it("registers the IE check without overwriting an existing window.onload", () => {
+            const existingOnload = jest.fn();
+            const originalOnload = window.onload;
+            const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+
+            jest.resetModules();
+            window.onload = existingOnload;
+
+            jest.isolateModules(() => {
+                require("../utils.js");
+            });
+
+            expect(window.onload).toBe(existingOnload);
+            expect(addEventListenerSpy).toHaveBeenCalledWith("load", expect.any(Function));
+
+            addEventListenerSpy.mockRestore();
+            window.onload = originalOnload;
+        });
+    });
+
     describe("toTitleCase()", () => {
         it("converts first character to uppercase", () => {
             expect(toTitleCase("hello")).toBe("Hello");

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -437,7 +437,7 @@ function waitForReadiness(callback, options = {}) {
 
 // Check for Internet Explorer
 
-window.onload = () => {
+window.addEventListener("load", () => {
     const userAgent = window.navigator.userAgent;
     // For IE 10 or older
     const MSIE = userAgent.indexOf("MSIE ");
@@ -484,7 +484,7 @@ window.onload = () => {
             "<a href='https://www.mozilla.org/en-US/firefox/new/' style='float: left; margin-left: 40px;display: inherit; font-family: Arial; font-size: 30px; color: #0327F1; text-decoration: none;'>Firefox</a>";
         document.body.innerHTML += "</div></div>";
     }
-};
+});
 
 /**
  * Retrieves a collection of elements by class name.
@@ -799,7 +799,10 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     try {
         obj = JSON.parse(pluginData);
     } catch (error) {
-        console.error(`PluginProcessor: Failed to parse plugin data from source "${pluginSource}":`, error);
+        console.error(
+            `PluginProcessor: Failed to parse plugin data from source "${pluginSource}":`,
+            error
+        );
         console.debug("Malformed plugin data:", pluginData);
         return null;
     }


### PR DESCRIPTION
Description
This PR fixes a global startup hook overwrite in `js/utils/utils.js`. The IE compatibility check was assigning directly to `window.onload`, which could replace an earlier load handler registered by other startup code.

Related Issue
Fixes #6721

PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [x] Tests - Adds or updates test coverage
- [ ] Documentation - Updates to docs, comments, or README

Changes Made
- Replaced the direct `window.onload = ...` assignment in `js/utils/utils.js` with `window.addEventListener("load", ...)`.
- Added a regression test to verify `utils.js` registers its IE check without clobbering an existing `window.onload` handler.
- Formatted the touched files so the changed-files lint and prettier workflow stays green.

Testing Performed
- `npx jest js/utils/__tests__/utils.test.js --runInBand --coverage=false`
- `npx eslint js/utils/utils.js js/utils/__tests__/utils.test.js`
- `npx prettier --check js/utils/utils.js js/utils/__tests__/utils.test.js`

Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run npm run lint and npx prettier --check . with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled "Allow edits from maintainers" (required for auto-rebase; this only affects the PR branch, not your fork).

Additional Notes for Reviewers
- Validation here is intentionally scoped to the touched `utils.js` load-handler logic and its regression coverage.
- I ran ESLint and Prettier on the changed files, but not the full repo-wide `npm run lint` or `npx prettier --check .` commands.
