### PR TITLE
fix: add Pointer Events support to Music Keyboard and Rhythm Ruler widgets for touch/mobile devices

### DIFF
--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update();
+            this.activity.stage.update(event);
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -220,7 +220,7 @@ class PlanetInterface {
                 return Promise.resolve(null);
             }
 
-            this.activity.stage.update(event);
+            this.activity.stage.update();
             const data = this.activity.prepareExport();
             const svgData = doSVG(
                 this.activity.canvas,

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -552,7 +552,10 @@ function MusicKeyboard(activity) {
 
         // Prevent the browser from scrolling or showing a context menu when the
         // user presses a key on a touch device.
-        element.style.touchAction = "none";
+        // Use pan-x instead of none so that the 700 px-wide keyboard can
+        // still be scrolled horizontally on narrow mobile viewports by
+        // dragging on a key; pinch-zoom is still suppressed.
+        element.style.touchAction = "pan-x";
 
         /**
          * Start a musical note when the element is pressed (mouse or touch).

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -522,7 +522,9 @@ function MusicKeyboard(activity) {
     };
 
     /**
-     * Handles the loading of musical keyboard elements and defines behavior for mouse events.
+     * Handles the loading of musical keyboard elements and defines pointer event
+     * handlers for each key. Uses the Pointer Events API (pointerdown/pointerup/
+     * pointercancel) to support mouse, touch, and stylus input uniformly.
      * @param {HTMLElement} element - The HTML element representing a musical key.
      * @param {number} i - The index of the musical key in the layout.
      * @param {number} blockNumber - The block number associated with the musical key.
@@ -548,8 +550,12 @@ function MusicKeyboard(activity) {
         let startDate = new Date();
         let startTime = 0;
 
+        // Prevent the browser from scrolling or showing a context menu when the
+        // user presses a key on a touch device.
+        element.style.touchAction = "none";
+
         /**
-         * Start a musical note when the element is clicked.
+         * Start a musical note when the element is pressed (mouse or touch).
          */
         const __startNote = element => {
             startDate = new Date();
@@ -565,10 +571,15 @@ function MusicKeyboard(activity) {
             );
         };
 
-        element.onmousedown = function () {
+        // Use Pointer Events so that mouse clicks, touchscreen taps, and stylus
+        // presses all trigger the same note-start behaviour.  The legacy
+        // onmousedown handler was silently ignored on touch devices.
+        element.addEventListener("pointerdown", function (e) {
+            e.preventDefault(); // prevent ghost mouse events on touch screens
+            element.setPointerCapture(e.pointerId); // keep events even if finger slides off
             activeKey = element;
-            __startNote(this);
-        };
+            __startNote(element);
+        });
 
         /**
          * End a musical note when the element is released.
@@ -613,11 +624,11 @@ function MusicKeyboard(activity) {
             this._updateWidgetWindowSize();
         };
 
-        element.onmouseup = function () {
+        element.addEventListener("pointerup", function () {
             if (activeKey === element) {
-                __endNote(this);
+                __endNote(element);
                 activeKey = null;
-            } else {
+            } else if (activeKey !== null) {
                 const id = activeKey.id;
                 if (id.includes("blackRow")) {
                     activeKey.style.backgroundColor = "black";
@@ -626,7 +637,16 @@ function MusicKeyboard(activity) {
                 }
                 activeKey = null;
             }
-        };
+        });
+
+        // Clean up note state if the pointer is cancelled mid-press
+        // (e.g., an incoming phone call dismisses the touch).
+        element.addEventListener("pointercancel", function () {
+            if (activeKey === element) {
+                __endNote(element);
+                activeKey = null;
+            }
+        });
     };
 
     /**

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -1362,6 +1362,10 @@ class RhythmRuler {
      * @returns {void}
      */
     __addCellEventHandlers(cell, cellWidth, noteValue) {
+        // Prevent the browser from scrolling the page when the user drags
+        // across rhythm cells on a touchscreen.
+        cell.style.touchAction = "none";
+
         const __mouseOverHandler = event => {
             const cell = event.currentTarget;
             if (cell === null || cell.parentNode === null) {
@@ -1471,11 +1475,15 @@ class RhythmRuler {
             cell.addEventListener("mouseout", __mouseOutHandler);
         }
 
-        cell.removeEventListener("mousedown", __mouseDownHandler);
-        cell.addEventListener("mousedown", __mouseDownHandler);
+        // Use Pointer Events API instead of legacy mouse events so that rhythm
+        // cells respond to touchscreen taps and stylus input as well as mouse
+        // clicks.  The Pointer Events spec guarantees these fire for all input
+        // device types on modern browsers.
+        cell.removeEventListener("pointerdown", __mouseDownHandler);
+        cell.addEventListener("pointerdown", __mouseDownHandler);
 
-        cell.removeEventListener("mouseup", __mouseUpHandler);
-        cell.addEventListener("mouseup", __mouseUpHandler);
+        cell.removeEventListener("pointerup", __mouseUpHandler);
+        cell.addEventListener("pointerup", __mouseUpHandler);
 
         cell.removeEventListener("click", __clickHandler);
         cell.addEventListener("click", __clickHandler);
@@ -3030,16 +3038,27 @@ class RhythmRuler {
                 this._circularCanvas = document.createElement("canvas");
                 this._circularCanvas.style.display = "block";
                 this._circularCanvas.style.margin = "auto";
-                this._circularCanvas.addEventListener("mousedown", event => {
+                // touch-action: none lets us handle all pointer movement
+                // ourselves without the browser intercepting pinch/pan gestures.
+                this._circularCanvas.style.touchAction = "none";
+                // Use Pointer Events so the circular drag-to-edit works on
+                // touchscreens and stylus devices, not just mouse.
+                this._circularCanvas.addEventListener("pointerdown", event => {
                     this._onCircularMouseDown(event);
                 });
-                this._circularCanvas.addEventListener("mousemove", event => {
+                this._circularCanvas.addEventListener("pointermove", event => {
                     this._onCircularMouseMove(event);
                 });
-                this._circularCanvas.addEventListener("mouseup", event => {
+                this._circularCanvas.addEventListener("pointerup", event => {
                     this._onCircularMouseUp(event);
                 });
-                this._circularCanvas.addEventListener("mouseleave", () => {
+                this._circularCanvas.addEventListener("pointercancel", () => {
+                    if (this._circularDragTo !== null) {
+                        this._circularDragTo = null;
+                        this._drawCircularView();
+                    }
+                });
+                this._circularCanvas.addEventListener("pointerleave", () => {
                     if (this._circularDragTo !== null) {
                         this._circularDragTo = null;
                         this._drawCircularView();

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -1362,9 +1362,10 @@ class RhythmRuler {
      * @returns {void}
      */
     __addCellEventHandlers(cell, cellWidth, noteValue) {
-        // Prevent the browser from scrolling the page when the user drags
-        // across rhythm cells on a touchscreen.
-        cell.style.touchAction = "none";
+        // Allow horizontal panning (pan-x) on cells so wide ruler patterns
+        // can still be scrolled on mobile when they overflow the viewport,
+        // while still suppressing pinch-zoom on individual cells.
+        cell.style.touchAction = "pan-x";
 
         const __mouseOverHandler = event => {
             const cell = event.currentTarget;
@@ -1423,7 +1424,12 @@ class RhythmRuler {
         const __mouseUpHandler = event => {
             this._clearWidgetTimeout(this._longPressBeep);
             this._longPressBeep = null;
-            const cell = event.currentTarget;
+            // On touch with Pointer Events, the browser implicitly captures the
+            // pointer to the pointerdown target, so event.target is always the
+            // cell that received pointerdown — meaning drag-across-cells-to-tie
+            // would never fire on mobile. elementFromPoint resolves the actual
+            // element under the finger at release time for both mouse and touch.
+            const cell = document.elementFromPoint(event.clientX, event.clientY) || event.target;
             this._mouseUpCell = cell;
             if (this._mouseDownCell !== this._mouseUpCell) {
                 this._tieRuler(event, cell.parentNode.getAttribute("data-row"));
@@ -3052,18 +3058,17 @@ class RhythmRuler {
                 this._circularCanvas.addEventListener("pointerup", event => {
                     this._onCircularMouseUp(event);
                 });
-                this._circularCanvas.addEventListener("pointercancel", () => {
+                // Both pointercancel and pointerleave perform the same
+                // cleanup — extract to a named handler to avoid duplication
+                // and match the __mouseDownHandler/__mouseUpHandler convention.
+                const __onCircularDragEnd = () => {
                     if (this._circularDragTo !== null) {
                         this._circularDragTo = null;
                         this._drawCircularView();
                     }
-                });
-                this._circularCanvas.addEventListener("pointerleave", () => {
-                    if (this._circularDragTo !== null) {
-                        this._circularDragTo = null;
-                        this._drawCircularView();
-                    }
-                });
+                };
+                this._circularCanvas.addEventListener("pointercancel", __onCircularDragEnd);
+                this._circularCanvas.addEventListener("pointerleave", __onCircularDragEnd);
                 this.widgetWindow.getWidgetBody().append(this._circularCanvas);
             }
             this._circularCanvas.style.display = "block";


### PR DESCRIPTION
### Description

The **Music Keyboard** (`js/widgets/musickeyboard.js`) and **Rhythm Ruler** (`js/widgets/rhythmruler.js`) widgets were completely unresponsive on touch devices. All interactive elements in both widgets relied exclusively on legacy `onmousedown`/`onmouseup` handlers and `mousedown`/`mouseup` event listeners — none of which are dispatched by mobile browsers for touch input.

This PR replaces those handlers with the **W3C Pointer Events API** (`pointerdown`, `pointerup`, `pointercancel`, `pointermove`, `pointerleave`), which unifies mouse, touch, and stylus input into a single event model supported by all modern browsers. Desktop behaviour is fully preserved — pointer events fire for mouse input as well.

Fixes: Music Keyboard piano keys produce no sound on mobile. Rhythm Ruler cells and circular canvas are completely unresponsive on touch.

Issue #7111 

### Expected Behavior

- Tapping a piano key in the Music Keyboard on a touchscreen highlights the key and plays the note
- Tapping a rhythm cell in the Rhythm Ruler dissects or interacts with the cell
- Dragging on the Rhythm Ruler circular canvas works via touch

### Screenshots

_Reproducible via Chrome DevTools → F12 → Toggle Device Toolbar → enable touch simulation_

### How to Reproduce

1. Open https://musicblocks.sugarlabs.org on mobile (Chrome Android / Safari iOS) or Chrome DevTools touch emulation
2. Open the **Music Keyboard** widget → tap any piano key → no sound, no highlight
3. Open the **Rhythm Ruler** widget → tap any rhythm cell → no response
4. Toggle the circular view → drag on the canvas → no response

### Console log Errors:

No JS errors are thrown — the touch events were simply never registered. Root cause confirmed via code audit:

**`js/widgets/musickeyboard.js` (~line 568):**
```js
// Before (broken on touch):
element.onmousedown = function () { ... };
element.onmouseup   = function () { ... };

// After (works on all devices):
element.addEventListener("pointerdown", function (e) { ... });
element.addEventListener("pointerup",   function ()  { ... });
element.addEventListener("pointercancel", function () { ... });
```
**`js/widgets/rhythmruler.js` (~line 1447 and ~line 3005):**
```js
// Before: mousedown/mouseup/mousemove/mouseleave
// After:  pointerdown/pointerup/pointermove/pointerleave/pointercancel
```

### Environment:

- Operating System: macOS / Android / iOS (reproducible on all)
- Browser: Chrome for Android, Safari for iOS, Chrome DevTools touch emulation
- Version of Software/Project: master branch (latest)

### Checklist

- [x] I have read and followed the project's code of conduct.
- [x] I have searched for similar issues before creating this one.
- [x] I have provided all the necessary information to understand and reproduce the issue.
- [x] I am willing to contribute to the resolution of this issue.

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

