### PR TITLE
fix: ensure startSound and stopSound throw on missing instrument

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2224,7 +2224,9 @@ function Synth() {
     };
 
     this.startSound = (turtle, instrumentName, note) => {
-        if (!instrumentsSource[instrumentName] || !instruments[turtle]?.[instrumentName]) return;
+        if (!instrumentsSource[instrumentName] || !instruments[turtle]?.[instrumentName]) {
+            throw new Error(`Instrument ${instrumentName} not found for turtle ${turtle}`);
+        }
         const flag = instrumentsSource[instrumentName][0];
         switch (flag) {
             case 1: // drum
@@ -2237,7 +2239,9 @@ function Synth() {
     };
 
     this.stopSound = (turtle, instrumentName, note) => {
-        if (!instrumentsSource[instrumentName] || !instruments[turtle]?.[instrumentName]) return;
+        if (!instrumentsSource[instrumentName] || !instruments[turtle]?.[instrumentName]) {
+            throw new Error(`Instrument ${instrumentName} not found for turtle ${turtle}`);
+        }
         const flag = instrumentsSource[instrumentName][0];
         switch (flag) {
             case 1: // drum


### PR DESCRIPTION
### Description
This PR resolves 4 failing unit tests in `js/utils/__tests__/synthutils.test.js`. The tests were expecting `startSound` and `stopSound` to throw an error when an invalid instrument or turtle was provided, but the implementation was returning early with a guard clause.

### Changes
- Modified `this.startSound` in `js/utils/synthutils.js` to throw an `Error` instead of returning early when `instrumentsSource[instrumentName]` or `instruments[turtle]?.[instrumentName]` is missing.
- Modified `this.stopSound` in `js/utils/synthutils.js` to perform the same error throwing behavior for consistency and to satisfy test requirements.

### PR Category
- [x] Tests

### Verification Results
I have verified the fix by running the full test suite for `synthutils.test.js`. All 99 tests passed successfully.

```bash
npx jest js/utils/__tests__/synthutils.test.js
