### PR TITLE
Fix project image fallback and report progress state

### DIFF
--- a/planet/js/ProjectViewer.js
+++ b/planet/js/ProjectViewer.js
@@ -110,7 +110,7 @@ class ProjectViewer {
 
         const proj = this.ProjectCache[this.id];
         let image = Planet.ProjectStorage.ImageDataURL;
-        if (proj.ProjectImage !== "") image = proj.ProjectImage;
+        if (proj.ProjectImage !== "" && proj.ProjectImage !== null) image = proj.ProjectImage;
 
         Planet.SaveInterface.saveHTML(
             proj.ProjectName,
@@ -163,7 +163,7 @@ class ProjectViewer {
             document.getElementById("report-error").style.display = "block";
             return;
         } else {
-            document.getElementById("projectviewer-report-progress").style.visibility = "hidden";
+            document.getElementById("projectviewer-report-progress").style.visibility = "visible";
             this.Planet.ServerInterface.reportProject(this.id, text, this.afterReport.bind(this));
         }
     }


### PR DESCRIPTION
Fixed two things in [ProjectViewer.js](vscode-file://vscode-app/c:/Users/Rudra/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

First, [afterDownload()](vscode-file://vscode-app/c:/Users/Rudra/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now treats both null and an empty string as “no image” and falls back to the Music Blocks/Turtle Blocks placeholder. That was needed because some projects can have [ProjectImage = null](vscode-file://vscode-app/c:/Users/Rudra/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and before this change that value was being passed straight into [saveHTML()](vscode-file://vscode-app/c:/Users/Rudra/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which could produce a broken or missing preview image in the exported HTML.

Second, [submitReporter()](vscode-file://vscode-app/c:/Users/Rudra/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now makes the report progress indicator visible before sending the report request. That was needed because the UI was hiding that element in the submit path, so users never saw any loading state while the report was being submitted.

In short: one fix prevents bad image data from leaking into the exported file, and the other makes the report dialog reflect that a request is actually in progress.

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation