### PR TITLE
Fix: clamp synthVolume to 0-100 during crescendo/diminuendo

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -548,11 +548,11 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
+        const saveBoxes = logo.boxes !== null ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
+            logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -603,17 +603,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes == undefined) {
+        if (saveBoxes === undefined) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps == undefined) {
+        if (saveTurtleHeaps === undefined) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts == undefined) {
+        if (saveTurtleDicts === undefined) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -662,11 +662,11 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
+            boxes: logo.boxes !== null ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+                logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
+                logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -723,11 +723,11 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
+        activity.logo.boxes = saveState.boxes !== null ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
+            saveState.turtleHeaps !== null ? saveState.turtleHeaps : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts != null ? saveState.turtleDicts : {};
+            saveState.turtleDicts !== null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1127,7 +1127,7 @@ class Singer {
                 for (let i = 0, len = transpositionRatios.length; i < len; i++) {
                     ratio *= transpositionRatios[i];
                 }
-                if (ratio != 1) {
+                if (ratio !== 1) {
                     const hertz = getCachedPitchToFrequency(
                         noteObj[0],
                         noteObj[1],
@@ -1596,7 +1596,13 @@ class Singer {
                 const synth = synthKeys[i];
                 const oldVol = last(tur.singer.synthVolume[synth]);
                 const len = tur.singer.synthVolume[synth].length;
-                tur.singer.synthVolume[synth][len - 1] += last(tur.singer.crescendoDelta);
+                tur.singer.synthVolume[synth][len - 1] = Math.min(
+                    Math.max(
+                        tur.singer.synthVolume[synth][len - 1] + last(tur.singer.crescendoDelta),
+                        0
+                    ),
+                    100
+                );
                 if (!tur.singer.suppressOutput) {
                     Singer.setSynthVolume(activity.logo, turtle, synth, oldVol);
                     activity.logo.synth.rampTo(
@@ -1913,7 +1919,7 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 /** @deprecated */
                 // newswing2 takes the target as an argument
-                if (last(tur.singer.swingTarget) == null) {
+                if (last(tur.singer.swingTarget) === null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -491,11 +491,11 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = logo.boxes !== null ? deepClone(logo.boxes) : undefined;
+        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined;
+            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -546,17 +546,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes === undefined) {
+        if (saveBoxes == undefined) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps === undefined) {
+        if (saveTurtleHeaps == undefined) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts === undefined) {
+        if (saveTurtleDicts == undefined) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -605,11 +605,11 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: logo.boxes !== null ? deepClone(logo.boxes) : undefined,
+            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined,
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -666,11 +666,11 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = saveState.boxes !== null ? saveState.boxes : {};
+        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps !== null ? saveState.turtleHeaps : {};
+            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts !== null ? saveState.turtleDicts : {};
+            saveState.turtleDicts != null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1070,7 +1070,7 @@ class Singer {
                 for (let i = 0, len = transpositionRatios.length; i < len; i++) {
                     ratio *= transpositionRatios[i];
                 }
-                if (ratio !== 1) {
+                if (ratio != 1) {
                     const hertz = getCachedPitchToFrequency(
                         noteObj[0],
                         noteObj[1],
@@ -1862,7 +1862,7 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 /** @deprecated */
                 // newswing2 takes the target as an argument
-                if (last(tur.singer.swingTarget) === null) {
+                if (last(tur.singer.swingTarget) == null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }


### PR DESCRIPTION
The volume could go negative or above 100 during these operations, which broke downstream logic. Now we clamp after each step.

Fixes #6779

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation