### PR TITLE
fix: remove correct loop block in doBreak execution queue

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1018,7 +1018,7 @@ class Logo {
                 loopBlkIdx = turtle.queue[i].blk;
                 parentLoopBlock = this.blockList[loopBlkIdx];
                 // Flush the parent from the queue
-                turtle.queue.pop();
+                turtle.queue.splice(i, 1);
                 break;
             } else if (
                 ["forever", "repeat", "while", "until"].includes(
@@ -1029,7 +1029,7 @@ class Logo {
                 loopBlkIdx = turtle.queue[i].parentBlk;
                 parentLoopBlock = this.blockList[loopBlkIdx];
                 // Flush the parent from the queue
-                turtle.queue.pop();
+                turtle.queue.splice(i, 1);
                 break;
             }
         }


### PR DESCRIPTION
- [x] Bug Fix : #6757 

### Summary
Fixed a critical logic bug in the execution engine's `doBreak` function where the wrong block was being removed from the execution queue during nested loop operations.

### The Problem
When a `break` block is executed, the engine searches the execution queue backwards to find the parent loop to exit. However, the existing code used `turtle.queue.pop()`, which **always** removes the last item in the queue regardless of where the loop block was found. 

In nested loops or complex stacks, this caused the engine to "pop" an unrelated block (like the next instruction) while leaving the loop block in the queue, causing the break to fail or the execution state to become corrupted.

### The Fix
Switched from `pop()` to `splice(i, 1)` to ensure that the engine specifically removes the loop block located at index `i`, correctly terminating the loop without affecting other queued blocks.
