### PR TITLE
Feat: Add Web Share API support for project export

### DIFF
--- a/index.html
+++ b/index.html
@@ -907,11 +907,13 @@
                     </nav>
 
                     <ul id="saveddropdownbeg" class="dropdown-content">
+                        <li><a id="share-project-beg" role="button" tabindex="0"></a></li>
                         <li><a id="save-html-beg" role="button" tabindex="0"></a></li>
                         <li><a id="save-png-beg" role="button" tabindex="0"></a></li>
                     </ul>
 
                     <ul id="saveddropdown" class="dropdown-content">
+                        <li><a id="share-project" role="button" tabindex="0"></a></li>
                         <li><a id="save-html" role="button" tabindex="0"></a></li>
                         <li><a id="save-midi" role="button" tabindex="0"></a></li>
                         <li><a id="save-svg" role="button" tabindex="0"></a></li>

--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -1041,6 +1041,56 @@ class SaveInterface {
             this.activity.logo.runningMxml = false;
         });
     }
+
+    /**
+     * Share the project file using Native Web Share API.
+     *
+     * @param {SaveInterface} activity - The activity object to share.
+     * @returns {void}
+     * @memberof SaveInterface
+     * @method
+     * @instance
+     */
+    shareProject(activity) {
+        if (!navigator.share || !navigator.canShare) {
+            activity.errorMsg(_("Your browser does not support the Web Share API."));
+            return;
+        }
+
+        let filename = STR_MY_PROJECT;
+        if (activity.PlanetInterface !== undefined) {
+            filename = activity.PlanetInterface.getCurrentProjectName();
+        }
+
+        if (fileExt(filename) !== "html") {
+            filename += ".html";
+        }
+
+        try {
+            const htmlContent = activity.save.prepareHTML();
+            const file = new File([htmlContent], filename, { type: "text/html" });
+
+            if (navigator.canShare({ files: [file] })) {
+                navigator
+                    .share({
+                        files: [file],
+                        title: filename,
+                        text: _("Check out my Music Blocks project!")
+                    })
+                    .catch(error => {
+                        console.debug("Error sharing:", error);
+                        if (error.name !== "AbortError") {
+                            activity.errorMsg(_("Failed to share the project."));
+                        }
+                    });
+            } else {
+                activity.errorMsg(_("Your system does not support sharing files."));
+            }
+        } catch (err) {
+            console.error("Share error:", err);
+            activity.errorMsg(_("An error occurred while preparing the project to share."));
+        }
+    }
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -103,14 +103,14 @@ describe("Toolbar Class", () => {
     test("sets correct strings for _THIS_IS_MUSIC_BLOCKS_ true", () => {
         global._THIS_IS_MUSIC_BLOCKS_ = true;
         toolbar.init({});
-        expect(global._).toHaveBeenCalledTimes(141);
+        expect(global._).toHaveBeenCalledTimes(144);
         expect(global._).toHaveBeenNthCalledWith(1, "About Music Blocks");
     });
 
     test("sets correct strings for _THIS_IS_MUSIC_BLOCKS_ false", () => {
         global._THIS_IS_MUSIC_BLOCKS_ = false;
         toolbar.init({});
-        expect(global._).toHaveBeenCalledTimes(123);
+        expect(global._).toHaveBeenCalledTimes(126);
         expect(global._).toHaveBeenNthCalledWith(1, "About Turtle Blocks");
     });
 
@@ -476,8 +476,10 @@ describe("Toolbar Class", () => {
         const elements = {
             "saveButton": { onclick: null, style: { display: "" } },
             "saveButtonAdvanced": { onclick: null, style: { display: "" } },
+            "share-project-beg": { onclick: null, style: { display: "" } },
             "save-html-beg": { onclick: null },
             "save-png-beg": { onclick: null, disabled: false, className: "" },
+            "share-project": { onclick: null, style: { display: "" } },
             "save-html": { onclick: null },
             "save-svg": { onclick: null, disabled: false, className: "" },
             "save-png": { onclick: null, disabled: false, className: "" },
@@ -512,7 +514,8 @@ describe("Toolbar Class", () => {
             abc_onclick: jest.fn(),
             mxml_onclick: jest.fn(),
             blockartworksvg_onclick: jest.fn(),
-            blockartworkpng_onclick: jest.fn()
+            blockartworkpng_onclick: jest.fn(),
+            share_onclick: jest.fn()
         };
 
         const toolbar = new Toolbar();
@@ -859,7 +862,8 @@ describe("Toolbar Class", () => {
                 saveAbc: jest.fn(),
                 saveMxml: jest.fn(),
                 saveBlockArtwork: jest.fn(),
-                saveBlockArtworkPNG: jest.fn()
+                saveBlockArtworkPNG: jest.fn(),
+                shareProject: jest.fn()
             },
             toolbar: {
                 renderSaveIcons: jest.fn(),
@@ -938,6 +942,9 @@ describe("Toolbar Class", () => {
 
         renderSaveIconsArgs[10]();
         expect(mockActivity.save.saveBlockArtworkPNG).toHaveBeenCalled();
+
+        renderSaveIconsArgs[11]();
+        expect(mockActivity.save.shareProject).toHaveBeenCalled();
     });
 
     test("renderRunStepIcon sets onclick and handles Japanese beginner mode", () => {
@@ -1264,7 +1271,8 @@ describe("Toolbar Class", () => {
                 saveBlockArtwork: jest.fn(),
                 saveThumbnail: jest.fn(),
                 saveBlockArtworkSVG: jest.fn(),
-                saveBlockArtworkPNG: jest.fn()
+                saveBlockArtworkPNG: jest.fn(),
+                shareProject: jest.fn()
             }
         };
         global.setScroller = jest.fn();

--- a/js/activity.js
+++ b/js/activity.js
@@ -8269,7 +8269,8 @@ class Activity {
                 this.save.saveAbc.bind(this.save),
                 this.save.saveMxml.bind(this.save),
                 this.save.saveBlockArtwork.bind(this.save),
-                this.save.saveBlockArtworkPNG.bind(this.save)
+                this.save.saveBlockArtworkPNG.bind(this.save),
+                this.save.shareProject.bind(this.save)
             );
             this.toolbar.renderPlanetIcon(this.planet, doOpenSamples);
             this.toolbar.renderMenuIcon(showHideAuxMenu);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -114,6 +114,8 @@ class Toolbar {
                 ["beginnerMode", _("Switch to beginner mode")],
                 ["advancedMode", _("Switch to advanced mode")],
                 ["languageSelectIcon", _("Select language")],
+                ["share-project-beg", _("Share project file"), "innerHTML"],
+                ["share-project", _("Share project file"), "innerHTML"],
                 ["save-html-beg", _("Save project as HTML"), "innerHTML"],
                 ["save-png-beg", _("Save mouse artwork as PNG"), "innerHTML"],
                 ["save-html", _("Save project as HTML"), "innerHTML"],
@@ -186,6 +188,7 @@ class Toolbar {
                 _("Switch to beginner mode"),
                 _("Switch to advanced mode"),
                 _("Select language"),
+                _("Share project file"),
                 _("Save project as HTML"),
                 _("Save project as MIDI"),
                 _("Save mouse artwork as SVG"),
@@ -261,6 +264,8 @@ class Toolbar {
                 ["beginnerMode", _("Switch to beginner mode")],
                 ["advancedMode", _("Switch to advanced mode")],
                 ["languageSelectIcon", _("Select language")],
+                ["share-project-beg", _("Share project file"), "innerHTML"],
+                ["share-project", _("Share project file"), "innerHTML"],
                 ["save-html-beg", _("Save project as HTML"), "innerHTML"],
                 ["save-png-beg", _("Save turtle artwork as PNG"), "innerHTML"],
                 ["save-html", _("Save project as HTML"), "innerHTML"],
@@ -327,6 +332,7 @@ class Toolbar {
                 _("Switch to beginner mode"),
                 _("Switch to advanced mode"),
                 _("Select language"),
+                _("Share project file"),
                 _("Save project as HTML"),
                 _("Save turtle artwork as PNG"),
                 _("Save project as HTML"),
@@ -876,7 +882,8 @@ class Toolbar {
         abc_onclick,
         mxml_onclick,
         blockartworksvg_onclick,
-        blockartworkpng_onclick
+        blockartworkpng_onclick,
+        share_onclick
     ) {
         const saveButton = docById("saveButton");
         const saveButtonAdvanced = docById("saveButtonAdvanced");
@@ -893,6 +900,15 @@ class Toolbar {
                     saveHTML.onclick = () => {
                         html_onclick(this.activity);
                     };
+
+                    const shareProjectBeg = docById("share-project-beg");
+                    if (navigator.share) {
+                        shareProjectBeg.onclick = () => {
+                            share_onclick(this.activity);
+                        };
+                    } else {
+                        shareProjectBeg.style.display = "none";
+                    }
 
                     const savePNG = docById("save-png-beg");
                     const svgData = doSVG_onclick(
@@ -926,6 +942,16 @@ class Toolbar {
                 saveHTML.onclick = () => {
                     html_onclick(this.activity);
                 };
+
+                const shareProject = docById("share-project");
+                if (navigator.share) {
+                    shareProject.onclick = () => {
+                        share_onclick(this.activity);
+                    };
+                } else {
+                    shareProject.style.display = "none";
+                }
+
                 const saveSVG = docById("save-svg");
                 const savePNG = docById("save-png");
                 const svgData = doSVG_onclick(
@@ -1410,7 +1436,8 @@ class Toolbar {
                 this.activity.save.saveAbc.bind(this.activity.save),
                 this.activity.save.saveMxml.bind(this.activity.save),
                 this.activity.save.saveBlockArtwork.bind(this.activity.save),
-                this.activity.save.saveBlockArtworkPNG.bind(this.activity.save)
+                this.activity.save.saveBlockArtworkPNG.bind(this.activity.save),
+                this.activity.save.shareProject.bind(this.activity.save)
             );
         };
 


### PR DESCRIPTION

# PR Description: Native Web Share API Integration

## Summary
This PR implements the **Native Web Share API** for Music Blocks, allowing users to share their project `.html` files directly through their operating system's native share sheet. This is a major accessibility improvement for mobile users and those collaborating across different devices.

## Related Issue
Closes #6868

## Changes
### 🎨 UI & UX
- Added **"Share project file"** option to the Save dropdown menu in both **Beginner** and **Advanced** modes.
- Added localization strings for "Share project file" to support international users.
- Implemented **Feature Detection**: The share button only appears if the browser supports the `navigator.share` API (hides automatically on unsupported platforms like Desktop Firefox).

<img width="1599" height="678" alt="Screenshot 2026-04-25 192706" src="https://github.com/user-attachments/assets/d265cde1-5790-4bf8-ad92-fdc566fc1edd" />
---
<img width="1403" height="818" alt="Screenshot 2026-04-25 192647" src="https://github.com/user-attachments/assets/a06803a8-1b2c-470e-9a4d-19f776211b9d" />
 

### ⚙️ Core Logic
- **`js/SaveInterface.js`**: Added `shareProject(activity)` method which:
    - Generates the project HTML content.
    - Constructs a `File` object (`text/html`).
    - Triggers `navigator.share()` with the file, project title, and a descriptive message.
- **`js/toolbar.js`**: Refactored `renderSaveIcons` to handle the new `share_onclick` callback and wire it to the UI elements.
- **`js/activity.js`**: Connected the `SaveInterface` logic to the `Toolbar` during initialization.

### 🧪 Quality & Testing
- Updated **`js/__tests__/toolbar.test.js`** to:
    - Include mocks for the new sharing dependency.
    - Verify that `renderSaveIcons` receives the correct callback.
    - Adjusted assertion counts for localization strings.
- Verified that all 39 tests in the toolbar suite are passing.

## Verification Plan

### Automated Tests
- Ran `npm test js/__tests__/toolbar.test.js` (All tests passed).
- Verified no linting errors were introduced.

### Manual Verification
1. Start the dev server: `npm run dev`.
2. Open `http://127.0.0.1:3000` in a supported browser (Chrome, Edge, or Safari).
3. Click the **Save/Download** icon in the toolbar.
4. Click **"Share project file"**.
5. **Expected Result:** The system's native share dialog opens, allowing you to share the `.html` file via Email, AirDrop, messaging apps, etc.

### PR Category
- [ ] Bug Fix  
- [x] Feature  
- [ ] Enhancement  
- [ ] Refactoring  
- [ ] Documentation  
---