### PR TITLE
fix: Handle deletion of active local project and prevent stale workspace state

### DIFF
--- a/planet/js/LocalPlanet.js
+++ b/planet/js/LocalPlanet.js
@@ -112,6 +112,7 @@ class LocalPlanet {
     openProject(id) {
         const Planet = this.Planet;
         Planet.ProjectStorage.setCurrentProjectID(id);
+        console.log(this.ProjectTable);
         Planet.loadProjectFromData(this.ProjectTable[id].ProjectData);
     }
 

--- a/planet/js/LocalPlanet.js
+++ b/planet/js/LocalPlanet.js
@@ -112,7 +112,6 @@ class LocalPlanet {
     openProject(id) {
         const Planet = this.Planet;
         Planet.ProjectStorage.setCurrentProjectID(id);
-        console.log(this.ProjectTable);
         Planet.loadProjectFromData(this.ProjectTable[id].ProjectData);
     }
 

--- a/planet/js/Planet.js
+++ b/planet/js/Planet.js
@@ -224,7 +224,10 @@ class Planet {
     }
 
     async closeButton() {
-        if (this.ProjectStorage.getCurrentProjectID() !== this.oldCurrentProjectID) {
+        const currentProjectID = this.ProjectStorage.getCurrentProjectID();
+        const currentProject = this.ProjectStorage.data.Projects[currentProjectID];
+
+        if (currentProjectID !== this.oldCurrentProjectID || currentProject === undefined) {
             const data = await this.ProjectStorage.getCurrentProjectData();
             !data ? this.loadNewProject() : this.loadProjectFromData(data);
         } else this.planetClose();
@@ -258,3 +261,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
 });
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = Planet;
+}

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -57,14 +57,7 @@ class ProjectStorage {
         return prefix + suffix;
     }
 
-    async saveLocally(data, image) {
-        console.log(
-            "Saving project locally with data:",
-            data,
-            "name:",
-            this.getCurrentProjectName()
-        );
-        console.log(this.projectTable);
+    async saveLocally(data, image) {  
         // Ensure data is loaded before saving
         await this.dataLoaded;
 
@@ -118,9 +111,6 @@ class ProjectStorage {
     }
 
     async initialiseNewProject(name, data, image) {
-        console.log(this);
-        console.log("Initialising new project:", name);
-        console.log("Current data before initialization:", data);
         name = name ?? this.defaultProjectName;
         data = data ?? null;
         image = image ?? null;

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -57,7 +57,7 @@ class ProjectStorage {
         return prefix + suffix;
     }
 
-    async saveLocally(data, image) {  
+    async saveLocally(data, image) {
         // Ensure data is loaded before saving
         await this.dataLoaded;
 

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -58,10 +58,22 @@ class ProjectStorage {
     }
 
     async saveLocally(data, image) {
-        if (this.data.CurrentProject === undefined) this.initialiseNewProject();
+        console.log(
+            "Saving project locally with data:",
+            data,
+            "name:",
+            this.getCurrentProjectName()
+        );
+        console.log(this.projectTable);
+        // Ensure data is loaded before saving
+        await this.dataLoaded;
 
-        const c = this.data.CurrentProject;
-        if (this.data.Projects[c] === undefined) {
+        let c = this.data.CurrentProject;
+
+        // If no current project or project doesn't exist, create a new one
+        if (c === undefined || this.data.Projects[c] === undefined) {
+            c = this.generateID();
+            this.data.CurrentProject = c;
             this.data.Projects[c] = {};
             this.data.Projects[c].ProjectName = this.defaultProjectName;
             this.data.Projects[c].ProjectData = null;
@@ -106,6 +118,9 @@ class ProjectStorage {
     }
 
     async initialiseNewProject(name, data, image) {
+        console.log(this);
+        console.log("Initialising new project:", name);
+        console.log("Current data before initialization:", data);
         name = name ?? this.defaultProjectName;
         data = data ?? null;
         image = image ?? null;
@@ -131,8 +146,34 @@ class ProjectStorage {
         await this.save();
     }
 
+    getLatestProjectID() {
+        const projectIDs = Object.keys(this.data.Projects);
+
+        if (projectIDs.length === 0) {
+            return null;
+        }
+
+        projectIDs.sort((a, b) => {
+            return this.data.Projects[b].DateLastModified - this.data.Projects[a].DateLastModified;
+        });
+
+        return projectIDs[0];
+    }
+
     async deleteProject(id) {
+        const deletedCurrentProject = this.data.CurrentProject === id;
         delete this.data.Projects[id];
+
+        if (deletedCurrentProject) {
+            const nextProjectID = this.getLatestProjectID();
+
+            if (nextProjectID === null) {
+                delete this.data.CurrentProject;
+            } else {
+                this.data.CurrentProject = nextProjectID;
+            }
+        }
+
         await this.save();
         this.Planet.LocalPlanet.updateProjects();
     }

--- a/planet/js/__tests__/Planet.test.js
+++ b/planet/js/__tests__/Planet.test.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Music Blocks Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+
+global._ = jest.fn(str => str);
+global.setCookie = jest.fn();
+global.getCookie = jest.fn(() => "");
+global.StringHelper = jest.fn();
+global.ProjectStorage = jest.fn();
+global.ServerInterface = jest.fn();
+global.Converter = jest.fn();
+global.SaveInterface = jest.fn();
+global.LocalPlanet = jest.fn();
+global.GlobalPlanet = jest.fn();
+
+const Planet = require("../Planet");
+
+describe("Planet", () => {
+    let planet;
+
+    beforeEach(() => {
+        planet = new Planet(true, {});
+        planet.ProjectStorage = {
+            data: {
+                Projects: {
+                    proj1: { ProjectData: "data-1" },
+                    proj2: { ProjectData: "data-2" }
+                }
+            },
+            getCurrentProjectID: jest.fn(),
+            getCurrentProjectData: jest.fn()
+        };
+        planet.loadProjectFromData = jest.fn();
+        planet.loadNewProject = jest.fn();
+        planet.planetClose = jest.fn();
+        planet.oldCurrentProjectID = "proj1";
+    });
+
+    it("closeButton should load the replacement project after the current one is deleted", async () => {
+        planet.ProjectStorage.getCurrentProjectID.mockReturnValue("proj2");
+        planet.ProjectStorage.getCurrentProjectData.mockResolvedValue("data-2");
+
+        await planet.closeButton();
+
+        expect(planet.loadProjectFromData).toHaveBeenCalledWith("data-2");
+        expect(planet.loadNewProject).not.toHaveBeenCalled();
+        expect(planet.planetClose).not.toHaveBeenCalled();
+    });
+
+    it("closeButton should create a new project when the deleted project has no replacement", async () => {
+        planet.ProjectStorage.data.Projects = {};
+        planet.ProjectStorage.getCurrentProjectID.mockReturnValue(undefined);
+        planet.ProjectStorage.getCurrentProjectData.mockResolvedValue(null);
+
+        await planet.closeButton();
+
+        expect(planet.loadNewProject).toHaveBeenCalled();
+        expect(planet.loadProjectFromData).not.toHaveBeenCalled();
+        expect(planet.planetClose).not.toHaveBeenCalled();
+    });
+
+    it("closeButton should close normally when the original project still exists", async () => {
+        planet.ProjectStorage.getCurrentProjectID.mockReturnValue("proj1");
+        planet.ProjectStorage.getCurrentProjectData.mockResolvedValue("data-1");
+
+        await planet.closeButton();
+
+        expect(planet.planetClose).toHaveBeenCalled();
+        expect(planet.loadNewProject).not.toHaveBeenCalled();
+        expect(planet.loadProjectFromData).not.toHaveBeenCalled();
+    });
+});

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -406,6 +406,8 @@ describe("ProjectStorage", () => {
                 ReportedProjects: {},
                 DefaultCreatorName: "anonymous"
             };
+            storage.fireDataLoaded();
+            await Promise.resolve();
         });
 
         it("should update project data and image", async () => {
@@ -422,9 +424,11 @@ describe("ProjectStorage", () => {
 
         it("should create a new project if CurrentProject is undefined", async () => {
             storage.data.CurrentProject = undefined;
-            const initSpy = jest.spyOn(storage, "initialiseNewProject").mockResolvedValue();
             await storage.saveLocally("data", "img");
-            expect(initSpy).toHaveBeenCalled();
+            const id = storage.getCurrentProjectID();
+            expect(id).toBeDefined();
+            expect(storage.data.Projects[id].ProjectData).toBe("data");
+            expect(storage.data.Projects[id].ProjectImage).toBe("img");
         });
     });
 
@@ -464,6 +468,53 @@ describe("ProjectStorage", () => {
             const saveSpy = jest.spyOn(storage, "save").mockResolvedValue();
             await storage.deleteProject("proj1");
             expect(storage.data.Projects["proj1"]).toBeUndefined();
+            expect(saveSpy).toHaveBeenCalled();
+        });
+
+        it("deleteProject should switch to the most recently modified remaining project", async () => {
+            const saveSpy = jest.spyOn(storage, "save").mockResolvedValue();
+            storage.data = {
+                CurrentProject: "proj1",
+                Projects: {
+                    proj1: {
+                        ProjectName: "Song A",
+                        ProjectData: "block-data",
+                        ProjectImage: null,
+                        PublishedData: null,
+                        DateLastModified: 1000
+                    },
+                    proj2: {
+                        ProjectName: "Song B",
+                        ProjectData: "block-data-b",
+                        ProjectImage: null,
+                        PublishedData: null,
+                        DateLastModified: 3000
+                    },
+                    proj3: {
+                        ProjectName: "Song C",
+                        ProjectData: "block-data-c",
+                        ProjectImage: null,
+                        PublishedData: null,
+                        DateLastModified: 2000
+                    }
+                },
+                LikedProjects: {},
+                ReportedProjects: {},
+                DefaultCreatorName: "anonymous"
+            };
+
+            await storage.deleteProject("proj1");
+
+            expect(storage.getCurrentProjectID()).toBe("proj2");
+            expect(saveSpy).toHaveBeenCalled();
+        });
+
+        it("deleteProject should clear CurrentProject when the last project is deleted", async () => {
+            const saveSpy = jest.spyOn(storage, "save").mockResolvedValue();
+
+            await storage.deleteProject("proj1");
+
+            expect(storage.getCurrentProjectID()).toBeUndefined();
             expect(saveSpy).toHaveBeenCalled();
         });
 


### PR DESCRIPTION
## Bug Fix: Prevent stale workspace after deleting active local project

Fixes #6905

---

### Summary
This PR fixes an issue where deleting the currently open local project from Planet could leave the workspace pointing to stale project data after closing Planet.

The fix ensures that the workspace always transitions to a valid project state and never remains attached to a deleted project.

---

### What Changed
- Detects when the deleted project is the currently active project  
- Switches to the most recent remaining local project (if available)  
- Falls back to creating/loading a fresh default project when no local projects remain  
- Strengthens the Planet close flow to avoid stale project references  
- Adds focused tests for deletion fallback behavior  
- Fixes hanging `ProjectStorage` tests by resolving `dataLoaded` in test setup  
- Updates outdated test expectations  

---

### Testing
- [x] Ran `npm run lint`  
- [x] Verified formatting with Prettier  
- [x] Added and executed focused Jest tests  
- [x] Ran full test suite (`npm test`)  
- [x] Manual verification of deletion flow  

---

### Expected Behavior
- Deleting the active project does not leave the workspace in a broken state  
- A valid project is always loaded after closing Planet  
- If no projects remain, a new default project is created  
- Workspace state remains consistent and predictable  

---
### ScreenShots
Before
https://github.com/user-attachments/assets/f7ca2c5c-a778-472a-bf5a-5d2c16b384b2

---
After
https://github.com/user-attachments/assets/10e4e08d-db2c-4528-98ca-b7e5a567235b


---
### PR Category
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Refactoring  
- [ ] Documentation  

---

### Checklist
- [x] I have read and followed the project's code of conduct  
- [x] I have searched for similar issues before creating this PR  
- [x] I have provided all necessary information  
- [x] I have tested the changes locally  