### PR TITLE
fix: enable keyboard focus and activation for toolbar and tempo buttons (#5809)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7580,7 +7580,6 @@ class Activity {
             await lazyLoad("widgets/help");
             new HelpWidget(this, false);
         };
-
         /*
          * Makes non-toolbar buttons, e.g., the palette menu buttons
          */
@@ -7590,6 +7589,21 @@ class Activity {
             container.setAttribute("class", "tooltipped");
             container.setAttribute("data-tooltip", label);
             container.setAttribute("data-position", "top");
+
+            // --- GUIDELINE COMPLIANT ACCESSIBILITY ADDITIONS ---
+            container.setAttribute("tabindex", "0");
+            container.setAttribute("role", "button");
+            const cleanLabel = label ? label.replace(/\s*\[.*\]$/, "") : "Button";
+            container.setAttribute("aria-label", cleanLabel);
+
+            container.addEventListener("keydown", event => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    container.dispatchEvent(new MouseEvent("mousedown"));
+                }
+            });
+            // ----------------------------------------------------
+
             window.jQuery(".tooltipped").tooltip({
                 html: true,
                 delay: 100
@@ -7614,11 +7628,9 @@ class Activity {
 
             const img = new Image();
             img.src = "data:image/svg+xml;base64," + window.btoa(base64Encode(name));
-            // Accessibility: derive alt text from the button label
             const altText = label ? label.replace(/\s*\[.*\]$/, "") : "Toolbar button";
             img.setAttribute("alt", altText);
 
-            // Batch DOM reads before writes to avoid forced synchronous layout
             const rightPos = document.body.clientWidth - x;
             container.appendChild(img);
             container.setAttribute(
@@ -7628,7 +7640,6 @@ class Activity {
             document.getElementById("buttoncontainerBOTTOM").appendChild(container);
             return container;
         };
-
         /**
          * Handles button dragging, long hovering and prevents multiple button presses.
          * @param container longAction

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -80,6 +80,16 @@ class Tempo {
         };
 
         const pauseBtn = widgetWindow.addButton("pause-button.svg", Tempo.ICONSIZE, _("Pause"));
+        // --- INSERT THIS ACCESSIBILITY BLOCK ---
+        pauseBtn.setAttribute("tabindex", "0");
+        pauseBtn.setAttribute("role", "button");
+        pauseBtn.addEventListener("keydown", event => {
+            if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                pauseBtn.click(); // Triggers the onclick logic below
+            }
+        });
+        // ----------------------------------------
         pauseBtn.onclick = () => {
             if (this.isMoving) {
                 this.pause();
@@ -107,15 +117,33 @@ class Tempo {
         };
 
         this._save_lock = false;
-        widgetWindow.addButton("export-chunk.svg", Tempo.ICONSIZE, _("Save tempo"), "").onclick =
-            () => {
-                // Debounce button
-                if (!this._get_save_lock()) {
-                    this._save_lock = true;
-                    this._saveTempo();
-                    setTimeout(() => (this._save_lock = false), 1000);
-                }
-            };
+        // Assign to a variable so we can add attributes
+        const saveBtn = widgetWindow.addButton(
+            "export-chunk.svg",
+            Tempo.ICONSIZE,
+            _("Save tempo"),
+            ""
+        );
+
+        // --- ADD ACCESSIBILITY ---
+        saveBtn.setAttribute("tabindex", "0");
+        saveBtn.setAttribute("role", "button");
+        saveBtn.addEventListener("keydown", e => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                saveBtn.click();
+            }
+        });
+        // -------------------------
+
+        saveBtn.onclick = () => {
+            // Debounce button
+            if (!this._get_save_lock()) {
+                this._save_lock = true;
+                this._saveTempo();
+                setTimeout(() => (this._save_lock = false), 1000);
+            }
+        };
 
         this.bodyTable = document.createElement("table");
         this.widgetWindow.getWidgetBody().appendChild(this.bodyTable);
@@ -134,24 +162,47 @@ class Tempo {
             r1 = this.bodyTable.insertRow();
             r2 = this.bodyTable.insertRow();
             r3 = this.bodyTable.insertRow();
-            widgetWindow.addButton(
+
+            // --- REPLACEMENT FOR SPEED UP BUTTON ---
+            const upBtn = widgetWindow.addButton(
                 "up.svg",
                 Tempo.ICONSIZE,
                 _("speed up"),
                 r1.insertCell()
-            ).onclick = (
+            );
+            upBtn.setAttribute("tabindex", "0");
+            upBtn.setAttribute("role", "button");
+            upBtn.addEventListener("keydown", e => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    upBtn.click();
+                }
+            });
+            upBtn.onclick = (
                 i => () =>
                     this.speedUp(i)
             )(i);
-            widgetWindow.addButton(
+
+            // --- REPLACEMENT FOR SLOW DOWN BUTTON ---
+            const downBtn = widgetWindow.addButton(
                 "down.svg",
                 Tempo.ICONSIZE,
                 _("slow down"),
                 r2.insertCell()
-            ).onclick = (
+            );
+            downBtn.setAttribute("tabindex", "0");
+            downBtn.setAttribute("role", "button");
+            downBtn.addEventListener("keydown", e => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    downBtn.click();
+                }
+            });
+            downBtn.onclick = (
                 i => () =>
                     this.slowDown(i)
             )(i);
+            // ------------------------------------------
 
             this.BPMInputs[i] = widgetWindow.addInputButton(this.BPMs[i], r3.insertCell());
             this.tempoCanvases[i] = document.createElement("canvas");


### PR DESCRIPTION
This PR resolves #5809 by adding keyboard accessibility to the canvas-level toolbar buttons and the Tempo widget controls. Previously, these elements were only accessible via mouse interactions.

Changes
Main Toolbar (js/activity.js): Added tabindex="0", role="button", and aria-label to the _makeButton function. Implemented a keydown listener to trigger the button action when Enter or Space is pressed.

Tempo Widget (js/widgets/tempo.js): Updated the Pause, Save, Speed Up, and Slow Down buttons to be focusable and activatable via keyboard.

Code Quality: Formatted both files using Prettier and verified with the project linter to ensure 0 errors.

Testing
Manually verified that Home, Search, and Zoom buttons can be navigated using the Tab key and triggered using Enter.

Verified that all buttons in the Tempo widget are reachable via keyboard and correctly update the BPM.

Screenshot showing the focus ring on the Search button during Tab navigation
<img width="960" height="837" alt="musi" src="https://github.com/user-attachments/assets/fd82c049-11b8-4e46-a1a8-d0422bb49d88" />



- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation

Closes #5809

