### PR TITLE
fix: guard against division by zero in PhraseMaker audio

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -313,6 +313,10 @@ const PhraseMakerAudio = {
             // push [note/chord, relative-duration-inverse (e.g. 8 for 1/8)]
             const cellAlt = Number(cell.getAttribute("alt"));
             if (!cellAlt || !isFinite(cellAlt)) {
+                console.warn(
+                    "PhraseMaker: skipping cell with invalid alt attribute:",
+                    cell.getAttribute("alt")
+                );
                 continue;
             }
             notes.push([note, 1 / cellAlt]);

--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -311,7 +311,11 @@ const PhraseMakerAudio = {
                 }
             }
             // push [note/chord, relative-duration-inverse (e.g. 8 for 1/8)]
-            notes.push([note, 1 / cell.getAttribute("alt")]);
+            const cellAlt = Number(cell.getAttribute("alt"));
+            if (!cellAlt || !isFinite(cellAlt)) {
+                continue;
+            }
+            notes.push([note, 1 / cellAlt]);
         }
 
         pm._notesToPlay = notes;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Added validation for `cell.getAttribute("alt")` before using it as a divisor in `PhraseMakerAudio.js`
- Cells with invalid alt values (null, "0", non-numeric) are now skipped instead of producing Infinity/NaN

## Root Cause

`js/widgets/PhraseMakerAudio.js:314` computed `1 / cell.getAttribute("alt")` without validation:
- `null` → `Infinity`
- `"0"` → `Infinity`
- Non-numeric string → `NaN`

These corrupt all downstream duration calculations, causing broken playback.

## Changes

```javascript
// Before
notes.push([note, 1 / cell.getAttribute("alt")]);

// After
const cellAlt = Number(cell.getAttribute("alt"));
if (!cellAlt || !isFinite(cellAlt)) {
    continue;
}
notes.push([note, 1 / cellAlt]);
```

## Test Plan

- [ ] Open Phrase Maker, create a normal phrase, verify playback works correctly
- [ ] Verify no Infinity/NaN values appear in note durations

Fixes #6891