### PR TITLE
fix: bump i18next-http-backend to resolve path traversal CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "howler": "1.1.25",
                 "http-server": "^14.1.1",
                 "i18next": "^25.8.18",
-                "i18next-http-backend": "^3.0.2",
+                "i18next-http-backend": "^3.0.5",
                 "jquery": "3.7.1",
                 "jquery-ui-dist": "1.12.1",
                 "materialize-css": "0.100.2",
@@ -9546,9 +9546,9 @@
             }
         },
         "node_modules/i18next-http-backend": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.4.tgz",
-            "integrity": "sha512-udwrBIE6cNpqn1gRAqRULq3+7MzIIuaiKRWrz++dVz5SqWW2VwXmPJtAgkI0JtMLFaADC9qNmnZAxWAhsxXx2g==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+            "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
             "license": "MIT",
             "dependencies": {
                 "cross-fetch": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "howler": "1.1.25",
         "http-server": "^14.1.1",
         "i18next": "^25.8.18",
-        "i18next-http-backend": "^3.0.2",
+        "i18next-http-backend": "^3.0.5",
         "jquery": "3.7.1",
         "jquery-ui-dist": "1.12.1",
         "materialize-css": "0.100.2",


### PR DESCRIPTION
Bumps i18next-http-backend from ^3.0.2 to ^3.0.5, resolving a moderate path traversal CVE (GHSA-q89c-q3h5-w34g).

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation