### PR TITLE
Fix Planet init when localStorage is unavailable during ProjectStorage migration

### DIFF
--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -283,7 +283,16 @@ class ProjectStorage {
     }
 
     async port() {
-        const oldProjectData = localStorage.getItem(this.LocalStorageKey);
+        let oldProjectData = null;
+        try {
+            oldProjectData = localStorage.getItem(this.LocalStorageKey);
+        } catch (e) {
+            console.warn(
+                "[ProjectStorage] Unable to access legacy localStorage during migration:",
+                e
+            );
+        }
+
         const isPortedAlready = await this.get(this.VersionKey);
         if (isPortedAlready !== this.Version) {
             // port

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -323,6 +323,45 @@ describe("ProjectStorage", () => {
         });
     });
 
+    describe("port()", () => {
+        it("should not throw when legacy localStorage access fails", async () => {
+            const originalLocalStorage = global.localStorage;
+            global.localStorage = {
+                ...originalLocalStorage,
+                getItem: () => {
+                    throw new Error("Access denied");
+                }
+            };
+
+            await expect(storage.port()).resolves.toBeUndefined();
+            await expect(storage.get(storage.VersionKey)).resolves.toBe("v2");
+            global.localStorage = originalLocalStorage;
+        });
+
+        it("should allow init to complete when legacy localStorage is unavailable", async () => {
+            const originalLocalStorage = global.localStorage;
+            global.localStorage = {
+                ...originalLocalStorage,
+                getItem: () => {
+                    throw new Error("Blocked by policy");
+                }
+            };
+
+            global.localforage = mockLocalforage;
+            await expect(storage.init()).resolves.toBeUndefined();
+
+            expect(storage.data).toEqual(
+                expect.objectContaining({
+                    Projects: {},
+                    LikedProjects: {},
+                    ReportedProjects: {},
+                    DefaultCreatorName: "anonymous"
+                })
+            );
+            global.localStorage = originalLocalStorage;
+        });
+    });
+
     describe("auto-save", () => {
         it("should not start auto-save in init (auto-save lives in activity.js)", async () => {
             // Mock port() to avoid real localStorage access


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary
- guard legacy `localStorage` access in `ProjectStorage.port()` with `try/catch`
- continue migration/init even when browser policy blocks `localStorage`
- keep migration behavior intact by still setting storage version in IndexedDB-backed storage
- add regression tests for restricted `localStorage` scenarios

## Why
Issue #6926 reports that Planet init can fail in restricted environments because migration reads `localStorage` unguarded. This change prevents startup crashes in that path.

## Testing
- `npx jest planet/js/__tests__/ProjectStorage.test.js --coverage=false`

Closes #6926
