### PR TITLE
fix(blocks): guard hideContents click in trash flow

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7340,7 +7340,10 @@ class Blocks {
             }
             this.activity.refreshCanvas();
             this.activity.trashcan.stopHighlightAnimation();
-            document.getElementById("hideContents").click();
+            const hideContents = document.getElementById("hideContents");
+            if (hideContents) {
+                hideContents.click();
+            }
         };
 
         /***


### PR DESCRIPTION
## Summary
This PR fixes an unguarded `#hideContents` click in the block-deletion trash flow.

Fixes #7158

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
In `js/blocks.js` (inside `sendStackToTrash` path), the code directly called:

- `document.getElementById("hideContents").click();`

If `#hideContents` is absent in the current DOM state, this throws:

- `TypeError: Cannot read properties of null (reading 'click')`

That can interrupt trash cleanup in a core editing action.

## Fix
Replaced the direct call with a null guard:

```js
const hideContents = document.getElementById("hideContents");
if (hideContents) {
    hideContents.click();
}
```

## Why this is safe
- No behavior change when `#hideContents` exists.
- Prevents runtime crash when it doesn't.
- Scope is minimal and limited to the problematic call site.

## Validation
- Ran targeted Jest test locally:
  - `npx jest --runInBand --coverage=false js/__tests__/activity_listeners.test.js` ?
