### PR TITLE
fix: support portrait orientation in PWA manifest

### DIFF
--- a/android_chrome_manifest.json
+++ b/android_chrome_manifest.json
@@ -78,7 +78,7 @@
   "background_color": "#F9F9F9",
   "theme_color": "#2196F3",
   "display": "standalone",
-  "orientation": "landscape",
+  "orientation": "any",
   "dir": "ltr",
   "lang": "en",
   "categories": ["code", "education"],


### PR DESCRIPTION
## Summary

The PWA manifest (`android_chrome_manifest.json`) currently locks the app to landscape-only orientation. This prevents portrait mode on mobile devices, which is the natural hold position for phones.

## Change

- `"orientation": "landscape"` → `"orientation": "any"`

This allows the app to be used in both portrait and landscape on Android Chrome and other PWA-capable browsers, which is especially important for improving the mobile editing experience.

## Testing

Verified that the manifest JSON remains valid after the change. The `"any"` value is a standard [Web App Manifest orientation member](https://developer.mozilla.org/en-US/docs/Web/Manifest/orientation) value that permits all orientations.

Related to #6603

PR Category

- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation