### PR TITLE
fix: stop render loop from running when idle or tab is hidden

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -548,9 +548,16 @@ class Activity {
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs) {
                         this.stage.update();
                         this.stageDirty = false;
+                        // Continue the loop only if there's work to do
+                        this._renderLoopRafId = requestAnimationFrame(renderLoop);
+                    } else {
+                        // Nothing to render — let the loop go idle
+                        this._renderLoopRunning = false;
+                        this._renderLoopRafId = null;
                     }
+                } else {
+                    this._renderLoopRafId = requestAnimationFrame(renderLoop);
                 }
-                this._renderLoopRafId = requestAnimationFrame(renderLoop);
             };
 
             this._renderLoopRafId = requestAnimationFrame(renderLoop);
@@ -4415,6 +4422,8 @@ class Activity {
                 ) {
                     this.saveLocally();
                 }
+                // Pause render loop while tab is hidden
+                this._stopRenderLoop();
                 return;
             }
 
@@ -4426,6 +4435,9 @@ class Activity {
                     this._onResize(false);
                 }, 250);
             }
+            // Resume render loop when tab becomes visible again
+            this.stageDirty = true;
+            this._startRenderLoop();
         };
         this.addEventListener(document, "visibilitychange", this._handleVisibilityChange);
 


### PR DESCRIPTION
## 📄 Issue Description

Music Blocks was running a 60fps render loop non-stop — even when nothing was happening on screen, and even when you switched to a different tab. On the low-end hardware this app is built for (Chromebooks, older tablets), that's a real battery and CPU drain.

Fixes #7155

### PR Category

- [ ] Accessibility
- [ ] Bug Fix
- [x] Performance
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

---

## 🎯 Objectives
- Stop the render loop from firing when there's nothing to draw
- Pause the loop when the browser tab is hidden
- Reduce CPU usage and battery drain on idle
- Ensure the loop wakes back up correctly when needed

---

## 🧱 Scope of Implementation

### 1. 🔁 Self-terminating Render Loop
- Modified `_startRenderLoop` in `js/activity.js`
- Loop now exits naturally when `stageDirty` is false, no active tweens, and no active GIFs
- Wakes back up automatically when something needs rendering

### 2. 👁️ Page Visibility API
- Merged render loop pause/resume into the existing `_handleVisibilityChange` method
- Tab hidden → `_stopRenderLoop()` is called
- Tab visible again → `stageDirty = true` + `_startRenderLoop()` resumes
- Avoided adding a duplicate `visibilitychange` listener — all tab-visibility logic stays in one place

---

## ✅ How to Verify

1. Open Music Blocks, sit idle on the start screen
2. Open DevTools → Performance — no `requestAnimationFrame` should be firing
3. Switch tabs → CPU usage should drop to near zero
4. Switch back → app wakes up and renders correctly
5. Play a project → works as expected throughout