### PR TITLE
perf: implement state guards for canvas context properties

### DIFF
--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -322,8 +322,12 @@ class Painter {
             // Save the current stroke width
             const savedStroke = this.stroke;
             this.stroke = 1;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
 
             // Draw a hollow line
             const step = savedStroke < 3 ? 0.5 : (savedStroke - 2) / 2;
@@ -380,14 +384,20 @@ class Painter {
 
             // Restore stroke
             this.stroke = savedStroke;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.moveTo(nx, ny);
         } else if (this._penDown) {
             const capAngleRadians = (this.turtle.orientation * Math.PI) / 180.0;
 
             if (linePart) {
-                this.turtle.ctx.lineCap = "butt";
+                if (this.turtle.ctx.lineCap !== "butt") {
+                    this.turtle.ctx.lineCap = "butt";
+                }
                 if (linePart === "first") {
                     this.turtle.ctx.beginPath();
                     this.turtle.ctx.arc(
@@ -581,8 +591,12 @@ class Painter {
             // Save the current stroke width
             const savedStroke = this.stroke;
             this.stroke = 1;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
 
             // Draw a hollow line
             const step = savedStroke < 3 ? 0.5 : (savedStroke - 2) / 2;
@@ -636,8 +650,12 @@ class Painter {
 
             // Restore stroke
             this.stroke = savedStroke;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.moveTo(nx, ny);
         } else if (this._penDown) {
             if (!this._svgPath) {
@@ -688,8 +706,12 @@ class Painter {
         this._processColor();
 
         if (!this._fillState) {
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.beginPath();
             this.turtle.ctx.moveTo(this.turtle.container.x, this.turtle.container.y);
         }
@@ -801,8 +823,12 @@ class Painter {
         this._processColor();
 
         if (!this._fillState) {
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.beginPath();
             this.turtle.ctx.moveTo(this.turtle.container.x, this.turtle.container.y);
         }
@@ -934,8 +960,12 @@ class Painter {
         this._processColor();
 
         if (!this._fillState) {
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.beginPath();
             this.turtle.ctx.moveTo(this.turtle.container.x, this.turtle.container.y);
         }
@@ -1072,8 +1102,12 @@ class Painter {
 
             const savedStroke = this.stroke;
             this.stroke = 1;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
 
             const step = savedStroke < 3 ? 0.5 : (savedStroke - 2) / 2;
             const steps = Math.max(Math.floor(savedStroke), 1);
@@ -1194,8 +1228,12 @@ class Painter {
 
             // Restore stroke
             this.stroke = savedStroke;
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
             this.turtle.ctx.moveTo(fx, fy);
             this.turtle.x = x2;
             this.turtle.y = y2;
@@ -1204,8 +1242,12 @@ class Painter {
             this._svgPath = false;
         } else if (this._penDown) {
             this._processColor();
-            this.turtle.ctx.lineWidth = this.stroke;
-            this.turtle.ctx.lineCap = "round";
+            if (this.turtle.ctx.lineWidth !== this.stroke) {
+                this.turtle.ctx.lineWidth = this.stroke;
+            }
+            if (this.turtle.ctx.lineCap !== "round") {
+                this.turtle.ctx.lineCap = "round";
+            }
 
             // Convert from turtle coordinates to screen coordinates
             fx = turtles.turtleX2screenX(x2);
@@ -1445,8 +1487,12 @@ class Painter {
 
             if (turtle.painter.penState) {
                 turtle.painter._processColor();
-                this.turtle.ctx.lineWidth = turtle.painter.stroke;
-                this.turtle.ctx.lineCap = "round";
+                if (this.turtle.ctx.lineWidth !== turtle.painter.stroke) {
+                    this.turtle.ctx.lineWidth = turtle.painter.stroke;
+                }
+                if (this.turtle.ctx.lineCap !== "round") {
+                    this.turtle.ctx.lineCap = "round";
+                }
                 this.turtle.ctx.beginPath();
                 this.turtle.ctx.moveTo(turtle.container.x + dx, turtle.container.y + dy);
                 this.turtle.ctx.lineTo(turtle.container.x, turtle.container.y);
@@ -1529,7 +1575,9 @@ class Painter {
     doSetPensize(size) {
         this.closeSVG();
         this.stroke = size;
-        this.turtle.ctx.lineWidth = this.stroke;
+        if (this.turtle.ctx.lineWidth !== this.stroke) {
+            this.turtle.ctx.lineWidth = this.stroke;
+        }
     }
 
     /**


### PR DESCRIPTION
- [x] Performance fix : #6800 

### Summary
Implemented "state guards" for Canvas 2D context properties (`lineWidth` and `lineCap`) in `turtle-painter.js` to eliminate redundant GPU synchronization and improve rendering performance.

### Rationale
Assigning properties to a `CanvasRenderingContext2D` triggers internal state invalidations and cross-process communication with the GPU. In Music Blocks, high-frequency drawing operations (like `doScrollXY` or complex `doBezier` curves) previously "blindly" assigned these values on every tick, even if they hadn't changed. This led to unnecessary CPU overhead and noticeable micro-stutters.

### Changes
- Added conditional checks in `turtle-painter.js` for all core drawing methods to ensure `ctx` properties are only modified when a value change actually occurs.
- Optimized: `_move`, `_arc`, `doForward`, `doSetXY`, `doBezier`, `doScrollXY`, and `doSetPensize`.
