### PR TITLE
fix: show correct interval numeric tabs in piemenu; add unit test

### DIFF
--- a/js/__tests__/piemenus-intervals.test.js
+++ b/js/__tests__/piemenus-intervals.test.js
@@ -1,0 +1,106 @@
+const { piemenuIntervals } = require("../piemenus");
+
+// Minimal mocks similar to existing piemenus tests
+global.docById = jest.fn().mockReturnValue({
+    style: { display: "", opacity: "" },
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getBoundingClientRect: jest.fn().mockReturnValue({ x: 0, y: 0 })
+});
+global.document = { getElementById: global.docById };
+global.window = { innerWidth: 1024, addEventListener: jest.fn(), removeEventListener: jest.fn() };
+
+global.wheelnav = jest.fn().mockImplementation(function (div) {
+    this.navItems = Array.from({ length: 40 }, () => ({
+        title: "",
+        enabled: true,
+        navItem: { hide: jest.fn(), show: jest.fn() },
+        sliceSelectedAttr: {},
+        sliceHoverAttr: {},
+        titleSelectedAttr: {},
+        titleHoverAttr: {}
+    }));
+    this.selectedNavItemIndex = 0;
+    this.colors = [];
+    this.raphael = { canvas: {} };
+    this.on = jest.fn();
+    this.createWheel = jest.fn(labels => {
+        if (labels) labels.forEach((l, i) => (this.navItems[i].title = l));
+    });
+    this.initWheel = jest.fn();
+    this.navigateWheel = jest.fn(index => {
+        this.selectedNavItemIndex = index;
+        if (this.navItems[index] && typeof this.navItems[index].navigateFunction === "function") {
+            this.navItems[index].navigateFunction();
+        }
+    });
+    this.removeWheel = jest.fn();
+    this.refreshWheel = jest.fn();
+    this.setTooltips = jest.fn();
+});
+
+global.slicePath = jest.fn().mockReturnValue({
+    DonutSlice: jest.fn(),
+    DonutSliceCustomization: jest.fn().mockReturnValue({ minRadiusPercent: 0, maxRadiusPercent: 0 })
+});
+
+global.platformColor = {
+    intervalWheelcolors: ["#fff"],
+    intervalNameWheelcolors: ["#fff"],
+    exitWheelcolors: ["#000"]
+};
+global._ = jest.fn(s => s);
+
+// Define INTERVALS so piemenuIntervals can use it
+global.INTERVALS = [
+    ["perfect", "perfect", [1, 4, 5, 8]],
+    ["minor", "minor", [2, 3, 6, 7]],
+    ["diminished", "diminished", [2, 3, 4, 5, 6, 7, 8]],
+    ["augmented", "augmented", [1, 2, 3, 4, 5, 6, 7, 8]],
+    ["major", "major", [2, 3, 6, 7]]
+];
+
+describe("piemenuIntervals tab gating", () => {
+    let mockBlock;
+
+    beforeEach(() => {
+        mockBlock = {
+            container: { x: 0, y: 0, setChildIndex: jest.fn(), children: [] },
+            blocks: {
+                stageClick: false,
+                blockScale: 1,
+                turtles: { _canvas: { width: 800, height: 600 } }
+            },
+            activity: {
+                canvas: { offsetLeft: 0, offsetTop: 0 },
+                blocksContainer: { x: 0, y: 0 },
+                getStageScale: () => 1
+            },
+            connections: [],
+            updateCache: jest.fn(),
+            text: { text: "" },
+            value: ""
+        };
+        jest.clearAllMocks();
+    });
+
+    test("shows only allowed numeric tabs for selected interval", () => {
+        // Choose "perfect 1" as selectedInterval
+        piemenuIntervals(mockBlock, "perfect 1");
+
+        // interval index for "perfect" is 0; its active tabs are [1,4,5,8]
+        // For interval 0, nav item indices are 0*8 + j (j 0..7) -> indices 0..7
+        // Allowed j indices: 0,3,4,7
+        const allowed = new Set([0, 3, 4, 7]);
+
+        for (let j = 0; j < 8; j++) {
+            const nav = mockBlock._intervalWheel.navItems[j];
+            if (!nav) continue;
+            if (allowed.has(j)) {
+                expect(nav.navItem.show).toHaveBeenCalled();
+            } else {
+                expect(nav.navItem.hide).toHaveBeenCalled();
+            }
+        }
+    });
+});

--- a/js/__tests__/piemenus-intervals.test.js
+++ b/js/__tests__/piemenus-intervals.test.js
@@ -1,3 +1,21 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 nickhil_verma
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 const { piemenuIntervals } = require("../piemenus");
 
 // Minimal mocks similar to existing piemenus tests

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3127,6 +3127,12 @@ const piemenuIntervals = (block, selectedInterval) => {
         }
     }
     block._intervalWheel.createWheel(numbers);
+    // Initially hide all numeric tabs; we'll show only active ones
+    for (let idx = 0; idx < block._intervalWheel.navItems.length; idx++) {
+        if (block._intervalWheel.navItems[idx] && block._intervalWheel.navItems[idx].navItem) {
+            block._intervalWheel.navItems[idx].navItem.hide();
+        }
+    }
 
     block._exitWheel.colors = platformColor.exitWheelcolors;
     block._exitWheel.slicePathFunction = slicePath().DonutSlice;
@@ -3180,7 +3186,7 @@ const piemenuIntervals = (block, selectedInterval) => {
         ) + "px";
 
     // Add function to each main menu for show/hide sub menus
-    // TODO: Add all tabs to each interval
+    // Status: tabs gating implemented
     const __setupAction = (i, activeTabs) => {
         that._intervalNameWheel.navItems[i].navigateFunction = () => {
             for (let l = 0; l < labels.length; l++) {
@@ -3217,6 +3223,14 @@ const piemenuIntervals = (block, selectedInterval) => {
     }
 
     block._intervalNameWheel.navigateWheel(i);
+
+    // Ensure the corresponding numeric tabs are shown for the selected interval
+    if (
+        block._intervalNameWheel.navItems[i] &&
+        typeof block._intervalNameWheel.navItems[i].navigateFunction === "function"
+    ) {
+        block._intervalNameWheel.navItems[i].navigateFunction();
+    }
 
     // Enable scroll-to-rotate
     enableWheelScroll(block._intervalNameWheel, labels.length);
@@ -4530,5 +4544,5 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches };
+    module.exports = { piemenuPitches, piemenuIntervals };
 }


### PR DESCRIPTION
# PR: Fix numeric tab gating in interval pie menu

## Overview

This PR implements gating for numeric tabs in the interval pie menu so that each interval displays only its allowed numeric tabs. It also introduces a focused unit test to validate this behavior.

---

## PR Category

- [x] Bug Fix
- [x] Tests

---

## What Changed

- Updated `piemenus.js`:
  - Hide numeric tabs initially
  - Trigger interval handler on load
  - Removed TODO comment and replaced with implementation

- Exported `piemenuIntervals` for testing purposes

- Added new test file:
  - `piemenus-intervals.test.js`
  - Verifies only allowed numeric tabs are shown for the **"perfect" interval**

---

## Verification

### Local Testing

- Reproduced behavior locally
- Verified fix through unit tests

### Test Results

- `piemenus.test.js` — PASS  
- `piemenus-intervals.test.js` — PASS  

---

## Checklist

- [x] Code follows project style guidelines  
- [x] Self-reviewed changes  
- [x] Removed TODO and added proper implementation  
- [x] No new warnings introduced  
- [x] Added unit tests for the fix  
- [x] All tests pass locally  

---

## Files Changed

- `piemenus.js`
- `piemenus-intervals.test.js`

---

## Notes

This change ensures correct UI behavior by restricting numeric tab visibility based on interval selection, improving consistency and preventing invalid combinations.