### PR TITLE
fix(blocks.js): guard against undefined block entries in adjustDocks to prevent potential TypeError

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1110,9 +1110,9 @@ class Blocks {
                 }
 
                 /** Guard against invalid block connections */
-                const blk = this.blockList[cblk];
-                if (!blk || !Array.isArray(blk.connections)) {
-                    console.warn("Invalid block connection detected - skipping.");
+                const connectedBlock = this.blockList[cblk];
+                if (!connectedBlock || !Array.isArray(connectedBlock.connections)) {
+                    console.debug("Invalid block connection detected - skipping.");
                     continue;
                 }
 
@@ -1121,10 +1121,10 @@ class Blocks {
                 let matchingBlock;
                 for (
                     matchingBlock = 0;
-                    matchingBlock < blk.connections.length;
+                    matchingBlock < connectedBlock.connections.length;
                     matchingBlock++
                 ) {
-                    if (blk.connections[matchingBlock] === blk) {
+                    if (connectedBlock.connections[matchingBlock] === blk) {
                         foundMatch = true;
                         break;
                     }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1112,7 +1112,7 @@ class Blocks {
                 /** Guard against invalid block connections */
                 const connectedBlock = this.blockList[cblk];
                 if (!connectedBlock || !Array.isArray(connectedBlock.connections)) {
-                    console.debug("Invalid block connection detected - skipping.");
+                    console.warn(`Invalid block connection detected - cblk: ${cblk}, block: ${connectedBlock?.name || 'undefined'}, parent block: ${myBlock.name} (${blk})`);
                     continue;
                 }
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1109,15 +1109,22 @@ class Blocks {
                     continue;
                 }
 
+                /** Guard against invalid block connections */
+                const blk = this.blockList[cblk];
+                if (!blk || !Array.isArray(blk.connections)) {
+                    console.warn("Invalid block connection detected - skipping.");
+                    continue;
+                }
+
                 /** Find the dock position in the connected block. */
                 let foundMatch = false;
                 let matchingBlock;
                 for (
                     matchingBlock = 0;
-                    matchingBlock < this.blockList[cblk].connections.length;
+                    matchingBlock < blk.connections.length;
                     matchingBlock++
                 ) {
-                    if (this.blockList[cblk].connections[matchingBlock] === blk) {
+                    if (blk.connections[matchingBlock] === blk) {
                         foundMatch = true;
                         break;
                     }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1112,7 +1112,17 @@ class Blocks {
                 /** Guard against invalid block connections */
                 const connectedBlock = this.blockList[cblk];
                 if (!connectedBlock || !Array.isArray(connectedBlock.connections)) {
-                    console.warn(`Invalid block connection detected - cblk: ${cblk}, block: ${connectedBlock?.name || 'undefined'}, parent block: ${myBlock.name} (${blk})`);
+                    console.warn(
+                        "Invalid block connection detected - cblk: " +
+                            cblk +
+                            ", block: " +
+                            (connectedBlock ? connectedBlock.name : "undefined") +
+                            ", parent block: " +
+                            myBlock.name +
+                            " (" +
+                            blk +
+                            ")"
+                    );
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

Adds a defensive check in `adjustDocks` (`js/blocks.js`) to prevent potential runtime errors when accessing block connections.

---

## Related Issue

Fixes #6947

---

## Problem

The function assumes that:

`this.blockList[cblk].connections`

always exists.

If `cblk` refers to an index that is out-of-bounds or temporarily uninitialized, `this.blockList[cblk]` becomes `undefined`, and accessing `.connections` can result in:

TypeError: Cannot read properties of undefined (reading 'connections')

---

## Why This Happens

During drag-and-drop operations, block connections may temporarily reference indices that:
- are not yet initialized, or
- have shifted due to dynamic updates in `blockList`

This creates a short-lived inconsistent state.

---

## Solution

Added a guard before accessing `.connections`:

    const blk = this.blockList[cblk];
    if (!blk || !Array.isArray(blk.connections)) {
        console.warn("Invalid block connection detected - skipping.");
        continue;
    }

---

## PR Category

- [x] Bug Fix