### PR TITLE
fix: replace document.onkeydown with addEventListener in help widget

### DIFF
--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -220,15 +220,19 @@ describe("HelpWidget", () => {
             expect(mockWidgetWindow.destroy).toHaveBeenCalled();
         });
 
-        test("onclose restores document.onkeydown to the handler active before Help opened", () => {
+        test("onclose removes the keydown listener added by Help", () => {
             const activity = createMockActivity();
-            const prevHandler = jest.fn();
-            document.onkeydown = prevHandler;
+            const removeSpy = jest.spyOn(document, "removeEventListener");
 
-            new HelpWidget(activity, false);
+            const hw = new HelpWidget(activity, false);
+            // Trigger _blockHelp so _keydownHandler is set
+            jest.runAllTimers();
+
             mockWidgetWindow.onclose();
 
-            expect(document.onkeydown).toBe(prevHandler);
+            expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+            expect(hw._keydownHandler).toBeNull();
+            removeSpy.mockRestore();
         });
 
         test("calls windowFor with correct arguments", () => {
@@ -791,7 +795,7 @@ describe("HelpWidget", () => {
             const clickSpy = jest.spyOn(rightArrow, "click");
 
             const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
-            document.onkeydown(event);
+            document.dispatchEvent(event);
 
             expect(clickSpy).toHaveBeenCalled();
         });

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -41,7 +41,7 @@ class HelpWidget {
         this.appendedBlockList = [];
         this.index = 0;
         this.isOpen = true;
-        this._prevKeyHandler = document.onkeydown;
+        this._keydownHandler = null;
 
         const widgetWindow = window.widgetWindows.windowFor(this, "help", "help", false);
         //widgetWindow.getWidgetBody().style.overflowY = "auto";
@@ -52,7 +52,10 @@ class HelpWidget {
         widgetWindow.show();
         widgetWindow.onclose = () => {
             this.isOpen = false;
-            document.onkeydown = this._prevKeyHandler;
+            if (this._keydownHandler) {
+                document.removeEventListener("keydown", this._keydownHandler);
+                this._keydownHandler = null;
+            }
             widgetWindow.destroy();
             // Trigger the hint only if they were on the first page of the tour
             if (this.index === 0 && typeof this.activity.textMsg === "function") {
@@ -123,13 +126,17 @@ class HelpWidget {
             leftArrow.setAttribute("title", _("Previous"));
             leftArrow.setAttribute("aria-label", _("Previous"));
 
-            document.onkeydown = function handleArrowKeys(event) {
+            if (this._keydownHandler) {
+                document.removeEventListener("keydown", this._keydownHandler);
+            }
+            this._keydownHandler = (event) => {
                 if (event.key === "ArrowLeft") {
                     leftArrow.click();
                 } else if (event.key === "ArrowRight") {
                     rightArrow.click();
                 }
             };
+            document.addEventListener("keydown", this._keydownHandler);
 
             let cell = docById("left-arrow");
             if (page === 0) {
@@ -531,13 +538,17 @@ class HelpWidget {
         const rightArrow = docById("right-arrow");
         const leftArrow = docById("left-arrow");
 
-        document.onkeydown = function handleArrowKeys(event) {
+        if (this._keydownHandler) {
+            document.removeEventListener("keydown", this._keydownHandler);
+        }
+        this._keydownHandler = (event) => {
             if (event.key === "ArrowLeft") {
                 leftArrow.click();
             } else if (event.key === "ArrowRight") {
                 rightArrow.click();
             }
         };
+        document.addEventListener("keydown", this._keydownHandler);
 
         if (this.index === this.appendedBlockList.length - 1) {
             rightArrow.classList.add("disabled");

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -129,7 +129,7 @@ class HelpWidget {
             if (this._keydownHandler) {
                 document.removeEventListener("keydown", this._keydownHandler);
             }
-            this._keydownHandler = (event) => {
+            this._keydownHandler = event => {
                 if (event.key === "ArrowLeft") {
                     leftArrow.click();
                 } else if (event.key === "ArrowRight") {
@@ -542,7 +542,7 @@ class HelpWidget {
         if (this._keydownHandler) {
             document.removeEventListener("keydown", this._keydownHandler);
         }
-        this._keydownHandler = (event) => {
+        this._keydownHandler = event => {
             if (event.key === "ArrowLeft") {
                 leftArrow.click();
             } else if (event.key === "ArrowRight") {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -516,6 +516,7 @@ class HelpWidget {
      * @returns {void}
      */
     _blockHelp(block) {
+        if (!block) return;
         const widgetWindow = window.widgetWindows.windowFor(this, "help", "help");
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Replaced all `document.onkeydown = ...` assignments with `addEventListener`/`removeEventListener` in `js/widgets/help.js`
- Previous handler is removed before adding a new one (prevents stacking)
- Listener is properly cleaned up when the widget is closed

## Root Cause

The help widget directly overwrote `document.onkeydown` in two places (lines 126 and 534) to set up arrow key navigation. This silently broke keyboard handling in any other widget that was open at the same time. On close, it restored only the handler from when help was opened, which could be wrong if multiple widgets were involved.

## Changes

| Location | Before | After |
|----------|--------|-------|
| Init (line 44) | `this._prevKeyHandler = document.onkeydown` | `this._keydownHandler = null` |
| Tour pages (line 126) | `document.onkeydown = function...` | `document.addEventListener("keydown", this._keydownHandler)` |
| Block help (line 534) | `document.onkeydown = function...` | `document.addEventListener("keydown", this._keydownHandler)` |
| Close (line 55) | `document.onkeydown = this._prevKeyHandler` | `document.removeEventListener("keydown", this._keydownHandler)` |

## Test Plan

- [ ] Open the Help widget, verify arrow keys navigate pages
- [ ] Open another widget with keyboard shortcuts, then open Help — verify the other widget's shortcuts still work after closing Help
- [ ] Close Help widget, verify no stale keyboard handlers remain

Fixes #6897