### PR TITLE
fix: handle click event state after stop in action block

### DIFF
--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -1070,6 +1070,10 @@ function setupActionBlocks(activity) {
                 const tur = activity.turtles.ithTurtle(turtle);
 
                 const __listener = event => {
+                    if (logo.stopTurtle) {
+                        return;
+                    }
+
                     if (tur.running) {
                         const queueBlock = new Queue(logo.actions[args[1]], 1, blk);
                         tur.parentFlowQueue.push(blk);
@@ -1081,7 +1085,9 @@ function setupActionBlocks(activity) {
                         // First, we need to reset the turtle's
                         // elapsed time since it has been falling behind.
                         const elapsedTime =
-                            (new Date().getTime() - activity.logo.firstNoteTime) / 1000;
+                            activity.logo.firstNoteTime === null
+                                ? 0
+                                : (new Date().getTime() - activity.logo.firstNoteTime) / 1000;
                         tur.singer.turtleTime = elapsedTime;
 
                         logo.runFromBlockNow(

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -964,5 +964,49 @@ describe("ActionBlocks", () => {
             expect(tur.singer.runningFromEvent).toBe(true);
             expect(logo.runFromBlockNow).toHaveBeenCalled();
         });
+
+        test("starts event timing at zero when no note has played yet", () => {
+            const block = activity.registeredBlocks["listen"];
+            logo.actions["testAction"] = [];
+            activity.logo = { firstNoteTime: null };
+            const tur = {
+                running: false,
+                queue: [],
+                parentFlowQueue: [],
+                singer: { justCounting: [], runningFromEvent: false, turtleTime: 0 }
+            };
+            activity.turtles.ithTurtle = jest.fn(() => tur);
+            block.flow(["event1", "testAction"], logo, 0, 10);
+            const listenerCall = logo.setTurtleListener.mock.calls[0];
+            const listenerFn = listenerCall[2];
+
+            listenerFn({});
+
+            expect(tur.singer.turtleTime).toBe(0);
+            expect(logo.runFromBlockNow).toHaveBeenCalled();
+        });
+
+        test("ignores events after stop", () => {
+            const block = activity.registeredBlocks["listen"];
+            logo.actions["testAction"] = [];
+            logo.stopTurtle = true;
+            activity.logo = { firstNoteTime: Date.now() };
+            const tur = {
+                running: false,
+                queue: [],
+                parentFlowQueue: [],
+                singer: { justCounting: [], runningFromEvent: false, turtleTime: 0 }
+            };
+            activity.turtles.ithTurtle = jest.fn(() => tur);
+            block.flow(["event1", "testAction"], logo, 0, 10);
+            const listenerCall = logo.setTurtleListener.mock.calls[0];
+            const listenerFn = listenerCall[2];
+
+            listenerFn({});
+
+            expect(tur.singer.runningFromEvent).toBe(false);
+            expect(tur.singer.turtleTime).toBe(0);
+            expect(logo.runFromBlockNow).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
## PR Category:
- [x] Bug Fix
 
## Summary

This PR fixes two related `on click do action` event-state issues:

- Ignore mouse click events while `stopTurtle` is true, so clicking the mouse after pressing Stop does not partially enter the event listener path.
- Start event-triggered timing from `0` when no note has played yet, preventing the first mouse click after Run from using an invalid elapsed time.

## Problem

In an `on click do action` project, the click listener remains registered after the initial Run finishes. If the user presses Stop during an event-triggered action and then clicks the mouse while stopped, the listener could still mutate event state even though execution was stopped.

Also, when the initial Run only registered the click listener and no notes had played yet, `firstNoteTime` could still be `null`. The first event-triggered click then calculated elapsed time from `null`, which could make `turtleTime` incorrect.

## Fix

- Added a guard in the click listener to return early when `logo.stopTurtle` is true.
- Updated event timing setup so `turtleTime` starts at `0` when `firstNoteTime` is `null`.
- Added regression tests for both cases.

 fixes regressions discovered while testing PR #6838.

### Video after applying the fix :

https://github.com/user-attachments/assets/8e5bb389-8f86-429e-ad2c-f96ba4ca692d
