### PR TITLE
fix: use tempo activity instance

### DIFF
--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -87,10 +87,6 @@ describe("Tempo Widget", () => {
             errorMsg: jest.fn() // This is what the code calls!
         };
 
-        // --- FIX 1: Set the Global 'activity' variable ---
-        // The widget code calls 'activity.errorMsg', relying on it being global.
-        global.activity = mockActivity;
-
         // Manually setup initial state usually handled by init()
         tempoWidget.activity = mockActivity;
         tempoWidget.BPMs = [100]; // Start at 100 BPM

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -193,7 +193,7 @@ class Tempo {
             );
         }
 
-        activity.textMsg(_("Adjust the tempo with the buttons."), 3000);
+        this.activity.textMsg(_("Adjust the tempo with the buttons."), 3000);
         this.resume();
 
         widgetWindow.sendToCenter();
@@ -272,17 +272,17 @@ class Tempo {
         const input = this.BPMInputs[i].value;
 
         if (isNaN(input)) {
-            activity.errorMsg(_("Please enter a number between 30 and 1000"), 3000);
+            this.activity.errorMsg(_("Please enter a number between 30 and 1000"), 3000);
             return;
         }
 
         this.BPMs[i] = this.BPMInputs[i].value;
         if (this.BPMs[i] > 1000) {
             this.BPMs[i] = 1000;
-            activity.errorMsg(_("The beats per minute must be between 30 and 1000."), 3000);
+            this.activity.errorMsg(_("The beats per minute must be between 30 and 1000."), 3000);
         } else if (this.BPMs[i] < 30) {
             this.BPMs[i] = 30;
-            activity.errorMsg(_("The beats per minute must be between 30 and 1000."), 3000);
+            this.activity.errorMsg(_("The beats per minute must be between 30 and 1000."), 3000);
         }
 
         this._updateBPM(i);
@@ -298,7 +298,7 @@ class Tempo {
         this.BPMs[i] = parseFloat(this.BPMs[i]) + Math.round(0.1 * this.BPMs[i]);
 
         if (this.BPMs[i] > 1000) {
-            activity.errorMsg(_("The beats per minute must be below 1000."), 3000);
+            this.activity.errorMsg(_("The beats per minute must be below 1000."), 3000);
             this.BPMs[i] = 1000;
         }
 
@@ -314,7 +314,7 @@ class Tempo {
     slowDown(i) {
         this.BPMs[i] = parseFloat(this.BPMs[i]) - Math.round(0.1 * this.BPMs[i]);
         if (this.BPMs[i] < 30) {
-            activity.errorMsg(_("The beats per minute must be above 30"), 3000);
+            this.activity.errorMsg(_("The beats per minute must be above 30"), 3000);
             this.BPMs[i] = 30;
         }
 
@@ -432,7 +432,7 @@ class Tempo {
                 [5, ["vspace", {}], 0, 0, [0, null]]
             ];
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
         }, 200 * i);
     }
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
## Summary

Fixes the Tempo widget so it uses its own stored activity instance instead of relying on a global `activity` variable.

## Changes

- Replaced remaining `activity.errorMsg(...)` and `activity.textMsg(...)` calls in `js/widgets/tempo.js` with `this.activity...`.
- Removed the `global.activity` workaround from `js/widgets/__tests__/tempo.test.js`.

## Why

`Tempo.init(activity)` already stores the activity object as `this.activity`. Some methods still used the global `activity`, which made the widget harder to test and more fragile if reused outside the normal global app context.
