### PR TITLE
Guard PlanetInterface open/save paths when Planet backend is unavailable

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -110,6 +110,7 @@ describe("PlanetInterface", () => {
     });
 
     test("openPlanet calls saveLocally, hideMusicBlocks, and showPlanet", () => {
+        planetInterface.planet = { ProjectStorage: {}, open: jest.fn() };
         jest.spyOn(planetInterface, "saveLocally").mockImplementation(() => {});
         jest.spyOn(planetInterface, "hideMusicBlocks").mockImplementation(() => {});
         jest.spyOn(planetInterface, "showPlanet").mockImplementation(() => {});
@@ -117,6 +118,23 @@ describe("PlanetInterface", () => {
         expect(planetInterface.saveLocally).toHaveBeenCalled();
         expect(planetInterface.hideMusicBlocks).toHaveBeenCalled();
         expect(planetInterface.showPlanet).toHaveBeenCalled();
+    });
+
+    test("openPlanet: does not crash when Planet backend is unavailable", () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        planetInterface.planet = null;
+        jest.spyOn(planetInterface, "saveLocally");
+        jest.spyOn(planetInterface, "hideMusicBlocks");
+        jest.spyOn(planetInterface, "showPlanet");
+
+        expect(() => planetInterface.openPlanet()).not.toThrow();
+        expect(planetInterface.saveLocally).not.toHaveBeenCalled();
+        expect(planetInterface.hideMusicBlocks).not.toHaveBeenCalled();
+        expect(planetInterface.showPlanet).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+            "[PlanetInterface] openPlanet called before Planet is ready."
+        );
+        errorSpy.mockRestore();
     });
 
     test("closePlanet calls hidePlanet and showMusicBlocks", () => {
@@ -199,6 +217,16 @@ describe("PlanetInterface", () => {
         });
     });
 
+    test("saveLocally: returns null without throwing when Planet storage is unavailable", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        planetInterface.planet = null;
+
+        await expect(planetInterface.saveLocally()).resolves.toBeNull();
+        expect(errorSpy).toHaveBeenCalledWith(
+            "[PlanetInterface] saveLocally called before Planet storage is ready."
+        );
+        errorSpy.mockRestore();
+    });
     test("getCurrentProjectDescription/Image/TimeLastSaved", () => {
         const D = new Date(2020, 1, 1);
         planetInterface.planet = {

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -76,6 +76,11 @@ class PlanetInterface {
          * Shows the planet interface.
          */
         this.showPlanet = () => {
+            if (!this.planet || typeof this.planet.open !== "function") {
+                console.error("[PlanetInterface] showPlanet called before Planet is ready.");
+                return;
+            }
+
             const png = docById("overlayCanvas").toDataURL("image/png");
             this.planet.open(png); // this.mainCanvas.toDataURL("image/png"));
             this.iframe.style.display = "block";
@@ -98,6 +103,15 @@ class PlanetInterface {
          * Opens the planet interface.
          */
         this.openPlanet = () => {
+            if (
+                !this.planet ||
+                !this.planet.ProjectStorage ||
+                typeof this.planet.open !== "function"
+            ) {
+                console.error("[PlanetInterface] openPlanet called before Planet is ready.");
+                return;
+            }
+
             this.saveLocally();
             this.hideMusicBlocks();
             this.showPlanet();
@@ -199,6 +213,13 @@ class PlanetInterface {
          * Prepares project data for export, generates SVG data, and saves the project data locally.
          */
         this.saveLocally = () => {
+            if (!this.planet || !this.planet.ProjectStorage) {
+                console.error(
+                    "[PlanetInterface] saveLocally called before Planet storage is ready."
+                );
+                return Promise.resolve(null);
+            }
+
             this.activity.stage.update(event);
             const data = this.activity.prepareExport();
             const svgData = doSVG(


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [x] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation

## Summary
- guard `openPlanet()` against unavailable Planet backend (`this.planet` / `ProjectStorage` / `open`)
- guard `showPlanet()` when Planet is not ready
- guard `saveLocally()` when `ProjectStorage` is unavailable and return a safe resolved value
- add regression tests for degraded backend state behavior

## Why
Issue #6969 reports a crash when UI actions call `openPlanet()` while Planet backend init has failed. The existing flow dereferences `this.planet.ProjectStorage` without availability checks.

## Testing
- `npx jest js/__tests__/planetInterface.test.js --coverage=false`

Closes #6969
