### PR TITLE
fix: report divide by zero correctly in the mod block

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -52,11 +52,23 @@ function setupNumberBlocks(activity) {
     };
 
     /**
-     * Handle math operation errors with standardized response
+     * Handle math operation errors with standardized response.
+     * Maps known error types to their dedicated error messages so that callers
+     * do not need to repeat the same dispatch table.
      */
-    const handleMathError = (logo, error, blk, onError = NANERRORMSG) => {
+    const handleMathError = (logo, error, blk, onError) => {
         logo.stopTurtle = true;
-        activity.errorMsg(onError, blk);
+        let message = onError;
+        if (message === undefined) {
+            if (error && error.message === "DivByZeroError") {
+                message = ZERODIVIDEERRORMSG;
+            } else if (error && error.message === "NoSqrtError") {
+                message = NOSQRTERRORMSG;
+            } else {
+                message = NANERRORMSG;
+            }
+        }
+        activity.errorMsg(message, blk);
     };
 
     /**

--- a/js/blocks/__tests__/NumberBlocks.test.js
+++ b/js/blocks/__tests__/NumberBlocks.test.js
@@ -283,6 +283,19 @@ describe("setupNumberBlocks", () => {
             expect(result).toEqual(0);
             global.MathUtility.doMod = (a, b) => Number(a) % Number(b);
         });
+
+        it("should show ZERODIVIDEERRORMSG when MathUtility.doMod throws DivByZeroError", () => {
+            activity.blocks.blockList[110] = { connections: [null, "c1", "c2"] };
+            logo.parseArg = jest.fn(() => 5);
+            global.MathUtility.doMod = () => {
+                throw new Error("DivByZeroError");
+            };
+            const modBlock = createdBlocks["mod"];
+            const result = modBlock.arg(logo, 0, 110, null);
+            expect(activity.errorMsg).toHaveBeenCalledWith(global.ZERODIVIDEERRORMSG, 110);
+            expect(result).toEqual(0);
+            global.MathUtility.doMod = (a, b) => Number(a) % Number(b);
+        });
     });
 
     describe("PowerBlock - extra branches", () => {

--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -161,6 +161,18 @@ describe("MathUtility", () => {
         test("throws error when second arg is string", () => {
             expect(() => MathUtility.doMod(10, "a")).toThrow("Invalid number input");
         });
+
+        test("throws DivByZeroError when divisor is zero", () => {
+            expect(() => MathUtility.doMod(5, 0)).toThrow("DivByZeroError");
+        });
+
+        test("throws DivByZeroError for negative dividend with zero divisor", () => {
+            expect(() => MathUtility.doMod(-5, 0)).toThrow("DivByZeroError");
+        });
+
+        test("throws DivByZeroError for floating dividend with zero divisor", () => {
+            expect(() => MathUtility.doMod(5.5, 0)).toThrow("DivByZeroError");
+        });
     });
 
     describe("doSqrt", () => {
@@ -557,7 +569,7 @@ describe("MathUtility", () => {
 
     describe("edge cases - Infinity, NaN, and boundary values", () => {
         test("doMod throws an error when divisor is zero", () => {
-            expect(() => MathUtility.doMod(5, 0)).toThrow();
+            expect(() => MathUtility.doMod(5, 0)).toThrow("DivByZeroError");
         });
 
         test("doSqrt handles Infinity", () => {

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -125,12 +125,12 @@ class MathUtility {
      * @param {number} a
      * @param {number} b
      * @returns {number} - Result of a modulo b.
-     * @throws {string} DivByZeroError if divisor is zero, or NanError if arguments are not valid numbers.
+     * @throws {Error} DivByZeroError if the divisor is zero, or "Invalid number input" if arguments are not valid numbers.
      */
     static doMod(a, b) {
         if (typeof a === "number" && typeof b === "number") {
             if (Number(b) === 0) {
-                throw new Error("Division by zero");
+                throw new Error("DivByZeroError");
             }
             return Number(a) % Number(b);
         } else {


### PR DESCRIPTION
## Description

`MathUtility.doMod` and `MathUtility.doDivide` are documented to throw the same divisor-zero error, but the runtime tokens have drifted: `doMod` throws `Error("Division by zero")` while `doDivide` throws `Error("DivByZeroError")`. The `mod` block catches the error through the shared `handleMathError` helper, which defaulted every catch to `NANERRORMSG`, so a `mod x 0` evaluation surfaced the misleading **"Not a Number"** toast instead of **"Cannot divide by zero."**

This PR standardises the divisor-zero error token across `mathutils.js` and teaches `handleMathError` to map the well-known `DivByZeroError` and `NoSqrtError` tokens to their dedicated messages. The result is that any future math operation that throws those tokens will display the correct toast without each block having to repeat the dispatch.

## Related Issue

This PR fixes #7056

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   Updated `MathUtility.doMod` in `js/utils/mathutils.js` to throw `Error("DivByZeroError")` for a zero divisor (matching `doDivide`) and synced the JSDoc.
-   Reworked `handleMathError` in `js/blocks/NumberBlocks.js` to inspect `error.message` and pick `ZERODIVIDEERRORMSG` for `DivByZeroError`, `NOSQRTERRORMSG` for `NoSqrtError`, and `NANERRORMSG` otherwise. Existing call sites already pass through this helper, so `mod x 0` now surfaces the correct toast and any future math op throwing the same tokens benefits automatically.
-   Added Jest coverage in `js/utils/__tests__/mathutils.test.js` asserting the exact `DivByZeroError` token (positive, negative, and floating-point dividends), and an existing edge-case spec was tightened from `toThrow()` to `toThrow("DivByZeroError")`.
-   Added a `NumberBlocks.test.js` case that asserts the block-level toast switches from `NANERRORMSG` to `ZERODIVIDEERRORMSG` when `MathUtility.doMod` throws `DivByZeroError`.

## Testing Performed

-   `npx jest js/utils/__tests__/mathutils.test.js js/blocks/__tests__/NumberBlocks.test.js` — 207 tests pass (123 + 84).
-   `npm test` — full suite is green other than the pre-existing `PlanetInterface saveLocally` failure already tracked by #7000 / #7016, which is untouched here.
-   `npm run lint` — clean on the touched files.
-   `npx prettier --check .` — clean on the touched files.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The new `handleMathError` is fully backwards compatible. The optional `onError` parameter is still honoured when a caller passes an explicit message, so the helper's existing call signature is unchanged. The remaining math blocks (`int`, `power`, `abs`, `multiply`, `minus`, `bool`, `octave`, …) all flow through the same helper, which means the mapping table can be extended in a single place if other operations gain dedicated toasts in the future.
