### PR TITLE
Fix auxiliary toolbar toggle button class corruption. Fixes #6771

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -702,7 +702,11 @@ describe("Toolbar Class", () => {
                 }
             },
             "toggleAuxBtn": {
-                className: ""
+                className: "tooltipped aux-toggle",
+                classList: {
+                    add: jest.fn(),
+                    remove: jest.fn()
+                }
             },
             "chooseKeyDiv": {
                 style: { display: "" }
@@ -725,7 +729,7 @@ describe("Toolbar Class", () => {
 
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, false);
         expect(elements.menu.innerHTML).toBe("more_vert");
-        expect(elements.toggleAuxBtn.className).toBe("blue darken-1");
+        expect(elements.toggleAuxBtn.classList.add).toHaveBeenCalledWith("blue", "darken-1");
         expect(elements.search.classList.toggle).toHaveBeenCalledWith("open");
 
         elements["aux-toolbar"].style.display = "block";
@@ -734,7 +738,8 @@ describe("Toolbar Class", () => {
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, true);
         expect(elements["aux-toolbar"].style.display).toBe("none");
         expect(elements.menu.innerHTML).toBe("menu");
-        expect(elements.toggleAuxBtn.className).toBe(NaN);
+        expect(elements.toggleAuxBtn.classList.remove).toHaveBeenCalledWith("blue", "darken-1");
+        expect(elements.toggleAuxBtn.className).toBe("tooltipped aux-toggle");
         expect(elements.chooseKeyDiv.style.display).toBe("none");
     });
 
@@ -1058,7 +1063,13 @@ describe("Toolbar Class", () => {
         const elements = {
             "aux-toolbar": { style: { display: "block" } },
             "menu": { innerHTML: "" },
-            "toggleAuxBtn": { className: "some-class blue darken-1" }
+            "toggleAuxBtn": {
+                className: "some-class blue darken-1",
+                classList: {
+                    add: jest.fn(),
+                    remove: jest.fn()
+                }
+            }
         };
 
         global.docById.mockImplementation(id => elements[id] || {});
@@ -1068,6 +1079,7 @@ describe("Toolbar Class", () => {
         expect(elements["aux-toolbar"].style.display).toBe("none");
         expect(elements.menu.innerHTML).toBe("menu");
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, false);
+        expect(elements.toggleAuxBtn.classList.remove).toHaveBeenCalledWith("blue", "darken-1");
     });
     test("renderLanguageSelectIcon highlights Japanese kana variant correctly", () => {
         const mockLangElement = {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -904,7 +904,7 @@ class Toolbar {
                         1.0
                     );
 
-                    if (svgData == "") {
+                    if (svgData === "") {
                         savePNG.disabled = true;
                         savePNG.className = "grey-text inactiveLink";
                     } else {
@@ -938,7 +938,7 @@ class Toolbar {
                 );
 
                 // if there is no mouse artwork to save then grey out
-                if (svgData == "") {
+                if (svgData === "") {
                     saveSVG.disabled = true;
                     savePNG.disabled = true;
                     saveSVG.className = "grey-text inactiveLink";
@@ -1170,16 +1170,16 @@ class Toolbar {
         menuIcon.onclick = () => {
             const searchBar = docById("search");
             searchBar.classList.toggle("open");
-            if (auxToolbar.style.display == "" || auxToolbar.style.display == "none") {
+            if (auxToolbar.style.display === "" || auxToolbar.style.display === "none") {
                 onclick(this.activity, false);
                 auxToolbar.style.display = "block";
                 menuIcon.innerHTML = "more_vert";
-                docById("toggleAuxBtn").className = "blue darken-1";
+                this._setAuxToolbarButtonState(true);
             } else {
                 onclick(this.activity, true);
                 auxToolbar.style.display = "none";
                 menuIcon.innerHTML = "menu";
-                docById("toggleAuxBtn").className -= "blue darken-1";
+                this._setAuxToolbarButtonState(false);
                 docById("chooseKeyDiv").style.display = "none";
                 docById("movable").style.display = "none";
             }
@@ -2239,9 +2239,40 @@ class Toolbar {
             const menuIcon = docById("menu");
             auxToolbar.style.display = "none";
             menuIcon.innerHTML = "menu";
-            docById("toggleAuxBtn").className -= "blue darken-1";
+            this._setAuxToolbarButtonState(false);
         }
     };
+
+    /**
+     * Updates the auxiliary menu button highlight without corrupting its existing classes.
+     *
+     * @param {boolean} isActive - Whether the auxiliary toolbar is currently open.
+     * @returns {void}
+     */
+    _setAuxToolbarButtonState(isActive) {
+        const toggleAuxBtn = docById("toggleAuxBtn");
+        if (!toggleAuxBtn) return;
+
+        if (toggleAuxBtn.classList) {
+            if (isActive) {
+                toggleAuxBtn.classList.add("blue", "darken-1");
+            } else {
+                toggleAuxBtn.classList.remove("blue", "darken-1");
+            }
+            return;
+        }
+
+        const classNames = new Set((toggleAuxBtn.className || "").split(/\s+/).filter(Boolean));
+        if (isActive) {
+            classNames.add("blue");
+            classNames.add("darken-1");
+        } else {
+            classNames.delete("blue");
+            classNames.delete("darken-1");
+        }
+
+        toggleAuxBtn.className = Array.from(classNames).join(" ");
+    }
 }
 
 /**


### PR DESCRIPTION
Description
This fixes the auxiliary toolbar close path so the auxiliary menu button keeps a valid class state instead of being corrupted when the menu is dismissed.

The previous implementation tried to clear the active aux-menu highlight with string subtraction on `className`. Because `className` is a string, that coerced the value to `NaN` instead of removing the classes. This update switches the button state handling to class-safe add/remove logic and reuses that logic in both menu close paths.

Related Issue
Fixes #6771

PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior
- [x] Tests - Adds or updates test coverage
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [ ] Documentation - Updates to docs, comments, or README

Changes Made
- Replaced the broken `className -= "blue darken-1"` logic with a shared helper that safely adds or removes the aux-menu highlight classes.
- Updated `renderMenuIcon()` and `closeAuxToolbar()` to use the shared helper instead of mutating `className` directly.
- Added regression assertions in `js/__tests__/toolbar.test.js` to verify the aux button classes are added and removed through `classList` rather than being corrupted.
- Cleaned up nearby strict-equality warnings in the touched toolbar file so the changed-file lint step stays green.

Testing Performed
- `npx jest js/__tests__/toolbar.test.js --runInBand --coverage=false`
- `npx eslint js/toolbar.js js/__tests__/toolbar.test.js`
- `npx prettier --check js/toolbar.js js/__tests__/toolbar.test.js`

Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run the relevant local checks with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" if needed for auto-rebase.

Additional Notes for Reviewers
This change is intentionally narrow and only touches the auxiliary toolbar button state handling plus regression coverage for the close/open paths.
