### PR TITLE
fix: replace string-based GIF data handling with byte arrays and complete TODO

### DIFF
--- a/lib/libgif.js
+++ b/lib/libgif.js
@@ -141,12 +141,22 @@
     };
 
     var lzwDecode = function (minCodeSize, data) {
-        // TODO: Now that the GIF parser is a bit different, maybe this should get an array of bytes instead of a String?
-        var pos = 0; // Maybe this streaming thing should be merged with the Stream?
+       
+        var pos = 0; // bit position within the data stream
         var readCode = function (size) {
             var code = 0;
             for (var i = 0; i < size; i++) {
-                if (data.charCodeAt(pos >> 3) & (1 << (pos & 7))) {
+                var byteIndex = pos >> 3;
+                var bitIndex = pos & 7;
+                var currentByte;
+                if (typeof data === "string") {
+                    // Legacy path: string input (backwards compatibility)
+                    currentByte = data.charCodeAt(byteIndex);
+                } else {
+                    // Preferred path: Uint8Array or array-like of bytes
+                    currentByte = data[byteIndex];
+                }
+                if (currentByte & (1 << bitIndex)) {
                     code |= 1 << i;
                 }
                 pos++;
@@ -223,9 +233,35 @@
             return ct;
         };
 
-        var readSubBlocks = function () {
-            var size, data;
-            data = '';
+        /**
+         * Read GIF sub-blocks.
+         * If `asBytes` is true, returns a single Uint8Array containing
+         * the concatenated sub-block bytes (preferred for image/LZW data).
+         * Otherwise returns a string (legacy behavior) for comment/app text.
+         */
+        var readSubBlocks = function (asBytes) {
+            var size;
+            if (asBytes) {
+                var chunks = [];
+                var total = 0;
+                do {
+                    size = st.readByte();
+                    if (size) {
+                        var bytes = st.readBytes(size);
+                        chunks.push(bytes);
+                        total += bytes.length;
+                    }
+                } while (size !== 0);
+
+                var out = new Uint8Array(total);
+                var offset = 0;
+                for (var i = 0; i < chunks.length; i++) {
+                    out.set(chunks[i], offset);
+                    offset += chunks[i].length;
+                }
+                return out;
+            }
+            var data = '';
             do {
                 size = st.readByte();
                 data += st.read(size);
@@ -388,7 +424,10 @@
 
             img.lzwMinCodeSize = st.readByte();
 
-            var lzwData = readSubBlocks();
+            // Read LZW data as raw bytes (Uint8Array) instead of a string.
+            // This avoids constructing large strings for binary data and
+            // allows the decoder to operate directly on bytes.
+            var lzwData = readSubBlocks(true);
 
             img.pixels = lzwDecode(img.lzwMinCodeSize, lzwData);
 
@@ -995,6 +1034,12 @@
             set_frame_offset: setFrameOffset
         };
     };
+
+    // Expose the LZW decoder for testing and advanced use. This is
+    // non-breaking: consumers still get the `SuperGif` constructor as
+    // the module export. The exposed function helps unit tests verify
+    // behavior for both string and byte-array inputs.
+    SuperGif._lzwDecode = lzwDecode;
 
     return SuperGif;
 }));


### PR DESCRIPTION
This PR completes the pending TODO in `libgif.js` by refactoring GIF data handling from string-based processing to a byte-based approach.

---

## PR Category

- [x] Bug Fix
- [x] Performance

---

## Changes Included

- Refactored `lzwDecode` to support both:
  - `Uint8Array` / byte arrays (preferred)
  - string input (for backward compatibility)

- Updated `readSubBlocks`:
  - Added byte-mode (`Uint8Array`) for efficient binary handling
  - Retained legacy string mode for text-based data

- Modified LZW data flow:
  - Now reads sub-blocks as raw bytes instead of strings
  - Eliminates unnecessary string construction for binary data

- Exposed `_lzwDecode` for testing and advanced usage

---

## Improvements

- Reduced memory overhead from large string allocations
- Improved decoding performance for GIF images
- Better alignment with modern binary data handling practices

---

## Checklist

- [x] Code follows project guidelines  
- [x] Backward compatibility preserved  
- [x] Verified functionality locally  
- [x] No new warnings or errors introduced  

---

## Files Changed

- `lib/libgif.js`