### PR TITLE
fix: refresh palette collapse handle theme color

### DIFF
--- a/js/themebox.js
+++ b/js/themebox.js
@@ -405,6 +405,12 @@ class ThemeBox {
                     paletteElement.childNodes[0].style.border = `1px solid ${window.platformColor.selectorSelected}`;
                 }
 
+                const paletteToggle = document.getElementById("paletteToggle");
+                if (paletteToggle) {
+                    paletteToggle.style.backgroundColor = platformColor.paletteLabelBackground;
+                    paletteToggle.style.color = "white";
+                }
+
                 // Refresh palette selector icons with new theme colors
                 const tr = document.querySelector("#palette > div > table > thead > tr");
                 if (tr) {


### PR DESCRIPTION
## Summary

- Updated the palette collapse handle to use the current theme’s palette label background color.
- Refreshed the collapse handle color immediately when switching themes, so it no longer keeps the previous theme color until hover.

## Testing

- Ran `npx.cmd prettier --check js/palette.js js/themebox.js`


## Before 
<img width="318" height="595" alt="Screenshot 2026-04-26 154546" src="https://github.com/user-attachments/assets/a88f3bb2-e9c4-4a62-8292-0424e9eecb84" />

## After
 <img width="215" height="643" alt="Screenshot 2026-04-26 160558" src="https://github.com/user-attachments/assets/d21e3b12-90c3-4610-a559-74e9d198a15c" />

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation