### PR TITLE
Guard startup paths when localStorage is unavailable (#6873)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1040,8 +1040,15 @@
         <script>
             // Register service worker only in production (not on localhost)
             if ("serviceWorker" in navigator) {
+                const readStorage = key => {
+                    try {
+                        return localStorage.getItem(key);
+                    } catch (e) {
+                        return null;
+                    }
+                };
                 // Localhost SW is disabled to avoid caching; set allowLocalPwa to test installs.
-                const allowLocalPwa = localStorage.getItem("allowLocalPwa") === "true";
+                const allowLocalPwa = readStorage("allowLocalPwa") === "true";
 
                 // Detect if running on localhost for development
                 const runtimeEnv = window.MB_ENV;
@@ -1121,12 +1128,28 @@
         <script>
             document.addEventListener("DOMContentLoaded", function () {
                 window._ = window._ || (x => x);
+                const readStorage = key => {
+                    try {
+                        return localStorage.getItem(key);
+                    } catch (e) {
+                        return null;
+                    }
+                };
+                const writeStorage = (key, value) => {
+                    try {
+                        localStorage.setItem(key, value);
+                        return true;
+                    } catch (e) {
+                        return false;
+                    }
+                };
                 let loadL10nSplashScreen = function () {
                     console.debug("The browser is set to " + navigator.language);
                     let lang = navigator.language;
-                    if (localStorage.languagePreference) {
-                        console.debug("Music Blocks is set to " + localStorage.languagePreference);
-                        lang = localStorage.languagePreference;
+                    const savedLanguage = readStorage("languagePreference");
+                    if (savedLanguage) {
+                        console.debug("Music Blocks is set to " + savedLanguage);
+                        lang = savedLanguage;
                     }
 
                     console.debug("Using " + lang);
@@ -1169,9 +1192,8 @@
                         link.addEventListener("click", function (e) {
                             e.preventDefault(); // prevent default <a> behavior
                             const selectedLang = this.id; // ID corresponds to language code
-                            const currentLang = localStorage.getItem("languagePreference");
-                            if (currentLang !== selectedLang) {
-                                localStorage.setItem("languagePreference", selectedLang);
+                            const currentLang = readStorage("languagePreference");
+                            if (currentLang !== selectedLang && writeStorage("languagePreference", selectedLang)) {
                                 location.reload(); // automatically reload
                             }
                         });

--- a/js/activity.js
+++ b/js/activity.js
@@ -323,7 +323,12 @@ class Activity {
         this.keyboardEnableFlag;
         this.inTempoWidget = false;
         this.projectID = null;
-        this.storage = localStorage;
+        try {
+            this.storage = localStorage;
+        } catch (e) {
+            // Fall back to in-memory storage when browser storage is restricted.
+            this.storage = {};
+        }
 
         // Flag to indicate whether the user is performing a 2D drag operation.
         this.isDragging = false;
@@ -1837,7 +1842,12 @@ class Activity {
              */
 
             async function recordScreen() {
-                const mode = localStorage.getItem("musicBlocksRecordMode");
+                let mode = null;
+                try {
+                    mode = localStorage.getItem("musicBlocksRecordMode");
+                } catch (e) {
+                    mode = null;
+                }
 
                 if (mode === "canvas") {
                     return await recordCanvasOnly();

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -1594,7 +1594,11 @@ class BaseBlock extends ProtoBlock {
          * Language preference for the block.
          * @type {string}
          */
-        this.lang = localStorage.languagePreference || navigator.language;
+        try {
+            this.lang = localStorage.languagePreference || navigator.language;
+        } catch (e) {
+            this.lang = navigator.language;
+        }
     }
 
     /**

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -19,6 +19,43 @@
 let WRAP = true;
 const $j = window.jQuery;
 let play_button_debounce_timeout = null;
+
+const safeStorageGet = key => {
+    try {
+        if (typeof localStorage === "undefined" || localStorage === null) {
+            return undefined;
+        }
+
+        if (typeof localStorage.getItem === "function") {
+            const value = localStorage.getItem(key);
+            if (value !== null) {
+                return value;
+            }
+        }
+
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
+
+const safeStorageSet = (key, value) => {
+    try {
+        if (typeof localStorage === "undefined" || localStorage === null) {
+            return;
+        }
+
+        if (typeof localStorage.setItem === "function") {
+            localStorage.setItem(key, value);
+            return;
+        }
+
+        localStorage[key] = value;
+    } catch (e) {
+        console.debug(`Storage write skipped for ${key}:`, e);
+    }
+};
+
 class Toolbar {
     /**
      * Constructs a new Toolbar instance.
@@ -27,7 +64,7 @@ class Toolbar {
      */
     constructor() {
         this.stopIconColorWhenPlaying = window.platformColor.stopIconcolor;
-        this.language = localStorage.languagePreference;
+        this.language = safeStorageGet("languagePreference");
         if (this.language === undefined) {
             this.language = navigator.language;
         }
@@ -744,7 +781,7 @@ class Toolbar {
         if (!icon) return;
 
         themes.forEach(theme => {
-            if (localStorage.themePreference === theme) {
+            if (safeStorageGet("themePreference") === theme) {
                 icon.innerHTML = docById(theme).innerHTML;
             }
         });
@@ -1031,7 +1068,7 @@ class Toolbar {
 
         // Set the onclick handler
         Record.onclick = function () {
-            const savedMode = localStorage.getItem("musicBlocksRecordMode") || "screen";
+            const savedMode = safeStorageGet("musicBlocksRecordMode") || "screen";
             rec_onclick();
         };
 
@@ -1088,7 +1125,7 @@ class Toolbar {
 
         // Function to update highlighting based on current mode
         const updateModeHighlight = () => {
-            const currentMode = localStorage.getItem("musicBlocksRecordMode") || "screen";
+            const currentMode = safeStorageGet("musicBlocksRecordMode") || "screen";
 
             // Remove highlight from both
             if (recordWithMenus) {
@@ -1116,7 +1153,7 @@ class Toolbar {
         if (recordWithMenus) {
             recordWithMenus.onclick = e => {
                 e.preventDefault();
-                localStorage.setItem("musicBlocksRecordMode", "screen");
+                safeStorageSet("musicBlocksRecordMode", "screen");
                 updateModeHighlight();
                 // Reset arrow after selection
                 const arrowIcon = RecordDropdownArrow.querySelector("i");
@@ -1127,7 +1164,7 @@ class Toolbar {
         if (recordCanvasOnly) {
             recordCanvasOnly.onclick = e => {
                 e.preventDefault();
-                localStorage.setItem("musicBlocksRecordMode", "canvas");
+                safeStorageSet("musicBlocksRecordMode", "canvas");
                 updateModeHighlight();
 
                 // Reset arrow after selection
@@ -1419,7 +1456,7 @@ class Toolbar {
             this.activity.beginnerMode = !this.activity.beginnerMode;
 
             try {
-                localStorage.setItem("beginnerMode", this.activity.beginnerMode.toString());
+                safeStorageSet("beginnerMode", this.activity.beginnerMode.toString());
             } catch (e) {
                 console.error(e);
             }
@@ -1647,7 +1684,7 @@ class Toolbar {
 
             // Handle Japanese variants (ja-kanji, ja-kana stored vs ja/kana displayed)
             if (selectedLang && selectedLang.startsWith("ja")) {
-                if (selectedLang === "ja-kana" || localStorage.kanaPreference === "kana") {
+                if (selectedLang === "ja-kana" || safeStorageGet("kanaPreference") === "kana") {
                     langToHighlight = "kana";
                 } else {
                     langToHighlight = "ja";
@@ -1676,7 +1713,7 @@ class Toolbar {
 
         languageSelectIcon.onclick = () => {
             // Get current language preference
-            const currentLang = localStorage.languagePreference || navigator.language;
+            const currentLang = safeStorageGet("languagePreference") || navigator.language;
 
             // Highlight the currently selected language
             updateSelectedLanguageHighlight(currentLang);

--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -19,7 +19,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* exported showButtonHighlight */
 
-const themePreference = localStorage.themePreference || undefined;
+let themePreference;
+try {
+    themePreference = localStorage.themePreference || undefined;
+} catch (e) {
+    themePreference = undefined;
+}
 
 window.platform = {
     android: /Android/i.test(navigator.userAgent),


### PR DESCRIPTION
## Summary
This PR hardens startup and early UI initialization when browser storage access is restricted (for example, environments where `localStorage` throws on access).

It prevents initialization-time crashes by replacing unguarded `localStorage` reads in startup-critical paths with safe fallbacks.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## What changed
- `js/activity.js`
  - Guarded `this.storage = localStorage` with fallback to in-memory object.
  - Guarded record-mode read path to avoid throwing if storage is blocked.
- `js/toolbar.js`
  - Added `safeStorageGet`/`safeStorageSet` helpers.
  - Replaced direct storage reads/writes in constructor and toolbar flows with guarded helpers.
- `js/protoblocks.js`
  - Guarded language preference read with navigator fallback.
- `js/utils/platformstyle.js`
  - Guarded theme preference read with safe default.
- `index.html`
  - Guarded storage reads in service-worker gating and splash/language initialization script.
  - Guarded language preference write before reload.

## Why this fixes #6873
When storage is restricted, unguarded `localStorage` access can throw synchronously and abort startup. This PR ensures those code paths degrade gracefully and continue with defaults.

## Validation
- `npx eslint js/activity.js js/toolbar.js js/protoblocks.js js/utils/platformstyle.js`
- `npx jest --runTestsByPath js/__tests__/toolbar.test.js js/__tests__/protoblocks.test.js js/utils/__tests__/platformstyle.test.js js/__tests__/activity_listeners.test.js js/__tests__/activity_blur_handler.test.js --coverage=false`

Closes #6873.
