### PR TITLE
perf: modernize UI rendering with requestAnimationFrame

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6074,7 +6074,7 @@ class Blocks {
                 }
                 bIndex = chunkEnd;
                 if (bIndex < totalBlocks) {
-                    setTimeout(processChunk, 0);
+                    window.requestAnimationFrame(processChunk);
                 }
             };
 

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -73,7 +73,7 @@ class HelpWidget {
         this._helpDiv = document.createElement("div");
 
         // Give the DOM time to create the div.
-        setTimeout(() => this._setup(useActiveBlock, 0), 0);
+        window.requestAnimationFrame(() => this._setup(useActiveBlock, 0));
 
         // Position center
         setTimeout(this.widgetWindow.sendToCenter, 50);

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -200,7 +200,7 @@ class ModeWidget {
 
         //.TRANS: A circle of notes represents the musical mode.
         activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
-        this._setTimeout(() => this.widgetWindow.sendToCenter(), 0);
+        window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
     }
 
     /**

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -191,7 +191,7 @@ class PitchSlider {
 
         activity.textMsg(_("Use the up/down buttons or arrow keys to change pitch."), 3000);
         activity.textMsg(_("Click on the slider to create a note block."), 3000);
-        setTimeout(this.widgetWindow.sendToCenter, 0);
+        window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
     }
 
     /**


### PR DESCRIPTION
### Description
This PR replaces legacy UI-bound `setTimeout(..., 0)` calls with `window.requestAnimationFrame()` to synchronize layout calculations with the display's native refresh rate, resolving "jitter" and dropped frames.

### Related Issue 
Fix :- #7153 

### Changes Made
- **`js/blocks.js`**: Chunked block-loading now aligns with the paint cycle, eliminating stutter during large project loads.
- **`js/widgets/pitchslider.js` & `modewidget.js`**: Widget centering instantly calculates on the next frame to prevent 1-frame visual jumps.
- **`js/widgets/help.js`**: Prevents layout thrashing by syncing DOM population with the paint cycle.

### Testing
- Passed `npm run lint`, `npx prettier`, and `npm test` locally.
- Their functioning same as ever but get enhanced on large project.

### PR category 
- [x] Performance