### PR TITLE
fix: apply dynamic theme colors to Import MIDI dialog buttons

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1559,6 +1559,14 @@ class Activity {
             const importConfirm = document.createElement("button");
             importConfirm.classList.add("confirm-button");
             importConfirm.textContent = _("Confirm");
+            importConfirm.style.backgroundColor = platformColor.blueButton;
+            importConfirm.style.color = platformColor.blueButtonText;
+            importConfirm.style.border = "none";
+            importConfirm.style.borderRadius = "4px";
+            importConfirm.style.padding = "8px 16px";
+            importConfirm.style.fontWeight = "bold";
+            importConfirm.style.cursor = "pointer";
+            importConfirm.style.marginRight = "16px";
             importConfirm.addEventListener("click", () => {
                 const maxNoteBlocks = select.value;
                 require(["activity/midi"], function () {


### PR DESCRIPTION
Follow-up to #6681

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Summary

Updates the Import MIDI dialog's "Confirm" button to correctly respect the active theme, specifically High Contrast.

### Screenshots

**Before**
<img width="1919" height="828" alt="Screenshot 2026-04-18 192924" src="https://github.com/user-attachments/assets/76bfc898-408e-4a82-8dea-b4cc3951588c" />

**After**
<img width="1908" height="831" alt="Screenshot 2026-04-19 213047" src="https://github.com/user-attachments/assets/d83b9aed-08a3-4e20-8dc8-b2e7ca88aecb" />

### What changed

- Updated the `importConfirm` button in `js/activity.js` to use `platformColor.blueButton` and `platformColor.blueButtonText`.
- This ensures the button correctly switches to the High Contrast theme colors (black text on cyan) when enabled, rather than being stuck on the default CSS Dark mode styles.

### Verification

- [x] `npm run lint` passed (0 errors)
- [x] `npx prettier --check` passed
- [x] `npm test` passed (all 4761 tests passed)
