### PR TITLE
perf: optimize docks deepClone in blockfactory.js

### DIFF
--- a/js/__tests__/blockfactory.test.js
+++ b/js/__tests__/blockfactory.test.js
@@ -20,6 +20,12 @@
 const { SVG } = require("../blockfactory");
 const { platformColor } = require("../utils/platformstyle");
 global.platformColor = platformColor;
+global.deepClone = value => {
+    if (typeof structuredClone === "function") {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+};
 
 jest.mock("../utils/platformstyle", () => ({
     platformColor: { header: "#FFFFFF" }

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -11,10 +11,12 @@
 
 // Borrowing loosely from tasprite_factory.py in the Python version.
 
-/* global platformColor */
+/* global platformColor, deepClone */
 /* Global Locations 
     js/utils/platformstyle.js
         platformColor
+    js/utils/utils.js
+        deepClone
 */
 /* exported SVG */
 const __svgCache = new Map();
@@ -1108,7 +1110,7 @@ class SVG {
         const finalSvg = this._header(false) + svg;
         __svgCache.set(cacheKey, {
             svg: finalSvg,
-            docks: JSON.parse(JSON.stringify(this.docks)),
+            docks: deepClone(this.docks),
             width: this._width,
             height: this._height
         });
@@ -1430,7 +1432,7 @@ class SVG {
         const finalSvg = this._header(false) + svg;
         __svgCache.set(cacheKey, {
             svg: finalSvg,
-            docks: JSON.parse(JSON.stringify(this.docks)),
+            docks: deepClone(this.docks),
             width: this._width,
             height: this._height
         });
@@ -1679,7 +1681,7 @@ class SVG {
         const finalSvg = this._header(false) + svg;
         __svgCache.set(cacheKey, {
             svg: finalSvg,
-            docks: JSON.parse(JSON.stringify(this.docks)),
+            docks: deepClone(this.docks),
             width: this._width,
             height: this._height
         });
@@ -1834,7 +1836,7 @@ class SVG {
         const finalSvg = this._header(false) + svg;
         __svgCache.set(cacheKey, {
             svg: finalSvg,
-            docks: JSON.parse(JSON.stringify(this.docks)),
+            docks: deepClone(this.docks),
             width: this._width,
             height: this._height
         });


### PR DESCRIPTION
<!--- Describe the changes introduced by this pull request. -->
<!--- Explain what problem it solves or what feature/fix it adds. -->

This PR improves how block docking definitions are copied in `js/blockfactory.js`.
Previously the code used `JSON.parse(JSON.stringify(this.docks))` to duplicate `this.docks`. It is slow for complex block arrays and creates extra memory usage.

To fix this, the PR replaces that approach with the project’s shared `deepClone` utility. Since `deepClone` can use `structuredClone` when available, it provides a faster and more efficient way to copy data, while also reducing unnecessary garbage collection. The related unit tests were also updated to correctly mock the new `global.deepClone` dependency.

## PR Category

<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Replaced `JSON.parse(JSON.stringify(this.docks))` with `deepClone(this.docks)` within the `SVG` class to optimize the caching mechanism.
- Added `global.deepClone` mock to `js/__tests__/blockfactory.test.js` to ensure the test suite continues to pass without side effects.
- Added `deepClone` to global variables in the header comments of `js/blockfactory.js`.

