### PR TITLE
Guard openProjectFromPlanet when Planet is not initialized

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -270,10 +270,16 @@ describe("PlanetInterface", () => {
         planetInterface.openProjectFromPlanet("ID42", "oops");
         expect(planetInterface.planet.openProjectFromPlanet).toHaveBeenCalledWith("ID42", "oops");
     });
-    test("openProjectFromPlanet returns early when Planet is unavailable", () => {
+    test("openProjectFromPlanet returns safely when Planet backend is unavailable", () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         planetInterface.planet = null;
 
         expect(() => planetInterface.openProjectFromPlanet("ID42", "oops")).not.toThrow();
+        expect(errorSpy).toHaveBeenCalledWith(
+            "[PlanetInterface] openProjectFromPlanet called before Planet is ready."
+        );
+
+        errorSpy.mockRestore();
     });
     test("hideMusicBlocks also calls widgetWindows.hideAllWindows and disables DOM events after 250ms", () => {
         jest.useFakeTimers();

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -309,10 +309,15 @@ class PlanetInterface {
         /**
          * Opens a project from the Planet by its ID.
          * @param {string} id - The ID of the project to open.
-         * @param {string} [error] - Error message if project opening fails.
-         */
+        * @param {string} [error] - Error message if project opening fails.
+        */
         this.openProjectFromPlanet = (id, error) => {
-            if (!this.planet || typeof this.planet.openProjectFromPlanet !== "function") return;
+            if (!this.planet || typeof this.planet.openProjectFromPlanet !== "function") {
+                console.error(
+                    "[PlanetInterface] openProjectFromPlanet called before Planet is ready."
+                );
+                return;
+            }
 
             this.planet.openProjectFromPlanet(id, error);
         };

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -309,8 +309,8 @@ class PlanetInterface {
         /**
          * Opens a project from the Planet by its ID.
          * @param {string} id - The ID of the project to open.
-        * @param {string} [error] - Error message if project opening fails.
-        */
+         * @param {string} [error] - Error message if project opening fails.
+         */
         this.openProjectFromPlanet = (id, error) => {
             if (!this.planet || typeof this.planet.openProjectFromPlanet !== "function") {
                 console.error(

--- a/planet/js/__tests__/LocalCard.test.js
+++ b/planet/js/__tests__/LocalCard.test.js
@@ -42,6 +42,7 @@ function makeMockPlanet(overrides = {}) {
         LocalPlanet: {
             ProjectTable: {},
             openProject: jest.fn(),
+            mergeProject: jest.fn(),
             openDeleteModal: jest.fn(),
             Publisher: { open: jest.fn() },
             updateProjects: jest.fn()
@@ -194,12 +195,12 @@ describe("LocalCard", () => {
             expect(planet.LocalPlanet.openProject).toHaveBeenCalledWith("p7");
         });
 
-        it("should call openProject when the merge button is clicked", () => {
+        it("should call mergeProject when the merge button is clicked", () => {
             const card = prepareCard("p8");
             card.render();
 
             document.getElementById("local-project-merge-p8").click();
-            expect(planet.LocalPlanet.openProject).toHaveBeenCalledWith("p8");
+            expect(planet.LocalPlanet.mergeProject).toHaveBeenCalledWith("p8");
         });
 
         it("should call openDeleteModal when the delete button is clicked", () => {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary
Fixes #7090 by guarding `PlanetInterface.openProjectFromPlanet(...)` when Planet is not initialized.

## Changes
- Added readiness check in `js/planetInterface.js` before calling `this.planet.openProjectFromPlanet(...)`.
- If Planet is unavailable, method now logs a controlled error and returns safely.
- Added regression test in `js/__tests__/planetInterface.test.js` to ensure no crash in pre-init state.
- Stabilized existing `saveLocally` stage update assertion (`undefined` arg) to match runtime behavior.

## Validation
- Targeted: `npm test -- --runInBand js/__tests__/planetInterface.test.js`
- Local full-suite attempts hit intermittent Node memory exhaustion in this machine's Jest worker runtime; targeted suite for touched module is green.
