### PR TITLE
fix: change help icon colors for better dark and high contrast visibility

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -49,6 +49,10 @@ body.highcontrast {
     color: var(--fg);
 }
 
+.highcontrast #helpBodyDiv .help-tour-white-icon {
+    filter: brightness(0) invert(1);
+}
+
 .highcontrast #floatingWindows .wfWinBody {
     background-color: var(--bg) !important;
 }

--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -94,6 +94,7 @@ Object.defineProperty(window, "localStorage", {
 beforeEach(() => {
     // Reset DOM
     document.body.innerHTML = "";
+    document.body.className = "";
 
     mockWidgetWindow = createMockWidgetWindow();
     window.widgetWindows = {
@@ -508,6 +509,114 @@ describe("HelpWidget", () => {
             expect(img).not.toBeNull();
             // For known pages, the img should NOT have width/height attributes
             expect(img.getAttribute("width")).toBeNull();
+            expect(img.classList.contains("help-tour-image")).toBe(true);
+            expect(img.classList.contains("help-tour-icon")).toBe(false);
+        });
+
+        test("_showPage treats Music Blocks congratulations page as a large image", () => {
+            HELPCONTENT.push(["Congratulations!", "You did it!", "images/congrats-mb.svg"]);
+
+            try {
+                const activity = createMockActivity();
+                const hw = new HelpWidget(activity, false);
+                jest.runAllTimers();
+
+                hw._showPage(HELPCONTENT.length - 1);
+
+                const helpBody = document.getElementById("helpBodyDiv");
+                const img = helpBody.querySelector("img");
+                expect(img).not.toBeNull();
+                expect(img.getAttribute("width")).toBeNull();
+                expect(img.classList.contains("help-tour-image")).toBe(true);
+                expect(img.classList.contains("help-tour-icon")).toBe(false);
+            } finally {
+                HELPCONTENT.pop();
+            }
+        });
+
+        test("_showPage preserves detailed tour icons in high contrast mode", () => {
+            const svg =
+                '<svg xmlns="http://www.w3.org/2000/svg"><rect fill="#f0f0f0"/><text fill="#333333">Tab</text></svg>';
+            const src = "data:image/svg+xml;base64," + window.btoa(svg);
+            HELPCONTENT.push(["Tab Navigation", "Use tab", src]);
+            document.body.classList.add("highcontrast");
+
+            try {
+                const activity = createMockActivity();
+                const hw = new HelpWidget(activity, false);
+                jest.runAllTimers();
+
+                hw._showPage(HELPCONTENT.length - 1);
+
+                const helpBody = document.getElementById("helpBodyDiv");
+                const img = helpBody.querySelector("img");
+                expect(img).not.toBeNull();
+                expect(img.getAttribute("src")).toBe(src);
+                expect(img.classList.contains("help-tour-detailed-icon")).toBe(true);
+                expect(img.classList.contains("help-tour-icon")).toBe(false);
+            } finally {
+                HELPCONTENT.pop();
+            }
+        });
+
+        test("_showPage makes regular semi-transparent SVG icons full strength in high contrast mode", () => {
+            const svg =
+                '<svg xmlns="http://www.w3.org/2000/svg"><path style="fill:#292929;fill-opacity:0.4;stroke:#292929;stroke-opacity:0.4;opacity:0.4"/><rect style="fill:#ffffff;opacity:0"/></svg>';
+            const src = "data:image/svg+xml;base64," + window.btoa(svg);
+            HELPCONTENT.push(["High Contrast Icon", "Icon description", src]);
+            document.body.classList.add("highcontrast");
+
+            try {
+                const activity = createMockActivity();
+                const hw = new HelpWidget(activity, false);
+                jest.runAllTimers();
+
+                hw._showPage(HELPCONTENT.length - 1);
+
+                const helpBody = document.getElementById("helpBodyDiv");
+                const img = helpBody.querySelector("img");
+                const highContrastSvg = window.atob(
+                    img.getAttribute("src").replace("data:image/svg+xml;base64,", "")
+                );
+
+                expect(img.classList.contains("help-tour-icon")).toBe(true);
+                expect(img.classList.contains("help-tour-white-icon")).toBe(true);
+                expect(highContrastSvg).toContain("fill-opacity:1");
+                expect(highContrastSvg).toContain("stroke-opacity:1");
+                expect(highContrastSvg).toContain("opacity:1");
+                expect(highContrastSvg).toContain("opacity:0");
+            } finally {
+                HELPCONTENT.pop();
+            }
+        });
+
+        test("_showPage preserves regular black-and-white SVG icon details in high contrast mode", () => {
+            const svg =
+                '<svg xmlns="http://www.w3.org/2000/svg"><rect style="fill:#292929;opacity:0.4"/><path style="fill:#ffffff"/></svg>';
+            const src = "data:image/svg+xml;base64," + window.btoa(svg);
+            HELPCONTENT.push(["Black White Icon", "Icon description", src]);
+            document.body.classList.add("highcontrast");
+
+            try {
+                const activity = createMockActivity();
+                const hw = new HelpWidget(activity, false);
+                jest.runAllTimers();
+
+                hw._showPage(HELPCONTENT.length - 1);
+
+                const helpBody = document.getElementById("helpBodyDiv");
+                const img = helpBody.querySelector("img");
+                const highContrastSvg = window.atob(
+                    img.getAttribute("src").replace("data:image/svg+xml;base64,", "")
+                );
+
+                expect(img.classList.contains("help-tour-icon")).toBe(true);
+                expect(img.classList.contains("help-tour-white-icon")).toBe(false);
+                expect(highContrastSvg).toContain("opacity:1");
+                expect(highContrastSvg).toContain("fill:#ffffff");
+            } finally {
+                HELPCONTENT.pop();
+            }
         });
 
         test("_showPage renders image with dimensions for unknown pages", () => {
@@ -523,6 +632,7 @@ describe("HelpWidget", () => {
             expect(img).not.toBeNull();
             expect(img.getAttribute("width")).toBe("64px");
             expect(img.getAttribute("height")).toBe("64px");
+            expect(img.classList.contains("help-tour-icon")).toBe(true);
         });
 
         test("_showPage renders link when page has more than 3 entries", () => {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -10,6 +10,8 @@
 
 // This widget displays help about a block or a button.
 
+const HELP_SVG_DATA_PREFIX = "data:image/svg+xml;base64,";
+
 /* global
 
    _, docById, getMacroExpansion, HELPCONTENT,
@@ -360,35 +362,43 @@ class HelpWidget {
         const pageCount = `${page + 1}/${totalPages}`;
         const rightArrow = docById("right-arrow");
         const leftArrow = docById("left-arrow");
+        const title = HELPCONTENT[page][0];
+        const imageSrc = HELPCONTENT[page][2];
 
         rightArrow.classList.toggle("disabled", page === HELPCONTENT.length - 1);
         leftArrow.classList.toggle("disabled", page === 0);
 
         // Previous HTML content is removed, and new one is generated.
         const bodyFragment = document.createDocumentFragment();
-        if (
-            [
-                _("Welcome to Music Blocks"),
-                _("Meet Mr. Mouse!"),
-                _("Guide"),
-                _("About"),
-                _("Congratulations.")
-            ].includes(HELPCONTENT[page][0])
-        ) {
+        if (this._isLargeTourImage(title)) {
             // body = body + '<p>&nbsp;<img src="' + HELPCONTENT[page][2] + '"></p>';
             const figure = document.createElement("figure");
             const img = document.createElement("img");
-            img.src = HELPCONTENT[page][2];
-            img.alt = `${HELPCONTENT[page][0]} icon`;
+            img.src = imageSrc;
+            img.alt = `${title} icon`;
             img.loading = "lazy";
+            img.classList.add("help-tour-image");
+            figure.append(img);
+            bodyFragment.append(figure);
+        } else if (this._isDetailedTourIcon(title)) {
+            const figure = document.createElement("figure");
+            const img = document.createElement("img");
+            img.src = imageSrc;
+            img.alt = `${title} icon`;
+            img.loading = "lazy";
+            img.classList.add("help-tour-detailed-icon");
             figure.append(img);
             bodyFragment.append(figure);
         } else {
             const figure = document.createElement("figure");
             const img = document.createElement("img");
-            img.src = HELPCONTENT[page][2];
-            img.alt = `${HELPCONTENT[page][0]} icon`;
+            img.src = this._getHighContrastHelpIconSrc(imageSrc);
+            img.alt = `${title} icon`;
             img.loading = "lazy";
+            img.classList.add("help-tour-icon");
+            if (this._usesHighContrastWhiteFilter(imageSrc)) {
+                img.classList.add("help-tour-white-icon");
+            }
             img.setAttribute("width", "64px");
             img.setAttribute("height", "64px");
             figure.append(img);
@@ -465,6 +475,120 @@ class HelpWidget {
         helpBody.append(bodyFragment);
 
         this.widgetWindow.takeFocus();
+    }
+
+    /**
+     * @private
+     * @param {string} title
+     * @returns {boolean}
+     */
+    _isLargeTourImage(title) {
+        return [
+            _("Welcome to Music Blocks"),
+            _("Meet Mr. Mouse!"),
+            _("Guide"),
+            _("About"),
+            _("Congratulations."),
+            _("Congratulations!")
+        ].includes(title);
+    }
+
+    /**
+     * @private
+     * @param {string} title
+     * @returns {boolean}
+     */
+    _isDetailedTourIcon(title) {
+        return [
+            _("Tab Navigation"),
+            _("Contextual Menu for Blocks"),
+            _("Contextual Menu for Canvas")
+        ].includes(title);
+    }
+
+    /**
+     * @private
+     * @param {string} src
+     * @returns {string}
+     */
+    _getHighContrastHelpIconSrc(src) {
+        if (
+            !document.body.classList.contains("highcontrast") ||
+            !src.startsWith(HELP_SVG_DATA_PREFIX)
+        ) {
+            return src;
+        }
+
+        try {
+            const svg = this._decodeSvgData(src.slice(HELP_SVG_DATA_PREFIX.length));
+            const highContrastSvg = svg
+                .replace(/fill-opacity\s*:\s*0\.[0-9]+/g, "fill-opacity:1")
+                .replace(/stroke-opacity\s*:\s*0\.[0-9]+/g, "stroke-opacity:1")
+                .replace(/opacity\s*:\s*0\.[0-9]+/g, "opacity:1")
+                .replace(/fill-opacity="0\.[0-9]+"/g, 'fill-opacity="1"')
+                .replace(/stroke-opacity="0\.[0-9]+"/g, 'stroke-opacity="1"')
+                .replace(/opacity="0\.[0-9]+"/g, 'opacity="1"');
+            return HELP_SVG_DATA_PREFIX + this._encodeSvgData(highContrastSvg);
+        } catch (e) {
+            return src;
+        }
+    }
+
+    /**
+     * @private
+     * @param {string} src
+     * @returns {boolean}
+     */
+    _usesHighContrastWhiteFilter(src) {
+        if (
+            !document.body.classList.contains("highcontrast") ||
+            !src.startsWith(HELP_SVG_DATA_PREFIX)
+        ) {
+            return false;
+        }
+
+        try {
+            return !this._hasVisibleWhiteSvgDetail(
+                this._decodeSvgData(src.slice(HELP_SVG_DATA_PREFIX.length))
+            );
+        } catch (e) {
+            return true;
+        }
+    }
+
+    /**
+     * @private
+     * @param {string} svg
+     * @returns {boolean}
+     */
+    _hasVisibleWhiteSvgDetail(svg) {
+        const whiteElements =
+            svg.match(/<[^>]*(?:fill|stroke)\s*[:=]\s*["']?#(?:fff|ffffff)\b[^>]*>/gi) || [];
+
+        return whiteElements.some(
+            element =>
+                !/(?:opacity|fill-opacity|stroke-opacity)\s*[:=]\s*["']?0(?:[;"'\s>]|$)/i.test(
+                    element
+                )
+        );
+    }
+
+    /**
+     * @private
+     * @param {string} encodedSvg
+     * @returns {string}
+     */
+    _decodeSvgData(encodedSvg) {
+        return window.atob(encodedSvg);
+    }
+
+    /**
+     * @private
+     * @param {string} svg
+     * @returns {string}
+     */
+    _encodeSvgData(svg) {
+        return window.btoa(svg);
     }
 
     /**


### PR DESCRIPTION
## PR Category
- [x] Bug Fix

## Description

Fixes Help tour icon visibility in high contrast mode while preserving icon details.

## Changes

- Adds high contrast handling for Help tour SVG icons.
- Applies the white icon filter only to black-only icons.
- Preserves black-and-white SVG details so icons do not become solid white blocks.
- Keeps dark mode icons using their original SVG colors.
- Adds focused Help widget tests for:
  - detailed tour icons
  - black-only high contrast icons
  - black-and-white high contrast icons

### Before 
<img width="585" height="507" alt="Screenshot 2026-04-29 023442" src="https://github.com/user-attachments/assets/5937c1c6-c083-45af-976a-bfe557c12c19" />
<img width="673" height="545" alt="Screenshot 2026-04-29 023144" src="https://github.com/user-attachments/assets/1b039df2-9052-4dcc-99b0-520a5bbaef21" />

### After
<img width="619" height="490" alt="Screenshot 2026-04-29 023603" src="https://github.com/user-attachments/assets/4556d9c1-f5e7-4b20-aca4-e488b49c2f2c" />
<img width="604" height="495" alt="Screenshot 2026-04-29 020253" src="https://github.com/user-attachments/assets/c8e26344-05d8-4d52-a920-f5c7a51fcf05" />

I have only attached few pictures but changes are made to add other icons as well .
