### PR TITLE
fix: guard doSetXY against non-finite coordinates

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -924,6 +924,13 @@ class Painter {
      * @param y - on-screen y coordinate of the point to where the turtle is moved
      */
     doSetXY(x, y) {
+        x = Number(x);
+        y = Number(y);
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            this.turtles.activity.errorMsg(NANERRORMSG);
+            return;
+        }
+
         this._processColor();
 
         if (!this._fillState) {
@@ -938,8 +945,8 @@ class Painter {
         const oy = this.turtles.screenY2turtleY(this.turtle.container.y);
 
         // New turtle point
-        const nx = Number(x);
-        const ny = Number(y);
+        const nx = x;
+        const ny = y;
 
         this._move(ox, oy, nx, ny, true);
         this._scheduleCanvasUpdate();


### PR DESCRIPTION
 - [x] Bug Fix

## Summary
Fixes silent state corruption in doSetXY when x or y becomes NaN / Infinity. Same issue was already fixed in doForward, doArc, and doRight/doSetHeading, but was missing here.

---

## Impact
- Turtle position gets corrupted permanently (NaN / Infinity)
- Nothing draws on canvas (silent failure)
- No error shown to user → very confusing
- Corruption keeps coming back via note restore paths (doSetXY(saveX, saveY))
- Affects multiple blocks (singer, intervals, etc.)

---

## Fix
Added same guard used in other movement APIs:

```js
x = Number(x);
y = Number(y);

if (!Number.isFinite(x) || !Number.isFinite(y)) {
this.turtles.activity.errorMsg(NANERRORMSG);
return;
}
```

Also removed redundant Number() calls later.

---

## Notes
- No change for valid inputs
- Behavior now consistent across all movement functions
- Converts silent corruption → visible error

