### PR TITLE
fix: failing synthutils tests

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1212,6 +1212,35 @@ describe("Utility Functions (logic-only)", () => {
             expect(Synth.audioURL).toBeNull();
         });
     });
+
+    describe("resolveInstrumentName", () => {
+        it("should return the internal key for a translated voice name", () => {
+            // In English, _("piano") is "piano".
+            // Our resolveInstrumentName matches against BOTH VOICENAMES[i][0] and [1].
+            expect(resolveInstrumentName("piano")).toBe("piano");
+        });
+
+        it("should return the internal key for a raw internal voice name", () => {
+            expect(resolveInstrumentName("electric guitar")).toBe("electric guitar");
+        });
+
+        it("should return the internal key for a drum name", () => {
+            expect(resolveInstrumentName("snare drum")).toBe("snare drum");
+        });
+
+        it("should return the internal key for a translated noise name", () => {
+            expect(resolveInstrumentName("white noise")).toBe("noise1");
+        });
+
+        it("should return the original name if not found in any mapping", () => {
+            expect(resolveInstrumentName("unknown-synth")).toBe("unknown-synth");
+        });
+
+        it("should handle null or undefined gracefully", () => {
+            expect(resolveInstrumentName(null)).toBe(null);
+            expect(resolveInstrumentName(undefined)).toBe(undefined);
+        });
+    });
 });
 
 describe("Tuner Utilities (Audio Test Functions)", () => {
@@ -1695,34 +1724,5 @@ describe("Use-after-dispose race in Synth.trigger async path", () => {
 
         expect(synthRef.triggers).toHaveLength(0);
         expect(synthRef.disposed).toBe(true);
-    });
-
-    describe("resolveInstrumentName", () => {
-        it("should return the internal key for a translated voice name", () => {
-            // In English, _("piano") is "piano".
-            // Our resolveInstrumentName matches against BOTH VOICENAMES[i][0] and [1].
-            expect(resolveInstrumentName("piano")).toBe("piano");
-        });
-
-        it("should return the internal key for a raw internal voice name", () => {
-            expect(resolveInstrumentName("electric guitar")).toBe("electric guitar");
-        });
-
-        it("should return the internal key for a drum name", () => {
-            expect(resolveInstrumentName("snare drum")).toBe("snare drum");
-        });
-
-        it("should return the internal key for a translated noise name", () => {
-            expect(resolveInstrumentName("white noise")).toBe("noise1");
-        });
-
-        it("should return the original name if not found in any mapping", () => {
-            expect(resolveInstrumentName("unknown-synth")).toBe("unknown-synth");
-        });
-
-        it("should handle null or undefined gracefully", () => {
-            expect(resolveInstrumentName(null)).toBe(null);
-            expect(resolveInstrumentName(undefined)).toBe(undefined);
-        });
     });
 });


### PR DESCRIPTION
## Description

This pull request fixes a ReferenceError in the `synthutils.test.js` file where `resolveInstrumentName` was reported as not defined. The issue was caused by test code being located outside the scope where its dependencies were initialized.

## PR Category

<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

* Relocated the `resolveInstrumentName` describe block from an isolated scope back into the main Utility Functions (logic-only) describe block.
* Ensured that instrument resolution tests have access to the `Synth` instance and mock environment initialized in the primary `beforeAll` hook.

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

-   All tests passing on npm test

Before:
<img width="649" height="175" alt="image" src="https://github.com/user-attachments/assets/8d5532f1-bddf-4a95-b36a-593188b591b0" />

After:
<img width="437" height="120" alt="image" src="https://github.com/user-attachments/assets/d14ad78e-8c53-4bb7-8148-f06e83aa161b" />


Thank you for contributing to our project! We appreciate your help in improving it.

📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md).

🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).