### PR TITLE
fix: resolve parameter shadowing in resetSynth

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -548,11 +548,11 @@ class Logo {
         }
 
         this.deps.Singer.setMasterVolume(this.activity.logo, DEFAULTVOLUME);
-        for (const turtle in this.activity.turtles.turtleList) {
+        for (const t in this.activity.turtles.turtleList) {
             // Cache ithTurtle result to avoid redundant function calls in inner loop
-            const tur = this.activity.turtles.ithTurtle(turtle);
+            const tur = this.activity.turtles.ithTurtle(t);
             for (const synth in tur.singer.synthVolume) {
-                this.deps.Singer.setSynthVolume(this, turtle, synth, DEFAULTVOLUME);
+                this.deps.Singer.setSynthVolume(this, t, synth, DEFAULTVOLUME);
             }
         }
 


### PR DESCRIPTION
- [x] Bug Fix : #6767 
### Summary
small but important bug in the `resetSynth` function where a loop variable was accidentally "hiding" (shadowing) a function parameter.

### The Problem
In `js/logo.js`, the `resetSynth` function takes a `turtle` as a parameter. However, inside the function, there was a loop that also used the name `turtle` for its own counter. 

