### PR TITLE
fix: replace debug console statements with proper error handling in AIWidget

### DIFF
--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -864,6 +864,7 @@ function AIWidget() {
                 await this.midiBuffer.prime();
                 this.midiBuffer.start();
             } catch (error) {
+                console.warn("synth error", error);
                 this.activity.errorMsg(_("Synth error: ") + error.message);
             }
         } else {

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -862,13 +862,12 @@ function AIWidget() {
                 });
 
                 await this.midiBuffer.prime();
-                console.log("Playing ABC:", abc);
                 this.midiBuffer.start();
             } catch (error) {
-                console.warn("synth error", error);
+                this.activity.errorMsg(_("Synth error: ") + error.message);
             }
         } else {
-            console.warn("Audio not supported in this browser");
+            this.activity.errorMsg(_("Audio not supported in this browser."));
         }
     };
 
@@ -1216,7 +1215,6 @@ function AIWidget() {
                     textarea.value = abcNotationSong;
                 })
                 .catch(error => {
-                    console.error("Error:", error);
                     textarea.value = "An error occurred: " + error.message;
                 })
                 .finally(() => {


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Replaces debug console statements in AIWidget with proper error handling 
using the activity.errorMsg() pattern used across the codebase, while 
keeping console.warn for debugging purposes.

## Changes
- Removed console.log("Playing ABC:", abc)
- Replaced console.warn("synth error") with console.warn + activity.errorMsg()
- Replaced console.warn("Audio not supported") with activity.errorMsg()
- Removed console.error("Error:") from catch block

Closes #6610