### PR TITLE
fix: prevent crash on malformed HTML project files

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -8379,20 +8379,25 @@ class Activity {
                                     )
                                 );
                             } else {
-                                const cleanData = rawData.replace("\n", " ");
+                                const cleanData = rawData.replace(/\n/g, " ");
                                 let obj;
                                 try {
                                     if (cleanData.includes("html")) {
                                         let extracted;
+                                        let match;
                                         if (cleanData.includes('id="codeBlock"')) {
-                                            extracted = cleanData.match(
+                                            match = cleanData.match(
                                                 '<div class="code" id="codeBlock">(.+?)</div>'
-                                            )[1];
+                                            );
                                         } else {
-                                            extracted = cleanData.match(
+                                            match = cleanData.match(
                                                 '<div class="code">(.+?)</div>'
-                                            )[1];
+                                            );
                                         }
+                                        if (!match) {
+                                            throw new Error("No project data found in HTML file");
+                                        }
+                                        extracted = match[1];
                                         obj = JSON.parse(unescapeHTML(extracted));
                                     } else {
                                         obj = JSON.parse(cleanData);
@@ -8504,20 +8509,23 @@ class Activity {
                                 _("Cannot load project from the file. Please check the file type.")
                             );
                         } else {
-                            const cleanData = rawData.replace("\n", " ");
+                            const cleanData = rawData.replace(/\n/g, " ");
                             let obj;
                             try {
                                 if (cleanData.includes("html")) {
                                     let extracted;
+                                    let match;
                                     if (cleanData.includes('id="codeBlock"')) {
-                                        extracted = cleanData.match(
+                                        match = cleanData.match(
                                             '<div class="code" id="codeBlock">(.+?)</div>'
-                                        )[1];
+                                        );
                                     } else {
-                                        extracted = cleanData.match(
-                                            '<div class="code">(.+?)</div>'
-                                        )[1];
+                                        match = cleanData.match('<div class="code">(.+?)</div>');
                                     }
+                                    if (!match) {
+                                        throw new Error("No project data found in HTML file");
+                                    }
+                                    extracted = match[1];
                                     obj = JSON.parse(unescapeHTML(extracted));
                                 } else {
                                     obj = JSON.parse(cleanData);


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
- Fixes #6981
- `.match()[1]` crashes with TypeError when HTML files don't contain the expected `<div class="code">` structure — now validates match result before accessing index
- `.replace("\n", " ")` only replaced the first newline — changed to `/\n/g` regex to handle all newlines in large HTML-exported projects
- Fixed in both file chooser (line ~8388) and drag-and-drop (line ~8513) code paths

## Test plan
- [ ] Try loading a normal HTML file (not a Music Blocks export) — should show error message instead of crashing
- [ ] Try loading a large HTML-exported project with multiple newlines — should load successfully
- [ ] Try loading a valid HTML-exported project — should still work as before
- [ ] Try drag-and-drop with a malformed HTML file — should show error instead of crash