### PR TITLE
fix:   [Bug] AI music widget Not opening #6853

### DIFF
--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -751,7 +751,11 @@ function AIWidget() {
                 const analyser = this.pitchAnalysers[id];
                 if (analyser) {
                     for (const synth in instruments[0]) {
-                        instruments[0][synth].disconnect(analyser);
+                        try {
+                            instruments[0][synth].disconnect(analyser);
+                        } catch (e) {
+                            console.debug("Failed to disconnect synth from analyser:", e);
+                        }
                     }
                     analyser.dispose();
                 }
@@ -958,14 +962,22 @@ function AIWidget() {
             }
 
             if (this.pitchAnalysers[analyser]) {
-                instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                try {
+                    instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                } catch (e) {
+                    console.debug("Failed to disconnect synth from analyser:", e);
+                }
                 instruments[0][synth].connect(this.pitchAnalysers[analyser]);
             }
 
             if (synth === "customsample_" + this.originalSampleName) {
                 analyser = 1;
                 if (this.pitchAnalysers[analyser]) {
-                    instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                    try {
+                        instruments[0][synth].disconnect(this.pitchAnalysers[analyser]);
+                    } catch (e) {
+                        console.debug("Failed to disconnect synth from analyser:", e);
+                    }
                     instruments[0][synth].connect(this.pitchAnalysers[analyser]);
                 }
             }


### PR DESCRIPTION
**Fixes:** #6853

**Describe the bug:**
Clicking the "AI Music" block in the workspace failed to open the widget interface. Instead, it triggered an `Uncaught InvalidAccessError` originating from `Tone.js` in the console, completely halting the widget's initialization thread.

<img width="1919" height="1000" alt="image" src="https://github.com/user-attachments/assets/8fab6a54-7693-4dae-abbc-393384ed26df" />



**Root cause:**
When the AI Music widget initializes (`init()`), it establishes a connection to the pitch analyzer by calling `reconnectSynthsToAnalyser()`. This function tries to ensure a clean connection state by first disconnecting the synth from the analyzer before reconnecting it:
```javascript
instruments[0][synth].disconnect(this.pitchAnalysers[analyser]); 
```
However, the native Web Audio API throws an `InvalidAccessError` when `disconnect()` is called on a destination node that the audio node isn't currently connected to. Because the synth was not yet connected during the first launch, the unhandled error broke the UI initialization.

**Solution implemented:**
Wrapped the vulnerable `disconnect()` calls in `reconnectSynthsToAnalyser()` and the `widgetWindow.onclose()` handler inside `try...catch` blocks within `musicblocks/js/widgets/aiwidget.js`. This safely catches and ignores the `InvalidAccessError` when a node isn't connected, allowing the thread to continue and successfully connect the nodes.

**How to Test:**
1. Open the MusicBlocks workspace.
2. Find the **AI Music** widget block in the palette.
3. Drag the block into the workspace.
4. Click on the block to launch it.
5. Verify that the AI widget opens successfully without throwing an `InvalidAccessError` in the console.