### PR TITLE
fix: correct ABC notation for end-decrescendo decoration

### DIFF
--- a/js/__tests__/abc.test.js
+++ b/js/__tests__/abc.test.js
@@ -159,6 +159,7 @@ describe("processABCNotes - Control Strings", () => {
         expect(out).toContain("!<(!");
         expect(out).toContain("!<)!");
         expect(out).toContain("!>(!");
+        expect(out).toContain("!>)!");
         expect(out).toContain("V:1");
         expect(out).toContain("V:2");
         expect(out).toContain("V:3");

--- a/js/abc.js
+++ b/js/abc.js
@@ -144,7 +144,7 @@ const processABCNotes = function (logo, turtle) {
                     parts.push("!>(!");
                     break;
                 case "end decrescendo":
-                    parts.push("!<(!");
+                    parts.push("!>)!");
                     break;
                 case "begin slur":
                     queueSlur = true;
@@ -210,7 +210,7 @@ const processABCNotes = function (logo, turtle) {
 
             // If it is a tuplet, look ahead to see if it is complete.
             // While you are at it, add up the durations.
-            if (obj[NOTATIONTUPLETVALUE] != null) {
+            if (obj[NOTATIONTUPLETVALUE] !== undefined && obj[NOTATIONTUPLETVALUE] !== null) {
                 targetDuration = 1 / logo.notation.notationStaging[turtle][i][NOTATIONDURATION];
                 tupletDuration = 1 / logo.notation.notationStaging[turtle][i][NOTATIONROUNDDOWN];
                 let j = 1;

--- a/js/abc.js
+++ b/js/abc.js
@@ -210,7 +210,7 @@ const processABCNotes = function (logo, turtle) {
 
             // If it is a tuplet, look ahead to see if it is complete.
             // While you are at it, add up the durations.
-            if (obj[NOTATIONTUPLETVALUE] !== undefined && obj[NOTATIONTUPLETVALUE] !== null) {
+            if (obj[NOTATIONTUPLETVALUE] != null) {
                 targetDuration = 1 / logo.notation.notationStaging[turtle][i][NOTATIONDURATION];
                 tupletDuration = 1 / logo.notation.notationStaging[turtle][i][NOTATIONROUNDDOWN];
                 let j = 1;


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
## Summary

`processABCNotes` emitted `!<(!` (begin crescendo) for the `end decrescendo` case instead of `!>)!`. Fix the case and add a regression assertion.

## Demonstration

The existing test exercised all four dynamics commands but never asserted on the `end decrescendo` output. Adding `expect(out).toContain("!>)!")` fails on master and passes after the fix.

## Changes

- `js/abc.js:147` — `"!<(!"` → `"!>)!"`
- `js/__tests__/abc.test.js` — regression assertion for `!>)!`