### PR TITLE
test: add missing test coverage for normalizeNoteAccidentals

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -106,6 +106,7 @@ const {
     numberToPitch,
     GetNotesForInterval,
     base64Encode,
+    normalizeNoteAccidentals,
     NOTESTEP,
     ACCIDENTALNAMES,
     NOTESFLAT,
@@ -2610,5 +2611,51 @@ describe("ACCIDENTALNAMES", () => {
             "flat \u266d",
             "double flat \ud834\udd2b"
         ]);
+    });
+});
+
+describe("normalizeNoteAccidentals", () => {
+    it("replaces unicode flat ♭ with ascii b", () => {
+        expect(normalizeNoteAccidentals("C♭")).toBe("Cb");
+    });
+
+    it("replaces unicode sharp ♯ with ascii #", () => {
+        expect(normalizeNoteAccidentals("D♯")).toBe("D#");
+    });
+
+    it("replaces double-flat symbol 𝄫 with bb", () => {
+        expect(normalizeNoteAccidentals("E𝄫")).toBe("Ebb");
+    });
+
+    it("replaces double-sharp symbol 𝄪 with x", () => {
+        expect(normalizeNoteAccidentals("F𝄪")).toBe("Fx");
+    });
+
+    it("returns a natural note letter unchanged", () => {
+        expect(normalizeNoteAccidentals("G")).toBe("G");
+    });
+
+    it("returns an empty string unchanged", () => {
+        expect(normalizeNoteAccidentals("")).toBe("");
+    });
+
+    it("replaces multiple unicode flats ♭♭ with bb", () => {
+        expect(normalizeNoteAccidentals("A♭♭")).toBe("Abb");
+    });
+
+    it("replaces multiple unicode sharps ♯♯ with ##", () => {
+        expect(normalizeNoteAccidentals("B♯♯")).toBe("B##");
+    });
+
+    it("handles a note string that includes an octave digit", () => {
+        expect(normalizeNoteAccidentals("C♭4")).toBe("Cb4");
+    });
+
+    it("leaves a non-note string like solfege name unchanged", () => {
+        expect(normalizeNoteAccidentals("do")).toBe("do");
+    });
+
+    it("handles mixed unicode accidentals in one string", () => {
+        expect(normalizeNoteAccidentals("C♭♯")).toBe("Cb#");
     });
 });


### PR DESCRIPTION
### Related issue

Fixes #6909 

### What this PR does

Adds 11 Jest tests for `normalizeNoteAccidentals` in `js/utils/__tests__/musicutils.test.js`.

`normalizeNoteAccidentals`  converts Unicode musical accidental symbols to their ASCII equivalents. It is called inside `getNote` on every note resolution path, but had zero test coverage before this PR.

### Changes

- `js/utils/__tests__/musicutils.test.js`
- Added `normalizeNoteAccidentals` to the named import block at the top
- Added a new `describe("normalizeNoteAccidentals", ...)` block at the bottom with 11 tests

No source files were modified.

### Tests added

| Input | Expected output | What it covers |
|-------|----------------|----------------|
| `C♭` | `Cb` | Single unicode flat |
| `D♯` | `D#` | Single unicode sharp |
| `E𝄫` | `Ebb` | Double-flat symbol (surrogate pair) |
| `F𝄪` | `Fx` | Double-sharp symbol (surrogate pair) |
| `G` | `G` | Natural note — no change |
| `""` | `""` | Empty string — no change |
| `A♭♭` | `Abb` | Multiple flats |
| `B♯♯` | `B##` | Multiple sharps |
| `C♭4` | `Cb4` | Note with octave digit |
| `do` | `do` | Non-note string — no change |
| `C♭♯` | `Cb#` | Mixed accidentals |

### PR Category

- [ ] Bug Fix
- [x] Tests
- [ ] Features
- [ ] Performance
- [ ] Documentation