### PR TITLE
fix: Docker setup to load the app correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,3 @@ coverage/
 .eslintrc*
 .prettierrc*
 .editorconfig
-
-dist/
-build/

--- a/dockerfile
+++ b/dockerfile
@@ -1,14 +1,16 @@
 # First stage: Build stage
-FROM python:3.9-slim AS build
+FROM node:20-slim AS build
 
 WORKDIR /app
 
-RUN useradd -m appuser
+COPY package*.json ./
+
+RUN npm install
 
 COPY . .
 
 # Second stage: Final stage
-FROM python:3.9-slim
+FROM node:20-slim
 
 RUN useradd -m appuser
 
@@ -20,4 +22,6 @@ USER appuser
 
 EXPOSE 3000
 
-CMD ["python", "-m", "http.server", "3000", "--bind", "0.0.0.0"]
+ENV HOST=0.0.0.0
+
+CMD ["node", "index.js"]

--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ app.use(
     })
 );
 
+const HOST = process.env.HOST || "127.0.0.1";
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, "127.0.0.1", () => {
-    console.log(`Music Blocks running at http://127.0.0.1:${PORT}/`);
+app.listen(PORT, HOST, () => {
+    console.log(`Music Blocks running at http://${HOST}:${PORT}/`);
     console.log("Compression enabled");
 });


### PR DESCRIPTION
## Related Issue
fixes #7064

This PR removes the `dist/` and `build/` folders from `.dockerignore` to include them when copying inside the container (as they contain important assets for running the app). Also, the server hardcodes `127.0.0.1` as the bind address in `index.js`, which works fine locally but breaks Docker's port forwarding. This PR makes the bind address configurable via a `HOST` environment variable, defaulting to `0.0.0.0`. 

Additionally, the python base image is replaced with node base image.

## PR Category
- [x] bug fix 