### PR TITLE
Harden Activity _loadProject against secondary Planet failures

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5232,25 +5232,49 @@ class Activity {
             this.doLoadAnimation();
 
             // palettes.updatePalettes();
-            this.textMsg(this.planet.getCurrentProjectName());
+            try {
+                const projectName =
+                    this.planet && typeof this.planet.getCurrentProjectName === "function"
+                        ? this.planet.getCurrentProjectName()
+                        : _("My Project");
+                this.textMsg(projectName);
+            } catch (e) {
+                console.error(e);
+                this.textMsg(_("My Project"));
+            }
 
             const that = this;
             setTimeout(() => {
+                const finishLoading = () => {
+                    that.loading = false;
+                    document.body.style.cursor = "default";
+                    that.update = true;
+                };
+
                 try {
-                    that.planet.openProjectFromPlanet(projectID, () => {
-                        that.loadStartWrapper(loadStart);
-                    });
+                    if (that.planet && typeof that.planet.openProjectFromPlanet === "function") {
+                        that.planet.openProjectFromPlanet(projectID, () => {
+                            that.loadStartWrapper(loadStart);
+                        });
+                    } else {
+                        throw new Error("Planet openProjectFromPlanet is unavailable.");
+                    }
                 } catch (e) {
                     console.error(e);
                     that.loadStartWrapper(loadStart);
                 }
 
-                that.planet.initialiseNewProject();
-                // Restore default cursor
-                that.loading = false;
+                if (that.planet && typeof that.planet.initialiseNewProject === "function") {
+                    try {
+                        that.planet.initialiseNewProject();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                } else {
+                    console.error("Planet initialiseNewProject is unavailable.");
+                }
 
-                document.body.style.cursor = "default";
-                that.update = true;
+                finishLoading();
             }, 2500);
 
             const run = flags.run;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation

## Summary
- harden `_loadProject()` against degraded Planet backend states
- guard project-name retrieval before `textMsg` so load flow is not interrupted
- guard `openProjectFromPlanet` availability and retain fallback behavior when unavailable
- guard `initialiseNewProject` availability and catch its failures so recovery path cannot crash
- centralize loading-state cleanup in a single `finishLoading()` helper within the timeout flow

## Why
Issue #6972 identifies that `_loadProject()` had partial error handling: some Planet calls before/after the main guarded block could still throw and break fallback recovery.

This patch ensures the fallback path remains resilient even when Planet methods are missing or throw.

## Testing
- `npx eslint js/activity.js`
- `npx jest js/__tests__/activity_blur_handler.test.js --coverage=false`

Closes #6972
