### PR TITLE
fix: resolve multi-click race condition on project likes

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -26,6 +26,7 @@ class GlobalCard {
         this.ProjectData = null;
         this.id = null;
         this.likeTimeout = null;
+        this.likePending = false;
         this.clipboard = null;
         this.PlaceholderMBImage = "images/mbgraphic.png";
         this.PlaceholderTBImage = "images/tbgraphic.png";
@@ -261,12 +262,15 @@ class GlobalCard {
     }
 
     like() {
+        if (this.likePending) return;
         const Planet = this.Planet;
         clearTimeout(this.likeTimeout);
         let like = true;
         if (Planet.ProjectStorage.isLiked(this.id)) like = false;
+        this.likePending = true;
         this.likeTimeout = setTimeout(() => {
             Planet.ServerInterface.likeProject(this.id, like, data => {
+                this.likePending = false;
                 this.afterLike(data, like);
             });
         }, 500);


### PR DESCRIPTION
### PR Category
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

### Description
This PR resolves a race condition in the Planet project viewer where rapid, multiple clicks on the "Like" button could queue duplicate network requests, eventually causing the database like counter to break or fall into the negatives.

**The Fix:**
I implemented a simple lock-and-unlock mechanism using a new `likePending` state variable in `GlobalCard.js`:
 **Lock (`likePending = true`)**: As soon as the user clicks the button, the function locks, instantly blocking any subsequent spam clicks from queuing additional actions.
 **Wait**: The UI remains locked while the initial request travels to the server and is processed.
 **Unlock (`likePending = false`)**: Once the server successfully responds, the function unlocks, safely allowing the user to interact with the button again.

This guarantees that it is impossible for the user to send overlapping or contradictory like/unlike requests over the network.
