### PR TITLE
fix: replace createjs.Graphics.getRGB with native rgba() in muns…

### DIFF
--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -14,12 +14,6 @@
 // which is a vast improvement over the Munsell Perl module
 // written by Walter Bender and Jon Orwant back in the day.
 
-/*
-   Note: This file previously referenced createjs.Graphics.getRGB().
-   That dependency has been removed. interpColor() now returns a native
-   rgba() CSS string.
- */
-
 /* exported getMunsellColor, getcolor, searchColors, COLORS40 */
 
 /**

--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -14,12 +14,10 @@
 // which is a vast improvement over the Munsell Perl module
 // written by Walter Bender and Jon Orwant back in the day.
 
-/* global createjs */
-
 /*
-   Global locations
-    js/loader.js
-        createjs
+   Note: This file previously referenced createjs.Graphics.getRGB().
+   That dependency has been removed. interpColor() now returns a native
+   rgba() CSS string.
  */
 
 /* exported getMunsellColor, getcolor, searchColors, COLORS40 */
@@ -6729,7 +6727,7 @@ const MUNSELL = [
  * @param {string} hex1 - The first hex color value.
  * @param {string} hex2 - The second hex color value.
  * @param {number} p - The interpolation parameter (between 0 and 1).
- * @returns {string} The interpolated hex color value.
+ * @returns {string} The interpolated color as a CSS rgba() string (e.g., "rgba(255, 0, 0, 1)").
  */
 const interpColor = (hex1, hex2, p) => {
     if (hex1 === undefined && hex2 === undefined) {
@@ -6756,7 +6754,7 @@ const interpColor = (hex1, hex2, p) => {
         const ng = Math.floor(g1 * p + g2 * (1 - p));
         const nb = Math.floor(b1 * p + b2 * (1 - p));
 
-        return createjs.Graphics.getRGB(nr, ng, nb, 1.0);
+        return `rgba(${nr}, ${ng}, ${nb}, 1)`;
     }
 };
 


### PR DESCRIPTION
## Summary
This is the first step in migrating Music Blocks away from the abandoned
CreateJS library (`easeljs`, `tweenjs`, `preloadjs`) towards modern, maintained
alternatives.
### What was changed
In `js/utils/munsell.js`, the `interpColor()` function used
`createjs.Graphics.getRGB(nr, ng, nb, 1.0)` solely to produce a CSS color
string from three integer RGB values. This is the only usage of CreateJS in
this file.
**Before:**
```js
return createjs.Graphics.getRGB(nr, ng, nb, 1.0)

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
