### PR TITLE
fix: wrap JSON.parse in try-catch in Publisher.dataToTags

### DIFF
--- a/planet/js/Publisher.js
+++ b/planet/js/Publisher.js
@@ -40,13 +40,19 @@ class Publisher {
 
     dataToTags(DATA) {
         // convert to blocks like structure.
-        DATA = JSON.parse(DATA);
+        let parsed;
+        try {
+            parsed = JSON.parse(DATA);
+        } catch (e) {
+            console.error("Publisher.dataToTags: Invalid JSON data", e);
+            return [];
+        }
 
         const blocks = {
             blockList: []
         };
 
-        for (const i of DATA) {
+        for (const i of parsed) {
             const block = {};
             block.name = typeof i[1] === "string" ? i[1] : i[1][0];
             block.connections = i[4];


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Wrapped `JSON.parse(DATA)` in `Publisher.dataToTags()` with a `try-catch` block to prevent unhandled `SyntaxError` crashes when processing malformed or corrupted project data
- Returns empty tags array `[]` as a graceful fallback on invalid JSON input

## Root Cause

`planet/js/Publisher.js:43` called `JSON.parse()` directly without error handling. If a user loads a corrupted project or the server returns malformed data, the entire Publisher component crashes with an unhandled exception.

## Test Plan

- [ ] Load a valid project and verify tags are generated correctly (no regression)
- [ ] Simulate malformed project data and verify the Publisher does not crash
- [ ] Verify console shows an error message for invalid JSON

Fixes #6888