### PR TITLE
Fix SaveInterface export load hook overwrite. Fixes #6762

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -125,14 +125,14 @@ class SaveInterface {
             '";' +
             "  }" +
             "}" +
-            "window.onload = function() {" +
+            'window.addEventListener("load", function() {' +
             '  var codeBlock = document.getElementById("codeBlock");' +
             '  var showHideButton = document.getElementById("showhide");' +
             '  codeBlock.style.display = "none";' +
             '  showHideButton.textContent = "' +
             STR_SHOW +
             '";' +
-            "};" +
+            "});" +
             "function copyCode() {" +
             '  var text = document.getElementById("codeBlock").innerText;' +
             "  navigator.clipboard.writeText(text).then(function() {" +

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -316,6 +316,22 @@ describe("save HTML methods", () => {
         expect(html).toContain("&lt;/script&gt;");
     });
 
+    it("should compose exported page initialization with other load handlers", () => {
+        const si = new SaveInterface({
+            PlanetInterface: {
+                getCurrentProjectName: jest.fn(() => "Mock Project"),
+                getCurrentProjectDescription: jest.fn(() => "Mock Description"),
+                getCurrentProjectImage: jest.fn(() => "mock-image.png")
+            },
+            prepareExport: jest.fn(() => "Mock Exported Data")
+        });
+
+        const html = si.prepareHTML();
+
+        expect(html).toContain('window.addEventListener("load", function() {');
+        expect(html).not.toContain("window.onload = function()");
+    });
+
     it("escapeHTML should encode all five HTML special characters", () => {
         expect(escapeHTML("&<>\"'")).toBe("&amp;&lt;&gt;&quot;&#039;");
     });


### PR DESCRIPTION
Description
This fixes the exported HTML load-hook overwrite in SaveInterface.

The generated HTML page was assigning directly to `window.onload`, which could replace any earlier startup logic added to the exported page. This update switches the generated initialization code to `window.addEventListener("load", ...)` so the export composes with other page scripts instead of clobbering them.

Related Issue
Fixes #6762

PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior
- [x] Tests - Adds or updates test coverage
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [ ] Documentation - Updates to docs, comments, or README

Changes Made
- Replaced the exported `window.onload = function() { ... }` template with `window.addEventListener("load", function() { ... })` in `js/SaveInterface.js`.
- Added a regression test that verifies the generated exported HTML uses a load event listener and does not emit a direct `window.onload` overwrite.

Testing Performed
- `npx jest js/__tests__/SaveInterface.test.js --runInBand --coverage=false`
- `npx eslint js/SaveInterface.js js/__tests__/SaveInterface.test.js`
- `npx prettier --check js/SaveInterface.js js/__tests__/SaveInterface.test.js`

Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run the relevant local checks with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" if needed for auto-rebase.

Additional Notes for Reviewers
This change is intentionally narrow and only touches the exported HTML initialization path plus regression coverage for that output.
