### PR TITLE
fix: remove implicit global event from stage update path

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -5150,7 +5150,7 @@ class Activity {
         const loadStart = async that => {
             const __afterLoad = async () => {
                 if (!that.turtles.running()) {
-                    that.stage.update(event);
+                    that.stage.update();
                     for (let turtle = 0; turtle < that.turtles.getTurtleCount(); turtle++) {
                         that.logo.turtleHeaps[turtle] = [];
                         that.logo.turtleDicts[turtle] = {};


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
This PR fixes a load-finalization bug in `Activity` where `stage.update(...)` was called with an undeclared `event` identifier.

## What changed
- In `js/activity.js`, replaced:
  - `that.stage.update(event);`
- With:
  - `that.stage.update();`

## Why
The callback does not define an `event` parameter. Relying on ambient/global `event` is environment-dependent and can throw `ReferenceError: event is not defined`.

## Impact
- Removes fragile implicit global usage.
- Keeps stage refresh behavior intact during post-load finalization.
- Prevents avoidable runtime errors in stricter/non-browser-global contexts.

Fixes #6998