### PR TITLE
fix: intervalsBlocks failing tests import mismatch, deepClone mock

### DIFF
--- a/js/__tests__/IntervalsBlocks.test.js
+++ b/js/__tests__/IntervalsBlocks.test.js
@@ -103,7 +103,7 @@ global.Singer = {
     }
 };
 
-const setupIntervalsBlocks = require("../blocks/IntervalsBlocks.js");
+const { setupIntervalsBlocks } = require("../blocks/IntervalsBlocks.js");
 
 function makeTurSinger(overrides = {}) {
     return {

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -65,6 +65,7 @@ describe("setupIntervalsBlocks", () => {
 
         global._ = jest.fn(msg => msg);
         global.last = jest.fn(arr => arr[arr.length - 1]);
+        global.deepClone = obj => JSON.parse(JSON.stringify(obj));
 
         global.ValueBlock = DummyValueBlock;
         global.FlowBlock = DummyFlowBlock;
@@ -737,7 +738,7 @@ describe("setupIntervalsBlocks", () => {
             expect(logo.setDispatchBlock).toHaveBeenCalledWith(
                 "blkArp",
                 turtleIndex,
-                "_duplicate_0"
+                "_duplicate_0_blkArp"
             );
             expect(logo.setTurtleListener).toHaveBeenCalled();
             expect(global.Queue).toHaveBeenCalled();


### PR DESCRIPTION
### Summary
This PR fixes failing tests in IntervalsBlocks by resolving test setup issues and aligning expectations with current implementation.

### Changes
- Fixed incorrect import usage in test files to match module export format
- Added a mock for `deepClone` in the test environment to prevent runtime errors
- Updated outdated test expectation for DuplicateBlock listener naming:
  - `_duplicate_0` → `_duplicate_0_blkArp`

### PR Category
- [x] Tests fix

<img width="668" height="210" alt="image" src="https://github.com/user-attachments/assets/fb92e70f-2922-4970-897e-0c8702b76e47" />

- All tests passing (143/143 test suites, 4797/4797 tests)
