### PR TITLE
fix: honor configured timeout in planet request manager

### DIFF
--- a/planet/js/RequestManager.js
+++ b/planet/js/RequestManager.js
@@ -188,7 +188,8 @@ class RequestManager {
                     const delay = this.baseRetryDelay * Math.pow(2, attempt);
 
                     console.debug(
-                        `[RequestManager] Retry attempt ${attempt + 1}/${this.maxRetries
+                        `[RequestManager] Retry attempt ${attempt + 1}/${
+                            this.maxRetries
                         } after ${delay}ms`
                     );
 
@@ -210,7 +211,8 @@ class RequestManager {
                 const delay = this.baseRetryDelay * Math.pow(2, attempt);
 
                 console.debug(
-                    `[RequestManager] Retry attempt ${attempt + 1}/${this.maxRetries
+                    `[RequestManager] Retry attempt ${attempt + 1}/${
+                        this.maxRetries
                     } after ${delay}ms (error: ${error.message})`
                 );
 
@@ -234,8 +236,8 @@ class RequestManager {
     _promisifyRequest(requestFn) {
         return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
-                resolve({ success: false, error: "REQUEST_TIMEOUT" });;
-            }, 30000); // 30 seconds
+                resolve({ success: false, error: "REQUEST_TIMEOUT" });
+            }, this.timeoutMs);
 
             try {
                 requestFn(result => {

--- a/planet/js/__tests__/RequestManager.test.js
+++ b/planet/js/__tests__/RequestManager.test.js
@@ -39,6 +39,11 @@ describe("RequestManager", () => {
             expect(requestManager.maxConcurrent).toBe(2);
         });
 
+        it("should initialize with custom timeout", () => {
+            const rm = new RequestManager({ timeoutMs: 1234 });
+            expect(rm.timeoutMs).toBe(1234);
+        });
+
         it("should initialize empty pending requests", () => {
             expect(requestManager.pendingRequests.size).toBe(0);
         });
@@ -161,6 +166,22 @@ describe("RequestManager", () => {
 
             // After all retries, should return the failure result
             expect(result.success).toBe(false);
+        });
+
+        it("should use configured timeout in the callback wrapper", async () => {
+            jest.useFakeTimers();
+
+            const rm = new RequestManager({ timeoutMs: 25 });
+            const promise = rm._promisifyRequest(() => {});
+
+            jest.advanceTimersByTime(25);
+
+            await expect(promise).resolves.toEqual({
+                success: false,
+                error: "REQUEST_TIMEOUT"
+            });
+
+            jest.useRealTimers();
         });
     });
 


### PR DESCRIPTION

### Summary
This PR fixes a timeout inconsistency in the Planet request layer.

`RequestManager` accepts a configurable `timeoutMs`, but `_promisifyRequest()` was using a hardcoded `30000 ms` timeout. As a result, custom timeout values were not respected in the callback-based request flow.

This change ensures that `this.timeoutMs` is used consistently across all request paths.

---

### What Changed
- Updated `planet/js/RequestManager.js`
  - Replaced hardcoded `30000` timeout in `_promisifyRequest()` with `this.timeoutMs`

- Updated `planet/js/__tests__/RequestManager.test.js`
  - Added test to verify custom `timeoutMs` is stored correctly
  - Added regression test to ensure `_promisifyRequest()` respects configured timeout

---

### Why This Fix Matters
Previously, timeout configuration was only partially applied, leading to inconsistent behavior and confusion when using custom timeout values.

Now, timeout handling is consistent across the entire request manager.

---
### Verification
- Tests pass successfully  
- Regression test confirms timeout respects `timeoutMs`  
- Code formatting verified using Prettier  

---
Closes #6839 

---
### PR Category
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Refactoring  
- [ ] Documentation  

--
### How to Test
```bash
npx jest planet/js/__tests__/RequestManager.test.js --runInBand
npx prettier --check planet/js/RequestManager.js planet/js/__tests__/RequestManager.test.js