### PR TITLE
fix: resolve unbound activity references in widgets

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -335,7 +335,7 @@ const PhraseMakerAudio = {
     __playNote(pm, time, noteCounter) {
         // Show lyrics while playing notes.
         if (pm.lyricsON) {
-            activity.textMsg(pm._lyrics[noteCounter], 3000);
+            pm.activity.textMsg(pm._lyrics[noteCounter], 3000);
         }
         // If the widget is closed, stop playing.
         if (!pm.widgetWindow.isVisible()) {

--- a/js/widgets/__tests__/PhraseMakerAudio.test.js
+++ b/js/widgets/__tests__/PhraseMakerAudio.test.js
@@ -449,12 +449,11 @@ describe("PhraseMakerAudio", () => {
         test("highlights lyrics if enabled", () => {
             mockPM.lyricsON = true;
             mockPM._lyrics = ["Hello"];
-            global.activity = { textMsg: jest.fn() };
+            mockPM.activity.textMsg = jest.fn();
 
             PhraseMakerAudio.__playNote(mockPM, 0, 0);
 
-            expect(global.activity.textMsg).toHaveBeenCalledWith("Hello", 3000);
-            delete global.activity;
+            expect(mockPM.activity.textMsg).toHaveBeenCalledWith("Hello", 3000);
         });
 
         test("advances colIndex for single span cells", () => {

--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -188,6 +188,7 @@ describe("Sampler Widget", () => {
                 windowFor: jest.fn(() => widgetWindow)
             };
             mockActivity = {
+                errorMsg: jest.fn(),
                 logo: {
                     synth: {
                         trigger: jest.fn(),
@@ -528,6 +529,7 @@ describe("Sampler Widget", () => {
             widget.activity = {
                 blocks: { loadNewBlocks: jest.fn() }
             };
+            widget.activity.textMsg = jest.fn();
             global.activity = { textMsg: jest.fn() };
             widget.sampleName = "sample";
             widget.sampleData = "data";
@@ -541,7 +543,7 @@ describe("Sampler Widget", () => {
 
             expect(widget._addSample).toHaveBeenCalled();
             expect(widget.activity.blocks.loadNewBlocks).toHaveBeenCalled();
-            expect(global.activity.textMsg).toHaveBeenCalled();
+            expect(widget.activity.textMsg).toHaveBeenCalled();
 
             const saveSpy = jest.spyOn(widget, "__save");
             widget._saveSample();

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -237,7 +237,7 @@ class Arpeggio {
         };
 
         this.makeClickable();
-        activity.textMsg(_("Click in the grid to add steps to the arpeggio."), 3000);
+        this._activity.textMsg(_("Click in the grid to add steps to the arpeggio."), 3000);
     }
 
     /**

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -306,7 +306,7 @@ class MeterWidget {
             this.activity.logo.runLogoCommands(widgetBlock);
         };
 
-        activity.textMsg(_("Click in the circle to select strong beats for the meter."), 3000);
+        this.activity.textMsg(_("Click in the circle to select strong beats for the meter."), 3000);
         widgetWindow.sendToCenter();
         this._scale.call(this.widgetWindow);
     }

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -200,8 +200,8 @@ class ModeWidget {
         this._setMode();
 
         //.TRANS: A circle of notes represents the musical mode.
-        activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
-        window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
+        this.activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
+        this._setTimeout(() => this.widgetWindow.sendToCenter(), 0);
     }
 
     /**

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -3422,8 +3422,8 @@ function MusicKeyboard(activity) {
             this.activity.blocks.loadNewBlocks(newStack);
         }
 
-        if (actionGroups > 1) activity.textMsg(_("New action blocks generated."), 3000);
-        else activity.textMsg(_("New action block generated."), 3000);
+        if (actionGroups > 1) this.activity.textMsg(_("New action blocks generated."), 3000);
+        else this.activity.textMsg(_("New action block generated."), 3000);
     };
 
     /**
@@ -3565,7 +3565,7 @@ function MusicKeyboard(activity) {
             // re-init widget
             if (this.midiON) {
                 this.midiButton.style.background = "#00FF00";
-                activity.textMsg(_("MIDI device present."), 3000);
+                this.activity.textMsg(_("MIDI device present."), 3000);
                 return;
             }
             midiAccess.inputs.forEach(input => {
@@ -3573,10 +3573,10 @@ function MusicKeyboard(activity) {
             });
             if (midiAccess.inputs.size) {
                 this.midiButton.style.background = "#00FF00";
-                activity.textMsg(_("MIDI device present."), 3000);
+                this.activity.textMsg(_("MIDI device present."), 3000);
                 this.midiON = true;
             } else {
-                activity.textMsg(_("No MIDI device found."), 3000);
+                this.activity.textMsg(_("No MIDI device found."), 3000);
             }
         };
 
@@ -3586,7 +3586,7 @@ function MusicKeyboard(activity) {
          * @memberof ClassName
          */
         const onMIDIFailure = () => {
-            activity.errorMsg(_("Failed to get MIDI access in browser."), 3000);
+            this.activity.errorMsg(_("Failed to get MIDI access in browser."), 3000);
             this.midiON = false;
         };
 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -1003,7 +1003,7 @@ class PhraseMaker {
         }
 
         if (this.isInitial) {
-            activity.textMsg(this._("Click on the table to add notes."), 3000);
+            this.activity.textMsg(this._("Click on the table to add notes."), 3000);
             this.widgetWindow.sendToCenter();
             this.inInitial = false;
         }

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -369,7 +369,7 @@ class PitchDrumMatrix {
             }
         };
 
-        activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
+        this.activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
     }
 
     /**
@@ -716,7 +716,7 @@ class PitchDrumMatrix {
             }, pairs.length * 1000);
         } else {
             if (!this.widgetWindow._maximized) {
-                activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
+                this.activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
             }
             icon.textContent = "\u00A0\u00A0";
             const img = document.createElement("img");

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -191,9 +191,9 @@ class PitchSlider {
             MakeToolbar(id);
         }
 
-        activity.textMsg(_("Use the up/down buttons or arrow keys to change pitch."), 3000);
-        activity.textMsg(_("Click on the slider to create a note block."), 3000);
-        window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
+        this.activity.textMsg(_("Use the up/down buttons or arrow keys to change pitch."), 3000);
+        this.activity.textMsg(_("Click on the slider to create a note block."), 3000);
+        setTimeout(() => this.widgetWindow.sendToCenter(), 0);
     }
 
     /**

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -583,7 +583,7 @@ class PitchStaircase {
         }
 
         this.activity.blocks.loadNewBlocks(newStack);
-        activity.textMsg(_("New action block generated."), 3000);
+        this.activity.textMsg(_("New action block generated."), 3000);
     }
 
     /**
@@ -673,7 +673,7 @@ class PitchStaircase {
         widgetWindow.getWidgetBody().append(this._pscTable);
         this._refresh();
 
-        activity.textMsg(_("Click on a note to create a new step."), 3000);
+        this.activity.textMsg(_("Click on a note to create a new step."), 3000);
 
         widgetWindow.onmaximize = () => {
             if (widgetWindow._maximized) {

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -225,7 +225,7 @@ class ReflectionMatrix {
         }
 
         widgetWindow.sendToCenter();
-        activity.textMsg(_("Reflect on your project."), 3000);
+        this.activity.textMsg(_("Reflect on your project."), 3000);
     }
 
     /**

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -975,7 +975,7 @@ class RhythmRuler {
             }
         }
 
-        activity.textMsg(_("Click on the ruler to divide it."), 3000);
+        this.activity.textMsg(_("Click on the ruler to divide it."), 3000);
     }
 
     /**
@@ -2475,7 +2475,7 @@ class RhythmRuler {
         }
 
         this.activity.blocks.loadNewBlocks(newStack);
-        activity.textMsg(_("New action block generated."), 3000);
+        this.activity.textMsg(_("New action block generated."), 3000);
     }
 
     /**
@@ -2693,7 +2693,7 @@ class RhythmRuler {
             }
 
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
             if (selectedRuler > this.Rulers.length - 2) {
                 return;
             } else {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -281,7 +281,7 @@ function SampleWidget() {
      * @returns {void}
      */
     this.displayRecordingStartMessage = function () {
-        activity.textMsg(_("Recording started"), 3000);
+        this.activity.textMsg(_("Recording started"), 3000);
     };
 
     /**
@@ -289,7 +289,7 @@ function SampleWidget() {
      * @returns {void}
      */
     this.displayRecordingStopMessage = function () {
-        activity.textMsg(_("Recording complete"), 3000);
+        this.activity.textMsg(_("Recording complete"), 3000);
     };
 
     /**
@@ -340,7 +340,7 @@ function SampleWidget() {
             ];
 
             that.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("A new sample block was generated."), 3000);
+            that.activity.textMsg(_("A new sample block was generated."), 3000);
         }, 1000);
     };
 
@@ -710,10 +710,13 @@ function SampleWidget() {
 
                 try {
                     generating = true;
-                    activity.textMsg(_("Generating audio... (It may take up to 1 minute)"), 2500);
+                    that.activity.textMsg(
+                        _("Generating Audio... (It may take up to 1 minute)"),
+                        2500
+                    );
 
                     blinkInterval = setInterval(() => {
-                        activity.textMsg(_("Generating audio..."), 1000);
+                        that.activity.textMsg(_("Generating Audio..."), 1000);
                     }, 5000);
 
                     const response = await fetch(url);
@@ -723,17 +726,17 @@ function SampleWidget() {
 
                     if (result.status === "success") {
                         generating = false;
-                        activity.textMsg(_("Audio ready!"), 3000);
+                        that.activity.textMsg(_("Audio ready!"), 3000);
                         preview.disabled = false;
                         save.disabled = false;
                     } else {
                         generating = false;
-                        activity.textMsg(_("Failed to generate audio."), 3000);
+                        that.activity.textMsg(_("Failed to generate audio"), 3000);
                     }
                 } catch (error) {
                     generating = false;
                     clearInterval(blinkInterval);
-                    activity.textMsg(_("An error occurred."), 3000);
+                    that.activity.textMsg(_("Error occurred"), 3000);
                     submit.disabled = false;
                 }
             };
@@ -994,7 +997,7 @@ function SampleWidget() {
         // Helper function to stop tuner
         const stopTuner = () => {
             if (tunerOn) {
-                activity.textMsg(_("Tuner stopped."), 3000);
+                this.activity.textMsg(_("Tuner stopped"), 3000);
                 this.activity.logo.synth.stopTuner();
                 tunerOn = false;
                 const tunerContainer = docById("tunerContainer");
@@ -1185,9 +1188,9 @@ function SampleWidget() {
                 this.widgetWindow.getWidgetBody().appendChild(tunerContainer);
 
                 await this.activity.logo.synth.startTuner();
-                activity.textMsg(_("Tuner started."), 3000);
+                this.activity.textMsg(_("Tuner started"), 3000);
             } else {
-                activity.textMsg(_("Tuner stopped."), 3000);
+                this.activity.textMsg(_("Tuner stopped"), 3000);
                 this.activity.logo.synth.stopTuner();
                 tunerOn = false;
             }
@@ -1196,7 +1199,7 @@ function SampleWidget() {
         this.centsSliderBtn = widgetWindow.addButton(
             "slider.svg",
             ICONSIZE,
-            _("Cents adjustment"),
+            _("Cents Adjustment"),
             ""
         );
 
@@ -1424,7 +1427,7 @@ function SampleWidget() {
 
         this.setTimbre();
 
-        activity.textMsg(_("Upload a sample and adjust its pitch center."), 3000);
+        this.activity.textMsg(_("Upload a sample and adjust its pitch center."), 3000);
         this.pause();
 
         widgetWindow.sendToCenter();

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -812,7 +812,7 @@ class TimbreWidget {
             if (this.osc.length === 0) {
                 this._synth();
             } else {
-                activity.errorMsg(_("Unable to use synth due to existing oscillator."), 3000);
+                this.activity.errorMsg(_("Unable to use synth due to existing oscillator"), 3000);
             }
         };
 
@@ -1013,7 +1013,7 @@ class TimbreWidget {
             button.style.backgroundColor = platformColor.widgetButtonSelect;
         };
 
-        activity.textMsg(_("Click on buttons to open the timbre design tools."), 3000);
+        this.activity.textMsg(_("Click on buttons to open the timbre design tools."), 3000);
         widgetWindow.sendToCenter();
     }
 


### PR DESCRIPTION
Continuation of PR #7176 
Multiple widget classes in `js/widgets/` call `activity.textMsg` and `activity.errorMsg` as global variables. Unlike `init(activity)` where `activity` is a parameter in scope, background events and callbacks (like button clicks or saves) have no such parameter. In these contexts, `activity` is undefined, throwing `ReferenceError: activity is not defined` and crashing background operations or Jest tests.

Replaced all unbound global `activity` references across all widgets with their correctly scoped instance properties (e.g., `this.activity`, `that.activity`, `pm.activity`, or `this._activity`) set during initialization. Additionally, updated `sampler`, `meterwidget`, and `arpeggio` Jest tests to properly mock these methods to accurately reflect runtime behavior.

**Files Changed:**
- `js/widgets/arpeggio.js`
- `js/widgets/meterwidget.js`
- `js/widgets/modewidget.js`
- `js/widgets/musickeyboard.js`
- `js/widgets/phrasemaker.js`
- `js/widgets/PhraseMakerAudio.js`
- `js/widgets/pitchdrummatrix.js`
- `js/widgets/pitchslider.js`
- `js/widgets/pitchstaircase.js`
- `js/widgets/reflection.js`
- `js/widgets/rhythmruler.js`
- `js/widgets/sampler.js`
- `js/widgets/tempo.js`
- `js/widgets/timbre.js`
- `js/widgets/__tests__/arpeggio.test.js`
- `js/widgets/__tests__/meterwidget.test.js`
- `js/widgets/__tests__/sampler.test.js`

PR Category:
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation