### PR TITLE
fix: resolve logic error in rationalSum where arrays were compared to 0 (Fix #6937)

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1694,10 +1694,6 @@ let rationalSum = (a, b) => {
         console.warn("Invalid input passed to rationalSum:", a, b);
         return [0, 1];
     }
-    if (a === 0 || b === 0) {
-        // console.debug("divide by zero?");
-        return [0, 1];
-    }
 
     // Make sure a and b components are integers.
     let obja0, objb0, obja1, objb1;


### PR DESCRIPTION
## Description

Resolves a logic error in `js/utils/utils.js` where rational duration arrays (e.g., `[1, 4]`) were being incorrectly compared to the primitive integer `0`. This fix ensures that `rationalSum` correctly validates its inputs and returns accurate sums for musical durations.

## Related Issue

This PR fixes #6937 

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance
-   [ ] Tests — Adds or updates test coverage

## Changes Made

-   Removed the redundant and incorrect `a === 0 || b === 0` check in `js/utils/utils.js`.
-   Ensured valid rational arrays are processed through the core summing logic without being short-circuited.