### PR TITLE
Fix file chooser reset for same-file reload (#6872)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -8354,8 +8354,8 @@ class Activity {
                 }
             }
 
-            this.fileChooser.addEventListener("click", () => {
-                that.value = null;
+            this.fileChooser.addEventListener("click", event => {
+                event.currentTarget.value = "";
             });
 
             this.fileChooser.addEventListener(
@@ -8629,13 +8629,13 @@ class Activity {
             dropZone.addEventListener("dragover", __handleDragOver, false);
             dropZone.addEventListener("drop", __handleFileSelect, false);
 
-            this.allFilesChooser.addEventListener("click", () => {
-                this.value = null;
+            this.allFilesChooser.addEventListener("click", event => {
+                event.currentTarget.value = "";
             });
 
-            this.pluginChooser.addEventListener("click", () => {
+            this.pluginChooser.addEventListener("click", event => {
                 window.scroll(0, 0);
-                this.value = null;
+                event.currentTarget.value = "";
             });
 
             this.pluginChooser.addEventListener(


### PR DESCRIPTION
## Summary
Fixes issue #6872 by correctly clearing the actual file input element on chooser click.

Previously, click handlers wrote `.value = null` to the `Activity` instance context (`that` / lexical `this`) instead of the input element, so selecting the same file again could fail to trigger `change`.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Changes
- `js/activity.js`
- Updated these click handlers to clear `event.currentTarget.value`:
  - `this.fileChooser`
  - `this.allFilesChooser`
  - `this.pluginChooser`

## Why this fix
Using `event.currentTarget.value = ""` guarantees we reset the clicked `<input type="file">` directly, independent of lexical `this` binding.

## Validation
- `npx eslint js/activity.js`
- `npx jest --runTestsByPath js/__tests__/activity_listeners.test.js js/__tests__/activity_blur_handler.test.js --coverage=false`

Closes #6872.
