### PR TITLE
fix: correct incorrect key mappings in modeMapper function

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3201,13 +3201,13 @@ const modeMapper = (key, mode) => {
                     key = "b";
                     break;
                 case "d" + SHARP:
-                    key = "b";
+                    key = "c" + SHARP;
                     break;
                 case "f" + SHARP:
-                    key = "f";
+                    key = "e";
                     break;
                 case "g" + SHARP:
-                    key = "b";
+                    key = "f" + SHARP;
                     break;
                 case "a" + SHARP:
                     key = "g" + SHARP;
@@ -3247,7 +3247,7 @@ const modeMapper = (key, mode) => {
                     key = "c";
                     break;
                 case "f":
-                    key = "b";
+                    key = "d" + FLAT;
                     break;
                 case "g":
                     key = "c";
@@ -3382,7 +3382,7 @@ const modeMapper = (key, mode) => {
                     key = "e";
                     break;
                 case "c" + SHARP:
-                    key = "b";
+                    key = "f" + SHARP;
                     break;
                 case "d" + SHARP:
                     key = "g" + SHARP;
@@ -3391,7 +3391,7 @@ const modeMapper = (key, mode) => {
                     key = "b";
                     break;
                 case "g" + SHARP:
-                    key = "b";
+                    key = "c" + SHARP;
                     break;
                 case "a" + SHARP:
                     key = "c";
@@ -3433,7 +3433,7 @@ const modeMapper = (key, mode) => {
                     key = "f";
                     break;
                 case "f":
-                    key = "b";
+                    key = "g" + FLAT;
                     break;
                 case "g":
                     key = "g" + SHARP;
@@ -3454,7 +3454,7 @@ const modeMapper = (key, mode) => {
                     key = "g";
                     break;
                 case "g" + SHARP:
-                    key = "a ";
+                    key = "a";
                     break;
                 case "a" + SHARP:
                     key = "b";


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Description

The `modeMapper` function in `js/utils/musicutils.js` contains multiple incorrect mappings for musical modes (Dorian, Phrygian, Mixolydian, and Locrian). This function maps a mode/key combination to its relative major or minor equivalent to determine the correct key signature and solfege positions. Several cases returned incorrect keys due to copy-paste errors during implementation.

## Changes Made

Fixed 8 incorrect key mappings in the `modeMapper` function:

**Dorian Mode:**
- D# Dorian: `["b", "major"]` → `["c#", "major"]`
- F# Dorian: `["f", "major"]` → `["e", "major"]`
- G# Dorian: `["b", "major"]` → `["f#", "major"]`

**Phrygian Mode:**
- F Phrygian: `["b", "major"]` → `["db", "major"]`

**Mixolydian Mode:**
- C# Mixolydian: `["b", "major"]` → `["f#", "major"]`
- G# Mixolydian: `["b", "major"]` → `["c#", "major"]`

**Locrian Mode:**
- F Locrian: `["b", "major"]` → `["gb", "major"]`
- G# Locrian: Fixed trailing space bug (`"a "` → `"a"`)

## Root Cause

Copy-paste errors in switch statements where multiple cases incorrectly mapped to the same key. For example:

```javascript
// Before (incorrect)
case "c" + SHARP:
    key = "b";
    break;
case "d" + SHARP:
    key = "b";  // ❌ Wrong - should be "c#"
    break;

// After (correct)
case "c" + SHARP:
    key = "b";
    break;
case "d" + SHARP:
    key = "c" + SHARP;  // ✅ Correct
    break;
```

## Impact

**Before:** Users selecting affected mode/key combinations would see:
- Wrong key signatures on the staff
- Incorrect solfege positioning ("Do" anchored to wrong pitch)
- Broken audio logic producing wrong frequencies

**After:** All modal key mappings now follow correct music theory principles.

## Testing

- ✅ All existing tests pass (4755 tests)
- ✅ Linter passes with no new warnings
- ✅ Verified mappings against music theory (mode degree formulas)
- ✅ Manual verification: `modeMapper("f#", "dorian")` now returns `["e", "major"]` (correct)

## Related Issues

Fixes #6794

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [x] All tests pass locally
- [x] Commit message follows conventional commit format
