### PR TITLE
Replace blocking alert with console.warn on copy failure

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -171,7 +171,7 @@ class GlobalCard {
         frag.getElementById(`global-project-share-${this.id}`).addEventListener("click", evt => {
             const s = document.getElementById(`global-sharebox-${this.id}`);
 
-            if (s.style.display == "none") {
+            if (s.style.display === "none") {
                 s.style.display = "initial";
                 hideOnClickOutside(
                     [document.getElementById(`global-share-${this.id}`)],
@@ -215,14 +215,12 @@ class GlobalCard {
         this.clipboard = new ClipboardJS(`.copyshareurl[data-clipboard-text*="${this.id}"]`);
 
         this.clipboard.on("success", e => {
-            // eslint-disable-next-line no-console
             console.info("Copied:", e.text);
             e.clearSelection();
         });
 
         this.clipboard.on("error", e => {
-            alert("Failed to copy!");
-            // eslint-disable-next-line no-console
+            console.warn("Failed to copy to clipboard");
             console.error("Failed to copy:", e.action);
         });
     }

--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -100,6 +100,24 @@ class GlobalCard {
          `;
     }
 
+    showToast(message, isError = false) {
+        // Reuse existing SaveInterface.showToast but add error styling if needed
+        if (this.Planet && this.Planet.SaveInterface) {
+            this.Planet.SaveInterface.showToast(message);
+
+            // If it's an error, modify the toast to be red
+            if (isError) {
+                setTimeout(() => {
+                    const toasts = document.querySelectorAll(".toast");
+                    if (toasts.length > 0) {
+                        const lastToast = toasts[toasts.length - 1];
+                        lastToast.style.background = "#f44336"; // Red for errors
+                    }
+                }, 10);
+            }
+        }
+    }
+
     render() {
         const Planet = this.Planet;
         const html = this.renderData.replace(new RegExp("{ID}", "g"), this.id);
@@ -216,12 +234,14 @@ class GlobalCard {
 
         this.clipboard.on("success", e => {
             console.info("Copied:", e.text);
+            this.showToast(_("Link copied to clipboard!"));
             e.clearSelection();
         });
 
         this.clipboard.on("error", e => {
             console.warn("Failed to copy to clipboard");
             console.error("Failed to copy:", e.action);
+            this.showToast(_("Failed to copy link to clipboard"), true);
         });
     }
 


### PR DESCRIPTION
Showing an alert when clipboard copy fails is annoying and unnecessary. Swapped it for console.warn—you can still see the error in dev tools, but the UI doesn't grind to a halt.

The success path doesn't block, so the error path shouldn't either.

fixes: #5483 

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation