### PR TITLE
Remove legacy synth block path

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -53,7 +53,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            Singer.PitchActions.playHertz(args[0], turtle, blk);
+            Singer.PitchActions.playSynthFrequency(args[0], turtle, blk);
         }
     }
 
@@ -76,7 +76,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            Singer.PitchActions.playHertz(args[0], turtle, blk);
+            Singer.PitchActions.playSynthFrequency(args[0], turtle, blk);
         }
     }
 
@@ -99,7 +99,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            Singer.PitchActions.playHertz(args[0], turtle, blk);
+            Singer.PitchActions.playSynthFrequency(args[0], turtle, blk);
         }
     }
 
@@ -122,7 +122,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            Singer.PitchActions.playHertz(args[0], turtle, blk);
+            Singer.PitchActions.playSynthFrequency(args[0], turtle, blk);
         }
     }
 

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -25,6 +25,25 @@
 
 /* exported setupPitchBlocks */
 
+const shouldWarnOnDeprecatedSynthBlocks =
+    typeof process !== "undefined" &&
+    process !== null &&
+    process.env &&
+    process.env.NODE_ENV !== "production";
+
+const deprecatedSynthBlocksWarned = new Set();
+
+function warnDeprecatedSynthBlock(blockName) {
+    if (!shouldWarnOnDeprecatedSynthBlocks || deprecatedSynthBlocksWarned.has(blockName)) {
+        return;
+    }
+
+    deprecatedSynthBlocksWarned.add(blockName);
+    console.warn(
+        `${blockName} is deprecated and still relies on Singer.playSynthBlock(); migrate it before removing the legacy path.`
+    );
+}
+
 function setupPitchBlocks(activity) {
     class RestBlock extends ValueBlock {
         constructor() {
@@ -53,6 +72,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
+            warnDeprecatedSynthBlock("square");
             Singer.playSynthBlock(args, activity, logo, turtle, blk);
         }
     }
@@ -76,6 +96,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
+            warnDeprecatedSynthBlock("triangle");
             Singer.playSynthBlock(args, activity, logo, turtle, blk);
         }
     }
@@ -99,6 +120,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
+            warnDeprecatedSynthBlock("sine");
             Singer.playSynthBlock(args, activity, logo, turtle, blk);
         }
     }
@@ -122,6 +144,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
+            warnDeprecatedSynthBlock("sawtooth");
             Singer.playSynthBlock(args, activity, logo, turtle, blk);
         }
     }

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -25,25 +25,6 @@
 
 /* exported setupPitchBlocks */
 
-const shouldWarnOnDeprecatedSynthBlocks =
-    typeof process !== "undefined" &&
-    process !== null &&
-    process.env &&
-    process.env.NODE_ENV !== "production";
-
-const deprecatedSynthBlocksWarned = new Set();
-
-function warnDeprecatedSynthBlock(blockName) {
-    if (!shouldWarnOnDeprecatedSynthBlocks || deprecatedSynthBlocksWarned.has(blockName)) {
-        return;
-    }
-
-    deprecatedSynthBlocksWarned.add(blockName);
-    console.warn(
-        `${blockName} is deprecated and still relies on Singer.playSynthBlock(); migrate it before removing the legacy path.`
-    );
-}
-
 function setupPitchBlocks(activity) {
     class RestBlock extends ValueBlock {
         constructor() {
@@ -72,8 +53,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            warnDeprecatedSynthBlock("square");
-            Singer.playSynthBlock(args, activity, logo, turtle, blk);
+            Singer.PitchActions.playHertz(args[0], turtle, blk);
         }
     }
 
@@ -96,8 +76,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            warnDeprecatedSynthBlock("triangle");
-            Singer.playSynthBlock(args, activity, logo, turtle, blk);
+            Singer.PitchActions.playHertz(args[0], turtle, blk);
         }
     }
 
@@ -120,8 +99,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            warnDeprecatedSynthBlock("sine");
-            Singer.playSynthBlock(args, activity, logo, turtle, blk);
+            Singer.PitchActions.playHertz(args[0], turtle, blk);
         }
     }
 
@@ -144,8 +122,7 @@ function setupPitchBlocks(activity) {
         }
 
         flow(args, logo, turtle, blk) {
-            warnDeprecatedSynthBlock("sawtooth");
-            Singer.playSynthBlock(args, activity, logo, turtle, blk);
+            Singer.PitchActions.playHertz(args[0], turtle, blk);
         }
     }
 

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -319,6 +319,25 @@ describe("setupPitchBlocks", () => {
     });
 
     describe("Synth Blocks", () => {
+        let warnSpy;
+
+        beforeEach(() => {
+            warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it("warns when deprecated synth blocks are used", () => {
+            const block = createdBlocks["square"];
+
+            block.flow([440], logo, 0, 10);
+
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("square is deprecated"));
+            expect(global.Singer.playSynthBlock).toHaveBeenCalled();
+        });
+
         ["square", "triangle", "sine", "sawtooth"].forEach(name => {
             it(`${name} block flow calls Singer.playSynthBlock`, () => {
                 const block = createdBlocks[name];

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -199,6 +199,7 @@ describe("setupPitchBlocks", () => {
                 numToPitch: jest.fn(() => "C"),
                 playPitch: jest.fn(),
                 playHertz: jest.fn(),
+                playSynthFrequency: jest.fn(),
                 playPitchNumber: jest.fn(),
                 playNthModalPitch: jest.fn(),
                 setScalarTranspose: jest.fn(),
@@ -319,11 +320,15 @@ describe("setupPitchBlocks", () => {
 
     describe("Synth Blocks", () => {
         ["square", "triangle", "sine", "sawtooth"].forEach(name => {
-            it(`${name} block flow calls Singer.PitchActions.playHertz`, () => {
+            it(`${name} block flow calls Singer.PitchActions.playSynthFrequency`, () => {
                 const block = createdBlocks[name];
                 if (block) {
                     block.flow([440], logo, 0, 10);
-                    expect(global.Singer.PitchActions.playHertz).toHaveBeenCalledWith(440, 0, 10);
+                    expect(global.Singer.PitchActions.playSynthFrequency).toHaveBeenCalledWith(
+                        440,
+                        0,
+                        10
+                    );
                     // Coverage for updateParameter if applicable
                     if (block.updateParameter) block.updateParameter(logo, 0, 10);
                 }

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -191,7 +191,6 @@ describe("setupPitchBlocks", () => {
         global.scaleDegreeToPitchMapping = jest.fn(() => "C");
 
         global.Singer = {
-            playSynthBlock: jest.fn(),
             processPitch: jest.fn(),
             PitchActions: {
                 consonantStepSize: jest.fn(() => 1),
@@ -319,31 +318,12 @@ describe("setupPitchBlocks", () => {
     });
 
     describe("Synth Blocks", () => {
-        let warnSpy;
-
-        beforeEach(() => {
-            warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-        });
-
-        afterEach(() => {
-            warnSpy.mockRestore();
-        });
-
-        it("warns when deprecated synth blocks are used", () => {
-            const block = createdBlocks["square"];
-
-            block.flow([440], logo, 0, 10);
-
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("square is deprecated"));
-            expect(global.Singer.playSynthBlock).toHaveBeenCalled();
-        });
-
         ["square", "triangle", "sine", "sawtooth"].forEach(name => {
-            it(`${name} block flow calls Singer.playSynthBlock`, () => {
+            it(`${name} block flow calls Singer.PitchActions.playHertz`, () => {
                 const block = createdBlocks[name];
                 if (block) {
                     block.flow([440], logo, 0, 10);
-                    expect(global.Singer.playSynthBlock).toHaveBeenCalled();
+                    expect(global.Singer.PitchActions.playHertz).toHaveBeenCalledWith(440, 0, 10);
                     // Coverage for updateParameter if applicable
                     if (block.updateParameter) block.updateParameter(logo, 0, 10);
                 }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -290,63 +290,6 @@ class Singer {
             : 1;
     static masterVolume = [typeof DEFAULTVOLUME !== "undefined" ? DEFAULTVOLUME : 50];
 
-    // ========= Deprecated ===================================================
-
-    /**
-     * @deprecated
-     * @static
-     * @param {*[]} args - arguments (parameters)
-     * @param {Object} logo - Logo object
-     * @param {Object} turtle - Turtle object
-     * @param {Object} blk - corresponding Block object index in blocks.blockList
-     */
-    static playSynthBlock(args, activity, logo, turtle, blk) {
-        if (args.length === 1) {
-            const obj = frequencyToPitch(args[0]);
-
-            if (logo.inMatrix) {
-                logo.phraseMaker.addRowBlock(blk);
-                if (!logo.pitchBlocks.includes(blk)) {
-                    logo.pitchBlocks.push(blk);
-                }
-
-                logo.phraseMaker.rowLabels.push(activity.logo.blocks.blockList[blk].name);
-                logo.phraseMaker.rowArgs.push(args[0]);
-            } else if (logo.inLegoWidget && !logo.inMatrix) {
-                logo.legoWidget.addRowBlock(blk);
-                if (!logo.pitchBlocks.includes(blk)) {
-                    logo.pitchBlocks.push(blk);
-                }
-
-                logo.legoWidget.rowLabels.push(activity.logo.blocks.blockList[blk].name);
-                logo.legoWidget.rowArgs.push(args[0]);
-            } else if (logo.inPitchSlider) {
-                logo.pitchSlider.frequency = args[0];
-            } else {
-                const tur = activity.turtles.ithTurtle(turtle);
-
-                tur.singer.oscList[last(tur.singer.inNoteBlock)].push(
-                    activity.blocks.blockList[blk].name
-                );
-
-                // We keep track of pitch and octave for notation purposes
-                tur.singer.notePitches[last(tur.singer.inNoteBlock)].push(obj[0]);
-                tur.singer.noteOctaves[last(tur.singer.inNoteBlock)].push(obj[1]);
-                tur.singer.noteCents[last(tur.singer.inNoteBlock)].push(obj[2]);
-                if (obj[2] !== 0) {
-                    tur.singer.noteHertz[last(tur.singer.inNoteBlock)].push(
-                        getCachedPitchToFrequency(obj[0], obj[1], obj[2], tur.singer.keySignature)
-                    );
-                } else {
-                    tur.singer.noteHertz[last(tur.singer.inNoteBlock)].push(0);
-                }
-
-                tur.singer.noteBeatValues[last(tur.singer.inNoteBlock)].push(tur.singer.beatFactor);
-                tur.singer.pushedNote = true;
-            }
-        }
-    }
-
     // ========= Utilities ====================================================
 
     /**

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -355,6 +355,58 @@ function setupPitchActions(activity) {
         }
 
         /**
+         * Plays a synth block from a raw frequency input while preserving the
+         * legacy widget behavior for matrix, LEGO, and pitch slider contexts.
+         *
+         * @param {Number} hertz - frequency in hertz
+         * @param {Number} turtle - Turtle index in turtles.turtleList
+         * @param {Number|String} blk - corresponding Block object index in blocks.blockList
+         */
+        static playSynthFrequency(hertz, turtle, blk) {
+            const tur = activity.turtles.ithTurtle(turtle);
+            const obj = frequencyToPitch(hertz);
+
+            if (activity.logo.inMatrix) {
+                activity.logo.phraseMaker.addRowBlock(blk);
+                if (!activity.logo.pitchBlocks.includes(blk)) {
+                    activity.logo.pitchBlocks.push(blk);
+                }
+
+                activity.logo.phraseMaker.rowLabels.push(activity.blocks.blockList[blk].name);
+                activity.logo.phraseMaker.rowArgs.push(hertz);
+            } else if (activity.logo.inLegoWidget && !activity.logo.inMatrix) {
+                activity.logo.legoWidget.addRowBlock(blk);
+                if (!activity.logo.pitchBlocks.includes(blk)) {
+                    activity.logo.pitchBlocks.push(blk);
+                }
+
+                activity.logo.legoWidget.rowLabels.push(activity.blocks.blockList[blk].name);
+                activity.logo.legoWidget.rowArgs.push(hertz);
+            } else if (activity.logo.inPitchSlider) {
+                activity.logo.pitchSlider.frequency = hertz;
+            } else {
+                tur.singer.oscList[last(tur.singer.inNoteBlock)].push(
+                    activity.blocks.blockList[blk].name
+                );
+
+                // We keep track of pitch and octave for notation purposes.
+                tur.singer.notePitches[last(tur.singer.inNoteBlock)].push(obj[0]);
+                tur.singer.noteOctaves[last(tur.singer.inNoteBlock)].push(obj[1]);
+                tur.singer.noteCents[last(tur.singer.inNoteBlock)].push(obj[2]);
+                if (obj[2] !== 0) {
+                    tur.singer.noteHertz[last(tur.singer.inNoteBlock)].push(
+                        pitchToFrequency(obj[0], obj[1], obj[2], tur.singer.keySignature)
+                    );
+                } else {
+                    tur.singer.noteHertz[last(tur.singer.inNoteBlock)].push(0);
+                }
+
+                tur.singer.noteBeatValues[last(tur.singer.inNoteBlock)].push(tur.singer.beatFactor);
+                tur.singer.pushedNote = true;
+            }
+        }
+
+        /**
          * Creates sharps and flats.
          *
          * @param {String} accidental - type of accidental

--- a/js/turtleactions/__tests__/PitchActions.test.js
+++ b/js/turtleactions/__tests__/PitchActions.test.js
@@ -94,6 +94,20 @@ describe("Tests for Singer.PitchActions setup", () => {
             logo: {
                 inMatrix: false,
                 inMusicKeyboard: false,
+                inLegoWidget: false,
+                inPitchSlider: false,
+                pitchBlocks: [],
+                phraseMaker: {
+                    addRowBlock: jest.fn(),
+                    rowLabels: [],
+                    rowArgs: []
+                },
+                legoWidget: {
+                    addRowBlock: jest.fn(),
+                    rowLabels: [],
+                    rowArgs: []
+                },
+                pitchSlider: {},
                 synth: { inTemperament: "equal", startingPitch: "A0" },
                 runningLilypond: false,
                 setDispatchBlock(name, t, l) {
@@ -347,6 +361,26 @@ describe("Tests for Singer.PitchActions setup", () => {
         expect(spyMark).not.toHaveBeenCalled();
 
         spyMark.mockRestore();
+    });
+
+    test("playSynthFrequency preserves matrix row frequency", () => {
+        activity.logo.inMatrix = true;
+        activity.blocks.blockList[blkId] = { name: "square" };
+
+        Singer.PitchActions.playSynthFrequency(440, 0, blkId);
+
+        expect(activity.logo.phraseMaker.addRowBlock).toHaveBeenCalledWith(blkId);
+        expect(activity.logo.phraseMaker.rowLabels).toContain("square");
+        expect(activity.logo.phraseMaker.rowArgs).toContain(440);
+    });
+
+    test("playSynthFrequency preserves pitch slider frequency", () => {
+        activity.logo.inPitchSlider = true;
+        activity.logo.pitchSlider.frequency = null;
+
+        Singer.PitchActions.playSynthFrequency(440, 0, blkId);
+
+        expect(activity.logo.pitchSlider.frequency).toBe(440);
     });
 
     describe("Tests for setAccidental", () => {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [x] Tests

## Summary
- Route the four legacy synth blocks (`square`, `triangle`, `sine`, `sawtooth`) through a dedicated `Singer.PitchActions.playSynthFrequency()` helper instead of the deprecated `Singer.playSynthBlock()` path.
- Remove the dead `playSynthBlock()` implementation from `js/turtle-singer.js`.
- Preserve the legacy matrix, LEGO, and pitch slider behavior for synth-style frequency input while keeping the deprecated API name out of the codebase.
- Update the Jest coverage to assert the new helper path and its widget semantics.

## Validation
- `npx jest js/blocks/__tests__/PitchBlocks.test.js js/turtleactions/__tests__/PitchActions.test.js --runInBand --coverage=false`
- `npx prettier --check js/blocks/PitchBlocks.js js/blocks/__tests__/PitchBlocks.test.js js/turtleactions/PitchActions.js js/turtleactions/__tests__/PitchActions.test.js`
- `npx eslint js/blocks/PitchBlocks.js js/blocks/__tests__/PitchBlocks.test.js js/turtleactions/PitchActions.js js/turtleactions/__tests__/PitchActions.test.js`

Related to #6747.