### PR TITLE
fix: disconnect synth before toDestination to prevent duplicate audio graph connections

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2012,6 +2012,11 @@ function Synth() {
                                 synth &&
                                 typeof synth.toDestination === "function"
                             ) {
+                                try {
+                                    synth.disconnect();
+                                } catch (_) {
+                                    // Already disconnected — safe to ignore.
+                                }
                                 synth.toDestination();
                             }
                         } catch (e) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation

## Summary
- Fixes #6961
- After effects cleanup in `_performNotes`, `synth.toDestination()` was called without first disconnecting the old effects chain path, creating duplicate connections to `Tone.Destination`
- This leaked Web Audio nodes and degraded audio quality/CPU over long playback sessions with effects (Vibrato, Distortion, Tremolo, etc.)
- Added `synth.disconnect()` before `synth.toDestination()` to ensure a single clean connection is re-established

## Test plan
- [ ] Play a project with Vibrato/Tremolo effects on repeated notes (50+) — verify no audio crackling
- [ ] Verify non-effects notes still produce sound after effects notes finish
- [ ] Monitor browser DevTools Performance tab for stable audio node count
- [ ] Run `npx jest js/utils/__tests__/synthutils.test.js` — all 99 tests pass