### PR TITLE
test: update synthutils tests to validate graceful no-op behavior

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -628,8 +628,12 @@ describe("Utility Functions (logic-only)", () => {
             const instrumentName = "nonexistent";
             const note = "C4";
 
-            // Act & Assert
-            expect(() => startSound(turtle, instrumentName, note)).toThrow();
+            // Act
+            startSound(turtle, instrumentName, note);
+
+            // Assert
+            expect(instruments[turtle].flute.triggerAttack).not.toHaveBeenCalled();
+            expect(instruments[turtle].guitar.start).not.toHaveBeenCalled();
         });
 
         test("should handle undefined turtle gracefully", () => {
@@ -639,7 +643,7 @@ describe("Utility Functions (logic-only)", () => {
             const note = "C4";
 
             // Act & Assert
-            expect(() => startSound(invalidTurtle, instrumentName, note)).toThrow();
+            expect(() => startSound(invalidTurtle, instrumentName, note)).not.toThrow();
         });
     });
 
@@ -702,8 +706,13 @@ describe("Utility Functions (logic-only)", () => {
             // Arrange
             const instrumentName = "nonexistent";
             const note = "C4";
-            // Act & Assert
-            expect(() => stopSound(turtle, instrumentName, note)).toThrow();
+
+            // Act
+            stopSound(turtle, instrumentName, note);
+
+            // Assert
+            expect(instruments[turtle].flute.triggerRelease).not.toHaveBeenCalled();
+            expect(instruments[turtle].guitar.stop).not.toHaveBeenCalled();
         });
 
         test("should handle invalid turtle gracefully", () => {
@@ -713,7 +722,7 @@ describe("Utility Functions (logic-only)", () => {
             const note = "C4";
 
             // Act & Assert
-            expect(() => stopSound(invalidTurtle, instrumentName, note)).toThrow();
+            expect(() => stopSound(invalidTurtle, instrumentName, note)).not.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #6833

Updates test expectations in `synthutils.test.js` to align with the actual implementation of `startSound` and `stopSound`.

The current tests expect errors to be thrown for invalid inputs (undefined/invalid turtle or instrument), while the implementation in `synthutils.js` handles these cases gracefully via early returns.

---

## Changes

* Replaced `expect(...).toThrow()` with assertions ensuring no exceptions are thrown
* Updated tests to reflect graceful no-op behavior for invalid inputs
* Ensured no synth-related methods are invoked when inputs are invalid

---

## Affected Tests

* `startSound › should handle undefined instrument gracefully`
* `startSound › should handle undefined turtle gracefully`
* `stopSound › should handle invalid instrument gracefully`
* `stopSound › should handle invalid turtle gracefully`

---

## Why this change?

* Resolves mismatch between tests and implementation
* Prevents false test failures
* Aligns test suite with intended design behavior

---

## Testing

* Ran `npm test`
* All tests pass successfully after updates

---
### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation

---
## Checklist

* [x] Tests updated to reflect correct behavior
* [x] No breaking changes introduced
* [x] Follows project testing guidelines
