### PR TITLE
fix: correct enharmonic note lookup in sampler/tuner for flat notes

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -3046,7 +3046,8 @@ function Synth() {
                                         };
 
                                         // Extract note and octave (handle double accidentals ##/bb)
-                                        const noteMatch = noteWithOctave.match(/([A-G][#b]{0,2})(\d+)/);
+                                        const noteMatch =
+                                            noteWithOctave.match(/([A-G][#b]{0,2})(\d+)/);
                                         if (!noteMatch) {
                                             throw new Error("Invalid note format");
                                         }
@@ -3054,12 +3055,26 @@ function Synth() {
                                         const [, note, octave] = noteMatch;
                                         // Map enharmonic equivalents to sharp-based names for lookup
                                         const enharmonicMap = {
-                                            "Cb": "B",  "Db": "C#", "Eb": "D#", "Fb": "E",
-                                            "Gb": "F#", "Ab": "G#", "Bb": "A#",
-                                            "Dbb": "C", "Ebb": "D", "Fbb": "D#", "Gbb": "F",
-                                            "Abb": "G", "Bbb": "A", "Cbb": "A#",
-                                            "C##": "D", "D##": "E", "E##": "F#", "F##": "G",
-                                            "G##": "A", "A##": "B"
+                                            "Cb": "B",
+                                            "Db": "C#",
+                                            "Eb": "D#",
+                                            "Fb": "E",
+                                            "Gb": "F#",
+                                            "Ab": "G#",
+                                            "Bb": "A#",
+                                            "Dbb": "C",
+                                            "Ebb": "D",
+                                            "Fbb": "D#",
+                                            "Gbb": "F",
+                                            "Abb": "G",
+                                            "Bbb": "A",
+                                            "Cbb": "A#",
+                                            "C##": "D",
+                                            "D##": "E",
+                                            "E##": "F#",
+                                            "F##": "G",
+                                            "G##": "A",
+                                            "A##": "B"
                                         };
                                         const lookupNote = enharmonicMap[note] || note;
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -3045,17 +3045,23 @@ function Synth() {
                                             "B": 493.88
                                         };
 
-                                        // Extract note and octave
-                                        const noteMatch = noteWithOctave.match(/([A-G][#b]?)(\d+)/);
+                                        // Extract note and octave (handle double accidentals ##/bb)
+                                        const noteMatch = noteWithOctave.match(/([A-G][#b]{0,2})(\d+)/);
                                         if (!noteMatch) {
                                             throw new Error("Invalid note format");
                                         }
 
                                         const [, note, octave] = noteMatch;
-                                        // Convert flats to sharps for lookup
-                                        const lookupNote = note
-                                            .replace("b", "#")
-                                            .replace("bb", "##");
+                                        // Map enharmonic equivalents to sharp-based names for lookup
+                                        const enharmonicMap = {
+                                            "Cb": "B",  "Db": "C#", "Eb": "D#", "Fb": "E",
+                                            "Gb": "F#", "Ab": "G#", "Bb": "A#",
+                                            "Dbb": "C", "Ebb": "D", "Fbb": "D#", "Gbb": "F",
+                                            "Abb": "G", "Bbb": "A", "Cbb": "A#",
+                                            "C##": "D", "D##": "E", "E##": "F#", "F##": "G",
+                                            "G##": "A", "A##": "B"
+                                        };
+                                        const lookupNote = enharmonicMap[note] || note;
 
                                         // Get base frequency for the note
                                         let freq = baseFrequencies[lookupNote];


### PR DESCRIPTION
## Description

Fixes incorrect frequency calculation in the sampler/tuner pitch selector when flat or double-accidental notes are selected. Closes part of issue #7044.

### Root cause

The `updateTargetNote` function in `js/utils/synthutils.js` contained two related bugs:

**1. Regex only matched 0 or 1 accidental characters**

```js
// ❌ Before – [#b]? only matches a single # or b, so Dbb or C## would return null
const noteMatch = noteWithOctave.match(/([A-G][#b]?)(\d+)/);
```

When the user selected a double-flat (𝄫) or double-sharp (𝄪) accidental, `noteMatch` was `null` and the function fell into the catch block, silently defaulting the frequency to 440 Hz (A4) regardless of the chosen note.

**2. Flat→sharp conversion was incorrect**

```js
// ❌ Before – string.replace() converts one char at a time, not semitone-aware
const lookupNote = note
    .replace(b, #)   // Db → D# (wrong — should be C#)
    .replace(bb, ##); // Dbb → D## (wrong — should be C)
```

`String.replace` performs a character substitution, not a music-theory–aware enharmonic conversion. `Db` (C# enharmonically) was being looked up as `D#`, producing a frequency one semitone too high. Double-flats were similarly wrong.

### Fix

```js
// ✅ After – regex handles up to two accidentals
const noteMatch = noteWithOctave.match(/([A-G][#b]{0,2})(\d+)/);

// ✅ After – explicit enharmonic map, sharps only (matches baseFrequencies keys)
const enharmonicMap = {
    Cb: B,  Db: C#, Eb: D#, Fb: E,
    Gb: F#, Ab: G#, Bb: A#,
    Dbb: C, Ebb: D, Fbb: D#, Gbb: F,
    Abb: G, Bbb: A, Cbb: A#,
    C##: D, D##: E, E##: F#, F##: G,
    G##: A, A##: B
};
const lookupNote = enharmonicMap[note] || note;
```

### Testing

1. Open the sampler/tuner widget for a pitched instrument block.
2. Select a flat note (e.g., D♭4): the tuner should now show ~277 Hz (C#4), not ~311 Hz (D#4).
3. Select a double-flat note (e.g., D𝄫4): should resolve to ~261 Hz (C4) with no console error.

Related to #7044

## PR Category
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation