### PR TITLE
fix planetinterface failing test

### DIFF
--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,11 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update(event);
+            if (typeof event !== "undefined") {
+                this.activity.stage.update(event);
+            } else {
+                this.activity.stage.update();
+            }
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,


### PR DESCRIPTION

This PR fixes a failing test in `PlanetInterface` by correcting how `stage.update()` is called inside `saveLocally().`

The code was calling:
        ` stage.update(undefined);`
        
 stage.update() should either:
- be called without arguments, or
- be called with a valid event object

Passing undefined explicitly caused the test to fail.      



the fix -- 

Added a small guard:
If a valid event exists --> pass it to `stage.update(event)`
Otherwise --> call `stage.update()` with no arguments

This avoids passing undefined and matches expected behavior.

## tests 

### before

<img width="824" height="538" alt="Screenshot 2026-05-01 152201" src="https://github.com/user-attachments/assets/97f63bb1-681b-4b8e-b0fb-64a70afdf7b6" />

###after 

<img width="399" height="125" alt="image" src="https://github.com/user-attachments/assets/9e80bfa0-d987-413a-bbc2-c35ecaa525f3" />



- [x] Bug fix


 

 
