### PR TITLE
Fix silent audio corruption on invalid vibrato rate (#7178)

### DIFF
--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -135,11 +135,13 @@ function setupToneActions(activity) {
             if (intensity < 1 || intensity > 100) {
                 activity.errorMsg(_("Vibrato intensity must be between 1 and 100."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             if (rate <= 0) {
                 activity.errorMsg(_("Vibrato rate must be greater than 0."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);


### PR DESCRIPTION
This PR fixes a bug in the `doVibrato` function within `js/turtleactions/ToneActions.js`. Previously, when validating `intensity` and `rate`, the code would display an error message and set `activity.logo.stopTurtle = true`, but it lacked an early return. This allowed execution to fall through, pushing `Infinity` (when rate is `0`) or negative values onto `vibratoRate`, and installing the vibrato listener regardless of the error. This resulted in silent audio corruption and playback continued. 
By adding an early `return` after the validation failure, we prevent corrupted values from reaching the audio pipeline, matching the correct behavior implemented for the `setStaccato` and `setSlur` blocks.

## Related Issue
This PR fixes #7178

## PR Category
-   [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made
- Added an early `return;` statement after the intensity validation check in `doVibrato` (`js/turtleactions/ToneActions.js`).
- Added an early `return;` statement after the rate validation check in `doVibrato`.
- 
## Testing Performed
- Verified that connecting a block evaluating to `0` or `<0` into the vibrato `rate` input properly halts execution after the error toast is shown, without pushing invalid values like `Infinity` to the audio engine.