### PR TITLE
fix: remove false coverage from PitchBlocks tests

### DIFF
--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -739,18 +739,6 @@ describe("setupPitchBlocks", () => {
         });
     });
 
-    describe("Macro Execution", () => {
-        it("calls makeMacro on all blocks that have it", () => {
-            Object.values(createdBlocks).forEach(block => {
-                if (block.makeMacro) {
-                    block.makeMacro(100, 100);
-                    block.makeMacro(null, null);
-                }
-            });
-            expect(true).toBe(true);
-        });
-    });
-
     describe("Existence", () => {
         const blocks = [
             "rest",


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [x] Test

### Summary
Remove false coverage test that called all methods and then asserted `expect(true).toBe(true)`.

### What Changed
- Deleted the `Macro Execution` describe block from `js/blocks/__tests__/PitchBlocks.test.js`.
- Removed a test that asserted no meaningful behavior.

### Why
The test looped over blocks but ended with `expect(true).toBe(true)`, giving misleading coverage numbers.

