### PR TITLE
fix: block unvetted plugin setup execution

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -92,7 +92,9 @@ const {
     closeWidgets,
     closeBlkWidgets,
     resolveObject,
-    importMembers
+    importMembers,
+    isVettedPluginSource,
+    processPluginData
 } = require("../utils.js");
 
 describe("Utility Functions (logic-only)", () => {
@@ -124,6 +126,133 @@ describe("Utility Functions (logic-only)", () => {
 
         it("returns undefined if not a string", () => {
             expect(toTitleCase(123)).toBeUndefined();
+        });
+    });
+
+    describe("plugin source vetting", () => {
+        it("trusts built-in plugin sources", () => {
+            expect(isVettedPluginSource("plugins/weather.json")).toBe(true);
+            expect(isVettedPluginSource("./plugins/weather.json")).toBe(true);
+            expect(isVettedPluginSource("localStorage:plugins")).toBe(true);
+        });
+
+        it("does not trust uploaded or unknown plugin sources", () => {
+            expect(isVettedPluginSource("file:custom.json")).toBe(false);
+            expect(isVettedPluginSource("https://example.com/plugin.json")).toBe(false);
+            expect(isVettedPluginSource("")).toBe(false);
+            expect(isVettedPluginSource(undefined)).toBe(false);
+        });
+    });
+
+    describe("processPluginData()", () => {
+        let originalConfirm;
+        let originalBlob;
+        let originalUrl;
+        let originalSetTimeout;
+        let appendChildSpy;
+        let warnSpy;
+
+        const makeActivity = () => ({
+            palettes: {
+                buttons: {},
+                pluginMacros: {},
+                add: jest.fn(),
+                makePalettes: jest.fn(),
+                updatePalettes: jest.fn(),
+                show: jest.fn()
+            },
+            pluginsImages: {},
+            logo: {
+                evalFlowDict: {},
+                evalArgDict: {},
+                evalSetterDict: {},
+                evalParameterDict: {},
+                evalOnStartList: {},
+                evalOnStopList: {}
+            },
+            blocks: {
+                protoBlockDict: {}
+            }
+        });
+
+        beforeEach(() => {
+            originalConfirm = global.confirm;
+            originalBlob = global.Blob;
+            originalUrl = global.URL;
+            originalSetTimeout = global.setTimeout;
+
+            global._ = value => value;
+            global.confirm = jest.fn(() => true);
+            global.Blob = jest.fn();
+            global.URL = {
+                createObjectURL: jest.fn(() => "blob:plugin"),
+                revokeObjectURL: jest.fn()
+            };
+            appendChildSpy = jest
+                .spyOn(global.document.head, "appendChild")
+                .mockImplementation(() => {});
+            global.setTimeout = callback => {
+                callback();
+                return 1;
+            };
+
+            warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            global.confirm = originalConfirm;
+            global.Blob = originalBlob;
+            global.URL = originalUrl;
+            global.setTimeout = originalSetTimeout;
+            appendChildSpy.mockRestore();
+            warnSpy.mockRestore();
+        });
+
+        it("blocks uploaded plugin setup code from Blob script injection", async () => {
+            const activity = makeActivity();
+            const pluginData = JSON.stringify({
+                FLOWPLUGINS: {
+                    uploadedFlow: "window.localStorage.clear();"
+                },
+                BLOCKPLUGINS: {
+                    uploadedBlock: "window.parent.document.body.innerHTML = '';"
+                },
+                GLOBALS: "window.secret = localStorage.getItem('token');",
+                ONLOAD: {
+                    uploadedOnload: "document.body.remove();"
+                }
+            });
+
+            const result = await processPluginData(
+                activity,
+                pluginData,
+                "file:uploaded-plugin.json"
+            );
+
+            expect(result).not.toBeNull();
+            expect(global.confirm).toHaveBeenCalled();
+            expect(activity.logo.evalFlowDict.uploadedFlow).toBe("window.localStorage.clear();");
+            expect(global.Blob).not.toHaveBeenCalled();
+            expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+            expect(appendChildSpy).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledWith(
+                "Blocked unvetted plugin setup code:",
+                "BLOCKPLUGINS:uploadedBlock",
+                "from",
+                "file:uploaded-plugin.json"
+            );
+            expect(warnSpy).toHaveBeenCalledWith(
+                "Blocked unvetted plugin setup code:",
+                "GLOBALS",
+                "from",
+                "file:uploaded-plugin.json"
+            );
+            expect(warnSpy).toHaveBeenCalledWith(
+                "Blocked unvetted plugin setup code:",
+                "ONLOAD:uploadedOnload",
+                "from",
+                "file:uploaded-plugin.json"
+            );
         });
     });
 

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -754,6 +754,42 @@ if (typeof window !== "undefined") {
 }
 
 /**
+ * Determines whether plugin code comes from a source that ships with Music Blocks
+ * or has already been accepted into the local plugin store.
+ * @param {string} source - The plugin source identifier.
+ * @returns {boolean} True when the plugin source is trusted for direct execution.
+ */
+const isVettedPluginSource = source => {
+    if (!source) return false;
+
+    if (source.startsWith("plugins/") || source.startsWith("./plugins/")) {
+        return true;
+    }
+
+    return source === "localStorage:plugins";
+};
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports.isVettedPluginSource = isVettedPluginSource;
+}
+
+/**
+ * Reports and blocks setup code from plugins that are not trusted for direct
+ * execution in the main application context.
+ * @param {string} label - Human-readable plugin section label.
+ * @param {string} pluginSource - The plugin source identifier.
+ * @returns {void}
+ */
+const blockUnvettedPluginSetupCode = (label, pluginSource) => {
+    console.warn(
+        "Blocked unvetted plugin setup code:",
+        label,
+        "from",
+        pluginSource || "unknown source"
+    );
+};
+
+/**
  * Processes plugin data and updates the activity based on the provided JSON-encoded dictionary.
  * @param {object} activity - The activity object to update.
  * @param {string} pluginData - The JSON-encoded plugin data.
@@ -765,21 +801,9 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
         return null;
     }
 
-    const isVettedPlugin = source => {
-        if (!source) return false;
-        // Plugins from the local plugins folder are considered vetted (provenance)
-        if (source.startsWith("plugins/") || source.startsWith("./plugins/")) {
-            return true;
-        }
-        // Known plugins from local storage are also trusted as they were approved previously
-        if (source === "localStorage:plugins") {
-            return true;
-        }
-        return false;
-    };
-
     // Use the vetted check to determine initial trust
-    let userConfirmed = isVettedPlugin(pluginSource);
+    const isVettedPlugin = isVettedPluginSource(pluginSource);
+    let userConfirmed = isVettedPlugin;
 
     if (!userConfirmed) {
         userConfirmed = confirm(
@@ -807,6 +831,11 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
 
     const safeEval = (code, label = "plugin") => {
         if (typeof code !== "string" || !userConfirmed) return;
+
+        if (!isVettedPlugin) {
+            blockUnvettedPluginSetupCode(label, pluginSource);
+            return;
+        }
 
         // Basic sanity limit
         if (code.length > 500000) {
@@ -914,7 +943,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
             // Pre-compile trusted plugins for performance.
             // UNTRUSTED plugins (if any made it past confirmation) are stored as strings
             // and handled via whitelist in safePluginExecute.
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const flowCode = obj["FLOWPLUGINS"][flow];
                 const registryName = `flow_${flow}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -932,7 +961,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, rec
     // Populate the arg-block dictionary
     if ("ARGPLUGINS" in obj) {
         for (const arg in obj["ARGPLUGINS"]) {
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const argCode = obj["ARGPLUGINS"][arg];
                 const registryName = `arg_${arg}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -964,7 +993,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // Populate the setter dictionary
     if ("SETTERPLUGINS" in obj) {
         for (const setter in obj["SETTERPLUGINS"]) {
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const setterCode = obj["SETTERPLUGINS"][setter];
                 const registryName = `setter_${setter}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -999,7 +1028,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
 
     if ("PARAMETERPLUGINS" in obj) {
         for (const parameter in obj["PARAMETERPLUGINS"]) {
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const paramCode = obj["PARAMETERPLUGINS"][parameter];
                 const registryName = `param_${parameter}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -1024,7 +1053,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
     // Code to execute when turtle code is started
     if ("ONSTART" in obj) {
         for (const arg in obj["ONSTART"]) {
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const onStartCode = obj["ONSTART"][arg];
                 const registryName = `onstart_${arg}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -1042,7 +1071,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo) {
     // Code to execute when turtle code is stopped
     if ("ONSTOP" in obj) {
         for (const arg in obj["ONSTOP"]) {
-            if (isVettedPlugin(pluginSource)) {
+            if (isVettedPlugin) {
                 const onStopCode = obj["ONSTOP"][arg];
                 const registryName = `onstop_${arg}_${Math.random().toString(36).substr(2, 9)}`;
                 blobScriptContent += `
@@ -2103,6 +2132,8 @@ if (typeof module !== "undefined" && module.exports) {
         closeBlkWidgets,
         resolveObject,
         importMembers,
-        escapeHTML
+        escapeHTML,
+        isVettedPluginSource,
+        processPluginData
     };
 }


### PR DESCRIPTION
This PR adds a focused security hardening step for plugin loading related to #7046.

Uploaded or otherwise unvetted plugins could still execute setup code through dynamically injected Blob scripts after a confirmation prompt. This change prevents unvetted plugin setup sections from being executed directly in the main application context.

Changes:-
1. Added a shared `isVettedPluginSource()` helper for plugin source trust checks.
2. Blocked unvetted `BLOCKPLUGINS`, `GLOBALS`, and `ONLOAD` setup code from Blob script injection.
3. Kept vetted built-in/local plugins on the existing direct execution path for compatibility and performance.
4. Added regression tests to verify uploaded plugin setup code does not create Blob scripts or inject script tags.
- [x] Security Fix
- [x] Bug Fix