### PR TITLE
fix: correct "pich" typo in number to pitch block help string

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -716,7 +716,7 @@ function setupPitchBlocks(activity) {
             super(name || "number2pitch", displayName || _("number to pitch"));
             this.setPalette("pitch", activity);
             this.setHelpString([
-                _("The Number to pitch block will convert a pitch number to a pich name."),
+                _("The Number to pitch block will convert a pitch number to a pitch name."),
                 "documentation",
                 ""
             ]);


### PR DESCRIPTION
## Summary

Fixes a typo in the help text for the `number to pitch` block in `js/blocks/PitchBlocks.js`.

> "The Number to pitch block will convert a pitch number to a pich name."

→

> "The Number to pitch block will convert a pitch number to a pitch name."

## Why

- "pich" is a typo and inconsistent with the rest of the sentence and file.

## Translation impact

The typo was part of the translation key. Only the source string is updated; translation files will be updated via Weblate.

## Test plan

- Verified the change is a one-line fix in a translation string
- Lint and tests pass

## PR Category

- [x] Bug Fix

Closes #7123 