### PR TITLE
Security Fix: Restrict `open project` to trusted Music Blocks URLs

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -679,6 +679,14 @@ function setupProgramBlocks(activity) {
          * @param {number} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            const showOpenProjectError = message => {
+                activity.errorMsg(message, blk);
+                // Show a visible banner message in addition to the arrow highlight.
+                if (typeof activity.textMsg === "function") {
+                    activity.textMsg(message, 5000);
+                }
+            };
+
             if (args[0] === null) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 return;
@@ -1448,6 +1456,14 @@ function setupProgramBlocks(activity) {
          * @param {number} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            const showOpenProjectError = message => {
+                activity.errorMsg(message, blk);
+                // Keep the block arrow indicator and also show a visible text banner.
+                if (typeof activity.textMsg === "function") {
+                    activity.textMsg(message, 5000);
+                }
+            };
+
             if (args[0] === null) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 return;
@@ -1455,15 +1471,61 @@ function setupProgramBlocks(activity) {
 
             const url = args[0];
 
-            // Use the centralized isSafeUrl utility (from utils.js) to enforce
-            // only http: and https: protocols, preventing open redirect attacks
-            // via javascript:, data:, vbscript:, or other dangerous URI schemes.
-            if (!isSafeUrl(url)) {
-                activity.errorMsg(_("Please enter a valid URL."), blk);
+            // We only allow opening Music Blocks project hosts (and the current host).
+            // This prevents untrusted projects from opening arbitrary external sites.
+            const trimmedUrl = String(url).trim();
+            // Disallow bare domains like "evil.com" (treated as a relative path by URL()).
+            // Accept either absolute http(s) URLs or explicit relative paths (starting with '/').
+            if (!/^https?:\/\//i.test(trimmedUrl) && !/^\//.test(trimmedUrl)) {
+                showOpenProjectError(
+                    _(
+                        "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
+                    )
+                );
                 return;
             }
 
-            const win = window.open(url, "_blank", "noopener,noreferrer");
+            let parsedUrl;
+            try {
+                // Allow relative URLs by resolving against the current page.
+                parsedUrl = new URL(trimmedUrl, window.location.href);
+            } catch (e) {
+                showOpenProjectError(
+                    _(
+                        "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
+                    )
+                );
+                return;
+            }
+
+            // Use the centralized isSafeUrl utility (from utils.js) to enforce
+            // only http: and https: protocols, preventing open redirect attacks
+            // via javascript:, data:, vbscript:, or other dangerous URI schemes.
+            if (!isSafeUrl(parsedUrl.href)) {
+                showOpenProjectError(
+                    _(
+                        "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
+                    )
+                );
+                return;
+            }
+
+            const allowedHosts = new Set([
+                window.location.hostname,
+                "musicblocks.sugarlabs.org",
+                "musicblocks.net",
+                "www.musicblocks.net"
+            ]);
+            if (!allowedHosts.has(parsedUrl.hostname)) {
+                showOpenProjectError(
+                    _(
+                        "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
+                    )
+                );
+                return;
+            }
+
+            const win = window.open(parsedUrl.href, "_blank", "noopener,noreferrer");
             if (win === null) {
                 // Browser has blocked it.
                 alert(_("Please allow popups for this site"));

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -789,15 +789,12 @@ describe("ProgramBlocks", () => {
             window.alert = jest.fn();
         });
 
-        test("opens valid http URL", () => {
+        test("opens URL on current host", () => {
             const block = getBlock("openProject");
-            block.flow(["http://example.com"], logo, 0, 5);
+            const url = `${window.location.origin}/index.html?id=123&run=true`;
+            block.flow([url], logo, 0, 5);
 
-            expect(window.open).toHaveBeenCalledWith(
-                "http://example.com",
-                "_blank",
-                "noopener,noreferrer"
-            );
+            expect(window.open).toHaveBeenCalledWith(url, "_blank", "noopener,noreferrer");
         });
 
         test("opens valid https URL", () => {
@@ -811,12 +808,26 @@ describe("ProgramBlocks", () => {
             );
         });
 
+        test("blocks external http(s) URL on other hosts", () => {
+            const block = getBlock("openProject");
+            block.flow(["https://example.com"], logo, 0, 5);
+
+            expect(window.open).not.toHaveBeenCalled();
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net).",
+                5
+            );
+        });
+
         test("blocks javascript: protocol (CVE-11 open redirect)", () => {
             const block = getBlock("openProject");
             block.flow(["javascript:alert(document.cookie)"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Please enter a valid project URL (for example: /index.html?id=123&run=true).",
+                5
+            );
         });
 
         test("blocks data: URI scheme", () => {
@@ -824,7 +835,10 @@ describe("ProgramBlocks", () => {
             block.flow(["data:text/html,<script>alert(1)</script>"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Please enter a valid project URL (for example: /index.html?id=123&run=true).",
+                5
+            );
         });
 
         test("blocks vbscript: protocol", () => {
@@ -832,7 +846,10 @@ describe("ProgramBlocks", () => {
             block.flow(["vbscript:MsgBox('xss')"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Please enter a valid project URL (for example: /index.html?id=123&run=true).",
+                5
+            );
         });
 
         test("rejects bare domain without protocol", () => {
@@ -840,7 +857,10 @@ describe("ProgramBlocks", () => {
             block.flow(["evil.com"], logo, 0, 5);
 
             expect(window.open).not.toHaveBeenCalled();
-            expect(activity.errorMsg).toHaveBeenCalledWith("Please enter a valid URL.", 5);
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Please enter a valid project URL (for example: /index.html?id=123&run=true).",
+                5
+            );
         });
 
         test("rejects null input", () => {
@@ -855,7 +875,7 @@ describe("ProgramBlocks", () => {
             const block = getBlock("openProject");
             window.open = jest.fn(() => null);
 
-            block.flow(["https://example.com"], logo, 0, 5);
+            block.flow([`${window.location.origin}/index.html?id=123&run=true`], logo, 0, 5);
 
             expect(window.open).toHaveBeenCalled();
             expect(window.alert).toHaveBeenCalledWith("Please allow popups for this site");


### PR DESCRIPTION
### Summary
This PR hardens the `open project` block in the Program palette to prevent untrusted projects from opening arbitrary external websites.

Previously, `open project` accepted any `http(s)` URL, which could be abused for phishing-style redirects or unsafe navigation in shared projects.  
Now it only allows trusted Music Blocks project links and provides clear user-facing error feedback.

---
Closes #7053

---
### What Changed

#### 1. URL Validation Hardening
- In `js/blocks/ProgramBlocks.js`, `OpenProjectBlock.flow` now:
  - Resolves URL input safely
  - Rejects bare-domain inputs like `evil.com`
  - Allows only:
    - current site host
    - `musicblocks.sugarlabs.org`
    - `musicblocks.net`
    - `www.musicblocks.net`
- Blocks external arbitrary hosts (e.g. `example.com`)

---

#### 2. Clear User Feedback
- Added explicit user-friendly validation messages:
  - Invalid format guidance with example project URL
  - Host allowlist explanation
- Keeps existing block-level error arrow and adds visible text feedback so users understand why it was blocked.

---

#### 3. Tests Updated
- Updated `js/blocks/__tests__/ProgramBlocks.test.js` to cover:
  - allowed same-host URL
  - allowed official Music Blocks host
  - blocked external host
  - blocked `javascript:`, `data:`, `vbscript:`
  - blocked bare-domain input
  - popup-blocker behavior

---

### Why This Matters
- Reduces phishing/open-redirect abuse through shared projects
- Preserves legitimate `open project` use for Music Blocks links

---

### How to Test
1. Add `start` + `open project` block.
2. Try:
   - Allowed: `/index.html?id=123&run=true`
   - Allowed: `https://musicblocks.sugarlabs.org/index.html?id=...`
   - Blocked: `https://example.com`
   - Blocked: `evil.com`
3. Run and verify:
   - allowed URLs open
   - blocked URLs show clear message and do not open

---

### Verification
- Updated ProgramBlocks unit tests pass
- Manual behavior aligns with allowlist/security expectations

---

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation