### PR TITLE
Store Groq key in session storage

### DIFF
--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -148,9 +148,36 @@ describe("AIWidget Utilities", () => {
 describe("AIWidget Instance", () => {
     let aiWidget;
     let mockActivity;
+    let widgetButtons;
 
     beforeEach(() => {
+        widgetButtons = {};
+        global.prompt = jest.fn();
+        global.alert = jest.fn();
+        const sessionStorageMock = {
+            getItem: jest.fn(),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        Object.defineProperty(window, "sessionStorage", {
+            value: sessionStorageMock,
+            configurable: true
+        });
+        global.sessionStorage = sessionStorageMock;
+        const localStorageMock = {
+            getItem: jest.fn(),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        Object.defineProperty(window, "localStorage", {
+            value: localStorageMock,
+            configurable: true
+        });
+        global.localStorage = localStorageMock;
         mockActivity = {
+            storage: {
+                groq_api_key: "legacy-storage-key"
+            },
             logo: {
                 synth: {
                     loadSynth: jest.fn()
@@ -180,9 +207,14 @@ describe("AIWidget Instance", () => {
                     div.getBoundingClientRect = jest.fn(() => ({ width: 800, height: 600 }));
                     return div;
                 }),
-                addButton: jest.fn(() => ({
-                    onclick: null
-                })),
+                addButton: jest.fn((...args) => {
+                    const label = args[2];
+                    const button = {
+                        onclick: null
+                    };
+                    widgetButtons[label] = button;
+                    return button;
+                }),
                 addCheckbox: jest.fn(() => ({
                     onclick: null
                 })),
@@ -215,5 +247,20 @@ describe("AIWidget Instance", () => {
             "Warning: Sample is bigger than 1MB.",
             undefined
         );
+    });
+
+    it("should keep the Groq API key in sessionStorage", () => {
+        sessionStorage.getItem.mockReturnValue("stored-session-key");
+        prompt.mockReturnValue("  new-groq-key  ");
+
+        aiWidget.init(mockActivity);
+
+        widgetButtons["Set API Key"].onclick();
+
+        expect(prompt).toHaveBeenCalledWith("Enter your Groq API Key:", "stored-session-key");
+        expect(sessionStorage.setItem).toHaveBeenCalledWith("groq_api_key", "new-groq-key");
+        expect(localStorage.setItem).not.toHaveBeenCalled();
+        expect(localStorage.removeItem).not.toHaveBeenCalled();
+        expect(mockActivity.storage.groq_api_key).toBe("legacy-storage-key");
     });
 });

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -37,6 +37,43 @@ function AIWidget() {
     const DEFAULTSAMPLE = "electronic synth";
     const CENTERPITCHHERTZ = 220;
     const SAMPLEWAITTIME = 500;
+    const GROQ_API_KEY_STORAGE_KEY = "groq_api_key";
+
+    // Keep the API key out of localStorage. Fall back to memory when sessionStorage
+    // is unavailable so the widget still works in restricted environments.
+    let groqApiKeyMemory = "";
+
+    function getGroqApiKey() {
+        try {
+            if (typeof sessionStorage !== "undefined") {
+                const stored = sessionStorage.getItem(GROQ_API_KEY_STORAGE_KEY);
+                if (stored !== null) {
+                    return stored;
+                }
+            }
+        } catch (e) {
+            // Ignore storage access failures and use the in-memory fallback below.
+        }
+
+        return groqApiKeyMemory;
+    }
+
+    function setGroqApiKey(value) {
+        const normalizedValue = (value || "").trim();
+        groqApiKeyMemory = normalizedValue;
+
+        try {
+            if (typeof sessionStorage !== "undefined") {
+                if (normalizedValue) {
+                    sessionStorage.setItem(GROQ_API_KEY_STORAGE_KEY, normalizedValue);
+                } else {
+                    sessionStorage.removeItem(GROQ_API_KEY_STORAGE_KEY);
+                }
+            }
+        } catch (e) {
+            // Ignore storage access failures and keep the in-memory fallback.
+        }
+    }
 
     // Oscilloscope constants
     const SAMPLEANALYSERSIZE = 8192;
@@ -798,12 +835,9 @@ function AIWidget() {
 
         widgetWindow.addButton("utility-button.svg", ICONSIZE, _("Set API Key"), "").onclick =
             function () {
-                const key = prompt(
-                    _("Enter your Groq API Key:"),
-                    that.activity.storage.groq_api_key || ""
-                );
+                const key = prompt(_("Enter your Groq API Key:"), getGroqApiKey());
                 if (key !== null) {
-                    that.activity.storage.groq_api_key = key.trim();
+                    setGroqApiKey(key.trim());
                 }
             };
 
@@ -1095,7 +1129,7 @@ function AIWidget() {
                 return;
             }
 
-            const apiKey = that.activity.storage.groq_api_key;
+            const apiKey = getGroqApiKey();
             if (!apiKey) {
                 alert(
                     _("Please set your Groq API Key using the settings button (wrench icon) first.")


### PR DESCRIPTION
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

What changed
- Store the Groq API key in sessionStorage instead of localStorage.
- Keep an in-memory fallback so the key field still works if sessionStorage is unavailable.
- Add tests that verify the key no longer goes through localStorage.

Why
- The key should not survive a browser restart.
- This reduces the risk of lingering secrets in long-lived browser storage.

Fixes #6823

Checks
- npx jest js/widgets/__tests__/aiwidget.test.js --runInBand --coverage=false
- npx eslint js/widgets/aiwidget.js js/widgets/__tests__/aiwidget.test.js
