### PR TITLE
fix(#6870): clear typing indicator interval before resetting conversation

### DIFF
--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -613,6 +613,7 @@ function AIDebuggerWidget() {
         this.chatHistory = [];
         this.promptCount = 0; // Reset prompt count
         this.conversationId = this._generateConversationId();
+        this._hideTypingIndicator();
         this.chatLog.innerHTML = "";
 
         this._loadProjectAndInitialize();


### PR DESCRIPTION
## PR Category
- [x] Bug Fix

## Summary
- Calls `_hideTypingIndicator()` before `chatLog.innerHTML = ""` in `_resetConversation()` so the active `setInterval` is properly cleared.
- Without this fix, resetting the conversation while the typing indicator is active causes the interval to leak indefinitely.

## Related Issue
Fixes #6870

## Test plan
- [ ] Open AI Debugger widget
- [ ] Send a message and while "Debugger is typing..." is visible, click Reset
- [ ] Confirm no leaked intervals (check browser DevTools > Sources > Event Listener Breakpoints or monitor timer count)
- [ ] Confirm the reset works normally and new typing indicator appears correctly