### PR TITLE
Guard PlanetInterface storage access before init

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -214,7 +214,7 @@ describe("PlanetInterface", () => {
         planetInterface.planet = { ProjectStorage: { saveLocally: jest.fn() } };
 
         return planetInterface.saveLocally().then(() => {
-            expect(mockActivity.stage.update).toHaveBeenCalledWith();
+            expect(mockActivity.stage.update).toHaveBeenCalledWith(undefined);
             expect(planetInterface.planet.ProjectStorage.saveLocally).toHaveBeenCalledWith(D, null);
         });
     });
@@ -247,6 +247,15 @@ describe("PlanetInterface", () => {
             ProjectStorage: { getCurrentProjectData: jest.fn(async () => 123) }
         };
         await expect(planetInterface.openCurrentProject()).resolves.toBe(123);
+    });
+    test("openCurrentProject returns null when Planet storage is unavailable", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        planetInterface.planet = null;
+        await expect(planetInterface.openCurrentProject()).resolves.toBeNull();
+        expect(errorSpy).toHaveBeenCalledWith(
+            "[PlanetInterface] openCurrentProject called before Planet storage is ready."
+        );
+        errorSpy.mockRestore();
     });
     test("openProjectFromPlanet proxies arguments", () => {
         planetInterface.planet = { openProjectFromPlanet: jest.fn() };
@@ -478,14 +487,19 @@ describe("PlanetInterface", () => {
         iframe.contentWindow.makePlanet = jest
             .fn()
             .mockRejectedValue(new Error("Failed to make planet"));
-        try {
-            await planetInterface.init();
-        } catch (e) {
-            expect(e).toBeInstanceOf(TypeError);
-        }
+        await expect(planetInterface.init()).resolves.toBeUndefined();
         expect(consoleSpy).toHaveBeenCalledWith(expect.any(Error));
         expect(consoleSpy.mock.calls[0][0].message).toBe("Failed to make planet");
         expect(planetInterface.planet).toBeNull();
+        expect(window.Converter).toBeUndefined();
         consoleSpy.mockRestore();
+    });
+
+    it("project getters return safe defaults when Planet storage is unavailable", () => {
+        planetInterface.planet = null;
+        expect(planetInterface.getCurrentProjectName()).toBe("");
+        expect(planetInterface.getCurrentProjectDescription()).toBe("");
+        expect(planetInterface.getCurrentProjectImage()).toBeNull();
+        expect(planetInterface.getTimeLastSaved()).toBeNull();
     });
 });

--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -180,6 +180,14 @@ describe("PlanetInterface", () => {
         expect(mockActivity.blocks.trashStacks).toEqual([]);
     });
 
+    test("initialiseNewProject returns early when Planet storage is unavailable", () => {
+        planetInterface.planet = null;
+
+        expect(() => planetInterface.initialiseNewProject("New Name")).not.toThrow();
+        expect(mockActivity.sendAllToTrash).not.toHaveBeenCalled();
+        expect(mockActivity.refreshCanvas).not.toHaveBeenCalled();
+    });
+
     test("loadProjectFromData: default merge=false", () => {
         planetInterface.iframe = { style: { display: "block" } };
         mockActivity.blocks.loadNewBlocks.mockClear();
@@ -261,6 +269,11 @@ describe("PlanetInterface", () => {
         planetInterface.planet = { openProjectFromPlanet: jest.fn() };
         planetInterface.openProjectFromPlanet("ID42", "oops");
         expect(planetInterface.planet.openProjectFromPlanet).toHaveBeenCalledWith("ID42", "oops");
+    });
+    test("openProjectFromPlanet returns early when Planet is unavailable", () => {
+        planetInterface.planet = null;
+
+        expect(() => planetInterface.openProjectFromPlanet("ID42", "oops")).not.toThrow();
     });
     test("hideMusicBlocks also calls widgetWindows.hideAllWindows and disables DOM events after 250ms", () => {
         jest.useFakeTimers();

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -209,7 +209,10 @@ class PlanetInterface {
          * @param {string} [name] - The name of the new project.
          */
         this.initialiseNewProject = name => {
-            this.planet.ProjectStorage.initialiseNewProject(name);
+            const projectStorage = this._getProjectStorage();
+            if (!projectStorage) return;
+
+            projectStorage.initialiseNewProject(name);
             this.activity.sendAllToTrash();
             this.activity.refreshCanvas();
             this.activity.blocks.trashStacks = [];
@@ -309,6 +312,8 @@ class PlanetInterface {
          * @param {string} [error] - Error message if project opening fails.
          */
         this.openProjectFromPlanet = (id, error) => {
+            if (!this.planet || typeof this.planet.openProjectFromPlanet !== "function") return;
+
             this.planet.openProjectFromPlanet(id, error);
         };
 

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -31,6 +31,13 @@ class PlanetInterface {
         this.iframe = null;
         this.mainCanvas = null;
         this.activity = activity;
+        this._getProjectStorage = () => {
+            if (!this.planet || !this.planet.ProjectStorage) {
+                return null;
+            }
+
+            return this.planet.ProjectStorage;
+        };
 
         /**
          * Hides music blocks and related elements.
@@ -285,7 +292,15 @@ class PlanetInterface {
          * @returns {Promise} - A promise that resolves with the current project data.
          */
         this.openCurrentProject = async () => {
-            return await this.planet.ProjectStorage.getCurrentProjectData();
+            const projectStorage = this._getProjectStorage();
+            if (!projectStorage || typeof projectStorage.getCurrentProjectData !== "function") {
+                console.error(
+                    "[PlanetInterface] openCurrentProject called before Planet storage is ready."
+                );
+                return null;
+            }
+
+            return await projectStorage.getCurrentProjectData();
         };
 
         /**
@@ -310,7 +325,12 @@ class PlanetInterface {
          * @returns {string} - The name of the current project.
          */
         this.getCurrentProjectName = () => {
-            return this.planet.ProjectStorage.getCurrentProjectName();
+            const projectStorage = this._getProjectStorage();
+            if (!projectStorage || typeof projectStorage.getCurrentProjectName !== "function") {
+                return "";
+            }
+
+            return projectStorage.getCurrentProjectName();
         };
 
         /**
@@ -318,7 +338,15 @@ class PlanetInterface {
          * @returns {string} - The description of the current project.
          */
         this.getCurrentProjectDescription = () => {
-            return this.planet.ProjectStorage.getCurrentProjectDescription();
+            const projectStorage = this._getProjectStorage();
+            if (
+                !projectStorage ||
+                typeof projectStorage.getCurrentProjectDescription !== "function"
+            ) {
+                return "";
+            }
+
+            return projectStorage.getCurrentProjectDescription();
         };
 
         /**
@@ -326,7 +354,12 @@ class PlanetInterface {
          * @returns {string} - The URL of the image associated with the current project.
          */
         this.getCurrentProjectImage = () => {
-            return this.planet.ProjectStorage.getCurrentProjectImage();
+            const projectStorage = this._getProjectStorage();
+            if (!projectStorage || typeof projectStorage.getCurrentProjectImage !== "function") {
+                return null;
+            }
+
+            return projectStorage.getCurrentProjectImage();
         };
 
         /**
@@ -334,7 +367,12 @@ class PlanetInterface {
          * @returns {Date} - The timestamp of the last save operation.
          */
         this.getTimeLastSaved = () => {
-            return this.planet.ProjectStorage.TimeLastSaved;
+            const projectStorage = this._getProjectStorage();
+            if (!projectStorage) {
+                return null;
+            }
+
+            return projectStorage.TimeLastSaved ?? null;
         };
 
         /**
@@ -360,7 +398,7 @@ class PlanetInterface {
                 this.planet = null;
             }
 
-            window.Converter = this.planet.Converter;
+            window.Converter = this.planet ? this.planet.Converter : undefined;
             this.mainCanvas = this.activity.canvas;
         };
     }


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary
Fixes #7085 by preventing `PlanetInterface` public API methods from crashing when Planet storage is not initialized yet.

## What changed
- Added a private helper in `PlanetInterface` to safely resolve `ProjectStorage`.
- Guarded these public methods against pre-init access:
  - `openCurrentProject()`
  - `getCurrentProjectName()`
  - `getCurrentProjectDescription()`
  - `getCurrentProjectImage()`
  - `getTimeLastSaved()`
- Updated `init()` fallback behavior to avoid null-deref when Planet initialization fails:
  - `window.Converter = this.planet ? this.planet.Converter : undefined`

## Tests
- Extended `js/__tests__/planetInterface.test.js` to cover pre-init behavior:
  - safe defaults for getters
  - `openCurrentProject()` returns `null` and logs controlled error when storage is unavailable
  - `init()` failure path no longer throws
- Stabilized one existing assertion for stage update argument shape (`undefined`)

## Validation
- `npm test -- --runInBand` (full Jest suite): passed
