### PR TITLE
fix: improve missing argument warning bubble

### DIFF
--- a/images/noinput.svg
+++ b/images/noinput.svg
@@ -8,7 +8,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg2"
    height="42"
-   width="300"
+   width="380"
    version="1.0">
   <metadata
      id="metadata73">
@@ -568,7 +568,7 @@
      ry="3.3251483"
      rx="2.979018"
      height="39.901779"
-     width="297.90176" />
+     width="377.90176" />
   <g
      id="g17"
      transform="translate(6,2)">
@@ -608,7 +608,7 @@
        style="font-size:24px;fill:#ff0000;fill-opacity:1"
        id="tspan2620"
        y="31"
-       x="187.27734">???</tspan></text>
+       x="187.27734"></tspan></text>
   <g
      id="g4701"
      transform="matrix(1.5,0,0,1.5,75,3)">
@@ -619,7 +619,7 @@
   </g>
   <g
      id="g929"
-     transform="translate(9)">
+     transform="translate(89)">
     <rect
        style="opacity:1;fill:#b0b0b0;fill-opacity:1;stroke:none;stroke-width:13.86169147;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect920"

--- a/js/activity.js
+++ b/js/activity.js
@@ -3235,6 +3235,8 @@ class Activity {
                 container.addChild(text);
                 text.x = 70;
                 text.y = 10;
+                const detailText = new createjs.Text("", "bold 16px Sans", "#ff0000");
+                container.addChild(detailText);
 
                 const bounds = container.getBounds();
                 container.cache(bounds.x, bounds.y, bounds.width, bounds.height);
@@ -6113,7 +6115,32 @@ class Activity {
                     );
                     break;
                 case NOINPUTERRORMSG:
+                    this.errorArtwork["noinput"].children[1].text = _(NOINPUTERRORMSG);
+                    this.errorArtwork["noinput"].children[2].text = "";
+                    if (
+                        blk !== undefined &&
+                        blk !== null &&
+                        blk in this.blocks.blockList &&
+                        this.blocks.blockList[blk].protoblock.staticLabels.length > 0
+                    ) {
+                        const blockLabel = this.blocks.blockList[blk].protoblock.staticLabels[0];
+                        const shortLabel =
+                            blockLabel.length > 8 ? blockLabel.substr(0, 8) + "..." : blockLabel;
+                        this.errorArtwork["noinput"].children[2].text = shortLabel;
+                    }
+                    this.errorArtwork["noinput"].children[1].font = "16px Sans";
+                    this.errorArtwork["noinput"].children[1].color = "#ff0000";
+                    this.errorArtwork["noinput"].children[1].x = 170;
+                    this.errorArtwork["noinput"].children[1].y = 13;
+                    this.errorArtwork["noinput"].children[2].font = "bold 16px Sans";
+                    this.errorArtwork["noinput"].children[2].color = "#ff0000";
+                    this.errorArtwork["noinput"].children[2].x =
+                        this.errorArtwork["noinput"].children[1].x +
+                        this.errorArtwork["noinput"].children[1].getMeasuredWidth() +
+                        5;
+                    this.errorArtwork["noinput"].children[2].y = 13;
                     this.errorArtwork["noinput"].visible = true;
+                    this.errorArtwork["noinput"].updateCache();
                     this.stage.setChildIndex(
                         this.errorArtwork["noinput"],
                         this.stage.children.length - 1

--- a/js/activity.js
+++ b/js/activity.js
@@ -3235,8 +3235,10 @@ class Activity {
                 container.addChild(text);
                 text.x = 70;
                 text.y = 10;
+                container.messageText = text;
                 const detailText = new createjs.Text("", "bold 16px Sans", "#ff0000");
                 container.addChild(detailText);
+                container.detailText = detailText;
 
                 const bounds = container.getBounds();
                 container.cache(bounds.x, bounds.y, bounds.width, bounds.height);
@@ -6115,8 +6117,15 @@ class Activity {
                     );
                     break;
                 case NOINPUTERRORMSG:
-                    this.errorArtwork["noinput"].children[1].text = _(NOINPUTERRORMSG);
-                    this.errorArtwork["noinput"].children[2].text = "";
+                    if (
+                        !this.errorArtwork["noinput"].messageText ||
+                        !this.errorArtwork["noinput"].detailText
+                    ) {
+                        break;
+                    }
+
+                    this.errorArtwork["noinput"].messageText.text = _(NOINPUTERRORMSG);
+                    this.errorArtwork["noinput"].detailText.text = "";
                     if (
                         blk !== undefined &&
                         blk !== null &&
@@ -6126,19 +6135,19 @@ class Activity {
                         const blockLabel = this.blocks.blockList[blk].protoblock.staticLabels[0];
                         const shortLabel =
                             blockLabel.length > 8 ? blockLabel.substr(0, 8) + "..." : blockLabel;
-                        this.errorArtwork["noinput"].children[2].text = shortLabel;
+                        this.errorArtwork["noinput"].detailText.text = shortLabel;
                     }
-                    this.errorArtwork["noinput"].children[1].font = "16px Sans";
-                    this.errorArtwork["noinput"].children[1].color = "#ff0000";
-                    this.errorArtwork["noinput"].children[1].x = 170;
-                    this.errorArtwork["noinput"].children[1].y = 13;
-                    this.errorArtwork["noinput"].children[2].font = "bold 16px Sans";
-                    this.errorArtwork["noinput"].children[2].color = "#ff0000";
-                    this.errorArtwork["noinput"].children[2].x =
-                        this.errorArtwork["noinput"].children[1].x +
-                        this.errorArtwork["noinput"].children[1].getMeasuredWidth() +
+                    this.errorArtwork["noinput"].messageText.font = "16px Sans";
+                    this.errorArtwork["noinput"].messageText.color = "#ff0000";
+                    this.errorArtwork["noinput"].messageText.x = 170;
+                    this.errorArtwork["noinput"].messageText.y = 13;
+                    this.errorArtwork["noinput"].detailText.font = "bold 16px Sans";
+                    this.errorArtwork["noinput"].detailText.color = "#ff0000";
+                    this.errorArtwork["noinput"].detailText.x =
+                        this.errorArtwork["noinput"].messageText.x +
+                        this.errorArtwork["noinput"].messageText.getMeasuredWidth() +
                         5;
-                    this.errorArtwork["noinput"].children[2].y = 13;
+                    this.errorArtwork["noinput"].detailText.y = 13;
                     this.errorArtwork["noinput"].visible = true;
                     this.errorArtwork["noinput"].updateCache();
                     this.stage.setChildIndex(


### PR DESCRIPTION
## Summary

Improves the missing-argument warning shown when a block has a required input missing.
fixes #6843 

- [x] Bug fix

## What changed

- Removed the hardcoded `???` placeholder from `images/noinput.svg`
- Widened the missing-input warning bubble so text fits cleanly
- Moved the close button to match the wider bubble
- Updated `NOINPUTERRORMSG` rendering to show the real error message dynamically
- Shows the target block label separately in bold, e.g. `Missing argument. note`

## Verification

- `npx prettier --check js/activity.js`
- `npx eslint js/activity.js`
- `npx jest js/__tests__/artwork.test.js js/__tests__/logoconstants.test.js js/__tests__/activity_pure_functions.test.js --runInBand --coverage=false`


## Screenshots 
Before 
<img width="411" height="145" alt="image" src="https://github.com/user-attachments/assets/9f161608-33c0-4c80-8256-0cf5af475399" />


After 
<img width="522" height="140" alt="image" src="https://github.com/user-attachments/assets/4932d5e1-4e98-4612-ba50-5457f3c970fb" />

