### PR TITLE
feat: add block keyboard shortcuts

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -53,7 +53,7 @@ try {
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
    SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
-   unescapeHTML
+   unescapeHTML, KeyboardShortcuts
  */
 
 /*
@@ -91,6 +91,7 @@ let MYDEFINES = [
     // on demand when the widget is opened, saving ~3-5 MB of heap memory.
     // "Chart",
     "utils/utils",
+    "utils/keyboardShortcuts",
     "utils/retryWithBackoff",
     "utils/debugLog",
     "activity/artwork",
@@ -3812,6 +3813,9 @@ class Activity {
                     this.inTempoWidget = true;
                     break;
                 }
+            }
+            if (!disableKeys && KeyboardShortcuts.handleKeyDown(event, this)) {
+                return false;
             }
             if (
                 (event.altKey && !disableKeys) ||
@@ -8224,6 +8228,7 @@ class Activity {
             this.turtles = new Turtles(this);
             this.boundary = new Boundary(this.blocksContainer);
             this.blocks = new Blocks(this);
+            KeyboardShortcuts.trackBlockSelection(this.blocks);
             this.palettes = new Palettes(this);
             this.palettes.init();
             this.logo = new Logo(this);

--- a/js/loader.js
+++ b/js/loader.js
@@ -60,6 +60,10 @@ requirejs.config({
             deps: ["utils/platformstyle"],
             exports: "_"
         },
+        "utils/keyboardShortcuts": {
+            deps: ["utils/utils"],
+            exports: "KeyboardShortcuts"
+        },
         "utils/retryWithBackoff": {
             deps: ["utils/utils"],
             exports: "retryWithBackoff"

--- a/js/utils/__tests__/keyboardShortcuts.test.js
+++ b/js/utils/__tests__/keyboardShortcuts.test.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 Music Blocks contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+global._ = value => value;
+
+const KeyboardShortcuts = require("../keyboardShortcuts");
+
+describe("KeyboardShortcuts", () => {
+    const makeEvent = options => ({
+        key: options.key,
+        ctrlKey: options.ctrlKey || false,
+        metaKey: options.metaKey || false,
+        target: options.target || { tagName: "BODY" },
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn()
+    });
+
+    const makeActivity = () => ({
+        blocks: {
+            activeBlock: 0,
+            lastSelectedBlock: null,
+            blockList: [
+                { blockIndex: 0, trash: false },
+                { blockIndex: 1, trash: false },
+                { blockIndex: 2, trash: true }
+            ],
+            trashStacks: [4],
+            moveStackRelative: jest.fn(),
+            blockMoved: jest.fn(),
+            adjustDocks: jest.fn(),
+            sendStackToTrash: jest.fn()
+        },
+        _restoreTrashById: jest.fn(),
+        textMsg: jest.fn(),
+        stageDirty: false
+    });
+
+    test("deletes the active block with Delete", () => {
+        const activity = makeActivity();
+        const event = makeEvent({ key: "Delete" });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(true);
+        expect(activity.blocks.sendStackToTrash).toHaveBeenCalledWith(activity.blocks.blockList[0]);
+        expect(activity.blocks.activeBlock).toBeNull();
+        expect(activity.stageDirty).toBe(true);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("nudges the last selected block when activeBlock has been cleared", () => {
+        const activity = makeActivity();
+        activity.blocks.activeBlock = null;
+        activity.blocks.lastSelectedBlock = 1;
+        const event = makeEvent({ key: "ArrowRight" });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(true);
+        expect(activity.blocks.activeBlock).toBe(1);
+        expect(activity.blocks.moveStackRelative).toHaveBeenCalledWith(1, 10, 0);
+        expect(activity.blocks.blockMoved).toHaveBeenCalledWith(1);
+        expect(activity.blocks.adjustDocks).toHaveBeenCalledWith(1, true);
+        expect(activity.stageDirty).toBe(true);
+    });
+
+    test("tracks the last selected block when activeBlock changes", () => {
+        const blocks = {
+            activeBlock: null
+        };
+
+        KeyboardShortcuts.trackBlockSelection(blocks);
+        blocks.activeBlock = 1;
+        blocks.activeBlock = null;
+
+        expect(blocks.activeBlock).toBeNull();
+        expect(blocks.lastSelectedBlock).toBe(1);
+    });
+
+    test("restores the last deleted block with Ctrl+Z", () => {
+        const activity = makeActivity();
+        const event = makeEvent({ key: "z", ctrlKey: true });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(true);
+        expect(activity._restoreTrashById).toHaveBeenCalledWith(4);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("restores the last deleted block with Cmd+Z", () => {
+        const activity = makeActivity();
+        const event = makeEvent({ key: "z", metaKey: true });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(true);
+        expect(activity._restoreTrashById).toHaveBeenCalledWith(4);
+    });
+
+    test("does not run shortcuts while typing in an input", () => {
+        const activity = makeActivity();
+        const event = makeEvent({ key: "Backspace", target: { tagName: "INPUT" } });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(false);
+        expect(activity.blocks.sendStackToTrash).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test("does not nudge a trashed last selected block", () => {
+        const activity = makeActivity();
+        activity.blocks.activeBlock = null;
+        activity.blocks.lastSelectedBlock = 2;
+        const event = makeEvent({ key: "ArrowUp" });
+
+        expect(KeyboardShortcuts.handleKeyDown(event, activity)).toBe(false);
+        expect(activity.blocks.moveStackRelative).not.toHaveBeenCalled();
+    });
+});

--- a/js/utils/keyboardShortcuts.js
+++ b/js/utils/keyboardShortcuts.js
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Music Blocks contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/*
+   global
+
+   _
+ */
+
+/*
+   exported
+
+   KeyboardShortcuts
+ */
+
+const KeyboardShortcuts = (() => {
+    const NUDGE_DISTANCE = 10;
+    const INPUT_TAGS = ["INPUT", "TEXTAREA", "SELECT"];
+
+    const isEditableTarget = target => {
+        if (!target) {
+            return false;
+        }
+
+        if (target.tagName === "INPUT" || INPUT_TAGS.includes(target.tagName)) {
+            return true;
+        }
+
+        return target.isContentEditable === true;
+    };
+
+    const getTargetBlock = activity => {
+        if (!activity || !activity.blocks) {
+            return null;
+        }
+
+        const blocks = activity.blocks;
+        const blockIndex =
+            blocks.activeBlock !== null && blocks.activeBlock !== undefined
+                ? blocks.activeBlock
+                : blocks.lastSelectedBlock;
+
+        if (blockIndex === null || blockIndex === undefined) {
+            return null;
+        }
+
+        const block = blocks.blockList && blocks.blockList[blockIndex];
+        if (!block || block.trash) {
+            return null;
+        }
+
+        return blockIndex;
+    };
+
+    const trackBlockSelection = blocks => {
+        if (!blocks || blocks._keyboardShortcutsTrackingActiveBlock) {
+            return;
+        }
+
+        let activeBlock = blocks.activeBlock;
+        blocks.lastSelectedBlock = null;
+
+        Object.defineProperty(blocks, "activeBlock", {
+            configurable: true,
+            get: () => activeBlock,
+            set: blockIndex => {
+                activeBlock = blockIndex;
+                if (blockIndex !== null && blockIndex !== undefined) {
+                    blocks.lastSelectedBlock = blockIndex;
+                }
+            }
+        });
+
+        blocks._keyboardShortcutsTrackingActiveBlock = true;
+    };
+
+    const finishBlockChange = (activity, blockIndex) => {
+        const blocks = activity.blocks;
+        if (typeof blocks.blockMoved === "function") {
+            blocks.blockMoved(blockIndex);
+        }
+
+        if (typeof blocks.adjustDocks === "function") {
+            blocks.adjustDocks(blockIndex, true);
+        }
+
+        activity.stageDirty = true;
+    };
+
+    const nudgeBlock = (activity, dx, dy) => {
+        const blockIndex = getTargetBlock(activity);
+        if (blockIndex === null) {
+            return false;
+        }
+
+        activity.blocks.activeBlock = blockIndex;
+        activity.blocks.moveStackRelative(blockIndex, dx, dy);
+        finishBlockChange(activity, blockIndex);
+        return true;
+    };
+
+    const deleteBlock = activity => {
+        const blockIndex = getTargetBlock(activity);
+        if (blockIndex === null) {
+            return false;
+        }
+
+        const block = activity.blocks.blockList[blockIndex];
+        activity.blocks.sendStackToTrash(block);
+        activity.blocks.activeBlock = null;
+        activity.stageDirty = true;
+        return true;
+    };
+
+    const restoreLastDeletedBlock = activity => {
+        const blocks = activity && activity.blocks;
+        if (!blocks || !blocks.trashStacks || blocks.trashStacks.length === 0) {
+            if (activity && typeof activity.textMsg === "function") {
+                activity.textMsg(_("Trash can is empty."), 3000);
+            }
+            return false;
+        }
+
+        const blockIndex = blocks.trashStacks[blocks.trashStacks.length - 1];
+        if (typeof activity._restoreTrashById === "function") {
+            activity._restoreTrashById(blockIndex);
+            return true;
+        }
+
+        return false;
+    };
+
+    const handleKeyDown = (event, activity) => {
+        if (!event || isEditableTarget(event.target)) {
+            return false;
+        }
+
+        const key = event.key;
+        const lowerKey = typeof key === "string" ? key.toLowerCase() : "";
+        let handled = false;
+
+        if ((event.ctrlKey || event.metaKey) && lowerKey === "z") {
+            handled = restoreLastDeletedBlock(activity);
+        } else if (key === "Delete" || key === "Backspace") {
+            handled = deleteBlock(activity);
+        } else if (key === "ArrowUp") {
+            handled = nudgeBlock(activity, 0, -NUDGE_DISTANCE);
+        } else if (key === "ArrowDown") {
+            handled = nudgeBlock(activity, 0, NUDGE_DISTANCE);
+        } else if (key === "ArrowLeft") {
+            handled = nudgeBlock(activity, -NUDGE_DISTANCE, 0);
+        } else if (key === "ArrowRight") {
+            handled = nudgeBlock(activity, NUDGE_DISTANCE, 0);
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        return handled;
+    };
+
+    return {
+        trackBlockSelection,
+        handleKeyDown
+    };
+})();
+
+if (typeof window !== "undefined") {
+    window.KeyboardShortcuts = KeyboardShortcuts;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = KeyboardShortcuts;
+}


### PR DESCRIPTION
Adds keyboard shortcut support for common canvas block operations(Fixes #7030)

This improves accessibility for keyboard-driven users and gives power users faster block editing controls.

 Changes:-

1. Added `js/utils/keyboardShortcuts.js` as a centralized shortcut handler.
2. Added Delete / Backspace support for sending the selected block stack to trash.
3. Added Arrow key support for nudging the selected block stack by 10px.
4. Added Ctrl+Z / Cmd+Z support for restoring the last deleted block from trash.
5. Added `lastSelectedBlock` tracking so shortcuts still work after `activeBlock` is cleared.
6. Prevented shortcuts from firing while typing in text inputs.
7. Wired the utility into `js/activity.js` and RequireJS loader setup.
8. Added focused Jest coverage for the shortcut behavior.

- [x] Feature