### PR TITLE
fix(blocks): add defensive null checks in expandable block traversal (part 1)

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4699,6 +4699,7 @@ class Blocks {
 
             const connectedBlock = this.blockList[cblk];
             if (!connectedBlock || typeof connectedBlock.isExpandableBlock !== "function") return null;
+            if (!Array.isArray(connectedBlock.connections)) return null;
 
             if (connectedBlock.isExpandableBlock()) {
                 /** If it is the last connection, keep searching. */
@@ -4732,6 +4733,7 @@ class Blocks {
 
             const connectedBlock = this.blockList[cblk];
             if (!connectedBlock || typeof connectedBlock.isExpandableBlock !== "function") return null;
+            if (!Array.isArray(connectedBlock.connections)) return null;
 
             if (connectedBlock.isExpandableBlock()) {
                 if (block.name === "forever") {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4691,30 +4691,29 @@ class Blocks {
          * @returns expandable block
          */
         this.insideExpandableBlock = blk => {
-            if (this.blockList[blk] == null) {
-                /** race condition? */
+            const block = this.blockList[blk];
+            if (!block || !Array.isArray(block.connections)) return null;
 
-                console.debug("null block in blockList? " + blk);
-                return null;
-            } else if (this.blockList[blk].connections[0] == null) {
-                return null;
-            } else {
-                const cblk = this.blockList[blk].connections[0];
-                if (this.blockList[cblk].isExpandableBlock()) {
-                    /** If it is the last connection, keep searching. */
-                    if (
-                        this.blockList[cblk].isArgFlowClampBlock() ||
-                        this.blockList[cblk].isLeftClampBlock()
-                    ) {
-                        return cblk;
-                    } else if (blk === last(this.blockList[cblk].connections)) {
-                        return this.insideExpandableBlock(cblk);
-                    } else {
-                        return cblk;
-                    }
-                } else {
+            const cblk = block.connections[0];
+            if (cblk == null) return null;
+
+            const connectedBlock = this.blockList[cblk];
+            if (!connectedBlock || typeof connectedBlock.isExpandableBlock !== "function") return null;
+
+            if (connectedBlock.isExpandableBlock()) {
+                /** If it is the last connection, keep searching. */
+                if (
+                    connectedBlock.isArgFlowClampBlock() ||
+                    connectedBlock.isLeftClampBlock()
+                ) {
+                    return cblk;
+                } else if (blk === last(connectedBlock.connections)) {
                     return this.insideExpandableBlock(cblk);
+                } else {
+                    return cblk;
                 }
+            } else {
+                return this.insideExpandableBlock(cblk);
             }
         };
 
@@ -4725,40 +4724,41 @@ class Blocks {
          * @returns note block
          */
         this._insideNoteBlock = blk => {
-            if (this.blockList[blk] == null) {
-                console.debug("null block in blockList? " + blk);
-                return null;
-            } else if (this.blockList[blk].connections[0] == null) {
-                return null;
-            } else {
-                const cblk = this.blockList[blk].connections[0];
-                if (this.blockList[cblk].isExpandableBlock()) {
-                    if (this.blockList[blk].name === "forever") {
-                        if (this._isConnectedToNoteValue(cblk)) {
-                            this.activity.errorMsg(
-                                _(
-                                    "Forever loop detected inside a note value block. Unexpected things may happen."
-                                )
-                            );
-                            return null;
-                        }
-                    }
-                    /** If it is the last connection, keep searching. */
-                    if (blk === last(this.blockList[cblk].connections)) {
-                        return this._insideNoteBlock(cblk);
-                    } else if (blk === this.blockList[cblk].connections[1]) {
-                        /** Connection 1 of a note block is not inside the clamp. */
+            const block = this.blockList[blk];
+            if (!block || !Array.isArray(block.connections)) return null;
+
+            const cblk = block.connections[0];
+            if (cblk == null) return null;
+
+            const connectedBlock = this.blockList[cblk];
+            if (!connectedBlock || typeof connectedBlock.isExpandableBlock !== "function") return null;
+
+            if (connectedBlock.isExpandableBlock()) {
+                if (block.name === "forever") {
+                    if (this._isConnectedToNoteValue(cblk)) {
+                        this.activity.errorMsg(
+                            _(
+                                "Forever loop detected inside a note value block. Unexpected things may happen."
+                            )
+                        );
                         return null;
-                    } else {
-                        if (NOTEBLOCKS.includes(this.blockList[cblk].name)) {
-                            return cblk;
-                        } else {
-                            return null;
-                        }
                     }
-                } else {
-                    return this._insideNoteBlock(cblk);
                 }
+                /** If it is the last connection, keep searching. */
+                if (blk === last(connectedBlock.connections)) {
+                    return this._insideNoteBlock(cblk);
+                } else if (blk === connectedBlock.connections[1]) {
+                    /** Connection 1 of a note block is not inside the clamp. */
+                    return null;
+                } else {
+                    if (NOTEBLOCKS.includes(connectedBlock.name)) {
+                        return cblk;
+                    } else {
+                        return null;
+                    }
+                }
+            } else {
+                return this._insideNoteBlock(cblk);
             }
         };
 


### PR DESCRIPTION
fix(blocks): add defensive null checks in expandable block traversal (part 1)

### Fixes #6954 (Part 1)

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
This PR introduces defensive null checks in expandable block traversal functions to prevent runtime crashes during save and cleanup operations.

## Problem
During save and cleanup flows, `blockList` may contain undefined or partially initialized block references due to asynchronous loading. Several functions continue execution after partial checks, leading to runtime errors such as:

TypeError: Cannot read properties of undefined

This issue is consistently observed in:
- insideExpandableBlock
- _insideNoteBlock

## Root Cause
The traversal logic assumes:
- `blockList[blk]` is always defined
- `block.connections` is always a valid array
- `blockList[cblk]` exists and is fully initialized

However, during async loading and cleanup, these assumptions do not always hold. As a result, property access on undefined objects causes repeated crashes.

## Changes
- Added early return guards for:
  - missing or undefined `block`
  - invalid or missing `connections` arrays
  - missing `connectedBlock`
  - invalid `connectedBlock.connections`
- Prevented unsafe property access on undefined references
- Standardized defensive checks across traversal logic

## Impact
- Eliminates repeated TypeError crashes during save/playback
- Improves stability of cleanup operations
- Safely handles transient or partially initialized block states

## Scope
This PR focuses only on expandable block traversal functions:
- insideExpandableBlock
- _insideNoteBlock

Related fixes in other affected functions (e.g., `_getStackSize`, `adjustDocks`) will be submitted in a follow-up PR to keep the review scope minimal and focused.

## Testing
Steps used to reproduce and verify:

1. Open Music Blocks
2. Run a project using the Play button
3. Trigger Save during or after playback
4. Observe browser console

After applying this fix:
- No `TypeError: Cannot read properties of undefined` occurs in the affected traversal paths

## Notes
- This is Part 1 of the fix for #6954
- Changes are intentionally scoped to simplify review and ensure incremental validation

## Additional Comment
This PR addresses part of the null reference issues reported in #6954 by focusing on expandable block traversal functions.

The fixes have been split into smaller PRs to make review easier and more focused. A follow-up PR will address remaining affected areas.

Feedback is welcome.