### PR TITLE
Handle denied microphone permission in Sampler widget

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2427,15 +2427,9 @@ function Synth() {
         await Tone.start();
         this.mic = new Tone.UserMedia();
         this.recorder = new Tone.Recorder();
-        await this.mic
-            .open()
-            .then(() => {
-                this.mic.connect(this.recorder);
-                this.recorder.start();
-            })
-            .catch(error => {
-                console.error(error);
-            });
+        await this.mic.open();
+        this.mic.connect(this.recorder);
+        this.recorder.start();
     };
 
     const _disposeRecordingPlayer = () => {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2658,15 +2658,9 @@ function Synth() {
 
         this.mic = new Tone.UserMedia();
         this.recorder = new Tone.Recorder();
-        await this.mic
-            .open()
-            .then(() => {
-                this.mic.connect(this.recorder);
-                this.recorder.start();
-            })
-            .catch(error => {
-                console.error(error);
-            });
+        await this.mic.open();
+        this.mic.connect(this.recorder);
+        this.recorder.start();
     };
 
     const _disposeRecordingPlayer = () => {

--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -690,6 +690,21 @@ describe("Sampler Widget", () => {
 
             await widget._recordBtn.onclick();
             expect(widget.is_recording).toBe(true);
+
+            // Reset for mic denial test
+            widget.is_recording = false;
+            mockActivity.logo.synth.startRecording.mockRejectedValueOnce(
+                new Error("Permission denied")
+            );
+            widget.showMicDeniedMessage = jest.fn();
+            await widget._recordBtn.onclick();
+            expect(widget.is_recording).toBe(false);
+            expect(widget.showMicDeniedMessage).toHaveBeenCalled();
+
+            // Resume normal recording for subsequent tests
+            mockActivity.logo.synth.startRecording.mockResolvedValue();
+            await widget._recordBtn.onclick();
+            expect(widget.is_recording).toBe(true);
             await widget._recordBtn.onclick();
             expect(widget.is_recording).toBe(false);
 
@@ -980,6 +995,7 @@ describe("Sampler Widget", () => {
 
         test("startPitchDetection handles getUserMedia failure", async () => {
             widget.widgetWindow = widgetWindow;
+            widget.activity = mockActivity;
             const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
             global.AudioContext = jest.fn(() => ({
                 sampleRate: 44100,
@@ -998,14 +1014,14 @@ describe("Sampler Widget", () => {
                 },
                 configurable: true
             });
-            global.alert = jest.fn();
+            widget.showMicDeniedMessage = jest.fn();
 
             widget.makeTuner(400, 300);
             const startButton = document.getElementById("start");
             startButton.click();
 
             await Promise.resolve();
-            expect(global.alert).toHaveBeenCalled();
+            expect(widget.showMicDeniedMessage).toHaveBeenCalled();
             errorSpy.mockRestore();
         });
     });

--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -239,7 +239,8 @@ describe("Sampler Widget", () => {
                 },
                 canvas: { width: 1000, height: 800 },
                 getStageScale: () => 1,
-                textMsg: jest.fn()
+                textMsg: jest.fn(),
+                errorMsg: jest.fn()
             };
             global.activity = mockActivity;
             widget.activity = mockActivity;
@@ -724,6 +725,20 @@ describe("Sampler Widget", () => {
 
             await widget._recordBtn.onclick();
             expect(widget.is_recording).toBe(true);
+
+            // Reset for mic denial test
+            widget.is_recording = false;
+            mockActivity.logo.synth.startRecording.mockRejectedValueOnce(
+                new Error("Permission denied")
+            );
+            await widget._recordBtn.onclick();
+            expect(widget.is_recording).toBe(false);
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(_("Microphone access denied."));
+
+            // Resume normal recording for subsequent tests
+            mockActivity.logo.synth.startRecording.mockResolvedValue();
+            await widget._recordBtn.onclick();
+            expect(widget.is_recording).toBe(true);
             await widget._recordBtn.onclick();
             expect(widget.is_recording).toBe(false);
 
@@ -1070,6 +1085,7 @@ describe("Sampler Widget", () => {
         test("startPitchDetection handles getUserMedia failure", async () => {
             widget.widgetWindow = widgetWindow;
             mockActivity.errorMsg = jest.fn();
+            widget.activity = mockActivity;
             const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
             global.AudioContext = jest.fn(() => ({
                 sampleRate: 44100,

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -300,6 +300,42 @@ function SampleWidget() {
     };
 
     /**
+     * Displays a user-facing message when microphone access is denied.
+     * @param {string} msg - The message to display.
+     * @returns {void}
+     */
+    this.showMicDeniedMessage = function (msg) {
+        const printText = document.getElementById("printText");
+        const printTextContent = document.getElementById("printTextContent");
+        if (!printText || !printTextContent) {
+            return;
+        }
+
+        printTextContent.textContent = msg;
+        printText.classList.add("show");
+        printText.style.width = "";
+        printText.style.height = "";
+        printText.style.clip = "";
+        printText.style.overflow = "";
+        printText.style.padding = "";
+        printText.style.margin = "";
+        printText.style.whiteSpace = "";
+        printText.style.border = "";
+
+        setTimeout(function () {
+            printText.classList.remove("show");
+            printText.style.width = "1px";
+            printText.style.height = "1px";
+            printText.style.clip = "rect(0 0 0 0)";
+            printText.style.overflow = "hidden";
+            printText.style.padding = "0";
+            printText.style.margin = "-1px";
+            printText.style.whiteSpace = "nowrap";
+            printText.style.border = "0";
+        }, 3000);
+    };
+
+    /**
      * Saves the sample and generates a new sample block with the provided data.
      * @private
      * @returns {void}
@@ -947,11 +983,16 @@ function SampleWidget() {
         this._recordBtn.onclick = async () => {
             stopTuner();
             if (!this.is_recording) {
-                await this.activity.logo.synth.startRecording();
-                this.is_recording = true;
-                this._recordBtn.getElementsByTagName("img")[0].src = "header-icons/record.svg";
-                this.displayRecordingStartMessage();
-                this.activity.logo.synth.LiveWaveForm();
+                try {
+                    await this.activity.logo.synth.startRecording();
+                    this.is_recording = true;
+                    this._recordBtn.getElementsByTagName("img")[0].src = "header-icons/record.svg";
+                    this.displayRecordingStartMessage();
+                    this.activity.logo.synth.LiveWaveForm();
+                } catch (err) {
+                    console.error(err);
+                    this.showMicDeniedMessage(_("Microphone access denied."));
+                }
             } else {
                 this.recordingURL = await this.activity.logo.synth.stopRecording();
                 this.is_recording = false;
@@ -2271,7 +2312,7 @@ function SampleWidget() {
             this.pitchDetectionAnimationId = requestAnimationFrame(updatePitch);
         } catch (err) {
             console.error(`${err.name}: ${err.message}`);
-            alert(_("Microphone access failed: %s").replace(/%s/g, err.message));
+            this.showMicDeniedMessage(_("Microphone access denied."));
             // Clean up any partially initialized resources
             this.stopPitchDetection();
         }

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -921,11 +921,16 @@ function SampleWidget() {
         this._recordBtn.onclick = async () => {
             stopTuner();
             if (!this.is_recording) {
-                await this.activity.logo.synth.startRecording();
-                this.is_recording = true;
-                this._recordBtn.getElementsByTagName("img")[0].src = "header-icons/record.svg";
-                this.displayRecordingStartMessage();
-                this.activity.logo.synth.LiveWaveForm();
+                try {
+                    await this.activity.logo.synth.startRecording();
+                    this.is_recording = true;
+                    this._recordBtn.getElementsByTagName("img")[0].src = "header-icons/record.svg";
+                    this.displayRecordingStartMessage();
+                    this.activity.logo.synth.LiveWaveForm();
+                } catch (err) {
+                    console.error(err);
+                    this.activity.errorMsg(_("Microphone access denied."));
+                }
             } else {
                 this.recordingURL = await this.activity.logo.synth.stopRecording();
                 this.is_recording = false;


### PR DESCRIPTION
### Problem

When a user clicks the mic button in the Sampler widget and denies browser permission, the widget still acts as if the mic is active, the button changes to recording, ` is_recording ` becomes ` true `, and the button can't be toggled off. No error is shown to the user.

### Why This Happened
` startRecording() ` in  `synthutils.js` internally caught the mic permission error and only logged it to console. The caller (the Sampler widget) had no way to know the operation failed, so it always proceeded to update the UI state as if recording started successfully.

**How It's Fixed**
**1. Don't swallow errors in utility functions : `startRecording()`**
 no longer catches the mic error internally. It lets the rejection propagate so callers can decide how to handle it. As a general rule, low-level utility functions should let errors bubble up rather than silently logging them, the caller has the context to show the right message.

**2. Only update state after confirming success :** The recording button handler now wraps the async mic call in a try/catch. State changes (is_recording = true, icon swap) only happen inside the try block after the await resolves. On failure, the state stays unchanged and activity.errorMsg() shows a user-facing message. This is the same error banner pattern already used in the widget for file upload errors.

**3. Use consistent error messaging** : The tuner's pitch detection had a similar gap, it used a raw browser alert() on mic failure. Replaced with activity.errorMsg() to match the rest of the codebase.

**VIdeo:**

https://github.com/user-attachments/assets/de6667fe-5e5c-402b-b452-4e1c834d72d1

- [x] Feature