### PR TITLE
Fix idle watcher cleanup mismatch by using canonical teardown (#6875)

### DIFF
--- a/js/__tests__/activity_listeners.test.js
+++ b/js/__tests__/activity_listeners.test.js
@@ -148,6 +148,14 @@ describe("Activity Event Listener Management", () => {
         expect(activity._listeners).toHaveLength(0);
     });
 
+    test("should delegate idle watcher cleanup through _stopIdleWatcher", () => {
+        activity._stopIdleWatcher = jest.fn();
+
+        activity.cleanupEventListeners();
+
+        expect(activity._stopIdleWatcher).toHaveBeenCalledTimes(1);
+    });
+
     test("should handle boolean options vs object options", () => {
         // true === { capture: true } in our logic?
         // _areOptionsEqual logic: normalize boolean to boolean, object to !!opt.capture

--- a/js/activity.js
+++ b/js/activity.js
@@ -3135,26 +3135,9 @@ class Activity {
             const IDLE_THRESHOLD = 5000; // 5 seconds
             const ACTIVE_FPS = 60;
             const IDLE_FPS = 1;
-            const idleEvents = ["mousemove", "mousedown", "keydown", "touchstart", "wheel"];
-
-            if (this._idleWatcherResetHandler) {
-                idleEvents.forEach(eventType => {
-                    window.removeEventListener(eventType, this._idleWatcherResetHandler);
-                });
-            }
-
-            if (this._idleWatcherIntervalId) {
-                clearInterval(this._idleWatcherIntervalId);
-                this._idleWatcherIntervalId = null;
-            }
 
             let lastActivity = Date.now();
             this.isAppIdle = false;
-
-            // Prevent duplicate intervals
-            if (this._idleWatcherIntervalId) {
-                clearInterval(this._idleWatcherIntervalId);
-            }
 
             // Wake up function - restores full framerate
             // Stored as instance property for cleanup
@@ -9010,16 +8993,9 @@ class Activity {
             }
         }
 
-        if (this._idleWatcherResetHandler) {
-            ["mousemove", "mousedown", "keydown", "touchstart", "wheel"].forEach(eventType => {
-                window.removeEventListener(eventType, this._idleWatcherResetHandler);
-            });
-            this._idleWatcherResetHandler = null;
-        }
-
-        if (this._idleWatcherIntervalId) {
-            clearInterval(this._idleWatcherIntervalId);
-            this._idleWatcherIntervalId = null;
+        // Keep idle watcher cleanup centralized to avoid stale field mismatches.
+        if (typeof this._stopIdleWatcher === "function") {
+            this._stopIdleWatcher();
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #6875 by removing stale idle-watcher field cleanup paths and centralizing idle-watcher teardown in one canonical method.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Changes
- `js/activity.js`
  - Removed stale cleanup references to `_idleWatcherIntervalId` and `_idleWatcherResetHandler` from `_initIdleWatcher()`.
  - Updated `cleanupEventListeners()` to call `_stopIdleWatcher()` as the single source of truth.
- `js/__tests__/activity_listeners.test.js`
  - Added regression test to ensure `cleanupEventListeners()` delegates idle-watcher cleanup via `_stopIdleWatcher()`.

## Why this fix
Idle watcher runtime state uses `_idleWatcherInterval` and `_resetIdleTimer`. Cleaning different fields leaves lifecycle behavior inconsistent and risks missed cleanup. Centralizing teardown avoids this mismatch class entirely.

## Validation
- `npx eslint js/activity.js js/__tests__/activity_listeners.test.js`
- `npx jest --runTestsByPath js/__tests__/activity_listeners.test.js js/__tests__/activity_blur_handler.test.js --coverage=false`

Closes #6875.
