### PR TITLE
[Fix]: double-routing of effects in _performNotes causing incorrect audio and volume

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1814,7 +1814,7 @@ function Synth() {
                 _effectsInFlight.set(synth, (_effectsInFlight.get(synth) || 0) + 1);
                 try {
                     synth.disconnect();
-                } catch (_) {
+                } catch (e) {
                     /* already disconnected */
                 }
                 const chainNodes = [];

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -446,6 +446,11 @@ const instruments = { 0: {} };
  */
 const instrumentsSource = {};
 
+// Tracks how many _performNotes graph-rewire calls are in-flight per synth instance.
+// Used to prevent the cleanup callback from restoring the dry path while another
+// effects chain is still active on the same synth.
+const _effectsInFlight = new WeakMap();
+
 /**
  * Object containing effects associated with instruments in the timbre widget.
  * @type {Object.<number, Object>}
@@ -1806,7 +1811,12 @@ function Synth() {
                 // ─────────────────────────────────────────────────────────────────────
 
                 // Remove the dry path so effects are routed serially, not in parallel
-                synth.disconnect(Tone.Destination);
+                _effectsInFlight.set(synth, (_effectsInFlight.get(synth) || 0) + 1);
+                try {
+                    synth.disconnect();
+                } catch (_) {
+                    /* already disconnected */
+                }
                 const chainNodes = [];
 
                 if (paramsFilters !== null && paramsFilters !== undefined) {
@@ -1974,9 +1984,16 @@ function Synth() {
                                 });
                             }
 
-                            // Re-establish the dry path so subsequent notes
-                            // that do not use effects still reach the speakers.
-                            if (synth && typeof synth.toDestination === "function") {
+                            // Re-establish the dry path only when no other effects chain
+                            // is still active on this synth; otherwise the direct
+                            // connection would bypass the in-flight chain.
+                            const remaining = (_effectsInFlight.get(synth) || 1) - 1;
+                            _effectsInFlight.set(synth, remaining);
+                            if (
+                                remaining === 0 &&
+                                synth &&
+                                typeof synth.toDestination === "function"
+                            ) {
                                 synth.toDestination();
                             }
                         } catch (e) {
@@ -2000,8 +2017,9 @@ function Synth() {
                 }
             });
 
-            // Re-establish the dry path on error as well.
-            if (synth && typeof synth.toDestination === "function") {
+            const remaining = (_effectsInFlight.get(synth) || 1) - 1;
+            _effectsInFlight.set(synth, remaining);
+            if (remaining === 0 && synth && typeof synth.toDestination === "function") {
                 synth.toDestination();
             }
         }


### PR DESCRIPTION
- [x] Bug Fix

## Summary
Fixes audio graph corruption in _performNotes where consecutive notes with effects were getting double-routed (previous + current effect chain), causing wrong sound and higher volume.

---

## Impact
- Effects (vibrato, distortion, etc.) sound incorrect after first note
- Volume becomes higher than expected (~2x)
- Wet/dry mix becomes inconsistent
- Happens on every note after first in normal usage
- Persists across runs due to cleanup timing

This affects all effect blocks and is noticeable in real classroom usage.

---

## Root cause
synth.disconnect(Tone.Destination);
synth.chain(...chainNodes, Tone.Destination);


disconnect(Tone.Destination) only removes direct connection, not previous effect chain connections.

So at runtime:
- synth → oldChain → destination (still active)
- synth → newChain → destination (added)

Also cleanup later:
```js
setTimeout(() => {
synth.toDestination();
}, ...)
```

This adds a third (dry) path while effects are still active.

---

## Fix
- Added per-synth in-flight counter using WeakMap
- Replaced partial disconnect with full disconnect:
synth.disconnect(); // removes all connections


- Only reconnect to destination when no effects are active:
```js
if (inFlightCount === 0) {
synth.toDestination();
}
```
---

## Notes
- Ensures only one active audio path per note
- Prevents overlapping effect chains
- Keeps behavior unchanged for valid single-note cases
- Minimal fix without changing architecture

---

## Tests
- Verified no double-routing across consecutive notes
- Verified correct effect behavior on all notes
- All test suites pass