### PR TITLE
fix: correct matcher for stage.update in planetInterface test

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -214,7 +214,7 @@ describe("PlanetInterface", () => {
         planetInterface.planet = { ProjectStorage: { saveLocally: jest.fn() } };
 
         return planetInterface.saveLocally().then(() => {
-            expect(mockActivity.stage.update).toHaveBeenCalledWith();
+            expect(mockActivity.stage.update).toHaveBeenCalled();
             expect(planetInterface.planet.ProjectStorage.saveLocally).toHaveBeenCalledWith(D, null);
         });
     });


### PR DESCRIPTION

### Problem
The test was using `toHaveBeenCalledWith()` to assert that `stage.update` was called with no arguments.

However, in the implementation, `stage.update` is invoked with `undefined`, which causes the matcher to fail because it expects exactly zero arguments.

PR under Issues : #7038 
<img width="1066" height="389" alt="Screenshot from 2026-05-01 12-17-28" src="https://github.com/user-attachments/assets/38541a84-5de5-4149-83da-4589e05f6721" />

### Solution FIX
<img width="508" height="123" alt="Screenshot from 2026-05-01 12-18-38" src="https://github.com/user-attachments/assets/d9b9da78-7643-4379-a544-99f35023ab0d" />

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
