### PR TITLE
fix: add ManagedTimer to MusicKeyboard for proper widget cleanup

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -2,6 +2,7 @@ global.localStorage = {
     beginnerMode: "false"
 };
 
+const ManagedTimer = require("../../utils/ManagedTimer");
 const MusicKeyboard = require("../musickeyboard.js");
 
 describe("MusicKeyboard document key handler lifecycle", () => {
@@ -74,5 +75,96 @@ describe("MusicKeyboard document key handler lifecycle", () => {
 
         expect(keyboard._savedDocumentOnKeyDown).toBeUndefined();
         expect(keyboard._savedDocumentOnKeyUp).toBeUndefined();
+    });
+});
+
+describe("MusicKeyboard widget timer lifecycle", () => {
+    let originalManagedTimer;
+    let originalDocById;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        originalManagedTimer = global.ManagedTimer;
+        originalDocById = global.docById;
+        global.ManagedTimer = ManagedTimer;
+        global.docById = jest.fn(() => null);
+    });
+
+    afterEach(() => {
+        if (originalManagedTimer === undefined) {
+            delete global.ManagedTimer;
+        } else {
+            global.ManagedTimer = originalManagedTimer;
+        }
+
+        if (originalDocById === undefined) {
+            delete global.docById;
+        } else {
+            global.docById = originalDocById;
+        }
+
+        jest.useRealTimers();
+    });
+
+    test("tracks widget intervals through ManagedTimer", () => {
+        const keyboard = new MusicKeyboard({});
+        const callback = jest.fn();
+
+        const id = keyboard._setWidgetInterval(callback, 1000);
+
+        expect(keyboard._timerManager).toBeInstanceOf(ManagedTimer);
+        expect(keyboard._timerManager.activeIntervalCount).toBe(1);
+
+        jest.advanceTimersByTime(1000);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        expect(keyboard._clearWidgetInterval(id)).toBe(true);
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
+    });
+
+    test("stopMetronome clears the managed interval and audio loop", () => {
+        const countdownContainer = { remove: jest.fn() };
+        global.docById.mockImplementation(id =>
+            id === "countdownContainer" ? countdownContainer : null
+        );
+
+        const keyboard = new MusicKeyboard({});
+        const intervalCallback = jest.fn();
+        keyboard.tickButton = { style: { removeProperty: jest.fn() } };
+        keyboard.tick = true;
+        keyboard.firstNote = true;
+        keyboard.metronomeON = true;
+        keyboard.loopTick = { stop: jest.fn() };
+        keyboard.metronomeInterval = keyboard._setWidgetInterval(intervalCallback, 1000);
+
+        keyboard.stopMetronome();
+        jest.advanceTimersByTime(1000);
+
+        expect(keyboard.tickButton.style.removeProperty).toHaveBeenCalledWith("background");
+        expect(keyboard.loopTick.stop).toHaveBeenCalledTimes(1);
+        expect(countdownContainer.remove).toHaveBeenCalledTimes(1);
+        expect(intervalCallback).not.toHaveBeenCalled();
+        expect(keyboard.tick).toBe(false);
+        expect(keyboard.firstNote).toBe(false);
+        expect(keyboard.metronomeON).toBe(false);
+        expect(keyboard.metronomeInterval).toBeNull();
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
+    });
+
+    test("clearWidgetTimers cancels outstanding managed timers", () => {
+        const keyboard = new MusicKeyboard({});
+        const firstCallback = jest.fn();
+        const secondCallback = jest.fn();
+
+        keyboard._setWidgetInterval(firstCallback, 1000);
+        keyboard._setWidgetInterval(secondCallback, 1000);
+
+        expect(keyboard._timerManager.activeIntervalCount).toBe(2);
+        expect(keyboard._clearWidgetTimers()).toBe(2);
+
+        jest.advanceTimersByTime(1000);
+        expect(firstCallback).not.toHaveBeenCalled();
+        expect(secondCallback).not.toHaveBeenCalled();
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
     });
 });

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -12,6 +12,7 @@ const musicutils = require("../../utils/musicutils.js");
 Object.assign(global, musicutils);
 global.debugLog = jest.fn();
 
+const ManagedTimer = require("../../utils/ManagedTimer");
 const MusicKeyboard = require("../musickeyboard.js");
 
 describe("MusicKeyboard document key handler lifecycle", () => {
@@ -1212,5 +1213,96 @@ describe("MusicKeyboard core logic", () => {
             expect(img.title).toBe("Play");
             expect(img.alt).toBe("Play");
         });
+    });
+});
+
+describe("MusicKeyboard widget timer lifecycle", () => {
+    let originalManagedTimer;
+    let originalDocById;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        originalManagedTimer = global.ManagedTimer;
+        originalDocById = global.docById;
+        global.ManagedTimer = ManagedTimer;
+        global.docById = jest.fn(() => null);
+    });
+
+    afterEach(() => {
+        if (originalManagedTimer === undefined) {
+            delete global.ManagedTimer;
+        } else {
+            global.ManagedTimer = originalManagedTimer;
+        }
+
+        if (originalDocById === undefined) {
+            delete global.docById;
+        } else {
+            global.docById = originalDocById;
+        }
+
+        jest.useRealTimers();
+    });
+
+    test("tracks widget intervals through ManagedTimer", () => {
+        const keyboard = new MusicKeyboard({});
+        const callback = jest.fn();
+
+        const id = keyboard._setWidgetInterval(callback, 1000);
+
+        expect(keyboard._timerManager).toBeInstanceOf(ManagedTimer);
+        expect(keyboard._timerManager.activeIntervalCount).toBe(1);
+
+        jest.advanceTimersByTime(1000);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        expect(keyboard._clearWidgetInterval(id)).toBe(true);
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
+    });
+
+    test("stopMetronome clears the managed interval and audio loop", () => {
+        const countdownContainer = { remove: jest.fn() };
+        global.docById.mockImplementation(id =>
+            id === "countdownContainer" ? countdownContainer : null
+        );
+
+        const keyboard = new MusicKeyboard({});
+        const intervalCallback = jest.fn();
+        keyboard.tickButton = { style: { removeProperty: jest.fn() } };
+        keyboard.tick = true;
+        keyboard.firstNote = true;
+        keyboard.metronomeON = true;
+        keyboard.loopTick = { stop: jest.fn() };
+        keyboard.metronomeInterval = keyboard._setWidgetInterval(intervalCallback, 1000);
+
+        keyboard.stopMetronome();
+        jest.advanceTimersByTime(1000);
+
+        expect(keyboard.tickButton.style.removeProperty).toHaveBeenCalledWith("background");
+        expect(keyboard.loopTick.stop).toHaveBeenCalledTimes(1);
+        expect(countdownContainer.remove).toHaveBeenCalledTimes(1);
+        expect(intervalCallback).not.toHaveBeenCalled();
+        expect(keyboard.tick).toBe(false);
+        expect(keyboard.firstNote).toBe(false);
+        expect(keyboard.metronomeON).toBe(false);
+        expect(keyboard.metronomeInterval).toBeNull();
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
+    });
+
+    test("clearWidgetTimers cancels outstanding managed timers", () => {
+        const keyboard = new MusicKeyboard({});
+        const firstCallback = jest.fn();
+        const secondCallback = jest.fn();
+
+        keyboard._setWidgetInterval(firstCallback, 1000);
+        keyboard._setWidgetInterval(secondCallback, 1000);
+
+        expect(keyboard._timerManager.activeIntervalCount).toBe(2);
+        expect(keyboard._clearWidgetTimers()).toBe(2);
+
+        jest.advanceTimersByTime(1000);
+        expect(firstCallback).not.toHaveBeenCalled();
+        expect(secondCallback).not.toHaveBeenCalled();
+        expect(keyboard._timerManager.activeIntervalCount).toBe(0);
     });
 });

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -15,7 +15,7 @@
    global
 
    docById, platformColor, FIXEDSOLFEGE, FIXEDSOLFEGE1, SHARP, FLAT,
-   last, Singer, noteToFrequency, EIGHTHNOTEWIDTH,
+   last, ManagedTimer, Singer, noteToFrequency, EIGHTHNOTEWIDTH,
    MATRIXSOLFEHEIGHT, i18nSolfege, MATRIXSOLFEWIDTH, toFraction,
    wheelnav, slicePath, getNote, PREVIEWVOLUME, DEFAULTVOICE,
    PITCHES3, SOLFEGENAMES, SOLFEGECONVERSIONTABLE, NOTESSHARP,
@@ -26,6 +26,8 @@
         slicePath, wheelnav
     - js/utils/utils.js
         _, docById, last
+    - js/utils/ManagedTimer.js
+        ManagedTimer
     - js/turtle-singer.js
         Singer
     - js/utils/musicutils.js
@@ -100,6 +102,7 @@ function MusicKeyboard(activity) {
 
     this._savedDocumentOnKeyDown = undefined;
     this._savedDocumentOnKeyUp = undefined;
+    this._timerManager = typeof ManagedTimer !== "undefined" ? new ManagedTimer() : null;
 
     /**
      * Flag indicating whether playback is currently active.
@@ -131,6 +134,35 @@ function MusicKeyboard(activity) {
         document.onkeyup = this._savedDocumentOnKeyUp;
         this._savedDocumentOnKeyDown = undefined;
         this._savedDocumentOnKeyUp = undefined;
+    };
+
+    this._setWidgetInterval = function (callback, interval) {
+        if (this._timerManager !== null) {
+            return this._timerManager.setInterval(callback, interval);
+        }
+
+        return setInterval(callback, interval);
+    };
+
+    this._clearWidgetInterval = function (id) {
+        if (id === null || id === undefined || id === false) {
+            return false;
+        }
+
+        if (this._timerManager !== null && this._timerManager.clearInterval(id)) {
+            return true;
+        }
+
+        clearInterval(id);
+        return true;
+    };
+
+    this._clearWidgetTimers = function () {
+        if (this._timerManager !== null) {
+            return this._timerManager.clearAll();
+        }
+
+        return 0;
     };
 
     /**
@@ -178,7 +210,7 @@ function MusicKeyboard(activity) {
     /** Flag to track if the metronome is on.
      * @type {boolean}
      */
-    this.metronomeInterval = false;
+    this.metronomeInterval = null;
 
     /**
      * Meter arguments.
@@ -210,6 +242,27 @@ function MusicKeyboard(activity) {
      * @type {boolean}
      */
     this.firstNote = false;
+
+    // Turn off metronome and release timer/audio resources owned by it.
+    this.stopMetronome = () => {
+        if (this.tickButton) {
+            this.tickButton.style.removeProperty("background");
+        }
+        if (this.tick && this.loopTick) {
+            this.loopTick.stop();
+        }
+        this.tick = false;
+        this.firstNote = false;
+        this.metronomeON = false;
+        const countdownContainer = docById("countdownContainer");
+        if (countdownContainer) {
+            countdownContainer.remove();
+        }
+        if (this.metronomeInterval) {
+            this._clearWidgetInterval(this.metronomeInterval);
+            this.metronomeInterval = null;
+        }
+    };
 
     /**
      * Array of selected notes.
@@ -683,15 +736,8 @@ function MusicKeyboard(activity) {
                 myNode.innerHTML = "";
             }
 
-            // Ensure countdown interval/loop resources are cleaned up on close.
-            if (typeof this.stopMetronome === "function") {
-                this.stopMetronome();
-            } else {
-                this.tick = false;
-                this.firstNote = false;
-                this.metronomeON = false;
-                if (this.loopTick) this.loopTick.stop();
-            }
+            this.stopMetronome();
+            this._clearWidgetTimers();
 
             selectedNotes = [];
             docById("wheelDivptm").style.display = "none";
@@ -766,25 +812,6 @@ function MusicKeyboard(activity) {
          */
         this.tickButton = widgetWindow.addButton("metronome.svg", ICONSIZE, _("Metronome"));
 
-        // Turn off metronome
-        this.stopMetronome = () => {
-            this.tickButton.style.removeProperty("background");
-            if (this.tick && this.loopTick) {
-                this.loopTick.stop();
-            }
-            this.tick = false;
-            this.firstNote = false;
-            this.metronomeON = false;
-            const countdownContainer = docById("countdownContainer");
-            if (countdownContainer) {
-                countdownContainer.remove();
-            }
-            if (this.metronomeInterval) {
-                clearInterval(this.metronomeInterval);
-                this.metronomeInterval = null;
-            }
-        };
-
         this.tickButton.onclick = () => {
             if (this.metronomeInterval || this.metronomeON) {
                 this.stopMetronome();
@@ -805,11 +832,11 @@ function MusicKeyboard(activity) {
 
                 // Start countdown
                 let count = 3;
-                this.metronomeInterval = setInterval(() => {
+                this.metronomeInterval = this._setWidgetInterval(() => {
                     count--;
 
                     if (count === 0) {
-                        clearInterval(this.metronomeInterval);
+                        this._clearWidgetInterval(this.metronomeInterval);
                         this.metronomeInterval = null;
 
                         countdownContainer.remove();

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -15,7 +15,7 @@
    global
 
    docById, platformColor, FIXEDSOLFEGE, FIXEDSOLFEGE1, SHARP, FLAT,
-   last, Singer, noteToFrequency, EIGHTHNOTEWIDTH,
+   last, ManagedTimer, Singer, noteToFrequency, EIGHTHNOTEWIDTH,
    MATRIXSOLFEHEIGHT, i18nSolfege, MATRIXSOLFEWIDTH, toFraction,
    wheelnav, slicePath, getNote, PREVIEWVOLUME, DEFAULTVOICE,
    PITCHES3, SOLFEGENAMES, SOLFEGECONVERSIONTABLE, NOTESSHARP,
@@ -26,6 +26,8 @@
         slicePath, wheelnav
     - js/utils/utils.js
         _, docById, last, debugLog
+    - js/utils/ManagedTimer.js
+        ManagedTimer
     - js/turtle-singer.js
         Singer
     - js/utils/musicutils.js
@@ -153,6 +155,7 @@ function MusicKeyboard(activity) {
 
     this._savedDocumentOnKeyDown = undefined;
     this._savedDocumentOnKeyUp = undefined;
+    this._timerManager = typeof ManagedTimer !== "undefined" ? new ManagedTimer() : null;
 
     /**
      * Flag indicating whether playback is currently active.
@@ -184,6 +187,35 @@ function MusicKeyboard(activity) {
         document.onkeyup = this._savedDocumentOnKeyUp;
         this._savedDocumentOnKeyDown = undefined;
         this._savedDocumentOnKeyUp = undefined;
+    };
+
+    this._setWidgetInterval = function (callback, interval) {
+        if (this._timerManager !== null) {
+            return this._timerManager.setInterval(callback, interval);
+        }
+
+        return setInterval(callback, interval);
+    };
+
+    this._clearWidgetInterval = function (id) {
+        if (id === null || id === undefined || id === false) {
+            return false;
+        }
+
+        if (this._timerManager !== null && this._timerManager.clearInterval(id)) {
+            return true;
+        }
+
+        clearInterval(id);
+        return true;
+    };
+
+    this._clearWidgetTimers = function () {
+        if (this._timerManager !== null) {
+            return this._timerManager.clearAll();
+        }
+
+        return 0;
     };
 
     /**
@@ -231,7 +263,7 @@ function MusicKeyboard(activity) {
     /** Flag to track if the metronome is on.
      * @type {boolean}
      */
-    this.metronomeInterval = false;
+    this.metronomeInterval = null;
 
     /**
      * Meter arguments.
@@ -269,6 +301,27 @@ function MusicKeyboard(activity) {
      * @type {boolean}
      */
     this.firstNote = false;
+
+    // Turn off metronome and release timer/audio resources owned by it.
+    this.stopMetronome = () => {
+        if (this.tickButton) {
+            this.tickButton.style.removeProperty("background");
+        }
+        if (this.tick && this.loopTick) {
+            this.loopTick.stop();
+        }
+        this.tick = false;
+        this.firstNote = false;
+        this.metronomeON = false;
+        const countdownContainer = docById("countdownContainer");
+        if (countdownContainer) {
+            countdownContainer.remove();
+        }
+        if (this.metronomeInterval) {
+            this._clearWidgetInterval(this.metronomeInterval);
+            this.metronomeInterval = null;
+        }
+    };
 
     /**
      * Array of selected notes.
@@ -760,15 +813,8 @@ function MusicKeyboard(activity) {
                 myNode.replaceChildren();
             }
 
-            // Ensure countdown interval/loop resources are cleaned up on close.
-            if (typeof this.stopMetronome === "function") {
-                this.stopMetronome();
-            } else {
-                this.tick = false;
-                this.firstNote = false;
-                this.metronomeON = false;
-                if (this.loopTick) this.loopTick.stop();
-            }
+            this.stopMetronome();
+            this._clearWidgetTimers();
 
             // Stop any active pointer/keyboard notes
             if (activeKey !== null) {
@@ -870,25 +916,6 @@ function MusicKeyboard(activity) {
          */
         this.tickButton = widgetWindow.addButton("metronome.svg", ICONSIZE, _("Metronome"));
 
-        // Turn off metronome
-        this.stopMetronome = () => {
-            this.tickButton.style.removeProperty("background");
-            if (this.tick && this.loopTick) {
-                this.loopTick.stop();
-            }
-            this.tick = false;
-            this.firstNote = false;
-            this.metronomeON = false;
-            const countdownContainer = docById("countdownContainer");
-            if (countdownContainer) {
-                countdownContainer.remove();
-            }
-            if (this.metronomeInterval) {
-                clearInterval(this.metronomeInterval);
-                this.metronomeInterval = null;
-            }
-        };
-
         this.tickButton.onclick = () => {
             if (this.metronomeInterval || this.metronomeON) {
                 this.stopMetronome();
@@ -909,11 +936,11 @@ function MusicKeyboard(activity) {
 
                 // Start countdown
                 let count = 3;
-                this.metronomeInterval = setInterval(() => {
+                this.metronomeInterval = this._setWidgetInterval(() => {
                     count--;
 
                     if (count === 0) {
-                        clearInterval(this.metronomeInterval);
+                        this._clearWidgetInterval(this.metronomeInterval);
                         this.metronomeInterval = null;
 
                         countdownContainer.remove();


### PR DESCRIPTION
## PR Category:
- [x] Performance  
- [X] Bug Fix 

## Summary

Applies the existing ManagedTimer utility to MusicKeyboard widget for proper lifecycle cleanup.

- Adds per-instance `ManagedTimer` to track metronome and widget-level timers
- Replaces raw `setInterval`/`clearInterval` with managed timer helpers
- Ensures all timers are cancelled on widget close via `_clearWidgetTimers()`
- Makes `stopMetronome()` a stable instance method callable from cleanup paths
- Adds lifecycle tests covering close-time cleanup, interval clearing, audio loop stop, and idempotent cleanup

## Motivation

Widget timer cleanup is handled inconsistently across Music Blocks widgets. MusicKeyboard specifically had raw timer IDs that could survive widget close, potentially causing metronome to continue after widget is closed. Using ManagedTimer provides centralized timer ownership and a single cleanup switch.


## refrenced  and followed  up from 
#5799