### PR TITLE
fix: correct sampler tuner frequency for flat and double-accidental notes

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -61,6 +61,7 @@ describe("Utility Functions (logic-only)", () => {
         newTone,
         preloadProjectSamples,
         resolveInstrumentName,
+        computeTargetPitchFrequency,
         Synth;
 
     const turtle = "turtle1";
@@ -150,6 +151,7 @@ describe("Utility Functions (logic-only)", () => {
                 VOICENAMES: typeof VOICENAMES !== "undefined" ? VOICENAMES : undefined,
                 DRUMNAMES: typeof DRUMNAMES !== "undefined" ? DRUMNAMES : undefined,
                 NOISENAMES: typeof NOISENAMES !== "undefined" ? NOISENAMES : undefined,
+                computeTargetPitchFrequency: typeof computeTargetPitchFrequency !== "undefined" ? computeTargetPitchFrequency : undefined,
                   };
         `);
         const results = wrapper();
@@ -193,6 +195,7 @@ describe("Utility Functions (logic-only)", () => {
         newTone = Synth.newTone;
         preloadProjectSamples = Synth.preloadProjectSamples;
         resolveInstrumentName = Synth.resolveInstrumentName;
+        computeTargetPitchFrequency = results.computeTargetPitchFrequency;
     });
 
     describe("setupRecorder", () => {
@@ -1167,6 +1170,72 @@ describe("Utility Functions (logic-only)", () => {
             Synth.tunerAnalyser = { getValue: jest.fn(() => new Float32Array(16)) };
             Synth.detectPitch = jest.fn(() => 261.63);
             expect(getTunerFrequency()).toBe(261.63);
+        });
+    });
+
+    describe("computeTargetPitchFrequency", () => {
+        // Equal-temperament frequencies relative to A4 = 440 Hz, rounded to
+        // 2 decimals to match the historical baseFrequencies table.
+        const closeTo = (actual, expected) => {
+            expect(actual).toBeCloseTo(expected, 1);
+        };
+
+        it("returns the canonical A4 reference frequency", () => {
+            closeTo(computeTargetPitchFrequency("A4"), 440.0);
+        });
+
+        it("returns correct frequencies for natural notes in octave 4", () => {
+            closeTo(computeTargetPitchFrequency("C4"), 261.63);
+            closeTo(computeTargetPitchFrequency("D4"), 293.66);
+            closeTo(computeTargetPitchFrequency("E4"), 329.63);
+            closeTo(computeTargetPitchFrequency("F4"), 349.23);
+            closeTo(computeTargetPitchFrequency("G4"), 392.0);
+            closeTo(computeTargetPitchFrequency("B4"), 493.88);
+        });
+
+        it("returns correct frequencies for sharp notes", () => {
+            closeTo(computeTargetPitchFrequency("C#4"), 277.18);
+            closeTo(computeTargetPitchFrequency("D#4"), 311.13);
+            closeTo(computeTargetPitchFrequency("F#4"), 369.99);
+            closeTo(computeTargetPitchFrequency("G#4"), 415.3);
+            closeTo(computeTargetPitchFrequency("A#4"), 466.16);
+        });
+
+        it("returns the correct enharmonic frequencies for flat notes", () => {
+            // Regression test for the bug where Db/Eb/Gb/Ab/Bb were
+            // resolved by `note.replace("b","#")`, producing wrong
+            // frequencies (D#/E#/G#/A#/B#) — and silently falling through
+            // to 440 Hz for the ones not present in the lookup table.
+            closeTo(computeTargetPitchFrequency("Db4"), 277.18); // = C#4
+            closeTo(computeTargetPitchFrequency("Eb4"), 311.13); // = D#4
+            closeTo(computeTargetPitchFrequency("Gb4"), 369.99); // = F#4
+            closeTo(computeTargetPitchFrequency("Ab4"), 415.3); // = G#4
+            closeTo(computeTargetPitchFrequency("Bb4"), 466.16); // = A#4
+        });
+
+        it("returns the correct enharmonic frequencies for double accidentals", () => {
+            // The original regex /[A-G][#b]?(\d+)/ rejected the double
+            // accidentals exposed by the same UI, which then defaulted to
+            // 440 Hz.
+            closeTo(computeTargetPitchFrequency("C##4"), 293.66); // = D4
+            closeTo(computeTargetPitchFrequency("D##4"), 329.63); // = E4
+            closeTo(computeTargetPitchFrequency("Cbb4"), 233.08); // = Bb3
+            closeTo(computeTargetPitchFrequency("Dbb4"), 261.63); // = C4
+        });
+
+        it("scales correctly across octaves", () => {
+            closeTo(computeTargetPitchFrequency("A3"), 220.0);
+            closeTo(computeTargetPitchFrequency("A5"), 880.0);
+            closeTo(computeTargetPitchFrequency("Bb3"), 233.08);
+            closeTo(computeTargetPitchFrequency("Bb5"), 932.33);
+        });
+
+        it("returns NaN for invalid input rather than a misleading value", () => {
+            expect(Number.isNaN(computeTargetPitchFrequency(""))).toBe(true);
+            expect(Number.isNaN(computeTargetPitchFrequency("C"))).toBe(true);
+            expect(Number.isNaN(computeTargetPitchFrequency("notapitch"))).toBe(true);
+            expect(Number.isNaN(computeTargetPitchFrequency(null))).toBe(true);
+            expect(Number.isNaN(computeTargetPitchFrequency(undefined))).toBe(true);
         });
     });
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -464,6 +464,45 @@ const instrumentsEffects = { 0: {} };
 const instrumentsFilters = { 0: {} };
 
 /**
+ * Compute the equal-temperament frequency of a target pitch string used by
+ * the sampler tuner.
+ *
+ * Accepts notes in the form `<letter><accidental?><octave>` where the
+ * accidental is one of `#`, `b`, `##`, `bb`, `♯`, `♭`, `𝄪`, `𝄫`, or `*`,
+ * and the octave is a (signed) integer. Examples: `"C4"`, `"Bb4"`,
+ * `"C##5"`, `"D𝄫3"`.
+ *
+ * @function
+ * @param {string} noteWithOctave - The target pitch including its octave.
+ * @returns {number} Frequency in Hz, or `NaN` if the input cannot be parsed.
+ */
+const computeTargetPitchFrequency = noteWithOctave => {
+    if (typeof noteWithOctave !== "string" || noteWithOctave.length < 2) {
+        return NaN;
+    }
+    // Split into pitch (letter + optional accidentals) and octave (trailing
+    // signed integer). We do not trust the trailing character to be a single
+    // digit because some accidentals are multi-character (e.g. "##", "bb"),
+    // and very low or high octaves may eventually appear.
+    const match = noteWithOctave.match(/^(.+?)(-?\d+)$/);
+    if (!match) {
+        return NaN;
+    }
+    let pitch = match[1];
+    const octave = parseInt(match[2], 10);
+    if (!pitch || Number.isNaN(octave)) {
+        return NaN;
+    }
+    // pitchToNumber recognises "bb"/`𝄫` for double flat but only the unicode
+    // `𝄪` form for double sharp; ASCII "##" is not handled. Normalise so
+    // callers can use the same accidental form for both.
+    if (pitch.length > 1 && pitch.slice(-2) === "##") {
+        pitch = pitch.slice(0, -2) + DOUBLESHARP;
+    }
+    return pitchToFrequency(pitch, octave, 0, "C major");
+};
+
+/**
  * Synth constructor function.
  * @constructor
  */
@@ -3091,58 +3130,16 @@ function Synth() {
                                     // Update target pitch
                                     targetPitch.note = noteWithOctave;
 
-                                    // Calculate the frequency for the target pitch
+                                    // Calculate the frequency for the target pitch.
+                                    // Delegate to musicutils so single and double accidentals
+                                    // (#, b, ##, bb, ♯, ♭, 𝄪, 𝄫, *) are all handled correctly.
                                     try {
-                                        // Define base frequencies for each note (C4 = 261.63 Hz)
-                                        const baseFrequencies = {
-                                            "C": 261.63,
-                                            "C#": 277.18,
-                                            "D": 293.66,
-                                            "D#": 311.13,
-                                            "E": 329.63,
-                                            "F": 349.23,
-                                            "F#": 369.99,
-                                            "G": 392.0,
-                                            "G#": 415.3,
-                                            "A": 440.0,
-                                            "A#": 466.16,
-                                            "B": 493.88
-                                        };
-
-                                        // Extract note and octave
-                                        const noteMatch = noteWithOctave.match(/([A-G][#b]?)(\d+)/);
-                                        if (!noteMatch) {
-                                            throw new Error("Invalid note format");
-                                        }
-
-                                        const [, note, octave] = noteMatch;
-                                        // Convert flats to sharps for lookup
-                                        const lookupNote = note
-                                            .replace("b", "#")
-                                            .replace("bb", "##");
-
-                                        // Get base frequency for the note
-                                        let freq = baseFrequencies[lookupNote];
-                                        if (!freq) {
-                                            throw new Error("Invalid note");
-                                        }
-
-                                        // Adjust for octave (C4 is the reference octave)
-                                        const octaveDiff = parseInt(octave) - 4;
-                                        freq *= Math.pow(2, octaveDiff);
-
-                                        targetPitch.frequency = freq;
-
-                                        // Validate frequency
-                                        if (
-                                            isNaN(targetPitch.frequency) ||
-                                            targetPitch.frequency <= 0
-                                        ) {
-                                            console.error(
-                                                "Invalid frequency calculated:",
-                                                targetPitch.frequency
-                                            );
+                                        const freq = computeTargetPitchFrequency(noteWithOctave);
+                                        if (!isFinite(freq) || freq <= 0) {
+                                            console.error("Invalid frequency calculated:", freq);
                                             targetPitch.frequency = 440; // Default to A4 if calculation fails
+                                        } else {
+                                            targetPitch.frequency = freq;
                                         }
                                     } catch (error) {
                                         console.error("Error calculating frequency:", error);
@@ -3819,6 +3816,7 @@ if (typeof module !== "undefined" && module.exports) {
         instrumentsFilters,
         instruments,
         instrumentsSource,
+        computeTargetPitchFrequency,
         DEFAULTSYNTHVOLUME
     };
 }


### PR DESCRIPTION
## Description

The sampler widget's tuner (`startTuner` in `js/utils/synthutils.js`) computed the **target pitch frequency** from a hand-rolled lookup that converted flats to sharps with `note.replace("b","#").replace("bb","##")`. Because `String.prototype.replace` only replaces the first occurrence, flat-named pitches resolved to the wrong enharmonic:

| User picks | Internal lookup | Frequency used | Correct frequency |
|------------|-----------------|----------------|-------------------|
| `Db4` | `D#` | 311.13 Hz | 277.18 Hz |
| `Eb4` | `E#` (missing → 440 fallback) | 440.00 Hz | 311.13 Hz |
| `Gb4` | `G#` | 415.30 Hz | 369.99 Hz |
| `Ab4` | `A#` | 466.16 Hz | 415.30 Hz |
| `Bb4` | `B#` (missing → 440 fallback) | 440.00 Hz | 466.16 Hz |
| `C𝄪4`, `D𝄫4` | regex `/[A-G][#b]?(\d+)/` rejects `##`/`bb` → 440 fallback | 440.00 Hz | enharmonic value |

The cents-from-target reading (`1200 * Math.log2(pitch / targetPitch.frequency)`) was therefore comparing against the wrong reference, so the tuner could not guide a user to any flat-named or double-accidental pitch.

This PR replaces the buggy reimplementation with `pitchToFrequency` from `js/utils/musicutils.js` (already declared as a global in `synthutils.js`), which handles every accidental form supported by the rest of the codebase. The call is extracted into a new module-level helper `computeTargetPitchFrequency` so the conversion is independently testable.

## Related Issue

This PR fixes #7044

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README

## Changes Made

- `js/utils/synthutils.js`
    - Add a top-level helper `computeTargetPitchFrequency(noteWithOctave)` that splits the input into pitch + octave and delegates to `pitchToFrequency` from `musicutils.js`.
    - Normalise ASCII `##` to the unicode double-sharp `𝄪` before delegation, because `pitchToNumber` accepts ASCII `bb` for double-flat but not ASCII `##` for double-sharp (an existing asymmetry in `pitchToNumber`).
    - Inside `Synth.startTuner`'s `updateTargetNote`, replace the inline `baseFrequencies` table, the buggy `note.replace("b","#")` conversion, and the single-accidental regex with a single call to the new helper. The 440 Hz fallback is preserved for any input that cannot be parsed.
- `js/utils/__tests__/synthutils.test.js`
    - Expose `computeTargetPitchFrequency` from the test wrapper.
    - Add a new `describe("computeTargetPitchFrequency", ...)` block with seven tests covering naturals, sharps, flats (the regression cases), double accidentals (`##`/`bb`), multiple octaves, and NaN handling for invalid input.

## Testing Performed

- `npx jest js/utils/__tests__/synthutils.test.js` — **106 passed** (99 baseline + 7 new tuner tests).
- `npx jest js/widgets/__tests__/sampler.test.js` — **43 passed** (no regression in the widget tests, which mock `startTuner`).
- `npx eslint js/utils/synthutils.js js/utils/__tests__/synthutils.test.js` — clean (0 warnings, 0 errors).
- `npx prettier --check js/utils/synthutils.js js/utils/__tests__/synthutils.test.js` — clean.
- `npm run lint` — no new warnings introduced.

The bug surface is the inline `updateTargetNote` callback that fires when the user picks a target pitch in the sampler tuner UI. Browser-level verification of the visible cents reading would require granting microphone access and producing a calibrated reference tone, but the new unit tests cover every accidental that the UI can produce, and the underlying `pitchToFrequency` helper is already exercised across the codebase.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

- The new helper lives at module scope in `synthutils.js` so it is reachable from the tuner closure without any change to load order or globals; `pitchToFrequency` and `DOUBLESHARP` are already declared in the existing `/* global */` header.
- The `##` → `𝄪` normalisation is intentionally local to this helper. Lifting it into `pitchToNumber` itself (so ASCII `##` is treated symmetrically with ASCII `bb`) would also be reasonable, but I kept the change surgical to the reported bug; happy to do that in a follow-up if maintainers prefer.
- Existing 440 Hz fallback semantics are preserved for any unparseable input, so the worst-case behaviour after this fix is no worse than today.
