### PR TITLE
fix: migrate raw timers in core widgets to ManagedTimer

### DIFF
--- a/js/widgets/__tests__/reflection.test.js
+++ b/js/widgets/__tests__/reflection.test.js
@@ -40,7 +40,14 @@ function createMockWidgetWindow() {
             return btn;
         }),
         getWidgetBody: jest.fn(() => widgetBody),
-        destroy: jest.fn()
+        destroy: jest.fn(),
+        timerManager: {
+            setInterval: jest.fn().mockImplementation((cb, t) => setInterval(cb, t)),
+            clearInterval: jest.fn().mockImplementation(id => clearInterval(id)),
+            setTimeout: jest.fn().mockImplementation((cb, t) => setTimeout(cb, t)),
+            clearTimeout: jest.fn().mockImplementation(id => clearTimeout(id)),
+            clearAll: jest.fn()
+        }
     };
 }
 

--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -182,6 +182,13 @@ describe("Sampler Widget", () => {
                 show: jest.fn(),
                 sendToCenter: jest.fn(),
                 destroy: jest.fn(),
+                timerManager: {
+                    setInterval: jest.fn().mockImplementation((cb, t) => setInterval(cb, t)),
+                    clearInterval: jest.fn().mockImplementation(id => clearInterval(id)),
+                    setTimeout: jest.fn().mockImplementation((cb, t) => setTimeout(cb, t)),
+                    clearTimeout: jest.fn().mockImplementation(id => clearTimeout(id)),
+                    clearAll: jest.fn()
+                },
                 _buttons: buttons
             };
             window.widgetWindows = {

--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -450,7 +450,11 @@ function AIDebuggerWidget() {
 
         // Add animation
         let dots = 0;
-        const animateTyping = setInterval(() => {
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
+        const animateTyping = timer.setInterval(() => {
             dots = (dots + 1) % 4;
             typingDiv.textContent = "Debugger is typing" + ".".repeat(dots);
         }, 500);
@@ -467,10 +471,14 @@ function AIDebuggerWidget() {
      */
     this._hideTypingIndicator = function () {
         const typingIndicators = this.chatLog.querySelectorAll(".typing-indicator");
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
         typingIndicators.forEach(indicator => {
             const animationId = indicator.getAttribute("data-animation-id");
             if (animationId) {
-                clearInterval(parseInt(animationId));
+                timer.clearInterval(parseInt(animationId));
             }
             indicator.remove();
         });

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -261,7 +261,11 @@ class ReflectionMatrix {
         // Start animation
         let dotCount = 0;
         const maxDots = 3;
-        this.dotsInterval = setInterval(() => {
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
+        this.dotsInterval = timer.setInterval(() => {
             dotCount = (dotCount + 1) % (maxDots + 1);
             this.dotsContainer.textContent = ".".repeat(dotCount);
         }, 500);
@@ -272,13 +276,17 @@ class ReflectionMatrix {
      * @returns {void}
      */
     hideTypingIndicator() {
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
         if (this.startChatTypingTimeout) {
-            clearTimeout(this.startChatTypingTimeout);
+            timer.clearTimeout(this.startChatTypingTimeout);
             this.startChatTypingTimeout = null;
         }
 
         if (this.typingDiv) {
-            clearInterval(this.dotsInterval);
+            timer.clearInterval(this.dotsInterval);
             this.typingDiv.remove();
             this.typingDiv = null;
         }
@@ -432,7 +440,11 @@ class ReflectionMatrix {
         // Reset summarization state for a fresh session
         this.conversationSummary = "";
         this.summarizedUpTo = 0;
-        this.startChatTypingTimeout = setTimeout(() => {
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
+        this.startChatTypingTimeout = timer.setTimeout(() => {
             this.startChatTypingTimeout = null;
             if (this.isOpen) {
                 this.showTypingIndicator("Reading code");

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -307,7 +307,11 @@ function SampleWidget() {
      */
     this.__save = function () {
         const that = this;
-        setTimeout(function () {
+        const timer =
+            this.widgetWindow && this.widgetWindow.timerManager
+                ? this.widgetWindow.timerManager
+                : window;
+        timer.setTimeout(function () {
             that._addSample();
 
             // Include the cent adjustment value in the sample block
@@ -597,7 +601,11 @@ function SampleWidget() {
                 if (!that._get_save_lock()) {
                     that._save_lock = true;
                     that._saveSample();
-                    setTimeout(function () {
+                    const timer =
+                        that.widgetWindow && that.widgetWindow.timerManager
+                            ? that.widgetWindow.timerManager
+                            : window;
+                    timer.setTimeout(function () {
                         that._save_lock = false;
                     }, 1000);
                 }
@@ -712,14 +720,18 @@ function SampleWidget() {
                     generating = true;
                     activity.textMsg(_("Generating Audio... (It may take up to 1 minute)"), 2500);
 
-                    blinkInterval = setInterval(() => {
+                    const timer =
+                        that.widgetWindow && that.widgetWindow.timerManager
+                            ? that.widgetWindow.timerManager
+                            : window;
+                    blinkInterval = timer.setInterval(() => {
                         activity.textMsg(_("Generating Audio..."), 1000);
                     }, 5000);
 
                     const response = await fetch(url);
                     const result = await response.json();
 
-                    clearInterval(blinkInterval);
+                    timer.clearInterval(blinkInterval);
 
                     if (result.status === "success") {
                         generating = false;
@@ -732,7 +744,11 @@ function SampleWidget() {
                     }
                 } catch (error) {
                     generating = false;
-                    clearInterval(blinkInterval);
+                    const timer =
+                        that.widgetWindow && that.widgetWindow.timerManager
+                            ? that.widgetWindow.timerManager
+                            : window;
+                    timer.clearInterval(blinkInterval);
                     activity.textMsg(_("Error occurred"), 3000);
                     submit.disabled = false;
                 }


### PR DESCRIPTION
<!--- Describe the changes introduced by this pull request. -->
<!--- Explain what problem it solves or what feature/fix it adds. -->
Following the introduction of `ManagedTimer` in `WidgetWindow` (PR #7017), this pr migrates the remaining core widgets that were still using raw `setInterval` and `setTimeout`. Specifically, the **AIDebugger**, **Reflection**, and **Sampler** widgets have been updated to use `this.widgetWindow.timerManager` for all their asynchronous loops and timeouts (such as typing indicators, summary debouncing, sample generation polling, and UI blinking). 

These changes ensure that all background intervals and timeouts spawned by these widgets are correctly tracked and instantly cleaned up when the widgets are closed, eliminating memory leaks, phantom animations, and background CPU usage. Additionally, their respective unit tests (`reflection.test.js` and `sampler.test.js`) have been updated with mocked `timerManager` instances.

## PR Category

<!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
<!--- Check all categories that apply to this pull request. -->

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- **`js/widgets/aidebugger.js`**: Migrated typing animation loops to `widgetWindow.timerManager.setInterval()`.
- **`js/widgets/reflection.js`**: Replaced raw `setInterval`/`setTimeout` with `timerManager` counterparts for the chat typing indicator (`dotsInterval`) and reading code debouncing (`startChatTypingTimeout`).
- **`js/widgets/sampler.js`**: Converted the sample generation UI blinking (`blinkInterval`), save locking timeouts, and sample saving deferrals to the managed timer system with backward-compatible fallbacks.
- **`js/widgets/__tests__/reflection.test.js` & `js/widgets/__tests__/sampler.test.js`**: Added a mock `timerManager` containing spies for `setInterval`, `clearInterval`, `setTimeout`, and `clearTimeout` to the simulated `widgetWindow` object to prevent test environment crashes.
