### PR TITLE
fix: unescape HTML project data on load to fix JSON parsing

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -52,7 +52,8 @@ try {
    SHARP, FLAT, buildScale, TREBLE_F, TREBLE_G, GIFAnimator,
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
-   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS
+   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
+   unescapeHTML
  */
 
 /*
@@ -8343,17 +8344,17 @@ class Activity {
                                 let obj;
                                 try {
                                     if (cleanData.includes("html")) {
+                                        let extracted;
                                         if (cleanData.includes('id="codeBlock"')) {
-                                            obj = JSON.parse(
-                                                cleanData.match(
-                                                    '<div class="code" id="codeBlock">(.+?)</div>'
-                                                )[1]
-                                            );
+                                            extracted = cleanData.match(
+                                                '<div class="code" id="codeBlock">(.+?)</div>'
+                                            )[1];
                                         } else {
-                                            obj = JSON.parse(
-                                                cleanData.match('<div class="code">(.+?)</div>')[1]
-                                            );
+                                            extracted = cleanData.match(
+                                                '<div class="code">(.+?)</div>'
+                                            )[1];
                                         }
+                                        obj = JSON.parse(unescapeHTML(extracted));
                                     } else {
                                         obj = JSON.parse(cleanData);
                                     }
@@ -8468,9 +8469,17 @@ class Activity {
                             let obj;
                             try {
                                 if (cleanData.includes("html")) {
-                                    obj = JSON.parse(
-                                        cleanData.match('<div class="code">(.+?)</div>')[1]
-                                    );
+                                    let extracted;
+                                    if (cleanData.includes('id="codeBlock"')) {
+                                        extracted = cleanData.match(
+                                            '<div class="code" id="codeBlock">(.+?)</div>'
+                                        )[1];
+                                    } else {
+                                        extracted = cleanData.match(
+                                            '<div class="code">(.+?)</div>'
+                                        )[1];
+                                    }
+                                    obj = JSON.parse(unescapeHTML(extracted));
                                 } else {
                                     obj = JSON.parse(cleanData);
                                 }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -39,7 +39,7 @@
    oneHundredToFraction, prepareMacroExports, preparePluginExports,
    processMacroData, processRawPluginData, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, windowHeight, windowWidth,
-    fnBrowserDetect, waitForReadiness, isSafeUrl
+    fnBrowserDetect, waitForReadiness, isSafeUrl, unescapeHTML
 */
 
 /**
@@ -703,6 +703,30 @@ if (typeof module !== "undefined" && module.exports) {
 }
 if (typeof window !== "undefined") {
     window.escapeHTML = escapeHTML;
+}
+
+/**
+ * Reverses HTML entity escaping produced by escapeHTML().
+ * Used when loading project data that was escaped for safe HTML embedding.
+ * @param {string} str - The HTML-escaped string to unescape.
+ * @returns {string} The unescaped string with original characters restored.
+ */
+function unescapeHTML(str) {
+    const unescapeMap = {
+        "&amp;": "&",
+        "&lt;": "<",
+        "&gt;": ">",
+        "&quot;": '"',
+        "&#039;": "'"
+    };
+    return String(str).replace(/&amp;|&lt;|&gt;|&quot;|&#039;/g, match => unescapeMap[match]);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports.unescapeHTML = unescapeHTML;
+}
+if (typeof window !== "undefined") {
+    window.unescapeHTML = unescapeHTML;
 }
 
 /**


### PR DESCRIPTION
Fixes #6806 
### Description
This PR fixes a bug where users were unable to load projects from downloaded HTML files. 

A previous security update added `escapeHTML()` to the JSON project data during the save process to prevent XSS vulnerabilities. While this properly secured the generated HTML file, it caused `JSON.parse()` to throw a Syntax Error during the load process because it could not interpret HTML entities like `&quot;`. 

This PR resolves the issue by adding an `unescapeHTML()` utility on the load path, safely reversing the escaping in memory right before the data is parsed. **The XSS protection on the generated HTML files remains fully intact.**

### PR Category
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other

### Proposed Changes
- Created `unescapeHTML()` in `js/utils/utils.js` as the inverse of `escapeHTML()`.
- Updated the file chooser load handler in `js/activity.js` to unescape HTML data before JSON parsing.
- Updated the drag-and-drop load handler in `js/activity.js` to unescape HTML data before JSON parsing.

### How to Test
1. Run the local server and open Music Blocks.
2. Create a simple project with a few blocks.
3. Click "Save project as HTML".
4. Clear the workspace.
5. Click "Load project" and select the downloaded HTML file.
6. Verify the project loads successfully without errors in the console.
