### PR TITLE
fix: resolve Flatpak EOL, fix service worker crash, and implement workspace auto-center on load

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -39,7 +39,8 @@ const mockActivity = {
     turtles: {},
     loading: false,
     prepareExport: jest.fn(),
-    _allClear: jest.fn()
+    _allClear: jest.fn(),
+    _findBlocks: jest.fn()
 };
 
 document.body.innerHTML = `

--- a/js/activity.js
+++ b/js/activity.js
@@ -5169,6 +5169,7 @@ class Activity {
                     }
                     // Set flag to 1 to enable keyboard after MB finishes loading
                     that.keyboardEnableFlag = 1;
+                    that._findBlocks();
                 }
 
                 document.removeEventListener("finishedLoading", __afterLoad);
@@ -8529,6 +8530,7 @@ class Activity {
                                 that.stage.removeAllEventListeners("trashsignal");
 
                                 const __afterLoad = () => {
+                                    that._findBlocks();
                                     document.removeEventListener("finishedLoading", __afterLoad);
                                 };
 

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -140,6 +140,7 @@ class PlanetInterface {
             this.activity.blocks.palettes._hideMenus(true);
 
             const __afterLoad = () => {
+                this.activity._findBlocks();
                 document.removeEventListener("finishedLoading", __afterLoad);
             };
 

--- a/org.sugarlabs.MusicBlocks.json
+++ b/org.sugarlabs.MusicBlocks.json
@@ -1,0 +1,36 @@
+{
+  "app-id": "org.sugarlabs.MusicBlocks",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "24.08",
+  "sdk": "org.freedesktop.Sdk",
+  "base": "org.electronjs.Electron2.BaseApp",
+  "base-version": "24.08",
+  "command": "musicblocks",
+  "separate-locales": false,
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--share=network",
+    "--device=dri",
+    "--filesystem=xdg-documents:rw",
+    "--filesystem=xdg-download:rw"
+  ],
+  "modules": [
+    {
+      "name": "musicblocks",
+      "buildsystem": "simple",
+      "build-commands": [
+        "npm install",
+        "npm run dist -- --linux flatpak"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "."
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "tone": "^15.1.22"
     },
     "build": {
-        "appId": "com.musicblocks.app",
+        "appId": "org.sugarlabs.MusicBlocks",
         "productName": "Music Blocks",
         "mac": {
             "category": "public.app-category.music",
@@ -85,7 +85,14 @@
             "target": "nsis"
         },
         "linux": {
-            "target": "AppImage"
+            "target": [
+                "AppImage",
+                "flatpak"
+            ],
+            "flatpak": {
+                "runtime": "org.freedesktop.Platform",
+                "runtimeVersion": "24.08"
+            }
         }
     },
     "overrides": {

--- a/sw.js
+++ b/sw.js
@@ -9,18 +9,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/*
-  global
-
-    offlineFallbackPage
-*/
-
 // This is the "Offline page" service worker
 
 const CACHE = "pwabuilder-precache";
+const offlineFallbackPage = "./index.html";
 const precacheFiles = [
     /* Add an array of files to precache for your app */
-    "./index.html"
+    offlineFallbackPage
 ];
 
 self.addEventListener("install", function (event) {

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // This is the "Offline page" service worker
 
 const CACHE = "pwabuilder-precache";
-const offlineFallbackPage = "./index.html";
+const offlineFallbackPage = "/index.html";
 const precacheFiles = [
     /* Add an array of files to precache for your app */
     offlineFallbackPage

--- a/sw.js
+++ b/sw.js
@@ -9,13 +9,18 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+/*
+  global
+
+    offlineFallbackPage
+*/
+
 // This is the "Offline page" service worker
 
 const CACHE = "pwabuilder-precache";
-const offlineFallbackPage = "/index.html";
 const precacheFiles = [
     /* Add an array of files to precache for your app */
-    offlineFallbackPage
+    "./index.html"
 ];
 
 self.addEventListener("install", function (event) {


### PR DESCRIPTION
# PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

### Summary
This PR upgrades the Flatpak runtime to resolve end-of-life (EOL) warnings and implements an automatic workspace centering feature to improve the initial user experience.

### Key Changes
1. **Auto-Center on Load**: Programmatically triggers the "Zoom-extents" logic (_findBlocks) whenever a project is loaded (at startup, via file upload, or from Planet cloud storage).
2. **Flatpak Runtime Upgrade**: Updated the Flatpak runtime from 21.08 to 24.08 and configured package.json with the correct appId and build targets to resolve security EOL warnings.
3. **Initialization Timing Verification**: Confirmed that `finishedLoading` is dispatched only after all blocks are fully initialized, ensuring the centering logic uses accurate workspace dimensions.
4. **PR Cleanup & Rebase**: 
   * Synchronized the branch with the latest master via rebase.
   * Removed previous changes to sw.js and synthutils.test.js to avoid redundancy with other open PRs, as requested.
   * Updated planetInterface.test.js to include required mocks for the new centering logic.

---
- Resolves Flatpak Runtime EOL warning on Ubuntu 24.04.
- Fixes workspace centering for a better initial user experience.
- Fixes #6580
