### PR TITLE
fix: prevent zombie timers and overlapping playback in PhraseMaker

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -138,6 +138,7 @@ const PhraseMakerAudio = {
                 pm._playbackTimer = null;
             }
             pm._stopOrCloseClicked = true;
+            PhraseMakerUI.resetMatrix(pm);
             pm.widgetWindow.modifyButton(
                 0,
                 "play-button.svg",

--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -133,6 +133,10 @@ const PhraseMakerAudio = {
 
             this.__playNote(pm, 0, 0);
         } else {
+            if (pm._playbackTimer) {
+                clearTimeout(pm._playbackTimer);
+                pm._playbackTimer = null;
+            }
             pm._stopOrCloseClicked = true;
             pm.widgetWindow.modifyButton(
                 0,
@@ -337,7 +341,7 @@ const PhraseMakerAudio = {
         let noteValue = pm._notesToPlay[noteCounter][1];
         time = 1 / noteValue;
 
-        setTimeout(
+        pm._playbackTimer = setTimeout(
             () => {
                 let row, cell, tupletCell;
                 // Did we just play the last note?
@@ -351,6 +355,7 @@ const PhraseMakerAudio = {
                         pm._("Play")
                     );
                     pm.playingNow = false;
+                    pm._playbackTimer = null;
                     pm._playButton.innerHTML = `&nbsp;&nbsp;<img 
                     src="header-icons/play-button.svg" 
                     title="${pm._("Play")}" 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -427,6 +427,10 @@ class PhraseMaker {
 
             this.activity.logo.synth.stopSound(0, this._instrumentName);
             this.activity.logo.synth.stop();
+            if (this._playbackTimer) {
+                clearTimeout(this._playbackTimer);
+                this._playbackTimer = null;
+            }
             this._stopOrCloseClicked = true;
             this.activity.hideMsgs();
             this.docById("wheelDivptm").style.display = "none";


### PR DESCRIPTION
### Summary
This PR fixes a bug in the PhraseMaker widget where playback loops could overlap or continue running after stopping or closing the widget.

Previously, `PhraseMakerAudio.js` used a recursive `setTimeout` pattern for note sequencing but did not track or cancel scheduled timers. As a result, rapidly stopping and restarting playback—or closing the widget mid-playback—could leave previously scheduled callbacks active.

This caused:
- Overlapping audio playback
- UI desynchronization (matrix highlighting issues)
- Background timer accumulation

### Changes
- **`js/widgets/PhraseMakerAudio.js`**
  - Added tracking of the active timeout via `pm._playbackTimer`
  - Cleared the timeout in the `playAll` stop case
  - Reset timer reference after playback completes

- **`js/widgets/phrasemaker.js`**
  - Cleared any active timeout in the widget `onclose` handler

### Verification
- Confirmed that only one playback loop runs at a time
- Verified timers are cleared on both stop and widget close
- Tested rapid stop/start interactions with no overlapping playback
- Ensured no errors occur when clearing null/undefined timers

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

closes #6976