### PR TITLE
fix: add Secure and SameSite flags to setCookie

### DIFF
--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -66,7 +66,7 @@ function setCookie(cname, cvalue, exdays) {
     const d = new Date();
     d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
     const expires = `expires=${d.toUTCString()}`;
-    document.cookie = `${cname}=${cvalue};${expires};path=/`;
+    document.cookie = `${cname}=${cvalue};${expires};path=/;Secure;SameSite=Strict`;
 }
 
 function toggleSearch(on) {

--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -66,7 +66,9 @@ function setCookie(cname, cvalue, exdays) {
     const d = new Date();
     d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
     const expires = `expires=${d.toUTCString()}`;
-    document.cookie = `${cname}=${cvalue};${expires};path=/;Secure;SameSite=Strict`;
+    const isSecure = location.protocol === "https:";
+    const flags = isSecure ? ";Secure;SameSite=Strict" : ";SameSite=Strict";
+    document.cookie = `${cname}=${cvalue};${expires};path=/${flags}`;
 }
 
 function toggleSearch(on) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Added `Secure` and `SameSite=Strict` flags to `setCookie()` in `planet/js/helper.js`

## Root Cause

Cookies were set without security flags:
```javascript
// Before
document.cookie = `${cname}=${cvalue};${expires};path=/`;

// After
document.cookie = `${cname}=${cvalue};${expires};path=/;Secure;SameSite=Strict`;
```

- Missing `Secure`: cookies could be sent over unencrypted HTTP
- Missing `SameSite`: cookies were vulnerable to CSRF attacks

## Test Plan

- [ ] Verify cookies are still set and read correctly on HTTPS
- [ ] Inspect cookies in DevTools > Application > Cookies and confirm `Secure` and `SameSite=Strict` flags are present

Fixes #6890