### PR TITLE
fix: route yield setTimeout through _timerManager to prevent ghost ex…

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1982,8 +1982,8 @@ class Logo {
                 logo._syncCounter++;
                 if (logo._syncCounter >= logo._YIELD_AFTER_SYNC_RUNS) {
                     logo._syncCounter = 0;
-                    setTimeout(() => {
-                        if (!logo.stopTurtle) {
+                    logo._timerManager.setGuardedTimeout(
+                        () =>
                             logo.runFromBlockNow(
                                 logo,
                                 turtle,
@@ -1991,9 +1991,10 @@ class Logo {
                                 isflow,
                                 passArg,
                                 queueStart
-                            );
-                        }
-                    }, 0);
+                            ),
+                        0,
+                        () => logo.stopTurtle
+                    );
                 } else {
                     logo.runFromBlockNow(logo, turtle, nextBlock, isflow, passArg, queueStart);
                 }


### PR DESCRIPTION
- [x] Bug Fix

## Summary
Fixes a zombie-timer bug in `runFromBlockNow` where a bare `setTimeout` was not tracked by `_timerManager`. On Stop → immediate Run, this timer could fire and inject stale execution from the previous program into the new run.

---

## Impact
- Stale callbacks execute in a new run (ghost steps)
- Wrong notes scheduled / timing glitches
- Turtle draws unexpected paths
- Non-deterministic behavior (hard to debug)
- Happens in common classroom flow (Stop → Play quickly)

---

## Root Cause
`runFromBlockNow` used an unmanaged timer:

```js
setTimeout(() => {
    if (!logo.stopTurtle) {
        logo.runFromBlockNow(logo, turtle, nextBlock, isflow, passArg, queueStart);
    }
}, 0);
``` 

- Not tracked by `_timerManager`
- `doStopTurtles()` calls `_timerManager.clearAll()` → this timer survives
- On next Run, `stopTurtle` is reset → guard passes
- Callback runs with stale closure values

---

## Fix
Route the yield through `_timerManager` using a guarded timeout:

```js id="k3p9dw"
logo._timerManager.setGuardedTimeout(
    () => logo.runFromBlockNow(logo, turtle, nextBlock, isflow, passArg, queueStart),
    0,
    () => logo.stopTurtle
);
```
- Timer is now tracked and cancelled on Stop
- Guard prevents execution if a stop is in effect
- Removed inline if (!logo.stopTurtle) (handled by guard)