### PR TITLE
Added a Diable and Enable Feature to the blocks

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -281,6 +281,7 @@ class Block {
         this.collapsed = false; // Is this collapsible block collapsed?
         this.inCollapsed = false; // Is this block in a collapsed stack?
         this.trash = false; // Is this block in the trash?
+        this.disabled = false; // Is this block disabled (skipped during execution)?
         this.loadComplete = false; // Has the block finished loading?
         this.label = null; // Editable textview in DOM.
         this.labelattr = null; // Editable textview in DOM.
@@ -2514,6 +2515,26 @@ class Block {
         this.updateCache();
         this.unhighlight();
         this.activity.refreshCanvas();
+    }
+
+    /**
+     * Toggles the disabled state of the block.
+     * When disabled, the block is skipped during execution.
+     */
+    toggleDisabled() {
+        this.disabled = !this.disabled;
+        // Reduce opacity when disabled to give visual feedback
+        this.container.alpha = this.disabled ? 0.5 : 1;
+        this.updateCache();
+        this.activity.refreshCanvas();
+    }
+
+    /**
+     * Checks if the block is disabled.
+     * @returns {boolean} true if the block is disabled
+     */
+    isDisabled() {
+        return this.disabled;
     }
 
     /**

--- a/js/logo.js
+++ b/js/logo.js
@@ -1681,7 +1681,7 @@ class Logo {
                 } else {
                     nextFlow = logo.blockList[blk].connections[0];
                     if (
-                        nextFlow != null &&
+                        nextFlow !== null &&
                         (logo.blockList[nextFlow].name === "action" ||
                             logo.blockList[nextFlow].name === "backward")
                     ) {
@@ -1721,8 +1721,10 @@ class Logo {
         let childFlowCount = 0;
         const actionArgs = [];
 
-        // Highlight only the current executing block
-        if (logo.activity.blocks.visible) {
+        const currentBlock = logo.blockList[blk];
+
+        // Highlight only the current executing block (skip disabled blocks).
+        if (logo.activity.blocks.visible && !currentBlock.disabled) {
             if (!tur.singer.suppressOutput && tur.singer.justCounting.length === 0) {
                 // Unhighlight any previously highlighted block
                 if (
@@ -1741,8 +1743,7 @@ class Logo {
             }
         }
 
-        const currentBlock = logo.blockList[blk];
-        if (!currentBlock.isArgBlock()) {
+        if (!currentBlock.disabled && !currentBlock.isArgBlock()) {
             let res = null;
             // Is it a plugin?
             if (currentBlock.name in logo.evalFlowDict) {
@@ -1782,7 +1783,7 @@ class Logo {
                     return ret;
                 }
             }
-        } else {
+        } else if (!currentBlock.disabled) {
             if (
                 // If it's an arg block, print its value.
                 currentBlock.isArgBlock() ||

--- a/js/logo.js
+++ b/js/logo.js
@@ -1682,8 +1682,9 @@ class Logo {
                     nextFlow = logo.blockList[blk].connections[0];
                     if (
                         nextFlow !== null &&
-                        (logo.blockList[nextFlow].name === "action" ||
-                            logo.blockList[nextFlow].name === "backward")
+                         nextFlow !== undefined &&
+                        (logo.blockList[nextFlow]?.name === "action" ||
+                            logo.blockList[nextFlow]?.name === "backward")
                     ) {
                         nextFlow = null;
                     } else {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1682,7 +1682,7 @@ class Logo {
                     nextFlow = logo.blockList[blk].connections[0];
                     if (
                         nextFlow !== null &&
-                         nextFlow !== undefined &&
+                        nextFlow !== undefined &&
                         (logo.blockList[nextFlow]?.name === "action" ||
                             logo.blockList[nextFlow]?.name === "backward")
                     ) {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3761,6 +3761,7 @@ const piemenuBlockContext = block => {
         "imgsrc:header-icons/copy-button.svg",
         "imgsrc:header-icons/extract-button.svg",
         "imgsrc:header-icons/empty-trash-button.svg",
+        "imgsrc:header-icons/stop-button.svg",
         "imgsrc:header-icons/cancel-button.svg"
     ];
 
@@ -3798,13 +3799,14 @@ const piemenuBlockContext = block => {
     wheel.navItems[0].setTooltip(_("Duplicate"));
     wheel.navItems[1].setTooltip(_("Extract"));
     wheel.navItems[2].setTooltip(_("Move to trash"));
-    wheel.navItems[3].setTooltip(_("Close"));
+    wheel.navItems[3].setTooltip(block.disabled ? _("Enable") : _("Disable"));
+    wheel.navItems[4].setTooltip(_("Close"));
     if (
         ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
             block.blocks.blockList[topBlock].name
         )
     ) {
-        wheel.navItems[4].setTooltip(_("Save stack"));
+        wheel.navItems[5].setTooltip(_("Save stack"));
     }
 
     if (helpButton !== null) {
@@ -3861,6 +3863,12 @@ const piemenuBlockContext = block => {
     };
 
     wheel.navItems[3].navigateFunction = () => {
+        that.blocks.activeBlock = blockBlock;
+        that.blocks.blockList[blockBlock].toggleDisabled();
+        docById("contextWheelDiv").style.display = "none";
+    };
+
+    wheel.navItems[4].navigateFunction = () => {
         docById("contextWheelDiv").style.display = "none";
     };
 
@@ -3886,7 +3894,7 @@ const piemenuBlockContext = block => {
             block.name
         )
     ) {
-        wheel.navItems[4].navigateFunction = () => {
+        wheel.navItems[5].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
             that.blocks.prepareStackForCopy();
             that.blocks.saveStack();


### PR DESCRIPTION
## Feature: Disable/Enable Individual Blocks in Workspace

Closes #7025 

---
### Summary
This PR introduces a **Disable/Enable** toggle for individual blocks in Music Blocks.

Users can now temporarily disable a block from the context menu without deleting or restructuring their stack. Disabled blocks are visually dimmed and skipped during execution, which is especially useful for testing variations in musical output.

---
### Video Demo

https://github.com/user-attachments/assets/3b350fa0-9289-414f-babc-2be0ab676079

https://github.com/user-attachments/assets/5731d808-5e34-47b0-83ee-e177e5890b73

---
### What Changed

#### 1. Block State Support
- Added a new per-block runtime state:
  - `disabled` in `js/block.js` (default `false`)
- Added helper methods:
  - `toggleDisabled()`
  - `isDisabled()`

---

#### 2. Context Menu Integration
- Updated block context pie menu in `js/piemenus.js`
- Added a new action item for block state toggling:
  - shows **Disable** when block is enabled
  - shows **Enable** when block is disabled
- Wired menu action to toggle state of the selected block

---

#### 3. Visual Feedback
- Disabled blocks now render with reduced opacity:
  - `alpha = 0.5` when disabled
  - `alpha = 1` when enabled
- Canvas refresh/cache update ensures immediate UI feedback

---

#### 4. Runtime Execution Behavior
- Updated execution flow in `js/logo.js`
- Disabled blocks are now skipped during runtime:
  - no flow execution
  - no plugin execution
  - no arg-block execution behavior
- Execution continues to the next connected block normally
- Disabled blocks are not highlighted as currently executing blocks

---

### Why This Matters
- Makes stack experimentation easier without deleting blocks
- Helps isolate/debug behavior quickly
- Lets users suppress selected audio-generating blocks during playback
- Improves iterative composition workflow

---

### How to Test
- Right-click any block and choose **Disable**
- Confirm the block appears visually dimmed
- Run the project and verify disabled block behavior is skipped
- Confirm disabled sound-producing blocks do not play audio
- Right-click again and choose **Enable**
- Verify appearance and behavior are restored

---

### Verification
- ESLint passes on modified files:
  - `js/block.js`
  - `js/piemenus.js`
  - `js/logo.js`
- Relevant pie menu test suite passes:
  - `js/__tests__/piemenus.test.js`

---

### PR Category
- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation