### PR TITLE
Fix: Prevent main thread crash on localStorage QuotaExceededError

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -53,7 +53,7 @@ try {
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
    SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
-   unescapeHTML
+   unescapeHTML, safeStorage
  */
 
 /*
@@ -93,6 +93,7 @@ let MYDEFINES = [
     "utils/utils",
     "utils/retryWithBackoff",
     "utils/debugLog",
+    "utils/safeStorage",
     "activity/artwork",
     "widgets/status",
     "utils/munsell",
@@ -8990,8 +8991,8 @@ class Activity {
      */
     saveLocally() {
         try {
-            localStorage.setItem("beginnerMode", this.beginnerMode.toString());
-            localStorage.setItem("themePreference", this.themePreference.toString());
+            safeStorage.setItem("beginnerMode", this.beginnerMode.toString());
+            safeStorage.setItem("themePreference", this.themePreference.toString());
         } catch (e) {
             console.error("Error saving to localStorage:", e);
         }

--- a/js/loader.js
+++ b/js/loader.js
@@ -153,6 +153,7 @@ requirejs.config({
     },
     paths: {
         "utils": "js/utils",
+        "safeStorage": "utils/safeStorage",
         "widgets": "js/widgets",
         "activity": "js",
         "easeljs.min": "lib/easeljs.min",

--- a/js/utils/__tests__/safeStorage.test.js
+++ b/js/utils/__tests__/safeStorage.test.js
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Music Blocks contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/**
+ * @jest-environment jsdom
+ */
+
+describe("safeStorage", () => {
+    let safeStorage;
+
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        safeStorage = require("../safeStorage");
+        safeStorage._resetMemFallback();
+    });
+
+    it("should set and get a value via native localStorage", () => {
+        safeStorage.setItem("key1", "value1");
+
+        expect(localStorage.getItem("key1")).toBe("value1");
+        expect(safeStorage.getItem("key1")).toBe("value1");
+    });
+
+    it("should fall back to in-memory store on QuotaExceededError", () => {
+        const quotaError = new DOMException("quota exceeded", "QuotaExceededError");
+        const spy = jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw quotaError;
+        });
+        const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+        safeStorage.setItem("key2", "value2");
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("QuotaExceededError")
+        );
+
+        // Native localStorage should not contain the value
+        spy.mockRestore();
+        expect(localStorage.getItem("key2")).toBeNull();
+
+        // But safeStorage should return it from memory
+        expect(safeStorage.getItem("key2")).toBe("value2");
+
+        warnSpy.mockRestore();
+    });
+
+    it("should re-throw non-quota errors from setItem", () => {
+        const securityError = new DOMException("blocked", "SecurityError");
+        jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw securityError;
+        });
+
+        expect(() => safeStorage.setItem("key3", "value3")).toThrow("blocked");
+
+        jest.restoreAllMocks();
+    });
+
+    it("should return null for unknown keys", () => {
+        expect(safeStorage.getItem("nonexistent")).toBeNull();
+    });
+
+    it("should remove a key from both native and memory stores", () => {
+        safeStorage.setItem("key4", "value4");
+        expect(safeStorage.getItem("key4")).toBe("value4");
+
+        safeStorage.removeItem("key4");
+        expect(safeStorage.getItem("key4")).toBeNull();
+        expect(localStorage.getItem("key4")).toBeNull();
+    });
+
+    it("should clear both native and in-memory stores", () => {
+        safeStorage.setItem("a", "1");
+        safeStorage.setItem("b", "2");
+
+        // Force one into memory fallback
+        const quotaError = new DOMException("quota exceeded", "QuotaExceededError");
+        jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw quotaError;
+        });
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        safeStorage.setItem("c", "3");
+        jest.restoreAllMocks();
+
+        expect(safeStorage.getItem("c")).toBe("3");
+
+        safeStorage.clear();
+
+        expect(safeStorage.getItem("a")).toBeNull();
+        expect(safeStorage.getItem("b")).toBeNull();
+        expect(safeStorage.getItem("c")).toBeNull();
+    });
+
+    it("should handle getItem when native localStorage throws", () => {
+        // Put value in memory fallback first
+        const quotaError = new DOMException("quota exceeded", "QuotaExceededError");
+        jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw quotaError;
+        });
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        safeStorage.setItem("memKey", "memVal");
+        jest.restoreAllMocks();
+
+        // Now make getItem throw too
+        jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+            throw new Error("storage unavailable");
+        });
+
+        // Should fall back to memory
+        expect(safeStorage.getItem("memKey")).toBe("memVal");
+
+        jest.restoreAllMocks();
+    });
+});

--- a/js/utils/safeStorage.js
+++ b/js/utils/safeStorage.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Music Blocks contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/* exported safeStorage */
+
+/**
+ * Safe localStorage wrapper that catches QuotaExceededError and falls
+ * back to an in-memory object so the main thread never crashes on
+ * low-storage devices.
+ *
+ * API mirrors the subset of Storage used by Music Blocks:
+ *   safeStorage.setItem(key, value)
+ *   safeStorage.getItem(key)
+ *   safeStorage.removeItem(key)
+ *   safeStorage.clear()
+ */
+var safeStorage = (function () {
+    "use strict";
+
+    /** @type {Object<string, string>} In-memory fallback store. */
+    var _memFallback = {};
+
+    /**
+     * Returns true if the error is a storage-quota error.
+     * @param {Error} e - The error object to check.
+     * @returns {boolean} True if the error is a quota error, false otherwise.
+     */
+    function _isQuotaError(e) {
+        return (
+            e instanceof DOMException &&
+            // Chrome / modern browsers
+            (e.code === 22 ||
+                e.code === 1014 ||
+                e.name === "QuotaExceededError" ||
+                // Firefox
+                e.name === "NS_ERROR_DOM_QUOTA_REACHED")
+        );
+    }
+
+    /**
+     * Stores a key-value pair. Falls back to memory on quota errors.
+     * @param {string} key - The key of the item to store.
+     * @param {string} value - The value to store.
+     */
+    function setItem(key, value) {
+        try {
+            window.localStorage.setItem(key, value);
+        } catch (e) {
+            if (_isQuotaError(e)) {
+                console.warn(
+                    '[safeStorage] QuotaExceededError for key "' +
+                        key +
+                        '". Saving to in-memory fallback.'
+                );
+                _memFallback[key] = String(value);
+            } else {
+                // Re-throw non-quota errors (e.g. SecurityError in private mode)
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Retrieves a value. Checks native localStorage first, then memory.
+     * @param {string} key - The key of the item to retrieve.
+     * @returns {string|null} The value associated with the key, or null if not found.
+     */
+    function getItem(key) {
+        try {
+            var val = window.localStorage.getItem(key);
+            if (val !== null) {
+                return val;
+            }
+        } catch (_) {
+            // localStorage inaccessible — fall through to memory
+        }
+        return _memFallback.hasOwnProperty(key) ? _memFallback[key] : null;
+    }
+
+    /**
+     * Removes a key from both native localStorage and memory.
+     * @param {string} key - The key of the item to remove.
+     */
+    function removeItem(key) {
+        try {
+            window.localStorage.removeItem(key);
+        } catch (_) {
+            // ignore
+        }
+        delete _memFallback[key];
+    }
+
+    /**
+     * Clears both native localStorage and in-memory fallback.
+     */
+    function clear() {
+        try {
+            window.localStorage.clear();
+        } catch (_) {
+            // ignore
+        }
+        _memFallback = {};
+    }
+
+    return {
+        setItem: setItem,
+        getItem: getItem,
+        removeItem: removeItem,
+        clear: clear,
+        /** @private Exposed only for testing. */
+        _memFallback: _memFallback,
+        /** @private Reset memory fallback (testing helper). */
+        _resetMemFallback: function () {
+            _memFallback = {};
+        }
+    };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = safeStorage;
+}


### PR DESCRIPTION
`localStorage.setItem()` throws a synchronous `QuotaExceededError` on low-end educational devices when limits are hit, crashing the main thread. This PR wraps storage calls with a try/catch and an in-memory fallback to prevent data loss and UI freezes.

### Proposed Changes
- **safeStorage utility**: Added `js/utils/safeStorage.js` exposing safe versions of `setItem`, `getItem`, `removeItem`, and `clear`.
- **In-memory fallback**: On `QuotaExceededError` or `NS_ERROR_DOM_QUOTA_REACHED`, it logs a warning and falls back to an `{}` in-memory object.
- **Loader integration**: Registered `utils/safeStorage` in `js/loader.js`.
- **Activity update**: Added `safeStorage` to `MYDEFINES` in `js/activity.js` and replaced direct `localStorage.setItem` calls within `saveLocally()`.
- **JSDoc Style**: Follows existing utility modules' JSDoc comment structures for consistency.

### Verification
Manually verified in the browser by artificially exhausting the `localStorage` quota via DevTools and triggering a save. `safeStorage` successfully intercepts the quota crash and retains the session data in memory without freezing the UI. All local tests and lint checks pass.

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Fixes #6857