### PR TITLE
fix: prevent base64 encoding stack overflow

### DIFF
--- a/js/__tests__/base64Utils.test.js
+++ b/js/__tests__/base64Utils.test.js
@@ -41,6 +41,12 @@ describe("base64Utils", () => {
         expect(decoded).toBe(originalText);
     });
 
+    test("base64Encode should handle large strings without stack overflow", () => {
+        const originalText = "a".repeat(200000);
+        const encoded = base64Utils.base64Encode(originalText);
+        expect(base64Utils.base64Decode(encoded)).toBe(originalText);
+    });
+
     test("base64Encode should handle empty strings", () => {
         expect(base64Utils.base64Encode("")).toBe("");
     });

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1332,6 +1332,13 @@ describe("base64Encode", () => {
             expect(result.charCodeAt(i)).toBe(bytes[i]);
         }
     });
+    it("should handle large strings without stack overflow", () => {
+        const input = "a".repeat(200000);
+        const result = base64Encode(input);
+        expect(result.length).toBe(input.length);
+        expect(result.charCodeAt(0)).toBe("a".charCodeAt(0));
+        expect(result.charCodeAt(result.length - 1)).toBe("a".charCodeAt(0));
+    });
 });
 
 describe("getNote", () => {


### PR DESCRIPTION
## Description

Fixes a stack overflow in the Base64 encoding helpers when encoding large strings. Both helpers previously used `String.fromCharCode(...uint8Array)`, which passes the full encoded byte array as function arguments and throws `RangeError: Maximum call stack size exceeded` for large SVG/data strings.

This PR builds the binary string in bounded chunks so large encoded data can be processed without overflowing the JavaScript call stack.

## Related Issue

Fixes #7052

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   Chunked the byte-to-binary-string conversion in `js/base64Utils.js`.
-   Applied the same bounded conversion to the existing `musicutils.js` helper contract.
-   Added large-string regression coverage for both helpers.

## Testing Performed

-   `npx jest js/__tests__/base64Utils.test.js js/utils/__tests__/musicutils.test.js --runInBand --coverage=false`
-   `npx eslint js/base64Utils.js js/utils/musicutils.js js/__tests__/base64Utils.test.js js/utils/__tests__/musicutils.test.js`
-   `npx prettier --check js/base64Utils.js js/utils/musicutils.js js/__tests__/base64Utils.test.js js/utils/__tests__/musicutils.test.js`
-   `npm run lint` exits 0 with existing `eqeqeq` warnings.
-   `npm test -- --runInBand` reaches 5005 passing tests out of 5006; the remaining failure is the existing `planetInterface.test.js` failure already covered by #7016.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_

## Additional Notes for Reviewers

The implementation keeps the existing helper contracts unchanged. `js/base64Utils.js` still returns a Base64 string, while `musicutils.js` still returns the binary string consumed by existing `window.btoa(...)` call sites.
