### PR TITLE
Fix merge button behavior in LocalCard

### DIFF
--- a/planet/js/LocalCard.js
+++ b/planet/js/LocalCard.js
@@ -113,7 +113,7 @@ class LocalCard {
         if (this.ProjectData.ProjectImage !== null) imageSrc = this.ProjectData.ProjectImage;
         else {
             imageSrc =
-                Planet.IsMusicBlocks == 1 ? this.PlaceholderMBImage : this.PlaceholderTBImage;
+                Planet.IsMusicBlocks === 1 ? this.PlaceholderMBImage : this.PlaceholderTBImage;
         }
 
         const imageId = `local-project-image-${this.id}`;
@@ -136,8 +136,8 @@ class LocalCard {
 
         // set merge modify listener
 
-        frag.getElementById(`local-project-merge-${this.id}`).addEventListener("click", evt => {
-            Planet.LocalPlanet.openProject(this.id);
+        frag.getElementById(`local-project-merge-${this.id}`).addEventListener("click", () => {
+            Planet.LocalPlanet.mergeProject(this.id);
         });
 
         // set input modify listener


### PR DESCRIPTION
## 🐛 Issue  
The **"Merge with current project"** button was incorrectly opening the selected project instead of merging it with the current project.

## 🔧 Fix  
Updated the click handler in `LocalCard.js` to call `mergeProject` instead of `openProject`.

## 📝 Changes  
- Replaced:
  ```js
  Planet.LocalPlanet.openProject(this.id);

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation