### PR TITLE
fix: add epoch guard before setNote in synthutils

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1932,6 +1932,7 @@ function Synth() {
 
                 if (!paramsEffects.doNeighbor) {
                     if (setNote !== undefined && setNote) {
+                        if (this._instrumentEpoch !== epoch) return;
                         if (synth.oscillator !== undefined) {
                             synth.setNote(notes);
                         } else if (synth.voices !== undefined) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Added `_instrumentEpoch` check before `synth.setNote()` calls in `js/utils/synthutils.js`
- Prevents modifying a stale or disposed synth when instruments are switched during playback

## Root Cause

The `triggerAttackRelease` path (line 1945) correctly checks `this._instrumentEpoch === epoch` before playing a note, but the `setNote` path (lines 1934-1941) right above it had no such guard. If an instrument is disposed or switched while this code runs, `setNote()` could modify a stale synth, causing audio glitches or notes applied to the wrong instrument.

## Changes

```javascript
// Added before the setNote block:
if (this._instrumentEpoch !== epoch) return;
```

## Test Plan

- [ ] Play a project with multiple instruments and verify audio works correctly
- [ ] Rapidly switch instruments during playback and confirm no audio corruption
- [ ] Verify existing synth tests pass

Fixes #6899