### PR TITLE
fix: replace innerHTML concatenation with programmatic DOM creation

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2424,7 +2424,7 @@ class Activity {
                     messages.load_messages[
                         Math.floor(Math.random() * messages.load_messages.length)
                     ];
-                document.getElementById("messageText").innerHTML = randomLoadMessage + "...";
+                document.getElementById("messageText").textContent = randomLoadMessage + "...";
                 counter++;
                 if (counter >= messages.load_messages.length) {
                     counter = 0;
@@ -7605,11 +7605,18 @@ class Activity {
 
             const intro = document.createElement("div");
             intro.className = "keyboard-shortcuts-hero";
-            intro.innerHTML =
-                `<div class="keyboard-shortcuts-hero-title">${_("Keyboard shortcuts")}</div>` +
-                `<div class="keyboard-shortcuts-hero-copy">${_(
-                    "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
-                )}</div>`;
+            const titleDiv = document.createElement("div");
+            titleDiv.className = "keyboard-shortcuts-hero-title";
+            titleDiv.textContent = _("Keyboard shortcuts");
+
+            const copyDiv = document.createElement("div");
+            copyDiv.className = "keyboard-shortcuts-hero-copy";
+            copyDiv.textContent = _(
+                "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
+            );
+
+            intro.appendChild(titleDiv);
+            intro.appendChild(copyDiv);
             wrapper.appendChild(intro);
 
             shortcutSections.forEach(section => {


### PR DESCRIPTION
## Description

I had modified `js/activity.js` to eliminate `innerHTML` string concatenations when building UI components with dynamic or translated strings and also enforces the project's security guidelines outlined in `AGENTS.md`.

## Related Issues
Fix :- #7109 


## Changes made

1. **Keyboard Shortcuts Widget:** Replaced the `innerHTML` string concatenation with secure `document.createElement()` and `textContent` calls.

2. **Loading Messages:** Replaced the `innerHTML` assignment with `textContent` to ensure loading strings (`randomLoadMessage`) are safely rendered as text.

### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation