### PR TITLE
fix: add gated block timing in runFromBlockNow

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -921,6 +921,85 @@ describe("Logo comprehensive method coverage", () => {
         expect(logo.runFromBlock).toHaveBeenCalledWith(logo, 0, 1, 0, null);
     });
 
+    describe("runFromBlockNow profiling", () => {
+        let originalPerformance;
+        let originalPerformanceTracker;
+
+        beforeEach(() => {
+            originalPerformance = global.performance;
+            originalPerformanceTracker = global.performanceTracker;
+        });
+
+        afterEach(() => {
+            global.performance = originalPerformance;
+            global.performanceTracker = originalPerformanceTracker;
+        });
+
+        test("profiling off does not record block timings", () => {
+            global.performanceTracker = {
+                isEnabled: () => false,
+                enterBlock: jest.fn(),
+                exitBlock: jest.fn(),
+                disable: jest.fn()
+            };
+            global.performance = { now: jest.fn(() => 100) };
+            mockActivity.blocks.visible = false;
+
+            logo.blockList = [
+                {
+                    name: "noop",
+                    protoblock: {
+                        args: 0,
+                        dockTypes: [],
+                        flow: jest.fn(() => [null, null, true])
+                    },
+                    connections: [null],
+                    isValueBlock: () => false,
+                    isArgBlock: () => false
+                }
+            ];
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.blockTimings).toBeUndefined();
+        });
+
+        test("profiling on increments call count", () => {
+            let now = 0;
+            global.performanceTracker = {
+                isEnabled: () => true,
+                enterBlock: jest.fn(),
+                exitBlock: jest.fn(),
+                disable: jest.fn()
+            };
+            global.performance = {
+                now: jest.fn(() => {
+                    now += 5;
+                    return now;
+                })
+            };
+            mockActivity.blocks.visible = false;
+
+            logo.blockList = [
+                {
+                    name: "noop",
+                    protoblock: {
+                        args: 0,
+                        dockTypes: [],
+                        flow: jest.fn(() => [null, null, true])
+                    },
+                    connections: [null],
+                    isValueBlock: () => false,
+                    isArgBlock: () => false
+                }
+            ];
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.blockTimings.noop.calls).toBe(1);
+        });
+    });
+
     test("updateNotation delegates without split and splits across measure boundaries", () => {
         logo.notation.notationDrumStaging[0] = [];
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -1593,6 +1593,52 @@ class Logo {
             performanceTracker.enterBlock();
         }
 
+        const profilingEnabled =
+            typeof performanceTracker !== "undefined" &&
+            typeof performanceTracker.isEnabled === "function" &&
+            performanceTracker.isEnabled();
+        let profilingStart = null;
+        if (profilingEnabled) {
+            profilingStart =
+                typeof performance !== "undefined" && typeof performance.now === "function"
+                    ? performance.now()
+                    : Date.now();
+            if (!logo.blockTimings) {
+                logo.blockTimings = {};
+            }
+        }
+
+        const recordBlockTiming = () => {
+            if (!profilingEnabled || profilingStart === null) return;
+            try {
+                const endTime =
+                    typeof performance !== "undefined" && typeof performance.now === "function"
+                        ? performance.now()
+                        : Date.now();
+                const elapsed = endTime - profilingStart;
+                const blockRef = logo.blockList && logo.blockList[blk];
+                const blockName = blockRef && blockRef.name ? blockRef.name : "unknown";
+
+                if (!logo.blockTimings[blockName]) {
+                    logo.blockTimings[blockName] = { calls: 0, total: 0, max: 0 };
+                }
+
+                const entry = logo.blockTimings[blockName];
+                entry.calls += 1;
+                entry.total += elapsed;
+                if (elapsed > entry.max) {
+                    entry.max = elapsed;
+                }
+            } catch (e) {
+                if (
+                    typeof performanceTracker !== "undefined" &&
+                    typeof performanceTracker.disable === "function"
+                ) {
+                    performanceTracker.disable();
+                }
+            }
+        };
+
         this._alreadyRunning = true;
 
         this.receivedArg = receivedArg;
@@ -1607,6 +1653,7 @@ class Logo {
             logo._alreadyRunning = false;
             logo._syncCounter = 0;
             logo._totalIterations = 0;
+            recordBlockTiming();
             return;
         }
 
@@ -1776,6 +1823,7 @@ class Logo {
                 if (cf !== undefined) childFlow = cf;
                 if (cfc !== undefined) childFlowCount = cfc;
                 if (ret) {
+                    recordBlockTiming();
                     if (typeof performanceTracker !== "undefined") {
                         performanceTracker.exitBlock();
                     }
@@ -2150,6 +2198,7 @@ class Logo {
             logo._timerManager.setTimeout(__checkCompletionState, 100);
         }
 
+        recordBlockTiming();
         if (typeof performanceTracker !== "undefined") {
             performanceTracker.exitBlock();
         }


### PR DESCRIPTION
for - #6609 

## Description

This PR adds safe, gated block timing to `runFromBlockNow`

- No UI changes
- No audio changes
- No refactors
- Metrics are aggregated only: `calls , total,  max`

## Changes

- Add non‑invasive timing wrapper in runFromBlockNow.
- Add 2 small Jest tests for profiling on/off.

Tests

[npm test]
Known existing failure: `[planetInterface.test.js] (unrelated)` --> solved in #7077 

### Known issues (pre‑existing)


ESLint warning in `[logo.js:1731]`

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [x] Tests
- [ ] Documentation