### PR TITLE
Harden widget HTML rendering

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1370,7 +1370,7 @@ const piemenuNthModalPitch = (block, noteValues, note) => {
 
     // enable changing values while pie-menu is open
     const labelElem = docById("labelDiv");
-    labelElem.innerHTML = `<input id="numberLabel" style="position: absolute; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text;" class="number" type="number" value="${note}" />`;
+    labelElem.replaceChildren(createNumberLabelInput(note));
     labelElem.classList.add("hasKeyboard");
 
     block.label = docById("numberLabel");
@@ -1821,7 +1821,7 @@ const piemenuNoteValue = (block, noteValue) => {
     };
 
     const labelElem = docById("labelDiv");
-    labelElem.innerHTML = `<input id="numberLabel" style="position: absolute; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text;" class="number" type="number" value="${noteValue}" />`;
+    labelElem.replaceChildren(createNumberLabelInput(noteValue));
     labelElem.classList.add("hasKeyboard");
     block.label = docById("numberLabel");
 
@@ -2061,7 +2061,7 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
     };
 
     const labelElem = docById("labelDiv");
-    labelElem.innerHTML = `<input id="numberLabel" style="position: absolute; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text;" class="number" type="number" value="${selectedValue}" />`;
+    labelElem.replaceChildren(createNumberLabelInput(selectedValue));
     labelElem.classList.add("hasKeyboard");
     block.label = docById("numberLabel");
 
@@ -2262,6 +2262,24 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
 };
 
 /**
+ * Creates the numeric input used by pie menus without relying on HTML injection.
+ * @param {number|string} value
+ * @returns {HTMLInputElement}
+ */
+const createNumberLabelInput = value => {
+    const input = document.createElement("input");
+    input.id = "numberLabel";
+    input.style.position = "absolute";
+    input.style.webkitUserSelect = "text";
+    input.style.MozUserSelect = "text";
+    input.style.msUserSelect = "text";
+    input.className = "number";
+    input.type = "number";
+    input.value = value;
+    return input;
+};
+
+/**
  * Builds the color-selection pie menu for turtle and paint blocks.
  *
  * @param {Object} block Block instance invoking the menu
@@ -2371,7 +2389,7 @@ const piemenuColor = (block, wheelValues, selectedValue, mode) => {
     };
 
     const labelElem = docById("labelDiv");
-    labelElem.innerHTML = `<input id="numberLabel" style="position: absolute; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text;" class="number" type="number" value="${selectedValue}" />`;
+    labelElem.replaceChildren(createNumberLabelInput(selectedValue));
     labelElem.classList.add("hasKeyboard");
     block.label = docById("numberLabel");
 

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -389,8 +389,8 @@ class HelpWidget {
             img.src = HELPCONTENT[page][2];
             img.alt = `${HELPCONTENT[page][0]} icon`;
             img.loading = "lazy";
-            img.width = 64;
-            img.height = 64;
+            img.setAttribute("width", "64px");
+            img.setAttribute("height", "64px");
             figure.append(img);
             bodyFragment.append(figure);
         }

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -233,7 +233,7 @@ class HelpWidget {
                     const helpBody = docById("helpBodyDiv");
                     helpBody.style.height = "70vh";
 
-                    let body = "";
+                    const bodyFragment = document.createDocumentFragment();
                     if (message.length > 1) {
                         let path = message[1];
                         // We need to add a case here whenever we add
@@ -264,16 +264,24 @@ class HelpWidget {
 
                         // body = body + '<p><img src="' + path + "/" + name + '_block.svg"></p>';
                         const imageSrc = `Docs/${path}/${name}_block.svg`;
-                        body += `<figure style="width:100%;"><img style="max-width:100%;" src=${imageSrc}></figure>`;
+                        const figure = document.createElement("figure");
+                        figure.style.width = "100%";
+                        const img = document.createElement("img");
+                        img.style.maxWidth = "100%";
+                        img.src = imageSrc;
+                        figure.append(img);
+                        bodyFragment.append(figure);
                     }
 
-                    body += `<p>${message[0]}</p>`;
+                    const messageParagraph = document.createElement("p");
+                    messageParagraph.textContent = message[0];
+                    bodyFragment.append(messageParagraph);
 
                     const loadButtonHTML =
                         '<i style="margin-right: 10px" id="loadButton" data-toggle="tooltip" title="Load this block" class="material-icons md-48">get_app</i>';
                     iconsContainer.insertAdjacentHTML("afterbegin", loadButtonHTML);
 
-                    helpBody.insertAdjacentHTML("afterbegin", body);
+                    helpBody.append(bodyFragment);
 
                     if (
                         !this.activity.blocks.blockList[this.activity.blocks.activeBlock].protoblock
@@ -357,7 +365,7 @@ class HelpWidget {
         leftArrow.classList.toggle("disabled", page === 0);
 
         // Previous HTML content is removed, and new one is generated.
-        let body = "";
+        const bodyFragment = document.createDocumentFragment();
         if (
             [
                 _("Welcome to Music Blocks"),
@@ -368,21 +376,49 @@ class HelpWidget {
             ].includes(HELPCONTENT[page][0])
         ) {
             // body = body + '<p>&nbsp;<img src="' + HELPCONTENT[page][2] + '"></p>';
-            body = `<figure><img src="${HELPCONTENT[page][2]}" alt="${HELPCONTENT[page][0]} icon" loading="lazy"></figure>`;
+            const figure = document.createElement("figure");
+            const img = document.createElement("img");
+            img.src = HELPCONTENT[page][2];
+            img.alt = `${HELPCONTENT[page][0]} icon`;
+            img.loading = "lazy";
+            figure.append(img);
+            bodyFragment.append(figure);
         } else {
-            body = `<figure><img src="${HELPCONTENT[page][2]}" alt="${HELPCONTENT[page][0]} icon" loading="lazy" width="64px" height="64px"></figure>`;
+            const figure = document.createElement("figure");
+            const img = document.createElement("img");
+            img.src = HELPCONTENT[page][2];
+            img.alt = `${HELPCONTENT[page][0]} icon`;
+            img.loading = "lazy";
+            img.width = 64;
+            img.height = 64;
+            figure.append(img);
+            bodyFragment.append(figure);
         }
 
-        const helpContentHTML = `<h1 class="heading">${HELPCONTENT[page][0]}</h1> 
-         <p class="description">${HELPCONTENT[page][1]}</p>
-         <p>${pageCount}</p>`;
+        const heading = document.createElement("h1");
+        heading.classList.add("heading");
+        heading.textContent = HELPCONTENT[page][0];
+        bodyFragment.append(heading);
 
-        body += helpContentHTML;
+        const description = document.createElement("p");
+        description.classList.add("description");
+        description.textContent = HELPCONTENT[page][1];
+        bodyFragment.append(description);
+
+        const count = document.createElement("p");
+        count.textContent = pageCount;
+        bodyFragment.append(count);
 
         if (HELPCONTENT[page].length > 3) {
             const link = HELPCONTENT[page][3];
-            // console.debug(page + " " + link);
-            body += `<p><a href="${link}" target="_blank" rel="noopener noreferrer">${HELPCONTENT[page][4]}</a></p>`;
+            const linkParagraph = document.createElement("p");
+            const anchor = document.createElement("a");
+            anchor.href = link;
+            anchor.target = "_blank";
+            anchor.rel = "noopener noreferrer";
+            anchor.textContent = HELPCONTENT[page][4];
+            linkParagraph.append(anchor);
+            bodyFragment.append(linkParagraph);
         }
 
         if ([_("Congratulations.")].includes(HELPCONTENT[page][0])) {
@@ -426,7 +462,7 @@ class HelpWidget {
         }
 
         helpBody.style.color = "#505050";
-        helpBody.insertAdjacentHTML("afterbegin", body);
+        helpBody.append(bodyFragment);
 
         this.widgetWindow.takeFocus();
     }
@@ -569,7 +605,7 @@ class HelpWidget {
             helpBody.style.height = "70vh";
             // helpBody.style.backgroundColor = "#e8e8e8";
             if (message) {
-                let body = "";
+                const bodyFragment = document.createDocumentFragment();
                 if (message.length > 1) {
                     let path = message[1];
                     // We need to add a case here whenever we add
@@ -599,11 +635,20 @@ class HelpWidget {
                     }
 
                     const imageSrc = `Docs/documentation/${name}_block.svg`;
-                    body += `<figure class="blockImage-wrapper"><img class="blockImage" src="${imageSrc}"></figure>`;
+                    const figure = document.createElement("figure");
+                    figure.classList.add("blockImage-wrapper");
+                    const img = document.createElement("img");
+                    img.classList.add("blockImage");
+                    img.src = imageSrc;
+                    figure.append(img);
+                    bodyFragment.append(figure);
                 }
 
-                body += `<p class="message">${message[0]}</p>`;
-                helpBody.insertAdjacentHTML("afterbegin", body);
+                const messageParagraph = document.createElement("p");
+                messageParagraph.classList.add("message");
+                messageParagraph.textContent = message[0];
+                bodyFragment.append(messageParagraph);
+                helpBody.append(bodyFragment);
 
                 const loadIconHTML =
                     '<i style="margin-right: 10px" id="loadButton" data-toggle="tooltip" title="Load this block" class="material-icons md-48">get_app</i>';

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -57,6 +57,16 @@ function MusicKeyboard(activity) {
     const WHITEKEYS = [65, 83, 68, 70, 71, 72, 74, 75, 76];
     const SPACE = 32;
 
+    const setKeyboardCellLabel = (cell, label, octave, prefix = null) => {
+        cell.replaceChildren();
+        if (prefix !== null) {
+            const small = document.createElement("small");
+            small.textContent = `(${prefix})`;
+            cell.append(small, document.createElement("br"));
+        }
+        cell.append(document.createTextNode(`${label}${octave}`));
+    };
+
     const w = window.innerWidth;
     /**
      * Reference to the activity associated with the keyboard.
@@ -1596,13 +1606,13 @@ function MusicKeyboard(activity) {
             cell.style.left = "0px";
             cell.className = "headcol"; // This cell is fixed horizontally.
             if (this.displayLayout[i].noteName === "drum") {
-                cell.innerHTML = this.displayLayout[i].voice;
+                cell.textContent = this.displayLayout[i].voice;
             } else if (this.displayLayout[i].noteName === "hertz") {
-                cell.innerHTML = this.displayLayout[i].noteOctave.toString() + "HZ";
+                cell.textContent = this.displayLayout[i].noteOctave.toString() + "HZ";
             } else {
-                cell.innerHTML = `${i18nSolfege(
-                    this.displayLayout[i].noteName
-                )}<sub>${this.displayLayout[i].noteOctave.toString()}</sub>`;
+                cell.textContent = `${i18nSolfege(this.displayLayout[i].noteName)}${this.displayLayout[
+                    i
+                ].noteOctave.toString()}`;
             }
 
             cell.setAttribute("id", "labelcol" + (n - i - 1));
@@ -1646,7 +1656,7 @@ function MusicKeyboard(activity) {
         cell.style.minWidth = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) * 1.5 + "px";
         cell.style.maxWidth = cell.style.minWidth;
         cell.className = "headcol"; // This cell is fixed horizontally.
-        cell.innerHTML = _("Note value");
+        cell.textContent = _("Note value");
         cell.style.position = "sticky";
         cell.style.left = "0px";
         cell.style.zIndex = "1";
@@ -1698,7 +1708,7 @@ function MusicKeyboard(activity) {
             cell.style.maxWidth = cell.style.width;
             cell.style.lineHeight = 60 + "%";
             cell.style.textAlign = "center";
-            cell.innerHTML = `${dur[0].toString()}/${dur[1].toString()}`;
+            cell.textContent = `${dur[0].toString()}/${dur[1].toString()}`;
             cell.setAttribute("id", "cells-" + j);
             cell.setAttribute("start", selectedNotes[j].startTime);
             cell.setAttribute("dur", maxWidth);
@@ -2556,7 +2566,8 @@ function MusicKeyboard(activity) {
 
             const cell = docById("labelcol" + (this.layout.length - index - 1));
             this.layout[index].noteOctave = parseInt(blockValue);
-            cell.innerHTML = this.layout[index].noteName + this.layout[index].noteOctave.toString();
+            cell.textContent =
+                this.layout[index].noteName + this.layout[index].noteOctave.toString();
             this._notesPlayed.map(function (item) {
                 if (item.objId === this.layout[index].blockNumber) {
                     item.noteOctave = parseInt(blockValue);
@@ -2617,7 +2628,8 @@ function MusicKeyboard(activity) {
             const cell = docById("labelcol" + (this.layout.length - index - 1));
             this.layout[index].noteName = label;
             this.layout[index].noteOctave = octave;
-            cell.innerHTML = this.layout[index].noteName + this.layout[index].noteOctave.toString();
+            cell.textContent =
+                this.layout[index].noteName + this.layout[index].noteOctave.toString();
             const temp1 = label;
             let temp2;
             if (temp1 in FIXEDSOLFEGE1) {
@@ -2785,7 +2797,7 @@ function MusicKeyboard(activity) {
                 }
 
                 myrow2Id++;
-                newel2.innerHTML = "";
+                newel2.textContent = "";
                 newel2.style.visibility = "hidden";
                 parenttbl2.appendChild(newel2);
             } else if (this.displayLayout[p].noteName === "drum") {
@@ -2805,11 +2817,12 @@ function MusicKeyboard(activity) {
                     "whiteRow" + myrowId.toString(),
                     this.displayLayout[p].blockNumber
                 ]);
-                newel.innerHTML = `${
-                    myrowId < WHITEKEYS.length
-                        ? `<small>(${String.fromCharCode(WHITEKEYS[myrowId])})</small><br/>`
-                        : ""
-                }${this.displayLayout[p].voice}`;
+                setKeyboardCellLabel(
+                    newel,
+                    this.displayLayout[p].voice,
+                    "",
+                    myrowId < WHITEKEYS.length ? String.fromCharCode(WHITEKEYS[myrowId]) : null
+                );
 
                 this.displayLayout[p].objId = "whiteRow" + myrowId.toString();
 
@@ -2834,11 +2847,12 @@ function MusicKeyboard(activity) {
                     "hertzRow" + myrow3Id.toString(),
                     this.displayLayout[p].blockNumber
                 ]);
-                newel.innerHTML = `${
-                    myrow3Id < HERTZKEYS.length
-                        ? "<small>(${String.fromCharCode(HERTZKEYS[myrow3Id])})</small><br/>"
-                        : ""
-                }${this.displayLayout[p].noteOctave}`;
+                setKeyboardCellLabel(
+                    newel,
+                    "",
+                    this.displayLayout[p].noteOctave,
+                    myrow3Id < HERTZKEYS.length ? String.fromCharCode(HERTZKEYS[myrow3Id]) : null
+                );
 
                 this.displayLayout[p].objId = "hertzRow" + myrow3Id.toString();
 
@@ -2885,10 +2899,14 @@ function MusicKeyboard(activity) {
 
                 nname = this.displayLayout[p].noteName.replace(SHARP, "").replace("#", "");
                 if (this.displayLayout[p].blockNumber >= FAKEBLOCKNUMBER) {
-                    newel2.innerHTML =
+                    setKeyboardCellLabel(
+                        newel2,
+                        "",
+                        "",
                         myrow2Id < BLACKKEYS.length
-                            ? `<small>(${String.fromCharCode(BLACKKEYS[myrow2Id])})</small><br/>`
-                            : "";
+                            ? String.fromCharCode(BLACKKEYS[myrow2Id])
+                            : null
+                    );
                 }
                 if (p < this.layout.length) {
                     this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
@@ -2944,17 +2962,19 @@ function MusicKeyboard(activity) {
                 nname = this.displayLayout[p].noteName.replace(FLAT, "").replace("b", "");
                 if (this.displayLayout[p].blockNumber <= FAKEBLOCKNUMBER) {
                     if (SOLFEGENAMES.includes(nname)) {
-                        newel2.innerHTML = `<small>(${String.fromCharCode(
-                            BLACKKEYS[myrow2Id]
-                        )})</small><br/>${i18nSolfege(nname)}${FLAT}${
-                            this.displayLayout[p].noteOctave
-                        }`;
+                        setKeyboardCellLabel(
+                            newel2,
+                            `${i18nSolfege(nname)}${FLAT}`,
+                            this.displayLayout[p].noteOctave,
+                            String.fromCharCode(BLACKKEYS[myrow2Id])
+                        );
                     } else {
-                        newel2.innerHTML = `<small>(${String.fromCharCode(
-                            BLACKKEYS[myrow2Id]
-                        )})</small><br/>${this.displayLayout[p].noteName}${
-                            this.displayLayout[p].noteOctave
-                        }`;
+                        setKeyboardCellLabel(
+                            newel2,
+                            this.displayLayout[p].noteName,
+                            this.displayLayout[p].noteOctave,
+                            String.fromCharCode(BLACKKEYS[myrow2Id])
+                        );
                     }
                 }
                 if (p < this.layout.length) {
@@ -2988,19 +3008,23 @@ function MusicKeyboard(activity) {
 
                 if (this.displayLayout[p].blockNumber <= FAKEBLOCKNUMBER) {
                     if (SOLFEGENAMES.includes(this.displayLayout[p].noteName)) {
-                        newel.innerHTML = `${
+                        setKeyboardCellLabel(
+                            newel,
+                            i18nSolfege(this.displayLayout[p].noteName),
+                            this.displayLayout[p].noteOctave,
                             myrowId < WHITEKEYS.length
-                                ? `<small>(${String.fromCharCode(WHITEKEYS[myrowId])})</small><br/>`
-                                : ""
-                        }${i18nSolfege(this.displayLayout[p].noteName)}${
-                            this.displayLayout[p].noteOctave
-                        }`;
+                                ? String.fromCharCode(WHITEKEYS[myrowId])
+                                : null
+                        );
                     } else {
-                        newel.innerHTML = `${
+                        setKeyboardCellLabel(
+                            newel,
+                            this.displayLayout[p].noteName,
+                            this.displayLayout[p].noteOctave,
                             myrowId < WHITEKEYS.length
-                                ? `<small>(${String.fromCharCode(WHITEKEYS[myrowId])})</small><br/>`
-                                : ""
-                        }${this.displayLayout[p].noteName}${this.displayLayout[p].noteOctave}`;
+                                ? String.fromCharCode(WHITEKEYS[myrowId])
+                                : null
+                        );
                     }
                 }
                 if (p < this.layout.length) {
@@ -3020,7 +3044,7 @@ function MusicKeyboard(activity) {
         newel.style.textAlign = "center";
         newel.setAttribute("id", "rest");
         newel.setAttribute("alt", "R__");
-        newel.innerHTML = `<small>(${_("rest")})</small><br/>`;
+        setKeyboardCellLabel(newel, "", "", _("rest"));
         newel.style.position = "relative";
         newel.style.zIndex = "100";
 

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -724,7 +724,7 @@ class RhythmRuler {
             for (let j = 0; j < this.Rulers[i][0].length; j++) {
                 const noteValue = this.Rulers[i][0][j];
                 const rulerSubCell = rulerRow.insertCell(-1);
-                rulerSubCell.innerHTML = calcNoteValueToDisplay(noteValue, 1);
+                rulerSubCell.textContent = calcNoteValueToDisplay(noteValue, 1);
                 rulerSubCell.style.height = RhythmRuler.RULERHEIGHT + "px";
                 rulerSubCell.style.minHeight = rulerSubCell.style.height;
                 rulerSubCell.style.maxHeight = rulerSubCell.style.height;
@@ -1203,16 +1203,16 @@ class RhythmRuler {
             let obj;
             if (noteValue < 0) {
                 obj = rationalToFraction(Math.abs(Math.abs(-1 / noteValue)));
-                cell.innerHTML = `${calcNoteValueToDisplay(obj[1], obj[0])} ${_("silence")}}`;
+                cell.textContent = `${calcNoteValueToDisplay(obj[1], obj[0])} ${_("silence")}`;
             } else {
                 obj = rationalToFraction(Math.abs(Math.abs(1 / noteValue)));
-                cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
+                cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
             }
         };
 
         const __mouseOutHandler = event => {
             const cell = event.target;
-            cell.innerHTML = "";
+            cell.textContent = "";
         };
 
         const __mouseDownHandler = event => {
@@ -1288,9 +1288,9 @@ class RhythmRuler {
         let obj;
         if (cellWidth >= 18 && noteValue > 0) {
             obj = rationalToFraction(Math.abs(1 / noteValue));
-            cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
+            cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
         } else {
-            cell.innerHTML = "";
+            cell.textContent = "";
 
             cell.removeEventListener("mouseover", __mouseOverHandler);
             cell.addEventListener("mouseover", __mouseOverHandler);
@@ -1349,10 +1349,10 @@ class RhythmRuler {
                 const noteValue = noteValues[cell.cellIndex];
                 if (noteValue < 0) {
                     obj = rationalToFraction(Math.abs(Math.abs(-1 / noteValue)));
-                    cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]) + " " + _("silence");
+                    cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]) + " " + _("silence");
                 } else {
                     obj = rationalToFraction(Math.abs(Math.abs(1 / noteValue)));
-                    cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
+                    cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
                 }
             };
 
@@ -1363,17 +1363,17 @@ class RhythmRuler {
              */
             const __mouseOutHandler = event => {
                 const cell = event.target;
-                cell.innerHTML = "";
+                cell.textContent = "";
             };
 
             let obj;
             if (noteValue < 0) {
                 obj = rationalToFraction(Math.abs(1 / noteValue));
-                cell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
+                cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
                 cell.removeEventListener("mouseover", __mouseOverHandler);
                 cell.removeEventListener("mouseout", __mouseOutHandler);
             } else {
-                cell.innerHTML = "";
+                cell.textContent = "";
 
                 cell.removeEventListener("mouseover", __mouseOverHandler);
                 cell.addEventListener("mouseover", __mouseOverHandler);
@@ -1677,7 +1677,7 @@ class RhythmRuler {
             newCell.style.maxHeight = newCell.style.height;
 
             newCell.style.backgroundColor = platformColor.selectorBackground;
-            newCell.innerHTML = calcNoteValueToDisplay(oldCellNoteValue / inputNum, 1);
+            newCell.textContent = calcNoteValueToDisplay(oldCellNoteValue / inputNum, 1);
 
             noteValues[newCellIndex] = oldCellNoteValue / inputNum;
             noteValues.splice(newCellIndex + 1, inputNum - 1);
@@ -1711,7 +1711,7 @@ class RhythmRuler {
             newCell.style.backgroundColor = platformColor.selectorBackground;
 
             const obj = rationalToFraction(newNoteValue);
-            newCell.innerHTML = calcNoteValueToDisplay(obj[1], obj[0]);
+            newCell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
 
             noteValues[newCellIndex] = newNoteValue;
             noteValues.splice(newCellIndex + 1, oldNoteValues.length - 1);
@@ -1748,7 +1748,7 @@ class RhythmRuler {
                     newCell.style.maxHeight = newCell.style.height;
 
                     noteValues.splice(history[0][0] + i, 0, history[i][1]);
-                    newCell.innerHTML = calcNoteValueToDisplay(history[i][1], 1);
+                    newCell.textContent = calcNoteValueToDisplay(history[i][1], 1);
 
                     this.__addCellEventHandlers(newCell, newCellWidth, history[i][1]);
                 }

--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -133,21 +133,29 @@ class StatsWindow {
     displayInfo(stats) {
         const lowHertz = stats["lowestNote"][2] + 0.5;
         const highHertz = stats["highestNote"][2] + 0.5;
-        this.jsonObject.innerHTML = `<li>duples: ${stats["duples"]}</li>
-            <li>triplets: ${stats["triplets"]}</li>
-            <li>quintuplets: ${stats["quintuplets"]}</li>
-            <li style="white-space: pre-wrap; width: 150px">pitch names: ${Array.from(
-                stats["pitchNames"]
-            ).join(", ")}</li>
-            <li>number of notes: ${stats["numberOfNotes"]}</li>
-            <li style="white-space: pre-wrap; width: 150px">lowest note: ${
-                stats["lowestNote"][0]
-            },${lowHertz.toFixed(0)}Hz</li>
-            <li style="white-space: pre-wrap; width: 150px">highest note: ${
-                stats["highestNote"][0]
-            },${highHertz.toFixed(0)}Hz</li>
-            <li>rests used: ${stats["rests"]}</li>
-            <li>ornaments used: ${stats["ornaments"]}</li>`;
+        const items = [
+            ["duples", stats["duples"]],
+            ["triplets", stats["triplets"]],
+            ["quintuplets", stats["quintuplets"]],
+            ["pitch names", Array.from(stats["pitchNames"]).join(", ")],
+            ["number of notes", stats["numberOfNotes"]],
+            ["lowest note", `${stats["lowestNote"][0]},${lowHertz.toFixed(0)}Hz`],
+            ["highest note", `${stats["highestNote"][0]},${highHertz.toFixed(0)}Hz`],
+            ["rests used", stats["rests"]],
+            ["ornaments used", stats["ornaments"]]
+        ];
+
+        this.jsonObject.replaceChildren(
+            ...items.map(([label, value], index) => {
+                const li = document.createElement("li");
+                li.textContent = `${label}: ${value}`;
+                if (index === 3 || index === 5 || index === 6) {
+                    li.style.whiteSpace = "pre-wrap";
+                    li.style.width = "150px";
+                }
+                return li;
+            })
+        );
     }
 }
 /* istanbul ignore next */

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -454,9 +454,9 @@ class WidgetWindow {
      */
     addSelectorButton(list, initial, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
-        el.innerHTML = "";
-        el.insertAdjacentHTML("afterbegin", `<select value="${initial}" />`);
-        const selector = el.querySelector("select");
+        const selector = document.createElement("select");
+        selector.value = initial;
+        el.replaceChildren(selector);
         for (const i of list) {
             const newOption = new Option("turtle " + i, i);
             selector.add(newOption);
@@ -482,12 +482,13 @@ class WidgetWindow {
      * @returns {HTMLElement}
      */
     modifyButton(index, icon, iconSize, label) {
-        const innerHTML = `
-            <img src="header-icons/${icon}" title="${label}" alt="${label}" height="${iconSize}" width="${iconSize}"/> 
-            `;
-
-        this._buttons[index].innerHTML = "";
-        this._buttons[index].insertAdjacentHTML("afterbegin", innerHTML);
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.height = iconSize;
+        img.width = iconSize;
+        this._buttons[index].replaceChildren(img);
         return this._buttons[index];
     }
 
@@ -537,16 +538,13 @@ class WidgetWindow {
      */
     addButton(icon, iconSize, label, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
-
-        const innerHTML = `<img src="header-icons/${icon}" 
-                  title="${label}" 
-                  alt="${label}" 
-                  height="${iconSize}" 
-                  width="${iconSize}" 
-             />`;
-
-        el.innerHTML = "";
-        el.insertAdjacentHTML("afterbegin", innerHTML);
+        const img = document.createElement("img");
+        img.src = `header-icons/${icon}`;
+        img.title = label;
+        img.alt = label;
+        img.height = iconSize;
+        img.width = iconSize;
+        el.replaceChildren(img);
         this._buttons.push(el);
         return el;
     }


### PR DESCRIPTION
## What changed
- Replaced unsafe HTML string injection with DOM API rendering in widget windows, help screens, statistics, pie menus, the music keyboard, and the rhythm ruler.
- Kept the same UI behavior, but now user-controlled strings are written through `textContent` or element properties instead of `innerHTML` / `insertAdjacentHTML`.

## Why
- The issue reports XSS risk from interpolating block, help, and project data directly into HTML.
- These updates remove the injection sink while preserving the current widget output.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Validation
- `npx eslint js/widgets/widgetWindows.js js/widgets/help.js js/widgets/statistics.js js/piemenus.js js/widgets/musickeyboard.js js/widgets/rhythmruler.js`
- `git diff --check`