### PR TITLE
fix(blocks): handle undefined blocks in _getStackSize and adjustDocks (part 2)

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -928,6 +928,7 @@ class Blocks {
             const myBlock = this.blockList[blk];
             if (myBlock == null) {
                 console.debug("Something very broken in _getStackSize.");
+                return size;
             }
 
             let c;
@@ -1104,7 +1105,7 @@ class Blocks {
                 }
 
                 /** Another database integrity check. */
-                if (this.blockList[cblk] === null) {
+                if (this.blockList[cblk] == null) {
                     console.debug("This is not good: we encountered a null block: " + cblk);
                     continue;
                 }


### PR DESCRIPTION
fix(blocks): handle undefined blocks in _getStackSize and adjustDocks (part 2)

### Fixes #6954 (Part 2)

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
This PR adds defensive checks in `_getStackSize` and `adjustDocks` to prevent null/undefined block references from causing runtime crashes during save and cleanup operations.

## Problem
During save/cleanup flows, `blockList` may contain undefined or partially initialized entries due to asynchronous operations. Some functions assume the presence of valid block references and continue execution, resulting in runtime errors such as:

TypeError: Cannot read properties of undefined

This was observed in:
- `_getStackSize`
- `adjustDocks`

## Root Cause
The code previously:
- Checked only for `null` but not `undefined`
- Continued execution even when block references were missing

This led to unsafe property access on undefined objects.

## Changes
- Added early return in `_getStackSize` when `blockList[blk]` is null/undefined
- Updated check in `adjustDocks` from strict `=== null` to `== null` to handle both `null` and `undefined`
- Ensured traversal logic does not proceed with invalid block references

## Impact
- Prevents crashes during stack traversal and dock adjustment
- Eliminates additional sources of `TypeError` during save/playback
- Improves robustness of block traversal logic

## Scope
This PR is intentionally small and focused:
- `_getStackSize`
- `adjustDocks`

It complements Part 1, which addressed:
- `insideExpandableBlock`
- `_insideNoteBlock`

## Testing
Steps used to verify:

1. Open Music Blocks
2. Run a project using the Play button
3. Trigger Save during or after execution
4. Observe browser console

After applying both Part 1 and Part 2:
- No `TypeError: Cannot read properties of undefined` observed across affected paths

## Notes
- This PR is Part 2 of the fix for #6954
- Changes are minimal to ensure easy review and safe incremental merging
- Together with Part 1, this addresses the primary crash points identified in the issue

## Additional Comment
This PR completes the defensive checks for the major traversal paths identified in #6954.

The fix has been intentionally split into multiple smaller PRs to simplify review and reduce risk.

Feedback is welcome.