### PR TITLE
fix: drop images and retry save on quota error (Related to #2614)

### DIFF
--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -57,6 +57,35 @@ class ProjectStorage {
         return prefix + suffix;
     }
 
+    _isQuotaExceededError(e) {
+        if (e == null) return false; // eslint-disable-line eqeqeq
+        const name = e.name || "";
+        const message = e.message || "";
+        const code = e.code;
+        return (
+            name === "QuotaExceededError" ||
+            name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+            message.includes("QUOTA_EXCEEDED") ||
+            message.includes("quota exceeded") ||
+            code === 22 ||
+            code === 1014
+        );
+    }
+
+    _dropProjectImages() {
+        let count = 0;
+        for (const id in this.data.Projects) {
+            if (
+                this.data.Projects[id].ProjectImage !== null &&
+                this.data.Projects[id].ProjectImage !== undefined
+            ) {
+                this.data.Projects[id].ProjectImage = null;
+                count++;
+            }
+        }
+        return count;
+    }
+
     async saveLocally(data, image) {
         if (this.data.CurrentProject === undefined) this.initialiseNewProject();
 
@@ -210,6 +239,28 @@ class ProjectStorage {
                 this.TimeLastSaved = Date.now();
                 await this.set(this.LocalStorageKey, this.data);
             } catch (e) {
+                if (this._isQuotaExceededError(e)) {
+                    const removedCount = this._dropProjectImages();
+                    if (removedCount > 0) {
+                        try {
+                            await this.set(this.LocalStorageKey, this.data);
+                            console.warn(
+                                `[ProjectStorage] Storage quota exceeded. Removed ${removedCount} cached project image(s) and retried save.`
+                            );
+                            return;
+                        } catch (retryError) {
+                            console.warn(
+                                "[ProjectStorage] Storage quota still exceeded after dropping images. Please clear local storage space."
+                            );
+                            return;
+                        }
+                    } else {
+                        console.warn(
+                            "[ProjectStorage] Storage quota exceeded. No cached images to drop. Please clear local storage space."
+                        );
+                        return;
+                    }
+                }
                 console.error("[ProjectStorage] Save failed:", e);
             } finally {
                 this._saveInProgress = false;

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -194,6 +194,149 @@ describe("ProjectStorage", () => {
             await storage.save();
             expect(storage.TimeLastSaved).toBeGreaterThan(0);
         });
+
+        describe("storage quota handling", () => {
+            it("should detect QuotaExceededError by name", () => {
+                const error = new Error("Storage quota exceeded");
+                error.name = "QuotaExceededError";
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should detect NS_ERROR_DOM_QUOTA_REACHED by name", () => {
+                const error = new Error("Quota reached");
+                error.name = "NS_ERROR_DOM_QUOTA_REACHED";
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should detect quota error by message containing QUOTA_EXCEEDED", () => {
+                const error = new Error("QUOTA_EXCEEDED_ERR: storage limit reached");
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should detect quota error by message containing 'quota exceeded'", () => {
+                const error = new Error("The quota exceeded");
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should detect quota error by code 22", () => {
+                const error = new Error("Quota");
+                error.code = 22;
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should detect quota error by code 1014", () => {
+                const error = new Error("Quota");
+                error.code = 1014;
+                expect(storage._isQuotaExceededError(error)).toBe(true);
+            });
+
+            it("should return false for null error", () => {
+                expect(storage._isQuotaExceededError(null)).toBe(false);
+            });
+
+            it("should return false for non-quota errors", () => {
+                const error = new Error("Random disk error");
+                error.name = "DiskError";
+                expect(storage._isQuotaExceededError(error)).toBe(false);
+            });
+
+            it("should drop cached project images and retry successfully on quota error", async () => {
+                const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+                storage.data = {
+                    Projects: {
+                        proj1: { ProjectName: "A", ProjectImage: "image1" },
+                        proj2: { ProjectName: "B", ProjectImage: "image2" },
+                        proj3: { ProjectName: "C", ProjectImage: null }
+                    }
+                };
+
+                mockLocalforage.setItem.mockImplementation(async (key, value) => {
+                    if (key === storage.BackupStorageKey) {
+                        mockLocalforage._store[key] = value;
+                    } else if (key === storage.LocalStorageKey) {
+                        if (!mockLocalforage._store[key]) {
+                            mockLocalforage._store[key] = value;
+                            const quotaError = new Error("Quota exceeded");
+                            quotaError.name = "QuotaExceededError";
+                            throw quotaError;
+                        }
+                    }
+                });
+
+                await storage.save();
+
+                expect(mockLocalforage._store[storage.LocalStorageKey]).not.toBeNull();
+                expect(storage.data.Projects["proj1"].ProjectImage).toBeNull();
+                expect(storage.data.Projects["proj2"].ProjectImage).toBeNull();
+                expect(storage.data.Projects["proj3"].ProjectImage).toBeNull();
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("Storage quota exceeded") &&
+                        expect.stringContaining("Removed 2 cached project image")
+                );
+            });
+
+            it("should fail gracefully when quota error occurs but no images to drop", async () => {
+                const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+                storage.data = {
+                    Projects: {
+                        proj1: { ProjectName: "A", ProjectImage: null }
+                    }
+                };
+
+                mockLocalforage.setItem.mockImplementation(async key => {
+                    if (key === storage.LocalStorageKey) {
+                        const quotaError = new Error("Quota exceeded");
+                        quotaError.name = "QuotaExceededError";
+                        throw quotaError;
+                    }
+                });
+
+                await storage.save();
+
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("Storage quota exceeded") &&
+                        expect.stringContaining("No cached images to drop")
+                );
+            });
+
+            it("should fail gracefully when retry also fails after dropping images", async () => {
+                const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+                storage.data = {
+                    Projects: {
+                        proj1: { ProjectName: "A", ProjectImage: "image1" }
+                    }
+                };
+
+                mockLocalforage.setItem.mockImplementation(async () => {
+                    const quotaError = new Error("Still quota exceeded");
+                    quotaError.name = "QuotaExceededError";
+                    throw quotaError;
+                });
+
+                await storage.save();
+
+                expect(storage.data.Projects["proj1"].ProjectImage).toBeNull();
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("Storage quota still exceeded after dropping images")
+                );
+            });
+
+            it("should log error normally for non-quota errors", async () => {
+                const errorSpy = jest.spyOn(console, "error").mockImplementation();
+                storage.data = { Projects: {} };
+
+                mockLocalforage.setItem.mockImplementation(async () => {
+                    throw new Error("Random disk error");
+                });
+
+                await storage.save();
+
+                expect(errorSpy).toHaveBeenCalledWith(
+                    "[ProjectStorage] Save failed:",
+                    expect.any(Error)
+                );
+            });
+        });
     });
 
     describe("restore()", () => {


### PR DESCRIPTION
## Description

This PR implements a recovery mechanism for `QuotaExceededError` within the `ProjectStorage` subsystem. 

Previously, when the browser's local storage quota was reached, saving a project would fail outright, risking data loss or a broken state. Since `ProjectImage` (cached thumbnails) consumes a significant portion of the storage, this PR introduces a strategy to gracefully drop these cached images and retry the save operation. This significantly increases the likelihood of a successful save even in high-storage-pressure scenarios.

## Related Issues

Fixes #2614

## PR Category

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- **`planet/js/ProjectStorage.js`**:
  - Implemented `_isQuotaExceededError(e)` to reliably identify quota-related errors across different browser environments (e.g., `QuotaExceededError`, `NS_ERROR_DOM_QUOTA_REACHED`, code `22`, code `1014`).
  - Added `_dropProjectImages()` to iterate through all projects and nullify their `ProjectImage` data to free up space.
  - Updated `save()` to catch these quota errors, attempt the pruning mechanism, and retry the save one time. It also logs appropriate console warnings regarding the quota state.
- **`planet/js/__tests__/ProjectStorage.test.js`**:
  - Added unit tests to verify the successful retry when quota is exceeded.
  - Added unit tests to ensure it fails gracefully with an explicit warning when dropping images does not free enough space.
  - Added unit tests to verify standard errors (non-quota) bypass the retry logic and report accurately.


