### PR TITLE
Added a feature to preview the block in trash can which you want to restore

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -316,10 +316,14 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
 }
 
 .trash-item-icon {
-    width: 30px;
-    height: 30px;
-    margin-right: 10px;
+    width: 60px;
+    height: 60px;
+    margin-right: 15px;
     vertical-align: middle;
+    object-fit: contain;
+    background-color: #f0f0f0;
+    border-radius: 4px;
+    padding: 2px;
 }
 
 #restoreLastIcon,
@@ -338,6 +342,25 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
 
 .hidden {
     display: none;
+}
+
+.trash-preview-popup {
+    position: fixed;
+    z-index: 10001;
+    background-color: white;
+    border: 2px solid #2196f3;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    padding: 10px;
+    display: none;
+    pointer-events: none;
+}
+
+.trash-preview-popup img {
+    max-width: 400px;
+    max-height: 400px;
+    display: block;
+    object-fit: contain;
 }
 
 .ui-menu {

--- a/css/activities.css
+++ b/css/activities.css
@@ -321,8 +321,8 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
     margin-right: 15px;
     vertical-align: middle;
     object-fit: contain;
-    background-color: #f0f0f0;
-    border-radius: 4px;
+    background-color: var(--color-bg-tertiary);
+    border-radius: var(--radius-sm);
     padding: 2px;
 }
 
@@ -347,10 +347,10 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
 .trash-preview-popup {
     position: fixed;
     z-index: 10001;
-    background-color: white;
-    border: 2px solid #2196f3;
-    border-radius: 8px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    background-color: var(--color-bg-primary);
+    border: 2px solid var(--color-brand-primary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
     padding: 10px;
     display: none;
     pointer-events: none;

--- a/js/activity.js
+++ b/js/activity.js
@@ -3420,11 +3420,7 @@ class Activity {
         }
 
         this._renderTrashView = () => {
-            if (
-                !this.blocks ||
-                !this.blocks.trashStacks ||
-                this.blocks.trashStacks.length === 0
-            ) {
+            if (!this.blocks || !this.blocks.trashStacks || this.blocks.trashStacks.length === 0) {
                 return;
             }
             const trashList = document.getElementById("trashList");

--- a/js/activity.js
+++ b/js/activity.js
@@ -3421,9 +3421,9 @@ class Activity {
 
         this._renderTrashView = () => {
             if (
-                !activity.blocks ||
-                !activity.blocks.trashStacks ||
-                activity.blocks.trashStacks.length === 0
+                !this.blocks ||
+                !this.blocks.trashStacks ||
+                this.blocks.trashStacks.length === 0
             ) {
                 return;
             }
@@ -3468,13 +3468,17 @@ class Activity {
                 const listItem = document.createElement("div");
                 listItem.classList.add("trash-item");
 
-                const svgData = block.artwork;
-                const encodedData = svgData
-                    ? "data:image/svg+xml;utf8," + encodeURIComponent(svgData)
-                    : "";
+                const preview = this.blocks.trashPreviews[blockId];
+                let imgSrc;
+                if (preview) {
+                    imgSrc = preview;
+                } else {
+                    const svgData = block.artwork;
+                    imgSrc = "data:image/svg+xml;utf8," + encodeURIComponent(svgData);
+                }
 
                 const img = document.createElement("img");
-                img.src = encodedData;
+                img.src = imgSrc;
                 img.alt = "Block Icon";
                 img.classList.add("trash-item-icon");
 
@@ -3484,10 +3488,26 @@ class Activity {
                 listItem.appendChild(textNode);
                 listItem.dataset.blockId = blockId;
 
-                listItem.addEventListener("mouseover", () => listItem.classList.add("hover"));
-                listItem.addEventListener("mouseout", () => listItem.classList.remove("hover"));
+                listItem.addEventListener("mouseover", () => {
+                    listItem.classList.add("hover");
+                });
+                listItem.addEventListener("mouseout", () => {
+                    listItem.classList.remove("hover");
+                });
+
+                img.addEventListener("mouseover", event => {
+                    this._showTrashPreviewPopup(imgSrc, event);
+                });
+                img.addEventListener("mousemove", event => {
+                    this._showTrashPreviewPopup(imgSrc, event);
+                });
+                img.addEventListener("mouseout", () => {
+                    this._hideTrashPreviewPopup();
+                });
+
                 listItem.addEventListener("click", () => {
                     this._restoreTrashById(blockId);
+                    this._hideTrashPreviewPopup();
                     trashView.classList.add("hidden");
                 });
 
@@ -3499,9 +3519,62 @@ class Activity {
 
             const existingView = document.getElementById("trashView");
             if (existingView) {
-                existingView.remove(); // remove from DOM; GC can now collect listeners
+                trashList.replaceChild(trashView, existingView);
+            } else {
+                trashList.appendChild(trashView);
             }
-            trashList.appendChild(trashView);
+        };
+
+        /**
+         * Shows a larger preview popup for trashed items.
+         * @param {string} imgSrc - The source of the image.
+         * @param {MouseEvent} event - The mouse event.
+         * @private
+         */
+        this._showTrashPreviewPopup = (imgSrc, event) => {
+            let popup = document.getElementById("trashPreviewPopup");
+            if (!popup) {
+                popup = document.createElement("div");
+                popup.id = "trashPreviewPopup";
+                popup.classList.add("trash-preview-popup");
+                const img = document.createElement("img");
+                popup.appendChild(img);
+                document.body.appendChild(popup);
+            }
+            const img = popup.firstChild;
+            if (img.src !== imgSrc) {
+                img.src = imgSrc;
+            }
+            popup.style.display = "block";
+
+            // Position next to cursor
+            const xOffset = 20;
+            const yOffset = 20;
+            let x = event.clientX + xOffset;
+            let y = event.clientY + yOffset;
+
+            // Flip if near right edge
+            if (x + 300 > window.innerWidth) {
+                x = event.clientX - 320;
+            }
+            // Flip if near bottom edge
+            if (y + 300 > window.innerHeight) {
+                y = event.clientY - 320;
+            }
+
+            popup.style.left = x + "px";
+            popup.style.top = y + "px";
+        };
+
+        /**
+         * Hides the trash preview popup.
+         * @private
+         */
+        this._hideTrashPreviewPopup = () => {
+            const popup = document.getElementById("trashPreviewPopup");
+            if (popup) {
+                popup.style.display = "none";
+            }
         };
 
         /*
@@ -3618,7 +3691,11 @@ class Activity {
 
                 // If this block is at the top of a stack, push it
                 // onto the trashStacks list.
-                if (myBlock.connections[0] === null) {
+                if (this.blocks.blockList[blk].connections[0] === null) {
+                    const preview = this.blocks.captureStackPreview(blk);
+                    if (preview) {
+                        this.blocks.trashPreviews[blk] = preview;
+                    }
                     this.blocks.trashStacks.push(blk);
                 }
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -236,6 +236,8 @@ class Blocks {
 
         /** We keep a list of stacks in the trash. */
         this.trashStacks = [];
+        /** We keep a list of previews of stacks in the trash. */
+        this.trashPreviews = {};
 
         /** When true, checkBounds() calls are suppressed until
          *  _endDeferCheckBounds() runs one final check. */
@@ -7245,6 +7247,102 @@ class Blocks {
         };
 
         /**
+         * Capture a preview of the stack of blocks.
+         * @param {number} topBlockId - The ID of the top block of the stack.
+         * @returns {string|null} - Data URL of the stack preview or null.
+         */
+        this.captureStackPreview = topBlockId => {
+            this.findDragGroup(topBlockId);
+            const blocks = this.dragGroup.map(id => this.blockList[id]);
+            if (blocks.length === 0) return null;
+
+            // Find bounds of the entire stack
+            let minX = Infinity;
+            let minY = Infinity;
+            let maxX = -Infinity;
+            let maxY = -Infinity;
+
+            blocks.forEach(block => {
+                if (block.container) {
+                    // Use block.width/height if available, otherwise getBounds
+                    let b = { x: 0, y: 0, width: block.width || 0, height: block.height || 0 };
+                    if (b.width === 0 || b.height === 0) {
+                        const actualBounds = block.container.getBounds();
+                        if (actualBounds) {
+                            b = actualBounds;
+                        }
+                    }
+
+                    const x = block.container.x + b.x * (block.container.scaleX || 1);
+                    const y = block.container.y + b.y * (block.container.scaleY || 1);
+                    const w = b.width * (block.container.scaleX || 1);
+                    const h = b.height * (block.container.scaleY || 1);
+
+                    minX = Math.min(minX, x);
+                    minY = Math.min(minY, y);
+                    maxX = Math.max(maxX, x + w);
+                    maxY = Math.max(maxY, y + h);
+                }
+            });
+
+            if (minX === Infinity || maxX === -Infinity) return null;
+
+            // Add padding for better look
+            const padding = 20;
+            minX -= padding;
+            minY -= padding;
+            maxX += padding;
+            maxY += padding;
+
+            const width = maxX - minX;
+            const height = maxY - minY;
+
+            // Limit preview size to keep memory usage reasonable
+            const MAX_PREVIEW_WIDTH = 400;
+            const MAX_PREVIEW_HEIGHT = 400;
+            let scale = 1;
+            if (width > MAX_PREVIEW_WIDTH || height > MAX_PREVIEW_HEIGHT) {
+                scale = Math.min(MAX_PREVIEW_WIDTH / width, MAX_PREVIEW_HEIGHT / height);
+            }
+
+            const canvas = document.createElement("canvas");
+            canvas.width = Math.max(1, width * scale);
+            canvas.height = Math.max(1, height * scale);
+            const ctx = canvas.getContext("2d");
+
+            // Fill background to ensure visibility
+            ctx.fillStyle = "#ffffff";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.scale(scale, scale);
+
+            blocks.forEach(block => {
+                if (block.container) {
+                    ctx.save();
+                    ctx.translate(block.container.x - minX, block.container.y - minY);
+                    ctx.scale(block.container.scaleX || 1, block.container.scaleY || 1);
+                    
+                    // Temporarily uncache to ensure all children (text, etc.) are drawn correctly
+                    const wasCached = !!block.container.bitmapCache;
+                    if (wasCached) {
+                        block.container.uncache();
+                    }
+                    
+                    block.container.draw(ctx);
+                    
+                    // Re-cache if it was cached (though sendStackToTrash will uncache it anyway)
+                    if (wasCached) {
+                        block.container.cache(0, 0, block.width, block.height);
+                    }
+                    
+                    ctx.restore();
+                }
+            });
+
+            return canvas.toDataURL("image/png");
+        };
+
+        /**
          * Send a stack of blocks to the trash.
          * @param - myBlock
          * @public
@@ -7260,6 +7358,12 @@ class Blocks {
 
             const thisBlock = myBlock.blockIndex;
 
+            /** Capture a preview of the stack before hiding/uncaching. */
+            const preview = this.captureStackPreview(thisBlock);
+            if (preview) {
+                this.trashPreviews[thisBlock] = preview;
+            }
+
             /** Add this block to the list of blocks in the trash so we can undo this action. */
             this.trashStacks.push(thisBlock);
 
@@ -7267,7 +7371,10 @@ class Blocks {
             // Keep the 100 most recent trashed stacks.
             const MAX_TRASH_UNDO = 100;
             if (this.trashStacks.length > MAX_TRASH_UNDO) {
-                this.trashStacks = this.trashStacks.slice(-MAX_TRASH_UNDO);
+                const removed = this.trashStacks.shift();
+                if (removed !== undefined && this.trashPreviews[removed]) {
+                    delete this.trashPreviews[removed];
+                }
             }
 
             /** Disconnect block. */

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7321,20 +7321,20 @@ class Blocks {
                     ctx.save();
                     ctx.translate(block.container.x - minX, block.container.y - minY);
                     ctx.scale(block.container.scaleX || 1, block.container.scaleY || 1);
-                    
+
                     // Temporarily uncache to ensure all children (text, etc.) are drawn correctly
                     const wasCached = !!block.container.bitmapCache;
                     if (wasCached) {
                         block.container.uncache();
                     }
-                    
+
                     block.container.draw(ctx);
-                    
+
                     // Re-cache if it was cached (though sendStackToTrash will uncache it anyway)
                     if (wasCached) {
                         block.container.cache(0, 0, block.width, block.height);
                     }
-                    
+
                     ctx.restore();
                 }
             });


### PR DESCRIPTION

### **Overview**
This PR introduces a visual preview system for the "Restore from Trash" feature. Previously, users had to identify deleted blocks by name alone, which was difficult for complex stacks or projects with many similar blocks. Now, every deleted stack generates a snapshot that can be viewed in the trash list and expanded via hover.

---
Fixes : #6951

---
### **Technical Implementation**

#### **1. Intelligent Stack Capture (`js/blocks.js`)**
Added a `captureStackPreview` method to the `Blocks` class that generates a sharp, reliable snapshot of a block stack:
*   **Robust Bounds Calculation**: Instead of relying on volatile browser bounds, the system now uses `block.width` and `block.height` as primary sources, ensuring even small blocks (like "multiply" or math blocks) are captured correctly.
*   **Auto-Framing & Padding**: The capture logic calculates the bounding box of the entire stack and adds **20px of padding** to ensure blocks aren't cut off at the edges.
*   **Visibility Optimization**: 
    *   Adds a solid **white background** to the PNG to ensure white text (common on number blocks) and light-colored blocks remain visible.
    *   Temporarily **uncaches** blocks during capture to ensure that all sub-components (like text labels) are drawn accurately to the canvas.

#### **2. Hover Expansion System (`js/activity.js`)**
Implemented a dynamic popup system to handle large or complex stacks that might be hard to see as small thumbnails:
*   **Precise Triggering**: The large preview expansion is triggered specifically when hovering over the **thumbnail icon**, while the row itself handles basic selection highlighting.
*   **Smart Positioning**: The popup tracks the mouse cursor and includes logic to "flip" its orientation if it gets too close to the right or bottom edges of the viewport, ensuring it never goes off-screen.
*   **Memory Management**: Previews are stored as data URLs in a `trashPreviews` dictionary, which is automatically trimmed alongside the trash history to keep memory usage low.

#### **3. UI/UX Enhancements (`css/activities.css`)**
*   Increased the default trash icon size to **60x60px** for better initial visibility.
*   Added modern styling for the expansion popup, including a subtle border and shadow for a premium "glassmorphism" feel.

### ScreenShot
Before
<img width="904" height="440" alt="Screenshot 2026-04-27 164356" src="https://github.com/user-attachments/assets/e691e232-e490-4af1-b620-ed32273ff99a" />

---
After
<img width="1456" height="892" alt="image" src="https://github.com/user-attachments/assets/cb1ed095-22b0-45b5-8674-27db0ae8a44e" />

---
### **How to Verify**
1. Create a complex stack of blocks (including some with text, like Number blocks).
2. Delete the stack by dragging it to the trash or clearing the workspace.
3. Open the **Restore** menu.
4. **Observe**: The thumbnail shows the full stack clearly on a white background.
5. **Hover**: Move the mouse over the small icon to see the high-resolution expanded preview.
6. **Restore**: Click the item to confirm the stack returns to the workspace correctly.

### **Linting/Testing**
*   `npm test` passes (all core logic preserved).
*   `npm run lint` passes (no new errors introduced).

### PR Category
- [ ] Bug Fix  
- [x] Feature  
- [x] Enhancement  
- [ ] Refactoring  
- [ ] Documentation
---