### PR TITLE
fix: guard doRight and doSetHeading against non-finite degrees

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -897,7 +897,13 @@ class Painter {
      * @param degrees - degrees for right turn
      */
     doRight(degrees) {
-        this.turtle.orientation += Number(degrees);
+        degrees = Number(degrees);
+        if (!Number.isFinite(degrees)) {
+            this.turtles.activity.errorMsg(NANERRORMSG);
+            return;
+        }
+
+        this.turtle.orientation += degrees;
         while (this.turtle.orientation < 0) {
             this.turtle.orientation += 360;
         }
@@ -949,7 +955,13 @@ class Painter {
      * @param degrees - degrees turned to set the 'heading' of turtle
      */
     doSetHeading(degrees) {
-        this.turtle.orientation = Number(degrees);
+        degrees = Number(degrees);
+        if (!Number.isFinite(degrees)) {
+            this.turtles.activity.errorMsg(NANERRORMSG);
+            return;
+        }
+
+        this.turtle.orientation = degrees;
         while (this.turtle.orientation < 0) {
             this.turtle.orientation += 360;
         }


### PR DESCRIPTION
-[x] Bug Fix

## Summary
Fixes an infinite loop in `doRight` and `doSetHeading` when angle becomes non-finite (Infinity / -Infinity / NaN). This is the same bug pattern as previously fixed in `doForward` and `doArc`, but was missed in these rotation paths.

---

## Impact
- Passing non-finite values causes an infinite loop → browser tab freeze  
- Stop button becomes unresponsive (main thread blocked)  
- Auto-save cannot run → possible loss of student work  
- Trigger is not obvious:
  - `left turn (1 / 0)` → internally becomes `-Infinity`
  - `set heading (Math.log(0))` → `-Infinity`
  - Can also happen during project restore paths  

This affects commonly used blocks (`left turn`, `right turn`, `set heading`), so impact is high in real classroom usage.

---

## Fix

Added finite checks at the top of both functions (same pattern as doForward and doArc):

```js
degrees = Number(degrees);

if (!Number.isFinite(degrees)) {
    this.turtles.activity.errorMsg(NANERRORMSG);
    return;
}
```

Also removed redundant Number(...) conversions later in the functions since coercion is now done upfront.