### PR TITLE
fix: resolve systematic TypeErrors due to sparse blockList

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -193,4 +193,41 @@ describe("Blocks Foundation", () => {
             expect(Array.isArray(blocks.trashStacks)).toBe(true);
         });
     });
+
+    describe("Sparse Array Safety", () => {
+        it("should not throw TypeError in findStacks when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = { trash: false, connections: [null] }; // Index 0 is undefined
+
+            expect(() => blocks.findStacks()).not.toThrow();
+            expect(blocks.stackList).toEqual([1]);
+        });
+
+        it("should not throw TypeError in moveAllBlocksExcept when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = {
+                trash: false,
+                connections: [null],
+                findTopBlock: jest.fn().mockReturnValue(1),
+                moveBlockRelativeBatched: jest.fn()
+            };
+
+            expect(() => blocks.moveAllBlocksExcept(null, 10, 10)).not.toThrow();
+        });
+
+        it("should not throw TypeError in _findTwoArgs when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = {
+                trash: false,
+                isArgBlock: jest.fn().mockReturnValue(true),
+                isExpandableBlock: jest.fn().mockReturnValue(true)
+            };
+
+            expect(() => blocks._findTwoArgs()).not.toThrow();
+            expect(blocks._expandablesList).toEqual([1]);
+        });
+    });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -980,7 +980,7 @@ class Activity {
             const columnYPositions = Array(numColumns).fill(y);
 
             for (const blk in this.blocks.blockList) {
-                if (!this.blocks.blockList[blk].trash) {
+                if (this.blocks.blockList[blk] && !this.blocks.blockList[blk].trash) {
                     const myBlock = this.blocks.blockList[blk];
 
                     // Store original position only once
@@ -1084,7 +1084,7 @@ class Activity {
 
                 // Position "start" blocks first
                 for (const blk in this.blocks.blockList) {
-                    if (!this.blocks.blockList[blk].trash) {
+                    if (this.blocks.blockList[blk] && !this.blocks.blockList[blk].trash) {
                         const myBlock = this.blocks.blockList[blk];
                         if (myBlock.name !== "start") {
                             continue;
@@ -1120,7 +1120,7 @@ class Activity {
 
                 // Position other blocks
                 for (const blk in this.blocks.blockList) {
-                    if (!this.blocks.blockList[blk].trash) {
+                    if (this.blocks.blockList[blk] && !this.blocks.blockList[blk].trash) {
                         const myBlock = this.blocks.blockList[blk];
                         if (myBlock.name === "start") {
                             continue;
@@ -1193,7 +1193,7 @@ class Activity {
                 this.blocks._beginDeferCheckBounds();
 
                 for (const blk in this.blocks.blockList) {
-                    if (!this.blocks.blockList[blk].trash) {
+                    if (this.blocks.blockList[blk] && !this.blocks.blockList[blk].trash) {
                         const myBlock = this.blocks.blockList[blk];
                         if (myBlock.connections[0] === null) {
                             let minYIndex = 0;
@@ -1362,7 +1362,7 @@ class Activity {
             let yMax = 0;
             let parts;
             for (let i = 0; i < this.blocks.blockList.length; i++) {
-                if (this.blocks.blockList[i].ignore()) {
+                if (!this.blocks.blockList[i] || this.blocks.blockList[i].ignore()) {
                     continue;
                 }
 
@@ -4814,23 +4814,23 @@ class Activity {
             this.blocks._beginDeferCheckBounds();
 
             for (const blk in this.blocks.blockList) {
+                const myBlock = this.blocks.blockList[blk];
+                if (!myBlock) continue;
+
                 // If this block is at the top of a stack, push it
                 // onto the trashStacks list.
-                if (this.blocks.blockList[blk].connections[0] === null) {
+                if (myBlock.connections[0] === null) {
                     this.blocks.trashStacks.push(blk);
                 }
 
-                if (
-                    this.blocks.blockList[blk].name === "start" ||
-                    this.blocks.blockList[blk].name === "drum"
-                ) {
-                    const turtle = this.blocks.blockList[blk].value;
-                    if (!this.blocks.blockList[blk].trash && turtle !== null) {
+                if (myBlock.name === "start" || myBlock.name === "drum") {
+                    const turtle = myBlock.value;
+                    if (!myBlock.trash && turtle !== null) {
                         this.turtles.getTurtle(turtle).inTrash = true;
                         this.turtles.getTurtle(turtle).container.visible = false;
                     }
-                } else if (this.blocks.blockList[blk].name === "action") {
-                    if (!this.blocks.blockList[blk].trash) {
+                } else if (myBlock.name === "action") {
+                    if (!myBlock.trash) {
                         this.blocks.deleteActionBlock(this.blocks.blockList[blk]);
                         actionBlockCounter += 1;
                     }
@@ -6756,8 +6756,10 @@ class Activity {
             this.hasMatrixDataBlock = false;
             for (let blk = 0; blk < this.blocks.blockList.length; blk++) {
                 const myBlock = this.blocks.blockList[blk];
-                if (myBlock.trash) {
+                if (myBlock && myBlock.trash) {
                     // Don't save blocks in the trash.
+                    continue;
+                } else if (!myBlock) {
                     continue;
                 }
 
@@ -6768,12 +6770,12 @@ class Activity {
             const data = [];
             for (let blk = 0; blk < this.blocks.blockList.length; blk++) {
                 const myBlock = this.blocks.blockList[blk];
-                let args = null;
-
-                if (myBlock.trash) {
+                if (!myBlock || myBlock.trash) {
                     // Don't save blocks in the trash.
                     continue;
                 }
+
+                let args = null;
 
                 if (
                     myBlock.isValueBlock() ||

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -373,7 +373,7 @@ class Blocks {
             let palette;
             /** Regenerate all of the artwork at the new scale. */
             for (const block of this.blockList) {
-                if (block.trash) continue;
+                if (!block || block.trash) continue;
                 block.resize(scale);
             }
 
@@ -384,7 +384,7 @@ class Blocks {
 
             /** Make sure trash is still hidden. */
             for (const block of this.blockList) {
-                if (block.trash) {
+                if (block && block.trash) {
                     block.hide();
                 }
             }
@@ -501,7 +501,7 @@ class Blocks {
         this.bottomMostBlock = () => {
             let maxy = -1000;
             for (const block of this.blockList) {
-                if (block.trash) continue;
+                if (!block || block.trash) continue;
                 if (block.container.y > maxy) {
                     maxy = block.container.y;
                 }
@@ -520,7 +520,7 @@ class Blocks {
             let allCollapsed = true;
             let someCollapsed = false;
             for (const myBlock of this.blockList) {
-                if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
                     continue;
                 }
 
@@ -539,7 +539,7 @@ class Blocks {
                  * If any blocks are collapsed, collapse them all.
                  */
                 for (const myBlock of this.blockList) {
-                    if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
                         continue;
                     }
 
@@ -550,7 +550,7 @@ class Blocks {
             } else {
                 /** If no blocks are collapsed, collapse them all. */
                 for (const myBlock of this.blockList) {
-                    if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
                         continue;
                     }
 
@@ -2626,7 +2626,7 @@ class Blocks {
             if (this._topBlockCache == null) {
                 this._topBlockCache = new Map();
                 for (let i = 0; i < this.blockList.length; i++) {
-                    if (this.blockList[i].trash) continue;
+                    if (!this.blockList[i] || this.blockList[i].trash) continue;
                     this._topBlockCache.set(i, this.findTopBlock(i));
                 }
             }
@@ -2636,7 +2636,7 @@ class Blocks {
 
             this._beginDeferCheckBounds();
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
+                if (!this.blockList[i] || this.blockList[i].trash) continue;
                 if (this._topBlockCache.get(i) !== excludeTop) {
                     this.moveBlockRelativeBatched(i, dx, dy);
                 }
@@ -3035,7 +3035,7 @@ class Blocks {
         this.findStacks = () => {
             this.stackList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
+                if (!this.blockList[i] || this.blockList[i].trash) continue;
                 if (this.blockList[i].connections[0] == null) {
                     this.stackList.push(i);
                 }
@@ -3066,7 +3066,7 @@ class Blocks {
         this._findTwoArgs = () => {
             this._expandablesList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
+                if (!this.blockList[i] || this.blockList[i].trash) continue;
                 if (this.blockList[i].isArgBlock() && this.blockList[i].isExpandableBlock()) {
                     this._expandablesList.push(i);
                 } else if (this.blockList[i].isTwoArgBlock()) {
@@ -3082,7 +3082,7 @@ class Blocks {
          */
         this._searchForArgFlow = () => {
             for (const [blk, block] of this.blockList.entries()) {
-                if (block.trash) continue;
+                if (!block || block.trash) continue;
                 if (block.isArgFlowClampBlock()) {
                     this._searchCounter = 0;
                     this._searchForExpandables(blk);


### PR DESCRIPTION
## Description
Fixes systematic `TypeError` crashes occurring when `blockList` contains `undefined` entries (sparse arrays).

## Changes
- Added defensive null checks to loops iterating over `blockList` in `js/blocks.js` and `js/activity.js`.
- Added regression tests in `js/__tests__/blocks.test.js` to ensure safety against sparse arrays.

## PR Category
- [x] Tests

## Verification
Run the new regression suite:
```bash
npm test js/__tests__/blocks.test.js


