### PR TITLE
feat: Add Play/Pause toggle with resume support for playback

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -317,6 +317,7 @@ class Activity {
         this.firstTimeUser = false;
         this.beginnerMode = false;
         this.runMode = "normal";
+        this.isPlaying = false;
 
         // Flag to disable keyboard during loading of MB
         this.keyboardEnableFlag;
@@ -1721,9 +1722,76 @@ class Activity {
             activity._doFastButton(env);
         };
 
+        this._setPlaybackState = isPlaying => {
+            this.isPlaying = isPlaying;
+            if (this.toolbar && typeof this.toolbar.updatePlayPauseIcon === "function") {
+                this.toolbar.updatePlayPauseIcon(isPlaying);
+            }
+        };
+
+        this._pausePlayback = () => {
+            if (!this.logo._alreadyRunning || !this.isPlaying) {
+                return;
+            }
+
+            if (this.logo.timerManager && typeof this.logo.timerManager.pauseAll === "function") {
+                this.logo.timerManager.pauseAll();
+            }
+
+            if (this.logo?.synth?.pause) {
+                this.logo.synth.pause();
+            }
+
+            const widgetTitle = document.getElementsByClassName("wftTitle");
+            for (let i = 0; i < widgetTitle.length; i++) {
+                if (widgetTitle[i].innerHTML === "tempo") {
+                    if (this.logo.tempo.isMoving) {
+                        this.logo.tempo.pause();
+                    }
+                    break;
+                }
+            }
+
+            this._setPlaybackState(false);
+        };
+
+        this._resumePlayback = () => {
+            if (!this.logo._alreadyRunning || this.isPlaying) {
+                return;
+            }
+
+            if (this.logo?.synth?.resume) {
+                this.logo.synth.resume();
+            }
+            if (this.logo?.synth?.start) {
+                this.logo.synth.start();
+            }
+            if (this.logo.timerManager && typeof this.logo.timerManager.resumeAll === "function") {
+                this.logo.timerManager.resumeAll();
+            }
+
+            const widgetTitle = document.getElementsByClassName("wftTitle");
+            for (let i = 0; i < widgetTitle.length; i++) {
+                if (widgetTitle[i].innerHTML === "tempo") {
+                    if (this.logo.tempo.isMoving) {
+                        this.logo.tempo.pause();
+                    }
+
+                    this.logo.tempo.resume();
+                    break;
+                }
+            }
+
+            this._setPlaybackState(true);
+        };
+
         this._doFastButton = env => {
-            // Prevent spam-clicking by checking if already running
             if (this.logo._alreadyRunning) {
+                if (this.isPlaying) {
+                    this._pausePlayback();
+                } else {
+                    this._resumePlayback();
+                }
                 return;
             }
 
@@ -1760,6 +1828,7 @@ class Activity {
                     this.showBlocksAfterRun = true;
                 }
 
+                this._setPlaybackState(true);
                 this.logo.runLogoCommands(null, env);
                 const stopBtn = document.getElementById("stop");
                 if (stopBtn) {
@@ -2275,6 +2344,7 @@ class Activity {
             }
 
             this.logo.doStopTurtles();
+            this._setPlaybackState(false);
             document.getElementById("stop").style.display = "none";
 
             const widgetTitle = document.getElementsByClassName("wftTitle");
@@ -3932,12 +4002,9 @@ class Activity {
                     const hasOpenWidget = Object.values(window.widgetWindows.openWindows).some(
                         w => w
                     );
-                    if (this.turtles.running()) {
+                    if (!disableKeys && !hasOpenWidget) {
                         event.preventDefault();
-                        this._doHardStopButton();
-                    } else if (!disableKeys && !hasOpenWidget) {
-                        event.preventDefault();
-                        if (stopbtn) {
+                        if (stopbtn && !this.logo._alreadyRunning) {
                             stopbtn.style.color = platformColor.stopIconcolor;
                         }
                         this._doFastButton();
@@ -4900,6 +4967,7 @@ class Activity {
          * When turtle stops running restore stop button to normal state
          */
         this.onStopTurtle = () => {
+            this._setPlaybackState(false);
             if (this.showBlocksAfterRun) {
                 this.blocks.showBlocks();
                 const stopIcon = document.getElementById("stop");

--- a/js/logo.js
+++ b/js/logo.js
@@ -363,6 +363,7 @@ class Logo {
                 this._timerManager = {
                     _activeTimers: new Set(),
                     _activeIntervals: new Set(),
+                    _isPaused: false,
                     totalCreated: 0,
                     totalCancelled: 0,
                     totalFired: 0,
@@ -381,9 +382,18 @@ class Logo {
                     clearAll() {
                         return 0;
                     },
+                    pauseAll() {
+                        this._isPaused = true;
+                        return 0;
+                    },
+                    resumeAll() {
+                        this._isPaused = false;
+                        return 0;
+                    },
                     getStats() {
                         return {
                             active: 0,
+                            paused: this._isPaused,
                             created: 0,
                             cancelled: 0,
                             fired: 0,

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -18,7 +18,6 @@
 
 let WRAP = true;
 const $j = window.jQuery;
-let play_button_debounce_timeout = null;
 class Toolbar {
     /**
      * Constructs a new Toolbar instance.
@@ -35,6 +34,7 @@ class Toolbar {
         this._recordDropdownArrowElement = null;
         this._recordDropdownArrowClickHandler = null;
         this._recordDropdownOutsideClickHandler = null;
+        this._playStopClickHandler = () => {};
     }
 
     /**
@@ -468,55 +468,57 @@ class Toolbar {
         const stopIcon = docById("stop");
         const recordButton = docById("record");
         playIcon.setAttribute("role", "button");
-        playIcon.setAttribute("aria-label", _("Play project"));
         playIcon.setAttribute("tabindex", "0");
+        this.updatePlayPauseIcon(false);
         playIcon.addEventListener("keydown", e => {
             if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 playIcon.click();
             }
         });
-        let isPlayIconRunning = false;
-
-        function handleClick() {
-            if (!isPlayIconRunning) {
-                playIcon.onclick = null;
-            } else {
-                playIcon.onclick = tempClick;
-                isPlayIconRunning = false;
-            }
-        }
-
-        // Named handler to prevent memory leak from duplicate listeners
-        const stopClickHandler = () => {
-            clearTimeout(play_button_debounce_timeout);
-            isPlayIconRunning = true;
-            this.activity.hideMsgs();
-            handleClick();
-        };
-
-        var tempClick = (playIcon.onclick = () => {
-            const hideMsgs = () => {
-                this.activity.hideMsgs();
-            };
-            isPlayIconRunning = false;
+        playIcon.onclick = () => {
             onclick(this.activity);
-            handleClick();
-            stopIcon.style.color = this.stopIconColorWhenPlaying;
+            if (stopIcon) {
+                stopIcon.style.color = this.stopIconColorWhenPlaying;
+                stopIcon.removeEventListener("click", this._playStopClickHandler);
+
+                this._playStopClickHandler = () => {
+                    this.activity.hideMsgs();
+                };
+                stopIcon.addEventListener("click", this._playStopClickHandler);
+            }
             saveButton.disabled = true;
             saveButtonAdvanced.disabled = true;
             saveButton.className = "grey-text inactiveLink";
             saveButtonAdvanced.className = "grey-text inactiveLink";
             recordButton.className = "grey-text inactiveLink";
-            isPlayIconRunning = true;
-            play_button_debounce_timeout = setTimeout(function () {
-                handleClick();
-            }, 2000);
+            this.activity.hideMsgs();
+        };
+    }
 
-            // Remove existing listener before adding to prevent accumulation
-            stopIcon.removeEventListener("click", stopClickHandler);
-            stopIcon.addEventListener("click", stopClickHandler);
-        });
+    /**
+     * Updates the play button icon and accessible label to match playback state.
+     *
+     * @param {boolean} isPlaying
+     * @returns {void}
+     */
+    updatePlayPauseIcon(isPlaying) {
+        const playIcon = docById("play");
+        if (!playIcon) {
+            return;
+        }
+
+        const icon =
+            typeof playIcon.querySelector === "function" ? playIcon.querySelector("i") : null;
+        const label = isPlaying ? _("Pause project") : _("Play project");
+
+        if (icon) {
+            icon.textContent = isPlaying ? "pause" : "play_circle_filled";
+        }
+
+        playIcon.setAttribute("aria-label", label);
+        playIcon.setAttribute("title", label);
+        playIcon.setAttribute("data-tooltip", label);
     }
 
     /**

--- a/js/utils/ManagedTimer.js
+++ b/js/utils/ManagedTimer.js
@@ -53,14 +53,27 @@ class ManagedTimer {
          * @type {Set<number>}
          * @private
          */
-        this._activeTimers = new Set();
+        this._activeTimers = new Map();
 
         /**
          * Set of currently active interval IDs.
          * @type {Set<number>}
          * @private
          */
-        this._activeIntervals = new Set();
+        this._activeIntervals = new Map();
+
+        /**
+         * Tracks whether managed execution is currently paused.
+         * @type {boolean}
+         */
+        this._isPaused = false;
+
+        /**
+         * Internal ID counter used to track timer metadata separately from native IDs.
+         * @type {number}
+         * @private
+         */
+        this._nextTimerId = 1;
 
         /**
          * Total number of timers created over the lifetime of this instance.
@@ -123,15 +136,17 @@ class ManagedTimer {
      */
     setTimeout(callback, delay = 0) {
         this.totalCreated++;
+        const id = this._nextTimerId++;
+        const entry = {
+            callback,
+            guard: null,
+            delay,
+            nativeId: null,
+            startedAt: 0
+        };
 
-        let id;
-        id = setTimeout(() => {
-            this._activeTimers.delete(id);
-            this.totalFired++;
-            callback();
-        }, delay);
-
-        this._activeTimers.add(id);
+        this._activeTimers.set(id, entry);
+        this._scheduleTimeout(id, entry, delay);
         return id;
     }
 
@@ -152,19 +167,17 @@ class ManagedTimer {
      */
     setGuardedTimeout(callback, delay, aborted) {
         this.totalCreated++;
+        const id = this._nextTimerId++;
+        const entry = {
+            callback,
+            guard: aborted,
+            delay,
+            nativeId: null,
+            startedAt: 0
+        };
 
-        let id;
-        id = setTimeout(() => {
-            this._activeTimers.delete(id);
-            if (aborted()) {
-                this.totalSuppressed++;
-                return;
-            }
-            this.totalFired++;
-            callback();
-        }, delay);
-
-        this._activeTimers.add(id);
+        this._activeTimers.set(id, entry);
+        this._scheduleTimeout(id, entry, delay);
         return id;
     }
 
@@ -177,14 +190,18 @@ class ManagedTimer {
      */
     setInterval(callback, interval) {
         this.totalCreated++;
+        const id = this._nextTimerId++;
+        const entry = {
+            callback,
+            guard: null,
+            interval,
+            nativeId: null,
+            remaining: interval,
+            startedAt: 0
+        };
 
-        let id;
-        id = setInterval(() => {
-            this.totalFired++;
-            callback();
-        }, interval);
-
-        this._activeIntervals.add(id);
+        this._activeIntervals.set(id, entry);
+        this._scheduleInterval(id, entry, interval);
         return id;
     }
 
@@ -200,20 +217,18 @@ class ManagedTimer {
      */
     setGuardedInterval(callback, interval, aborted) {
         this.totalCreated++;
+        const id = this._nextTimerId++;
+        const entry = {
+            callback,
+            guard: aborted,
+            interval,
+            nativeId: null,
+            remaining: interval,
+            startedAt: 0
+        };
 
-        let id;
-        id = setInterval(() => {
-            if (aborted()) {
-                clearInterval(id);
-                this._activeIntervals.delete(id);
-                this.totalSuppressed++;
-                return;
-            }
-            this.totalFired++;
-            callback();
-        }, interval);
-
-        this._activeIntervals.add(id);
+        this._activeIntervals.set(id, entry);
+        this._scheduleInterval(id, entry, interval);
         return id;
     }
 
@@ -224,8 +239,9 @@ class ManagedTimer {
      * @returns {boolean} True if the timer was found and cancelled, false otherwise.
      */
     clearTimeout(id) {
-        if (this._activeTimers.has(id)) {
-            clearTimeout(id);
+        const entry = this._activeTimers.get(id);
+        if (entry) {
+            clearTimeout(entry.nativeId);
             this._activeTimers.delete(id);
             this.totalCancelled++;
             return true;
@@ -240,8 +256,9 @@ class ManagedTimer {
      * @returns {boolean} True if the interval was found and cancelled, false otherwise.
      */
     clearInterval(id) {
-        if (this._activeIntervals.has(id)) {
-            clearInterval(id);
+        const entry = this._activeIntervals.get(id);
+        if (entry) {
+            clearTimeout(entry.nativeId);
             this._activeIntervals.delete(id);
             this.totalCancelled++;
             return true;
@@ -258,19 +275,77 @@ class ManagedTimer {
     clearAll() {
         let count = 0;
 
-        for (const id of this._activeTimers) {
-            clearTimeout(id);
+        for (const entry of this._activeTimers.values()) {
+            clearTimeout(entry.nativeId);
             count++;
         }
         this._activeTimers.clear();
 
-        for (const id of this._activeIntervals) {
-            clearInterval(id);
+        for (const entry of this._activeIntervals.values()) {
+            clearTimeout(entry.nativeId);
             count++;
         }
         this._activeIntervals.clear();
+        this._isPaused = false;
 
         this.totalCancelled += count;
+        return count;
+    }
+
+    /**
+     * Pause all managed timers without discarding their remaining time.
+     *
+     * @returns {number} The number of active timers and intervals paused.
+     */
+    pauseAll() {
+        if (this._isPaused) {
+            return this.activeCount;
+        }
+
+        const now = Date.now();
+        let count = 0;
+
+        for (const entry of this._activeTimers.values()) {
+            clearTimeout(entry.nativeId);
+            entry.delay = Math.max(0, entry.delay - (now - entry.startedAt));
+            entry.nativeId = null;
+            count++;
+        }
+
+        for (const entry of this._activeIntervals.values()) {
+            clearTimeout(entry.nativeId);
+            entry.remaining = Math.max(0, entry.remaining - (now - entry.startedAt));
+            entry.nativeId = null;
+            count++;
+        }
+
+        this._isPaused = true;
+        return count;
+    }
+
+    /**
+     * Resume all previously paused managed timers.
+     *
+     * @returns {number} The number of timers and intervals resumed.
+     */
+    resumeAll() {
+        if (!this._isPaused) {
+            return this.activeCount;
+        }
+
+        let count = 0;
+
+        for (const [id, entry] of this._activeTimers.entries()) {
+            this._scheduleTimeout(id, entry, entry.delay);
+            count++;
+        }
+
+        for (const [id, entry] of this._activeIntervals.entries()) {
+            this._scheduleInterval(id, entry, entry.remaining);
+            count++;
+        }
+
+        this._isPaused = false;
         return count;
     }
 
@@ -295,11 +370,73 @@ class ManagedTimer {
             active: this.activeCount,
             activeTimeouts: this.activeTimeoutCount,
             activeIntervals: this.activeIntervalCount,
+            paused: this._isPaused,
             created: this.totalCreated,
             cancelled: this.totalCancelled,
             fired: this.totalFired,
             suppressed: this.totalSuppressed
         };
+    }
+
+    /**
+     * Schedule a tracked timeout.
+     *
+     * @param {number} id
+     * @param {Object} entry
+     * @param {number} delay
+     * @returns {void}
+     * @private
+     */
+    _scheduleTimeout(id, entry, delay) {
+        entry.delay = delay;
+        entry.startedAt = Date.now();
+        entry.nativeId = setTimeout(() => {
+            if (!this._activeTimers.has(id)) {
+                return;
+            }
+
+            this._activeTimers.delete(id);
+            if (entry.guard && entry.guard()) {
+                this.totalSuppressed++;
+                return;
+            }
+
+            this.totalFired++;
+            entry.callback();
+        }, delay);
+    }
+
+    /**
+     * Schedule the next tracked interval tick.
+     *
+     * @param {number} id
+     * @param {Object} entry
+     * @param {number} delay
+     * @returns {void}
+     * @private
+     */
+    _scheduleInterval(id, entry, delay) {
+        entry.remaining = delay;
+        entry.startedAt = Date.now();
+        entry.nativeId = setTimeout(() => {
+            if (!this._activeIntervals.has(id)) {
+                return;
+            }
+
+            if (entry.guard && entry.guard()) {
+                this._activeIntervals.delete(id);
+                this.totalSuppressed++;
+                return;
+            }
+
+            this.totalFired++;
+            entry.callback();
+            if (!this._activeIntervals.has(id)) {
+                return;
+            }
+
+            this._scheduleInterval(id, entry, entry.interval);
+        }, delay);
     }
 }
 

--- a/js/utils/__tests__/ManagedTimer.test.js
+++ b/js/utils/__tests__/ManagedTimer.test.js
@@ -1,0 +1,61 @@
+const ManagedTimer = require("../ManagedTimer.js");
+
+describe("ManagedTimer pause and resume", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(0);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test("pauses and resumes a timeout from its remaining time", () => {
+        const timer = new ManagedTimer();
+        const callback = jest.fn();
+
+        timer.setTimeout(callback, 1000);
+
+        jest.advanceTimersByTime(400);
+        jest.setSystemTime(400);
+        timer.pauseAll();
+
+        jest.advanceTimersByTime(1000);
+        expect(callback).not.toHaveBeenCalled();
+
+        jest.setSystemTime(1400);
+        timer.resumeAll();
+
+        jest.advanceTimersByTime(599);
+        expect(callback).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test("pauses and resumes an interval without losing the next tick", () => {
+        const timer = new ManagedTimer();
+        const callback = jest.fn();
+
+        timer.setInterval(callback, 500);
+
+        jest.advanceTimersByTime(200);
+        jest.setSystemTime(200);
+        timer.pauseAll();
+
+        jest.advanceTimersByTime(1000);
+        expect(callback).not.toHaveBeenCalled();
+
+        jest.setSystemTime(1200);
+        timer.resumeAll();
+
+        jest.advanceTimersByTime(299);
+        expect(callback).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(500);
+        expect(callback).toHaveBeenCalledTimes(2);
+    });
+});

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -50,6 +50,7 @@ describe("Utility Functions (logic-only)", () => {
         stopSound,
         loop,
         start,
+        pause,
         stop,
         rampTo,
         DEFAULTSYNTHVOLUME,
@@ -163,6 +164,7 @@ describe("Utility Functions (logic-only)", () => {
         stopSound = Synth.stopSound;
         loop = Synth.loop;
         start = Synth.start;
+        pause = Synth.pause;
         stop = Synth.stop;
         rampTo = Synth.rampTo;
         setVolume = Synth.setVolume;
@@ -828,6 +830,16 @@ describe("Utility Functions (logic-only)", () => {
             expect(stopSpy).toHaveBeenCalledTimes(1);
 
             stopSpy.mockRestore();
+        });
+
+        test("pause should call Tone.Transport.pause", () => {
+            const pauseSpy = jest.spyOn(Tone.Transport, "pause");
+
+            pause();
+
+            expect(pauseSpy).toHaveBeenCalledTimes(1);
+
+            pauseSpy.mockRestore();
         });
 
         test("start and stop should work in sequence", () => {

--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -149,6 +149,7 @@ class context {
 
 class Transport {
     static start() {}
+    static pause() {}
     static stop() {}
 }
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2268,6 +2268,12 @@ function Synth() {
         Tone.Transport.start();
     };
 
+    this.pause = () => {
+        if (Tone.Transport && typeof Tone.Transport.pause === "function") {
+            Tone.Transport.pause();
+        }
+    };
+
     this.stop = () => {
         Tone.Transport.stop();
     };


### PR DESCRIPTION
# feat: add play/pause toggle for music playback

## Summary

This PR adds a true Play / Pause toggle for Music Blocks playback using the existing playback flow.

Previously, playback could be started and fully stopped, but there was no way to pause and resume from the same position. This change keeps the current playback architecture intact and extends it to support pause/resume behavior.

## What Changed

- added toggle-based play/pause behavior to the existing Play button
- updated the Play button UI to reflect current playback state
- added Spacebar support for play/pause toggle
- used the existing Tone.js transport controls for pause/resume behavior
- preserved Stop as a separate full-stop/reset action
- coordinated execution timing so pause/resume continues from the same position instead of restarting

## Implementation Details

Main changes were made in:

- `js/activity.js`
  - added playback state handling with `isPlaying`
  - updated `_doFastButton()` to behave as a toggle
  - added pause/resume helpers
  - updated Spacebar behavior to toggle play/pause
  - reset playback state when execution stops

- `js/toolbar.js`
  - updated the existing Play button to swap between play and pause states dynamically
  - kept Stop button behavior unchanged
  - made the toolbar logic compatible with existing tests and lightweight mocks

- `js/utils/synthutils.js`
  - added `pause()` support using `Tone.Transport.pause()`

- `js/utils/ManagedTimer.js`
  - extended managed timer handling so pending execution timing can be paused and resumed
  - this avoids playback drift or unintended restart when execution is paused mid-run

- `js/logo.js`
  - updated the fallback timer manager shim to support the new pause/resume API

## Why ManagedTimer Was Updated

Using `Tone.Transport.pause()` alone was not enough for correct Music Blocks pause/resume behavior.

Music Blocks playback is not only driven by Tone transport. Execution also depends on managed timers for scheduled callbacks. Without pausing those timers, audio could pause while Logo execution continued advancing in the background, causing drift and incorrect resume behavior.

To support true resume-from-same-position behavior, `ManagedTimer` needed to store timer metadata rather than only raw timer IDs.

## Why These Files Changed

This feature needed changes in both playback UI and playback execution.

- `js/activity.js`
  - This is the main entry point for project playback.
  - It was updated so the existing Play action could become a true toggle instead of a start-only action.
  - Playback state, pause/resume behavior, and the Spacebar shortcut are coordinated here.

- `js/toolbar.js`
  - This file owns the toolbar button behavior and UI state.
  - It was updated so the existing Play button could switch visually between play and pause states without adding a separate control.
  - Small compatibility fixes were also made so existing toolbar tests and lightweight mocks still work.

- `js/utils/synthutils.js`
  - This file wraps the existing Tone.js audio controls.
  - It was updated to expose `pause()` through the current synth abstraction using `Tone.Transport.pause()`.
  - This keeps pause/resume within the existing audio flow rather than bypassing it.

- `js/utils/ManagedTimer.js`
  - Music Blocks playback is not controlled only by Tone transport.
  - Execution also depends on scheduled JavaScript timers for callbacks and multi-voice timing.
  - This file was updated so pending execution timing can pause and resume correctly; otherwise audio could pause while block execution kept advancing in the background.

- `js/logo.js`
  - This file contains the fallback timer manager path used in some environments.
  - It was updated so the new timer pause/resume methods remain compatible in fallback and test-related execution paths.

- `js/utils/__tests__/ManagedTimer.test.js`
  - Added focused tests for timer pause/resume behavior.
  - These tests verify that playback resumes from the same execution position rather than restarting.

- `js/utils/__tests__/synthutils.test.js`
  - Updated to verify that the new synth pause wrapper correctly calls `Tone.Transport.pause()`.

- `js/utils/__tests__/tonemock.js`
  - Updated the Tone mock so tests can support the new transport pause behavior.

## Acceptance Behavior

This PR enables the following:

1. Clicking Play starts playback when idle.
2. Clicking Play while playback is active pauses playback.
3. Clicking Play again resumes from the same position.
4. Playback does not restart after pause/resume.
5. Stop still fully stops and resets playback.
6. The Play button updates visually between play and pause states.
7. Spacebar toggles play/pause.
8. Playback continues to work across multiple Start blocks / voices.

## Testing

### Verified

- `npx prettier --check` on modified files
- `npm run lint` completed successfully with existing repo warnings
- focused `ManagedTimer` pause/resume test passed

### Notes

- some broader Jest coverage and unrelated existing test issues were present in the current repo/test environment
- toolbar compatibility issues found during testing were fixed to keep the change test-friendly

## Files Changed

- `js/activity.js`
- `js/toolbar.js`
- `js/utils/synthutils.js`
- `js/utils/ManagedTimer.js`
- `js/logo.js`
- `js/utils/__tests__/ManagedTimer.test.js`
- `js/utils/__tests__/synthutils.test.js`
- `js/utils/__tests__/tonemock.js`

## Manual Testing

1. Run `npm run dev` or `npm run serve:dev`
2. Open `http://127.0.0.1:3000`
3. Load a project with music playback
4. Click Play
5. Click Play again to pause
6. Click Play again to resume
7. Press Spacebar to verify keyboard toggle behavior
8. Verify Stop still fully stops/reset playback
9. Verify multi-voice / multiple Start block projects resume correctly without restarting

### PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation

## Related Issue

Closes #6790 