### PR TITLE
fix: resolve broken loop indexing in temperament widget

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -790,8 +790,9 @@ function TemperamentWidget() {
         for (let i = 0; i <= this.pitchNumber; i++) {
             notesRow[i] = docById("notes_" + i);
 
-            notesCell[(i, 0)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 0)].textContent = "\u00A0\u00A0";
+            notesCell[i] = [];
+            notesCell[i][0] = notesRow[i].insertCell(-1);
+            notesCell[i][0].textContent = "\u00A0\u00A0";
             const playImg = document.createElement("img");
             playImg.src = "header-icons/play-button.svg";
             playImg.title = _("Play");
@@ -800,17 +801,17 @@ function TemperamentWidget() {
             playImg.setAttribute("width", "20px");
             playImg.id = "play_" + i;
             playImg.setAttribute("data-id", i);
-            notesCell[(i, 0)].appendChild(playImg);
-            notesCell[(i, 0)].appendChild(document.createTextNode("\u00A0\u00A0"));
-            notesCell[(i, 0)].style.width = 40 + "px";
-            notesCell[(i, 0)].style.backgroundColor = platformColor.selectorBackground;
-            notesCell[(i, 0)].style.textAlign = "center";
+            notesCell[i][0].appendChild(playImg);
+            notesCell[i][0].appendChild(document.createTextNode("\u00A0\u00A0"));
+            notesCell[i][0].style.width = 40 + "px";
+            notesCell[i][0].style.backgroundColor = platformColor.selectorBackground;
+            notesCell[i][0].style.textAlign = "center";
 
-            notesCell[(i, 0)].onmouseover = function () {
+            notesCell[i][0].onmouseover = function () {
                 this.style.backgroundColor = platformColor.selectorBackgroundHOVER;
             };
 
-            notesCell[(i, 0)].onmouseout = function () {
+            notesCell[i][0].onmouseout = function () {
                 this.style.backgroundColor = platformColor.selectorBackground;
             };
 
@@ -825,66 +826,66 @@ function TemperamentWidget() {
             };
 
             //Pitch Number
-            notesCell[(i, 1)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 1)].id = "pitchNumber_" + i;
-            notesCell[(i, 1)].textContent = i;
-            notesCell[(i, 1)].style.backgroundColor = platformColor.selectorBackground;
-            notesCell[(i, 1)].style.textAlign = "center";
+            notesCell[i][1] = notesRow[i].insertCell(-1);
+            notesCell[i][1].id = "pitchNumber_" + i;
+            notesCell[i][1].textContent = i;
+            notesCell[i][1].style.backgroundColor = platformColor.selectorBackground;
+            notesCell[i][1].style.textAlign = "center";
 
             ratios[i] = this.ratios[i];
             ratios[i] = ratios[i].toFixed(2);
 
             //Ratio
-            notesCell[(i, 2)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 2)].textContent = ratios[i];
-            notesCell[(i, 2)].style.backgroundColor = platformColor.selectorBackground;
-            notesCell[(i, 2)].style.textAlign = "center";
+            notesCell[i][2] = notesRow[i].insertCell(-1);
+            notesCell[i][2].textContent = ratios[i];
+            notesCell[i][2].style.backgroundColor = platformColor.selectorBackground;
+            notesCell[i][2].style.textAlign = "center";
 
             if (!isCustomTemperament(this.inTemperament)) {
                 //Interval
-                notesCell[(i, 3)] = notesRow[i].insertCell(-1);
-                notesCell[(i, 3)].textContent = this.intervals[i];
-                notesCell[(i, 3)].style.width = 120 + "px";
-                notesCell[(i, 3)].style.backgroundColor = platformColor.selectorBackground;
-                notesCell[(i, 3)].style.textAlign = "center";
+                notesCell[i][3] = notesRow[i].insertCell(-1);
+                notesCell[i][3].textContent = this.intervals[i];
+                notesCell[i][3].style.width = 120 + "px";
+                notesCell[i][3].style.backgroundColor = platformColor.selectorBackground;
+                notesCell[i][3].style.textAlign = "center";
 
                 //Notes
-                notesCell[(i, 4)] = notesRow[i].insertCell(-1);
-                notesCell[(i, 4)].textContent = this.notes[i];
-                notesCell[(i, 4)].style.width = 50 + "px";
-                notesCell[(i, 4)].style.backgroundColor = platformColor.selectorBackground;
-                notesCell[(i, 4)].style.textAlign = "center";
+                notesCell[i][4] = notesRow[i].insertCell(-1);
+                notesCell[i][4].textContent = this.notes[i];
+                notesCell[i][4].style.width = 50 + "px";
+                notesCell[i][4].style.backgroundColor = platformColor.selectorBackground;
+                notesCell[i][4].style.textAlign = "center";
 
                 //Mode
-                notesCell[(i, 5)] = notesRow[i].insertCell(-1);
+                notesCell[i][5] = notesRow[i].insertCell(-1);
                 for (let j = 0; j < this.scaleNotes.length; j++) {
                     if (this.notes[i][0] === this.scaleNotes[j]) {
-                        notesCell[(i, 5)].textContent = j;
+                        notesCell[i][5].textContent = j;
                         break;
                     }
                 }
-                if (notesCell[(i, 5)].textContent === "") {
-                    notesCell[(i, 5)].textContent = _("non scalar");
+                if (notesCell[i][5].textContent === "") {
+                    notesCell[i][5].textContent = _("non scalar");
                 }
-                notesCell[(i, 5)].style.width = 100 + "px";
-                notesCell[(i, 5)].style.backgroundColor = platformColor.selectorBackground;
-                notesCell[(i, 5)].style.textAlign = "center";
+                notesCell[i][5].style.width = 100 + "px";
+                notesCell[i][5].style.backgroundColor = platformColor.selectorBackground;
+                notesCell[i][5].style.textAlign = "center";
             }
 
             //Frequency
-            notesCell[(i, 6)] = notesRow[i].insertCell(-1);
-            notesCell[(i, 6)].textContent = this.frequencies[i];
-            notesCell[(i, 6)].style.backgroundColor = platformColor.selectorBackground;
-            notesCell[(i, 6)].style.textAlign = "center";
+            notesCell[i][6] = notesRow[i].insertCell(-1);
+            notesCell[i][6].textContent = this.frequencies[i];
+            notesCell[i][6].style.backgroundColor = platformColor.selectorBackground;
+            notesCell[i][6].style.textAlign = "center";
 
             if (isCustomTemperament(this.inTemperament)) {
-                notesCell[(i, 1)].style.width = 130 + "px";
-                notesCell[(i, 6)].style.width = 130 + "px";
-                notesCell[(i, 2)].style.width = 130 + "px";
+                notesCell[i][1].style.width = 130 + "px";
+                notesCell[i][6].style.width = 130 + "px";
+                notesCell[i][2].style.width = 130 + "px";
             } else {
-                notesCell[(i, 1)].style.width = 60 + "px";
-                notesCell[(i, 6)].style.width = 80 + "px";
-                notesCell[(i, 2)].style.width = 60 + "px";
+                notesCell[i][1].style.width = 60 + "px";
+                notesCell[i][6].style.width = 80 + "px";
+                notesCell[i][2].style.width = 60 + "px";
             }
         }
     };


### PR DESCRIPTION
## Summary
The `_graphOfNotes` function in `js/widgets/temperament.js` contained a significant indexing bug where the comma operator was mistakenly used inside array brackets (e.g., `notesCell[(i, 0)]`).

In JavaScript, the expression `(i, 0)` evaluates to `0`, causing the loop to ignore the row index `i`. As a result, every iteration of the loop overwrote the same base indices (`0` through `6`) in the `notesCell` array. By the time the loop finished, the array only retained references to the cells of the final row, leading to loss of data and preventing reliable internal state management for the table.

## Solution
- Replaced the misused comma expressions with proper 2D array access: `notesCell[i][n]`
- Added initialization for each row array (`notesCell[i] = []`) within the loop  
- Ensured that all cell references (including play buttons, ratios, and frequency displays) are correctly preserved in a persistent matrix structure

## Changes
- **File:** `js/widgets/temperament.js`
- **Logic:** Updated the loop between lines 790 and 889 to use multi-dimensional indexing

## Verification
- Verified through code audit that the comma operator has been removed in favor of standard 2D indexing
- Confirmed that `notesCell` is local to the function and that this change safely rectifies the internal data loss without side effects

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

closes #6750 