### PR TITLE
fix: guard division by zero in Staccato and Slur blocks

### DIFF
--- a/js/turtleactions/OrnamentActions.js
+++ b/js/turtleactions/OrnamentActions.js
@@ -45,6 +45,10 @@ function setupOrnamentActions(activity) {
         static setStaccato(value, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
 
+            if (value === 0) {
+                activity.errorMsg(_("Staccato value must be non-zero."), blk);
+                return;
+            }
             tur.singer.staccato.push(1 / value);
 
             const listenerName = "_staccato_" + turtle + "_" + blk;
@@ -71,6 +75,10 @@ function setupOrnamentActions(activity) {
         static setSlur(value, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
 
+            if (value === 0) {
+                activity.errorMsg(_("Slur value must be non-zero."), blk);
+                return;
+            }
             tur.singer.staccato.push(-1 / value);
 
             if (tur.singer.justCounting.length === 0) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
- Fixes #6987
- `setStaccato` and `setSlur` in `OrnamentActions.js` compute `1 / value` without checking for zero, producing Infinity that corrupts all subsequent note timing
- Added zero-value guard with user-facing error message (`activity.errorMsg`) and early return for both functions

## Test plan
- [ ] Add a Staccato block with value 0 — verify error message appears and playback is not broken
- [ ] Add a Slur block with value 0 — verify error message appears
- [ ] Normal Staccato/Slur with valid values — verify audio still works correctly
- [ ] Run prettier — passes