### PR TITLE
fix: remove async lock polling in Duplicate and Arpeggio flows (Fix #6882)

### DIFF
--- a/js/blocks/FlowBlocks.js
+++ b/js/blocks/FlowBlocks.js
@@ -202,13 +202,7 @@ function setupFlowBlocks(activity) {
                     tur.singer.inDuplicate = false;
                     tur.singer.duplicateFactor /= factor;
 
-                    if (logo.connectionStoreLock) {
-                        console.warn(
-                            "connectionStoreLock: Lock already held in DuplicateBlock listener, forcing acquisition"
-                        );
-                    }
                     logo.connectionStoreLock = true;
-
                     try {
                         // The last turtle should restore the broken connections
                         if (__lookForOtherTurtles(blk, turtle) === null) {
@@ -231,15 +225,6 @@ function setupFlowBlocks(activity) {
                 // Set the turtle listener
                 logo.setTurtleListener(turtle, listenerName, __listener);
 
-                // Acquire lock for the main flow
-                // JavaScript is single-threaded, so if the lock is held here it means
-                // a previous critical section did not release it (likely due to an error).
-                // We warn and force-acquire since no spin-wait can help in a single thread.
-                if (logo.connectionStoreLock) {
-                    console.warn(
-                        "connectionStoreLock: Lock already held in DuplicateBlock flow, forcing acquisition"
-                    );
-                }
                 logo.connectionStoreLock = true;
 
                 try {

--- a/js/blocks/FlowBlocks.js
+++ b/js/blocks/FlowBlocks.js
@@ -197,43 +197,17 @@ function setupFlowBlocks(activity) {
 
                 tur.singer.inDuplicate = true;
 
-                /**
-                 * Acquires the connectionStoreLock with proper waiting.
-                 * Uses a polling mechanism to wait for the lock to be released.
-                 * @param {number} maxRetries - Maximum number of retry attempts
-                 * @param {number} retryInterval - Milliseconds between retries
-                 * @returns {Promise<boolean>} - Resolves to true when lock is acquired
-                 */
-                const __acquireLock = (maxRetries = 100, retryInterval = 10) => {
-                    return new Promise(resolve => {
-                        let retries = 0;
-                        const tryAcquire = () => {
-                            if (!logo.connectionStoreLock) {
-                                logo.connectionStoreLock = true;
-                                resolve(true);
-                            } else if (retries < maxRetries) {
-                                retries++;
-                                setTimeout(tryAcquire, retryInterval);
-                            } else {
-                                // Force acquire after max retries to prevent deadlock
-                                console.warn(
-                                    "connectionStoreLock: Max retries reached, forcing lock acquisition"
-                                );
-                                logo.connectionStoreLock = true;
-                                resolve(true);
-                            }
-                        };
-                        tryAcquire();
-                    });
-                };
-
                 // Listener function for handling the end of duplication
-                const __listener = async event => {
+                const __listener = event => {
                     tur.singer.inDuplicate = false;
                     tur.singer.duplicateFactor /= factor;
 
-                    // Acquire lock with proper waiting
-                    await __acquireLock();
+                    if (logo.connectionStoreLock) {
+                        console.warn(
+                            "connectionStoreLock: Lock already held in DuplicateBlock listener, forcing acquisition"
+                        );
+                    }
+                    logo.connectionStoreLock = true;
 
                     try {
                         // The last turtle should restore the broken connections

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -834,16 +834,6 @@ function setupIntervalsBlocks(activity) {
 
             logo.setTurtleListener(turtle, listenerName, __listener);
 
-            // Acquire lock for the main flow
-            // JavaScript is single-threaded, so if the lock is held here it means
-            // a previous critical section did not release it (likely due to an error).
-            // We warn and force-acquire since no spin-wait can help in a single thread.
-            if (logo.connectionStoreLock) {
-                ErrorHandler.warn(
-                    "connectionStoreLock: Lock already held in ArpeggioBlock flow, forcing acquisition",
-                    { operation: "arpeggioLock" }
-                );
-            }
             logo.connectionStoreLock = true;
 
             try {

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -806,44 +806,12 @@ function setupIntervalsBlocks(activity) {
 
             tur.singer.inDuplicate = true;
 
-            /**
-             * Acquires the connectionStoreLock with proper waiting.
-             * Uses a polling mechanism to wait for the lock to be released.
-             * @param {number} maxRetries - Maximum number of retry attempts
-             * @param {number} retryInterval - Milliseconds between retries
-             * @returns {Promise<boolean>} - Resolves to true when lock is acquired
-             */
-            const __acquireLock = (maxRetries = 100, retryInterval = 10) => {
-                return new Promise(resolve => {
-                    let retries = 0;
-                    const tryAcquire = () => {
-                        if (!logo.connectionStoreLock) {
-                            logo.connectionStoreLock = true;
-                            resolve(true);
-                        } else if (retries < maxRetries) {
-                            retries++;
-                            setTimeout(tryAcquire, retryInterval);
-                        } else {
-                            // Force acquire after max retries to prevent deadlock
-                            ErrorHandler.warn(
-                                "connectionStoreLock: Max retries reached, forcing lock acquisition",
-                                { operation: "acquireLock" }
-                            );
-                            logo.connectionStoreLock = true;
-                            resolve(true);
-                        }
-                    };
-                    tryAcquire();
-                });
-            };
-
-            const __listener = async event => {
+            const __listener = event => {
                 tur.singer.inDuplicate = false;
                 tur.singer.duplicateFactor /= factor;
                 tur.singer.arpeggio = [];
 
-                // Acquire lock with proper waiting
-                await __acquireLock();
+                logo.connectionStoreLock = true;
 
                 try {
                     // The last turtle should restore the broken connections.

--- a/js/blocks/__tests__/FlowBlocks.test.js
+++ b/js/blocks/__tests__/FlowBlocks.test.js
@@ -264,7 +264,7 @@ describe("FlowBlocks integration", () => {
         // Factor is multiplied before listener runs
         expect(turtle.singer.duplicateFactor).toBe(2);
         const listener = logo.setTurtleListener.mock.calls.pop()[2];
-        listener();
+        expect(listener()).toBeUndefined();
         expect(turtle.singer.duplicateFactor).toBe(1);
 
         // Path where another turtle already stored connections
@@ -312,6 +312,25 @@ describe("FlowBlocks integration", () => {
         }).toThrow();
 
         // The critical guarantee: lock is released even after an error
+        expect(logo.connectionStoreLock).toBe(false);
+    });
+
+    test("DuplicateBlock listener releases lock when restoration throws", () => {
+        const block = getBlock("duplicatenotes");
+        const blk = 0;
+        activity.blocks.blockList = {
+            0: { name: "duplicatenotes", connections: [null, 1, null, 2] },
+            1: { name: "visibleA", connections: [0, 2] },
+            2: { name: "hidden", connections: [1, null] }
+        };
+        activity.blocks.findBottomBlock = jest.fn(() => 1);
+        logo.connectionStore = { 0: {} };
+
+        block.flow([2, 1], logo, 0, blk, []);
+        logo.connectionStore[0][blk] = [["missing", 0, null]];
+        const listener = logo.setTurtleListener.mock.calls.pop()[2];
+
+        expect(() => listener()).toThrow();
         expect(logo.connectionStoreLock).toBe(false);
     });
 

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -793,7 +793,7 @@ describe("setupIntervalsBlocks", () => {
             expect(activity.blocks.blockList.hidden1.connections[1]).toBeNull();
         });
 
-        it("listener restores disconnected links", async () => {
+        it("listener restores disconnected links synchronously without polling", () => {
             activity.blocks.blockList.blkArp = { name: "arpeggio", connections: [null] };
             activity.blocks.blockList.child1 = {
                 name: "note",
@@ -812,12 +812,32 @@ describe("setupIntervalsBlocks", () => {
             const listener =
                 logo.setTurtleListener.mock.calls[logo.setTurtleListener.mock.calls.length - 1][2];
 
-            await listener();
+            jest.useFakeTimers();
+            expect(listener()).toBeUndefined();
+            expect(jest.getTimerCount()).toBe(0);
+            jest.useRealTimers();
 
             expect(activity.blocks.blockList.child1.connections[2]).toBe("child2");
             expect(activity.blocks.blockList.child2.connections[0]).toBe("child1");
             expect(turtleState.singer.duplicateFactor).toBe(1);
             expect(turtleState.singer.inDuplicate).toBe(false);
+            expect(logo.connectionStoreLock).toBe(false);
+        });
+
+        it("listener releases lock when restoration throws", () => {
+            activity.blocks.blockList.blkArp = { name: "arpeggio", connections: [null] };
+            activity.blocks.blockList.child1 = {
+                name: "note",
+                connections: ["blkArp", null, null]
+            };
+            activity.blocks.findBottomBlock = jest.fn(() => "child1");
+
+            createdBlocks.arpeggio.flow(["major", "child1"], logo, turtleIndex, "blkArp", "arg");
+            logo.connectionStore[0].blkArp = [["missing", 0, null]];
+            const listener =
+                logo.setTurtleListener.mock.calls[logo.setTurtleListener.mock.calls.length - 1][2];
+
+            expect(() => listener()).toThrow();
             expect(logo.connectionStoreLock).toBe(false);
         });
     });


### PR DESCRIPTION
## Description

This PR removes the asynchronous lock-polling mechanism from the `DuplicateBlock` and `ArpeggioBlock` execution paths.

The affected connection-store critical sections are fully synchronous. Polling with `setTimeout()` and awaiting lock acquisition introduced unnecessary event-loop boundaries while the lock remained held, and the fallback eventually force-acquired the same boolean lock.

The listeners and main flow now use the existing synchronous critical-section pattern, with `try/finally` ensuring that `logo.connectionStoreLock` is always released.

## Related Issue

Fixes #6882.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

* Removed `__acquireLock()` polling from `DuplicateBlock`.
* Removed `__acquireLock()` polling from `ArpeggioBlock`.
* Converted both end listeners from asynchronous to synchronous callbacks.
* Removed timeout retries, forced acquisition, and warning guards.
* Preserved the existing multi-turtle connection copy and restoration behaviour.
* Kept lock release inside `finally` blocks.
* Added focused tests for synchronous execution and lock cleanup after success and errors.

## Safety Validation

The affected critical sections were checked for asynchronous yield points.

The following operations are synchronous:

* `setTurtleListener`
* `findBottomBlock`
* `__lookForOtherTurtles`
* queue construction
* connection-array mutation and restoration

There are no promises, awaited calls, timers, asynchronous functions, or callback registration inside the critical sections.

This safety assumption should be revisited if asynchronous work is added to these paths in the future.

## Testing Performed

* FlowBlocks
* IntervalsBlocks
* RhythmBlocks
* ExtrasBlocks

Result: **187 tests passed**

Additional checks:

* Scoped ESLint passed
* Prettier passed
* `git diff --check` passed
* Codecov reports all modified and coverable lines covered

## Checklist

* [x] Tested locally
* [x] Added focused tests
* [x] Followed project coding style
* [x] Ran lint and formatting checks
* [x] Addressed previous reviewer feedback
* [x] Enabled maintainer edits