### PR TITLE
fix: resolve invalid CSS percentage value for lineHeight in RhythmRuler

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -734,7 +734,7 @@ class RhythmRuler {
                 rulerSubCell.border = "0px";
                 rulerSubCell.padding = "0px";
                 rulerSubCell.style.padding = "0px";
-                rulerSubCell.style.lineHeight = 60 + " % ";
+                rulerSubCell.style.lineHeight = "60%";
                 if (i % 2 === 0) {
                     if (j % 2 === 0) {
                         rulerSubCell.style.backgroundColor = platformColor.selectorBackground;


### PR DESCRIPTION
### Problem
The RhythmRuler widget was setting an invalid CSS value for the `lineHeight` property of its ruler cells. In `js/widgets/rhythmruler.js`, the code was:

rulerSubCell.style.lineHeight = 60 + " % ";

This produced the string "60 % ". According to CSS standards, percentage values must not contain whitespace between the number and the percent sign. This invalid syntax often causes browsers to ignore the property, leading to inconsistent vertical alignment of note labels within the cells.

### Solution
Corrected the lineHeight assignment to a valid CSS percentage string:

rulerSubCell.style.lineHeight = "60%";

### Changes
- File: js/widgets/rhythmruler.js
- Correction: Removed spaces in the percentage string to comply with CSS syntax rules.

### Impact
- Ensures proper vertical text centering in RhythmRuler cells.
- Cleans up "invalid property value" warnings in browser developer tools.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

closes #6736 