### PR TITLE
Fix plugin fetch failures showing only console output

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -109,6 +109,9 @@ function setupProgramBlocks(activity) {
                 })
                 .catch(error => {
                     console.debug("Fetch error:", error);
+                    if (error?.message !== "Network response was not ok") {
+                        activity.errorMsg(_("Failed to load plugin from URL"), blk);
+                    }
                     logo.turtleHeaps[name] = oldHeap;
                 });
         }

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -237,6 +237,7 @@ describe("ProgramBlocks", () => {
 
         test("handles network error", async () => {
             global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+            logo.turtleHeaps.testHeap = ["old-item"];
 
             const block = getBlock("loadHeapFromApp");
             block.flow(["testHeap", "http://test.com"], logo, 0, 1);
@@ -244,7 +245,8 @@ describe("ProgramBlocks", () => {
             // Wait for the async fetch to complete
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            // Should not throw, error is handled gracefully
+            expect(activity.errorMsg).toHaveBeenCalledWith("Failed to load plugin from URL", 1);
+            expect(logo.turtleHeaps.testHeap).toEqual(["old-item"]);
             expect(global.fetch).toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
## Summary\nThis PR addresses one concrete slice of issue #7154: when loading a plugin from a URL fails in ProgramBlocks.js, the failure now surfaces a visible error message and the heap state is restored cleanly.\n\n## What changed\n- Show a user-facing error for real fetch/network failures while loading a plugin from URL.\n- Keep the existing 404 handling unchanged so that path does not double-report.\n- Add regression coverage for the network-error path.\n\n## Validation\n- 
px jest js/blocks/__tests__/ProgramBlocks.test.js --runInBand --coverage=false\n- 
px eslint js/blocks/ProgramBlocks.js js/blocks/__tests__/ProgramBlocks.test.js\n- git diff --check\n\n## Scope\nThis PR intentionally stays narrow and only covers the plugin fetch failure path from #7154.