### PR TITLE
SECURITY: Added security flags to window.open calls in background.js

### DIFF
--- a/js/__tests__/background.test.js
+++ b/js/__tests__/background.test.js
@@ -142,7 +142,11 @@ describe("Browser Action Behavior", () => {
 
         mockChrome.browserAction.onClicked.callback({ id: "tab-123" });
 
-        expect(window.open).toHaveBeenCalledWith("chrome-extension://fake-id/index.html");
+        expect(window.open).toHaveBeenCalledWith(
+            "chrome-extension://fake-id/index.html",
+            "_blank",
+            "noopener,noreferrer"
+        );
         expect(mockChrome.runtime.getURL).toHaveBeenCalledWith("index.html");
     });
 
@@ -155,7 +159,11 @@ describe("Browser Action Behavior", () => {
 
         mockChrome.runtime.onInstalled.callback({ reason: "install" });
 
-        expect(window.open).toHaveBeenCalledWith("chrome-extension://fake-id/index.html");
+        expect(window.open).toHaveBeenCalledWith(
+            "chrome-extension://fake-id/index.html",
+            "_blank",
+            "noopener,noreferrer"
+        );
         expect(mockChrome.runtime.getURL).toHaveBeenCalledWith("index.html");
     });
 

--- a/js/background.js
+++ b/js/background.js
@@ -23,11 +23,11 @@ if (navigator.userAgent.search("Firefox") !== -1) {
     });
 } else {
     chrome.browserAction.onClicked.addListener(tab => {
-        window.open(chrome.runtime.getURL("index.html"));
+        window.open(chrome.runtime.getURL("index.html"), "_blank", "noopener,noreferrer");
     });
 
     chrome.runtime.onInstalled.addListener(details => {
-        window.open(chrome.runtime.getURL("index.html"));
+        window.open(chrome.runtime.getURL("index.html"), "_blank", "noopener,noreferrer");
     });
 }
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Description
Added security flags to `window.open` calls in the Chrome extension background script to prevent potential security vulnerabilities and follow modern web security best practices.

## Why it matters
The `window.open` calls in js/background.js were missing security flags, which could allow the opened window to access the opener via `window.opener` or leak referrer information. Adding `noopener,noreferrer` prevents these issues and aligns with current web security standards.

## Changes Made
- Modified two `window.open` calls in js/background.js (lines 26 and 30)
- Added `_blank`, `noopener,noreferrer` parameters to both calls
- No functional changes to extension behavior, only security hardening

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [x] Security
- [x] Refactor / Maintenance