### PR TITLE
Fix DuoSynth Panel Not Opening on First Click After Synth Switch

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1682,6 +1682,10 @@ input.timbreName {
     margin-left: 200px;
 }
 
+.insideDivSynth input[type="range"] + .thumb {
+    display: none !important;
+}
+
 .btn {
     background-color: #90c100;
     margin-top: 6px;

--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -470,11 +470,11 @@ function setupToneActions(activity) {
             }
 
             synthVibratoRate = Math.abs(synthVibratoRate);
-            synthVibratoAmount = Math.abs(synthVibratoAmount) / 100;
+            synthVibratoAmount = Math.abs(synthVibratoAmount);
 
             if (activity.logo.inTimbre) {
                 activity.logo.timbre.duoSynthParamVals["vibratoRate"] = synthVibratoRate;
-                activity.logo.timbre.duoSynthParamVals["vibratoAmount"] = synthVibratoAmount;
+                activity.logo.timbre.duoSynthParamVals["vibratoAmount"] = synthVibratoAmount / 100;
                 activity.logo.synth.createSynth(
                     turtle,
                     activity.logo.timbre.instrumentName,

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -629,7 +629,7 @@ describe("setupToneActions", () => {
         it("should define Duo synth correctly", () => {
             Singer.ToneActions.defDuoSynth(10, 20, 0, 1);
             expect(activity.logo.timbre.duoSynthParams).toContain(10);
-            expect(activity.logo.timbre.duoSynthParams).toContain(0.2);
+            expect(activity.logo.timbre.duoSynthParams).toContain(20);
             expect(activity.logo.synth.createSynth).toHaveBeenCalledWith(
                 0,
                 "default-voice",
@@ -653,19 +653,19 @@ describe("setupToneActions", () => {
         it("should handle null vibratoAmount", () => {
             Singer.ToneActions.defDuoSynth(10, null, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Missing input", 1);
-            expect(activity.logo.timbre.duoSynthParams).toContain(0.5);
+            expect(activity.logo.timbre.duoSynthParams).toContain(50);
         });
 
         it("should handle non-numeric vibratoAmount", () => {
             Singer.ToneActions.defDuoSynth(10, "string", 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Missing input", 1);
-            expect(activity.logo.timbre.duoSynthParams).toContain(0.5);
+            expect(activity.logo.timbre.duoSynthParams).toContain(50);
         });
 
         it("should handle negative inputs correctly", () => {
             Singer.ToneActions.defDuoSynth(-10, -20, 0, 1);
             expect(activity.logo.timbre.duoSynthParams).toContain(10);
-            expect(activity.logo.timbre.duoSynthParams).toContain(0.2);
+            expect(activity.logo.timbre.duoSynthParams).toContain(20);
         });
 
         it("should show error when oscillators exist", () => {

--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -21,6 +21,8 @@
  */
 
 // --- Global Mocks (must be set before require) ---
+const jsdomDocument = global.document;
+
 global._ = msg => msg;
 global.DEFAULTOSCILLATORTYPE = "sine";
 global.DEFAULTFILTERTYPE = "lowpass";
@@ -375,6 +377,164 @@ describe("TimbreWidget", () => {
             timbre.notesToPlay.push(["C4", 4]);
             timbre.notesToPlay = [];
             expect(timbre.notesToPlay).toHaveLength(0);
+        });
+    });
+
+    describe("DuoSynth selector", () => {
+        let mockDocument;
+        let mockDocById;
+        let mockDocByName;
+        let mockDelayExecution;
+
+        const createBlock = (name, connections, value) => ({
+            name,
+            connections,
+            value,
+            text: { text: value === undefined ? "" : value.toString() },
+            updateCache: jest.fn(),
+            isClampBlock: jest.fn(() => false)
+        });
+
+        const setupDuoSynthWidget = () => {
+            const blocks = {
+                blockList: [createBlock("settimbre", [null, null, null])],
+                clampBlocksToCheck: [],
+                findBottomBlock: jest.fn(() => null),
+                adjustDocks: jest.fn(),
+                adjustExpandableClampBlock: jest.fn(),
+                sendStackToTrash: jest.fn(),
+                loadNewBlocks: jest.fn(blockObjs => {
+                    const blockOffset = blocks.blockList.length;
+
+                    for (const blockObj of blockObjs) {
+                        const blockName = Array.isArray(blockObj[1]) ? blockObj[1][0] : blockObj[1];
+                        const value = Array.isArray(blockObj[1]) ? blockObj[1][1].value : undefined;
+                        const connections = blockObj[4].map(connection =>
+                            connection === null ? null : connection + blockOffset
+                        );
+
+                        blocks.blockList.push(createBlock(blockName, connections, value));
+                    }
+                })
+            };
+
+            timbre = new TimbreWidget();
+            timbre.blockNo = 0;
+            timbre._playNote = jest.fn();
+            timbre.activity = {
+                blocks,
+                logo: {
+                    synth: {
+                        createSynth: jest.fn()
+                    }
+                },
+                refreshCanvas: jest.fn(),
+                saveLocally: jest.fn()
+            };
+            timbre.timbreTableDiv = jsdomDocument.createElement("div");
+            jsdomDocument.body.appendChild(timbre.timbreTableDiv);
+        };
+
+        beforeEach(() => {
+            mockDocument = global.document;
+            mockDocById = global.docById;
+            mockDocByName = global.docByName;
+            mockDelayExecution = global.delayExecution;
+
+            global.document = jsdomDocument;
+            global.docById = id => jsdomDocument.getElementById(id);
+            global.docByName = name => jsdomDocument.getElementsByName(name);
+            global.delayExecution = jest.fn(() => new Promise(() => {}));
+            jsdomDocument.body.textContent = "";
+
+            setupDuoSynthWidget();
+        });
+
+        afterEach(() => {
+            jsdomDocument.body.textContent = "";
+            global.document = mockDocument;
+            global.docById = mockDocById;
+            global.docByName = mockDocByName;
+            global.delayExecution = mockDelayExecution;
+        });
+
+        test("renders controls on the first DuoSynth click without waiting", () => {
+            timbre._synth();
+
+            const duoRadio = jsdomDocument.querySelector('input[value="DuoSynth"]');
+            duoRadio.onclick({ target: duoRadio });
+
+            expect(global.delayExecution).not.toHaveBeenCalled();
+            expect(jsdomDocument.getElementById("wrapperS0")).not.toBeNull();
+            expect(jsdomDocument.getElementById("wrapperS1")).not.toBeNull();
+            expect(timbre.duoSynthesizer).toEqual([1]);
+            expect(timbre.duoSynthParamVals.vibratoAmount).toBe(0.06);
+            expect(timbre.activity.logo.synth.createSynth).toHaveBeenCalledWith(
+                0,
+                "custom",
+                "duosynth",
+                timbre.duoSynthParamVals
+            );
+        });
+
+        test.each(["AMSynth", "FMSynth"])(
+            "renders DuoSynth controls on the first click after %s",
+            synthName => {
+                timbre._synth();
+
+                const firstRadio = jsdomDocument.querySelector(`input[value="${synthName}"]`);
+                firstRadio.onclick({ target: firstRadio });
+                expect(jsdomDocument.getElementById("wrapperS0")).not.toBeNull();
+
+                const duoRadio = jsdomDocument.querySelector('input[value="DuoSynth"]');
+                duoRadio.onclick({ target: duoRadio });
+
+                expect(global.delayExecution).not.toHaveBeenCalled();
+                expect(jsdomDocument.getElementById("chosen").textContent).toBe("DuoSynth");
+                expect(jsdomDocument.getElementById("wrapperS0")).not.toBeNull();
+                expect(jsdomDocument.getElementById("wrapperS1")).not.toBeNull();
+                expect(timbre.duoSynthParamVals.vibratoRate).toBe(10);
+                expect(timbre.duoSynthParamVals.vibratoAmount).toBe(0.06);
+            }
+        );
+
+        test("reuses existing DuoSynth block values without double-normalizing amount", () => {
+            timbre.duoSynthesizer.push(1);
+            timbre.duoSynthParams.push(10);
+            timbre.duoSynthParams.push(20);
+            timbre._synth();
+
+            const duoRadio = jsdomDocument.querySelector('input[value="DuoSynth"]');
+            duoRadio.onclick({ target: duoRadio });
+
+            expect(jsdomDocument.getElementById("myRangeS0").value).toBe("10");
+            expect(jsdomDocument.getElementById("myRangeS1").value).toBe("20");
+            expect(timbre.duoSynthParamVals.vibratoRate).toBe(10);
+            expect(timbre.duoSynthParamVals.vibratoAmount).toBe(0.2);
+        });
+
+        test("updates the matching DuoSynth parameter from each slider", () => {
+            timbre._synth();
+
+            const duoRadio = jsdomDocument.querySelector('input[value="DuoSynth"]');
+            duoRadio.onclick({ target: duoRadio });
+
+            const changeEvent = new jsdomDocument.defaultView.Event("change", { bubbles: true });
+            const rateSlider = jsdomDocument.getElementById("myRangeS0");
+            rateSlider.value = "12";
+            rateSlider.dispatchEvent(changeEvent);
+
+            const amountSlider = jsdomDocument.getElementById("myRangeS1");
+            amountSlider.value = "7";
+            amountSlider.dispatchEvent(
+                new jsdomDocument.defaultView.Event("change", { bubbles: true })
+            );
+
+            expect(timbre.duoSynthParamVals.vibratoRate).toBe(12);
+            expect(timbre.duoSynthParamVals.vibratoAmount).toBe(0.07);
+            expect(timbre.duoSynthParams).toEqual(["12", "7"]);
+            expect(timbre.activity.blocks.blockList[2].value).toBe("12");
+            expect(timbre.activity.blocks.blockList[3].value).toBe("7");
         });
     });
 });

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -610,11 +610,10 @@ class TimbreWidget {
 
             docById("myRangeS0").value = parseFloat(this.duoSynthParams[0]);
             docById("myspanS0").textContent = this.duoSynthParams[0];
-            this.duoSynthParamVals["vibratoRate"] = parseFloat(this.duoSynthParams[0]);
             this._update(blockValue, this.duoSynthParams[0], 0);
             docById("myRangeS1").value = parseFloat(this.duoSynthParams[1]);
             docById("myspanS1").textContent = this.duoSynthParams[1];
-            this.duoSynthParamVals["vibratoAmount"] = parseFloat(this.duoSynthParams[1]);
+            this._setDuoSynthParamVals(this.duoSynthParams[0], this.duoSynthParams[1]);
             this._update(blockValue, this.duoSynthParams[1], 1);
             this.activity.logo.synth.createSynth(
                 0,
@@ -1102,6 +1101,48 @@ class TimbreWidget {
 
     /**
      * @private
+     * Updates DuoSynth values passed to Tone. The widget and block store amount as percent.
+     * @param {number|string} vibratoRate
+     * @param {number|string} vibratoAmount
+     * @returns {void}
+     */
+    _setDuoSynthParamVals(vibratoRate, vibratoAmount) {
+        this.duoSynthParamVals["vibratoRate"] = Math.abs(parseFloat(vibratoRate));
+        this.duoSynthParamVals["vibratoAmount"] = Math.abs(parseFloat(vibratoAmount)) / 100;
+    }
+
+    /**
+     * @private
+     * Creates the DuoSynth block stack and records default widget parameters.
+     * @param {number|null} bottomOfClamp
+     * @param {string} synthChosen
+     * @returns {void}
+     */
+    _addDuoSynthBlock(bottomOfClamp, synthChosen) {
+        const n = this.activity.blocks.blockList.length;
+        const DUOSYNTHOBJ = [
+            [0, ["duosynth", {}], 0, 0, [null, 1, 2, null]],
+            [1, ["number", { value: 10 }], 0, 0, [0]],
+            [2, ["number", { value: 6 }], 0, 0, [0]]
+        ];
+        this.activity.blocks.loadNewBlocks(DUOSYNTHOBJ);
+
+        this.duoSynthesizer.push(n);
+        this.duoSynthParams.push(10);
+        this.duoSynthParams.push(6);
+
+        this._changeBlock(last(this.duoSynthesizer), synthChosen, bottomOfClamp);
+        this._setDuoSynthParamVals(this.duoSynthParams[0], this.duoSynthParams[1]);
+        this.activity.logo.synth.createSynth(
+            0,
+            this.instrumentName,
+            "duosynth",
+            this.duoSynthParamVals
+        );
+    }
+
+    /**
+     * @private
      * Method pertaining to replacing blocks.
      * @param {number} oldblk
      * @param {number} newblk
@@ -1300,14 +1341,13 @@ class TimbreWidget {
                             this.activity.blocks.blockList[this.blockNo].connections[2];
                         const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
+                        const n = this.activity.blocks.blockList.length;
                         const AMSYNTHOBJ = [
                             [0, ["amsynth", {}], 0, 0, [null, 1, null]],
                             [1, ["number", { value: 1 }], 0, 0, [0]]
                         ];
                         this.activity.blocks.loadNewBlocks(AMSYNTHOBJ);
 
-                        await delayExecution(100);
-                        const n = this.activity.blocks.blockList.length - 2;
                         this.AMSynthesizer.push(n);
                         this.AMSynthParams.push(1);
 
@@ -1385,14 +1425,13 @@ class TimbreWidget {
                             this.activity.blocks.blockList[this.blockNo].connections[2];
                         const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
+                        const n = this.activity.blocks.blockList.length;
                         const FMSYNTHOBJ = [
                             [0, ["fmsynth", {}], 0, 0, [null, 1, null]],
                             [1, ["number", { value: 10 }], 0, 0, [0]]
                         ];
                         this.activity.blocks.loadNewBlocks(FMSYNTHOBJ);
 
-                        await delayExecution(100);
-                        const n = this.activity.blocks.blockList.length - 2;
                         this.FMSynthesizer.push(n);
                         this.FMSynthParams.push(10);
 
@@ -1473,14 +1512,13 @@ class TimbreWidget {
                             this.activity.blocks.blockList[this.blockNo].connections[2];
                         const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
+                        const n = this.activity.blocks.blockList.length;
                         const NOISESYNTHOBJ = [
                             [0, ["noisesynth", {}], 0, 0, [null, 1, null]],
                             [1, ["number", { value: 10 }], 0, 0, [0]]
                         ];
                         this.activity.blocks.loadNewBlocks(NOISESYNTHOBJ);
 
-                        await delayExecution(100);
-                        const n = this.activity.blocks.blockList.length - 2;
                         this.NoiseSynthesizer.push(n);
                         this.NoiseSynthParams.push("white");
 
@@ -1558,30 +1596,7 @@ class TimbreWidget {
                             this.activity.blocks.blockList[this.blockNo].connections[2];
                         const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
-                        const DUOSYNTHOBJ = [
-                            [0, ["duosynth", {}], 0, 0, [null, 1, 2, null]],
-                            [1, ["number", { value: 10 }], 0, 0, [0]],
-                            [2, ["number", { value: 6 }], 0, 0, [0]]
-                        ];
-                        this.activity.blocks.loadNewBlocks(DUOSYNTHOBJ);
-
-                        await delayExecution(100);
-                        const n = this.activity.blocks.blockList.length - 3;
-                        this.duoSynthesizer.push(n);
-                        this.duoSynthParams.push(10);
-                        this.duoSynthParams.push(6);
-
-                        this._changeBlock(last(this.duoSynthesizer), synthChosen, bottomOfClamp);
-                        this.duoSynthParamVals["vibratoRate"] = parseFloat(this.duoSynthParams[0]);
-                        this.duoSynthParamVals["vibratoAmount"] = parseFloat(
-                            this.duoSynthParams[1]
-                        );
-                        this.activity.logo.synth.createSynth(
-                            0,
-                            this.instrumentName,
-                            "duosynth",
-                            this.duoSynthParamVals
-                        );
+                        this._addDuoSynthBlock(bottomOfClamp, synthChosen);
                     }
 
                     const wrapperS0 = document.createElement("div");
@@ -1650,26 +1665,24 @@ class TimbreWidget {
                         blockValue = this.duoSynthesizer.length - 1;
                     }
 
-                    this.duoSynthParamVals["vibratoRate"] = parseFloat(this.duoSynthParams[0]);
-                    this.duoSynthParamVals["vibratoAmount"] = parseFloat(this.duoSynthParams[1]);
+                    this._setDuoSynthParamVals(this.duoSynthParams[0], this.duoSynthParams[1]);
 
                     for (let i = 0; i < 2; i++) {
                         document
                             .getElementById("wrapperS" + i)
                             .addEventListener("change", event => {
                                 const elem = event.target;
-                                const m = elem.id.slice(-1);
+                                const m = Number(elem.id.slice(-1));
+                                this.duoSynthParams[m] = elem.value;
                                 docById("myRangeS" + m).value = parseFloat(elem.value);
                                 if (m === 0) {
-                                    this.duoSynthParamVals["vibratoRate"] = parseFloat(elem.value);
+                                    this._setDuoSynthParamVals(elem.value, this.duoSynthParams[1]);
                                 } else if (m === 1) {
-                                    this.duoSynthParamVals["vibratoAmount"] = parseFloat(
-                                        elem.value
-                                    );
+                                    this._setDuoSynthParamVals(this.duoSynthParams[0], elem.value);
                                 }
 
                                 docById("myspanS" + m).textContent = elem.value;
-                                this._update(blockValue, elem.value, Number(m));
+                                this._update(blockValue, elem.value, m);
                                 this.activity.logo.synth.createSynth(
                                     0,
                                     this.instrumentName,


### PR DESCRIPTION
## PR Category : 
- [x] Bug Fix
## Summary

Fixes a Timbre widget issue where DuoSynth controls did not reliably open on the first click after selecting AM Synth or FM Synth.

This issue was found during manual testing.

## Problem

When switching from AM Synth or FM Synth to DuoSynth, the DuoSynth panel could fail to load on the first click.


## Fix

- Keep DuoSynth widget and block values as user-facing percent-style values, e.g. `6`.
- Normalize `vibratoAmount` before passing it to Tone, e.g. `6 -> 0.06`.
- Make synth selector block setup immediate so DuoSynth controls render on the first click after AM/FM.
- Ensure DuoSynth slider changes update the correct internal parameter values.

## Tests

Added regression coverage for:

- Opening DuoSynth on the first click.
- Opening DuoSynth on the first click after AM Synth.
- Opening DuoSynth on the first click after FM Synth.
- Updating DuoSynth vibrato rate and vibrato amount sliders.

### Before :

https://github.com/user-attachments/assets/7c286374-cec9-4f0a-a941-b9180e51564c

### After : 

https://github.com/user-attachments/assets/52b3dfd1-ac0f-4173-a84f-af847e405c70



