### PR TITLE
fix: resolve double-allocation memory leak of Tone.Sampler in _createSampleSynth

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1305,7 +1305,6 @@ function Synth() {
                 for (let i = 0; i < MULTIPITCH[sourceName].length; i++) {
                     noteDict[MULTIPITCH[sourceName][i]] = this.samples.voice[sourceName][i];
                 }
-                tempSynth = new Tone.Sampler(noteDict);
             } else {
                 noteDict["C4"] = this.samples.voice[sourceName];
             }


### PR DESCRIPTION
- [x] Bug Fix : #6903 


fixes a memory leak in the audio engine where `Tone.Sampler` was being instantiated twice for certain instruments (like the Mandolin). 

**Issue:**
When a multipitch instrument was loaded, the code created a sampler inside a loop branch and then immediately created *another* sampler outside the branch, orphaning the first one. This caused ~2-8MB of RAM to be leaked every time the instrument initialized.

**The Fix:**
Consolidated the sampler creation logic so it only fires once after the sample dictionary is fully prepared.

