### PR TITLE
Fix companion turtle not restored from trash (Fixes #7189)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4538,8 +4538,18 @@ class Activity {
 
             if (restoredBlock.name === "start" || restoredBlock.name === "drum") {
                 const turtle = restoredBlock.value;
-                this.turtles.getTurtle(turtle).inTrash = false;
-                this.turtles.getTurtle(turtle).container.visible = true;
+                const primaryTurtle = this.turtles.getTurtle(turtle);
+                primaryTurtle.inTrash = false;
+                primaryTurtle.container.visible = true;
+
+                const comp = primaryTurtle.companionTurtle;
+                if (comp != null) {
+                    const companionTurtle = this.turtles.getTurtle(comp);
+                    if (companionTurtle) {
+                        companionTurtle.inTrash = false;
+                        companionTurtle.container.visible = true;
+                    }
+                }
             } else if (restoredBlock.name === "action") {
                 const actionArg = this.blocks.blockList[restoredBlock.connections[1]];
                 if (actionArg !== null) {


### PR DESCRIPTION
When a `start` or `drum` block (using `onEveryBeatDo`) was deleted and then restored from the trash, the main turtle was restored properly, but its companion turtle remained in the trashed state (`inTrash = true`). Because of this, beat-synchronized actions stopped working after a restore, leading to a silent failure where the program ran but expected actions did not execute.

## Related Issue
This PR fixes #7189

## PR Category
-   [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made
- Updated the `_restoreTrashById` logic in `js/activity.js` to also check for and restore the companion turtle.
- Set `companionTurtle.inTrash = false` and made its container visible alongside the primary turtle when restoring.
- 
## Testing Performed
- Restored a `start` and `drum` block and verified that the `onEveryBeatDo` logic works properly and the companion turtle is fully restored.
