### PR TITLE
fix: handle sparse block lists

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -109,17 +109,46 @@ global.showZoomOverlay = jest.fn();
 describe("Blocks Foundation", () => {
     let mockActivity;
 
+    const makeBlock = (name, connections = [null], overrides = {}) => ({
+        name,
+        connections,
+        trash: false,
+        container: {
+            x: 0,
+            y: 0,
+            children: [],
+            setChildIndex: jest.fn(),
+            updateCache: jest.fn()
+        },
+        width: 100,
+        height: 40,
+        protoblock: {},
+        highlight: jest.fn(),
+        unhighlight: jest.fn(),
+        hide: jest.fn(),
+        show: jest.fn(),
+        regenerateArtwork: jest.fn(),
+        offScreen: jest.fn(() => false),
+        ...overrides
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
+        global.requestAnimationFrame = jest.fn(callback => callback());
 
         // Create a basic mock activity object as required by Blocks constructor
         mockActivity = {
             storage: {},
             trashcan: {},
             turtles: {},
-            boundary: {},
+            boundary: { hide: jest.fn() },
             macroDict: {},
-            palettes: { dict: {} },
+            palettes: {
+                dict: {},
+                hide: jest.fn(),
+                show: jest.fn(),
+                updatePalettes: jest.fn()
+            },
             logo: { synth: { loadSynth: jest.fn() } },
             blocksContainer: new global.createjs.Container(),
             canvas: { width: 1200, height: 900 },
@@ -194,40 +223,401 @@ describe("Blocks Foundation", () => {
         });
     });
 
-    describe("Sparse Array Safety", () => {
-        it("should not throw TypeError in findStacks when blockList is sparse", () => {
+    describe("Stack Traversal", () => {
+        it("should find the top and bottom blocks in a stack", () => {
             const blocks = new Blocks(mockActivity);
-            blocks.blockList = [];
-            blocks.blockList[1] = { trash: false, connections: [null] }; // Index 0 is undefined
+            blocks.blockList = [
+                makeBlock("start", [null, 1]),
+                makeBlock("forward", [0, 2]),
+                makeBlock("right", [1, null])
+            ];
 
-            expect(() => blocks.findStacks()).not.toThrow();
-            expect(blocks.stackList).toEqual([1]);
+            expect(blocks.findTopBlock(2)).toBe(0);
+            expect(blocks.findBottomBlock(0)).toBe(2);
+            expect(blocks.findTopBlock(null)).toBeNull();
+            expect(blocks.findBottomBlock(null)).toBeNull();
         });
 
-        it("should not throw TypeError in moveAllBlocksExcept when blockList is sparse", () => {
+        it("should detect blocks in the same flow generation", () => {
             const blocks = new Blocks(mockActivity);
-            blocks.blockList = [];
-            blocks.blockList[1] = {
-                trash: false,
-                connections: [null],
-                findTopBlock: jest.fn().mockReturnValue(1),
-                moveBlockRelativeBatched: jest.fn()
-            };
+            blocks.blockList = [
+                makeBlock("start", [null, 1]),
+                makeBlock("forward", [0, 2]),
+                makeBlock("right", [1, null]),
+                makeBlock("solo", [null])
+            ];
 
-            expect(() => blocks.moveAllBlocksExcept(null, 10, 10)).not.toThrow();
+            expect(blocks.sameGeneration(0, 2)).toBe(true);
+            expect(blocks.sameGeneration(0, 3)).toBe(false);
+            expect(blocks.sameGeneration(null, 2)).toBe(false);
+            expect(blocks.sameGeneration(2, null)).toBe(false);
         });
 
-        it("should not throw TypeError in _findTwoArgs when blockList is sparse", () => {
+        it("should collect top-level non-trash stacks", () => {
             const blocks = new Blocks(mockActivity);
-            blocks.blockList = [];
-            blocks.blockList[1] = {
-                trash: false,
-                isArgBlock: jest.fn().mockReturnValue(true),
-                isExpandableBlock: jest.fn().mockReturnValue(true)
+            blocks.blockList = [
+                makeBlock("start", [null, 1]),
+                makeBlock("forward", [0, null]),
+                makeBlock("trashed-start", [null], { trash: true }),
+                makeBlock("solo", [null])
+            ];
+
+            blocks.findStacks();
+
+            expect(blocks.stackList).toEqual([0, 3]);
+        });
+
+        it("should count nested blocks in a stack", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("repeat", [null, 1, 2]),
+                makeBlock("number", [0]),
+                makeBlock("forward", [0, 3]),
+                makeBlock("right", [2, null])
+            ];
+
+            expect(blocks._countBlocksInStack(0)).toBe(4);
+            expect(blocks._countBlocksInStack(null)).toBe(0);
+        });
+
+        it("should find block names inside a stack", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("start", [null, 1]),
+                makeBlock("forward", [0, 2]),
+                makeBlock("right", [1, null])
+            ];
+
+            expect(blocks._blockInStack(0, ["right"])).toBe(true);
+            expect(blocks._blockInStack(0, ["setxy"])).toBe(false);
+        });
+    });
+
+    describe("Drag Groups", () => {
+        it("should find all connected child blocks in a drag group", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("repeat", [null, 1, 2]),
+                makeBlock("number", [0]),
+                makeBlock("forward", [0, 3]),
+                makeBlock("right", [2, null])
+            ];
+
+            blocks.findDragGroup(0);
+
+            expect(blocks.dragGroup).toEqual([0, 1, 2, 3]);
+        });
+
+        it("should cache and clear drag groups", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [makeBlock("start", [null, 1]), makeBlock("forward", [0])];
+
+            blocks.cacheDragGroup(0);
+            expect(blocks._cachedDragGroup).toEqual([0, 1]);
+
+            blocks.clearCachedDragGroup();
+            expect(blocks._cachedDragGroup).toBeNull();
+        });
+    });
+
+    describe("Visibility and Selection", () => {
+        it("should change disabled status for matching non-trash blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            const matchingBlock = makeBlock("sensor");
+            const trashedBlock = makeBlock("sensor", [null], { trash: true });
+            blocks.blockList = [matchingBlock, trashedBlock, makeBlock("other")];
+
+            blocks.changeDisabledStatus("sensor", true);
+
+            expect(matchingBlock.protoblock.disabled).toBe(true);
+            expect(matchingBlock.regenerateArtwork).toHaveBeenCalledWith(false);
+            expect(trashedBlock.protoblock.disabled).toBeUndefined();
+            expect(trashedBlock.regenerateArtwork).not.toHaveBeenCalled();
+        });
+
+        it("should highlight and unhighlight visible blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [makeBlock("start"), makeBlock("forward")];
+
+            blocks.highlight(0, false);
+            expect(blocks.blockList[0].highlight).toHaveBeenCalled();
+            expect(blocks.highlightedBlock).toBe(0);
+
+            blocks.highlight(1, true);
+            expect(blocks.blockList[0].unhighlight).toHaveBeenCalled();
+            expect(blocks.blockList[1].highlight).toHaveBeenCalled();
+            expect(blocks.highlightedBlock).toBe(1);
+
+            blocks.unhighlight(null);
+            expect(blocks.blockList[1].unhighlight).toHaveBeenCalled();
+            expect(blocks.highlightedBlock).toBeNull();
+        });
+
+        it("should unhighlight every non-trash block", () => {
+            const blocks = new Blocks(mockActivity);
+            const firstBlock = makeBlock("start");
+            const trashedBlock = makeBlock("trash", [null], { trash: true });
+            const secondBlock = makeBlock("forward");
+            blocks.blockList = [firstBlock, trashedBlock, secondBlock];
+
+            blocks.unhighlightAll();
+
+            expect(firstBlock.unhighlight).toHaveBeenCalled();
+            expect(trashedBlock.unhighlight).not.toHaveBeenCalled();
+            expect(secondBlock.unhighlight).toHaveBeenCalled();
+        });
+
+        it("should ignore highlight changes while blocks are hidden", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [makeBlock("start")];
+            blocks.visible = false;
+
+            blocks.highlight(0, false);
+            blocks.unhighlight(0);
+
+            expect(blocks.blockList[0].highlight).not.toHaveBeenCalled();
+            expect(blocks.blockList[0].unhighlight).not.toHaveBeenCalled();
+        });
+
+        it("should hide every block and show only non-trash blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            const visibleBlock = makeBlock("forward");
+            const trashedBlock = makeBlock("right", [null], { trash: true });
+            blocks.blockList = [visibleBlock, trashedBlock];
+
+            blocks.hide();
+            expect(visibleBlock.hide).toHaveBeenCalled();
+            expect(trashedBlock.hide).toHaveBeenCalled();
+            expect(blocks.visible).toBe(false);
+
+            blocks.show();
+            expect(visibleBlock.show).toHaveBeenCalled();
+            expect(trashedBlock.show).not.toHaveBeenCalled();
+            expect(blocks.visible).toBe(true);
+        });
+
+        it("should update selection state and notify the activity", () => {
+            const blocks = new Blocks(mockActivity);
+
+            blocks.setSelection(true);
+            blocks.setSelectedBlocks([1, 2]);
+            blocks.setSelectionToActivity(false);
+
+            expect(blocks.selectionModeOn).toBe(true);
+            expect(blocks.selectedBlocks).toEqual([1, 2]);
+            expect(mockActivity.setSelectionMode).toHaveBeenCalledWith(false);
+        });
+
+        it("should detect whether coordinates are inside a non-trash block", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("forward", [null], {
+                    container: { x: 10, y: 20 },
+                    width: 50,
+                    height: 30
+                }),
+                makeBlock("trash", [null], {
+                    trash: true,
+                    container: { x: 0, y: 0 },
+                    width: 200,
+                    height: 200
+                })
+            ];
+
+            expect(blocks.isCoordinateOnBlock(25, 30)).toBe(true);
+            expect(blocks.isCoordinateOnBlock(5, 5)).toBe(false);
+        });
+
+        it("should hide and show blocks through palette wrappers", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.hide = jest.fn();
+            blocks.show = jest.fn();
+            blocks.bringToTop = jest.fn();
+
+            blocks.hideBlocks();
+            expect(mockActivity.palettes.hide).toHaveBeenCalled();
+            expect(blocks.hide).toHaveBeenCalled();
+            expect(mockActivity.refreshCanvas).toHaveBeenCalledTimes(1);
+
+            blocks.showBlocks();
+            expect(mockActivity.palettes.show).toHaveBeenCalled();
+            expect(blocks.show).toHaveBeenCalled();
+            expect(blocks.bringToTop).toHaveBeenCalled();
+            expect(mockActivity.refreshCanvas).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("Connection and Bounds Helpers", () => {
+        it("should validate allowed dock connection types", () => {
+            const blocks = new Blocks(mockActivity);
+
+            expect(blocks._testConnectionType("in", "out")).toBe(true);
+            expect(blocks._testConnectionType("numberin", "textout")).toBe(false);
+        });
+
+        it("should move blocks to rounded positions and check bounds", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.checkBounds = jest.fn();
+            blocks.blockList = [makeBlock("forward")];
+
+            blocks._moveBlock(0, 10.4, 20.6);
+
+            expect(blocks.blockList[0].container.x).toBe(10);
+            expect(blocks.blockList[0].container.y).toBe(21);
+            expect(blocks.checkBounds).toHaveBeenCalled();
+        });
+
+        it("should defer bounds checks while updating block positions", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.checkBounds = jest.fn();
+            blocks.blockList = [
+                makeBlock("start", [null], { container: { x: 1.2, y: 2.6 } }),
+                makeBlock("trash", [null], { trash: true, container: { x: 5, y: 6 } }),
+                makeBlock("solo", [null], { container: { x: 3.7, y: 4.1 } })
+            ];
+
+            blocks.updateBlockPositions();
+
+            expect(blocks.blockList[0].container).toEqual({ x: 1, y: 3 });
+            expect(blocks.blockList[2].container).toEqual({ x: 4, y: 4 });
+            expect(blocks.checkBounds).toHaveBeenCalledTimes(1);
+        });
+
+        it("should update home containers based on offscreen top blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("start", [null], { offScreen: jest.fn(() => true) }),
+                makeBlock("child", [0], { offScreen: jest.fn(() => false) })
+            ];
+
+            blocks.checkBounds();
+            expect(mockActivity.setHomeContainers).toHaveBeenCalledWith(true);
+
+            mockActivity.setHomeContainers.mockClear();
+            blocks.blockList[0].offScreen = jest.fn(() => false);
+            blocks.checkBounds();
+            expect(mockActivity.setHomeContainers).toHaveBeenCalledWith(false);
+            expect(mockActivity.boundary.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe("Name and Palette Helpers", () => {
+        it("should toggle action prototype visibility only when state changes", () => {
+            const blocks = new Blocks(mockActivity);
+            const namedDo = { name: "nameddo", defaults: [], hidden: true };
+            mockActivity.palettes.dict.action = {
+                protoList: [namedDo, { name: "nameddo", defaults: ["arg"], hidden: true }]
             };
 
-            expect(() => blocks._findTwoArgs()).not.toThrow();
-            expect(blocks._expandablesList).toEqual([1]);
+            blocks.setActionProtoVisibility(true);
+
+            expect(namedDo.hidden).toBe(false);
+            expect(mockActivity.palettes.updatePalettes).toHaveBeenCalledWith("action");
+        });
+
+        it("should find unique action names from existing action stacks", () => {
+            const blocks = new Blocks(mockActivity);
+            mockActivity.palettes.dict.action = { protoList: [] };
+            blocks.blockList = [
+                makeBlock("text", [1], { value: "action" }),
+                makeBlock("action", [null]),
+                makeBlock("text", [3], { value: "action1" }),
+                makeBlock("action", [null]),
+                makeBlock("text", [5], { value: "ignored", trash: true }),
+                makeBlock("action", [null])
+            ];
+
+            expect(blocks.findUniqueActionName("action")).toBe("action2");
+        });
+
+        it("should find unique custom and temperament names", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("text", [1], { value: "custom" }),
+                makeBlock("pitch", [null]),
+                makeBlock("text", [3], { value: "custom1" }),
+                makeBlock("pitch", [null]),
+                makeBlock("text", [5], { value: "temperament" }),
+                makeBlock("temperament1", [null])
+            ];
+
+            expect(blocks.findUniqueCustomName("custom")).toBe("custom2");
+            expect(blocks.findUniqueTemperamentName("temperament")).toBe("temperament1");
+        });
+
+        it("should load synths for drum url text blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [
+                makeBlock("text", [1], { value: "https://example.com/drum.wav" }),
+                makeBlock("playdrum", [null]),
+                makeBlock("string", [3], { value: "snare" }),
+                makeBlock("setvoice", [null])
+            ];
+
+            blocks._findDrumURLs();
+
+            expect(mockActivity.logo.synth.loadSynth).toHaveBeenCalledWith(
+                0,
+                "https://example.com/drum.wav"
+            );
+            expect(mockActivity.logo.synth.loadSynth).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Rename Helpers", () => {
+        it("should rename box labels connected to box blocks", () => {
+            const blocks = new Blocks(mockActivity);
+            const textBlock = makeBlock("text", [1], { value: "old", text: { text: "old" } });
+            blocks.blockList = [textBlock, makeBlock("box", [null])];
+
+            blocks.renameBoxes("old", "new");
+
+            expect(textBlock.value).toBe("new");
+            expect(textBlock.text.text).toBe("new");
+            expect(textBlock.container.updateCache).toHaveBeenCalled();
+        });
+
+        it("should rename storein text labels and storein2 private data", () => {
+            const blocks = new Blocks(mockActivity);
+            const textBlock = makeBlock("text", [1], { value: "old", text: { text: "old" } });
+            const storein2Block = makeBlock("storein2", [null], { privateData: "old" });
+            blocks.blockList = [textBlock, makeBlock("storein", [null]), storein2Block];
+
+            blocks.renameStoreinBoxes("old", "new");
+
+            expect(textBlock.value).toBe("new");
+            expect(textBlock.text.text).toBe("new");
+            expect(storein2Block.privateData).toBe("new");
+            expect(storein2Block.overrideName).toBe("new");
+            expect(storein2Block.regenerateArtwork).toHaveBeenCalled();
+            expect(textBlock.container.updateCache).toHaveBeenCalled();
+            expect(storein2Block.container.updateCache).toHaveBeenCalled();
+        });
+
+        it("should rename storein2 private data with default display names", () => {
+            const blocks = new Blocks(mockActivity);
+            const storein2Block = makeBlock("storein2", [null], { privateData: "old" });
+            blocks.blockList = [storein2Block];
+
+            blocks.renameStorein2Boxes("old", "box1");
+
+            expect(storein2Block.privateData).toBe("box1");
+            expect(storein2Block.overrideName).toBe("box1");
+            expect(storein2Block.regenerateArtwork).toHaveBeenCalled();
+            expect(storein2Block.container.updateCache).toHaveBeenCalled();
+        });
+
+        it("should rename namedbox private data", () => {
+            const blocks = new Blocks(mockActivity);
+            const namedBoxBlock = makeBlock("namedbox", [null], { privateData: "old" });
+            blocks.blockList = [namedBoxBlock];
+
+            blocks.renameNamedboxes("old", "box2");
+
+            expect(namedBoxBlock.privateData).toBe("box2");
+            expect(namedBoxBlock.overrideName).toBe("box2");
+            expect(namedBoxBlock.regenerateArtwork).toHaveBeenCalled();
+            expect(namedBoxBlock.container.updateCache).toHaveBeenCalled();
         });
     });
 });

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -620,4 +620,39 @@ describe("Blocks Foundation", () => {
             expect(namedBoxBlock.container.updateCache).toHaveBeenCalled();
         });
     });
+
+    describe("Sparse Array Safety", () => {
+        it("should not throw TypeError in findStacks when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = makeBlock("start", [null]);
+
+            expect(() => blocks.findStacks()).not.toThrow();
+            expect(blocks.stackList).toEqual([1]);
+        });
+
+        it("should not throw TypeError in moveAllBlocksExcept when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = makeBlock("start", [null]);
+            blocks.findTopBlock = jest.fn().mockReturnValue(1);
+            blocks.moveBlockRelativeBatched = jest.fn();
+
+            expect(() => blocks.moveAllBlocksExcept(null, 10, 10)).not.toThrow();
+            expect(blocks.moveBlockRelativeBatched).toHaveBeenCalledWith(1, 10, 10);
+        });
+
+        it("should not throw TypeError in _findTwoArgs when blockList is sparse", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.blockList[1] = makeBlock("arg", [null], {
+                isArgBlock: jest.fn().mockReturnValue(true),
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isTwoArgBlock: jest.fn().mockReturnValue(false)
+            });
+
+            expect(() => blocks._findTwoArgs()).not.toThrow();
+            expect(blocks._expandablesList).toEqual([1]);
+        });
+    });
 });

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -373,7 +373,7 @@ class Blocks {
             let palette;
             /** Regenerate all of the artwork at the new scale. */
             for (const block of this.blockList) {
-                if (!block || block.trash) continue;
+                if (block.trash) continue;
                 block.resize(scale);
             }
 
@@ -384,7 +384,7 @@ class Blocks {
 
             /** Make sure trash is still hidden. */
             for (const block of this.blockList) {
-                if (block && block.trash) {
+                if (block.trash) {
                     block.hide();
                 }
             }
@@ -411,7 +411,7 @@ class Blocks {
          * @returns {void}
          */
         this.extract = () => {
-            if (this.activeBlock != null) {
+            if (this.activeBlock !== null && this.activeBlock !== undefined) {
                 /** Don't extract silence blocks. */
                 if (this.blockList[this.activeBlock].name !== "rest2") {
                     this._extractBlock(this.activeBlock, true);
@@ -439,7 +439,7 @@ class Blocks {
 
                 let lastConnection = last(blkObj.connections);
 
-                if (firstConnection != null) {
+                if (firstConnection !== null && firstConnection !== undefined) {
                     connectionIdx = this.blockList[firstConnection].connections.indexOf(blk);
                 } else {
                     connectionIdx = null;
@@ -447,7 +447,7 @@ class Blocks {
 
                 blkObj.connections[0] = null;
 
-                if (lastConnection != null) {
+                if (lastConnection !== null && lastConnection !== undefined) {
                     /** Is it a hidden block? Keep it attached. */
                     if (
                         this.blockList[lastConnection].name === "hidden" ||
@@ -462,19 +462,19 @@ class Blocks {
                         blkObj.connections[blkObj.connections.length - 1] = null;
                     }
 
-                    if (lastConnection != null) {
+                    if (lastConnection !== null && lastConnection !== undefined) {
                         this.blockList[lastConnection].connections[0] = firstConnection;
                     }
                 }
 
-                if (firstConnection != null) {
+                if (firstConnection !== null && firstConnection !== undefined) {
                     this.blockList[firstConnection].connections[connectionIdx] = lastConnection;
                 }
 
                 this.moveStackRelative(blk, 4 * STANDARDBLOCKHEIGHT, 0);
                 this.blockMoved(blk);
 
-                if (adjustDock && firstConnection != null) {
+                if (adjustDock && firstConnection !== null && firstConnection !== undefined) {
                     this.adjustDocks(firstConnection, true);
                     if (clampList.length > 0) {
                         this.clampBlocksToCheck = clampList;
@@ -482,7 +482,7 @@ class Blocks {
                     }
                 }
             } else {
-                if (firstConnection != null) {
+                if (firstConnection !== null && firstConnection !== undefined) {
                     connectionIdx = this.blockList[firstConnection].connections.indexOf(blk);
                     this.blockList[firstConnection].connections[connectionIdx] = null;
                     blkObj.connections[0] = null;
@@ -501,7 +501,7 @@ class Blocks {
         this.bottomMostBlock = () => {
             let maxy = -1000;
             for (const block of this.blockList) {
-                if (!block || block.trash) continue;
+                if (block.trash) continue;
                 if (block.container.y > maxy) {
                     maxy = block.container.y;
                 }
@@ -520,7 +520,7 @@ class Blocks {
             let allCollapsed = true;
             let someCollapsed = false;
             for (const myBlock of this.blockList) {
-                if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
                     continue;
                 }
 
@@ -539,7 +539,7 @@ class Blocks {
                  * If any blocks are collapsed, collapse them all.
                  */
                 for (const myBlock of this.blockList) {
-                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
                         continue;
                     }
 
@@ -550,7 +550,7 @@ class Blocks {
             } else {
                 /** If no blocks are collapsed, collapse them all. */
                 for (const myBlock of this.blockList) {
-                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (["newnote", "interval", "osctime"].includes(myBlock.name)) {
                         continue;
                     }
 
@@ -664,7 +664,11 @@ class Blocks {
 
                 that._sizeCounter = 0;
                 let childFlowSize = 1;
-                if (c > 0 && myBlock.connections[c] != null) {
+                if (
+                    c > 0 &&
+                    myBlock.connections[c] !== null &&
+                    myBlock.connections[c] !== undefined
+                ) {
                     this._sizeCounter = 0;
                     childFlowSize = Math.max(that._getStackSize(myBlock.connections[c]), 1);
                 }
@@ -747,7 +751,7 @@ class Blocks {
             for (let i = 0; i < slotList.length; i++) {
                 const c = myBlock.connections[ci + i];
                 let size = 1; /** Minimum size */
-                if (c != null) {
+                if (c !== null && c !== undefined) {
                     size = Math.max(this._getBlockSize(c), 1);
                 }
 
@@ -781,7 +785,7 @@ class Blocks {
             /** Determine the size of the first argument. */
             const c = myBlock.connections[1];
             let firstArgumentSize = 1; /** Minimum size */
-            if (c != null) {
+            if (c !== null && c !== undefined) {
                 firstArgumentSize = Math.max(this._getBlockSize(c), 1);
             }
 
@@ -805,7 +809,7 @@ class Blocks {
 
             const c = myBlock.connections[myBlock.connections.length - 2];
             let secondArgumentSize = 1;
-            if (c != null) {
+            if (c !== null && c !== undefined) {
                 secondArgumentSize = Math.max(this._getBlockSize(c), 1);
             }
 
@@ -835,7 +839,7 @@ class Blocks {
                     const vspaceBlock = this.blockList[myBlock.connections[lastConnection]];
                     const nextBlockIndex = vspaceBlock.connections[1];
                     myBlock.connections[lastConnection] = nextBlockIndex;
-                    if (nextBlockIndex != null) {
+                    if (nextBlockIndex !== null && nextBlockIndex !== undefined) {
                         this.blockList[nextBlockIndex].connections[0] = blk;
                     }
                     vspaceBlock.connections = [null, null];
@@ -921,14 +925,13 @@ class Blocks {
                 return size;
             }
 
-            if (blk == null) {
+            if (blk === null || blk === undefined) {
                 return size;
             }
 
             const myBlock = this.blockList[blk];
-            if (myBlock == null) {
+            if (myBlock === null || myBlock === undefined) {
                 console.debug("Something very broken in _getStackSize.");
-                return size;
             }
 
             let c;
@@ -940,7 +943,7 @@ class Blocks {
                 csize = 0;
                 if (c > 0) {
                     cblk = myBlock.connections[c];
-                    if (cblk != null) {
+                    if (cblk !== null && cblk !== undefined) {
                         csize = this._getStackSize(cblk);
                     }
 
@@ -956,7 +959,7 @@ class Blocks {
                     csize = 0;
                     if (c > 0) {
                         cblk = myBlock.connections[c];
-                        if (cblk != null) {
+                        if (cblk !== null && cblk !== undefined) {
                             csize = this._getStackSize(cblk);
                         }
 
@@ -975,7 +978,7 @@ class Blocks {
             }
 
             /** If the note value block is collapsed, spoof size. */
-            if (this.blocksToCollapse.indexOf(blk) != -1) {
+            if (this.blocksToCollapse.indexOf(blk) !== -1) {
                 size = 1;
             } else if (
                 ["newnote", "interval", "osctime"].includes(myBlock.name) &&
@@ -987,7 +990,7 @@ class Blocks {
             /** check on any connected block */
             if (myBlock.connections.length > 1) {
                 cblk = last(myBlock.connections);
-                if (cblk != null) {
+                if (cblk !== null && cblk !== undefined) {
                     size += this._getStackSize(cblk);
                 }
             }
@@ -1018,7 +1021,7 @@ class Blocks {
 
             if (this._deferCheckBoundsCount === 0 && this._checkBoundsPending) {
                 this._checkBoundsPending = false;
-                this.scheduleCheckBounds();
+                this.checkBounds();
             }
         };
 
@@ -1040,7 +1043,7 @@ class Blocks {
             const myBlock = this.blockList[blk];
 
             /** For when we come in from makeBlock */
-            if (resetLoopCounter != null) {
+            if (resetLoopCounter !== null && resetLoopCounter !== undefined) {
                 this._loopCounter = 0;
             }
 
@@ -1048,13 +1051,13 @@ class Blocks {
              * These checks are to test for malformed data. All blocks
              * should have connections.
              */
-            if (myBlock == null) {
+            if (myBlock === null || myBlock === undefined) {
                 console.debug("Saw a null block: " + blk);
                 if (isOuterCall) this._endDeferCheckBounds();
                 return;
             }
 
-            if (myBlock.connections == null) {
+            if (myBlock.connections === null || myBlock.connections === undefined) {
                 console.debug("Saw a block with null connections: " + blk);
                 if (isOuterCall) this._endDeferCheckBounds();
                 return;
@@ -1105,7 +1108,7 @@ class Blocks {
                 }
 
                 /** Another database integrity check. */
-                if (this.blockList[cblk] == null) {
+                if (this.blockList[cblk] === null) {
                     console.debug("This is not good: we encountered a null block: " + cblk);
                     continue;
                 }
@@ -1160,7 +1163,7 @@ class Blocks {
                         dy = bdock[1] - cdock[1];
                     }
 
-                    if (myBlock.container == null) {
+                    if (myBlock.container === null || myBlock.container === undefined) {
                         console.debug("Does this ever happen any more?");
                     } else {
                         nx = myBlock.container.x + dx;
@@ -1200,7 +1203,7 @@ class Blocks {
          * @returns {void}
          */
         this.addDefaultBlock = (parentblk, oldBlock, skipOldBlock) => {
-            if (parentblk == null) {
+            if (parentblk === null || parentblk === undefined) {
                 return;
             }
 
@@ -1208,7 +1211,7 @@ class Blocks {
             const that = this;
             if (this.blockList[parentblk].name === "action") {
                 cblk = this.blockList[parentblk].connections[1];
-                if (cblk == null) {
+                if (cblk === null || cblk === undefined) {
                     /**
                      * Update Palette
                      * @param - args - arguments
@@ -1289,7 +1292,7 @@ class Blocks {
                 }
             } else if (this.blockList[parentblk].name === "temperament1") {
                 cblk = this.blockList[parentblk].connections[1];
-                if (cblk == null) {
+                if (cblk === null || cblk === undefined) {
                     const postProcess = args => {
                         const parentblk = args[0];
                         const oldBlock = args[1];
@@ -1312,7 +1315,7 @@ class Blocks {
                 }
             } else if (this.blockList[parentblk].name === "pitch") {
                 cblk = this.blockList[parentblk].connections[2];
-                if (cblk == null) {
+                if (cblk === null || cblk === undefined) {
                     /**
                      * Adjust Docks
                      * @param - args - arguments
@@ -1345,7 +1348,7 @@ class Blocks {
                 }
 
                 const oblk = this.blockList[parentblk].connections[1];
-                if (oblk == null) {
+                if (oblk === null || oblk === undefined) {
                     /**
                      * Adjust Docks
                      * @param - args - arguments
@@ -1407,7 +1410,7 @@ class Blocks {
                 }
             } else if (this.blockList[parentblk].name === "storein") {
                 cblk = this.blockList[parentblk].connections[1];
-                if (cblk == null) {
+                if (cblk === null || cblk === undefined) {
                     /**
                      * Adjust Docks
                      * @param - args - arguments
@@ -1438,7 +1441,7 @@ class Blocks {
                 }
             } else if (NOTEBLOCKS.includes(this.blockList[parentblk].name)) {
                 cblk = this.blockList[parentblk].connections[2];
-                if (cblk == null) {
+                if (cblk === null || cblk === undefined) {
                     const newVspaceBlock = this.makeBlock("vspace", "__NOARG__");
                     this.blockList[parentblk].connections[2] = newVspaceBlock;
                     this.blockList[newVspaceBlock].connections[0] = parentblk;
@@ -1448,7 +1451,8 @@ class Blocks {
                     this.blockList[newVspaceBlock].connections[1] = newSilenceBlock;
                 } else if (
                     this.blockList[cblk].name === "vspace" &&
-                    this.blockList[cblk].connections[1] == null
+                    (this.blockList[cblk].connections[1] === null ||
+                        this.blockList[cblk].connections[1] === undefined)
                 ) {
                     const newSilenceBlock = this.makeBlock("rest2", "__NOARG__");
                     this.blockList[newSilenceBlock].connections[0] = cblk;
@@ -1494,7 +1498,7 @@ class Blocks {
             }
 
             counter = 0;
-            while (thisBlock != null) {
+            while (thisBlock !== null && thisBlock !== undefined) {
                 if (this.blockList[thisBlock].connections.length < 2) {
                     console.debug("value block encountered??? " + thisBlock);
                     break;
@@ -1528,7 +1532,7 @@ class Blocks {
          * @returns {void}
          */
         this.deleteNextDefault = thisBlock => {
-            if (thisBlock == undefined) {
+            if (thisBlock === null || thisBlock === undefined) {
                 return;
             }
 
@@ -1548,9 +1552,9 @@ class Blocks {
             // Do not remove the silence block if only vspace blocks are added before the silence block.
 
             let block = thisBlockobj;
-            while (block?.name == "vspace") {
+            while (block?.name === "vspace") {
                 block = this.blockList[block.connections[0]];
-                if (block?.name == "newnote") {
+                if (block?.name === "newnote") {
                     return;
                 }
             }
@@ -1567,7 +1571,10 @@ class Blocks {
                     return;
                 }
 
-                while (last(thisBlockobj.connections) != null) {
+                while (
+                    last(thisBlockobj.connections) !== null &&
+                    last(thisBlockobj.connections) !== undefined
+                ) {
                     const lastc = thisBlockobj.connections.length - 1;
                     const i = thisBlockobj.connections[lastc];
                     if (this.blockList[i].name === "rest2") {
@@ -1606,7 +1613,10 @@ class Blocks {
                 this._deletePitchBlocks(thisBlock);
                 return this.blockList[thisBlock].connections[0];
             } else {
-                while (thisBlockobj.connections[0] != null) {
+                while (
+                    thisBlockobj.connections[0] !== null &&
+                    thisBlockobj.connections[0] !== undefined
+                ) {
                     const i = thisBlockobj.connections[0];
                     if (NOTEBLOCKS.includes(this.blockList[i].name)) {
                         break;
@@ -1684,7 +1694,7 @@ class Blocks {
             const initialTopBlock = this.findTopBlock(thisBlock);
             /** Find any containing expandable blocks. */
             this.clampBlocksToCheck = [];
-            if (thisBlock == null) {
+            if (thisBlock === null || thisBlock === undefined) {
                 console.debug("blockMoved called with null block.");
                 return;
             }
@@ -1693,13 +1703,13 @@ class Blocks {
             let expandableLoopCounter = 0;
 
             let parentblk = null;
-            if (blk != null) {
+            if (blk !== null && blk !== undefined) {
                 parentblk = blk;
             }
 
             let actionCheck = false;
 
-            while (blk != null) {
+            while (blk !== null && blk !== undefined) {
                 expandableLoopCounter += 1;
                 if (expandableLoopCounter > 2 * this.blockList.length) {
                     console.debug("Infinite loop encountered checking for expandables?");
@@ -1718,19 +1728,19 @@ class Blocks {
             this._checkTwoArgBlocks = [];
             const checkArgBlocks = [];
             const myBlock = this.blockList[thisBlock];
-            if (myBlock == null) {
+            if (myBlock === null || myBlock === undefined) {
                 console.debug("null block found in blockMoved method: " + thisBlock);
                 return;
             }
 
             const c = myBlock.connections[0];
             let cBlock;
-            if (c != null) {
+            if (c !== null && c !== undefined) {
                 cBlock = this.blockList[c];
             }
 
             /** If it is an arg block, where is it coming from? */
-            if (myBlock.isArgBlock() && c != null) {
+            if (myBlock.isArgBlock() && c !== null && c !== undefined) {
                 /**
                  * We care about twoarg (2arg) blocks with
                  * connections to the first arg;
@@ -1753,7 +1763,7 @@ class Blocks {
             const widgetTitle = document.getElementsByClassName("wftTitle");
 
             /** Disconnect from connection[0] (both sides of the connection). */
-            if (c != null) {
+            if (c !== null && c !== undefined) {
                 /** Disconnect both ends of the connection. */
                 for (let i = 1; i < cBlock.connections.length; i++) {
                     if (cBlock.connections[i] === thisBlock) {
@@ -1860,7 +1870,8 @@ class Blocks {
 
                     if (
                         i === this.blockList[b].connections.length - 1 &&
-                        this.blockList[b].connections[i] != null &&
+                        this.blockList[b].connections[i] !== null &&
+                        this.blockList[b].connections[i] !== undefined &&
                         this.blockList[this.blockList[b].connections[i]].isNoHitBlock()
                     ) {
                         /**
@@ -1871,7 +1882,8 @@ class Blocks {
                     } else if (
                         ["backward", "status"].includes(this.blockList[b].name) &&
                         i === 1 &&
-                        this.blockList[b].connections[1] != null &&
+                        this.blockList[b].connections[1] !== null &&
+                        this.blockList[b].connections[1] !== undefined &&
                         this.blockList[this.blockList[b].connections[1]].isNoHitBlock()
                     ) {
                         /**
@@ -1882,7 +1894,8 @@ class Blocks {
                     } else if (
                         this.blockList[b].name === "action" &&
                         i === 2 &&
-                        this.blockList[b].connections[2] != null &&
+                        this.blockList[b].connections[2] !== null &&
+                        this.blockList[b].connections[2] !== undefined &&
                         this.blockList[this.blockList[b].connections[2]].isNoHitBlock()
                     ) {
                         /**
@@ -1943,7 +1956,7 @@ class Blocks {
                 }
             }
 
-            if (newBlock != null) {
+            if (newBlock !== null && newBlock !== undefined) {
                 const n = this._countBlocksInStack(this.findTopBlock(newBlock));
                 if (n > LONGSTACK) {
                     this.activity.errorMsg(_("Consider breaking this stack into parts."));
@@ -1954,7 +1967,7 @@ class Blocks {
                 const connection = this.blockList[newBlock].connections[newConnection];
                 let bottom;
 
-                if (connection == null) {
+                if (connection === null || connection === undefined) {
                     if (this.blockList[newBlock].isArgClamp()) {
                         /** If it is an arg clamp, we may have to adjust the slot size. */
                         if (this.blockList[newBlock].isArgumentLikeBlock() && newConnection === 1) {
@@ -2043,15 +2056,17 @@ class Blocks {
                             /** Is there an empty slot below? */
                             for (let emptySlot = si; emptySlot < slotList.length; emptySlot++) {
                                 if (
-                                    this.blockList[newBlock].connections[ci + emptySlot - si] ==
-                                    null
+                                    this.blockList[newBlock].connections[ci + emptySlot - si] ===
+                                        null ||
+                                    this.blockList[newBlock].connections[ci + emptySlot - si] ===
+                                        undefined
                                 ) {
                                     emptyConnection = ci + emptySlot - si;
                                     break;
                                 }
                             }
 
-                            if (emptyConnection == null) {
+                            if (emptyConnection === null || emptyConnection === undefined) {
                                 slotList.push(1);
                                 if (this.blockList[newBlock].name !== "makeblock") {
                                     this._newLocalArgBlock(slotList.length);
@@ -2124,7 +2139,10 @@ class Blocks {
                                  * an entry in the palette we need to remove.
                                  */
                                 name = this.blockList[connection].value;
-                                if (this.protoBlockDict["myDo_" + name] != undefined) {
+                                if (
+                                    this.protoBlockDict["myDo_" + name] !== null &&
+                                    this.protoBlockDict["myDo_" + name] !== undefined
+                                ) {
                                     delete this.protoBlockDict["myDo_" + name];
                                     this.activity.palettes.dict["action"].hideMenu(true);
                                 }
@@ -2197,7 +2215,8 @@ class Blocks {
                  * adding a new block inside of a note block.
                  */
                 if (
-                    this._insideNoteBlock(thisBlock) != null &&
+                    this._insideNoteBlock(thisBlock) !== null &&
+                    this._insideNoteBlock(thisBlock) !== undefined &&
                     this.blockList[thisBlock].connections.length > 1
                 ) {
                     /** If blocks are inserted above the silence block. */
@@ -2221,7 +2240,10 @@ class Blocks {
                         }
 
                         if (this.blockList[b].name === "action") {
-                            if (this.blockList[b].connections[1] != null) {
+                            if (
+                                this.blockList[b].connections[1] !== null &&
+                                this.blockList[b].connections[1] !== undefined
+                            ) {
                                 if (
                                     this.blockList[this.blockList[b].connections[1]].value ===
                                     this.blockList[thisBlock].value
@@ -2298,7 +2320,7 @@ class Blocks {
                                     lockInit = true;
                                     newTopBlock = that.findTopBlock(thisBlock);
                                     if (
-                                        this.blockList[newTopBlock].protoblock.staticLabels[0] ==
+                                        this.blockList[newTopBlock].protoblock.staticLabels[0] ===
                                         widgetTitle[i].innerHTML
                                     ) {
                                         this.reInitWidget(newTopBlock, 1500);
@@ -2311,7 +2333,7 @@ class Blocks {
             }
 
             /** If it is an arg block, where is it coming from? */
-            if (myBlock.isArgumentLikeBlock() && newBlock != null) {
+            if (myBlock.isArgumentLikeBlock() && newBlock !== null && newBlock !== undefined) {
                 const parentBlock = this.blockList[newBlock];
 
                 // Find which connection index this block is attached to
@@ -2361,7 +2383,7 @@ class Blocks {
             /** Next, recheck if the connection is inside of a expandable block. */
             blk = this.insideExpandableBlock(thisBlock);
             expandableLoopCounter = 0;
-            while (blk != null) {
+            while (blk !== null && blk !== undefined) {
                 /** Extra check for malformed data. */
                 expandableLoopCounter += 1;
                 if (expandableLoopCounter > 2 * this.blockList.length) {
@@ -2427,7 +2449,7 @@ class Blocks {
 
             for (const [blk, myBlock] of this.blockList.entries()) {
                 if (myBlock.trash) continue;
-                if (myBlock.connections[0] == null) {
+                if (myBlock.connections[0] === null || myBlock.connections[0] === undefined) {
                     this._adjustTheseStacks.push(blk);
                 }
             }
@@ -2456,7 +2478,7 @@ class Blocks {
             let onScreen = true;
             for (const block of this.blockList) {
                 if (block.trash) continue;
-                if (block.connections[0] == null) {
+                if (block.connections[0] === null || block.connections[0] === undefined) {
                     if (block.offScreen(this.boundary)) {
                         this.activity.setHomeContainers(true);
                         /** Just highlight the button. */
@@ -2531,7 +2553,7 @@ class Blocks {
          */
         this._moveBlock = (blk, x, y) => {
             const myBlock = this.blockList[blk];
-            if (myBlock.container != null) {
+            if (myBlock.container !== null && myBlock.container !== undefined) {
                 /** Round position so font renders clearly. */
                 myBlock.container.x = Math.floor(x + 0.5);
                 myBlock.container.y = Math.floor(y + 0.5);
@@ -2539,7 +2561,7 @@ class Blocks {
                 if (this._deferCheckBoundsCount > 0) {
                     this._checkBoundsPending = true;
                 } else {
-                    this.scheduleCheckBounds();
+                    this.checkBounds();
                 }
             } else {
                 console.debug("No container yet for block " + myBlock.name);
@@ -2558,14 +2580,14 @@ class Blocks {
             this.inLongPress = false;
             this.isBlockMoving = true;
             const myBlock = this.blockList[blk];
-            if (myBlock.container != null) {
+            if (myBlock.container !== null && myBlock.container !== undefined) {
                 myBlock.container.x += dx;
                 myBlock.container.y += dy;
 
                 if (this._deferCheckBoundsCount > 0) {
                     this._checkBoundsPending = true;
                 } else {
-                    this.scheduleCheckBounds();
+                    this.checkBounds();
                 }
             } else {
                 console.debug("No container yet for block " + myBlock.name);
@@ -2586,7 +2608,7 @@ class Blocks {
             this.inLongPress = false;
             this.isBlockMoving = true;
             const myBlock = this.blockList[blk];
-            if (myBlock.container != null) {
+            if (myBlock.container !== null && myBlock.container !== undefined) {
                 myBlock.container.x += dx;
                 myBlock.container.y += dy;
             }
@@ -2623,10 +2645,10 @@ class Blocks {
             // Build top-block cache if not available.
             // The cache maps each block index to its top block index,
             // avoiding repeated O(depth) findTopBlock walks.
-            if (this._topBlockCache == null) {
+            if (this._topBlockCache === null || this._topBlockCache === undefined) {
                 this._topBlockCache = new Map();
                 for (let i = 0; i < this.blockList.length; i++) {
-                    if (!this.blockList[i] || this.blockList[i].trash) continue;
+                    if (this.blockList[i].trash) continue;
                     this._topBlockCache.set(i, this.findTopBlock(i));
                 }
             }
@@ -2636,7 +2658,7 @@ class Blocks {
 
             this._beginDeferCheckBounds();
             for (let i = 0; i < this.blockList.length; i++) {
-                if (!this.blockList[i] || this.blockList[i].trash) continue;
+                if (this.blockList[i].trash) continue;
                 if (this._topBlockCache.get(i) !== excludeTop) {
                     this.moveBlockRelativeBatched(i, dx, dy);
                 }
@@ -2654,7 +2676,7 @@ class Blocks {
         this.updateBlockText = blk => {
             const myBlock = this.blockList[blk];
             let maxLength = 8;
-            if (myBlock.text == null) {
+            if (myBlock.text === null || myBlock.text === undefined) {
                 return;
             }
 
@@ -2807,7 +2829,7 @@ class Blocks {
                     }
                     break;
                 default:
-                    if (myBlock.value == null) {
+                    if (myBlock.value === null || myBlock.value === undefined) {
                         label = "";
                     } else if (typeof myBlock.value !== "string") {
                         label = myBlock.value.toString();
@@ -2842,12 +2864,12 @@ class Blocks {
          */
         this.findTopBlock = blk => {
             /** Find the top block in a stack. */
-            if (blk == null) {
+            if (blk === null || blk === undefined) {
                 return null;
             }
 
             let myBlock = this.blockList[blk];
-            if (myBlock.connections == null) {
+            if (myBlock.connections === null || myBlock.connections === undefined) {
                 return blk;
             }
 
@@ -2858,7 +2880,8 @@ class Blocks {
             /** Test for corrupted-connection scenario. */
             if (
                 myBlock.connections.length > 1 &&
-                myBlock.connections[0] != null &&
+                myBlock.connections[0] !== null &&
+                myBlock.connections[0] !== undefined &&
                 myBlock.connections[0] === last(myBlock.connections)
             ) {
                 console.debug(
@@ -2876,7 +2899,7 @@ class Blocks {
             }
 
             let topBlockLoop = 0;
-            while (myBlock.connections[0] != null) {
+            while (myBlock.connections[0] !== null && myBlock.connections[0] !== undefined) {
                 topBlockLoop += 1;
                 if (topBlockLoop > 2 * this.blockList.length) {
                     /** Could happen if the block data is malformed. */
@@ -2901,7 +2924,12 @@ class Blocks {
          * @returns boolean
          */
         this.sameGeneration = (firstBlk, childBlk) => {
-            if (firstBlk == null || childBlk == null) {
+            if (
+                firstBlk === null ||
+                firstBlk === undefined ||
+                childBlk === null ||
+                childBlk === undefined
+            ) {
                 return false;
             }
 
@@ -2910,7 +2938,7 @@ class Blocks {
             }
 
             let myBlock = this.blockList[firstBlk];
-            if (myBlock.connections == null) {
+            if (myBlock.connections === null || myBlock.connections === undefined) {
                 return false;
             }
 
@@ -2919,7 +2947,7 @@ class Blocks {
             }
 
             let bottomBlockLoop = 0;
-            while (last(myBlock.connections) != null) {
+            while (last(myBlock.connections) !== null && last(myBlock.connections) !== undefined) {
                 bottomBlockLoop += 1;
                 if (bottomBlockLoop > 2 * this.blockList.length) {
                     /** Could happen if the block data is malformed. */
@@ -2947,7 +2975,7 @@ class Blocks {
         this._blockInStack = (thisBlock, names) => {
             /** Is there a block of any of these names in this stack? */
             let counter = 0;
-            while (thisBlock != null) {
+            while (thisBlock !== null && thisBlock !== undefined) {
                 if (names.includes(this.blockList[thisBlock].name)) {
                     return true;
                 }
@@ -2977,12 +3005,12 @@ class Blocks {
          */
         this.findBottomBlock = blk => {
             /** Find the bottom block in a stack. */
-            if (blk == null) {
+            if (blk === null || blk === undefined) {
                 return null;
             }
 
             let myBlock = this.blockList[blk];
-            if (myBlock.connections == null) {
+            if (myBlock.connections === null || myBlock.connections === undefined) {
                 return blk;
             }
 
@@ -2991,7 +3019,7 @@ class Blocks {
             }
 
             let bottomBlockLoop = 0;
-            while (last(myBlock.connections) != null) {
+            while (last(myBlock.connections) !== null && last(myBlock.connections) !== undefined) {
                 bottomBlockLoop += 1;
                 if (bottomBlockLoop > 2 * this.blockList.length) {
                     /** Could happen if the block data is malformed. */
@@ -3035,8 +3063,11 @@ class Blocks {
         this.findStacks = () => {
             this.stackList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (!this.blockList[i] || this.blockList[i].trash) continue;
-                if (this.blockList[i].connections[0] == null) {
+                if (this.blockList[i].trash) continue;
+                if (
+                    this.blockList[i].connections[0] === null ||
+                    this.blockList[i].connections[0] === undefined
+                ) {
                     this.stackList.push(i);
                 }
             }
@@ -3066,7 +3097,7 @@ class Blocks {
         this._findTwoArgs = () => {
             this._expandablesList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (!this.blockList[i] || this.blockList[i].trash) continue;
+                if (this.blockList[i].trash) continue;
                 if (this.blockList[i].isArgBlock() && this.blockList[i].isExpandableBlock()) {
                     this._expandablesList.push(i);
                 } else if (this.blockList[i].isTwoArgBlock()) {
@@ -3082,7 +3113,7 @@ class Blocks {
          */
         this._searchForArgFlow = () => {
             for (const [blk, block] of this.blockList.entries()) {
-                if (!block || block.trash) continue;
+                if (block.trash) continue;
                 if (block.isArgFlowClampBlock()) {
                     this._searchCounter = 0;
                     this._searchForExpandables(blk);
@@ -3100,8 +3131,10 @@ class Blocks {
         this._searchForExpandables = blk => {
             let c;
             while (
-                blk != null &&
-                this.blockList[blk] != null &&
+                blk !== null &&
+                blk !== undefined &&
+                this.blockList[blk] !== null &&
+                this.blockList[blk] !== undefined &&
                 !this.blockList[blk].isValueBlock()
             ) {
                 /** More checks for malformed or corrupted block data. */
@@ -3297,7 +3330,7 @@ class Blocks {
                 if (c === myBlock.docks.length) {
                     break;
                 }
-                if (connections[c] == null) {
+                if (connections[c] === null || connections[c] === undefined) {
                     myBlock.connections.push(null);
                 } else {
                     myBlock.connections.push(connections[c] + blockOffset);
@@ -3317,7 +3350,7 @@ class Blocks {
             /**
              * Create a new block
              */
-            if (this.protoBlockDict[name] == null) {
+            if (this.protoBlockDict[name] === null || this.protoBlockDict[name] === undefined) {
                 console.debug("makeNewBlock: no prototype for " + name);
                 return null;
             }
@@ -3346,7 +3379,7 @@ class Blocks {
                 this.blockList.push(new Block(this.protoBlockDict[name], this));
             }
 
-            if (last(this.blockList) == null) {
+            if (last(this.blockList) === null || last(this.blockList) === undefined) {
                 /** Should never happen */
 
                 console.debug("failed to make protoblock for " + name);
@@ -3551,7 +3584,7 @@ class Blocks {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = v;
-                    if (v == null) {
+                    if (v === null || v === undefined) {
                         that.blockList[b].image = "images/load-media.svg";
                     } else {
                         that.blockList[b].image = null;
@@ -3564,7 +3597,7 @@ class Blocks {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = CAMERAVALUE;
-                    if (v == null) {
+                    if (v === null || v === undefined) {
                         that.blockList[b].image = "images/camera.svg";
                     } else {
                         that.blockList[b].image = null;
@@ -3577,7 +3610,7 @@ class Blocks {
                     const b = args[0];
                     const v = args[1];
                     that.blockList[b].value = VIDEOVALUE;
-                    if (v == null) {
+                    if (v === null || v === undefined) {
                         that.blockList[b].image = "images/video.svg";
                     } else {
                         that.blockList[b].image = null;
@@ -3703,7 +3736,7 @@ class Blocks {
 
                 thisBlock = this.blockList.length;
                 if (myBlock.docks.length > i && myBlock.docks[i + 1][2] === "anyin") {
-                    if (value == null) {
+                    if (value === null || value === undefined) {
                         console.debug("cannot set default value");
                     } else if (typeof value === "string") {
                         postProcess = args => {
@@ -3773,7 +3806,7 @@ class Blocks {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
-                        if (v != null) {
+                        if (v !== null && v !== undefined) {
                             /** loadThumbnail(that, thisBlock, null); */
                         }
                     };
@@ -3816,7 +3849,7 @@ class Blocks {
          * @returns {void}
          */
         this.findDragGroup = blk => {
-            if (blk == null) {
+            if (blk === null || blk === undefined) {
                 console.debug("null block passed to findDragGroup");
                 return;
             }
@@ -3872,20 +3905,20 @@ class Blocks {
                 return;
             }
 
-            if (blk == null) {
+            if (blk === null || blk === undefined) {
                 console.debug("null block passed to calculateDragGroup");
                 return;
             }
 
             const myBlock = this.blockList[blk];
             /** If this happens, something is really broken. */
-            if (myBlock == null) {
+            if (myBlock === null || myBlock === undefined) {
                 console.debug("null block encountered... this is bad. " + blk);
                 return;
             }
 
             /** As before, does these ever happen? */
-            if (myBlock.connections == null) {
+            if (myBlock.connections === null || myBlock.connections === undefined) {
                 this.dragGroup = [blk];
                 return;
             }
@@ -3900,7 +3933,7 @@ class Blocks {
 
             for (let c = 1; c < myBlock.connections.length; c++) {
                 const cblk = myBlock.connections[c];
-                if (cblk != null) {
+                if (cblk !== null && cblk !== undefined) {
                     /** Recurse */
                     this._calculateDragGroup(cblk);
                 }
@@ -3988,7 +4021,8 @@ class Blocks {
                 if (block.name === "text" && !block.trash) {
                     const c = block.connections[0];
                     if (
-                        c != null &&
+                        c !== null &&
+                        c !== undefined &&
                         this.blockList[c].name === "pitch" &&
                         !this.blockList[c].trash
                     ) {
@@ -4019,7 +4053,8 @@ class Blocks {
                 if (block.name === "text" && !block.trash) {
                     const c = block.connections[0];
                     if (
-                        c != null &&
+                        c !== null &&
+                        c !== undefined &&
                         this.blockList[c].name === "temperament1" &&
                         !this.blockList[c].trash
                     ) {
@@ -4048,7 +4083,8 @@ class Blocks {
                 if (block.name === "text" || block.name === "string") {
                     const c = block.connections[0];
                     if (
-                        c != null &&
+                        c !== null &&
+                        c !== undefined &&
                         ["playdrum", "setdrum", "playnoise", "setvoice"].includes(
                             this.blockList[c].name
                         )
@@ -4079,7 +4115,7 @@ class Blocks {
                 if (block.trash) continue;
                 if (block.name === "text") {
                     const c = block.connections[0];
-                    if (c != null && this.blockList[c].name === "box") {
+                    if (c !== null && c !== undefined && this.blockList[c].name === "box") {
                         if (block.value === oldName) {
                             block.value = newName;
                             block.text.text = newName;
@@ -4121,7 +4157,7 @@ class Blocks {
                 if (block.trash) continue;
                 if (block.name === "text") {
                     const c = block.connections[0];
-                    if (c != null && this.blockList[c].name === "storein") {
+                    if (c !== null && c !== undefined && this.blockList[c].name === "storein") {
                         if (block.value === oldName) {
                             block.value = newName;
                             block.text.text = newName;
@@ -4275,7 +4311,7 @@ class Blocks {
                     continue;
                 }
                 const blkParent = this.blockList[myBlock.connections[0]];
-                if (blkParent == null) {
+                if (blkParent === null || blkParent === undefined) {
                     continue;
                 }
 
@@ -4382,10 +4418,10 @@ class Blocks {
          * short-from storein2 block covers all of the use cases.
          */
         this.newStoreinBlock = name => {
-            if (name == null) {
+            if (name === null) {
                 console.debug("null name passed to newStoreinBlock");
                 return;
-            } else if (name == undefined) {
+            } else if (name === undefined) {
                 console.debug("undefined name passed to newStoreinBlock");
                 return;
             } else if ("myStorein_" + name in this.protoBlockDict) {
@@ -4418,10 +4454,10 @@ class Blocks {
          * return {void}
          */
         this.newStorein2Block = name => {
-            if (name == null) {
+            if (name === null) {
                 console.debug("null name passed to newStorein2Block");
                 return;
-            } else if (name == undefined) {
+            } else if (name === undefined) {
                 console.debug("undefined name passed to newStorein2Block");
                 return;
             } else if ("yourStorein2_" + name in this.protoBlockDict) {
@@ -4450,10 +4486,10 @@ class Blocks {
          * return {void}
          */
         this.newNamedboxBlock = name => {
-            if (name == null) {
+            if (name === null) {
                 console.debug("null name passed to newNamedboxBlock");
                 return;
-            } else if (name == undefined) {
+            } else if (name === undefined) {
                 console.debug("undefined name passed to newNamedboxBlock");
                 return;
             } else if ("myBox_" + name in this.protoBlockDict) {
@@ -4636,12 +4672,15 @@ class Blocks {
 
         this._insideArgClamp = blk => {
             /** Returns a containing arg clamp block or null */
-            if (this.blockList[blk] == null) {
+            if (this.blockList[blk] === null || this.blockList[blk] === undefined) {
                 /** race condition? */
 
                 console.debug("null block in blockList? " + blk);
                 return null;
-            } else if (this.blockList[blk].connections[0] == null) {
+            } else if (
+                this.blockList[blk].connections[0] === null ||
+                this.blockList[blk].connections[0] === undefined
+            ) {
                 return null;
             } else {
                 const cblk = this.blockList[blk].connections[0];
@@ -4661,10 +4700,13 @@ class Blocks {
          * @returns list of clamp blocks
          */
         this.findNestedClampBlocks = (blk, clampList) => {
-            if (this.blockList[blk] == null) {
+            if (this.blockList[blk] === null || this.blockList[blk] === undefined) {
                 console.debug("null block in blockList? " + blk);
                 return [];
-            } else if (this.blockList[blk].connections[0] == null) {
+            } else if (
+                this.blockList[blk].connections[0] === null ||
+                this.blockList[blk].connections[0] === undefined
+            ) {
                 /** We reached the end, so return the list. */
                 return clampList;
             } else {
@@ -4692,12 +4734,15 @@ class Blocks {
          * @returns expandable block
          */
         this.insideExpandableBlock = blk => {
-            if (this.blockList[blk] == null) {
+            if (this.blockList[blk] === null || this.blockList[blk] === undefined) {
                 /** race condition? */
 
                 console.debug("null block in blockList? " + blk);
                 return null;
-            } else if (this.blockList[blk].connections[0] == null) {
+            } else if (
+                this.blockList[blk].connections[0] === null ||
+                this.blockList[blk].connections[0] === undefined
+            ) {
                 return null;
             } else {
                 const cblk = this.blockList[blk].connections[0];
@@ -4726,10 +4771,13 @@ class Blocks {
          * @returns note block
          */
         this._insideNoteBlock = blk => {
-            if (this.blockList[blk] == null) {
+            if (this.blockList[blk] === null || this.blockList[blk] === undefined) {
                 console.debug("null block in blockList? " + blk);
                 return null;
-            } else if (this.blockList[blk].connections[0] == null) {
+            } else if (
+                this.blockList[blk].connections[0] === null ||
+                this.blockList[blk].connections[0] === undefined
+            ) {
                 return null;
             } else {
                 const cblk = this.blockList[blk].connections[0];
@@ -4766,7 +4814,10 @@ class Blocks {
         this._isConnectedToNoteValue = blk => {
             if (NOTEBLOCKS.includes(this.blockList[blk].name)) {
                 return true;
-            } else if (this.blockList[blk].connections[0] == null) {
+            } else if (
+                this.blockList[blk].connections[0] === null ||
+                this.blockList[blk].connections[0] === undefined
+            ) {
                 return false;
             } else {
                 const cblk = this.blockList[blk].connections[0];
@@ -5283,7 +5334,7 @@ class Blocks {
          * @returns {void}
          */
         this.prepareStackForCopy = () => {
-            if (this.activeBlock == null) {
+            if (this.activeBlock === null || this.activeBlock === undefined) {
                 this.activity.errorMsg(_("There is no block selected."));
 
                 console.debug("No active block to copy.");
@@ -5306,7 +5357,7 @@ class Blocks {
          * @returns {void}
          */
         this.triggerLongPress = () => {
-            if (this.longPressTimeout != null) {
+            if (this.longPressTimeout !== null && this.longPressTimeout !== undefined) {
                 clearTimeout(this.longPressTimeout);
                 this.longPressTimeout = null;
             }
@@ -5321,7 +5372,7 @@ class Blocks {
          * @returns {void}
          */
         this.pasteStack = () => {
-            if (this.selectedStack == null) {
+            if (this.selectedStack === null || this.selectedStack === undefined) {
                 return;
             }
 
@@ -5331,7 +5382,7 @@ class Blocks {
             }
 
             /** Reposition the paste location relative to the stage position. */
-            if (this.selectedBlocksObj != null) {
+            if (this.selectedBlocksObj !== null && this.selectedBlocksObj !== undefined) {
                 const helpfulWheelDiv = docById("helpfulWheelDiv");
                 if (helpfulWheelDiv.style.display !== "none") {
                     this.selectedBlocksObj[0][2] =
@@ -5373,7 +5424,7 @@ class Blocks {
             let name = "---";
             if (["temperament1", "definemode", "action"].includes(blockObjs[0][1])) {
                 const nameBlk = blockObjs[0][4][1];
-                if (nameBlk == null) {
+                if (nameBlk === null || nameBlk === undefined) {
                     console.debug("action not named... skipping");
                 } else {
                     if (typeof blockObjs[nameBlk][1][1] === "string") {
@@ -5588,13 +5639,19 @@ class Blocks {
                 }
 
                 if (this.blockList[b].name === "action") {
-                    if (this.blockList[b].connections[1] != null) {
+                    if (
+                        this.blockList[b].connections[1] !== null &&
+                        this.blockList[b].connections[1] !== undefined
+                    ) {
                         currentActionNames.push(
                             this.blockList[this.blockList[b].connections[1]].value
                         );
                     }
                 } else if (this.blockList[b].name === "storein") {
-                    if (this.blockList[b].connections[1] != null) {
+                    if (
+                        this.blockList[b].connections[1] !== null &&
+                        this.blockList[b].connections[1] !== undefined
+                    ) {
                         currentStoreinNames.push(
                             this.blockList[this.blockList[b].connections[1]].value
                         );
@@ -5670,12 +5727,12 @@ class Blocks {
                         break;
                     case "action":
                     case "hat":
-                        if (blkData[4][1] != null) {
+                        if (blkData[4][1] !== null && blkData[4][1] !== undefined) {
                             actionNames[b] = blkData[4][1];
                         }
                         break;
                     case "storein":
-                        if (blkData[4][1] != null) {
+                        if (blkData[4][1] !== null && blkData[4][1] !== undefined) {
                             storeinNames[b] = blkData[4][1];
                         }
                         break;
@@ -5687,7 +5744,7 @@ class Blocks {
                         break;
                     case "do":
                     case "stack":
-                        if (blkData[4][1] != null) {
+                        if (blkData[4][1] !== null && blkData[4][1] !== undefined) {
                             doNames[b] = blkData[4][1];
                         }
                         break;
@@ -5853,7 +5910,7 @@ class Blocks {
                     case "tuplet2":
                     case "vibrato":
                         len = blockObjs[b][4].length;
-                        if (last(blockObjs[b][4]) == null) {
+                        if (last(blockObjs[b][4]) === null || last(blockObjs[b][4]) === undefined) {
                             /** If there is no next block, add a hidden block; */
 
                             console.debug(
@@ -5906,7 +5963,7 @@ class Blocks {
                             /** (1) add a vspace to the start of the clamp of a note block. */
                             const clampBlock = blockObjs[b][4][2];
                             blockObjs[b][4][2] = blockObjsLength + extraBlocksLength;
-                            if (clampBlock == null) {
+                            if (clampBlock === null || clampBlock === undefined) {
                                 blockObjs.push([
                                     blockObjsLength + extraBlocksLength,
                                     "vspace",
@@ -5930,7 +5987,7 @@ class Blocks {
                             /** (2) switch the first connection to divide 1 / arg. */
                             const argBlock = blockObjs[b][4][1];
                             blockObjs[b][4][1] = blockObjsLength + extraBlocksLength;
-                            if (argBlock == null) {
+                            if (argBlock === null || argBlock === undefined) {
                                 blockObjs.push([
                                     blockObjsLength + extraBlocksLength,
                                     "divide",
@@ -5992,7 +6049,7 @@ class Blocks {
                          * properly).
                          */
                         len = blockObjs[b][4].length;
-                        if (blockObjs[b][4][2] == null) {
+                        if (blockObjs[b][4][2] === null || blockObjs[b][4][2] === undefined) {
                             /** If there is no child flow block, add a hidden block; */
 
                             console.debug(
@@ -6114,13 +6171,13 @@ class Blocks {
                 let name = blkInfo[0];
                 let value;
                 let text;
-                if (blkInfo[1] == null) {
+                if (blkInfo[1] === null || blkInfo[1] === undefined) {
                     value = null;
                     text = "";
                 } else {
                     value = blkInfo[1]["value"];
                     text = blkInfo[1]["text"];
-                    if (text == null) {
+                    if (text === null || text === undefined) {
                         text = "";
                     }
                 }
@@ -6285,7 +6342,7 @@ class Blocks {
                                 }
                                 that.blockList[thisBlock].updateArgSlots(slotList);
                                 for (let i = 0; i < args[1].length; i++) {
-                                    if (args[1][i] != null) {
+                                    if (args[1][i] !== null && args[1][i] !== undefined) {
                                         that.blockList[thisBlock].connections[i] =
                                             args[1][i] + firstBlock;
                                     } else {
@@ -6320,7 +6377,7 @@ class Blocks {
                                 }
                                 that.blockList[thisBlock].updateArgSlots(slotList);
                                 for (let i = 0; i < args[2].length; i++) {
-                                    if (args[2][i] != null) {
+                                    if (args[2][i] !== null && args[2][i] !== undefined) {
                                         that.blockList[thisBlock].connections[i] =
                                             args[2][i] + firstBlock;
                                     } else {
@@ -6352,7 +6409,7 @@ class Blocks {
                                 }
                                 that.blockList[thisBlock].updateArgSlots(slotList);
                                 for (let i = 0; i < args[1].length; i++) {
-                                    if (args[1][i] != null) {
+                                    if (args[1][i] !== null && args[1][i] !== undefined) {
                                         that.blockList[thisBlock].connections[i] =
                                             args[1][i] + firstBlock;
                                     } else {
@@ -6387,7 +6444,7 @@ class Blocks {
                                 }
                                 that.blockList[thisBlock].updateArgSlots(slotList);
                                 for (let i = 0; i < args[2].length; i++) {
-                                    if (args[2][i] != null) {
+                                    if (args[2][i] !== null && args[2][i] !== undefined) {
                                         that.blockList[thisBlock].connections[i] =
                                             args[2][i] + firstBlock;
                                     } else {
@@ -6418,7 +6475,7 @@ class Blocks {
                                 }
                                 that.blockList[thisBlock].updateArgSlots(slotList);
                                 for (let i = 0; i < args[1].length; i++) {
-                                    if (args[1][i] != null) {
+                                    if (args[1][i] !== null && args[1][i] !== undefined) {
                                         that.blockList[thisBlock].connections[i] =
                                             args[1][i] + firstBlock;
                                     } else {
@@ -6608,7 +6665,7 @@ class Blocks {
                             const thisBlock = args[0];
                             const value = args[1];
                             that.blockList[thisBlock].value = value;
-                            if (value != null) {
+                            if (value !== null && value !== undefined) {
                                 /** Load artwork onto media block. */
                                 that.blockList[thisBlock].loadThumbnail(null);
                             }
@@ -6783,7 +6840,11 @@ class Blocks {
                         break;
                     default:
                         /** Check that name is in the proto list */
-                        if (!(name in this.protoBlockDict) || this.protoBlockDict[name] == null) {
+                        if (
+                            !(name in this.protoBlockDict) ||
+                            this.protoBlockDict[name] === null ||
+                            this.protoBlockDict[name] === undefined
+                        ) {
                             const postProcessUnknownBlock = args => {
                                 /** save original block name */
                                 that.blockList[args[0]].privateData = args[1];
@@ -6901,11 +6962,14 @@ class Blocks {
                 }
 
                 if (thisBlock === this.blockList.length - 1) {
-                    if (this.blockList[thisBlock].connections[0] == null) {
+                    if (
+                        this.blockList[thisBlock].connections[0] === null ||
+                        this.blockList[thisBlock].connections[0] === undefined
+                    ) {
                         this.blockList[thisBlock].container.x = blkData[2];
                         this.blockList[thisBlock].container.y = blkData[3];
                         this._adjustTheseDocks.push(thisBlock);
-                        if (blkData[4][0] == null) {
+                        if (blkData[4][0] === null || blkData[4][0] === undefined) {
                             this._adjustTheseStacks.push(thisBlock);
                         }
                         if (
@@ -6953,7 +7017,7 @@ class Blocks {
                 if (!this.blockList[blk].trash && this.blockList[blk].name === "action") {
                     const myBlock = this.blockList[blk];
                     const c = myBlock.connections[1];
-                    if (c != null && this.blockList[c].value !== _("action")) {
+                    if (c !== null && c !== undefined && this.blockList[c].value !== _("action")) {
                         const metadata = this.actionMetadata(blk);
                         if (
                             this.newNameddoBlock(
@@ -6977,13 +7041,15 @@ class Blocks {
                 if (!this.blockList[blk].trash && this.blockList[blk].name === "storein") {
                     const myBlock = this.blockList[blk];
                     const c = myBlock.connections[1];
-                    if (c != null && this.blockList[c].value !== _("box")) {
+                    if (c !== null && c !== undefined && this.blockList[c].value !== _("box")) {
                         const name = this.blockList[c].value;
                         if (name !== null) {
                             /** Is there an old block with this name still around? */
                             if (
-                                this.protoBlockDict["myStorein_" + name] == undefined ||
-                                this.protoBlockDict["yourStorein2_" + name] == undefined
+                                this.protoBlockDict["myStorein_" + name] === null ||
+                                this.protoBlockDict["myStorein_" + name] === undefined ||
+                                this.protoBlockDict["yourStorein2_" + name] === null ||
+                                this.protoBlockDict["yourStorein2_" + name] === undefined
                             ) {
                                 /** this.newStoreinBlock(this.blockList[c].value); */
                                 this.newStorein2Block(this.blockList[c].value);
@@ -7239,7 +7305,7 @@ class Blocks {
 
             /** Disconnect block. */
             const parentBlock = myBlock.connections[0];
-            if (parentBlock != null) {
+            if (parentBlock !== null && parentBlock !== undefined) {
                 for (const c in this.blockList[parentBlock].connections) {
                     if (this.blockList[parentBlock].connections[c] === thisBlock) {
                         this.blockList[parentBlock].connections[c] = null;
@@ -7256,7 +7322,7 @@ class Blocks {
 
             if (myBlock.name === "start" || myBlock.name === "drum") {
                 const turtle = myBlock.value;
-                if (turtle != null) {
+                if (turtle !== null && turtle !== undefined) {
                     console.debug("putting turtle " + turtle + " in the trash");
                     const comp = this.turtles.turtleList[turtle].companionTurtle;
                     if (comp) {
@@ -7302,7 +7368,7 @@ class Blocks {
             }
 
             /** Adjust the stack from which we just deleted blocks. */
-            if (parentBlock != null) {
+            if (parentBlock !== null && parentBlock !== undefined) {
                 const topBlk = this.findTopBlock(parentBlock);
                 this.findDragGroup(topBlk);
 
@@ -7356,7 +7422,10 @@ class Blocks {
                         continue;
                     }
                     this.blockList[blk].text.text = "";
-                    if (this.blockList[blk].container.cacheCanvas != null) {
+                    if (
+                        this.blockList[blk].container.cacheCanvas !== null &&
+                        this.blockList[blk].container.cacheCanvas !== undefined
+                    ) {
                         this.blockList[blk].container.updateCache();
                     }
                 }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2648,7 +2648,8 @@ class Blocks {
             if (this._topBlockCache === null || this._topBlockCache === undefined) {
                 this._topBlockCache = new Map();
                 for (let i = 0; i < this.blockList.length; i++) {
-                    if (this.blockList[i].trash) continue;
+                    const block = this.blockList[i];
+                    if (!block || block.trash) continue;
                     this._topBlockCache.set(i, this.findTopBlock(i));
                 }
             }
@@ -2658,7 +2659,7 @@ class Blocks {
 
             this._beginDeferCheckBounds();
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
+                if (!this.blockList[i] || this.blockList[i].trash) continue;
                 if (this._topBlockCache.get(i) !== excludeTop) {
                     this.moveBlockRelativeBatched(i, dx, dy);
                 }
@@ -3063,11 +3064,9 @@ class Blocks {
         this.findStacks = () => {
             this.stackList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
-                if (
-                    this.blockList[i].connections[0] === null ||
-                    this.blockList[i].connections[0] === undefined
-                ) {
+                const block = this.blockList[i];
+                if (!block || block.trash) continue;
+                if (block.connections[0] === null || block.connections[0] === undefined) {
                     this.stackList.push(i);
                 }
             }
@@ -3097,10 +3096,11 @@ class Blocks {
         this._findTwoArgs = () => {
             this._expandablesList = [];
             for (let i = 0; i < this.blockList.length; i++) {
-                if (this.blockList[i].trash) continue;
-                if (this.blockList[i].isArgBlock() && this.blockList[i].isExpandableBlock()) {
+                const block = this.blockList[i];
+                if (!block || block.trash) continue;
+                if (block.isArgBlock() && block.isExpandableBlock()) {
                     this._expandablesList.push(i);
-                } else if (this.blockList[i].isTwoArgBlock()) {
+                } else if (block.isTwoArgBlock()) {
                     this._expandablesList.push(i);
                 }
             }
@@ -3113,7 +3113,7 @@ class Blocks {
          */
         this._searchForArgFlow = () => {
             for (const [blk, block] of this.blockList.entries()) {
-                if (block.trash) continue;
+                if (!block || block.trash) continue;
                 if (block.isArgFlowClampBlock()) {
                     this._searchCounter = 0;
                     this._searchForExpandables(blk);


### PR DESCRIPTION
- [x] Tests 
- [x] Fix

## Summary
- Adds sparse-array safety coverage for Blocks workspace helpers
- Skips missing block entries in stack, movement, and expandable-block scans

## Verification
- npx.cmd jest js/__tests__/blocks.test.js --runInBand --coverage=false

resolved merge conflict in PR #7027 
