### PR TITLE
fix: stabilize startup load order for core scripts

### DIFF
--- a/cypress/e2e/startup-stability.cy.js
+++ b/cypress/e2e/startup-stability.cy.js
@@ -1,0 +1,72 @@
+describe("startup stability", () => {
+    const startupRuns = 8;
+    const startupTimeout = 60000;
+
+    it("loads the app repeatedly without startup failures", () => {
+        const consoleErrors = [];
+        const pageErrors = [];
+        const promiseRejections = [];
+        const alerts = [];
+
+        for (let i = 0; i < startupRuns; i++) {
+            cy.visit(`http://127.0.0.1:3000/?startupRun=${i}`, {
+                timeout: startupTimeout,
+                onBeforeLoad(win) {
+                    const originalConsoleError = win.console.error.bind(win.console);
+
+                    win.console.error = (...args) => {
+                        consoleErrors.push(args.map(String).join(" "));
+                        originalConsoleError(...args);
+                    };
+
+                    win.addEventListener("error", event => {
+                        pageErrors.push(event.message || "Unknown window error");
+                    });
+
+                    win.addEventListener("unhandledrejection", event => {
+                        const reason = event.reason;
+                        promiseRejections.push(
+                            reason && reason.message ? reason.message : String(reason)
+                        );
+                    });
+
+                    win.alert = message => {
+                        alerts.push(String(message));
+                    };
+                }
+            });
+
+            cy.get("#hideContents", { timeout: startupTimeout }).should("be.visible");
+            cy.get("#load-container", { timeout: startupTimeout }).should("not.be.visible");
+            cy.get("#toolbars", { timeout: startupTimeout }).should("be.visible");
+            cy.get("#myCanvas", { timeout: startupTimeout }).should("be.visible");
+
+            cy.window({ timeout: startupTimeout }).then(win => {
+                expect(win.createjs, `createjs should exist on run ${i + 1}`).to.exist;
+                expect(win.i18next, `i18next should exist on run ${i + 1}`).to.exist;
+
+                if (win.ActivityContext && typeof win.ActivityContext.getActivity === "function") {
+                    expect(
+                        win.ActivityContext.getActivity(),
+                        `Activity singleton should exist on run ${i + 1}`
+                    ).to.exist;
+                }
+            });
+
+            cy.clearLocalStorage();
+        }
+
+        cy.then(() => {
+            const startupConsoleErrors = consoleErrors.filter(message =>
+                /(FATAL:|Core bootstrap failed|Failed to load Music Blocks|Main execution failed|Failed to load activity\/activity)/i.test(
+                    message
+                )
+            );
+
+            expect(startupConsoleErrors, "startup console errors").to.deep.equal([]);
+            expect(pageErrors, "window errors").to.deep.equal([]);
+            expect(promiseRejections, "unhandled promise rejections").to.deep.equal([]);
+            expect(alerts, "unexpected startup alerts").to.deep.equal([]);
+        });
+    });
+});

--- a/index.html
+++ b/index.html
@@ -187,8 +187,6 @@
             onload="this.onload=null;this.rel='stylesheet'"
         />
         <noscript><link rel="stylesheet" href="css/themes.css?v=fixed" /></noscript>
-        <script src="lib/easeljs.min.js" defer></script>
-        <script src="lib/tweenjs.min.js" defer></script>
         <script>
             let ast2blocklist_config;
             window.ast2blocklist_config_failed = false;

--- a/js/__tests__/loader.test.js
+++ b/js/__tests__/loader.test.js
@@ -88,7 +88,14 @@ describe("loader.js coverage", () => {
             expect.objectContaining({
                 baseUrl: "./",
                 paths: expect.any(Object),
-                shim: expect.any(Object)
+                shim: expect.objectContaining({
+                    "tweenjs.min": expect.objectContaining({
+                        deps: ["easeljs.min"]
+                    }),
+                    "preloadjs.min": expect.objectContaining({
+                        deps: ["easeljs.min", "tweenjs.min"]
+                    })
+                })
             })
         );
     });

--- a/js/loader.js
+++ b/js/loader.js
@@ -25,9 +25,11 @@ requirejs.config({
             exports: "createjs"
         },
         "tweenjs.min": {
+            deps: ["easeljs.min"],
             exports: "createjs"
         },
         "preloadjs.min": {
+            deps: ["easeljs.min", "tweenjs.min"],
             exports: "createjs"
         },
         "Tone": {
@@ -363,35 +365,6 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
 
             i18next.on("languageChanged", updateContent);
 
-            // Two-phase bootstrap: load core modules first, then application modules
-            const waitForGlobals = async (retryCount = 0) => {
-                if (typeof window.createjs === "undefined" && retryCount < 50) {
-                    await new Promise(resolve => setTimeout(resolve, 100));
-                    return waitForGlobals(retryCount + 1);
-                }
-            };
-
-            await waitForGlobals();
-
-            // Only pre-define modules that are loaded via script tags in index.html
-            // These modules are already available as globals before RequireJS loads them
-            const PRELOADED_SCRIPTS = [
-                { name: "easeljs.min", export: () => window.createjs },
-                { name: "tweenjs.min", export: () => window.createjs }
-            ];
-
-            PRELOADED_SCRIPTS.forEach(mod => {
-                if (!requirejs.defined(mod.name) && mod.export && mod.export()) {
-                    define(mod.name, [], function () {
-                        return mod.export();
-                    });
-                }
-            });
-
-            // Note: Other modules like activity/*, utils/* are loaded by RequireJS
-            // from their file paths as configured in requirejs.config().
-            // Do NOT pre-define them here as that prevents RequireJS from loading the actual files.
-
             const CORE_BOOTSTRAP_MODULES = [
                 "easeljs.min",
                 "tweenjs.min",
@@ -419,51 +392,35 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
                         "loader.i18n.ready",
                         "loader.core_modules.ready"
                     );
-
-                    // Give scripts a moment to finish executing and set globals
-                    setTimeout(function () {
-                        // Verify core dependencies are loaded
-                        const verificationStatus = {
-                            createjs: typeof window.createjs !== "undefined",
-                            createDefaultStack: typeof window.createDefaultStack !== "undefined",
-                            Logo: typeof window.Logo !== "undefined",
-                            Blocks: typeof window.Blocks !== "undefined",
-                            Turtles: typeof window.Turtles !== "undefined"
-                        };
-
-                        // Check critical dependencies (only createjs is truly critical)
-                        if (typeof window.createjs === "undefined") {
-                            console.error(
-                                "FATAL: createjs (EaselJS/TweenJS) not found. Cannot proceed."
-                            );
-                            alert(t_("Failed to load EaselJS. Please refresh the page."));
-                            return;
-                        }
-
-                        // Proceed with activity loading
-                        requirejs(
-                            ["activity/activity"],
-                            function () {
-                                // Activity loaded successfully
-                                perfTracker.mark("loader.activity_module.ready");
-                                perfTracker.measure(
-                                    "loader.core_modules_to_activity_module_ready",
-                                    "loader.core_modules.ready",
-                                    "loader.activity_module.ready"
-                                );
-                                perfTracker.measure(
-                                    "loader.total_bootstrap",
-                                    "loader.main.start",
-                                    "loader.activity_module.ready"
-                                );
-                                perfTracker.report();
-                            },
-                            function (err) {
-                                console.error("Failed to load activity/activity:", err);
-                                alert(t_("Failed to load Music Blocks. Please refresh the page."));
-                            }
+                    if (typeof window.createjs === "undefined") {
+                        console.error(
+                            "FATAL: createjs (EaselJS/TweenJS) not found. Cannot proceed."
                         );
-                    }, 100); // Small delay to allow globals to be set
+                        alert(t_("Failed to load EaselJS. Please refresh the page."));
+                        return;
+                    }
+
+                    requirejs(
+                        ["activity/activity"],
+                        function () {
+                            perfTracker.mark("loader.activity_module.ready");
+                            perfTracker.measure(
+                                "loader.core_modules_to_activity_module_ready",
+                                "loader.core_modules.ready",
+                                "loader.activity_module.ready"
+                            );
+                            perfTracker.measure(
+                                "loader.total_bootstrap",
+                                "loader.main.start",
+                                "loader.activity_module.ready"
+                            );
+                            perfTracker.report();
+                        },
+                        function (err) {
+                            console.error("Failed to load activity/activity:", err);
+                            alert(t_("Failed to load Music Blocks. Please refresh the page."));
+                        }
+                    );
                 },
                 function (err) {
                     console.error("Core bootstrap failed:", err);


### PR DESCRIPTION
Music Blocks had a startup race where core createjs libraries were loaded through separate deferred script tags in index.html while the app was already booting through RequireJS. On slower or production-style loads, this could cause the app to initialize before those globals were ready, leading to intermittent startup failures and retry-based fallback behavior.

This change makes RequireJS the single owner of loading easeljs and tweenjs, adds explicit shim dependency order for the core createjs stack, and removes the duplicate HTML script-tag loading path. It also removes the loader polling/delay workaround that was masking the race. A repeated browser startup regression test was added to verify stable first-load behavior across multiple runs.

- [x] Performance
- fixes #2632 