### PR TITLE
fix: resolve Tone.js InvalidAccessError by updating PolySynth constru…

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1278,7 +1278,7 @@ function Synth() {
      */
     this.createDefaultSynth = turtle => {
         console.debug("create default poly/default/custom synth for turtle " + turtle);
-        const default_synth = new Tone.PolySynth(Tone.AMSynth, POLYCOUNT).toDestination();
+        const default_synth = new Tone.PolySynth(Tone.AMSynth, { maxPolyphony: POLYCOUNT }).toDestination();
         instruments[turtle]["electronic synth"] = default_synth;
         instrumentsSource["electronic synth"] = [0, "electronic synth"];
         instruments[turtle]["custom"] = default_synth;
@@ -1424,7 +1424,7 @@ function Synth() {
             case "poly":
                 instrumentsSource[instrumentName] = [0, "poly"];
                 // console.debug("poly");
-                builtin_synth = new Tone.PolySynth(Tone.AMSynth, synthOptions.polyphony);
+                builtin_synth = new Tone.PolySynth(Tone.AMSynth, { maxPolyphony: synthOptions.polyphony });
                 break;
             case "noise1":
             case "noise2":
@@ -1436,7 +1436,7 @@ function Synth() {
             default:
                 instrumentsSource[instrumentName] = [0, "poly"];
                 // console.debug("poly (default)");
-                builtin_synth = new Tone.PolySynth(Tone.AMSynth, POLYCOUNT);
+                builtin_synth = new Tone.PolySynth(Tone.AMSynth, { maxPolyphony: POLYCOUNT });
                 break;
         }
 
@@ -1464,7 +1464,7 @@ function Synth() {
         } else if (sourceName.toLowerCase() === "duosynth") {
             tempSynth = new Tone.DuoSynth(synthOptions);
         } else {
-            tempSynth = new Tone.PolySynth(Tone.AMSynth, POLYCOUNT);
+            tempSynth = new Tone.PolySynth(Tone.AMSynth, { maxPolyphony: POLYCOUNT });
         }
 
         return tempSynth;

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -751,7 +751,9 @@ function AIWidget() {
                 const analyser = this.pitchAnalysers[id];
                 if (analyser) {
                     for (const synth in instruments[0]) {
-                        instruments[0][synth].disconnect(analyser);
+                        try {
+                            instruments[0][synth].disconnect(analyser);
+                        } catch (e) {}
                     }
                     analyser.dispose();
                 }
@@ -958,14 +960,18 @@ function AIWidget() {
             }
 
             if (this.pitchAnalysers[analyser]) {
-                instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                try {
+                    instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                } catch (e) {}
                 instruments[0][synth].connect(this.pitchAnalysers[analyser]);
             }
 
             if (synth === "customsample_" + this.originalSampleName) {
                 analyser = 1;
                 if (this.pitchAnalysers[analyser]) {
-                    instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                    try {
+                        instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                    } catch (e) {}
                     instruments[0][synth].connect(this.pitchAnalysers[analyser]);
                 }
             }


### PR DESCRIPTION
# Pull Request: Fix AI Music Widget InvalidAccessError

## Overview
This Pull Request addresses the regression where the **AI Music widget** fails to launch, throwing an `Uncaught InvalidAccessError` in the console. This issue was specifically impacting the initialization of the 'electronic' synth and the AI Widget UI.

## The Root Causes
1. **Tone.js v15 PolySynth Constructor:** The first error stems from a breaking change in Tone.js v15. In previous versions, the `PolySynth` constructor accepted a raw integer as the second argument to define the maximum polyphony. In v15, `PolySynth` strictly expects an options object. Passing the constant `POLYCOUNT` (6) as a raw number caused Tone.js to attempt to access properties on a numeric primitive, resulting in an `InvalidAccessError`.
2. **Native Web Audio API Disconnect:** When the AI Music widget initializes, it attempts to clean the audio node connections by calling `disconnect()` on the synth nodes. However, calling `disconnect()` on an audio node that is not currently connected to the destination node throws a native `InvalidAccessError`, which broke the UI initialization thread.

## Changes Made
- Modified [js/utils/synthutils.js](cci:7://file:///home/nikhil/Documents/c4gt/musicblocks/js/utils/synthutils.js:0:0-0:0).
  - Updated all `Tone.PolySynth` instantiations to use the object-based configuration.
  - **Before:** `new Tone.PolySynth(Tone.Synth, POLYCOUNT)`
  - **After:** `new Tone.PolySynth(Tone.Synth, { maxPolyphony: POLYCOUNT })`
- Modified [js/widgets/aiwidget.js](cci:7://file:///home/nikhil/Documents/c4gt/musicblocks/js/widgets/aiwidget.js:0:0-0:0).
  - Wrapped `disconnect()` calls inside [reconnectSynthsToAnalyser()](cci:1://file:///home/nikhil/Documents/c4gt/musicblocks/js/widgets/aiwidget.js:939:4-978:6) and the `widgetWindow.onclose()` handler with `try...catch` blocks to safely ignore the `InvalidAccessError` when nodes are not yet connected.

## Verification & Testing
1.  **Reproduction:** Confirmed the `Tone.js:2 Uncaught InvalidAccessError` on `localhost:3000` when clicking the AI Music block in the workspace.
2.  **Fix Verification:** Applied changes and verified the widget interface now opens successfully without native Audio API errors.
3.  **Synth Loading:** Confirmed the `electronic` synth loads into the turtle without crashing.
4.  **Regression Check:** Ran existing tests to ensure no other instrument types were affected by the change in constructor syntax.

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Fixes
Fixes #6853