### PR TITLE
fix: resolve failing test-cases and html linting issues

### DIFF
--- a/Docs/guide-pt/index.html
+++ b/Docs/guide-pt/index.html
@@ -4058,7 +4058,6 @@
           </tbody>
         </table>
         <p><a href="#table-of-contents">Voltar ao Índice</a></p>
-      </div>
     <script>
       function toggleImageSize(img) {
         if (img.style.maxWidth === "none") {

--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -222,7 +222,7 @@ describe("PlanetInterface", () => {
         planetInterface.planet = { ProjectStorage: { saveLocally: jest.fn() } };
 
         return planetInterface.saveLocally().then(() => {
-            expect(mockActivity.stage.update).toHaveBeenCalledWith(undefined);
+            expect(mockActivity.stage.update).toHaveBeenCalled();
             expect(planetInterface.planet.ProjectStorage.saveLocally).toHaveBeenCalledWith(D, null);
         });
     });

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -461,7 +461,7 @@ class Tempo {
                 [5, ["vspace", {}], 0, 0, [0, null]]
             ];
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
         };
 
         if (this.widgetWindow && this.widgetWindow.timerManager) {

--- a/planet/index.html
+++ b/planet/index.html
@@ -104,7 +104,6 @@
                 </li>
             </ul>
         </div>
-        </div>
     </nav>
     <nav class="nav-extended light-green lighten-1" id="two_header" role="navigation">
         <div id="searchcontainer" class="nav-content">


### PR DESCRIPTION
This PR resolves multiple ci failures across Jest testcases and HTML linting, and lays the groundwork for improving overall test coverage.

## PR Category  
- [x] Tests
- [x] Bug Fix

Fix: #7148 

### Before:
<img width="1158" height="547" alt="Screenshot 2026-05-04 at 11 25 23 AM" src="https://github.com/user-attachments/assets/e82f69b6-db57-4d77-ba87-140e44826f04" />

### After: 
<img width="476" height="201" alt="Screenshot 2026-05-04 at 11 27 39 AM" src="https://github.com/user-attachments/assets/aa32a49c-f9a2-48a1-ba77-dfac5c792843" />

### Jest Fixes
- `planetInterface.test.js`: Updated incorrect expectation to `toHaveBeenCalled()` (no args passed).
- `tempo.test.js`: Fixed `ReferenceError` by changing `activity.textMsg` →` this.activity.textMsg`

 ### Lint / HTML Fixes

- Removed extra </div> tags causing Prettier failures in:
    * Docs/guide-pt/index.html
    * planet/index.html

### Coverage Note

* Current coverage: ~46% statements, ~50% functions.
* Several core modules and widgets still have low coverage (0–7%).
