### PR TITLE
fix: repair custom pitch pie menu behavior

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -12,7 +12,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const { piemenuPitches } = require("../piemenus");
+const {
+    piemenuPitches,
+    piemenuCustomNotes,
+    getPieMenuWheelOctaveDelta,
+    getCustomNoteLabels
+} = require("../piemenus");
 
 const piemenusPath = path.join(__dirname, "..", "piemenus.js");
 let piemenusContent;
@@ -33,11 +38,17 @@ global.window = {
     removeEventListener: jest.fn()
 };
 global.wheelnav = jest.fn().mockImplementation(function (div) {
-    const mockWheel = this;
     this.navItems = Array.from({ length: 20 }, () => ({
         title: "",
         enabled: true,
-        navItem: { hide: jest.fn(), show: jest.fn() },
+        navItem: { hide: jest.fn(), show: jest.fn(), title: "" },
+        basicNavTitleMax: { title: "" },
+        basicNavTitleMin: { title: "" },
+        hoverNavTitleMax: { title: "" },
+        hoverNavTitleMin: { title: "" },
+        selectedNavTitleMax: { title: "" },
+        selectedNavTitleMin: { title: "" },
+        initNavTitle: { title: "" },
         sliceSelectedAttr: {},
         sliceHoverAttr: {},
         titleSelectedAttr: {},
@@ -74,7 +85,9 @@ global.platformColor = {
     exitWheelcolors: ["#00ff00"],
     accidentalsWheelcolors: ["#0000ff"],
     octavesWheelcolors: ["#ffff00"],
-    accidentalsWheelcolorspush: "#cccccc"
+    accidentalsWheelcolorspush: "#cccccc",
+    intervalNameWheelcolors: ["#ff00ff"],
+    intervalWheelcolors: ["#00ffff"]
 };
 global._ = jest.fn(s => s);
 global.NOTENAMES = ["C", "D", "E", "F", "G", "A", "B"];
@@ -97,13 +110,14 @@ global.Synth = jest.fn().mockImplementation(() => ({
     loadSynth: jest.fn().mockResolvedValue(),
     setMasterVolume: jest.fn(),
     setVolume: jest.fn(),
+    getCustomFrequency: jest.fn().mockReturnValue(440),
     trigger: jest.fn().mockResolvedValue()
 }));
-global.instruments = [{}];
 global.DEFAULTVOICE = "sine";
 global.PREVIEWVOLUME = 0.5;
 global.getNote = jest.fn().mockReturnValue(["C", 4]);
 global.buildScale = jest.fn(() => [["C", "D", "E", "F", "G", "A", "B", "C"], []]);
+global.instruments = [{ sine: {} }];
 
 describe("piemenus behavioral tests", () => {
     let mockBlock;
@@ -128,7 +142,8 @@ describe("piemenus behavioral tests", () => {
                 blocksContainer: { x: 0, y: 0 },
                 getStageScale: jest.fn().mockReturnValue(1),
                 KeySignatureEnv: ["C", "major", false],
-                logo: { synth: new global.Synth(), errorMsg: jest.fn() }
+                logo: { synth: new global.Synth(), errorMsg: jest.fn() },
+                errorMsg: jest.fn()
             },
             connections: ["mock-id"],
             updateCache: jest.fn(),
@@ -198,6 +213,71 @@ describe("piemenus behavioral tests", () => {
         // prevPitch+delta = 4+1 = 5. 5 > 4, so deltaOctave = -1.
         // Octave 4 -> 3.
         expect(mockBlock.blocks.setPitchOctave).toHaveBeenCalledWith("mock-id", 3);
+    });
+
+    test("pitch wrap helper adjusts octave by musical direction", () => {
+        expect(getPieMenuWheelOctaveDelta(6, 0, 7)).toBe(-1);
+        expect(getPieMenuWheelOctaveDelta(0, 6, 7)).toBe(1);
+        expect(getPieMenuWheelOctaveDelta(4, 0, 5)).toBe(-1);
+        expect(getPieMenuWheelOctaveDelta(0, 4, 5)).toBe(1);
+    });
+
+    test("custom pitch labels are ordered high to low like regular pitch wheels", () => {
+        const temperament = {
+            pitchNumber: 5,
+            0: [1, "C", 4],
+            1: [1.2, "D#", 4],
+            2: [1.4, "F", 4],
+            3: [1.6, "G", 4],
+            4: [1.8, "A#", 4]
+        };
+
+        expect(getCustomNoteLabels(temperament)).toEqual(["A#", "G", "F", "D#", "C"]);
+    });
+
+    test("custom pitch wheel rotates, wraps octave, and previews selected frequency", async () => {
+        const temperament = {
+            pitchNumber: 5,
+            0: [1, "C", 4],
+            1: [1.2, "D#", 4],
+            2: [1.4, "F", 4],
+            3: [1.6, "G", 4],
+            4: [1.8, "A#", 4]
+        };
+
+        mockBlock.blocks.blockList["mock-id"].name = "pitch";
+        mockBlock.name = "customNote";
+        global.getNote.mockImplementation((note, octave) => [note, octave]);
+
+        piemenuCustomNotes(mockBlock, { custom: temperament }, ["custom"], "custom", "C");
+
+        expect(mockBlock._cusNoteWheel.clickModeRotate).toBe(true);
+        expect(mockBlock._cusNoteWheel.createWheel).toHaveBeenCalledWith([
+            "A#",
+            "G",
+            "F",
+            "D#",
+            "C"
+        ]);
+        expect(mockBlock._cusNoteWheel.selectedNavItemIndex).toBe(4);
+
+        mockBlock._cusNoteWheel.selectedNavItemIndex = 0;
+        await mockBlock._cusNoteWheel.navItems[0].navigateFunction();
+
+        expect(mockBlock.blocks.setPitchOctave).toHaveBeenCalledWith("mock-id", 3);
+        expect(mockBlock.activity.logo.synth.getCustomFrequency).toHaveBeenCalledWith(
+            "A#3",
+            "custom"
+        );
+        expect(mockBlock.activity.logo.synth.trigger).toHaveBeenCalledWith(
+            0,
+            440,
+            1 / 8,
+            "sine",
+            null,
+            null,
+            false
+        );
     });
 
     describe("Block Help Menu", () => {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -100,6 +100,60 @@ const getPieMenuSize = block => {
     return Math.min(canvas.width, canvas.height);
 };
 
+const getPieMenuWheelDelta = (previousIndex, currentIndex, itemCount) => {
+    const halfSpan = itemCount / 2;
+    const delta = currentIndex - previousIndex;
+
+    if (delta > halfSpan) {
+        return delta - itemCount;
+    } else if (delta < -halfSpan) {
+        return delta + itemCount;
+    }
+
+    return delta;
+};
+
+const getPieMenuWheelOctaveDelta = (previousIndex, currentIndex, itemCount) => {
+    const delta = getPieMenuWheelDelta(previousIndex, currentIndex, itemCount);
+
+    if (previousIndex + delta > itemCount - 1) {
+        return -1;
+    } else if (previousIndex + delta < 0) {
+        return 1;
+    }
+
+    return 0;
+};
+
+const getCustomNoteLabel = (key, value) => {
+    if (typeof value === "number") {
+        return key;
+    } else if (Array.isArray(value) && value.length > 1) {
+        return value[1];
+    }
+
+    return "";
+};
+
+const getCustomNoteLabels = temperament => {
+    return Object.keys(temperament)
+        .filter(key => key !== "pitchNumber" && key !== "interval")
+        .sort((a, b) => Number(b) - Number(a))
+        .map(key => getCustomNoteLabel(key, temperament[key]))
+        .filter(label => label !== "");
+};
+
+const navigateWheelWithoutAction = (wheel, index) => {
+    if (!wheel || !wheel.navItems || !wheel.navItems[index]) {
+        return;
+    }
+
+    const navigateFunction = wheel.navItems[index].navigateFunction;
+    wheel.navItems[index].navigateFunction = null;
+    wheel.navigateWheel(index);
+    wheel.navItems[index].navigateFunction = navigateFunction;
+};
+
 // Debounce resize handler for performance
 let wheelResizeTimeout;
 let wheelResizeListenerAttached = false;
@@ -569,25 +623,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
             const label = that._pitchWheel.navItems[that._pitchWheel.selectedNavItemIndex].title;
             const i = noteLabels.indexOf(label);
 
-            const noteCount = noteLabels.length;
-            const halfSpan = noteCount / 2;
-            const deltaPitch = i - prevPitch;
-            let delta;
-            if (deltaPitch > halfSpan) {
-                delta = deltaPitch - noteCount;
-            } else if (deltaPitch < -halfSpan) {
-                delta = deltaPitch + noteCount;
-            } else {
-                delta = deltaPitch;
-            }
-
-            // If we wrapped across C, we need to adjust the octave.
-            let deltaOctave = 0;
-            if (prevPitch + delta > noteCount - 1) {
-                deltaOctave = -1;
-            } else if (prevPitch + delta < 0) {
-                deltaOctave = 1;
-            }
+            const deltaOctave = getPieMenuWheelOctaveDelta(prevPitch, i, noteLabels.length);
             let attr;
             prevPitch = i;
             let note = noteValues[i];
@@ -1028,51 +1064,24 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         block._octavesWheel.createWheel(octaveLabels);
     }
 
-    //Disable rotation, set navAngle and create the menus
-    block._cusNoteWheel.clickModeRotate = false;
+    // Set navAngle and create the menus.
+    block._cusNoteWheel.clickModeRotate = true;
     block._cusNoteWheel.titleRotateAngle = 180;
     block._cusNoteWheel.animatetime = 0; // 300;
     const labelsDict = {};
     let labels = [];
-    let blockCustom = 0;
     let max = 0;
     for (const t of customLabels) {
         max = max > noteLabels[t]["pitchNumber"] ? max : noteLabels[t]["pitchNumber"];
     }
 
-    // There seems to be two different representations... maybe because
-    // of some legacy projects restoring customTemperamentNotes
     for (const t of customLabels) {
-        labelsDict[t] = [];
-        for (const k in noteLabels[t]) {
-            if (k !== "pitchNumber" && k !== "interval") {
-                if (typeof noteLabels[t][k] === "number") {
-                    // labels.push(k);
-                    labelsDict[t].push(k);
-                    blockCustom++;
-                } else {
-                    if (noteLabels[t][k].length === 3) {
-                        // labels.push(noteLabels[t][k][1]);
-                        labelsDict[t].push(noteLabels[t][k][1]);
-                        blockCustom++;
-                    } else {
-                        for (let ii = 0; ii < noteLabels[t][k].length; ii++) {
-                            // labels.push(noteLabels[t][k][ii][1]);
-                            labelsDict[t].push(noteLabels[t][k][1]);
-                            blockCustom++;
-                        }
-                    }
-                }
-            }
-        }
-        for (let extra = max - blockCustom; extra > 0; extra--) {
-            // labels.push("");
-        }
-        blockCustom = 0;
+        labelsDict[t] = getCustomNoteLabels(noteLabels[t]);
     }
     if (!(selectedCustom in labelsDict)) {
-        selectedCustom = labelsDict[0];
+        selectedCustom = customLabels[0];
     }
+    block.customID = selectedCustom;
     for (let i = 0; i < max; i++) {
         if (i < labelsDict[selectedCustom].length) {
             labels.push(labelsDict[selectedCustom][i]);
@@ -1103,6 +1112,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
     // Avoid auto-selecting the close button on open.
 
     const that = block;
+    let prevPitch = 0;
 
     // position widget
     const x = block.container.x;
@@ -1175,6 +1185,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
                 }
             }
             that._customWheel.refreshWheel();
+            prevPitch = 0;
             that._cusNoteWheel.navigateWheel(0);
         };
     };
@@ -1208,27 +1219,49 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         }
     }
 
-    if (typeof j === "number" && !isNaN(j)) {
-        block._cusNoteWheel.navigateWheel(max * customLabels.indexOf(selectedCustom) + j);
+    let startingPitchIndex = labels.indexOf(selectedNote);
+    if (startingPitchIndex === -1 && typeof j === "number" && !isNaN(j)) {
+        startingPitchIndex = labelsDict[selectedCustom].length - j - 1;
     }
+    if (startingPitchIndex !== -1) {
+        block._cusNoteWheel.navigateWheel(startingPitchIndex);
+    }
+    prevPitch = block._cusNoteWheel.selectedNavItemIndex;
 
     const __exitMenu = () => {
         that._piemenuExitTime = new Date().getTime();
         hideWheelDiv();
     };
 
-    const __selectionChanged = () => {
+    const __selectionChanged = async () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
+        if (!note) {
+            return;
+        }
+
         that.value = note;
         that.text.text = note;
         let octave = 4;
 
         if (hasOctaveWheel) {
-            // Set the octave of the pitch block if available
+            const selectedPitch = that._cusNoteWheel.selectedNavItemIndex;
+            const deltaOctave = getPieMenuWheelOctaveDelta(prevPitch, selectedPitch, labels.length);
+            prevPitch = selectedPitch;
+
             octave = Number(
                 that._octavesWheel.navItems[that._octavesWheel.selectedNavItemIndex].title
             );
+            octave += deltaOctave;
+            if (octave < 1) {
+                octave = 1;
+            } else if (octave > 8) {
+                octave = 8;
+            }
+
+            if (deltaOctave !== 0) {
+                navigateWheelWithoutAction(that._octavesWheel, 8 - octave);
+            }
             that.blocks.setPitchOctave(that.connections[0], octave);
         }
 
@@ -1236,29 +1269,61 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
 
-        const obj = getNote(note, octave, 0, "C major", false, null, that.activity.errorMsg, label);
-        const tur = that.activity.turtles.ithTurtle(0);
-
-        if (!tur.singer.instrumentNames.includes(DEFAULTVOICE)) {
-            that.activity.logo.synth.createDefaultSynth(0);
-            that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+        try {
+            await Tone.start();
+        } catch (e) {
+            console.debug("Tone.start() skipped or failed", e);
         }
 
-        that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
-        that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+        try {
+            const obj = getNote(
+                note,
+                octave,
+                0,
+                "C major",
+                false,
+                null,
+                that.activity.errorMsg,
+                label
+            );
 
-        if (!that._triggerLock) {
-            that._triggerLock = true;
-            // Get the frequency of the custom note for the preview.
-            const no = that.activity.logo.synth.getCustomFrequency([note + obj[1]], that.customID);
-            if (no !== undefined && no !== "undefined") {
-                instruments[0][DEFAULTVOICE].triggerAttackRelease(no, 1 / 8);
+            if (!that.activity.logo.synth.tone) {
+                that.activity.logo.synth.newTone();
             }
-        }
 
-        setTimeout(() => {
-            that._triggerLock = false;
-        }, 125); // 1/8 second in milliseconds
+            if (!instruments[0] || !instruments[0][DEFAULTVOICE]) {
+                that.activity.logo.synth.createDefaultSynth(0);
+                await that.activity.logo.synth.loadSynth(0, DEFAULTVOICE);
+            }
+
+            that.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
+            that.activity.logo.synth.setVolume(0, DEFAULTVOICE, PREVIEWVOLUME);
+
+            if (!that._triggerLock) {
+                that._triggerLock = true;
+                const frequency = that.activity.logo.synth.getCustomFrequency(
+                    note + obj[1],
+                    that.customID
+                );
+                if (frequency !== undefined && frequency !== "undefined") {
+                    await that.activity.logo.synth.trigger(
+                        0,
+                        frequency,
+                        1 / 8,
+                        DEFAULTVOICE,
+                        null,
+                        null,
+                        false
+                    );
+                }
+            }
+
+            setTimeout(() => {
+                that._triggerLock = false;
+            }, 125); // 1/8 second in milliseconds
+        } catch (e) {
+            console.error("Error in custom pitch preview:", e);
+        }
     };
 
     if (hasOctaveWheel) {
@@ -4530,5 +4595,10 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches };
+    module.exports = {
+        piemenuPitches,
+        piemenuCustomNotes,
+        getPieMenuWheelOctaveDelta,
+        getCustomNoteLabels
+    };
 }

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -433,6 +433,26 @@ describe("Utility Functions (logic-only)", () => {
         });
     });
 
+    describe("_performNotes", () => {
+        test("should accept numeric frequencies in custom temperaments", async () => {
+            const previousTemperament = Synth.inTemperament;
+            const mockSynth = {
+                triggerAttackRelease: jest.fn()
+            };
+
+            Synth.inTemperament = "custom";
+            await _performNotes(mockSynth, 440, 1 / 8, null, null, false, 0);
+
+            expect(mockSynth.triggerAttackRelease).toHaveBeenCalledWith(
+                440,
+                1 / 8,
+                expect.any(Number)
+            );
+
+            Synth.inTemperament = previousTemperament;
+        });
+    });
+
     describe("temperamentChanged", () => {
         it("should change the temperament", () => {
             expect(temperamentChanged("equal", "Bb3")).toBe(undefined);

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1731,7 +1731,10 @@ function Synth() {
 
         if (isCustomTemperament(this.inTemperament)) {
             const notes1 = notes;
-            if (notes.search("[+]") !== -1 || notes.search("[-]") !== -1) {
+            if (
+                typeof notes === "string" &&
+                (notes.search("[+]") !== -1 || notes.search("[-]") !== -1)
+            ) {
                 notes = this.getCustomFrequency(notes, this.inTemperament);
             }
             if (notes === undefined || notes === "undefined") {


### PR DESCRIPTION
## Summary
Fixes the Custom Pitch block pie menu behavior for custom temperaments.

## PR Category
- [x] Bug Fix
- [x] Tests
- [ ] Feature
- [ ] Performance
- [ ] Documentation

## Changes
- Order custom pitch labels high-to-low, matching regular pitch pie menus.
- Re-enable rotation for the custom pitch note wheel.
- Apply the same musical wrap logic used by pitch wheels so octave changes follow pitch direction.
- Use the synth preview path with `getCustomFrequency()` so selected custom pitches preview audibly.
- Guard custom-temperament preview playback when the synth receives a numeric frequency.
- Add behavior-level Jest coverage for ordering, wrap direction, rotation, octave updates, preview triggering, and numeric custom-frequency playback.

Fixes #2255

## Testing
- `npx.cmd jest js/__tests__/piemenus.test.js js/utils/__tests__/synthutils.test.js --runInBand --coverage=false`
- `npx.cmd prettier --check js/piemenus.js js/__tests__/piemenus.test.js js/utils/synthutils.js js/utils/__tests__/synthutils.test.js`
- `npm run lint`
- `npm.cmd test -- --runInBand`

Full test note: the full suite still has one unrelated existing failure in `js/__tests__/planetInterface.test.js`; 5007 tests passed.
