### PR TITLE
fix: guard rhythm palette language preference storage access

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -19,7 +19,14 @@
 
 /* exported setupRhythmBlockPaletteBlocks */
 
-const language = localStorage.languagePreference || navigator.language;
+let language;
+try {
+    language = localStorage.languagePreference;
+} catch (e) {
+    language = undefined;
+}
+language = language || navigator.language;
+
 let rhythmBlockPalette = language === "ja" ? "rhythm" : "widgets";
 if (_THIS_IS_TURTLE_BLOCKS_) {
     rhythmBlockPalette = "rhythm";
@@ -140,7 +147,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 // polyphonic rhythms.
                 if (logo.rhythmRulerMeasure === null) {
                     logo.rhythmRulerMeasure = arg0 * arg1;
-                } else if (logo.rhythmRulerMeasure != arg0 * arg1) {
+                } else if (logo.rhythmRulerMeasure !== arg0 * arg1) {
                     activity.textMsg(_("polyphonic rhythm"));
                 }
 
@@ -182,7 +189,8 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 const bpmFactor =
                     TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
-                const beatValue = bpmFactor == null ? 1 : bpmFactor / noteBeatValue;
+                const beatValue =
+                    bpmFactor === null || bpmFactor === undefined ? 1 : bpmFactor / noteBeatValue;
 
                 let __callback;
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Prevents rhythm palette module initialization from failing when Web Storage access is unavailable.

## What changed
- In `js/blocks/RhythmBlockPaletteBlocks.js`, replaced direct module-scope access:
  - `localStorage.languagePreference`
- With guarded retrieval:
  - `try/catch` around storage access
  - fallback to `navigator.language`
- Kept existing palette-selection behavior intact.
- Also resolved two strict-equality lint warnings in this file to keep CI/hook checks green.

## Why
This code executes at module load time. In restricted/privacy contexts, unguarded `localStorage` access can throw `SecurityError` before runtime safeguards run, breaking rhythm palette setup.

## Impact
- Improves startup reliability in storage-restricted environments.
- Prevents module-load-time failures in rhythm block palette initialization.

Fixes #7007