### PR TITLE
fix: guard widget localStorage reads in restricted environments

### DIFF
--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update(event);
+            this.activity.stage.update();
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -87,6 +87,7 @@ window.widgetWindows = {
 };
 
 Object.defineProperty(window, "localStorage", {
+    configurable: true,
     writable: true,
     value: { languagePreference: "en" }
 });
@@ -515,6 +516,26 @@ describe("HelpWidget", () => {
             expect(img.getAttribute("width")).toBeNull();
             expect(img.classList.contains("help-tour-image")).toBe(true);
             expect(img.classList.contains("help-tour-icon")).toBe(false);
+        });
+
+        test("_showPage falls back when localStorage is blocked", () => {
+            const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage");
+            const activity = createMockActivity();
+            const hw = new HelpWidget(activity, false);
+            jest.runAllTimers();
+
+            Object.defineProperty(window, "localStorage", {
+                configurable: true,
+                get() {
+                    throw new DOMException("Access denied", "SecurityError");
+                }
+            });
+
+            try {
+                expect(() => hw._showPage(0)).not.toThrow();
+            } finally {
+                Object.defineProperty(window, "localStorage", originalLocalStorage);
+            }
         });
 
         test("_showPage treats Music Blocks congratulations page as a large image", () => {

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -7,10 +7,12 @@ const MusicKeyboard = require("../musickeyboard.js");
 describe("MusicKeyboard document key handler lifecycle", () => {
     let originalOnKeyDown;
     let originalOnKeyUp;
+    let originalLocalStorage;
 
     beforeEach(() => {
         originalOnKeyDown = document.onkeydown;
         originalOnKeyUp = document.onkeyup;
+        originalLocalStorage = Object.getOwnPropertyDescriptor(global, "localStorage");
         document.onkeydown = null;
         document.onkeyup = null;
     });
@@ -18,6 +20,18 @@ describe("MusicKeyboard document key handler lifecycle", () => {
     afterEach(() => {
         document.onkeydown = originalOnKeyDown;
         document.onkeyup = originalOnKeyUp;
+        Object.defineProperty(global, "localStorage", originalLocalStorage);
+    });
+
+    test("opens when localStorage is blocked", () => {
+        Object.defineProperty(global, "localStorage", {
+            configurable: true,
+            get() {
+                throw new DOMException("Access denied", "SecurityError");
+            }
+        });
+
+        expect(() => new MusicKeyboard({})).not.toThrow();
     });
 
     test("captures the handlers active when the keyboard is opened", () => {

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -184,9 +184,11 @@ global.document = {
 describe("PhraseMaker Widget", () => {
     let phraseMaker;
     let mockDeps;
+    let originalLocalStorage;
 
     beforeEach(() => {
         jest.useFakeTimers();
+        originalLocalStorage = Object.getOwnPropertyDescriptor(global, "localStorage");
 
         mockDeps = {
             platformColor: global.platformColor,
@@ -216,6 +218,11 @@ describe("PhraseMaker Widget", () => {
     afterEach(() => {
         jest.useRealTimers();
         jest.clearAllMocks();
+        if (originalLocalStorage) {
+            Object.defineProperty(global, "localStorage", originalLocalStorage);
+        } else {
+            delete global.localStorage;
+        }
     });
 
     describe("constructor", () => {
@@ -277,6 +284,57 @@ describe("PhraseMaker Widget", () => {
             expect(phraseMaker.paramsEffects.vibratoIntensity).toBe(0);
             expect(phraseMaker.paramsEffects.distortionAmount).toBe(0);
             expect(phraseMaker.paramsEffects.tremoloFrequency).toBe(0);
+        });
+
+        test("opens when localStorage is blocked", () => {
+            Object.defineProperty(global, "localStorage", {
+                configurable: true,
+                get() {
+                    throw new DOMException("Access denied", "SecurityError");
+                }
+            });
+            window.widgetWindows = {
+                windowFor: jest.fn().mockReturnValue({
+                    clear: jest.fn(),
+                    show: jest.fn(),
+                    addButton: jest.fn().mockReturnValue({
+                        onclick: null,
+                        innerHTML: "",
+                        style: {},
+                        setAttribute: jest.fn()
+                    }),
+                    getWidgetBody: jest.fn().mockReturnValue({
+                        appendChild: jest.fn(),
+                        append: jest.fn()
+                    }),
+                    sendToCenter: jest.fn(),
+                    destroy: jest.fn()
+                })
+            };
+
+            const pm = new PhraseMaker(mockDeps);
+            const activity = {
+                logo: {
+                    synth: {
+                        loadSynth: jest.fn(),
+                        stopSound: jest.fn(),
+                        stop: jest.fn()
+                    }
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({
+                        singer: {
+                            beatsPerMeasure: 4,
+                            noteValuePerBeat: 4,
+                            instrumentNames: []
+                        }
+                    }))
+                },
+                hideMsgs: jest.fn(),
+                textMsg: jest.fn()
+            };
+
+            expect(() => pm.init(activity)).not.toThrow();
         });
     });
 

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -261,6 +261,29 @@ describe("StatusMatrix Widget", () => {
                 configurable: true
             });
         });
+
+        test("falls back when localStorage is blocked for bpm labels", () => {
+            const originalLocalStorage = Object.getOwnPropertyDescriptor(global, "localStorage");
+
+            Object.defineProperty(global, "localStorage", {
+                configurable: true,
+                get() {
+                    throw new DOMException("Access denied", "SecurityError");
+                }
+            });
+
+            mockActivity.blocks.blockList = {
+                0: { name: "bpm", protoblock: { staticLabels: ["beats per minute"] }, value: 120 }
+            };
+            mockActivity.logo.statusFields = [[0, "bpm"]];
+
+            try {
+                expect(() => statusMatrix.init(mockActivity)).not.toThrow();
+            } finally {
+                Object.defineProperty(global, "localStorage", originalLocalStorage);
+            }
+        });
+
         it("uses privateData for outputtools block", () => {
             mockActivity.blocks.blockList = {
                 0: { name: "outputtools", privateData: "someData", value: null }

--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -38,6 +38,7 @@ canvas.id = "myCanvas";
 document.body.appendChild(canvas);
 
 Object.defineProperty(window, "localStorage", {
+    configurable: true,
     writable: true,
     value: { languagePreference: "en" }
 });
@@ -93,6 +94,23 @@ describe("widgetWindows", () => {
             const win = createTestWindow();
 
             expect(win._visible).toBe(true);
+        });
+
+        test("falls back when localStorage is blocked during language setup", () => {
+            const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+            Object.defineProperty(window, "localStorage", {
+                configurable: true,
+                get() {
+                    throw new DOMException("Access denied", "SecurityError");
+                }
+            });
+
+            try {
+                expect(() => createTestWindow()).not.toThrow();
+            } finally {
+                Object.defineProperty(window, "localStorage", originalLocalStorage);
+            }
         });
 
         test("creates a window with _maximized set to false", () => {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -12,6 +12,14 @@
 
 const HELP_SVG_DATA_PREFIX = "data:image/svg+xml;base64,";
 
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
+
 /* global
 
    _, docById, getMacroExpansion, HELPCONTENT,
@@ -248,14 +256,14 @@ class HelpWidget {
                         // We need to add a case here whenever we add
                         // help artwort support for a new language.
                         // e.g., documentation-es
-                        let language = localStorage.languagePreference;
+                        let language = getLocalStorageValue("languagePreference");
                         if (language === undefined) {
                             language = navigator.language;
                         }
 
                         switch (language) {
                             case "ja":
-                                if (localStorage.kanaPreference === "kana") {
+                                if (getLocalStorageValue("kanaPreference") === "kana") {
                                     path = path + "-kana";
                                 } else {
                                     path = path + "-ja";
@@ -747,14 +755,14 @@ class HelpWidget {
                     // We need to add a case here whenever we add
                     // help artwort support for a new language.
                     // e.g., documentation-es
-                    let language = localStorage.languagePreference;
+                    let language = getLocalStorageValue("languagePreference");
                     if (language === undefined) {
                         language = navigator.language;
                     }
 
                     switch (language) {
                         case "ja":
-                            if (localStorage.kanaPreference === "kana") {
+                            if (getLocalStorageValue("kanaPreference") === "kana") {
                                 path = path + "-kana";
                             } else {
                                 path = path + "-ja";

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -12,7 +12,7 @@
 
 const HELP_SVG_DATA_PREFIX = "data:image/svg+xml;base64,";
 
-const getLocalStorageValue = key => {
+var getLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -56,6 +56,13 @@ function MusicKeyboard(activity) {
     const HERTZKEYS = [49, 50, 51, 52, 53, 54, 55, 56, 57, 48];
     const WHITEKEYS = [65, 83, 68, 70, 71, 72, 74, 75, 76];
     const SPACE = 32;
+    const getLocalStorageValue = key => {
+        try {
+            return localStorage[key];
+        } catch (e) {
+            return undefined;
+        }
+    };
 
     const setKeyboardCellLabel = (cell, label, octave, prefix = null) => {
         cell.replaceChildren();
@@ -84,7 +91,7 @@ function MusicKeyboard(activity) {
      * Indicates whether the keyboard is in beginner mode.
      * @type {boolean}
      */
-    const beginnerMode = localStorage.beginnerMode;
+    const beginnerMode = getLocalStorageValue("beginnerMode");
 
     /**
      * Number of units in beginner mode.

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -55,7 +55,7 @@ Globals location
 /* exported PhraseMaker */
 // The last selected index for piemenu
 let lastIndex = 5;
-const getLocalStorageValue = key => {
+var getLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -55,6 +55,13 @@ Globals location
 /* exported PhraseMaker */
 // The last selected index for piemenu
 let lastIndex = 5;
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
 
 /**
  * Represents a PhraseMaker widget for creating and managing musical phrases.
@@ -487,7 +494,7 @@ class PhraseMaker {
         widgetWindow.addButton("erase-button.svg", PhraseMaker.ICONSIZE, this._("Clear")).onclick =
             this._clear.bind(this);
 
-        if (!localStorage.beginnerMode) {
+        if (!getLocalStorageValue("beginnerMode")) {
             widgetWindow.addButton(
                 "export-button.svg",
                 PhraseMaker.ICONSIZE,

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -15,6 +15,14 @@
 /* global _, _THIS_IS_MUSIC_BLOCKS_ */
 
 /* exported StatusMatrix */
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
+
 class StatusMatrix {
     static BUTTONDIVWIDTH = 128;
     static BUTTONSIZE = 53;
@@ -151,7 +159,7 @@ class StatusMatrix {
                     break;
                 case "bpm":
                 case "bpmfactor":
-                    if (localStorage.languagePreference === "ja") {
+                    if (getLocalStorageValue("languagePreference") === "ja") {
                         label = _("beats per minute2");
                     } else {
                         label =

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -15,7 +15,7 @@
 /* global _, _THIS_IS_MUSIC_BLOCKS_ */
 
 /* exported StatusMatrix */
-const getLocalStorageValue = key => {
+var getLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -124,6 +124,14 @@ window.widgetWindows = {
     }
 };
 
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
+
 class WidgetWindow {
     /**
      * @param {string} key
@@ -394,7 +402,7 @@ class WidgetWindow {
      * @returns {void}
      */
     _setupLanguage() {
-        let language = localStorage.languagePreference;
+        let language = getLocalStorageValue("languagePreference");
         if (language === undefined) {
             language = navigator.language;
         }

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -124,7 +124,7 @@ window.widgetWindows = {
     }
 };
 
-const getLocalStorageValue = key => {
+var getLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Guards widget-level language and mode reads from `localStorage` so UI flows remain stable when Web Storage access is blocked (for example, strict privacy or restricted webview contexts).

## What changed
- Added safe storage accessors (`try/catch`) and replaced unguarded property reads in:
  - `js/widgets/help.js`
  - `js/widgets/widgetWindows.js`
  - `js/widgets/status.js`
  - `js/widgets/musickeyboard.js`
  - `js/widgets/phrasemaker.js`
- Preserved existing behavior and fallbacks (`navigator.language` where applicable).

## Why
Several common widget code paths accessed `localStorage` directly. In environments where storage access throws `SecurityError`, these paths can fail at runtime and break core UI interactions.

## Impact
- Improves reliability across restricted browser/storage environments.
- Prevents avoidable widget failures in help, status, keyboard, phrase maker, and widget window language setup.