### PR TITLE
fix: remove drag-and-drop listeners on sampler widget close

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -397,18 +397,22 @@ function SampleWidget() {
     };
 
     //Drag-and-Drop sample files
+    this._dragOverHandler = (e) => {
+        e.preventDefault();
+    };
+
+    this._dropHandler = (e) => {
+        e.preventDefault();
+        const sampleFiles = e.dataTransfer.files[0];
+        this.handleFiles(sampleFiles);
+    };
+
     this.drag_and_drop = () => {
-        const dropZone = document.getElementsByClassName("samplerCanvas")[0];
-
-        dropZone.addEventListener("dragover", e => {
-            e.preventDefault();
-        });
-
-        dropZone.addEventListener("drop", e => {
-            e.preventDefault();
-            const sampleFiles = e.dataTransfer.files[0];
-            this.handleFiles(sampleFiles);
-        });
+        this._dropZone = document.getElementsByClassName("samplerCanvas")[0];
+        if (this._dropZone) {
+            this._dropZone.addEventListener("dragover", this._dragOverHandler);
+            this._dropZone.addEventListener("drop", this._dropHandler);
+        }
     };
 
     /**
@@ -513,6 +517,13 @@ function SampleWidget() {
                 this._octavesWheel.removeWheel();
             }
             this.pitchAnalysers = {};
+
+            if (this._dropZone) {
+                this._dropZone.removeEventListener("dragover", this._dragOverHandler);
+                this._dropZone.removeEventListener("drop", this._dropHandler);
+                this._dropZone = null;
+            }
+
             widgetWindow.destroy();
         };
 

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -397,11 +397,11 @@ function SampleWidget() {
     };
 
     //Drag-and-Drop sample files
-    this._dragOverHandler = (e) => {
+    this._dragOverHandler = e => {
         e.preventDefault();
     };
 
-    this._dropHandler = (e) => {
+    this._dropHandler = e => {
         e.preventDefault();
         const sampleFiles = e.dataTransfer.files[0];
         this.handleFiles(sampleFiles);


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- Stored drag-and-drop handler references (`_dragOverHandler`, `_dropHandler`) so they can be removed later
- Added cleanup in the `widgetWindow.onclose` callback to remove both listeners
- Added null guard for the drop zone element

## Root Cause

`js/widgets/sampler.js` registered `dragover` and `drop` event listeners using anonymous arrow functions in the `drag_and_drop()` method (lines 400-412). Since anonymous functions can't be removed with `removeEventListener`, these listeners accumulated with every open/close cycle of the widget, causing a memory leak and potentially duplicate event handling.

## Changes

| Before | After |
|--------|-------|
| Anonymous arrow functions in `drag_and_drop()` | Named handler references stored on `this` |
| No cleanup on close | `removeEventListener` for both handlers in `onclose` |

## Test Plan

- [ ] Open the Sampler widget, drag a sample file onto the canvas — verify it loads
- [ ] Close and reopen the widget, drag another file — verify only one handler fires
- [ ] Verify no accumulated listeners in DevTools after multiple open/close cycles

Fixes #6898