### PR TITLE
perf: use deepClone in block copy hot paths

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -25,7 +25,7 @@
    getVoiceSynthName, i18nSolfege, last, MathUtility, mixedNumber,
    piemenuBlockContext, prepareMacroExports, ProtoBlock,
     setOctaveRatio, splitScaleDegree, splitSolfege, updateTemperaments,
-    docById, define, BlocksDependencies
+    docById, define, BlocksDependencies, deepClone
 */
 
 /* global showZoomOverlay */
@@ -44,7 +44,7 @@
         MathUtility
    - js/utils/utils.js
         _, last, closeBlkWidgets, mixedNumber, prepareMacroExports,
-        getTextWidth, delayExecution
+        getTextWidth, delayExecution, deepClone
    - js/utils/musicutils.js
         addTemperamentToDictionary,
         getDrumSynthName, getNoiseName, getNoiseSynthName,
@@ -5292,7 +5292,7 @@ class Blocks {
             this.selectedStack = this.activeBlock;
 
             /** Copy the selectedStack. */
-            this.selectedBlocksObj = JSON.parse(JSON.stringify(this._copyBlocksToObj(false)));
+            this.selectedBlocksObj = deepClone(this._copyBlocksToObj(false));
 
             /** Reset paste offset. */
             this.pasteDx = 0;

--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -43,6 +43,7 @@ global.docById = jest.fn().mockReturnValue({
     classList: { add: jest.fn(), remove: jest.fn() },
     innerHTML: ""
 });
+global.deepClone = value => JSON.parse(JSON.stringify(value));
 global.delayExecution = jest.fn().mockResolvedValue(undefined);
 global.last = arr => (arr && arr.length > 0 ? arr[arr.length - 1] : undefined);
 global.nearestBeat = jest.fn(val => val);
@@ -373,11 +374,14 @@ describe("RhythmRuler Widget", () => {
         test("should preserve old history entries for unused drums", () => {
             rhythmRuler.Drums = ["snare drum"];
             rhythmRuler.Rulers = [[[], [[0, 2]]]];
-            rhythmRuler._dissectHistory = [[[[0, 4]], "old drum"]];
+            const oldHistory = [[0, 4]];
+            rhythmRuler._dissectHistory = [[oldHistory, "old drum"]];
 
             rhythmRuler.saveDissectHistory();
+            oldHistory[0][1] = 8;
 
             expect(rhythmRuler._dissectHistory).toHaveLength(2);
+            expect(rhythmRuler._dissectHistory[1][0][0][1]).toBe(4);
         });
 
         test("should add hasKeyboard class to dissect number", () => {

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -17,7 +17,7 @@
 /*
    global
 
-   TONEBPM, Singer, _, delayExecution, docById,
+   TONEBPM, Singer, _, delayExecution, deepClone, docById,
    calcNoteValueToDisplay, platformColor, beginnerMode, last,
    EIGHTHNOTEWIDTH, nearestBeat, rationalToFraction, DRUMNAMES,
    VOICENAMES, EFFECTSNAMES
@@ -29,7 +29,7 @@
     - js/turtle-singer.js
         Singer
     - js/utils/utils.js
-        _, docById, delayExecution, last, nearestBeat, rationalToFraction
+        _, deepClone, docById, delayExecution, last, nearestBeat, rationalToFraction
     - js/utils/musicutils.js
         calcNoteValueToDisplay, EIGHTHNOTEWIDTH
     - js/utils/platformstyle.js
@@ -48,6 +48,7 @@
  * @requires Singer
  * @requires _
  * @requires docById
+ * @requires deepClone
  * @requires delayExecution
  * @requires last
  * @requires nearestBeat
@@ -463,12 +464,12 @@ class RhythmRuler {
             for (let i = 0; i < this._dissectHistory.length; i++) {
                 const drum = this._dissectHistory[i][1];
                 if (!drumsSet.has(drum)) {
-                    const history = JSON.parse(JSON.stringify(this._dissectHistory[i][0]));
+                    const history = deepClone(this._dissectHistory[i][0]);
                     dissectHistory.push([history, drum]);
                 }
             }
 
-            this._dissectHistory = JSON.parse(JSON.stringify(dissectHistory));
+            this._dissectHistory = deepClone(dissectHistory);
 
             this._playing = false;
             this._playingOne = false;
@@ -2798,12 +2799,12 @@ class RhythmRuler {
         for (let i = 0; i < this._dissectHistory.length; i++) {
             drum = this._dissectHistory[i][1];
             if (!drumsSet.has(drum)) {
-                history = JSON.parse(JSON.stringify(this._dissectHistory[i][0]));
+                history = deepClone(this._dissectHistory[i][0]);
                 dissectHistory.push([history, drum]);
             }
         }
 
-        this._dissectHistory = JSON.parse(JSON.stringify(dissectHistory));
+        this._dissectHistory = deepClone(dissectHistory);
     }
 
     /**


### PR DESCRIPTION
## PR Category
- [x] Performance

## Summary

- Replace direct `JSON.parse(JSON.stringify(...))` cloning in block copy and Rhythm Ruler history paths with the existing `deepClone(...)` utility.
- Add Rhythm Ruler test coverage to ensure preserved dissect history entries are cloned rather than aliased.
- Keep the change scoped to runtime hot paths in `blocks.js` and `rhythmruler.js`.

## Why

Music Blocks already provides `deepClone(...)`, which uses `structuredClone` when available and falls back safely where needed. These paths were still doing direct JSON serialization round-trips, which adds avoidable allocation and main-thread work during copy/history operations.
