### PR TITLE
perf: run mouse presence detection listener only once

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -4907,9 +4907,13 @@ class Block {
 // Track mouse presence
 window.hasMouse = false;
 // Mousemove is not emulated for touch
-document.addEventListener("mousemove", () => {
-    window.hasMouse = true;
-});
+document.addEventListener(
+    "mousemove",
+    () => {
+        window.hasMouse = true;
+    },
+    { once: true }
+);
 
 if (typeof module !== "undefined" && module.exports) {
     module.exports = Block;


### PR DESCRIPTION
## Summary

This PR updates the global mouse detection listener in `js/block.js` to run only once.

`window.hasMouse` is used as a one-way flag to detect whether the user has produced a real mouse movement. After it becomes `true`, the listener no longer needs to keep running on every `mousemove` event.

## PR Category
- [x]  Performance


## Changes

- Added `{ once: true }` to the document-level `mousemove` listener.
- Keeps the existing behavior: the first real mouse movement sets `window.hasMouse = true`.
- Lets the browser automatically remove the listener after mouse input is detected.

