### PR TITLE
fix: guard pitch staircase ratios against zero

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -195,4 +195,65 @@ describe("PitchStaircase Widget", () => {
             expect(psc.Stairs[1][2]).toBe(261.63);
         });
     });
+
+    // --- Ratio input sanitisation ---
+    describe("_dissectStair input sanitisation", () => {
+        const setupStairsForFrequency = (instance, frequency) => {
+            instance.Stairs = [["A", "", frequency, 1, 1, frequency, null]];
+            instance._history = [];
+            instance._makeStairs = jest.fn();
+        };
+
+        const fakeEvent = frequency => ({
+            target: { getAttribute: () => String(frequency) }
+        });
+
+        test("falls back to default 3 when ratio numerator (musicRatio1) is 0", () => {
+            const frequency = 440;
+            setupStairsForFrequency(psc, frequency);
+            psc._musicRatio1 = { value: "0" };
+            psc._musicRatio2 = { value: "2" };
+
+            psc._dissectStair(fakeEvent(frequency));
+
+            expect(psc._musicRatio1.value).toBe(3);
+            expect(psc._musicRatio2.value).toBe(2);
+            for (const stair of psc.Stairs) {
+                expect(Number.isFinite(stair[2])).toBe(true);
+                expect(stair[2]).not.toBe(0);
+            }
+        });
+
+        test("falls back to default 2 when ratio denominator (musicRatio2) is 0", () => {
+            const frequency = 440;
+            setupStairsForFrequency(psc, frequency);
+            psc._musicRatio1 = { value: "3" };
+            psc._musicRatio2 = { value: "0" };
+
+            psc._dissectStair(fakeEvent(frequency));
+
+            expect(psc._musicRatio1.value).toBe(3);
+            expect(psc._musicRatio2.value).toBe(2);
+            for (const stair of psc.Stairs) {
+                expect(Number.isFinite(stair[2])).toBe(true);
+                expect(stair[2]).not.toBe(0);
+            }
+        });
+
+        test("treats empty ratio inputs as defaults (Number('') === 0 edge)", () => {
+            const frequency = 440;
+            setupStairsForFrequency(psc, frequency);
+            psc._musicRatio1 = { value: "" };
+            psc._musicRatio2 = { value: "" };
+
+            psc._dissectStair(fakeEvent(frequency));
+
+            expect(psc._musicRatio1.value).toBe(3);
+            expect(psc._musicRatio2.value).toBe(2);
+            for (const stair of psc.Stairs) {
+                expect(Number.isFinite(stair[2])).toBe(true);
+                expect(stair[2]).not.toBe(0);
+            }
+        });
+    });
 });

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -199,6 +199,10 @@ class PitchStaircase {
             inputNum1 = Math.abs(Math.floor(inputNum1));
         }
 
+        if (inputNum1 === 0) {
+            inputNum1 = 3;
+        }
+
         this._musicRatio1.value = inputNum1;
         let inputNum2 = this._musicRatio2.value;
 
@@ -206,6 +210,10 @@ class PitchStaircase {
             inputNum2 = 2;
         } else {
             inputNum2 = Math.abs(Math.floor(inputNum2));
+        }
+
+        if (inputNum2 === 0) {
+            inputNum2 = 2;
         }
 
         this._musicRatio2.value = inputNum2;


### PR DESCRIPTION
## Description

`PitchStaircase._dissectStair()` only substituted defaults when `isNaN()` returned `true`, so a zero or empty ratio (`Number("0") === 0`, `Number("") === 0`) sneaked through `Math.abs(Math.floor(...))`, the resulting divisor became `0`, and the new step ended up with `Infinity`, `0`, or `NaN` frequencies that broke playback, save/load, and the frequency badge.

This PR adds explicit zero guards that fall back to the documented defaults (`3` for `_musicRatio1`, `2` for `_musicRatio2`), matching the silent default substitution that already happens for `isNaN`. The guard is intentionally minimal — it only adds two short branches and never alters valid input.

## Related Issue

This PR fixes #7058

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   `js/widgets/pitchstaircase.js`: extended the `_dissectStair` input sanitiser so `inputNum1` and `inputNum2` fall back to their respective defaults when the cleaned value is exactly `0`. This catches both literal `0` input and the `Number("") === 0` edge case.
-   `js/widgets/__tests__/pitchstaircase.test.js`: added a new `_dissectStair input sanitisation` describe block with three tests covering `_musicRatio1 = 0`, `_musicRatio2 = 0`, and the empty-string edge. Each test asserts the substituted defaults and verifies that no resulting stair frequency is `0`/`Infinity`/`NaN`.

## Testing Performed

-   `npx jest js/widgets/__tests__/pitchstaircase.test.js` — 21 tests pass (was 18 + 3 new).
-   `npm test` — full suite green other than the pre-existing `PlanetInterface saveLocally` failure already tracked by #7000 / #7016.
-   `npm run lint` — clean on touched files.
-   `npx prettier --check .` — clean on touched files.
-   Manual trace through `_dissectStair`: with `_musicRatio1.value = "0"` and `_musicRatio2.value = "2"`, both ratios resolve to the defaults (`3` and `2`), `inputNum` becomes `0.6667`, and `newFrequency` derives a finite value (e.g. `220 / 0.6667 ≈ 330 Hz`).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

I considered surfacing a textMsg telling the user "ratio cannot be zero" before falling back, but the existing widget already silently substitutes defaults on the adjacent `isNaN` branch, so adding an extra toast here would be inconsistent with the rest of the click handler. If maintainers prefer the noisier UX (the temperament ratio editor in #6979 takes that approach), I am happy to adjust in a follow-up.
