### PR TITLE
Feature: SVG asset selector.

### DIFF
--- a/css/svgAssetSelector.css
+++ b/css/svgAssetSelector.css
@@ -1,0 +1,243 @@
+/* SVG Asset Selector Modal Styles */
+
+#svgAssetSelectorOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+#svgAssetSelectorOverlay.visible {
+    opacity: 1;
+}
+
+#svgAssetSelectorModal {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    width: 520px;
+    max-width: 90vw;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transform: scale(0.9);
+    transition: transform 0.25s ease;
+    font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+}
+
+#svgAssetSelectorOverlay.visible #svgAssetSelectorModal {
+    transform: scale(1);
+}
+
+/* Header */
+.svg-selector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    background: #2196f3;
+    color: #fff;
+}
+
+.svg-selector-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 500;
+}
+
+.svg-selector-close {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    opacity: 0.85;
+    transition: opacity 0.15s;
+}
+
+.svg-selector-close:hover {
+    opacity: 1;
+}
+
+/* Tab buttons for choosing source */
+.svg-selector-tabs {
+    display: flex;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.svg-selector-tab {
+    flex: 1;
+    padding: 12px 16px;
+    background: #f5f5f5;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: #616161;
+    transition: background 0.2s, color 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.svg-selector-tab:hover {
+    background: #e3f2fd;
+    color: #1976d2;
+}
+
+.svg-selector-tab.active {
+    background: #fff;
+    color: #1976d2;
+    border-bottom: 3px solid #2196f3;
+}
+
+.svg-selector-tab .tab-icon {
+    font-size: 20px;
+}
+
+/* Built-in images grid */
+.svg-selector-grid-container {
+    padding: 16px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 200px;
+    max-height: 50vh;
+}
+
+.svg-selector-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 12px;
+}
+
+.svg-asset-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 10px 6px;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s, transform 0.15s;
+    background: #fafafa;
+}
+
+.svg-asset-item:hover {
+    border-color: #90caf9;
+    background: #e3f2fd;
+    transform: translateY(-2px);
+}
+
+.svg-asset-item.selected {
+    border-color: #2196f3;
+    background: #bbdefb;
+}
+
+.svg-asset-item img {
+    width: 72px;
+    height: 72px;
+    object-fit: contain;
+    pointer-events: none;
+}
+
+.svg-asset-item .asset-name {
+    margin-top: 6px;
+    font-size: 11px;
+    color: #616161;
+    text-align: center;
+    word-break: break-word;
+    line-height: 1.3;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Upload tab content */
+.svg-selector-upload {
+    padding: 32px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.svg-upload-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 28px;
+    background: #2196f3;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 15px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.svg-upload-btn:hover {
+    background: #1976d2;
+}
+
+.svg-upload-hint {
+    font-size: 13px;
+    color: #9e9e9e;
+}
+
+/* Footer with apply button */
+.svg-selector-footer {
+    padding: 12px 20px;
+    border-top: 1px solid #e0e0e0;
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    background: #fafafa;
+}
+
+.svg-selector-footer button {
+    padding: 8px 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.svg-apply-btn {
+    background: #2196f3;
+    color: #fff;
+    border: none;
+}
+
+.svg-apply-btn:hover {
+    background: #1976d2;
+}
+
+.svg-apply-btn:disabled {
+    background: #bdbdbd;
+    cursor: not-allowed;
+}
+
+.svg-cancel-btn {
+    background: #fff;
+    color: #616161;
+    border: 1px solid #bdbdbd;
+}
+
+.svg-cancel-btn:hover {
+    background: #f5f5f5;
+}

--- a/index.html
+++ b/index.html
@@ -92,6 +92,15 @@
                 this.rel = 'stylesheet';
             "
         />
+        <link
+            rel="preload"
+            href="css/svgAssetSelector.css"
+            as="style"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
+        />
         <link rel="prefetch" as="video" href="loading-animation.webm" type="video/webm" />
         <link rel="prefetch" as="video" href="loading-animation.mp4" type="video/mp4" />
 
@@ -159,6 +168,7 @@
         </script>
         <script src="lib/astring.min.js" defer></script>
         <script src="js/utils/mb-dialog.js" defer></script>
+        <script src="js/svgAssetSelector.js" defer></script>
         <script src="lib/acorn.min.js" defer></script>
         <script src="env.js" defer></script>
 

--- a/js/block.js
+++ b/js/block.js
@@ -2303,9 +2303,46 @@ class Block {
 
     /**
      * Opens media for the block.
+     * Shows a chooser modal for media blocks that lets the user
+     * either select a built-in SVG image or upload from their device.
      * @param {number} thisBlock - Index of the current block.
      */
     _doOpenMedia(thisBlock) {
+        const that = this;
+
+        // For non-media blocks (e.g., audiofile, loadFile), use the
+        // original file-chooser flow directly.
+        if (that.name !== "media") {
+            that._doOpenMediaFromDevice(thisBlock);
+            return;
+        }
+
+        // Show the built-in SVG asset selector modal.
+        if (typeof openSvgAssetSelector === "function") {
+            openSvgAssetSelector(
+                // Callback when a built-in image is selected
+                function (dataURL) {
+                    that.value = dataURL;
+                    that.loadThumbnail(null);
+                },
+                // Callback when the user chooses to upload from device
+                function () {
+                    that._doOpenMediaFromDevice(thisBlock);
+                }
+            );
+        } else {
+            // Fallback: if the selector module is not loaded,
+            // use the original file upload flow.
+            that._doOpenMediaFromDevice(thisBlock);
+        }
+    }
+
+    /**
+     * Opens a file chooser to upload media from the local device.
+     * This preserves the original upload behavior.
+     * @param {number} thisBlock - Index of the current block.
+     */
+    _doOpenMediaFromDevice(thisBlock) {
         const that = this;
         const fileChooser = that.name === "media" ? docById("myMedia") : docById("audio");
 

--- a/js/svgAssetSelector.js
+++ b/js/svgAssetSelector.js
@@ -1,0 +1,265 @@
+/**
+ * SVG Asset Selector
+ *
+ * Provides a modal UI for selecting built-in SVG images from the
+ * project's asset directories (images/ and mouse-art/) or uploading
+ * from the local file system.
+ *
+ * @module svgAssetSelector
+ * @see {@link https://github.com/sugarlabs/musicblocks/issues/1291}
+ */
+
+// Built-in SVG assets are loaded dynamically from js/svgAssets.json
+
+/**
+ * Opens the SVG asset selector modal.
+ *
+ * Presents two tabs:
+ *   1. "Built-in Images" — a grid of selectable SVG previews
+ *   2. "Upload from Device" — triggers the existing file-upload flow
+ *
+ * @param {Function} onSelectBuiltIn - Called with the data-URL of the
+ *     chosen built-in SVG when the user confirms a selection.
+ * @param {Function} onUploadFromDevice - Called (with no args) when
+ *     the user chooses to upload a local file instead.
+ */
+function openSvgAssetSelector(onSelectBuiltIn, onUploadFromDevice) {
+    // Prevent duplicate modals
+    const existing = document.getElementById("svgAssetSelectorOverlay");
+    if (existing) existing.remove();
+
+    fetch("./js/svgAssets.json")
+        .then(function (response) {
+            if (!response.ok) {
+                throw new Error("HTTP " + response.status);
+            }
+            return response.json();
+        })
+        .then(function (data) {
+            const BUILTIN_SVG_ASSETS = data.svgs;
+
+            // ── Build DOM ────────────────────────────────────────────────
+            const overlay = document.createElement("div");
+            overlay.id = "svgAssetSelectorOverlay";
+
+            const modal = document.createElement("div");
+            modal.id = "svgAssetSelectorModal";
+
+            // Header
+            const header = document.createElement("div");
+            header.className = "svg-selector-header";
+            header.innerHTML =
+                "<h3>Choose an Image</h3>" +
+                '<button class="svg-selector-close" aria-label="Close">&times;</button>';
+            modal.appendChild(header);
+
+            // Tabs
+            const tabBar = document.createElement("div");
+            tabBar.className = "svg-selector-tabs";
+
+            const tabBuiltIn = document.createElement("button");
+            tabBuiltIn.className = "svg-selector-tab active";
+            tabBuiltIn.id = "svgTabBuiltIn";
+            tabBuiltIn.innerHTML =
+                '<span class="tab-icon material-icons">collections</span> Built-in Images';
+
+            const tabUpload = document.createElement("button");
+            tabUpload.className = "svg-selector-tab";
+            tabUpload.id = "svgTabUpload";
+            tabUpload.innerHTML =
+                '<span class="tab-icon material-icons">file_upload</span> Upload from Device';
+
+            tabBar.appendChild(tabBuiltIn);
+            tabBar.appendChild(tabUpload);
+            modal.appendChild(tabBar);
+
+            // ── Built-in panel ──────────────────────────────────────────
+            const gridContainer = document.createElement("div");
+            gridContainer.className = "svg-selector-grid-container";
+            gridContainer.id = "svgGridPanel";
+
+            const grid = document.createElement("div");
+            grid.className = "svg-selector-grid";
+
+            let selectedAssetPath = null;
+
+            BUILTIN_SVG_ASSETS.forEach(function (asset) {
+                const item = document.createElement("div");
+                item.className = "svg-asset-item";
+                item.dataset.path = asset.path;
+
+                const img = document.createElement("img");
+                img.src = asset.path;
+                img.alt = asset.name;
+                img.loading = "lazy";
+                // Graceful fallback for missing images
+                img.onerror = function () {
+                    this.style.display = "none";
+                };
+
+                const label = document.createElement("span");
+                label.className = "asset-name";
+                label.textContent = asset.name;
+
+                item.appendChild(img);
+                item.appendChild(label);
+
+                item.addEventListener("click", function () {
+                    // Deselect previous
+                    const prev = grid.querySelector(".svg-asset-item.selected");
+                    if (prev) prev.classList.remove("selected");
+                    item.classList.add("selected");
+                    selectedAssetPath = asset.path;
+                    applyBtn.disabled = false;
+                });
+
+                grid.appendChild(item);
+            });
+
+            gridContainer.appendChild(grid);
+            modal.appendChild(gridContainer);
+
+            // ── Upload panel (hidden by default) ────────────────────────
+            const uploadPanel = document.createElement("div");
+            uploadPanel.className = "svg-selector-upload";
+            uploadPanel.id = "svgUploadPanel";
+            uploadPanel.style.display = "none";
+
+            const uploadBtn = document.createElement("button");
+            uploadBtn.className = "svg-upload-btn";
+            uploadBtn.innerHTML = '<span class="material-icons">cloud_upload</span> Choose File';
+
+            const uploadHint = document.createElement("span");
+            uploadHint.className = "svg-upload-hint";
+            uploadHint.textContent = "Supports PNG, JPG, SVG, GIF and other image formats";
+
+            uploadPanel.appendChild(uploadBtn);
+            uploadPanel.appendChild(uploadHint);
+            modal.appendChild(uploadPanel);
+
+            // ── Footer ──────────────────────────────────────────────────
+            const footer = document.createElement("div");
+            footer.className = "svg-selector-footer";
+
+            const cancelBtn = document.createElement("button");
+            cancelBtn.className = "svg-cancel-btn";
+            cancelBtn.textContent = "Cancel";
+
+            const applyBtn = document.createElement("button");
+            applyBtn.className = "svg-apply-btn";
+            applyBtn.textContent = "Apply";
+            applyBtn.disabled = true;
+
+            footer.appendChild(cancelBtn);
+            footer.appendChild(applyBtn);
+            modal.appendChild(footer);
+
+            overlay.appendChild(modal);
+            document.body.appendChild(overlay);
+
+            // Trigger enter animation
+            requestAnimationFrame(function () {
+                overlay.classList.add("visible");
+            });
+
+            // ── Event handlers ──────────────────────────────────────────
+            function closeModal() {
+                overlay.classList.remove("visible");
+                setTimeout(function () {
+                    overlay.remove();
+                }, 250);
+            }
+
+            // Close button
+            header.querySelector(".svg-selector-close").addEventListener("click", closeModal);
+            cancelBtn.addEventListener("click", closeModal);
+
+            // Click outside modal to close
+            overlay.addEventListener("click", function (e) {
+                if (e.target === overlay) closeModal();
+            });
+
+            // Tab switching
+            tabBuiltIn.addEventListener("click", function () {
+                tabBuiltIn.classList.add("active");
+                tabUpload.classList.remove("active");
+                gridContainer.style.display = "";
+                uploadPanel.style.display = "none";
+                footer.style.display = "";
+            });
+
+            tabUpload.addEventListener("click", function () {
+                tabUpload.classList.add("active");
+                tabBuiltIn.classList.remove("active");
+                gridContainer.style.display = "none";
+                uploadPanel.style.display = "";
+                footer.style.display = "none";
+            });
+
+            // Upload button → close modal and delegate to existing upload flow
+            uploadBtn.addEventListener("click", function () {
+                closeModal();
+                if (typeof onUploadFromDevice === "function") {
+                    onUploadFromDevice();
+                }
+            });
+
+            // Apply selected built-in image
+            applyBtn.addEventListener("click", function () {
+                if (!selectedAssetPath) return;
+
+                // Fetch the SVG/image and convert to data URL
+                _fetchAsDataURL(selectedAssetPath, function (dataURL) {
+                    closeModal();
+                    if (typeof onSelectBuiltIn === "function") {
+                        onSelectBuiltIn(dataURL);
+                    }
+                });
+            });
+        })
+        .catch(function (error) {
+            // eslint-disable-next-line no-console
+            console.error("Failed to load SVG assets:", error);
+            // Fallback to upload from device if built-in fails to load
+            if (typeof onUploadFromDevice === "function") {
+                onUploadFromDevice();
+            }
+        });
+}
+
+/**
+ * Fetches an asset file and converts it to a data-URL string.
+ *
+ * Works entirely offline because it reads from the project's own
+ * static assets via a relative path.
+ *
+ * @param {string} path - Relative path to the asset file.
+ * @param {Function} callback - Called with the resulting data-URL.
+ * @private
+ */
+function _fetchAsDataURL(path, callback) {
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", path, true);
+    xhr.responseType = "blob";
+    xhr.onload = function () {
+        if (xhr.status === 200 || xhr.status === 0) {
+            var reader = new FileReader();
+            reader.onloadend = function () {
+                callback(reader.result);
+            };
+            reader.readAsDataURL(xhr.response);
+        } else {
+            // eslint-disable-next-line no-console
+            console.error("Failed to load built-in asset: " + path);
+        }
+    };
+    xhr.onerror = function () {
+        // eslint-disable-next-line no-console
+        console.error("Network error loading built-in asset: " + path);
+    };
+    xhr.send();
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { openSvgAssetSelector };
+}

--- a/js/svgAssets.json
+++ b/js/svgAssets.json
@@ -1,0 +1,20 @@
+{
+    "svgs": [
+        { "name": "Mouse", "path": "images/mouse.svg" },
+        { "name": "Mouse 2", "path": "images/mouse2.svg" },
+        { "name": "Turtle", "path": "images/turtle.svg" },
+        { "name": "Turtle 2", "path": "images/turtle2.svg" },
+        { "name": "Cat", "path": "images/cat.svg" },
+        { "name": "Dog", "path": "images/dog.svg" },
+        { "name": "Duck", "path": "images/duck.svg" },
+        { "name": "Cricket", "path": "images/cricket.svg" },
+        { "name": "Rodent", "path": "mouse-art/Rodent.svg" },
+        { "name": "Mouse Drum", "path": "mouse-art/mouse-drum.svg" },
+        { "name": "Bubbles", "path": "images/bubbles.svg" },
+        { "name": "Bottle", "path": "images/bottle.svg" },
+        { "name": "Chime", "path": "images/chime.svg" },
+        { "name": "Cup", "path": "images/cup.svg" },
+        { "name": "Voices", "path": "images/voices.svg" },
+        { "name": "Synth", "path": "images/synth.svg" }
+    ]
+}


### PR DESCRIPTION
When a user clicks on a Media Block the app automatically opened a file picker. There was no way of choosing from the built in svg images which are already bundled in repository under images and mouse-art/. I intercepted the architectural flow by inserting a chooser modal before before the file picker opens (the only chnage from the exisiting flow).
Files modified are :- index.html (Added for css and js) + js/blocks (Split _doOpenMedia into chooser + _doOpenMediaFromDevice).
Files created are:- css/svgAssetSelector.css( modal styling ) + js/svgAssetSelector.js (ui + asset list + fetch to data url)

Reason for this approach:-
1.) zero breakage 
2.) works offline
3.) min coupling 
4.) Array in svgAssetSelector.js can easily be extended with more images without touching any other file.

How to test:-
Open applicaton in your browser :-
Open the Media palette (left sidebar → "Media" category)
Drag an Avatar block (or Show block with a Media input) onto the canvas
Click on the Media block (the image input - shows "load-media" icon)

(After this you can see and test everything.)

Before:-
<img width="1600" height="759" alt="1before" src="https://github.com/user-attachments/assets/69367311-bd7c-4894-bbf8-ba80a8f3152f" />
After:-
<img width="1600" height="800" alt="1after" src="https://github.com/user-attachments/assets/a174751b-d93e-4779-9764-b5521dca2f3f" />


closes issue #1291 

Category
-[x] Feature