### PR TITLE
fix: fixed the layout and colors of report submission form in planet modal

### DIFF
--- a/planet/css/planetThemes.css
+++ b/planet/css/planetThemes.css
@@ -109,7 +109,9 @@ s .dark #local-projects .card:hover {
 .dark .modal-footer .btn-flat {
     color: #ffffff !important;
     background-color: transparent !important;
-    transition: background-color 0.3s ease, color 0.3s ease;
+    transition:
+        background-color 0.3s ease,
+        color 0.3s ease;
     font-weight: bold;
 }
 
@@ -235,6 +237,108 @@ s .dark #local-projects .card:hover {
     box-shadow: 0 0 10px #ffff00 !important;
 }
 
+/* Report Project card readability */
+
+.dark #projectviewer-report-card {
+    background-color: #2f2f2f;
+    border: 1px solid #555555;
+    color: #f1f1f1;
+}
+
+.dark #projectviewer-report-card .card-content,
+.dark #projectviewer-report-card .card-action {
+    background-color: #2f2f2f;
+    color: #f1f1f1;
+}
+
+.dark #projectviewer-report-title,
+.dark #projectviewer-reportsubmit-title {
+    color: #f1f1f1;
+}
+
+.dark #projectviewer-report-conduct,
+.dark #submittext,
+.dark #projectviewer-report-reason {
+    color: #c7c7c7 !important;
+}
+
+.dark #projectviewer-report-card a {
+    color: #a8d5a8 !important;
+}
+
+.dark #projectviewer-report-card a:hover {
+    color: #c6e7c6 !important;
+}
+
+.dark #reportdescription {
+    color: #ffffff;
+    border-bottom: 1px solid #7a7a7a;
+}
+
+.dark #reportdescription:focus {
+    border-bottom: 1px solid #a8d5a8;
+    box-shadow: 0 1px 0 0 #a8d5a8;
+}
+
+.dark #report-error {
+    color: #ff8a80;
+}
+
+.highcontrast #projectviewer-report-card {
+    background-color: #001133;
+    border: 2px solid #ffff00;
+    outline: 1px solid #ffffff;
+    box-shadow:
+        0 0 0 3px #000000,
+        0 10px 24px rgba(0, 0, 0, 0.9);
+    color: #ffff00;
+}
+
+.highcontrast #projectviewer-report-card .card-content,
+.highcontrast #projectviewer-report-card .card-action {
+    background-color: #001133;
+    color: #ffff00;
+}
+
+.highcontrast #projectviewer-report-card .card-action {
+    background-color: #000a26;
+    border-top: 1px solid #ffff00;
+}
+
+.highcontrast #projectviewer-report-title,
+.highcontrast #projectviewer-reportsubmit-title {
+    color: #ffff00;
+}
+
+.highcontrast #projectviewer-report-conduct,
+.highcontrast #submittext,
+.highcontrast #projectviewer-report-reason {
+    color: #ffffff !important;
+}
+
+.highcontrast #projectviewer-report-card a {
+    color: #ffff00 !important;
+}
+
+.highcontrast #projectviewer-report-card a:hover {
+    background-color: #000080 !important;
+    color: #ffff00 !important;
+}
+
+.highcontrast #reportdescription {
+    color: #ffff00;
+    border-bottom: 2px solid #ffff00;
+}
+
+.highcontrast #reportdescription:focus {
+    border-bottom: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px #ffffff;
+}
+
+.highcontrast #report-error {
+    color: #ff4d4d;
+}
+
 .highcontrast #view-more-chips {
     color: #ffff00 !important;
 }
@@ -252,7 +356,7 @@ s .dark #local-projects .card:hover {
 .highcontrast #local-projects .card .card-content {
     color: #ffff00;
 }
-s .highcontrast #local-projects .card:hover {
+.highcontrast #local-projects .card:hover {
     background-color: #000080;
     box-shadow: 0px 6px 8px rgba(255, 255, 0, 0.5);
 }
@@ -300,7 +404,9 @@ s .highcontrast #local-projects .card:hover {
 .highcontrast .modal-footer .btn-flat {
     color: #ffff00 !important;
     background-color: transparent !important;
-    transition: background-color 0.3s ease, color 0.3s ease;
+    transition:
+        background-color 0.3s ease,
+        color 0.3s ease;
     font-weight: bold;
     border: 2px solid #ffff00;
 }

--- a/planet/css/planetThemes.css
+++ b/planet/css/planetThemes.css
@@ -288,10 +288,10 @@ s .dark #local-projects .card:hover {
     background-color: #001133;
     border: 2px solid #ffff00;
     outline: 1px solid #ffffff;
-    box-shadow:
-        0 0 0 3px #000000,
-        0 10px 24px rgba(0, 0, 0, 0.9);
+    outline-offset: -2px;
+    box-shadow: 0 0 0 3px #000000, 0 10px 24px rgba(0, 0, 0, 0.9);
     color: #ffff00;
+    bottom: -5px;
 }
 
 .highcontrast #projectviewer-report-card .card-content,

--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -442,7 +442,9 @@ a {
 	-ms-transform: translateX(-50%);
 	transform: translateX(10%);
 	min-width: 350px;
-	bottom: 40px;
+	bottom: 10px;
+	max-height: calc(100vh - 200px);
+	overflow-y: auto;
 	text-align: left;
 }
 


### PR DESCRIPTION
### PR Category
- [x] Bug fix / UI Fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

### Description
This PR improves the readability and visibility of the Report Project submission form inside the Planet modal. Previously, the form lacked proper theming, making it very difficult to read. 

I have explicitly defined the color palette for both the .dark and .highcontrast themes to ensure the form is accessible and matches the rest of the application.

### Color Changes Made to Increase Visibility:
* **Dark Mode**:
  * Changed the report card background to dark gray (`#2f2f2f`) with off-white text (`#f1f1f1`).
  * Changed links and input focus borders to a visible light green (`#a8d5a8`).
  * Changed validation error messages to a legible light red (`#ff8a80`).

* **High Contrast Mode**:
  * Changed the report card background to a deep navy blue (`#001133`) to maximize contrast.
  * Changed primary text, borders, and links to bright yellow (`#ffff00`).
  * Changed secondary text and input focus borders to pure white (`#ffffff`).
  * Changed validation error messages to bright red (`#ff4d4d`).

### Screenshots

### Dark Mode :

### Before

<img width="1161" height="655" alt="Screenshot 2026-04-22 025634" src="https://github.com/user-attachments/assets/d64d2bfc-c76e-4679-8e1c-dbf8e34013c7" />
 
### After

<img width="1915" height="824" alt="Screenshot 2026-04-22 055442" src="https://github.com/user-attachments/assets/3207446b-c186-459f-8761-371fdbc0a089" />

### High Contrast

### Before

<img width="1223" height="640" alt="Screenshot 2026-04-22 030016" src="https://github.com/user-attachments/assets/38503927-04ff-4b1e-953e-4ebf8e3a8d0b" />

### After

<img width="1919" height="831" alt="Screenshot 2026-04-22 055518" src="https://github.com/user-attachments/assets/a8c25491-d60d-4fe7-9f07-27e675b0e37e" />



