### PR TITLE
fix: cache block search autocomplete results

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -250,6 +250,7 @@ class Activity {
 
         this.cellSize = 55;
         this.searchSuggestions = [];
+        this._searchCache = {}; // Cache for search results to improve performance
         this._searchCloseListener = null;
         this.homeButtonContainer;
 
@@ -3263,6 +3264,7 @@ class Activity {
             this.searchBlockPosition = [100, 100];
 
             this.searchSuggestions = [];
+            this._searchCache = {}; // Reset cache to prevent memory leaks
             this.deprecatedBlockNames = [];
 
             // Guard: blocks may not be initialized yet during early loading
@@ -3488,6 +3490,13 @@ class Activity {
                     // Custom source so we can match on extraSearchTerms but show each block only once.
                     source: (request, response) => {
                         const term = (request.term || "").toLowerCase();
+
+                        // Check cache first for performance
+                        if (that._searchCache[term] !== undefined) {
+                            response(that._searchCache[term]);
+                            return;
+                        }
+
                         const results = that.searchSuggestions.filter(item => {
                             // If there is no active term, show all items.
                             if (!term || term.length === 0) {
@@ -3506,6 +3515,9 @@ class Activity {
                                 item.label.toLowerCase().indexOf(term) !== -1
                             );
                         });
+
+                        // Cache the results for future use
+                        that._searchCache[term] = results;
                         response(results);
                     },
                     appendTo: "body",
@@ -7216,6 +7228,13 @@ class Activity {
                 $helpfulSearch.autocomplete({
                     source: (request, response) => {
                         const term = (request.term || "").toLowerCase();
+
+                        // Check cache first for performance
+                        if (that._searchCache[term] !== undefined) {
+                            response(that._searchCache[term]);
+                            return;
+                        }
+
                         const results = that.searchSuggestions.filter(item => {
                             if (!term || term.length === 0) {
                                 return true;
@@ -7231,6 +7250,9 @@ class Activity {
                                 item.label.toLowerCase().indexOf(term) !== -1
                             );
                         });
+
+                        // Cache the results for future use
+                        that._searchCache[term] = results;
                         response(results);
                     },
                     appendTo: "body",

--- a/js/activity.js
+++ b/js/activity.js
@@ -3489,7 +3489,7 @@ class Activity {
                 $search.autocomplete({
                     // Custom source so we can match on extraSearchTerms but show each block only once.
                     source: (request, response) => {
-                        const term = (request.term || "").toLowerCase();
+                        const term = (request.term || "").toLowerCase().trim();
 
                         // Check cache first for performance
                         if (that._searchCache[term] !== undefined) {
@@ -7227,7 +7227,7 @@ class Activity {
             if (!$helpfulSearch.data("autocomplete-init")) {
                 $helpfulSearch.autocomplete({
                     source: (request, response) => {
-                        const term = (request.term || "").toLowerCase();
+                        const term = (request.term || "").toLowerCase().trim();
 
                         // Check cache first for performance
                         if (that._searchCache[term] !== undefined) {


### PR DESCRIPTION
Regex filtering hundreds of blocks on every keystroke was laggy. Now we cache
by lowercase search term. First hit filters, repeats are instant.

Added _searchCache property, check cache before filtering, reset in
prepSearchWidget() so stale data doesn't pile up.

Closes #6254

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation