### PR TITLE
test: add missing unit tests for BlocksDependencies and svgAssetSelector

### DIFF
--- a/js/__tests__/BlocksDependencies.test.js
+++ b/js/__tests__/BlocksDependencies.test.js
@@ -1,7 +1,7 @@
 /**
  * MusicBlocks v3.4.1
  *
- * @author Music Blocks contributors
+ * @author Sapnil Biswas
  *
  * @copyright 2026 Music Blocks contributors
  *

--- a/js/__tests__/BlocksDependencies.test.js
+++ b/js/__tests__/BlocksDependencies.test.js
@@ -1,0 +1,134 @@
+/**
+ * MusicBlocks v3.4.1
+ *
+ * @author Music Blocks contributors
+ *
+ * @copyright 2026 Music Blocks contributors
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const BlocksDependencies = require("../BlocksDependencies");
+
+describe("BlocksDependencies", () => {
+    let mockActivity;
+
+    beforeEach(() => {
+        mockActivity = {
+            storage: { save: jest.fn() },
+            trashcan: { empty: jest.fn() },
+            turtles: { getTurtle: jest.fn() },
+            boundary: { check: jest.fn() },
+            macroDict: { myMacro: [] },
+            palettes: { show: jest.fn() },
+            logo: { run: jest.fn() },
+            blocksContainer: { add: jest.fn() },
+            canvas: document.createElement("canvas"),
+            refreshCanvas: jest.fn(),
+            errorMsg: jest.fn(),
+            setSelectionMode: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            setHomeContainers: jest.fn(),
+            __tick: jest.fn()
+        };
+    });
+
+    it("should construct with explicitly provided dependencies", () => {
+        const deps = new BlocksDependencies({
+            storage: mockActivity.storage,
+            trashcan: mockActivity.trashcan,
+            turtles: mockActivity.turtles,
+            boundary: mockActivity.boundary,
+            macroDict: mockActivity.macroDict,
+            palettes: mockActivity.palettes,
+            logo: mockActivity.logo,
+            blocksContainer: mockActivity.blocksContainer,
+            canvas: mockActivity.canvas,
+            refreshCanvas: mockActivity.refreshCanvas,
+            errorMsg: mockActivity.errorMsg,
+            setSelectionMode: mockActivity.setSelectionMode,
+            stopLoadAnimation: mockActivity.stopLoadAnimation,
+            setHomeContainers: mockActivity.setHomeContainers,
+            tick: mockActivity.__tick
+        });
+
+        expect(deps.storage).toBe(mockActivity.storage);
+        expect(deps.trashcan).toBe(mockActivity.trashcan);
+        expect(deps.turtles).toBe(mockActivity.turtles);
+        expect(deps.boundary).toBe(mockActivity.boundary);
+        expect(deps.macroDict).toBe(mockActivity.macroDict);
+        expect(deps.palettes).toBe(mockActivity.palettes);
+        expect(deps.logo).toBe(mockActivity.logo);
+        expect(deps.blocksContainer).toBe(mockActivity.blocksContainer);
+        expect(deps.canvas).toBe(mockActivity.canvas);
+
+        deps.refreshCanvas();
+        expect(mockActivity.refreshCanvas).toHaveBeenCalled();
+
+        deps.errorMsg("error", "block");
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith("error", "block");
+
+        deps.setSelectionMode("mode");
+        expect(mockActivity.setSelectionMode).toHaveBeenCalledWith("mode");
+
+        deps.stopLoadAnimation();
+        expect(mockActivity.stopLoadAnimation).toHaveBeenCalled();
+
+        deps.setHomeContainers(true);
+        expect(mockActivity.setHomeContainers).toHaveBeenCalledWith(true);
+
+        deps.tick();
+        expect(mockActivity.__tick).toHaveBeenCalled();
+    });
+
+    it("should construct from an Activity object using fromActivity", () => {
+        const deps = BlocksDependencies.fromActivity(mockActivity);
+
+        expect(deps.storage).toBe(mockActivity.storage);
+        expect(deps.trashcan).toBe(mockActivity.trashcan);
+        expect(deps.turtles).toBe(mockActivity.turtles);
+        expect(deps.boundary).toBe(mockActivity.boundary);
+        expect(deps.macroDict).toBe(mockActivity.macroDict);
+        expect(deps.palettes).toBe(mockActivity.palettes);
+        expect(deps.logo).toBe(mockActivity.logo);
+        expect(deps.blocksContainer).toBe(mockActivity.blocksContainer);
+        expect(deps.canvas).toBe(mockActivity.canvas);
+
+        deps.refreshCanvas();
+        expect(mockActivity.refreshCanvas).toHaveBeenCalled();
+
+        deps.errorMsg("error", "block");
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith("error", "block");
+
+        deps.setSelectionMode("mode");
+        expect(mockActivity.setSelectionMode).toHaveBeenCalledWith("mode");
+
+        deps.stopLoadAnimation();
+        expect(mockActivity.stopLoadAnimation).toHaveBeenCalled();
+
+        deps.setHomeContainers(true);
+        expect(mockActivity.setHomeContainers).toHaveBeenCalledWith(true);
+
+        deps.tick();
+        expect(mockActivity.__tick).toHaveBeenCalled();
+    });
+
+    it("should identify a valid BlocksDependencies instance", () => {
+        const deps = BlocksDependencies.fromActivity(mockActivity);
+        expect(BlocksDependencies.isBlocksDependencies(deps)).toBe(true);
+        expect(BlocksDependencies.isBlocksDependencies({})).toBe(false);
+        expect(BlocksDependencies.isBlocksDependencies(null)).toBe(false);
+    });
+});

--- a/js/__tests__/svgAssetSelector.test.js
+++ b/js/__tests__/svgAssetSelector.test.js
@@ -1,7 +1,7 @@
 /**
  * MusicBlocks v3.4.1
  *
- * @author Music Blocks contributors
+ * @author Sapnil Biswas
  *
  * @copyright 2026 Music Blocks contributors
  *

--- a/js/__tests__/svgAssetSelector.test.js
+++ b/js/__tests__/svgAssetSelector.test.js
@@ -1,0 +1,123 @@
+/**
+ * MusicBlocks v3.4.1
+ *
+ * @author Music Blocks contributors
+ *
+ * @copyright 2026 Music Blocks contributors
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { openSvgAssetSelector } = require("../svgAssetSelector");
+
+describe("svgAssetSelector", () => {
+    let originalFetch;
+
+    beforeEach(() => {
+        // Clear DOM
+        document.body.innerHTML = "";
+
+        // Mock fetch for svgAssets.json
+        originalFetch = global.fetch;
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        svgs: [
+                            { name: "Test Icon 1", path: "assets/test1.svg" },
+                            { name: "Test Icon 2", path: "assets/test2.svg" }
+                        ]
+                    })
+            })
+        );
+
+        // Mock requestAnimationFrame
+        jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => {
+            cb();
+        });
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    it("should render the modal with built-in images when fetch succeeds", async () => {
+        const onSelect = jest.fn();
+        const onUpload = jest.fn();
+
+        openSvgAssetSelector(onSelect, onUpload);
+
+        // Wait for fetch to complete and DOM to update
+        await new Promise(process.nextTick);
+
+        const overlay = document.getElementById("svgAssetSelectorOverlay");
+        expect(overlay).toBeTruthy();
+
+        const grid = document.querySelector(".svg-selector-grid");
+        expect(grid).toBeTruthy();
+
+        const items = document.querySelectorAll(".svg-asset-item");
+        expect(items.length).toBe(2);
+        expect(items[0].querySelector(".asset-name").textContent).toBe("Test Icon 1");
+    });
+
+    it("should handle fetch errors gracefully and trigger onUploadFromDevice fallback", async () => {
+        global.fetch = jest.fn(() => Promise.reject(new Error("Network Error")));
+
+        // Suppress console.error for this test
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+        const onSelect = jest.fn();
+        const onUpload = jest.fn();
+
+        openSvgAssetSelector(onSelect, onUpload);
+
+        await new Promise(process.nextTick);
+
+        expect(consoleSpy).toHaveBeenCalledWith("Failed to load SVG assets:", expect.any(Error));
+        expect(onUpload).toHaveBeenCalled();
+
+        consoleSpy.mockRestore();
+    });
+
+    it("should switch tabs correctly", async () => {
+        openSvgAssetSelector(jest.fn(), jest.fn());
+        await new Promise(process.nextTick);
+
+        const tabBuiltIn = document.getElementById("svgTabBuiltIn");
+        const tabUpload = document.getElementById("svgTabUpload");
+        const gridContainer = document.getElementById("svgGridPanel");
+        const uploadPanel = document.getElementById("svgUploadPanel");
+
+        expect(tabBuiltIn.classList.contains("active")).toBe(true);
+        expect(uploadPanel.style.display).toBe("none");
+
+        // Click Upload tab
+        tabUpload.click();
+
+        expect(tabUpload.classList.contains("active")).toBe(true);
+        expect(tabBuiltIn.classList.contains("active")).toBe(false);
+        expect(gridContainer.style.display).toBe("none");
+        expect(uploadPanel.style.display).toBe("");
+
+        // Click Built-in tab again
+        tabBuiltIn.click();
+
+        expect(tabBuiltIn.classList.contains("active")).toBe(true);
+        expect(gridContainer.style.display).toBe("");
+    });
+});

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1212,6 +1212,35 @@ describe("Utility Functions (logic-only)", () => {
             expect(Synth.audioURL).toBeNull();
         });
     });
+
+    describe("resolveInstrumentName", () => {
+        it("should return the internal key for a translated voice name", () => {
+            // In English, _("piano") is "piano".
+            // Our resolveInstrumentName matches against BOTH VOICENAMES[i][0] and [1].
+            expect(resolveInstrumentName("piano")).toBe("piano");
+        });
+
+        it("should return the internal key for a raw internal voice name", () => {
+            expect(resolveInstrumentName("electric guitar")).toBe("electric guitar");
+        });
+
+        it("should return the internal key for a drum name", () => {
+            expect(resolveInstrumentName("snare drum")).toBe("snare drum");
+        });
+
+        it("should return the internal key for a translated noise name", () => {
+            expect(resolveInstrumentName("white noise")).toBe("noise1");
+        });
+
+        it("should return the original name if not found in any mapping", () => {
+            expect(resolveInstrumentName("unknown-synth")).toBe("unknown-synth");
+        });
+
+        it("should handle null or undefined gracefully", () => {
+            expect(resolveInstrumentName(null)).toBe(null);
+            expect(resolveInstrumentName(undefined)).toBe(undefined);
+        });
+    });
 });
 
 describe("Tuner Utilities (Audio Test Functions)", () => {
@@ -1695,34 +1724,5 @@ describe("Use-after-dispose race in Synth.trigger async path", () => {
 
         expect(synthRef.triggers).toHaveLength(0);
         expect(synthRef.disposed).toBe(true);
-    });
-
-    describe("resolveInstrumentName", () => {
-        it("should return the internal key for a translated voice name", () => {
-            // In English, _("piano") is "piano".
-            // Our resolveInstrumentName matches against BOTH VOICENAMES[i][0] and [1].
-            expect(resolveInstrumentName("piano")).toBe("piano");
-        });
-
-        it("should return the internal key for a raw internal voice name", () => {
-            expect(resolveInstrumentName("electric guitar")).toBe("electric guitar");
-        });
-
-        it("should return the internal key for a drum name", () => {
-            expect(resolveInstrumentName("snare drum")).toBe("snare drum");
-        });
-
-        it("should return the internal key for a translated noise name", () => {
-            expect(resolveInstrumentName("white noise")).toBe("noise1");
-        });
-
-        it("should return the original name if not found in any mapping", () => {
-            expect(resolveInstrumentName("unknown-synth")).toBe("unknown-synth");
-        });
-
-        it("should handle null or undefined gracefully", () => {
-            expect(resolveInstrumentName(null)).toBe(null);
-            expect(resolveInstrumentName(undefined)).toBe(undefined);
-        });
     });
 });


### PR DESCRIPTION
### Description
This PR addresses the lack of test coverage for two core project files by adding robust Jest unit test suites for them:
1. `BlocksDependencies.js`: Added tests to ensure it correctly maps the injected dependencies and maintains backward compatibility via the `fromActivity` static method.
2. `svgAssetSelector.js`: Added DOM tests mocking the built-in SVG modal UI. It correctly simulates the fetching of `js/svgAssets.json`, verifies tab switching (Built-in vs Upload), and covers fallback behavior when network requests fail.

**Resolves Issue**: #<issue_number> *(Replace with the issue number you created)*

### Type of change
- [x] Tests coverage (adding missing tests)

### How Has This Been Tested?
- [x] `npm test` runs successfully, including the two newly added files.
- [x] `npm run lint` passes successfully, and files comply with `prettier`.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added AGPL license headers to all new files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
