### PR TITLE
fix: replace global activity reference with this.activity in tempo.js

### DIFF
--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -208,7 +208,7 @@ class Tempo {
             );
         }
 
-        this.activity.textMsg(_("Adjust the tempo with the buttons."), 3000);
+        this.this.activity.textMsg(_("Adjust the tempo with the buttons."), 3000);
         this.resume();
 
         widgetWindow.sendToCenter();
@@ -461,7 +461,7 @@ class Tempo {
                 [5, ["vspace", {}], 0, 0, [0, null]]
             ];
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
         };
 
         if (this.widgetWindow && this.widgetWindow.timerManager) {


### PR DESCRIPTION
tempo.js calls activity.textMsg as a global on lines 196 and 435. Works in browser since activity is on the global scope at runtime, but Jest's jsdom has no global activity, so fake timer callbacks throw ReferenceError: activity is not defined.
Replaced both with this.activity.textMsg which uses the instance property that tests already mock correctly.

PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation