### PR TITLE
fix: add @xmldom/xmldom override to resolve high severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,57 +22,11 @@
                 "gulp-sourcemaps": "^3.0.0",
                 "howler": "1.1.25",
                 "http-server": "^14.1.1",
-                "i18next": "^25.3.2",
+                "i18next": "^25.8.18",
                 "i18next-http-backend": "^3.0.2",
                 "jquery": "3.7.1",
                 "jquery-ui-dist": "1.12.1",
                 "materialize-css": "0.100.2",
-                "postcss": "^8.5.6",
-                "sass": "^1.97.2",
-                "tone": "^15.1.22"
-            },
-            "devDependencies": {
-                "@babel/core": "^7.28.5",
-                "@babel/eslint-parser": "^7.28.5",
-                "@babel/preset-env": "^7.28.5",
-                "cross-env": "^7.0.3",
-                "cypress": "^15.9.0",
-                "electron": "40.8.5",
-                "electron-builder": "26.8.1",
-                "eslint": "^9.0.0",
-                "eslint-config-prettier": "^9.0.0",
-                "fake-indexeddb": "6.2.5",
-                "gulp": "^5.0.1",
-                "gulp-babel": "^8.0.0",
-                "gulp-clean-css": "^4.3.0",
-                "gulp-prettier": "^3.0.0",
-                "gulp-uglify": "^3.0.2",
-                "husky": "^9.1.7",
-                "jest": "^29.7.0",
-                "jest-environment-jsdom": "^30.2.0",
-                "lint-staged": "^15.5.2",
-                "nodemon": "^3.1.9",
-                "prettier": "^3.6.2"
-            }
-        },
-        "": {
-            "name": "musicblocks",
-            "version": "3.4.1",
-            "license": "AGPL-3.0 License",
-            "dependencies": {
-                "@tonejs/midi": "^2.0.28",
-                "autoprefixer": "^10.4.16",
-                "compression": "^1.8.1",
-                "cssnano": "^7.1.2",
-                "express": "5.2.1",
-                "gulp-concat": "^2.6.1",
-                "gulp-postcss": "^10.0.0",
-                "gulp-replace": "^1.1.4",
-                "gulp-sass": "^6.0.1",
-                "gulp-sourcemaps": "^3.0.0",
-                "http-server": "^14.1.1",
-                "i18next": "^25.8.18",
-                "i18next-http-backend": "^3.0.2",
                 "postcss": "^8.5.6",
                 "sass": "^1.98.0",
                 "tone": "^15.1.22"
@@ -4236,16 +4190,6 @@
             "optional": true,
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.8.12",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/7zip-bin": {
@@ -13543,6 +13487,16 @@
             },
             "engines": {
                 "node": ">=10.4.0"
+            }
+        },
+        "node_modules/plist/node_modules/@xmldom/xmldom": {
+            "version": "0.8.13",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/plugin-error": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "@isaacs/brace-expansion": "^5.0.1",
         "immutable": "^5.1.5",
         "svgo": "^4.0.1",
+        "@xmldom/xmldom": "^0.8.13",
         "@gulp-sourcemaps/identity-map": {
             "postcss": "^8.4.31"
         }


### PR DESCRIPTION
Adds package.json override to pin @xmldom/xmldom to >=0.8.13, resolving 4 high severity CVEs related to DoS and XML injection.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation