### PR TITLE
fix: correct off-by-one in Mouse constructor turtle assignment

### DIFF
--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -47,7 +47,7 @@ class Mouse {
             this.turtle = globalActivity.turtles.getTurtle(Mouse.MouseList.length);
         } else {
             globalActivity.turtles.addTurtle();
-            this.turtle = globalActivity.turtles.getTurtle(numberOfTurtles - 1);
+            this.turtle = globalActivity.turtles.getTurtle(numberOfTurtles);
             Mouse.AddedTurtles.push(this.turtle);
         }
 


### PR DESCRIPTION
- [x] Bug fix ; #6740 


#### The Problem
When the JS Editor requires more turtles than currently exist, it calls `addTurtle()`. However, it was then attempting to retrieve the new turtle using `getTurtle(numberOfTurtles - 1)`. Since `numberOfTurtles` was the count *before* the addition, this index pointed to the second-to-last turtle, causing two Mice to control one turtle while the new one remained orphaned.
#### The Fix
Updated the constructor to use `numberOfTurtles` as the index for the newly created turtle (maintaining 0-based indexing).