### PR TITLE
fix: centralise hardcoded API keys into env.js

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,3 +1,9 @@
 // File for static Musicblocks hosting e.g. https://sugarlabs.github.io/musicblocks/
 window.MB_ENV = "production";
 window.MB_IS_DEV = false;
+
+// API keys — centralised here so they are easy to rotate and audit.
+// Long-term these should be moved to a server-side proxy so that
+// secrets are never shipped to the client.
+window.MB_PLANET_API_KEY = "3f2d3a4c-c7a4-4c3c-892e-ac43784f7381";
+window.MB_PROJECT_API_KEY = "3tgTzMXbbw6xEKX7";

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -260,7 +260,7 @@ let httpGet = async projectName => {
     const response = await fetch(url, {
         method: "GET",
         headers: {
-            "x-api-key": "3tgTzMXbbw6xEKX7"
+            "x-api-key": window.MB_PROJECT_API_KEY || ""
         }
     });
 
@@ -282,7 +282,7 @@ let httpPost = async (projectName, data) => {
     const response = await fetch(window.server + projectName, {
         method: "POST",
         headers: {
-            "x-api-key": "3tgTzMXbbw6xEKX7"
+            "x-api-key": window.MB_PROJECT_API_KEY || ""
         },
         body: data
     });

--- a/planet/js/ServerInterface.js
+++ b/planet/js/ServerInterface.js
@@ -26,7 +26,7 @@ class ServerInterface {
         this.Planet = Planet;
         this.ServerURL = "https://musicblocks.sugarlabs.org/planet-server/index.php";
         this.ConnectionFailureData = { success: false, error: "ERROR_CONNECTION_FAILURE" };
-        this.APIKey = "3f2d3a4c-c7a4-4c3c-892e-ac43784f7381";
+        this.APIKey = window.MB_PLANET_API_KEY || "";
         this.disablePlanetCache = this.shouldDisablePlanetCache();
 
         // Initialize RequestManager for rate limiting and retry logic

--- a/planet/js/__tests__/ServerInterface.test.js
+++ b/planet/js/__tests__/ServerInterface.test.js
@@ -33,6 +33,8 @@ describe("ServerInterface", () => {
         originalConsoleError = console.error;
         originalConsoleDebug = console.debug;
 
+        window.MB_PLANET_API_KEY = "3f2d3a4c-c7a4-4c3c-892e-ac43784f7381";
+
         mockRequestManager = {
             throttledRequest: jest.fn((data, logic) => {
                 return new Promise(resolve => logic(resolve));
@@ -90,6 +92,7 @@ describe("ServerInterface", () => {
         delete global.jQuery;
         delete global.RequestManager;
         delete global.CacheManager;
+        delete window.MB_PLANET_API_KEY;
 
         jest.clearAllMocks();
     });
@@ -131,7 +134,7 @@ describe("ServerInterface", () => {
             server.getTagManifest(callback);
 
             const sentData = jQuery.ajax.mock.calls[0][0].data;
-            expect(sentData["api-key"]).toBe("3f2d3a4c-c7a4-4c3c-892e-ac43784f7381");
+            expect(sentData["api-key"]).toBe(window.MB_PLANET_API_KEY);
             expect(sentData.action).toBe("getTagManifest");
         });
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Removed hardcoded API keys from `planet/js/ServerInterface.js` and `js/utils/utils.js`
- Centralised all API keys into `env.js` as `window.MB_PLANET_API_KEY` and `window.MB_PROJECT_API_KEY`
- Source files now reference keys via `window.MB_*` globals instead of inline strings

## Root Cause

API keys were hardcoded directly in client-side JavaScript across multiple files:
- `planet/js/ServerInterface.js:29` — Planet server key
- `js/utils/utils.js:263,285` — Project server key

This made keys visible in DevTools/source, hard to rotate, and scattered across the codebase.

## Image 
<img width="1920" height="1080" alt="Screenshot 2026-04-26 at 3 03 22 AM (2)" src="https://github.com/user-attachments/assets/c98da356-fd7c-4ee6-8c78-d1bc6d28e45d" />
<img width="1280" height="800" alt="Screenshot 2026-04-26 at 3 03 37 AM" src="https://github.com/user-attachments/assets/8d006337-c9de-44e7-8e55-6e7d8d0924aa" />
<img width="1920" height="1080" alt="Screenshot 2026-04-26 at 3 03 37 AM (2)" src="https://github.com/user-attachments/assets/2702889f-de6d-4d01-a868-2a43757bccf8" />



## Changes

| File | Change |
|------|--------|
| `env.js` | Added `MB_PLANET_API_KEY` and `MB_PROJECT_API_KEY` globals |
| `planet/js/ServerInterface.js` | Read key from `window.MB_PLANET_API_KEY` |
| `js/utils/utils.js` | Read key from `window.MB_PROJECT_API_KEY` in httpGet/httpPost |



## Test Plan

- [ ] Verify Planet project loading still works (key is read correctly)
- [ ] Verify project save/load via httpGet/httpPost still works
- [ ] Verify no hardcoded keys remain in ServerInterface.js or utils.js

Fixes #6887

