### PR TITLE
fix: guard hideContents click in resize handlers

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4384,7 +4384,10 @@ class Activity {
                 canvasHolder.width = canvas.width;
                 canvasHolder.height = canvas.height;
             }
-            document.getElementById("hideContents").click();
+            const hideContents = document.getElementById("hideContents");
+            if (hideContents) {
+                hideContents.click();
+            }
             that.refreshCanvas();
         }
 
@@ -4433,7 +4436,10 @@ class Activity {
         const resizeCanvas_ = () => {
             try {
                 that._onResize(false);
-                document.getElementById("hideContents").click();
+                const hideContents = document.getElementById("hideContents");
+                if (hideContents) {
+                    hideContents.click();
+                }
             } catch (error) {
                 console.error("An error occurred in resizeCanvas_:", error);
             }


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [x] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation

## Summary
Fix the `#hideContents` null-dereference in the resize path by guarding both resize call sites in `js/activity.js`.

## Scope
- `handleResize()` now clicks `#hideContents` only when the element exists.
- `resizeCanvas_()` uses the same guard.
- This PR is intentionally limited to the resize handlers for issue #7092.

## Why
When `#hideContents` is missing, resize handling can throw and interrupt layout updates. Guarding the click keeps the resize flow stable without changing the happy path.

## Validation
- `npx jest js/__tests__/activity_listeners.test.js --runInBand --coverage=false`
- `npx eslint js/activity.js`
- `git diff --check`

Fixes #7092
