### PR TITLE
fix: guard core localStorage reads across palette, pie menus, language, and i18n

### DIFF
--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -17,6 +17,22 @@
 
 /* exported LanguageBox */
 
+const getLocalStorageItemSafely = key => {
+    try {
+        return localStorage.getItem(key);
+    } catch (e) {
+        return null;
+    }
+};
+
+const setLocalStorageItemSafely = (key, value) => {
+    try {
+        localStorage.setItem(key, value);
+    } catch (e) {
+        console.warn(`Could not save ${key}:`, e);
+    }
+};
+
 class LanguageBox {
     /**
      * @constructor
@@ -278,16 +294,12 @@ class LanguageBox {
             gug: "Actualice su navegador para cambiar su preferencia de idioma.",
             ur: "اپنی زبان کی ترجیح کو تبدیل کرنے کے لئے اپنے براؤزر کو تازہ دم کریں۔"
         };
-        if (localStorage.getItem("languagePreference") === this._language) {
+        if (getLocalStorageItemSafely("languagePreference") === this._language) {
             if (this._language.includes("ja")) {
                 this._language = this._language.split("-")[0];
             }
 
-            try {
-                localStorage.setItem("languagePreference", this._language);
-            } catch (e) {
-                console.warn("Could not save language preference:", e);
-            }
+            setLocalStorageItemSafely("languagePreference", this._language);
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;

--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -17,7 +17,7 @@
 
 /* exported LanguageBox */
 
-const getLocalStorageItemSafely = key => {
+const getLanguageBoxLocalStorageItemSafely = key => {
     try {
         return localStorage.getItem(key);
     } catch (e) {
@@ -25,7 +25,7 @@ const getLocalStorageItemSafely = key => {
     }
 };
 
-const setLocalStorageItemSafely = (key, value) => {
+const setLanguageBoxLocalStorageItemSafely = (key, value) => {
     try {
         localStorage.setItem(key, value);
     } catch (e) {
@@ -294,12 +294,12 @@ class LanguageBox {
             gug: "Actualice su navegador para cambiar su preferencia de idioma.",
             ur: "اپنی زبان کی ترجیح کو تبدیل کرنے کے لئے اپنے براؤزر کو تازہ دم کریں۔"
         };
-        if (getLocalStorageItemSafely("languagePreference") === this._language) {
+        if (getLanguageBoxLocalStorageItemSafely("languagePreference") === this._language) {
             if (this._language.includes("ja")) {
                 this._language = this._language.split("-")[0];
             }
 
-            setLocalStorageItemSafely("languagePreference", this._language);
+            setLanguageBoxLocalStorageItemSafely("languagePreference", this._language);
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;

--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -17,7 +17,7 @@
 
 /* exported LanguageBox */
 
-const getLocalStorageItemSafely = key => {
+const getLanguageBoxLocalStorageItemSafely = key => {
     try {
         return localStorage.getItem(key);
     } catch (e) {
@@ -25,7 +25,7 @@ const getLocalStorageItemSafely = key => {
     }
 };
 
-const setLocalStorageItemSafely = (key, value) => {
+const setLanguageBoxLocalStorageItemSafely = (key, value) => {
     try {
         localStorage.setItem(key, value);
     } catch (e) {
@@ -332,12 +332,12 @@ class LanguageBox {
             gug: "Actualice su navegador para cambiar su preferencia de idioma.",
             ur: "اپنی زبان کی ترجیح کو تبدیل کرنے کے لئے اپنے براؤزر کو تازہ دم کریں۔"
         };
-        if (getLocalStorageItemSafely("languagePreference") === this._language) {
+        if (getLanguageBoxLocalStorageItemSafely("languagePreference") === this._language) {
             if (this._language.includes("ja")) {
                 this._language = this._language.split("-")[0];
             }
 
-            setLocalStorageItemSafely("languagePreference", this._language);
+            setLanguageBoxLocalStorageItemSafely("languagePreference", this._language);
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;

--- a/js/languagebox.js
+++ b/js/languagebox.js
@@ -17,6 +17,22 @@
 
 /* exported LanguageBox */
 
+const getLocalStorageItemSafely = key => {
+    try {
+        return localStorage.getItem(key);
+    } catch (e) {
+        return null;
+    }
+};
+
+const setLocalStorageItemSafely = (key, value) => {
+    try {
+        localStorage.setItem(key, value);
+    } catch (e) {
+        console.warn(`Could not save ${key}:`, e);
+    }
+};
+
 class LanguageBox {
     /**
      * @constructor
@@ -316,16 +332,12 @@ class LanguageBox {
             gug: "Actualice su navegador para cambiar su preferencia de idioma.",
             ur: "اپنی زبان کی ترجیح کو تبدیل کرنے کے لئے اپنے براؤزر کو تازہ دم کریں۔"
         };
-        if (localStorage.getItem("languagePreference") === this._language) {
+        if (getLocalStorageItemSafely("languagePreference") === this._language) {
             if (this._language.includes("ja")) {
                 this._language = this._language.split("-")[0];
             }
 
-            try {
-                localStorage.setItem("languagePreference", this._language);
-            } catch (e) {
-                console.warn("Could not save language preference:", e);
-            }
+            setLocalStorageItemSafely("languagePreference", this._language);
             this.activity.textMsg(_("Music Blocks is already set to this language."));
         } else {
             this.activity.storage.languagePreference = this._language;

--- a/js/palette.js
+++ b/js/palette.js
@@ -26,6 +26,13 @@
 
 const PALETTE_SCALE_FACTOR = 0.5;
 const PALETTE_WIDTH_FACTOR = 3;
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
 
 const paletteBlockButtonPush = (blocks, name, arg) => {
     const blk = blocks.makeBlock(name, arg);
@@ -876,7 +883,7 @@ class Palettes {
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
         row.style.borderBottom = "1px solid #0CAFFF";
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
+        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";
@@ -916,7 +923,7 @@ class Palettes {
         img.style.height = `${this.cellSize}px`;
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
+        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";

--- a/js/palette.js
+++ b/js/palette.js
@@ -26,7 +26,7 @@
 
 const PALETTE_SCALE_FACTOR = 0.5;
 const PALETTE_WIDTH_FACTOR = 3;
-const getLocalStorageValue = key => {
+const getPaletteLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {
@@ -883,7 +883,8 @@ class Palettes {
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
         row.style.borderBottom = "1px solid #0CAFFF";
-        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
+        label.style.fontSize =
+            getPaletteLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";
@@ -923,7 +924,8 @@ class Palettes {
         img.style.height = `${this.cellSize}px`;
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
+        label.style.fontSize =
+            getPaletteLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";

--- a/js/palette.js
+++ b/js/palette.js
@@ -28,6 +28,13 @@ const _paletteIconCache = new Map();
 
 const PALETTE_SCALE_FACTOR = 0.5;
 const PALETTE_WIDTH_FACTOR = 3;
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
 
 const paletteBlockButtonPush = (blocks, name, arg) => {
     const blk = blocks.makeBlock(name, arg);
@@ -896,7 +903,7 @@ class Palettes {
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
         row.style.borderBottom = "1px solid #0CAFFF";
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
+        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";
@@ -936,7 +943,7 @@ class Palettes {
         img.style.height = `${this.cellSize}px`;
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        label.style.fontSize = localStorage.kanaPreference === "kana" ? "12px" : "16px";
+        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";

--- a/js/palette.js
+++ b/js/palette.js
@@ -28,7 +28,7 @@ const _paletteIconCache = new Map();
 
 const PALETTE_SCALE_FACTOR = 0.5;
 const PALETTE_WIDTH_FACTOR = 3;
-const getLocalStorageValue = key => {
+const getPaletteLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {
@@ -903,7 +903,8 @@ class Palettes {
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
         row.style.borderBottom = "1px solid #0CAFFF";
-        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
+        label.style.fontSize =
+            getPaletteLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";
@@ -943,7 +944,8 @@ class Palettes {
         img.style.height = `${this.cellSize}px`;
         label.textContent = toTitleCase(_(name));
         label.style.color = platformColor.paletteText;
-        label.style.fontSize = getLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
+        label.style.fontSize =
+            getPaletteLocalStorageValue("kanaPreference") === "kana" ? "12px" : "16px";
         label.style.padding = "4px";
         row.style.display = "flex";
         row.style.flexDirection = "row";

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -103,7 +103,7 @@ const getPieMenuSize = block => {
 // Debounce resize handler for performance
 let wheelResizeTimeout;
 let wheelResizeListenerAttached = false;
-const getLocalStorageValue = key => {
+const getPiemenuLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {
@@ -2901,7 +2901,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     showWheelDiv();
 
     // the voice selector
-    if (getLocalStorageValue("kanaPreference") === "kana") {
+    if (getPiemenuLocalStorageValue("kanaPreference") === "kana") {
         block._voiceWheel = new wheelnav("wheelDiv", null, 1200, 1200);
     } else {
         block._voiceWheel = new wheelnav("wheelDiv", null, 800, 800);
@@ -3079,7 +3079,7 @@ const piemenuIntervals = (block, selectedInterval) => {
     showWheelDiv();
 
     // Use advanced constructor for more wheelnav on same div
-    const language = getLocalStorageValue("languagePreference");
+    const language = getPiemenuLocalStorageValue("languagePreference");
     if (language === "ja") {
         block._intervalNameWheel = new wheelnav("wheelDiv", null, 1500, 1500);
     } else {
@@ -3518,7 +3518,7 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         // Special case for Japanese
-        const language = getLocalStorageValue("languagePreference");
+        const language = getPiemenuLocalStorageValue("languagePreference");
         if (language === "ja") {
             for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
                 that._modeNameWheel.navItems[i].titleAttr.font = "30 30px sans-serif";

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -103,6 +103,13 @@ const getPieMenuSize = block => {
 // Debounce resize handler for performance
 let wheelResizeTimeout;
 let wheelResizeListenerAttached = false;
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
 const debouncedSetWheelSize = () => {
     clearTimeout(wheelResizeTimeout);
     wheelResizeTimeout = setTimeout(setWheelSize, 150);
@@ -2894,7 +2901,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     showWheelDiv();
 
     // the voice selector
-    if (localStorage.kanaPreference === "kana") {
+    if (getLocalStorageValue("kanaPreference") === "kana") {
         block._voiceWheel = new wheelnav("wheelDiv", null, 1200, 1200);
     } else {
         block._voiceWheel = new wheelnav("wheelDiv", null, 800, 800);
@@ -3072,7 +3079,7 @@ const piemenuIntervals = (block, selectedInterval) => {
     showWheelDiv();
 
     // Use advanced constructor for more wheelnav on same div
-    const language = localStorage.languagePreference;
+    const language = getLocalStorageValue("languagePreference");
     if (language === "ja") {
         block._intervalNameWheel = new wheelnav("wheelDiv", null, 1500, 1500);
     } else {
@@ -3511,7 +3518,7 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         // Special case for Japanese
-        const language = localStorage.languagePreference;
+        const language = getLocalStorageValue("languagePreference");
         if (language === "ja") {
             for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
                 that._modeNameWheel.navItems[i].titleAttr.font = "30 30px sans-serif";

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -103,7 +103,7 @@ const getPieMenuSize = block => {
 let wheelResizeTimeout;
 let wheelResizeListenerAttached = false;
 let activeExitWheel = null;
-const getLocalStorageValue = key => {
+const getPiemenuLocalStorageValue = key => {
     try {
         return localStorage[key];
     } catch (e) {
@@ -3053,7 +3053,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     showWheelDiv();
 
     // the voice selector
-    if (getLocalStorageValue("kanaPreference") === "kana") {
+    if (getPiemenuLocalStorageValue("kanaPreference") === "kana") {
         block._voiceWheel = new wheelnav("wheelDiv", null, 1200, 1200);
     } else {
         block._voiceWheel = new wheelnav("wheelDiv", null, 800, 800);
@@ -3231,7 +3231,7 @@ const piemenuIntervals = (block, selectedInterval) => {
     showWheelDiv();
 
     // Use advanced constructor for more wheelnav on same div
-    const language = getLocalStorageValue("languagePreference");
+    const language = getPiemenuLocalStorageValue("languagePreference");
     if (language === "ja") {
         block._intervalNameWheel = new wheelnav("wheelDiv", null, 1500, 1500);
     } else {
@@ -3679,7 +3679,7 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         // Special case for Japanese
-        const language = getLocalStorageValue("languagePreference");
+        const language = getPiemenuLocalStorageValue("languagePreference");
         if (language === "ja") {
             for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
                 that._modeNameWheel.navItems[i].titleAttr.font = "30 30px sans-serif";

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -103,6 +103,13 @@ const getPieMenuSize = block => {
 let wheelResizeTimeout;
 let wheelResizeListenerAttached = false;
 let activeExitWheel = null;
+const getLocalStorageValue = key => {
+    try {
+        return localStorage[key];
+    } catch (e) {
+        return undefined;
+    }
+};
 const debouncedSetWheelSize = () => {
     clearTimeout(wheelResizeTimeout);
     wheelResizeTimeout = setTimeout(setWheelSize, 150);
@@ -3046,7 +3053,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     showWheelDiv();
 
     // the voice selector
-    if (localStorage.kanaPreference === "kana") {
+    if (getLocalStorageValue("kanaPreference") === "kana") {
         block._voiceWheel = new wheelnav("wheelDiv", null, 1200, 1200);
     } else {
         block._voiceWheel = new wheelnav("wheelDiv", null, 800, 800);
@@ -3224,7 +3231,7 @@ const piemenuIntervals = (block, selectedInterval) => {
     showWheelDiv();
 
     // Use advanced constructor for more wheelnav on same div
-    const language = localStorage.languagePreference;
+    const language = getLocalStorageValue("languagePreference");
     if (language === "ja") {
         block._intervalNameWheel = new wheelnav("wheelDiv", null, 1500, 1500);
     } else {
@@ -3672,7 +3679,7 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         // Special case for Japanese
-        const language = localStorage.languagePreference;
+        const language = getLocalStorageValue("languagePreference");
         if (language === "ja") {
             for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
                 that._modeNameWheel.navItems[i].titleAttr.font = "30 30px sans-serif";

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update(event);
+            this.activity.stage.update();
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -745,6 +745,15 @@ describe("_() i18n translation", () => {
         expect(_("test")).toBe("漢字");
     });
 
+    it("falls back to kanji when localStorage.getItem throws", () => {
+        i18next.language = "ja";
+        getItemSpy.mockImplementation(() => {
+            throw new Error("SecurityError: storage disabled");
+        });
+        i18next.t.mockReturnValue({ kanji: "漢字", kana: "かな" });
+        expect(_("test")).toBe("漢字");
+    });
+
     it("returns key when Japanese translation object lacks the script key", () => {
         i18next.language = "ja";
         getItemSpy.mockReturnValue("kanji");

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -83,7 +83,7 @@ if (typeof window !== "undefined") {
     window.safeJSONParse = safeJSONParse;
 }
 
-const getLocalStorageItemSafely = (key, fallback = null) => {
+const getUtilsLocalStorageItemSafely = (key, fallback = null) => {
     try {
         const value = localStorage.getItem(key);
         return value === null ? fallback : value;
@@ -132,7 +132,7 @@ function _(text, options = {}) {
         const lang = i18next.language;
 
         if (lang.startsWith("ja")) {
-            const kanaPref = getLocalStorageItemSafely("kanaPreference", "kanji");
+            const kanaPref = getUtilsLocalStorageItemSafely("kanaPreference", "kanji");
             const script = kanaPref === "kana" ? "kana" : "kanji";
 
             const resolveObj = key => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -83,6 +83,15 @@ if (typeof window !== "undefined") {
     window.safeJSONParse = safeJSONParse;
 }
 
+const getLocalStorageItemSafely = (key, fallback = null) => {
+    try {
+        const value = localStorage.getItem(key);
+        return value === null ? fallback : value;
+    } catch (e) {
+        return fallback;
+    }
+};
+
 /**
  * Enhanced _() method to handle case variations for translations
  * prioritize exact matches and preserve the case of the input text.
@@ -123,7 +132,7 @@ function _(text, options = {}) {
         const lang = i18next.language;
 
         if (lang.startsWith("ja")) {
-            const kanaPref = localStorage.getItem("kanaPreference") || "kanji";
+            const kanaPref = getLocalStorageItemSafely("kanaPreference", "kanji");
             const script = kanaPref === "kana" ? "kana" : "kanji";
 
             const resolveObj = key => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -85,8 +85,8 @@ if (typeof window !== "undefined") {
 
 const getUtilsLocalStorageItemSafely = (key, fallback = null) => {
     try {
-        const value = localStorage.getItem(key);
-        return value === null ? fallback : value;
+        const value = localStorage.getItem(key) ?? fallback;
+        return value;
     } catch (e) {
         return fallback;
     }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -86,8 +86,8 @@ const changeImage = (imgElement, from, to) => {
 
 const getUtilsLocalStorageItemSafely = (key, fallback = null) => {
     try {
-        const value = localStorage.getItem(key);
-        return value === null ? fallback : value;
+        const value = localStorage.getItem(key) ?? fallback;
+        return value;
     } catch (e) {
         return fallback;
     }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -84,6 +84,15 @@ const changeImage = (imgElement, from, to) => {
 // have been moved to js/utils/utils-logic.js.
 // They are loaded as a RequireJS dependency and assigned to window globals.
 
+const getLocalStorageItemSafely = (key, fallback = null) => {
+    try {
+        const value = localStorage.getItem(key);
+        return value === null ? fallback : value;
+    } catch (e) {
+        return fallback;
+    }
+};
+
 /**
  * Enhanced _() method to handle case variations for translations
  * prioritize exact matches and preserve the case of the input text.
@@ -124,7 +133,7 @@ function _(text, options = {}) {
         const lang = i18next.language;
 
         if (lang.startsWith("ja")) {
-            const kanaPref = localStorage.getItem("kanaPreference") || "kanji";
+            const kanaPref = getLocalStorageItemSafely("kanaPreference", "kanji");
             const script = kanaPref === "kana" ? "kana" : "kanji";
 
             const resolveObj = key => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -84,7 +84,7 @@ const changeImage = (imgElement, from, to) => {
 // have been moved to js/utils/utils-logic.js.
 // They are loaded as a RequireJS dependency and assigned to window globals.
 
-const getLocalStorageItemSafely = (key, fallback = null) => {
+const getUtilsLocalStorageItemSafely = (key, fallback = null) => {
     try {
         const value = localStorage.getItem(key);
         return value === null ? fallback : value;
@@ -133,7 +133,7 @@ function _(text, options = {}) {
         const lang = i18next.language;
 
         if (lang.startsWith("ja")) {
-            const kanaPref = getLocalStorageItemSafely("kanaPreference", "kanji");
+            const kanaPref = getUtilsLocalStorageItemSafely("kanaPreference", "kanji");
             const script = kanaPref === "kana" ? "kana" : "kanji";
 
             const resolveObj = key => {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Implements a focused first pass for issue #7074 by guarding remaining high-traffic `localStorage` reads in core UI/runtime modules.

## What changed
Added safe storage accessors and replaced unguarded reads in:

- `js/palette.js`
  - `localStorage.kanaPreference` -> guarded accessor
- `js/piemenus.js`
  - `localStorage.kanaPreference`
  - `localStorage.languagePreference`
- `js/languagebox.js`
  - `localStorage.getItem/setItem("languagePreference")` -> safe wrappers
- `js/utils/utils.js`
  - `localStorage.getItem("kanaPreference")` in i18n path -> guarded accessor

## Why
In restricted/privacy contexts, direct Web Storage access may throw and break UI/runtime flows. These modules are hit frequently and should fail gracefully.

## Impact
- Improves startup/UI resilience when Web Storage is unavailable.
- Preserves existing behavior and fallbacks.
- Moves #7074 forward with a low-risk, incremental patch.

Fixes #7074