### PR TITLE
fix: prevent division by zero in temperament ratio editor

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1278,6 +1278,10 @@ function TemperamentWidget() {
         divAppend.onclick = function (event) {
             const input1 = docById("ratioIn").value;
             const input2 = docById("ratioOut").value;
+            if (Number(input2) === 0) {
+                that.activity.errorMsg(_("Denominator cannot be zero."), 3000);
+                return;
+            }
             const recursion = docById("recursion").value;
             const len = that.frequencies.length;
             const ratio1 = input1 / input2;


### PR DESCRIPTION
### Summary

This PR fixes a potential division-by-zero issue in the Temperament widget’s ratio editor.

Previously, entering `0` in the denominator field (`ratioOut`) caused the computed ratio (`ratio1`) to become `Infinity`. This invalid value propagated through the frequency calculation logic and could lead to incorrect audio output or instability in the audio engine.

### Changes

- **`js/widgets/temperament.js`**
  - Added validation in the `divAppend.onclick` handler to ensure the denominator is not zero
  - If `0` is entered, the calculation is aborted
  - Displays a translated error message using:
  
    `that.activity.errorMsg(_("Denominator cannot be zero."), 3000);`

### Verification

- Confirmed the bug location around line 1283 in `js/widgets/temperament.js`
- Verified that `that.activity.errorMsg` is accessible within the event handler scope
- Ensured the fix uses the project’s translation helper `_()`
- Tested with `ratioOut = 0` and confirmed:
  - No calculation is performed
  - Error message is shown
  - No invalid values propagate to audio logic

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

closes #6978 