### PR TITLE
fix: recover startup when session JSON parse fails

### DIFF
--- a/js/__tests__/activity_startup_recovery.test.js
+++ b/js/__tests__/activity_startup_recovery.test.js
@@ -1,0 +1,108 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const loadLoadStart = () => {
+    const activityPath = path.resolve(__dirname, "../activity.js");
+    let code = fs.readFileSync(activityPath, "utf8");
+
+    const startPoint = code.indexOf("const loadStart = async that => {");
+    const endPoint = code.indexOf("        this.loadStartWrapper = async", startPoint);
+    if (startPoint === -1 || endPoint === -1) {
+        throw new Error("Could not locate loadStart in activity.js");
+    }
+    code = code.slice(startPoint, endPoint);
+    code += "\nthis.loadStart = loadStart;";
+
+    const sandbox = {
+        window: global.window,
+        document: global.document,
+        console,
+        _: key => key,
+        define: () => {},
+        require: () => {},
+        setTimeout,
+        createjs: {},
+        Turtles: class {},
+        Palettes: class {},
+        Blocks: class {},
+        Logo: class {},
+        LanguageBox: class {},
+        ThemeBox: class {},
+        SaveInterface: class {},
+        StatsWindow: class {},
+        Trashcan: class {},
+        PasteBox: class {},
+        HelpWidget: class {},
+        globalActivity: null,
+        _THIS_IS_MUSIC_BLOCKS_: true,
+        LEADING: 0,
+        MYDEFINES: []
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(code, sandbox);
+
+    return sandbox.loadStart;
+};
+
+describe("Activity startup recovery", () => {
+    let loadStart;
+
+    beforeAll(() => {
+        loadStart = loadLoadStart();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("clears malformed session data and falls back to a clean start", async () => {
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const removeItem = jest.fn();
+        const activity = {
+            storage: {
+                currentProject: "Corrupt Project",
+                removeItem,
+                ["SESSIONCorrupt Project"]: '{"broken":'
+            },
+            planet: null,
+            sessionData: null,
+            turtles: {
+                running: jest.fn(() => true)
+            },
+            stage: {
+                update: jest.fn(),
+                dispatchEvent: jest.fn()
+            },
+            logo: {
+                turtleHeaps: [],
+                turtleDicts: [],
+                notation: {
+                    notationStaging: [],
+                    notationDrumStaging: []
+                }
+            },
+            blocks: {
+                loadNewBlocks: jest.fn()
+            },
+            justLoadStart: jest.fn(),
+            doLoadAnimation: jest.fn(),
+            update: false
+        };
+
+        await loadStart(activity);
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.mock.calls[0][0]).toHaveProperty("name", "SyntaxError");
+        expect(consoleSpy.mock.calls[0][0].message).toMatch(/Unexpected end of JSON input/);
+        expect(removeItem).toHaveBeenCalledWith("SESSIONCorrupt Project");
+        expect(activity.justLoadStart).toHaveBeenCalledTimes(1);
+        expect(activity.blocks.loadNewBlocks).not.toHaveBeenCalled();
+        expect(activity.update).toBe(true);
+
+        document.dispatchEvent(new Event("finishedLoading"));
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -5190,19 +5190,21 @@ class Activity {
             that.keyboardEnableFlag = 0;
 
             that.sessionData = null;
+            const currentProject = that.storage.currentProject;
+            const sessionKey = currentProject !== undefined ? "SESSION" + currentProject : null;
 
             // Try restarting where we were when we hit save.
             if (that.planet) {
                 that.sessionData = await that.planet.openCurrentProject();
                 if (!that.sessionData) {
-                    const currentProject = that.storage.currentProject;
                     if (currentProject !== undefined) {
-                        that.sessionData = that.storage["SESSION" + currentProject];
+                        that.sessionData = that.storage[sessionKey];
                     }
                 }
             } else {
-                const currentProject = that.storage.currentProject;
-                that.sessionData = that.storage["SESSION" + currentProject];
+                if (sessionKey !== null) {
+                    that.sessionData = that.storage[sessionKey];
+                }
             }
 
             // After we have finished loading the project, clear all
@@ -5224,6 +5226,17 @@ class Activity {
                     }
                 } catch (e) {
                     console.error(e);
+                    if (sessionKey !== null) {
+                        try {
+                            if (typeof that.storage.removeItem === "function") {
+                                that.storage.removeItem(sessionKey);
+                            } else {
+                                delete that.storage[sessionKey];
+                            }
+                        } catch (storageError) {
+                            console.error(storageError);
+                        }
+                    }
                     that.justLoadStart();
                 }
             } else {

--- a/js/activity.js
+++ b/js/activity.js
@@ -5224,6 +5224,7 @@ class Activity {
                     }
                 } catch (e) {
                     console.error(e);
+                    that.justLoadStart();
                 }
             } else {
                 that.justLoadStart();


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
This PR adds startup recovery when persisted session JSON is malformed.

## What changed
- In `js/activity.js` (`loadStart` session restore path), added fallback recovery in the parse-error `catch` block:
  - `that.justLoadStart();`

## Why
When `that.sessionData` is corrupted or partially written, `JSON.parse` throws. The previous behavior only logged the error and stopped short of fallback, leaving startup in an incomplete state.

## Impact
- Restores deterministic startup behavior.
- Prevents startup flow from stalling on malformed session payloads.
- Aligns error handling with existing clean-start fallback behavior.

Fixes #7001