### PR TITLE
fix: guard division by zero in Neighbor ornament beat calculation

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -139,14 +139,30 @@ function setupRhythmActions(activity) {
 
                 if (tur.singer.inNoteBlock.length > 0) {
                     if (tur.singer.inNeighbor.length > 0) {
-                        tur.singer.neighborArgBeat.push(
-                            tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
-                        );
+                        if (
+                            tur.singer.neighborNoteValue === 0 ||
+                            !isFinite(1 / tur.singer.neighborNoteValue)
+                        ) {
+                            console.warn(
+                                "Neighbor: skipping invalid neighborNoteValue:",
+                                tur.singer.neighborNoteValue
+                            );
+                        } else {
+                            tur.singer.neighborArgBeat.push(
+                                tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
+                            );
 
-                        const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
-                        tur.singer.neighborArgCurrentBeat.push(
-                            tur.singer.beatFactor * (1 / nextBeat)
-                        );
+                            const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
+                            if (nextBeat <= 0 || !isFinite(nextBeat)) {
+                                console.warn(
+                                    "Neighbor: note value too large for current duration, skipping"
+                                );
+                            } else {
+                                tur.singer.neighborArgCurrentBeat.push(
+                                    tur.singer.beatFactor * (1 / nextBeat)
+                                );
+                            }
+                        }
                     }
 
                     Singer.processNote(

--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -148,16 +148,15 @@ function setupRhythmActions(activity) {
                                 tur.singer.neighborNoteValue
                             );
                         } else {
-                            tur.singer.neighborArgBeat.push(
-                                tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
-                            );
-
                             const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
                             if (nextBeat <= 0 || !isFinite(nextBeat)) {
                                 console.warn(
                                     "Neighbor: note value too large for current duration, skipping"
                                 );
                             } else {
+                                tur.singer.neighborArgBeat.push(
+                                    tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
+                                );
                                 tur.singer.neighborArgCurrentBeat.push(
                                     tur.singer.beatFactor * (1 / nextBeat)
                                 );


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
- Fixes #6982
- In `RhythmActions.js`, the Neighbor ornament calculates `1 / nextBeat` where `nextBeat` can be zero or negative, producing Infinity/NaN that corrupts the entire audio timeline
- Added guards for both `neighborNoteValue === 0` and `nextBeat <= 0` cases
- Added `console.warn` messages so these edge cases can be debugged

## Test plan
- [ ] Create a Neighbor ornament block with normal note values — verify audio plays correctly
- [ ] Use a fast neighboring note value (e.g., 1/16) with a similar main note — verify no Infinity/NaN in console
- [ ] Check that subsequent notes after a skipped neighbor still play with correct timing
- [ ] Run prettier — passes