### PR TITLE
Fix PlanetInterface error handler receiver in loadProjectFromData

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -32,6 +32,7 @@ const mockActivity = {
     _loadStart: jest.fn(),
     doLoadAnimation: jest.fn(),
     textMsg: jest.fn(),
+    errorMsg: jest.fn(),
     stage: { enableDOMEvents: jest.fn(), update: jest.fn() },
     blocks: { loadNewBlocks: jest.fn(), palettes: { _hideMenus: jest.fn() }, trashStacks: [] },
     logo: { doStopTurtles: jest.fn() },
@@ -75,6 +76,7 @@ describe("PlanetInterface", () => {
 
     beforeEach(() => {
         planetInterface = new PlanetInterface(mockActivity);
+        mockActivity.errorMsg.mockClear();
     });
 
     test("hideMusicBlocks hides relevant elements and disables DOM events", () => {
@@ -369,10 +371,9 @@ describe("PlanetInterface", () => {
     it("loadProjectFromData shows error and returns early if data is undefined", () => {
         const saved_ = global._;
         global._ = jest.fn(str => str);
-        planetInterface.errorMsg = jest.fn();
         planetInterface.iframe = { style: { display: "" } };
         planetInterface.loadProjectFromData(undefined, false);
-        expect(planetInterface.errorMsg).toHaveBeenCalledWith("project undefined");
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith("project undefined");
         global._ = saved_;
     });
 
@@ -399,12 +400,11 @@ describe("PlanetInterface", () => {
         delete document.attachEvent;
     });
 
-    it("loadProjectFromData catches JSON parse errors and calls errorMsg", () => {
+    it("loadProjectFromData catches JSON parse errors and calls activity.errorMsg", () => {
         planetInterface.iframe = { style: { display: "" } };
         planetInterface.getCurrentProjectName = jest.fn(() => "foo");
-        planetInterface.errorMsg = jest.fn();
         planetInterface.loadProjectFromData("invalid json");
-        expect(planetInterface.errorMsg).toHaveBeenCalledWith(expect.any(SyntaxError));
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith(expect.any(SyntaxError));
     });
 
     it("saveLocally handles quota exceeded error and shows storage warning", () => {

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -127,7 +127,7 @@ class PlanetInterface {
             }
 
             if (data === undefined) {
-                this.errorMsg(_("project undefined"));
+                this.activity.errorMsg(_("project undefined"));
                 return;
             }
             this.activity.textMsg(this.getCurrentProjectName());
@@ -153,7 +153,7 @@ class PlanetInterface {
                 const obj = JSON.parse(data);
                 this.activity.blocks.loadNewBlocks(obj);
             } catch (e) {
-                this.errorMsg(e);
+                this.activity.errorMsg(e);
             }
 
             this.activity.loading = false;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [x] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation

## Summary
- replace `this.errorMsg(...)` with `this.activity.errorMsg(...)` in `PlanetInterface.loadProjectFromData()`
- ensure undefined-data and JSON-parse error paths report through the activity error handler instead of throwing a secondary `TypeError`
- update unit tests to assert the correct receiver (`activity.errorMsg`) is called

## Why
Issue #6928 reports that `loadProjectFromData()` currently calls an undefined `this.errorMsg` on `PlanetInterface`, which can crash the error path and mask the original problem.

## Testing
- `npx jest js/__tests__/planetInterface.test.js --coverage=false`

Closes #6928
