### PR TITLE
fix: clean up phrase maker timers

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -18,6 +18,22 @@
 
 const PhraseMakerAudio = {
     /**
+     * Schedules a timeout through the owning PhraseMaker instance when available.
+     * @private
+     * @param {Object} pm - The PhraseMaker instance.
+     * @param {Function} callback - Callback to run after the delay.
+     * @param {number} delay - Delay in milliseconds.
+     * @returns {number} Timer ID.
+     */
+    _setTimeout(pm, callback, delay) {
+        if (typeof pm._setWidgetTimeout === "function") {
+            return pm._setWidgetTimeout(callback, delay);
+        }
+
+        return setTimeout(callback, delay);
+    },
+
+    /**
      * Plays all notes in the matrix.
      * Toggles between playing and stopping notes based on the current state.
      * @param {Object} pm - The PhraseMaker instance.
@@ -134,6 +150,9 @@ const PhraseMakerAudio = {
             this.__playNote(pm, 0, 0);
         } else {
             pm._stopOrCloseClicked = true;
+            if (typeof pm._clearWidgetTimers === "function") {
+                pm._clearWidgetTimers();
+            }
             pm.widgetWindow.modifyButton(
                 0,
                 "play-button.svg",
@@ -337,7 +356,8 @@ const PhraseMakerAudio = {
         let noteValue = pm._notesToPlay[noteCounter][1];
         time = 1 / noteValue;
 
-        setTimeout(
+        this._setTimeout(
+            pm,
             () => {
                 let row, cell, tupletCell;
                 // Did we just play the last note?
@@ -486,47 +506,70 @@ const PhraseMakerAudio = {
      * @param {number} noteValue - The duration value of the chord notes.
      */
     _playChord(pm, notes, noteValue) {
-        setTimeout(() => {
-            pm.activity.logo.synth.trigger(0, notes[0], noteValue, pm._instrumentName, null, null);
-        }, 1);
-
-        if (notes.length > 1) {
-            setTimeout(() => {
+        this._setTimeout(
+            pm,
+            () => {
                 pm.activity.logo.synth.trigger(
                     0,
-                    notes[1],
+                    notes[0],
                     noteValue,
                     pm._instrumentName,
                     null,
                     null
                 );
-            }, 1);
+            },
+            1
+        );
+
+        if (notes.length > 1) {
+            this._setTimeout(
+                pm,
+                () => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[1],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                },
+                1
+            );
         }
 
         if (notes.length > 2) {
-            setTimeout(() => {
-                pm.activity.logo.synth.trigger(
-                    0,
-                    notes[2],
-                    noteValue,
-                    pm._instrumentName,
-                    null,
-                    null
-                );
-            }, 1);
+            this._setTimeout(
+                pm,
+                () => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[2],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                },
+                1
+            );
         }
 
         if (notes.length > 3) {
-            setTimeout(() => {
-                pm.activity.logo.synth.trigger(
-                    0,
-                    notes[3],
-                    noteValue,
-                    pm._instrumentName,
-                    null,
-                    null
-                );
-            }, 1);
+            this._setTimeout(
+                pm,
+                () => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[3],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                },
+                1
+            );
         }
     },
 

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -21,6 +21,8 @@
  */
 
 const PhraseMaker = require("../phrasemaker.js");
+const PhraseMakerAudio = require("../PhraseMakerAudio.js");
+const ManagedTimer = require("../../utils/ManagedTimer.js");
 
 // --- Global Mocks ---
 
@@ -54,6 +56,8 @@ global.PhraseMakerUtils = {
 global.PhraseMakerUI = {
     calculateNoteWidth: jest.fn(() => 100)
 };
+global.PhraseMakerAudio = PhraseMakerAudio;
+global.ManagedTimer = ManagedTimer;
 global.DEFAULTVOICE = "electronic synth";
 global.DEFAULTDRUM = "kick drum";
 global.DEFAULTVOLUME = 50;
@@ -187,6 +191,7 @@ describe("PhraseMaker Widget", () => {
 
     beforeEach(() => {
         jest.useFakeTimers();
+        global.PhraseMakerAudio = PhraseMakerAudio;
 
         mockDeps = {
             platformColor: global.platformColor,
@@ -214,6 +219,9 @@ describe("PhraseMaker Widget", () => {
     });
 
     afterEach(() => {
+        if (phraseMaker && typeof phraseMaker._clearWidgetTimers === "function") {
+            phraseMaker._clearWidgetTimers();
+        }
         jest.useRealTimers();
         jest.clearAllMocks();
     });
@@ -369,6 +377,81 @@ describe("PhraseMaker Widget", () => {
             expect(phraseMaker._matrixHasTuplets).toBe(false);
             phraseMaker._matrixHasTuplets = true;
             expect(phraseMaker._matrixHasTuplets).toBe(true);
+        });
+    });
+
+    describe("timer lifecycle", () => {
+        test("tracks and clears widget-owned timeouts", () => {
+            const callback = jest.fn();
+
+            phraseMaker._setWidgetTimeout(callback, 500);
+
+            expect(phraseMaker._timerManager.activeTimeoutCount).toBe(1);
+            expect(phraseMaker._clearWidgetTimers()).toBe(1);
+
+            jest.advanceTimersByTime(500);
+
+            expect(callback).not.toHaveBeenCalled();
+            expect(phraseMaker._timerManager.activeTimeoutCount).toBe(0);
+        });
+
+        test("schedules chord preview playback through widget timers", () => {
+            const trigger = jest.fn();
+            phraseMaker.activity = {
+                logo: {
+                    synth: {
+                        trigger
+                    }
+                }
+            };
+            phraseMaker._instrumentName = "electronic synth";
+
+            PhraseMakerAudio._playChord(phraseMaker, ["C4", "E4"], 0.25);
+
+            expect(phraseMaker._timerManager.activeTimeoutCount).toBe(2);
+
+            jest.advanceTimersByTime(1);
+
+            expect(trigger).toHaveBeenCalledTimes(2);
+            expect(trigger).toHaveBeenNthCalledWith(
+                1,
+                0,
+                "C4",
+                0.25,
+                "electronic synth",
+                null,
+                null
+            );
+            expect(trigger).toHaveBeenNthCalledWith(
+                2,
+                0,
+                "E4",
+                0.25,
+                "electronic synth",
+                null,
+                null
+            );
+            expect(phraseMaker._timerManager.activeTimeoutCount).toBe(0);
+        });
+
+        test("cancels pending chord preview playback when widget timers are cleared", () => {
+            const trigger = jest.fn();
+            phraseMaker.activity = {
+                logo: {
+                    synth: {
+                        trigger
+                    }
+                }
+            };
+            phraseMaker._instrumentName = "electronic synth";
+
+            PhraseMakerAudio._playChord(phraseMaker, ["C4", "E4"], 0.25);
+            expect(phraseMaker._clearWidgetTimers()).toBe(2);
+
+            jest.advanceTimersByTime(1);
+
+            expect(trigger).not.toHaveBeenCalled();
+            expect(phraseMaker._timerManager.activeTimeoutCount).toBe(0);
         });
     });
 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -19,7 +19,7 @@
    noteIsSolfege, isCustomTemperament, i18nSolfege, getNote, DEFAULTDRUM, last,
    DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency,
    LCD, calcNoteValueToDisplay, NOTESYMBOLS,
-   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals
+   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals, ManagedTimer
 */
 
 /*
@@ -35,6 +35,9 @@ Globals location
 
 - js/utils/utils.js
     _, delayExecution, last, LCD, docById, docBySelector
+
+- js/utils/ManagedTimer.js
+    ManagedTimer
 
 - js/turtle-singer.js
     Singer
@@ -268,6 +271,63 @@ class PhraseMaker {
          * @type {boolean}
          */
         this.lyricsON = false;
+
+        /**
+         * Tracks timers owned by this widget so delayed callbacks can be cancelled
+         * when playback stops or the widget closes.
+         * @type {ManagedTimer|null}
+         * @private
+         */
+        this._timerManager = typeof ManagedTimer !== "undefined" ? new ManagedTimer() : null;
+
+        /**
+         * Fallback timeout tracking for environments where ManagedTimer is unavailable.
+         * @type {Set<number>}
+         * @private
+         */
+        this._activeTimeouts = new Set();
+    }
+
+    /**
+     * Schedules a timeout owned by the widget lifecycle.
+     * @private
+     * @param {Function} callback - Callback to run after the delay.
+     * @param {number} delay - Delay in milliseconds.
+     * @returns {number} Timer ID.
+     */
+    _setWidgetTimeout(callback, delay) {
+        if (this._timerManager !== null) {
+            return this._timerManager.setTimeout(callback, delay);
+        }
+
+        let id;
+        id = setTimeout(() => {
+            this._activeTimeouts.delete(id);
+            callback();
+        }, delay);
+        this._activeTimeouts.add(id);
+        return id;
+    }
+
+    /**
+     * Clears all timers owned by the widget lifecycle.
+     * @private
+     * @returns {number} Number of tracked timers cleared.
+     */
+    _clearWidgetTimers() {
+        let count = 0;
+
+        if (this._timerManager !== null) {
+            count += this._timerManager.clearAll();
+        }
+
+        for (const id of this._activeTimeouts) {
+            clearTimeout(id);
+            count++;
+        }
+        this._activeTimeouts.clear();
+
+        return count;
     }
 
     /**
@@ -428,6 +488,8 @@ class PhraseMaker {
             this.activity.logo.synth.stopSound(0, this._instrumentName);
             this.activity.logo.synth.stop();
             this._stopOrCloseClicked = true;
+            this.playingNow = false;
+            this._clearWidgetTimers();
             this.activity.hideMsgs();
             this.docById("wheelDivptm").style.display = "none";
             widgetWindow.destroy();
@@ -995,7 +1057,7 @@ class PhraseMaker {
 
         // Sort them if there are note blocks.
         if (!this.sorted) {
-            setTimeout(() => {
+            this._setWidgetTimeout(() => {
                 this._sort();
             }, 1000);
         } else {
@@ -1210,12 +1272,18 @@ class PhraseMaker {
             }
 
             if (aboveBlock === this.blockNo) {
-                setTimeout(() => this._addNotesBlockBetween(aboveBlock, newBlock, true), 500);
+                this._setWidgetTimeout(
+                    () => this._addNotesBlockBetween(aboveBlock, newBlock, true),
+                    500
+                );
                 this.rowLabels.splice(0, 0, rLabel);
                 this.rowArgs.splice(0, 0, rArg);
                 this._rowBlocks.splice(0, 0, newBlock);
             } else {
-                setTimeout(() => this._addNotesBlockBetween(aboveBlock, newBlock, false), 500);
+                this._setWidgetTimeout(
+                    () => this._addNotesBlockBetween(aboveBlock, newBlock, false),
+                    500
+                );
                 let i;
                 for (i = 0; i < this.columnBlocksMap.length; i++) {
                     if (this.columnBlocksMap[i][0] === aboveBlock) {
@@ -1256,7 +1324,7 @@ class PhraseMaker {
 
             this.makeClickable();
             if (label === "pitch") {
-                setTimeout(() => {
+                this._setWidgetTimeout(() => {
                     this.pitchBlockAdded(newBlock);
                 }, 200);
             }
@@ -1283,7 +1351,7 @@ class PhraseMaker {
             }
         }
 
-        setTimeout(() => this._createColumnPieSubmenu(i, "pitchblocks", true), 500);
+        this._setWidgetTimeout(() => this._createColumnPieSubmenu(i, "pitchblocks", true), 500);
     }
 
     /**
@@ -2291,7 +2359,7 @@ class PhraseMaker {
                     timeout = 0;
                 }
 
-                setTimeout(() => {
+                this._setWidgetTimeout(() => {
                     this.activity.logo.synth.setMasterVolume(DEFAULTVOLUME);
                     this._deps.Singer.setSynthVolume(this.activity.logo, 0, label, DEFAULTVOLUME);
                     this.activity.logo.synth.trigger(0, "G4", 1 / 4, label, null, null, false);
@@ -2566,8 +2634,8 @@ class PhraseMaker {
                 console.debug("skipping " + obj[1] + " " + this._deps.last(this.rowLabels));
                 this._sortedRowMap.push(this._deps.last(this._sortedRowMap));
                 if (oldColumnBlockMap[sortedList[lastObj][3]] !== undefined) {
-                    setTimeout(
-                        this._removePitchBlock(oldColumnBlockMap[sortedList[lastObj][3]][0]),
+                    this._setWidgetTimeout(
+                        () => this._removePitchBlock(oldColumnBlockMap[sortedList[lastObj][3]][0]),
                         500
                     );
                     this.columnBlocksMap = this.columnBlocksMap.filter(ele => {
@@ -3333,9 +3401,9 @@ class PhraseMaker {
         }
         this.activity.blocks.loadNewBlocks(RHYTHMOBJ);
         if (this.activity.blocks.blockList[bottomOfClamp].name === "vspace") {
-            setTimeout(() => this.blockConnection(6, bottomOfClamp), 500);
+            this._setWidgetTimeout(() => this.blockConnection(6, bottomOfClamp), 500);
         } else {
-            setTimeout(() => this.blockConnection(7, bottomOfClamp), 500);
+            this._setWidgetTimeout(() => this.blockConnection(7, bottomOfClamp), 500);
         }
         this.activity.refreshCanvas();
     }


### PR DESCRIPTION
## PR Category :
- [x] Bug Fix
## Summary

This PR adds managed timer cleanup to the Phrase Maker widget and `PhraseMakerAudio`.

It routes delayed Phrase Maker callbacks through the widget lifecycle so pending playback, preview, and delayed block-update work can be canceled when playback is stopped or the widget is closed.

## Changes

- Added `ManagedTimer` usage in `PhraseMaker`.
- Added widget-owned timer helpers for scheduling and clearing delayed callbacks.
- Clear pending Phrase Maker timers on widget close.
- Clear pending playback timers when Phrase Maker playback is stopped.
- Route `PhraseMakerAudio` delayed playback and chord-preview timers through the owning `PhraseMaker` instance.
- Replace raw Phrase Maker `setTimeout` usages with managed widget timers.
- Add focused Jest coverage for timer tracking and cancellation.

## Why

This prevents stale delayed callbacks from continuing after Phrase Maker playback is stopped or the widget is closed, including delayed preview playback and delayed block mutations.

This follows the same timer-management direction introduced by `ManagedTimer.js` in PR #5799 and continues the widget timer cleanup work.
