### PR TITLE
fix: support hex background colors in sensor fallback

### DIFF
--- a/js/blocks/SensorsBlocks.js
+++ b/js/blocks/SensorsBlocks.js
@@ -664,10 +664,34 @@ function setupSensorsBlocks(activity) {
          * @returns {number} - The background color index.
          */
         getBackgroundColor() {
-            const [r, g, b] = platformColor.background
-                .match(/\(([^)]+)\)/)[1]
-                .split(/,\s*/)
-                .map(Number);
+            const background = platformColor.background;
+            let r;
+            let g;
+            let b;
+
+            if (typeof background === "string" && background.startsWith("#")) {
+                let hex = background.slice(1);
+                if (hex.length === 3) {
+                    hex = hex
+                        .split("")
+                        .map(char => char + char)
+                        .join("");
+                }
+                if (hex.length !== 6) {
+                    throw new Error("Invalid hex background color");
+                }
+                r = parseInt(hex.slice(0, 2), 16);
+                g = parseInt(hex.slice(2, 4), 16);
+                b = parseInt(hex.slice(4, 6), 16);
+            } else {
+                const match =
+                    typeof background === "string" ? background.match(/\(([^)]+)\)/) : null;
+                if (!match) {
+                    throw new Error("Invalid rgb/rgba background color");
+                }
+                [r, g, b] = match[1].split(/,\s*/).slice(0, 3).map(Number);
+            }
+
             return searchColors(r, g, b);
         }
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Fixes background color parsing in the sensor fallback path so transparent-pixel detection uses the real theme background color.

## What changed
- Updated `getBackgroundColor()` in `js/blocks/SensorsBlocks.js` to support:
  - `#RGB`
  - `#RRGGBB`
  - existing `rgb(...)` / `rgba(...)` parsing path
- Preserved existing error flow: invalid formats still throw and upstream fallback handling remains intact.

## Why
`platformColor.background` is defined as hex in theme configuration, but sensor fallback previously assumed `rgb(...)` format only. That mismatch could throw and degrade color detection to generic gray.

## Impact
- Correct background-color mapping for transparent-pixel sensor reads.
- More accurate color sensor behavior across themes.
- Eliminates format mismatch between theme config and sensor parsing.

Fixes #7003