### PR TITLE
style: fix prettier formatting in delayExecution, lilypond, and mxml test files

### DIFF
--- a/js/__tests__/delayExecution.test.js
+++ b/js/__tests__/delayExecution.test.js
@@ -1,30 +1,30 @@
 const { delayExecution } = require("../utils/utils");
 
 describe("delayExecution utility", () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
 
-  test("resolves after specified delay", async () => {
-    const promise = delayExecution(1000);
+    test("resolves after specified delay", async () => {
+        const promise = delayExecution(1000);
 
-    jest.advanceTimersByTime(1000);
+        jest.advanceTimersByTime(1000);
 
-    await expect(promise).resolves.toBe(true);
-  });
+        await expect(promise).resolves.toBe(true);
+    });
 
-  test("multiple calls resolve independently", async () => {
-    const p1 = delayExecution(500);
-    const p2 = delayExecution(1000);
+    test("multiple calls resolve independently", async () => {
+        const p1 = delayExecution(500);
+        const p2 = delayExecution(1000);
 
-    jest.advanceTimersByTime(500);
-    await expect(p1).resolves.toBe(true);
+        jest.advanceTimersByTime(500);
+        await expect(p1).resolves.toBe(true);
 
-    jest.advanceTimersByTime(500);
-    await expect(p2).resolves.toBe(true);
-  });
+        jest.advanceTimersByTime(500);
+        await expect(p2).resolves.toBe(true);
+    });
 });

--- a/js/__tests__/lilypond.test.js
+++ b/js/__tests__/lilypond.test.js
@@ -375,8 +375,8 @@ describe("saveLilypondOutput", () => {
             logo: {
                 notation: {
                     notationStaging: {
-                        "0": [[["G4"], 4, 0, null, 0, -1, false]],
-                        "1": [[["E4"], 4, 0, null, 0, -1, false]]
+                        0: [[["G4"], 4, 0, null, 0, -1, false]],
+                        1: [[["E4"], 4, 0, null, 0, -1, false]]
                     },
                     notationDrumStaging: {}
                 },
@@ -388,8 +388,8 @@ describe("saveLilypondOutput", () => {
             },
             turtles: {
                 turtleList: {
-                    "0": { name: "Turtle 0" },
-                    "1": { name: "Turtle 1" }
+                    0: { name: "Turtle 0" },
+                    1: { name: "Turtle 1" }
                 },
                 getTurtle: function (t) {
                     return this.turtleList[t];
@@ -412,7 +412,7 @@ describe("saveLilypondOutput", () => {
 
     test("should handle drum staging correctly", () => {
         activity.logo.notation.notationDrumStaging = {
-            "0": [[["C4"], 4, 0, null, 0, -1, false]]
+            0: [[["C4"], 4, 0, null, 0, -1, false]]
         };
         const result = saveLilypondOutput(activity);
         expect(result).toContain("\\drummode {");
@@ -420,7 +420,7 @@ describe("saveLilypondOutput", () => {
 
     test("should handle empty drum staging correctly", () => {
         activity.logo.notation.notationDrumStaging = {
-            "0": []
+            0: []
         };
         const result = saveLilypondOutput(activity);
         expect(result).not.toContain("\\drummode {");
@@ -434,9 +434,9 @@ describe("saveLilypondOutput", () => {
 
     test("should handle unique short instrument names correctly", () => {
         activity.turtles.turtleList = {
-            "0": { name: "Turtle 0" },
-            "1": { name: "Turtle 1" },
-            "2": { name: "Turtle 2" }
+            0: { name: "Turtle 0" },
+            1: { name: "Turtle 1" },
+            2: { name: "Turtle 2" }
         };
         const result = saveLilypondOutput(activity);
         expect(result).toContain('shortInstrumentName = "Tu"');
@@ -470,19 +470,19 @@ describe("saveLilypondOutput", () => {
 
     test("should fallback to RODENTS names if instrument name is empty", () => {
         activity.turtles.getTurtle = jest.fn(t => ({ name: "" }));
-        activity.turtles.turtleList = { "0": {} };
+        activity.turtles.turtleList = { 0: {} };
         saveLilypondOutput(activity);
         expect(activity.logo.notationOutput).toContain(RODENTS[0]);
     });
 
     test("should handle multiple turtles with different clefs correctly", () => {
         activity.logo.notationNotes = {
-            "0": "\\note0",
-            "1": "\\note1"
+            0: "\\note0",
+            1: "\\note1"
         };
         activity.logo.notation.notationStaging = {
-            "0": ["note"],
-            "1": ["note"]
+            0: ["note"],
+            1: ["note"]
         };
         clef = ["treble", "bass_8"];
         CLEFS = ["treble", "bass_8"];
@@ -531,8 +531,8 @@ describe("saveLilypondOutput", () => {
     test("should properly format guitar tab output", () => {
         activity.logo.guitarOutputHead = "% Guitar Output Head\n";
         activity.logo.guitarOutputEnd = "% Guitar Output End\n";
-        activity.logo.notationNotes = { "0": "\\note0" };
-        activity.logo.notation.notationStaging = { "0": ["note"] };
+        activity.logo.notationNotes = { 0: "\\note0" };
+        activity.logo.notation.notationStaging = { 0: ["note"] };
 
         const result = saveLilypondOutput(activity);
         expect(result).toContain("% Guitar Output Head");
@@ -546,14 +546,14 @@ describe("saveLilypondOutput", () => {
     });
     test("should handle instrument short name collisions (no spaces)", () => {
         activity.turtles.turtleList = {
-            "0": { name: "Trumpet" },
-            "1": { name: "Trombone" },
-            "2": { name: "Tuba" }
+            0: { name: "Trumpet" },
+            1: { name: "Trombone" },
+            2: { name: "Tuba" }
         };
         activity.logo.notation.notationStaging = {
-            "0": ["note"],
-            "1": ["note"],
-            "2": ["note"]
+            0: ["note"],
+            1: ["note"],
+            2: ["note"]
         };
         frequencyToPitch.mockReturnValue(["C", 4]);
 
@@ -564,25 +564,25 @@ describe("saveLilypondOutput", () => {
 
     test("should handle instrument short name collisions (with spaces)", () => {
         activity.turtles.turtleList = {
-            "0": { name: "Violin One" },
-            "1": { name: "Violin Two" }
+            0: { name: "Violin One" },
+            1: { name: "Violin Two" }
         };
-        activity.logo.notation.notationStaging = { "0": ["note"], "1": ["note"] };
+        activity.logo.notation.notationStaging = { 0: ["note"], 1: ["note"] };
         const result = saveLilypondOutput(activity);
         expect(result).toContain('shortInstrumentName = "Vi"');
         expect(result).toContain('shortInstrumentName = "Vio"');
     });
     test("should map special turtle names (start, numeric) to Rodent names", () => {
         activity.turtles.turtleList = {
-            "0": { name: "start" },
-            "1": { name: "start drum" },
-            "2": { name: "2" }
+            0: { name: "start" },
+            1: { name: "start drum" },
+            2: { name: "2" }
         };
 
         activity.logo.notation.notationStaging = {
-            "0": ["note"],
-            "1": ["note"],
-            "2": ["note"]
+            0: ["note"],
+            1: ["note"],
+            2: ["note"]
         };
 
         const result = saveLilypondOutput(activity);
@@ -593,7 +593,7 @@ describe("saveLilypondOutput", () => {
         frequencyToPitch.mockReturnValue(["C", 1]);
 
         activity.logo.notation.notationStaging = {
-            "0": [[["C1"], 4, 0, null, 0, -1, false]]
+            0: [[["C1"], 4, 0, null, 0, -1, false]]
         };
         const result = saveLilypondOutput(activity);
         expect(result).toContain('\\clef "bass_8"');
@@ -601,7 +601,7 @@ describe("saveLilypondOutput", () => {
     test("should select bass clef for mid-low notes", () => {
         frequencyToPitch.mockReturnValue(["C", 3]);
         activity.logo.notation.notationStaging = {
-            "0": [[["C3"], 4, 0, null, 0, -1, false]]
+            0: [[["C3"], 4, 0, null, 0, -1, false]]
         };
 
         const result = saveLilypondOutput(activity);
@@ -610,7 +610,7 @@ describe("saveLilypondOutput", () => {
 
     test("should handle rest notes in octave calculation", () => {
         activity.logo.notation.notationStaging = {
-            "0": [[["R"], 4, 0, null, 0, -1, false]]
+            0: [[["R"], 4, 0, null, 0, -1, false]]
         };
         const result = saveLilypondOutput(activity);
         expect(result).toBeDefined();
@@ -619,7 +619,7 @@ describe("saveLilypondOutput", () => {
     test("should handle numeric frequency in octave calculation", () => {
         frequencyToPitch.mockReturnValue(["A", 4]);
         activity.logo.notation.notationStaging = {
-            "0": [[[440], 4, 0, null, 0, -1, false]]
+            0: [[[440], 4, 0, null, 0, -1, false]]
         };
         const result = saveLilypondOutput(activity);
         expect(result).toBeDefined();
@@ -627,14 +627,14 @@ describe("saveLilypondOutput", () => {
     });
     test("should handle short name collision for names without spaces (longer loop)", () => {
         activity.turtles.turtleList = {
-            "0": { name: "Trumpet" },
-            "1": { name: "Trombone" },
-            "2": { name: "Triangle" }
+            0: { name: "Trumpet" },
+            1: { name: "Trombone" },
+            2: { name: "Triangle" }
         };
         activity.logo.notation.notationStaging = {
-            "0": ["note"],
-            "1": ["note"],
-            "2": ["note"]
+            0: ["note"],
+            1: ["note"],
+            2: ["note"]
         };
         const result = saveLilypondOutput(activity);
 

--- a/js/__tests__/mxml.test.js
+++ b/js/__tests__/mxml.test.js
@@ -24,8 +24,8 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": [[["C"], 4, 0]],
-                    "1": []
+                    0: [[["C"], 4, 0]],
+                    1: []
                 }
             }
         };
@@ -43,11 +43,11 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": [
+                    0: [
                         [["C"], 4, 0],
                         [["D"], 4, 0]
                     ],
-                    "1": [
+                    1: [
                         [["E"], 4, 0],
                         [["F"], 4, 0]
                     ]
@@ -69,7 +69,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": ["voice one", [["C"], 4, 0], "voice two"]
+                    0: ["voice one", [["C"], 4, 0], "voice two"]
                 }
             }
         };
@@ -85,7 +85,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": ["tempo", 120, 4, [["C"], 4, 0]]
+                    0: ["tempo", 120, 4, [["C"], 4, 0]]
                 }
             }
         };
@@ -100,7 +100,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": ["meter", 3, 4, [["C"], 4, 0]]
+                    0: ["meter", 3, 4, [["C"], 4, 0]]
                 }
             }
         };
@@ -116,7 +116,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": [
+                    0: [
                         "begin crescendo",
                         [["C"], 4, 0],
                         "end crescendo",
@@ -141,7 +141,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    "0": [[["C"], 4, 0], "tie", [["C"], 4, 0]]
+                    0: [[["C"], 4, 0], "tie", [["C"], 4, 0]]
                 }
             }
         };


### PR DESCRIPTION
delayExecution.test.js, lilypond.test.js, and mxml.test.js had 
pre-existing prettier formatting issues causing CI failures on 
unrelated PRs. Running prettier --write on all three files.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation