### PR TITLE
fix: add missing validate task and cssTask to gulpfile.mjs

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -71,5 +71,11 @@ export function prettify() {
     return gulp.src(paths.scripts.src).pipe(prettier()).pipe(gulp.dest("js"));
 }
 
-export const build = gulp.series(gulp.parallel(jsTask, sassTask));
+export function validate() {
+    return gulp
+        .src(paths.scripts.src)
+        .pipe(prettier.check({ singleQuote: true, trailingComma: "all" }));
+}
+
+export const build = gulp.series(gulp.parallel(jsTask, cssTask, sassTask), validate);
 export default build;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
- Fixes #6963
- `gulpfile.mjs` was missing the prettier `validate()` step that `gulpfile.js` has, allowing ESM builds to skip formatting checks
- Also added `cssTask` to the parallel build step — it was defined but not included in the build pipeline
- Both gulpfiles now have consistent validation behavior

## Test plan
- [ ] Run `npx gulp --gulpfile gulpfile.mjs` — verify validate task runs and catches formatting issues
- [ ] Compare output of both gulpfiles — should produce consistent results
- [ ] Run prettier check on gulpfile.mjs — passes