### PR TITLE
fix: halt doVibrato when intensity or rate is invalid

### DIFF
--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -135,11 +135,13 @@ function setupToneActions(activity) {
             if (intensity < 1 || intensity > 100) {
                 activity.errorMsg(_("Vibrato intensity must be between 1 and 100."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             if (rate <= 0) {
                 activity.errorMsg(_("Vibrato rate must be greater than 0."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -266,6 +266,8 @@ describe("setupToneActions", () => {
                 1
             );
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.vibratoIntensity).toEqual([]);
+            expect(targetTurtle.singer.vibratoRate).toEqual([]);
         });
 
         it("should show error for invalid vibrato rate", () => {
@@ -275,6 +277,7 @@ describe("setupToneActions", () => {
                 1
             );
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.vibratoRate).toEqual([]);
         });
 
         it("should use last vibrato intensity in timbre mode", () => {


### PR DESCRIPTION
## Description

`Singer.ToneActions.doVibrato` had two validation guards that displayed an error message and set `activity.logo.stopTurtle = true`, but did **not** return. Execution fell through to:

```js
tur.singer.vibratoIntensity.push(intensity / 100);
tur.singer.vibratoRate.push(1 / rate);
```

So when the user supplied `rate === 0`, `Infinity` was pushed onto `vibratoRate` and the vibrato listener was still installed. With `rate < 0` the function silently accepted a negative rate even though the error said the value must be greater than 0. Out-of-range `intensity` had the same flaw — the bad value was still pushed onto `vibratoIntensity` and used by the timbre branch.

This is the same pattern that PR #6988 fixed for `setStaccato` / `setSlur` in the sibling file `js/turtleactions/OrnamentActions.js`. `doVibrato` was missed at the time.

## Related Issue

This PR fixes #<ISSUE-NUMBER>

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   `js/turtleactions/ToneActions.js`: added an early `return;` after each of the two validation guards in `doVibrato`, so the function actually halts on bad input instead of corrupting `vibratoIntensity` / `vibratoRate` and registering a listener.
-   `js/turtleactions/__tests__/ToneActions.test.js`: strengthened the existing "should show error for invalid vibrato intensity" and "should show error for invalid vibrato rate" specs with extra assertions that the singer state arrays remain empty after the guard fires. These new assertions fail on `master` and pass with this PR, locking in the regression.

Total diff: +5 / -0 across 2 files.

## Testing Performed

-   `npx jest js/turtleactions/__tests__/ToneActions.test.js` — 61 / 61 pass.
-   `npx eslint js/turtleactions/ToneActions.js js/turtleactions/__tests__/ToneActions.test.js` — clean.
-   `npx prettier --check js/turtleactions/ToneActions.js js/turtleactions/__tests__/ToneActions.test.js` — clean.
-   Manual smoke test in browser: a vibrato block fed `rate = 0` now stops execution with the error toast and leaves `tur.singer.vibratoRate` empty (previously held `Infinity`). A vibrato block with `rate = 5` still works normally.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable. (no docs are affected)
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

-   The fix is intentionally minimal and structurally identical to PR #6988, which makes the behaviour consistent across the `Ornament` and `Tone` action modules.
-   Fixing both guards (intensity *and* rate) is deliberate. They share the same architectural flaw — `stopTurtle = true` without an early `return` — so fixing only one would leave the same bug latent in the other path. The `intensity` path doesn't produce `Infinity`, but it still pushes a clamp-violating value into the audio pipeline.
-   No public API or behaviour for the happy path changes; only the error path now halts where previously it leaked state.
