### PR TITLE
fix: remove native alert() from ProgramBlocks.js

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -1466,7 +1466,7 @@ function setupProgramBlocks(activity) {
             const win = window.open(url, "_blank", "noopener,noreferrer");
             if (win === null) {
                 // Browser has blocked it.
-                alert(_("Please allow popups for this site"));
+                activity.errorMsg(_("Please allow popups for this site"), 3000);
             }
         }
     }

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -770,23 +770,18 @@ describe("ProgramBlocks", () => {
 
     describe("OpenProjectBlock", () => {
         let originalOpen;
-        let originalAlert;
 
         beforeAll(() => {
             originalOpen = window.open;
-            originalAlert = window.alert;
         });
 
         afterAll(() => {
             window.open = originalOpen;
-            window.alert = originalAlert;
         });
 
         beforeEach(() => {
             delete window.open;
             window.open = jest.fn(() => ({}));
-            delete window.alert;
-            window.alert = jest.fn();
         });
 
         test("opens valid http URL", () => {
@@ -858,7 +853,10 @@ describe("ProgramBlocks", () => {
             block.flow(["https://example.com"], logo, 0, 5);
 
             expect(window.open).toHaveBeenCalled();
-            expect(window.alert).toHaveBeenCalledWith("Please allow popups for this site");
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Please allow popups for this site",
+                3000
+            );
         });
     });
 


### PR DESCRIPTION
Replaces the native browser `alert()` call in `js/blocks/ProgramBlocks.js` with the project-standard `activity.errorMsg()` when a popup is blocked. Native alerts block the main thread and break accessibility. Using `activity.errorMsg()` provides a non-blocking UI toast notification instead.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   **js/blocks/ProgramBlocks.js:** Replaced alert() with activity.errorMsg() 
-   **js/blocks/\_\_tests\_\_/ProgramBlocks.test.js:** 
    - Updated the `handles popup blocker` test to assert `activity.errorMsg` is called instead of `window.alert`.
    - Removed the unnecessary `window.alert` mock setup and teardown from the `OpenProjectBlock` test suite.

---

Thank you for contributing to our project! We appreciate your help in improving it.

📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md).

🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).
