### PR TITLE
refactor: migrate tempo widget timers to ManagedTimer

### DIFF
--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update();
+            this.activity.stage.update(event);
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update(event);
+            this.activity.stage.update();
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -31,6 +31,13 @@ window.widgetWindows = {
     windowFor: jest.fn().mockReturnValue({
         clear: jest.fn(),
         show: jest.fn(),
+        timerManager: {
+            setInterval: jest.fn().mockImplementation((cb, t) => setInterval(cb, t)),
+            clearInterval: jest.fn().mockImplementation(id => clearInterval(id)),
+            setTimeout: jest.fn().mockImplementation((cb, t) => setTimeout(cb, t)),
+            clearTimeout: jest.fn().mockImplementation(id => clearTimeout(id)),
+            clearAll: jest.fn()
+        },
         addButton: jest.fn().mockReturnValue({ onclick: () => {} }),
         addInputButton: jest.fn().mockImplementation(val => ({
             value: val,

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -14,7 +14,7 @@
 
 /*
    global
-   _, getDrumSynthName, Singer, TONEBPM
+   _, getDrumSynthName, Singer, TONEBPM, ManagedTimer
  */
 
 /*
@@ -57,14 +57,22 @@ class Tempo {
         this._intervals = [];
         this.isMoving = true;
         if (this._intervalID !== undefined && this._intervalID !== null) {
-            clearInterval(this._intervalID);
+            if (this.widgetWindow && this.widgetWindow.timerManager) {
+                this.widgetWindow.timerManager.clearInterval(this._intervalID);
+            } else {
+                clearInterval(this._intervalID);
+            }
         }
 
         this._intervalID = null;
         this.activity.logo.synth.loadSynth(0, getDrumSynthName(Tempo.TEMPOSYNTH));
 
         if (this._intervalID !== null) {
-            clearInterval(this._intervalID);
+            if (this.widgetWindow && this.widgetWindow.timerManager) {
+                this.widgetWindow.timerManager.clearInterval(this._intervalID);
+            } else {
+                clearInterval(this._intervalID);
+            }
         }
 
         const widgetWindow = window.widgetWindows.windowFor(this, "tempo", "tempo", true);
@@ -74,7 +82,7 @@ class Tempo {
 
         widgetWindow.onclose = () => {
             if (this._intervalID !== null) {
-                clearInterval(this._intervalID);
+                widgetWindow.timerManager.clearInterval(this._intervalID);
             }
             widgetWindow.destroy();
         };
@@ -113,7 +121,14 @@ class Tempo {
                 if (!this._get_save_lock()) {
                     this._save_lock = true;
                     this._saveTempo();
-                    setTimeout(() => (this._save_lock = false), 1000);
+                    if (this.widgetWindow && this.widgetWindow.timerManager) {
+                        this.widgetWindow.timerManager.setTimeout(
+                            () => (this._save_lock = false),
+                            1000
+                        );
+                    } else {
+                        setTimeout(() => (this._save_lock = false), 1000);
+                    }
                 }
             };
 
@@ -237,7 +252,11 @@ class Tempo {
      * @returns {void}
      */
     pause() {
-        clearInterval(this._intervalID);
+        if (this.widgetWindow && this.widgetWindow.timerManager) {
+            this.widgetWindow.timerManager.clearInterval(this._intervalID);
+        } else {
+            clearInterval(this._intervalID);
+        }
     }
 
     /**
@@ -255,12 +274,22 @@ class Tempo {
 
         // Restart the interval.
         if (this._intervalID !== null) {
-            clearInterval(this._intervalID);
+            if (this.widgetWindow && this.widgetWindow.timerManager) {
+                this.widgetWindow.timerManager.clearInterval(this._intervalID);
+            } else {
+                clearInterval(this._intervalID);
+            }
         }
 
-        this._intervalID = setInterval(() => {
-            this._draw();
-        }, Tempo.TEMPOINTERVAL);
+        if (this.widgetWindow && this.widgetWindow.timerManager) {
+            this._intervalID = this.widgetWindow.timerManager.setInterval(() => {
+                this._draw();
+            }, Tempo.TEMPOINTERVAL);
+        } else {
+            this._intervalID = setInterval(() => {
+                this._draw();
+            }, Tempo.TEMPOINTERVAL);
+        }
     }
 
     /**
@@ -421,7 +450,7 @@ class Tempo {
      * @returns {void}
      */
     __save(i) {
-        setTimeout(() => {
+        const callback = () => {
             const delta = i * 42;
             const newStack = [
                 [0, ["setbpm3", {}], 100 + delta, 100 + delta, [null, 1, 2, 5]],
@@ -433,7 +462,13 @@ class Tempo {
             ];
             this.activity.blocks.loadNewBlocks(newStack);
             activity.textMsg(_("New action block generated."), 3000);
-        }, 200 * i);
+        };
+
+        if (this.widgetWindow && this.widgetWindow.timerManager) {
+            this.widgetWindow.timerManager.setTimeout(callback, 200 * i);
+        } else {
+            setTimeout(callback, 200 * i);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR migrates the `Tempo` widget's raw `setInterval` and `setTimeout` calls to the new `ManagedTimer` system via `this.widgetWindow.timerManager`. This ensures that all asynchronous timers and animation loops spawned by the widget are properly tracked and automatically cleaned up when the widget window is closed. Additionally, the unit tests have been updated to correctly mock the `timerManager` object within the mocked `widgetWindow`. 
This addresses background CPU usage and potential zombie timers that would persist after destroying the Tempo widget.

**Note: This PR depends on #7017 and should be reviewed/merged after that PR to ensure the changes apply correctly.**

## PR Category
<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->
-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
## Changes Made
<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->
- **`js/widgets/tempo.js`**: 
  - Migrated `setInterval` responsible for the widget's drawing loop (`this._draw()`) to use `this.widgetWindow.timerManager.setInterval()`.
  - Migrated UI debouncing and saving `setTimeout` calls to `this.widgetWindow.timerManager.setTimeout()`.
  - Implemented backwards compatibility fallbacks to the global `window` timer functions to prevent runtime errors if `timerManager` is uninitialized.
- **`js/widgets/__tests__/tempo.test.js`**: 
  - Updated the mocked `widgetWindow` object in test setups to expose a mock `timerManager` containing spies for `setInterval`, `clearInterval`, `setTimeout`, `clearTimeout`, and `clearAll`. This fixes test crashes that occurred when `onclose` attempted to invoke `clearInterval` on an undefined `timerManager`.