### PR TITLE
fix: replace global activity reference with this.activity in tempo.js __save()

### DIFF
--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -461,7 +461,7 @@ class Tempo {
                 [5, ["vspace", {}], 0, 0, [0, null]]
             ];
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
         };
 
         if (this.widgetWindow && this.widgetWindow.timerManager) {


### PR DESCRIPTION
__save() in tempo.js calls activity.textMsg as a global. Unlike init(activity) where activity is a parameter in scope, __save() has no such parameter ,i.e., activity is undefined in that context, throwing ReferenceError: activity is not defined when fake timers advance into the callback in Jest.
Replaced with this.activity.textMsg which references the instance property set during init().

PR Category:
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation