### PR TITLE
Fix: Helpful wheel leaks document click listeners (#6756)

### DIFF
--- a/js/__tests__/activity_listeners.test.js
+++ b/js/__tests__/activity_listeners.test.js
@@ -26,6 +26,11 @@ describe("Activity Event Listener Management", () => {
             "constructor() { this._listeners = []; return;"
         );
 
+        // Extract the helpful wheel logic so we can test it isolated from the constructor
+        const helpfulWheelMatch = code.match(
+            /this\._closeHelpfulWheelHandler = .*?return wasOpen;\s*\};/s
+        );
+
         // Mock global environment required by activity.js
         const sandbox = {
             window: global.window,
@@ -70,6 +75,10 @@ describe("Activity Event Listener Management", () => {
 
         // Expose Activity class to sandbox
         code += "\n this.Activity = Activity;";
+
+        if (helpfulWheelMatch) {
+            code += `\n Activity.prototype._injectHelpfulWheel = function() { \n${helpfulWheelMatch[0]}\n };`;
+        }
 
         vm.createContext(sandbox);
         try {
@@ -157,5 +166,42 @@ describe("Activity Event Listener Management", () => {
         activity.removeEventListener(target, "click", listener, { capture: true });
 
         expect(activity._listeners).toHaveLength(0);
+    });
+
+    test("should remove document click listener when helpful wheel is closed via internal path", () => {
+        // Inject the methods from activity.js dynamically into this instance
+        activity._injectHelpfulWheel();
+
+        // Set up the DOM
+        const helpfulWheelDiv = document.createElement("div");
+        helpfulWheelDiv.id = "helpfulWheelDiv";
+        helpfulWheelDiv.style.display = "block"; // Simulate wheel being open
+        document.body.appendChild(helpfulWheelDiv);
+
+        // Simulate the wheel opening which attaches the listener
+        activity.addEventListener(document, "click", activity._closeHelpfulWheelHandler);
+
+        // Assert listener is present
+        let hasCloseHandler = activity._listeners.some(
+            l => l.listener === activity._closeHelpfulWheelHandler
+        );
+        expect(hasCloseHandler).toBe(true);
+
+        // Close it via internal path
+        const wasOpen = activity.closeHelpfulWheel();
+
+        // Assert it returned true (was open)
+        expect(wasOpen).toBe(true);
+        // Assert it is now hidden
+        expect(helpfulWheelDiv.style.display).toBe("none");
+
+        // Assert the listener is actually removed
+        hasCloseHandler = activity._listeners.some(
+            l => l.listener === activity._closeHelpfulWheelHandler
+        );
+        expect(hasCloseHandler).toBe(false);
+
+        // Cleanup DOM
+        document.body.removeChild(helpfulWheelDiv);
     });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -629,11 +629,7 @@ class Activity {
         // hides helpfulSearchDiv on canvas
 
         this._hideHelpfulSearchWidget = e => {
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
+            this.closeHelpfulWheel();
             if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
                 this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
             }
@@ -664,6 +660,30 @@ class Activity {
                 },
                 false
             );
+        };
+
+        /*
+         * Helpful wheel unified close helpers to avoid memory leaks
+         */
+        this._closeHelpfulWheelHandler = e => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            if (helpfulWheelDiv) {
+                const isClickInside = helpfulWheelDiv.contains(e.target);
+                if (!isClickInside) {
+                    this.closeHelpfulWheel();
+                }
+            }
+        };
+
+        this.closeHelpfulWheel = () => {
+            let wasOpen = false;
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
+                helpfulWheelDiv.style.display = "none";
+                wasOpen = true;
+            }
+            this.removeEventListener(document, "click", this._closeHelpfulWheelHandler);
+            return wasOpen;
         };
 
         /*
@@ -724,15 +744,8 @@ class Activity {
                 wheel.navItems[i].setTooltip(_(ele.label));
                 wheel.navItems[i].navigateFunction = () => ele.fn(this);
             });
-            const closeHelpfulWheel = e => {
-                const isClickInside = helpfulWheelDiv.contains(e.target);
-                if (!isClickInside) {
-                    helpfulWheelDiv.style.display = "none";
-                    this.removeEventListener(document, "click", closeHelpfulWheel);
-                }
-            };
-
-            this.addEventListener(document, "click", closeHelpfulWheel);
+            this.removeEventListener(document, "click", this._closeHelpfulWheelHandler);
+            this.addEventListener(document, "click", this._closeHelpfulWheelHandler);
         };
 
         /**
@@ -809,10 +822,7 @@ class Activity {
          */
         const findBlocks = activity => {
             activity._findBlocks();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -1697,10 +1707,7 @@ class Activity {
                     table.remove();
                 }
 
-                // Cache DOM element reference for performance
-                const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-                if (helpfulWheelDiv.style.display !== "none") {
-                    helpfulWheelDiv.style.display = "none";
+                if (this.closeHelpfulWheel()) {
                     this.__tick();
                 }
 
@@ -2335,11 +2342,7 @@ class Activity {
         const setScroller = activity => {
             activity._setScroller();
             activity._setupBlocksContainerEvents();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
+            activity.closeHelpfulWheel();
         };
 
         /**
@@ -2432,10 +2435,7 @@ class Activity {
          */
         const doLargerBlocks = async activity => {
             await activity._doLargerBlocks();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -2469,10 +2469,7 @@ class Activity {
          */
         const doSmallerBlocks = async activity => {
             await activity._doSmallerBlocks();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -4445,10 +4442,7 @@ class Activity {
                 return;
             }
 
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -4465,10 +4459,7 @@ class Activity {
             this._restoreTrashById(this.blocks.trashStacks[this.blocks.trashStacks.length - 1]);
             activity.textMsg(_("Item restored from the trash."), 3000);
 
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -4861,10 +4852,7 @@ class Activity {
          */
         const changeBlockVisibility = activity => {
             activity._changeBlockVisibility();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -4897,10 +4885,7 @@ class Activity {
          */
         const toggleCollapsibleStacks = activity => {
             activity._toggleCollapsibleStacks();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
+            if (activity.closeHelpfulWheel()) {
                 activity.__tick();
             }
         };
@@ -5053,11 +5038,7 @@ class Activity {
          */
         const chooseKeyMenu = that => {
             piemenuKey(that);
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
+            that.closeHelpfulWheel();
         };
 
         /*
@@ -7203,7 +7184,7 @@ class Activity {
                     that.doHelpfulSearch();
                 }, 500);
 
-                document.getElementById("helpfulWheelDiv").style.display = "none";
+                this.closeHelpfulWheel();
             }
         };
 
@@ -7860,7 +7841,7 @@ class Activity {
                 this.blocks.setSelectionToActivity(false);
                 this.refreshCanvas();
                 // Cache DOM element reference for performance
-                document.getElementById("helpfulWheelDiv").style.display = "none";
+                this.closeHelpfulWheel();
             }
         };
 
@@ -7901,7 +7882,7 @@ class Activity {
                 this.blocks.setSelectedBlocks(this.selectedBlocks);
                 this.refreshCanvas();
                 // Cache DOM element reference for performance
-                document.getElementById("helpfulWheelDiv").style.display = "none";
+                this.closeHelpfulWheel();
             }
         };
 
@@ -7911,7 +7892,7 @@ class Activity {
             this.isSelecting
                 ? this.textMsg(_("Select is enabled."))
                 : this.textMsg(_("Select is disabled."));
-            document.getElementById("helpfulWheelDiv").style.display = "none";
+            this.closeHelpfulWheel();
         };
 
         this._create2Ddrag = () => {


### PR DESCRIPTION
### PR Category

- [x] Bug Fix

### Description
This PR resolves the memory leak issue described in #6756, where the "helpful wheel" component failed to remove document-level `click` event listeners when closed via internal code paths. 

### Root Cause
When the helpful wheel is opened, it attaches an event listener to the `document` to listen for outside clicks to close it. The proper way to close the wheel and remove this listener is by calling the `this.closeHelpfulWheel()` method. However, in several places (e.g., inside the search widget, selecting blocks, copying blocks), the wheel was hidden manually by directly setting `document.getElementById("helpfulWheelDiv").style.display = "none"`. This bypassed the cleanup logic, leaving the event listeners attached and causing a memory leak over time.

### Changes Made
- Centralized the closing logic by replacing all direct modifications of `helpfulWheelDiv.style.display = "none"` with `this.closeHelpfulWheel()`.
- This guarantees that the event listener cleanup (`this.removeEventListener`) runs successfully every time the wheel closes, regardless of whether it was closed by clicking outside or by a specific internal action.

### Fixes
Fixes #6756
