### PR TITLE
fix: guard turtledefs language preference storage access

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -307,6 +307,14 @@ const getAuxToolbarButtonNames = name => {
     );
 };
 
+const getLanguagePreference = () => {
+    try {
+        return localStorage.languagePreference;
+    } catch (e) {
+        return undefined;
+    }
+};
+
 const createDefaultStack = () => {
     if (_THIS_IS_TURTLE_BLOCKS_) {
         DATAOBJS = [
@@ -320,7 +328,7 @@ const createDefaultStack = () => {
             [7, ["number", { value: 90 }], 0, 0, [6]]
         ];
     } else {
-        let language = localStorage.languagePreference;
+        let language = getLanguagePreference();
         if (language === undefined) {
             language = navigator.language;
         }
@@ -407,7 +415,7 @@ const createDefaultStack = () => {
 };
 
 const createHelpContent = activity => {
-    let language = localStorage.languagePreference;
+    let language = getLanguagePreference();
     if (language === undefined) {
         language = navigator.language;
     }


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Guards language-preference reads in `turtledefs.js` so startup/help initialization does not fail when Web Storage access is unavailable.

## What changed
- Added `getLanguagePreference()` helper in `js/turtledefs.js`:
  - wraps `localStorage.languagePreference` in `try/catch`
  - returns `undefined` when storage access throws
- Reused this helper in:
  - `createDefaultStack`
  - `createHelpContent`
- Existing fallback behavior (`navigator.language`) is preserved.

## Why
In restricted/privacy contexts, direct storage access can throw `SecurityError`. These unguarded reads are in core initialization helpers, so they should fail gracefully.

## Impact
- Prevents avoidable runtime errors during startup/help content setup.
- Preserves current language resolution behavior.
- Aligns with existing guarded storage access patterns elsewhere in the codebase.

Fixes #7005