### PR TITLE
fix: render rhythm ruler note values as DOM nodes (Related to #6854)

### DIFF
--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -89,6 +89,7 @@ const mockWindow = {
                         appendChild: jest.fn(),
                         setAttribute: jest.fn(),
                         style: {},
+                        textContent: "",
                         innerHTML: "",
                         addEventListener: jest.fn()
                     })
@@ -116,6 +117,8 @@ global.document = {
             setAttribute: jest.fn(),
             insertCell: jest.fn().mockReturnValue({
                 style: {},
+                appendChild: jest.fn(),
+                textContent: "",
                 innerHTML: "",
                 setAttribute: jest.fn(),
                 addEventListener: jest.fn()
@@ -124,6 +127,8 @@ global.document = {
         cells: [],
         insertCell: jest.fn().mockReturnValue({
             style: {},
+            appendChild: jest.fn(),
+            textContent: "",
             innerHTML: ""
         }),
         deleteCell: jest.fn(),
@@ -145,6 +150,7 @@ global.document = {
             fillText: jest.fn()
         })
     })),
+    createTextNode: jest.fn().mockImplementation(text => ({ nodeType: 3, textContent: text })),
     getElementById: jest.fn().mockReturnValue({
         style: {},
         classList: { add: jest.fn(), remove: jest.fn() }
@@ -238,6 +244,49 @@ describe("RhythmRuler Widget", () => {
             expect(rhythmRuler._offsets).toEqual([]);
             expect(rhythmRuler._startingTime).toBeNull();
             expect(rhythmRuler._tapTimes).toEqual([]);
+        });
+    });
+
+    // =========================================================================
+    // NOTE VALUE DISPLAY TESTS
+    // =========================================================================
+    describe("Note Value Display", () => {
+        test("should render note value markup as DOM nodes", () => {
+            const cell = {
+                appendChild: jest.fn(),
+                textContent: "old"
+            };
+
+            global.calcNoteValueToDisplay.mockReturnValueOnce("1<br>&mdash;<br>4<br>note");
+
+            rhythmRuler.__setNoteValueDisplay(cell, 4, 1);
+
+            const appendedNodes = cell.appendChild.mock.calls.map(call => call[0]);
+            expect(cell.textContent).toBe("");
+            expect(appendedNodes.map(node => node.textContent)).toEqual([
+                "1",
+                "",
+                "\u2014",
+                "",
+                "4",
+                "",
+                "note"
+            ]);
+            expect(cell.appendChild).toHaveBeenCalledTimes(7);
+        });
+
+        test("should append silence label as text", () => {
+            const cell = {
+                appendChild: jest.fn(),
+                textContent: ""
+            };
+
+            global.calcNoteValueToDisplay.mockReturnValueOnce("1<br>&mdash;<br>4<br>note");
+
+            rhythmRuler.__setNoteValueDisplay(cell, 4, 1, "silence");
+
+            const appendedNodes = cell.appendChild.mock.calls.map(call => call[0]);
+            expect(appendedNodes[appendedNodes.length - 1].textContent).toBe(" silence");
         });
     });
 

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -724,7 +724,7 @@ class RhythmRuler {
             for (let j = 0; j < this.Rulers[i][0].length; j++) {
                 const noteValue = this.Rulers[i][0][j];
                 const rulerSubCell = rulerRow.insertCell(-1);
-                rulerSubCell.textContent = calcNoteValueToDisplay(noteValue, 1);
+                this.__setNoteValueDisplay(rulerSubCell, noteValue, 1);
                 rulerSubCell.style.height = RhythmRuler.RULERHEIGHT + "px";
                 rulerSubCell.style.minHeight = rulerSubCell.style.height;
                 rulerSubCell.style.maxHeight = rulerSubCell.style.height;
@@ -846,6 +846,34 @@ class RhythmRuler {
     }
 
     /**
+     * Renders the note value display returned by calcNoteValueToDisplay without
+     * inserting raw HTML into the widget.
+     * @private
+     * @param {HTMLTableCellElement} cell - The rhythm cell to update.
+     * @param {number} numerator - The numerator passed to calcNoteValueToDisplay.
+     * @param {number} denominator - The denominator passed to calcNoteValueToDisplay.
+     * @param {string} [suffix] - Optional text appended after the note value.
+     * @returns {void}
+     */
+    __setNoteValueDisplay(cell, numerator, denominator, suffix) {
+        const noteValueToDisplay = calcNoteValueToDisplay(numerator, denominator);
+        const parts = noteValueToDisplay.split("<br>");
+
+        cell.textContent = "";
+        for (let i = 0; i < parts.length; i++) {
+            let part = parts[i];
+            if (part === "&mdash;") part = "\u2014";
+
+            cell.appendChild(document.createTextNode(part));
+            if (i < parts.length - 1) cell.appendChild(document.createElement("br"));
+        }
+
+        if (suffix !== undefined) {
+            cell.appendChild(document.createTextNode(" " + suffix));
+        }
+    }
+
+    /**
      * Scales the width of the note cells based on the window size.
      * @private
      * @returns {void}
@@ -932,7 +960,7 @@ class RhythmRuler {
      * @returns {void}
      */
     _dissectRuler(event, ruler) {
-        const cell = event.target;
+        const cell = event.currentTarget || event.target;
         if (cell === null) {
             return;
         }
@@ -960,7 +988,7 @@ class RhythmRuler {
             // Tap a rhythm by clicking in a cell.
             if (this._tapCell === null) {
                 const noteValues = this.Rulers[this._rulerSelected][0];
-                this._tapCell = event.target;
+                this._tapCell = cell;
                 if (noteValues[this._tapCell.cellIndex] < 0) {
                     // Don't allow tapping in rests.
                     this._tapCell = null;
@@ -1080,7 +1108,7 @@ class RhythmRuler {
      * @returns {void}
      */
     __endTapping(event) {
-        const cell = event.target;
+        const cell = event.currentTarget || event.target;
         if (cell.parentNode === null) {
             // console.debug("Null parent node in endTapping");
             return;
@@ -1192,7 +1220,7 @@ class RhythmRuler {
      */
     __addCellEventHandlers(cell, cellWidth, noteValue) {
         const __mouseOverHandler = event => {
-            const cell = event.target;
+            const cell = event.currentTarget;
             if (cell === null || cell.parentNode === null) {
                 return;
             }
@@ -1203,20 +1231,20 @@ class RhythmRuler {
             let obj;
             if (noteValue < 0) {
                 obj = rationalToFraction(Math.abs(Math.abs(-1 / noteValue)));
-                cell.textContent = `${calcNoteValueToDisplay(obj[1], obj[0])} ${_("silence")}`;
+                this.__setNoteValueDisplay(cell, obj[1], obj[0], _("silence"));
             } else {
                 obj = rationalToFraction(Math.abs(Math.abs(1 / noteValue)));
-                cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
+                this.__setNoteValueDisplay(cell, obj[1], obj[0]);
             }
         };
 
         const __mouseOutHandler = event => {
-            const cell = event.target;
+            const cell = event.currentTarget;
             cell.textContent = "";
         };
 
         const __mouseDownHandler = event => {
-            const cell = event.target;
+            const cell = event.currentTarget;
             this._mouseDownCell = cell;
 
             const d = new Date();
@@ -1247,7 +1275,7 @@ class RhythmRuler {
          */
         const __mouseUpHandler = event => {
             clearTimeout(this._longPressBeep);
-            const cell = event.target;
+            const cell = event.currentTarget;
             this._mouseUpCell = cell;
             if (this._mouseDownCell !== this._mouseUpCell) {
                 this._tieRuler(event, cell.parentNode.getAttribute("data-row"));
@@ -1274,7 +1302,7 @@ class RhythmRuler {
         const __clickHandler = event => {
             if (event === undefined) return;
             if (!this.__getLongPressStatus()) {
-                const cell = event.target;
+                const cell = event.currentTarget;
                 if (cell !== null && cell.parentNode !== null) {
                     this._dissectRuler(event, cell.parentNode.getAttribute("data-row"));
                 } else {
@@ -1288,7 +1316,7 @@ class RhythmRuler {
         let obj;
         if (cellWidth >= 18 && noteValue > 0) {
             obj = rationalToFraction(Math.abs(1 / noteValue));
-            cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
+            this.__setNoteValueDisplay(cell, obj[1], obj[0]);
         } else {
             cell.textContent = "";
 
@@ -1337,7 +1365,7 @@ class RhythmRuler {
              * @returns {void}
              */
             const __mouseOverHandler = event => {
-                const cell = event.target;
+                const cell = event.currentTarget;
                 if (cell === null) {
                     return;
                 }
@@ -1349,10 +1377,10 @@ class RhythmRuler {
                 const noteValue = noteValues[cell.cellIndex];
                 if (noteValue < 0) {
                     obj = rationalToFraction(Math.abs(Math.abs(-1 / noteValue)));
-                    cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]) + " " + _("silence");
+                    this.__setNoteValueDisplay(cell, obj[1], obj[0], _("silence"));
                 } else {
                     obj = rationalToFraction(Math.abs(Math.abs(1 / noteValue)));
-                    cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
+                    this.__setNoteValueDisplay(cell, obj[1], obj[0]);
                 }
             };
 
@@ -1362,14 +1390,14 @@ class RhythmRuler {
              * @returns {void}
              */
             const __mouseOutHandler = event => {
-                const cell = event.target;
+                const cell = event.currentTarget;
                 cell.textContent = "";
             };
 
             let obj;
             if (noteValue < 0) {
                 obj = rationalToFraction(Math.abs(1 / noteValue));
-                cell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
+                this.__setNoteValueDisplay(cell, obj[1], obj[0]);
                 cell.removeEventListener("mouseover", __mouseOverHandler);
                 cell.removeEventListener("mouseout", __mouseOutHandler);
             } else {
@@ -1540,7 +1568,7 @@ class RhythmRuler {
         }
 
         // Does this work if there are more than 10 rulers?
-        const cell = event.target;
+        const cell = event.currentTarget || event.target;
         if (cell !== null && cell.parentNode !== null) {
             this._rulerSelected = cell.parentNode.getAttribute("data-row");
             this.__tie(true);
@@ -1677,7 +1705,7 @@ class RhythmRuler {
             newCell.style.maxHeight = newCell.style.height;
 
             newCell.style.backgroundColor = platformColor.selectorBackground;
-            newCell.textContent = calcNoteValueToDisplay(oldCellNoteValue / inputNum, 1);
+            this.__setNoteValueDisplay(newCell, oldCellNoteValue / inputNum, 1);
 
             noteValues[newCellIndex] = oldCellNoteValue / inputNum;
             noteValues.splice(newCellIndex + 1, inputNum - 1);
@@ -1711,7 +1739,7 @@ class RhythmRuler {
             newCell.style.backgroundColor = platformColor.selectorBackground;
 
             const obj = rationalToFraction(newNoteValue);
-            newCell.textContent = calcNoteValueToDisplay(obj[1], obj[0]);
+            this.__setNoteValueDisplay(newCell, obj[1], obj[0]);
 
             noteValues[newCellIndex] = newNoteValue;
             noteValues.splice(newCellIndex + 1, oldNoteValues.length - 1);
@@ -1748,7 +1776,7 @@ class RhythmRuler {
                     newCell.style.maxHeight = newCell.style.height;
 
                     noteValues.splice(history[0][0] + i, 0, history[i][1]);
-                    newCell.textContent = calcNoteValueToDisplay(history[i][1], 1);
+                    this.__setNoteValueDisplay(newCell, history[i][1], 1);
 
                     this.__addCellEventHandlers(newCell, newCellWidth, history[i][1]);
                 }


### PR DESCRIPTION

## Summary

Fixes https://github.com/sugarlabs/musicblocks/issues/6854.

This PR fixes Rhythm Ruler note-value labels rendering literal markup like `<br>` and `&mdash;` instead of displaying the intended stacked fraction layout.

## PR Category

- [x] Bug fix

## Changes

- Render Rhythm Ruler note values as DOM nodes instead of raw text.
- Convert `<br>` markers from `calcNoteValueToDisplay()` into real line breaks.
- Convert `&mdash;` into the visible dash character.
- Preserve safe rendering by avoiding `innerHTML`.
- Update cell event handling so hover/click interactions still work when note labels contain child nodes.
- Add focused Jest coverage for note-value rendering and silence labels.

## Manual Testing

1. Run `npm run dev` or `npm run serve:dev`.
2. Open `http://127.0.0.1:3000`.
3. Open the Rhythm Ruler / Rhythm Maker widget.
4. Confirm note values render as stacked fraction text with line breaks and a dash.
5. Confirm the UI no longer shows literal `<br>` or `&mdash;`.
6. Confirm hover/rest labels still behave correctly.

## Testing Video

Attach testing video here:

https://github.com/user-attachments/assets/e19cb0c5-70f4-4bd3-a443-423ef2572de6


