### PR TITLE
fix by adding defensive null checks inside _updateWidgetWindowSize()

### DIFF
--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1516,29 +1516,42 @@ function MusicKeyboard(activity) {
      * Update the widget window size based on whether it is maximized or not.
      */
     this._updateWidgetWindowSize = function () {
+        const outerDiv = docById("mkbOuterDiv");
+        if (!outerDiv) return;
+
         if (this.widgetWindow._maximized) {
             this.widgetWindow.getWidgetBody().style.position = "absolute";
             this.widgetWindow.getWidgetBody().style.height = "calc(100vh - 64px)";
             this.widgetWindow.getWidgetBody().style.width = "200vh";
-            const outerDiv = docById("mkbOuterDiv");
             outerDiv.style.maxHeight = "725px";
-            docById("mkbOuterDiv").style.height = "calc(100vh - 64px)";
-            docById("mkbOuterDiv").style.width = "calc(200vh - 64px)";
-            docById("keyboardHolder2").style.width = "calc(200vh - 64px)";
-            docById("mkbInnerDiv").style.width = "95.5vw";
-            docById("mkbInnerDiv").style.height = "75%";
+            outerDiv.style.height = "calc(100vh - 64px)";
+            outerDiv.style.width = "calc(200vh - 64px)";
+
+            const keyboardHolder = docById("keyboardHolder2");
+            if (keyboardHolder) {
+                keyboardHolder.style.width = "calc(200vh - 64px)";
+            }
+
             const innerDiv = docById("mkbInnerDiv");
-            innerDiv.scrollLeft = innerDiv.scrollWidth;
+            if (innerDiv) {
+                innerDiv.style.width = "95.5vw";
+                innerDiv.style.height = "75%";
+                innerDiv.scrollLeft = innerDiv.scrollWidth;
+            }
+
             this.widgetWindow.getWidgetBody().style.left = "60px";
         } else {
-            const outerDiv = docById("mkbOuterDiv");
             outerDiv.style.maxHeight = "400px";
             this.widgetWindow.getWidgetBody().style.position = "relative";
             this.widgetWindow.getWidgetBody().style.left = "0px";
             this.widgetWindow.getWidgetBody().style.height = "550px";
             this.widgetWindow.getWidgetBody().style.width = "1000px";
-            docById("mkbOuterDiv").style.width = w + "px";
-            docById("mkbInnerDiv").style.height = "100%";
+            outerDiv.style.width = w + "px";
+
+            const innerDiv = docById("mkbInnerDiv");
+            if (innerDiv) {
+                innerDiv.style.height = "100%";
+            }
         }
     };
 


### PR DESCRIPTION
## Title
[Bug] fix: prevent crash in Music Keyboard on Clear by adding null guards

---

## Summary
Fixes #7146

This PR fixes a crash in the Music Keyboard widget that occurs when clicking the **Clear** button after playing notes.

---

## Description
Clicking the **Clear** button triggers a JavaScript error because `_updateWidgetWindowSize()` accesses DOM elements that may no longer exist after `_createTable()` clears the widget DOM.

This results in a null reference crash when the code tries to access `.style` on removed elements.

---

## Steps to Reproduce
1. Open Music Blocks
2. Open the **Music Keyboard** widget
3. Play some notes
4. Click the **Clear** button (erase icon)
5. Observe the console error

---

## Expected Behavior
- Notes should be cleared successfully
- The widget should update and resize correctly
- No console errors should occur

---

## Actual Behavior
- A `TypeError` is thrown
- `_updateWidgetWindowSize()` tries to access removed DOM elements
- Widget update fails and a console error appears

---

## Console Error
Uncaught TypeError: Cannot read properties of null (reading 'style')
at MusicKeyboard._updateWidgetWindowSize (musickeyboard.js:1541:35)
at widgetWindow.addButton.onclick (musickeyboard.js:740:18)

---

## Root Cause
- `_createTable()` removes `mkbInnerDiv` when `selectedNotes.length < 1`
- `_updateWidgetWindowSize()` is still called after the DOM is cleared
- The function assumes elements like `mkbInnerDiv` and `keyboardHolder2` always exist
- Direct `.style` access on a null element causes the crash

---

## Solution
Added defensive null checks inside `_updateWidgetWindowSize()` so DOM elements are only accessed when they exist.

### Fix applied
const outerDiv = docById("mkbOuterDiv");
if (!outerDiv) return;

const keyboardHolder = docById("keyboardHolder2");
if (keyboardHolder) {
    keyboardHolder.style.width = "calc(200vh - 64px)";
}

const innerDiv = docById("mkbInnerDiv");
if (innerDiv) {
    innerDiv.style.width = "95.5vw";
    innerDiv.style.height = "75%";
    innerDiv.scrollLeft = innerDiv.scrollWidth;
}

---

## Why This Fix Works
- Prevents access to null DOM elements
- Ensures safe execution regardless of widget state
- Fixes the crash at the function level, not just the caller level
- Makes the widget more resilient to DOM changes after clearing

---

## Testing Performed

### Case 1: Clear after playing notes
- Open widget
- Play notes
- Click Clear
- No console error

### Case 2: Clear without notes
- Open widget
- Click Clear immediately
- No console error

### Case 3: Maximize + Clear
- Open widget
- Play notes
- Maximize
- Click Clear
- No console error

---

## Changes
- File modified: `js/widgets/musickeyboard.js`
- Added null guards in `_updateWidgetWindowSize()`
- Removed unsafe DOM access assumptions

---

## Checklist
- [x] Minimal and focused fix
- [x] Tested locally
- [x] No new dependencies
- [x] Prevents null DOM crashes

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation