### PR TITLE
feat: integrate ManagedTimer into widgetWindow lifecycle

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -9,7 +9,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* global _, docById */
+/* global _, docById, ManagedTimer */
 
 /*
 Globals location
@@ -141,6 +141,7 @@ class WidgetWindow {
         this._savedPos = null;
         this._maximized = false;
         this._fullscreenEnabled = fullscreen;
+        this.timerManager = typeof ManagedTimer !== "undefined" ? new ManagedTimer() : null;
 
         // Drag offset for correct positioning
         this._dx = this._dy = 0;
@@ -658,6 +659,9 @@ class WidgetWindow {
         }
         if (window.widgetWindows.focused === this) {
             window.widgetWindows.focused = null;
+        }
+        if (this.timerManager) {
+            this.timerManager.clearAll();
         }
         window.widgetWindows.openWindows[this._key] = undefined;
     }


### PR DESCRIPTION
This pull request integrates the `ManagedTimer` system directly into the core `WidgetWindow` lifecycle class. This ensures that every widget utilizing a `WidgetWindow` has a dedicated `timerManager` instance capable of safely handling `setInterval` and `setTimeout` operations. When a widget window is closed or destroyed, `clearAll()` is automatically invoked on its timer manager and eliminates CPU/memory leaks caused by unresolved background tasks.
## PR Category
<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->
-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
## Changes Made
<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->
- **`js/widgets/widgetWindows.js`**:
  - Added `ManagedTimer` to the list of expected global variables.
  - Instantiated `this.timerManager` using `new ManagedTimer()` within the `WidgetWindow` constructor (if `ManagedTimer` is available in the environment).
  - Updated the `destroy()` method to automatically invoke `this.timerManager.clearAll()` so that all pending timeouts and intervals tied to the widget are gracefully terminated.