### PR TITLE
 fix: implement robust error handling in Statistics widget to prevent UI deadlock

### DIFF
--- a/js/widgets/__tests__/statistics.test.js
+++ b/js/widgets/__tests__/statistics.test.js
@@ -65,6 +65,9 @@ describe("StatsWindow", () => {
         myChartMock = { getContext: jest.fn().mockReturnValue({}) };
         global.docById = jest.fn().mockReturnValue(myChartMock);
 
+        global._ = jest.fn(str => str);
+        window._ = global._;
+
         global.analyzeProject = jest.fn().mockReturnValue({});
         global.runAnalytics = jest.fn();
         global.scoreToChartData = jest.fn().mockReturnValue({});
@@ -79,6 +82,7 @@ describe("StatsWindow", () => {
         global.Chart = jest.fn().mockImplementation(() => ({
             Radar: jest.fn().mockReturnValue(radarMock)
         }));
+        window.Chart = global.Chart;
     });
 
     test("constructor initialises widget and calls doAnalytics", () => {
@@ -182,8 +186,8 @@ describe("StatsWindow", () => {
         expect(global.getChartOptions).toHaveBeenCalledWith(expect.any(Function));
         expect(global.Chart).toHaveBeenCalledWith(myChartMock.getContext.mock.results[0].value);
         expect(activity.blocks.activeBlock).toBeNull();
-        expect(document.body.style.cursor).toBe("wait");
-        expect(activity.loading).toBe(true);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.loading).toBe(false);
     });
 
     test("doAnalytics appends json list container with left float style", () => {

--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -99,30 +99,44 @@ class StatsWindow {
         this.activity.loading = true;
         document.body.style.cursor = "wait";
 
-        let myRadarChart = null;
-        const scores = analyzeProject(this.activity);
-        runAnalytics(this.activity);
-        const data = scoreToChartData(scores);
-        const __callback = () => {
-            const imageData = myRadarChart.toBase64Image();
-            const img = new Image();
-            img.src = imageData;
-            if (this.widgetWindow.isMaximized()) {
-                img.width = this.widgetWindow.getWidgetFrame().getBoundingClientRect().height - 80;
-            } else {
-                img.width = 200;
-            }
-            this.widgetWindow.getWidgetBody().appendChild(img);
-            this.activity.blocks.hideBlocks();
-            this.activity.showBlocksAfterRun = false;
-            document.body.style.cursor = "default";
-        };
-        const options = getChartOptions(__callback);
-        myRadarChart = new window.Chart(ctx).Radar(data, options);
+        try {
+            let myRadarChart = null;
+            const scores = analyzeProject(this.activity);
+            runAnalytics(this.activity);
+            const data = scoreToChartData(scores);
+            const __callback = () => {
+                const imageData = myRadarChart.toBase64Image();
+                const img = new Image();
+                img.src = imageData;
+                if (this.widgetWindow.isMaximized()) {
+                    img.width =
+                        this.widgetWindow.getWidgetFrame().getBoundingClientRect().height - 80;
+                } else {
+                    img.width = 200;
+                }
+                this.widgetWindow.getWidgetBody().appendChild(img);
+                this.activity.blocks.hideBlocks();
+                this.activity.showBlocksAfterRun = false;
+            };
+            const options = getChartOptions(__callback);
+            myRadarChart = new window.Chart(ctx).Radar(data, options);
 
-        this.jsonObject = document.createElement("ul");
-        this.jsonObject.style.float = "left";
-        this.widgetWindow.getWidgetBody().appendChild(this.jsonObject);
+            this.jsonObject = document.createElement("ul");
+            this.jsonObject.style.float = "left";
+            this.widgetWindow.getWidgetBody().appendChild(this.jsonObject);
+        } catch (err) {
+            console.error("Analysis failed:", err);
+            if (this.activity.errorMsg) {
+                const msg =
+                    typeof window._ === "function"
+                        ? window._("Analysis failed. Please check your project for errors.")
+                        : "Analysis failed. Please check your project for errors.";
+                this.activity.errorMsg(msg);
+            }
+        } finally {
+            this.activity.loading = false;
+            document.body.style.cursor = "default";
+        }
     }
 
     /**


### PR DESCRIPTION
### Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

---
### 📝 Summary
This PR addresses a critical UX bug where the Music Blocks UI could become permanently locked if the Statistics project analysis encountered an error.

Closes #7063 

---

### 🛠️ Changes Made

Refactored `doAnalytics` in `js/widgets/statistics.js`:

- Added a `try...catch...finally` block around async analysis  
- **Error Handling:**  
  - Logs errors to console  
  - Notifies users via `this.activity.errorMsg()`  

- **Guaranteed Cleanup:**  
  - Reset cursor (`document.body.style.cursor = "default"`)  
  - Reset loading state (`this.activity.loading = false`)  

- **UX Improvement:**  
  - Added user-friendly message:  
    `"Analysis failed. Please check your project for errors."`  

---

### 🔄 Before vs After

**Before:**
- UI freezes if `analyzeProject()` fails  
- Cursor remains stuck on "wait"  
- No user feedback  

**After:**
- Errors handled gracefully  
- UI always recovers  
- User is informed of failure  

---

### 🧪 Testing Instructions

1. Open Music Blocks  
2. Open the Statistics widget  
3. Observe that the analysis runs normally and the cursor returns to default upon completion  

**To verify the fix:**
- Manually trigger a rejection in `analyzeProject` via the console or a debugger  
- Observe that:
  - The cursor still returns to default  
  - An error message/toast appears  
  - The application remains usable  

---

### ✅ Checklist

- [x] Code follows the existing style of the Music Blocks project  
- [x] Error states are handled gracefully  
- [x] UI state is guaranteed to reset  
- [x] Verified that no regressions were introduced to the chart rendering logic 