### PR TITLE
fix: resolve planet sorting dropdown bugs

### DIFF
--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -251,6 +251,18 @@ div.select-wrapper * {
 	top: 100% !important ;
 }
 
+#globalcontents .select-wrapper ul.dropdown-content {
+	z-index: 99 !important;
+	width: auto !important;
+	min-width: 100%;
+	right: 0 !important;
+	left: auto !important;
+}
+
+#globalcontents .select-wrapper ul.dropdown-content li span {
+	white-space: nowrap;
+}
+
 .centre-button {
 	left: 50%;
 	-webkit-transform: translateX(-50%);

--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -72,7 +72,7 @@ class GlobalPlanet {
             t = new GlobalTag(Planet);
             t.init({ id: keys[i] });
             this.tags.push(t);
-            if (this.defaultMainTags.indexOf(Planet.TagsManifest[keys[i]].TagName) != -1) {
+            if (this.defaultMainTags.indexOf(Planet.TagsManifest[keys[i]].TagName) !== -1) {
                 t.selected = true;
                 tagsToInitialise.push(t);
             }
@@ -80,7 +80,7 @@ class GlobalPlanet {
 
         this.sortBy = document.getElementById("sort-select").value;
 
-        if (this.defaultTag != false) this.selectSpecialTag(this.defaultTag);
+        if (this.defaultTag !== false) this.selectSpecialTag(this.defaultTag);
 
         for (let i = 0; i < tagsToInitialise.length; i++) tagsToInitialise[i].select();
 
@@ -235,7 +235,6 @@ class GlobalPlanet {
         const toDownload = [];
 
         for (let i = 0; i < data.length; i++) {
-            // eslint-disable-next-line no-prototype-builtins
             if (this.cache.hasOwnProperty(data[i][0])) {
                 if (this.cache[data[i][0]].ProjectLastUpdated !== data[i][1])
                     toDownload.push(data[i]);
@@ -372,7 +371,6 @@ class GlobalPlanet {
         this.cleanContainer();
 
         for (let i = 0; i < data.length; i++) {
-            // eslint-disable-next-line no-prototype-builtins
             if (this.cache.hasOwnProperty(data[i][0])) {
                 const g = new GlobalCard(this.Planet);
                 g.init(data[i][0]);
@@ -518,6 +516,22 @@ class GlobalPlanet {
                 this.sortBy = document.getElementById("sort-select").value;
                 this.refreshProjects();
             });
+
+            jQuery("#sort-select")
+                .siblings(".select-dropdown, .caret")
+                .on("mousedown", function (e) {
+                    var input = jQuery(this).parent().find("input.select-dropdown");
+                    if (input.hasClass("active")) {
+                        e.preventDefault();
+                        // Block the upcoming click from reopening the dropdown
+                        jQuery(this).one("click", function (clickEvt) {
+                            clickEvt.preventDefault();
+                            clickEvt.stopImmediatePropagation();
+                        });
+                        // Close the dropdown
+                        jQuery(document).trigger("click");
+                    }
+                });
 
             if (Planet.IsMusicBlocks) {
                 this.defaultMainTags = ["Music"];


### PR DESCRIPTION
## PR Category 
- [x] Bug Fix

## Description
This PR resolves three UI/UX regressions in the Planet page "Sort by" dropdown menu. It addresses layout inconsistencies, broken toggle behavior, and z-index overlap with the sticky navigation header.

## Changes
### CSS Fixes (`planet/css/style.css`)
- Added `width: auto !important` and `min-width: 100%` to override Materialize's inline width constraints.
- Anchored the dropdown to the right (`right: 0`) to prevent horizontal overflow on mobile.
- Applied `white-space: nowrap` to dropdown items to prevent text wrapping.
- Set `z-index: 99 !important` to ensure the menu slides under the sticky navbar (which has `z-index: 100`).

### JS Fixes (`planet/js/GlobalPlanet.js`)
- Implemented a `mousedown` event handler on the dropdown trigger elements to enable a manual toggle-off behavior.
- Fixed two pre-existing `eqeqeq` lint warnings (`!=` to `!==`) and removed two unused `eslint-disable` comments to ensure a clean lint pass.

## Verification
- **Visual Check:** Verified that the dropdown now expands to the left to fit long labels and stays aligned to the right edge.
- **Interaction Check:** Verified that re-clicking the "Sort by" label correctly closes the menu.
- **Scroll Check:** Verified that the menu no longer overlaps the navigation header when scrolling.

Fixes #6840 

### After fix Video :

https://github.com/user-attachments/assets/e38029bb-f866-41d4-abe0-88359891bfc6

