### PR TITLE
fix(logo): execute ONSTOP plugin hooks on stop

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -483,6 +483,27 @@ describe("Logo Class", () => {
 
             expect(logo.stepQueue).toEqual({});
         });
+
+        test("executes ONSTOP plugin hooks", () => {
+            logo.sounds = [];
+            logo.synth = {
+                stop: jest.fn(),
+                stopSound: jest.fn(),
+                disposeAllInstruments: jest.fn(),
+                recorder: null
+            };
+            logo.evalOnStopList = {
+                firstHook: "code-first",
+                secondHook: "code-second"
+            };
+            logo.safePluginExecute = jest.fn();
+
+            logo.doStopTurtles();
+
+            expect(logo.safePluginExecute).toHaveBeenCalledTimes(2);
+            expect(logo.safePluginExecute).toHaveBeenNthCalledWith(1, "code-first", logo);
+            expect(logo.safePluginExecute).toHaveBeenNthCalledWith(2, "code-second", logo);
+        });
     });
 
     describe("step", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1142,6 +1142,10 @@ class Logo {
             this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
         }
 
+        for (const arg in this.evalOnStopList) {
+            this.safePluginExecute(this.evalOnStopList[arg], this);
+        }
+
         this.onStopTurtle();
         this.activity.blocks.bringToTop();
 


### PR DESCRIPTION
### Description
Execute plugin ONSTOP handlers when turtles stop.

### Problem
ONSTOP handlers were stored in `evalOnStopList` but never executed, so plugins could not run their cleanup logic on stop.

### Solution
Updated `doStopTurtles()` to iterate over `evalOnStopList` and execute each handler using `safePluginExecute(...)` before existing stop callbacks.

### Changes Made
- js/logo.js: execute ONSTOP handlers during stop
- js/__tests__/logo.test.js: added regression test

### Testing Performed
- Verified ONSTOP handlers are executed with correct arguments
- Ran full test suite (all tests passing)
- Lint and format checks passed for modified files

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

### Notes
- Minimal, low-risk change
- Uses existing `safePluginExecute(...)` (no new execution path)
- Runs only on stop → no runtime performance impact