### PR TITLE
fix: clean up timbre widget timers

### DIFF
--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -53,6 +53,8 @@ global.docById = jest.fn(() => ({
     }))
 }));
 global.docByName = jest.fn(() => []);
+const ManagedTimer = require("../../utils/ManagedTimer.js");
+global.ManagedTimer = ManagedTimer;
 
 global.window = {
     innerWidth: 1200,
@@ -111,6 +113,10 @@ describe("TimbreWidget", () => {
     });
 
     afterEach(() => {
+        if (timbre && typeof timbre._clearWidgetTimers === "function") {
+            timbre._clearWidgetTimers();
+        }
+        jest.useRealTimers();
         jest.clearAllMocks();
     });
 
@@ -229,6 +235,52 @@ describe("TimbreWidget", () => {
 
         test("should initialize _eventListeners as empty object", () => {
             expect(timbre._eventListeners).toEqual({});
+        });
+    });
+
+    describe("timer lifecycle", () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        test("should track and clear widget timeouts", () => {
+            const callback = jest.fn();
+
+            timbre._setWidgetTimeout(callback, 500);
+
+            expect(timbre._timerManager.activeTimeoutCount).toBe(1);
+            expect(timbre._clearWidgetTimers()).toBe(1);
+
+            jest.advanceTimersByTime(500);
+
+            expect(callback).not.toHaveBeenCalled();
+            expect(timbre._timerManager.activeTimeoutCount).toBe(0);
+        });
+
+        test("_changeBlock should schedule delayed block replacement through widget timers", () => {
+            timbre.AMSynthesizer = [4];
+            jest.spyOn(timbre, "_blockReplace").mockImplementation();
+
+            timbre._changeBlock(8, "FMSynth", null);
+
+            expect(timbre._timerManager.activeTimeoutCount).toBe(1);
+
+            jest.advanceTimersByTime(500);
+
+            expect(timbre._blockReplace).toHaveBeenCalledWith(4, 8);
+            expect(timbre._timerManager.activeTimeoutCount).toBe(0);
+        });
+
+        test("_clearWidgetTimers should cancel pending delayed block replacement", () => {
+            timbre.AMSynthesizer = [4];
+            jest.spyOn(timbre, "_blockReplace").mockImplementation();
+
+            timbre._changeBlock(8, "FMSynth", null);
+            timbre._clearWidgetTimers();
+            jest.advanceTimersByTime(500);
+
+            expect(timbre._blockReplace).not.toHaveBeenCalled();
+            expect(timbre._timerManager.activeTimeoutCount).toBe(0);
         });
     });
 

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -17,7 +17,7 @@
    DEFAULTOSCILLATORTYPE, platformColor, rationalToFraction, last,
    Singer, instrumentsEffects:writeable, instrumentsFilters:writeable,
    docById, DEFAULTFILTERTYPE, docByName, OSCTYPES, FILTERTYPES,
-   oneHundredToFraction, delayExecution
+   oneHundredToFraction, delayExecution, ManagedTimer
  */
 
 /*
@@ -28,6 +28,8 @@
         platformColor
     js/utils/utils.js
         rationalToFraction, last, _, docById, docByName, oneHundredToFraction
+    js/utils/ManagedTimer.js
+        ManagedTimer
     js/utils/synthutils.js
         instrumentsEffects, instrumentsFilters
     js/turtle-singer.js
@@ -48,6 +50,9 @@ class TimbreWidget {
         this.env = [];
         this.ENVs = [];
         this._eventListeners = {}; // Store event listeners for cleanup
+        this._timerManager = typeof ManagedTimer !== "undefined" ? new ManagedTimer() : null;
+        this._activeTimeouts = new Set();
+        this._previewTimerId = null;
         this.synthVals = {
             oscillator: {
                 type: "sine6",
@@ -137,6 +142,73 @@ class TimbreWidget {
         }
 
         this.timbreTableDiv = document.createElement("div");
+    }
+
+    /**
+     * Schedules a timeout owned by the widget lifecycle.
+     * @private
+     * @param {Function} callback - Callback to run after the delay.
+     * @param {number} delay - Delay in milliseconds.
+     * @returns {number} Timer ID.
+     */
+    _setWidgetTimeout(callback, delay) {
+        if (this._timerManager !== null) {
+            return this._timerManager.setTimeout(callback, delay);
+        }
+
+        let id;
+        id = setTimeout(() => {
+            this._activeTimeouts.delete(id);
+            callback();
+        }, delay);
+        this._activeTimeouts.add(id);
+        return id;
+    }
+
+    /**
+     * Clears a timeout owned by the widget lifecycle.
+     * @private
+     * @param {number} id - Timer ID returned by _setWidgetTimeout.
+     * @returns {boolean} Whether the timeout was tracked and cleared.
+     */
+    _clearWidgetTimeout(id) {
+        if (id === null || id === undefined) {
+            return false;
+        }
+
+        if (this._timerManager !== null && this._timerManager.clearTimeout(id)) {
+            return true;
+        }
+
+        if (this._activeTimeouts.has(id)) {
+            clearTimeout(id);
+            this._activeTimeouts.delete(id);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Clears all timers owned by the widget lifecycle.
+     * @private
+     * @returns {number} Number of tracked timers cleared.
+     */
+    _clearWidgetTimers() {
+        let count = 0;
+
+        if (this._timerManager !== null) {
+            count += this._timerManager.clearAll();
+        }
+
+        for (const id of this._activeTimeouts) {
+            clearTimeout(id);
+            count++;
+        }
+        this._activeTimeouts.clear();
+        this._previewTimerId = null;
+
+        return count;
     }
 
     /**
@@ -416,6 +488,8 @@ class TimbreWidget {
             cell.appendChild(stopImg);
             cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         } else {
+            this._clearWidgetTimeout(this._previewTimerId);
+            this._previewTimerId = null;
             this.activity.logo.synth.setMasterVolume(0);
             this.activity.logo.synth.stop();
             cell.textContent = "\u00A0\u00A0";
@@ -446,8 +520,9 @@ class TimbreWidget {
 
             i += 1;
             if (i < this.notesToPlay.length && this._playing) {
-                setTimeout(
+                this._previewTimerId = this._setWidgetTimeout(
                     () => {
+                        this._previewTimerId = null;
                         __playLoop(i);
                     },
                     Singer.defaultBPMFactor * 1000 * this.notesToPlay[i - 1][1]
@@ -729,6 +804,8 @@ class TimbreWidget {
         widgetWindow.getWidgetBody().style.overflowY = "auto";
 
         widgetWindow.onclose = () => {
+            this._playing = false;
+            this._clearWidgetTimers();
             // Clean up all event listeners
             this._cleanupEventListeners();
             this.activity.hideMsgs();
@@ -1046,17 +1123,17 @@ class TimbreWidget {
         let lastBlk = 0;
         if (this.AMSynthesizer.length !== 0 && synthChosen !== "AMSynth") {
             lastBlk = this.AMSynthesizer.pop();
-            setTimeout(() => this._blockReplace(lastBlk, newblk), 500);
+            this._setWidgetTimeout(() => this._blockReplace(lastBlk, newblk), 500);
         } else if (this.FMSynthesizer.length !== 0 && synthChosen !== "FMSynth") {
             lastBlk = this.FMSynthesizer.pop();
-            setTimeout(() => this._blockReplace(lastBlk, newblk), 500);
+            this._setWidgetTimeout(() => this._blockReplace(lastBlk, newblk), 500);
         } else if (this.duoSynthesizer.length !== 0 && synthChosen !== "DuoSynth") {
             lastBlk = this.duoSynthesizer.pop();
-            setTimeout(() => this._blockReplace(lastBlk, newblk), 500);
+            this._setWidgetTimeout(() => this._blockReplace(lastBlk, newblk), 500);
         } else if (synthChosen === "FMSynth" || synthChosen === "AMSynth") {
-            setTimeout(() => this.blockConnection(2, bottomOfClamp), 500);
+            this._setWidgetTimeout(() => this.blockConnection(2, bottomOfClamp), 500);
         } else {
-            setTimeout(() => this.blockConnection(3, bottomOfClamp), 500);
+            this._setWidgetTimeout(() => this.blockConnection(3, bottomOfClamp), 500);
         }
     }
 


### PR DESCRIPTION
## PR Category
- [x] Performance

## Summary

This PR extends the existing `ManagedTimer` lifecycle cleanup pattern to the Timbre widget.

Timbre schedules delayed callbacks for preview playback and synth block replacement/connection updates. Previously these used raw `setTimeout`, so callbacks could still fire after the Timbre widget was closed. That could allow preview playback or delayed block mutations to continue after the widget lifecycle ended.

This change routes Timbre-owned timers through widget timer helpers backed by `ManagedTimer`, and clears pending timers when the widget closes.

## Relation to Previous Work

This follows the same direction as #6936, where `ManagedTimer` was applied to Music Keyboard timers.

It also builds on the `ManagedTimer.js` infrastructure introduced in #5799 by applying it to another widget lifecycle path where stale timers can cause visible or audio side effects.

## What Changed

- Added `ManagedTimer` support to `TimbreWidget`
- Routed Timbre preview playback timers through widget-owned timer helpers
- Routed delayed synth block replacement/connection timers through widget-owned timer helpers
- Cleared pending Timbre timers on widget close
- Added focused Jest coverage for timer tracking and cancellation behavior
### Before:

https://github.com/user-attachments/assets/7364c6e0-4ba5-4f35-88ae-2b45b385c9b6

### After:

https://github.com/user-attachments/assets/dd4f051b-0062-473a-968d-d3398a22cb95


 
