### PR TITLE
fix: guard indexOf() before array access in rubrics and turtle-singer

### DIFF
--- a/js/rubrics.js
+++ b/js/rubrics.js
@@ -637,13 +637,19 @@ const analyzeProject = activity => {
 
     for (let c = 0; c < cats.length; c++) {
         if (cats[c] in TASCORE) {
-            scores[PALS.indexOf(TAPAL[cats[c]])] += TASCORE[cats[c]];
+            const idx = PALS.indexOf(TAPAL[cats[c]]);
+            if (idx !== -1) {
+                scores[idx] += TASCORE[cats[c]];
+            }
         }
     }
 
     for (let p = 0; p < pals.length; p++) {
         if (pals[p] in TASCORE) {
-            scores[PALS.indexOf(pals[p])] += TASCORE[pals[p]];
+            const idx = PALS.indexOf(pals[p]);
+            if (idx !== -1) {
+                scores[idx] += TASCORE[pals[p]];
+            }
         }
     }
 

--- a/js/rubrics.js
+++ b/js/rubrics.js
@@ -640,6 +640,8 @@ const analyzeProject = activity => {
             const idx = PALS.indexOf(TAPAL[cats[c]]);
             if (idx !== -1) {
                 scores[idx] += TASCORE[cats[c]];
+            } else {
+                console.warn("rubrics: TAPAL value not found in PALS:", TAPAL[cats[c]]);
             }
         }
     }
@@ -649,6 +651,8 @@ const analyzeProject = activity => {
             const idx = PALS.indexOf(pals[p]);
             if (idx !== -1) {
                 scores[idx] += TASCORE[pals[p]];
+            } else {
+                console.warn("rubrics: pal not found in PALS:", pals[p]);
             }
         }
     }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1357,6 +1357,8 @@ class Singer {
                 const idx = tur.singer.inNoteBlock.indexOf(blk);
                 if (idx !== -1) {
                     tur.singer.inNoteBlock.splice(idx, 1);
+                } else {
+                    console.warn("Singer: block", blk, "not found in inNoteBlock");
                 }
             });
         }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1354,7 +1354,10 @@ class Singer {
             tur.singer.pushedNote = true;
 
             Singer.processNote(activity, tur.singer.defaultNoteValue, false, blk, turtle, () => {
-                tur.singer.inNoteBlock.splice(tur.singer.inNoteBlock.indexOf(blk), 1);
+                const idx = tur.singer.inNoteBlock.indexOf(blk);
+                if (idx !== -1) {
+                    tur.singer.inNoteBlock.splice(idx, 1);
+                }
             });
         }
     }


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Added index bounds check before using `indexOf()` result for array access in `js/rubrics.js` (lines 640, 646)
- Added index bounds check before `splice()` in `js/turtle-singer.js` (line 1357)

## Root Cause

`Array.indexOf()` returns `-1` when an item is not found. Using that value directly causes:
- **rubrics.js**: `scores[-1]` silently creates a property on the array object instead of updating the correct score, corrupting rubric results
- **turtle-singer.js**: `splice(-1, 1)` removes the **last** element of `inNoteBlock` instead of doing nothing, which can break downstream note processing

## Changes

| File | Change |
|------|--------|
| `js/rubrics.js` | Guard both `scores[PALS.indexOf(...)]` with `idx !== -1` check |
| `js/turtle-singer.js` | Guard `inNoteBlock.splice(indexOf(...), 1)` with `idx !== -1` check |

## Test Plan

- [ ] Run existing rubrics tests to verify no regression
- [ ] Verify rubric scoring works correctly for valid projects
- [ ] Verify note playback works correctly with various block configurations

Fixes #6889