### PR TITLE
Fix Custom Pitch Blocks: retain identity and enable correct preview sound

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1389,6 +1389,10 @@ class Blocks {
                             newBlockName = this.blockList[oldBlock].name;
                             newBlockValue = "sol";
                             break;
+                        case "customNote":
+                            newBlockName = "customNote";
+                            newBlockValue = "C(+0¢)";
+                            break;
                         case "scaledegree2":
                             newBlockName = this.blockList[oldBlock].name;
                             newBlockValue = "5";

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1192,7 +1192,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         docById("wheelDiv").style.display = "none";
     };
 
-    const __selectionChanged = () => {
+    const __selectionChanged = async () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
         that.value = note;
@@ -1210,8 +1210,11 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         // Make sure text is on top.
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
-
-        const obj = getNote(note, octave, 0, "C major", false, null, that.activity.errorMsg, label);
+        try {
+            await Tone.start();
+        } catch (e) {
+            console.debug("Tone.start() skipped or failed", e);
+        }
         const tur = that.activity.turtles.ithTurtle(0);
 
         if (!tur.singer.instrumentNames.includes(DEFAULTVOICE)) {
@@ -1225,7 +1228,10 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         if (!that._triggerLock) {
             that._triggerLock = true;
             // Get the frequency of the custom note for the preview.
-            const no = that.activity.logo.synth.getCustomFrequency([note + obj[1]], that.customID);
+            const customID = that.customID || label;
+            // Pass note + octave directly to getCustomFrequency (bypass getNote
+            // which cannot parse custom note names like "C(+0¢)").
+            const no = that.activity.logo.synth.getCustomFrequency([note + octave], customID);
             if (no !== undefined && no !== "undefined") {
                 instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
             }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -779,6 +779,19 @@ function Synth() {
                         }
                     }
                 }
+
+                // Fallback: handle pitch-index keys (e.g., "0", "1")
+                // for equal-style temperament data where entries are
+                // plain numbers (ratios) instead of [ratio, name, octave] arrays.
+                if (thisTemperament[oneNote] !== undefined) {
+                    const entry = thisTemperament[oneNote];
+                    const ratio = typeof entry === "number" ? entry : entry[0];
+                    const entryOctave = typeof entry === "number" ? 4 : Number(entry[2]);
+                    const octaveDiff = octave - entryOctave;
+                    return Number(
+                        ratio * startPitchFrequency * Math.pow(getOctaveRatio(), octaveDiff)
+                    );
+                }
             }
             return oneNote;
         };


### PR DESCRIPTION
## Description

This PR fully addresses **#4724** — fixing both issues with Custom Pitch Blocks:

1. **Identity Loss:** Custom Pitch Blocks were reverting to regular Pitch Blocks when dragged from the palette.
2. **Missing Preview Sound:** Clicking on notes in the Custom Pitch Block's pie menu produced static noise or silence instead of a pitch preview.

## Root Cause

### Identity Loss ([js/blocks.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/blocks.js:0:0-0:0))

The switch statement that handles block replacement when dragging from the palette had no `case` for `"customNote"`. Without it, custom pitch blocks fell through to the default behavior and were replaced with regular pitch blocks.

### Missing Preview Sound ([js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0) + [js/utils/synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0))

The [__selectionChanged](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:2028:4-2035:6) handler in [piemenuCustomNotes](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:913:0-1262:2) ([js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0)) had two problems:

1. **No audio context initialization** — `Tone.start()` was never called. Modern browsers require this after user interaction before audio can play.

2. **[getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1) can't parse custom note names** — Custom notes like [C(+0¢)](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/block.js:2025:4-2031:5) were passed through [getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1), which only understands standard note names (C, D, E...), producing invalid output that caused the frequency lookup to fail.

Additionally, [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6) in [synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0) could not handle **pitch-index labels** (e.g., `"0"`, `"1"`) — when custom temperament data stores entries as plain ratio numbers instead of `[ratio, name, octave]` arrays, the function failed to find a match and returned a string instead of a frequency.

## Changes

### [js/blocks.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/blocks.js:0:0-0:0)
- Added `case "customNote"` to the block replacement switch statement so Custom Pitch Blocks retain their identity when dragged from the palette.

### [js/utils/synthutils.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:0:0-0:0) — [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6)
- Added a fallback after the existing note-name matching loop: when no match is found, it checks if the note is a **pitch-index key** (e.g., `"0"`) in the temperament data and computes the frequency directly from the ratio.

### [js/piemenus.js](cci:7://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/piemenus.js:0:0-0:0) — `piemenuCustomNotes.__selectionChanged()`
- Made the handler `async` and added `Tone.start()` for proper audio context initialization.
- Replaced [getNote()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/musicutils.js:4096:0-4744:1) (which can't parse custom note names) with direct `note + octave` passed to [getCustomFrequency()](cci:1://file:///Users/shaikhibrahimrahman/Desktop/MusicLabs/musicblocks/js/utils/synthutils.js:798:4-855:6).

## Testing

- All existing tests pass (3861 tests, 123 suites)
- Manually verified:
  - Custom Pitch Blocks retain their identity when dragged from the palette
  - Pie menu plays clean preview sounds for both regular and Define Temperament workflows

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
