### PR TITLE
[Bug fix] Single click unmaximize instantly bug

### DIFF
--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -207,7 +207,12 @@ class WidgetWindow {
 
         if (this._fullscreenEnabled) {
             this._drag.ondblclick = e => {
-                this._maximize();
+                if (this._maximized) {
+                    this._restore();
+                    this.sendToCenter();
+                } else {
+                    this._maximize();
+                }
                 this.takeFocus();
                 this.onmaximize();
                 e.preventDefault();
@@ -237,20 +242,6 @@ class WidgetWindow {
 
         this._nonclose.onmousedown = e => {
             window.widgetWindows.draggingWindow = this;
-            if (this._maximized) {
-                // Perform special repositioning to make the drag feel right when
-                // restoring a window from maximized.
-                let bcr = this._drag.getBoundingClientRect();
-                let dx = (bcr.left - e.clientX) / (bcr.right - bcr.left);
-                const dy = bcr.top - e.clientY;
-
-                this._restore();
-                this.onmaximize();
-
-                bcr = this._drag.getBoundingClientRect();
-                dx *= bcr.right - bcr.left;
-                this.setPosition(e.clientX + dx, e.clientY + dy);
-            }
 
             this.takeFocus();
 
@@ -339,6 +330,17 @@ class WidgetWindow {
      * @returns {void}
      */
     _docMouseMoveHandler(e) {
+        if (this._maximized) {
+            const bcr = this._drag.getBoundingClientRect();
+            const dxRatio = (bcr.left - e.clientX) / (bcr.right - bcr.left);
+            const dy = bcr.top - e.clientY;
+
+            this._restore();
+            this.onmaximize();
+
+            const newBcr = this._drag.getBoundingClientRect();
+            this.setPosition(e.clientX + dxRatio * (newBcr.right - newBcr.left), e.clientY + dy);
+        }
         // Throttle using requestAnimationFrame to prevent layout thrashing
         if (this._rafTicking) return;
         this._rafTicking = true;


### PR DESCRIPTION
Fixes #3739

### Current behavior:
 
- Single clicking anywhere on the widget top bar unmaximizes the window  
- This happens even on a simple drag when trying to hold the top bar, it unmaximizes without any widget movement.

### Desired behavior:

- Double click should toggle maximize / restore
- On holding the top bar the window should stay as it is and only unmaximize when dragging it.

### Cause:

The _restore() logic was executed inside the onmousedown event handler of the top bar, causing the window to unmaximize immediately on any click.

### FIx:

- Removed _restore() logic from the onmousedown handler.
- Moved restore behavior to the drag phase (_docMouseMoveHandler), ensuring it only occurs during actual dragging.
- Updated double-click behavior to toggle between maximize and restore.

### Impact

- Improves UX consistency with standard desktop and app behavior.
- Prevents accidental unmaximize
- Keeps existing drag behavior intact

## PR Category
<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->
-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README