### PR TITLE
fix: improve non-12 EDO temperament runtime

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -320,7 +320,7 @@ class Singer {
             logo.synth.inTemperament
         );
 
-        if (isCustomTemperament(logo.synth.inTemperament)) {
+        if (isCustomTemperament(logo.synth.inTemperament) || getOctaveInterval(activity) !== 12) {
             noteObj = getNote(
                 noteObj[0],
                 noteObj[1],

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -75,10 +75,10 @@ function setupIntervalsActions(activity) {
          */
         static getTemperamentLength() {
             const currentTemperament = activity.logo.synth.inTemperament;
-            if (!currentTemperament) {
-                return 12; // Default fallback for tests/uninitialized state
-            }
-            return TEMPERAMENT[currentTemperament]["pitchNumber"];
+            return TEMPERAMENT[currentTemperament] &&
+                typeof TEMPERAMENT[currentTemperament].pitchNumber === "number"
+                ? TEMPERAMENT[currentTemperament].pitchNumber
+                : TEMPERAMENT.equal.pitchNumber;
         }
 
         /**

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -184,10 +184,18 @@ function setupPitchActions(activity) {
             number = Math.abs(number);
 
             const obj = keySignatureToMode(tur.singer.keySignature);
+            const temperamentLength =
+                Singer.IntervalsActions &&
+                typeof Singer.IntervalsActions.getTemperamentLength === "function"
+                    ? Singer.IntervalsActions.getTemperamentLength()
+                    : 12;
             let modeLength;
 
-            if (isCustomTemperament(activity.logo.synth.inTemperament)) {
-                modeLength = Singer.IntervalsActions.getTemperamentLength();
+            if (
+                isCustomTemperament(activity.logo.synth.inTemperament) ||
+                temperamentLength !== 12
+            ) {
+                modeLength = temperamentLength;
             } else {
                 modeLength = MUSICALMODES[obj[1]].length;
             }

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -58,6 +58,7 @@ const {
     TEMPERAMENT,
     getTemperamentsList,
     getTemperament,
+    getTemperamentPitchNumber,
     getTemperamentKeys,
     addTemperamentToList,
     addTemperamentToDictionary,
@@ -246,6 +247,17 @@ describe("Temperament Functions", () => {
         it("should return undefined for an invalid key", () => {
             const invalidTemperament = getTemperament("invalid");
             expect(invalidTemperament).toBeUndefined();
+        });
+    });
+
+    describe("getTemperamentPitchNumber", () => {
+        it("returns the active temperament pitch count", () => {
+            expect(getTemperamentPitchNumber("equal5")).toBe(5);
+            expect(getTemperamentPitchNumber("equal31")).toBe(31);
+        });
+
+        it("falls back to 12 for unknown temperaments", () => {
+            expect(getTemperamentPitchNumber("unknown temperament")).toBe(12);
         });
     });
 
@@ -1533,6 +1545,11 @@ describe("getStepSize", () => {
     it('should return the correct step size for "C" in "C major" with a non-standard temperament', () => {
         const result = _getStepSize("C major", "C", "up", 0, "just");
         expect(result).toBe(0);
+    });
+
+    it("maps scalar steps directly to temperament steps for non-12 EDO", () => {
+        expect(_getStepSize("C major", "C", "up", 3, "equal5")).toBe(3);
+        expect(_getStepSize("C major", "C", "down", 3, "equal5")).toBe(-3);
     });
 });
 
@@ -2834,6 +2851,16 @@ describe("numberToPitch additional temperament paths", () => {
         });
 
         expect(numberToPitch(12, "existing", "C4", 0)).toEqual(["Sa", 4]);
+    });
+
+    it("wraps predefined non-12 EDO pitch numbers by temperament length", () => {
+        expect(numberToPitch(0, "equal5", "C4", 0)).toEqual(["C", 4]);
+        expect(numberToPitch(5, "equal5", "C4", 0)).toEqual(["C", 5]);
+        expect(numberToPitch(6, "equal5", "C4", 0)).toEqual(["D" + FLAT, 5]);
+    });
+
+    it("handles negative predefined non-12 EDO pitch numbers", () => {
+        expect(numberToPitch(-1, "equal5", "C4", 0)).toEqual(["F" + SHARP, 3]);
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -46,7 +46,7 @@ const _b64Cache = new Map();
   getFilterTypes, getOscillatorTypes, getDrumIcon, getDrumSynthName,
   getNoiseName, getNoiseIcon, getNoiseSynthName, getVoiceName,
   getVoiceIcon, getVoiceSynthName, getTemperamentKeys,
-  getTemperamentName, getStepSizeUp, getStepSizeDown, getModeLength,
+  getTemperamentName, getStepSizeUp, getStepSizeDown, getModeLength, getTemperamentPitchNumber,
   nthDegreeToPitch, getInterval, calcNoteValueToDisplay,
   durationToNoteValue, noteToFrequency, getSolfege, splitScaleDegree,
   getNumNote, calcOctave, calcOctaveInterval, isInt,
@@ -2340,6 +2340,19 @@ const getTemperament = entry => {
 };
 
 /**
+ * Get the number of pitches in a temperament octave.
+ * @function
+ * @param {string} temperament - The temperament name.
+ * @returns {number} The temperament pitch count, defaulting to 12.
+ */
+const getTemperamentPitchNumber = temperament => {
+    const temperamentDefinition = getTemperament(temperament);
+    return temperamentDefinition && typeof temperamentDefinition.pitchNumber === "number"
+        ? temperamentDefinition.pitchNumber
+        : TEMPERAMENT.equal.pitchNumber;
+};
+
+/**
  * Get the keys of the temperament dictionary.
  * @function
  * @returns {Array<string>} The keys of the temperament dictionary.
@@ -4012,16 +4025,24 @@ const numberToPitch = (i, temperament, startPitch, offset, activity) => {
     if (temperament === undefined) {
         temperament = "equal";
     }
+    if (startPitch === undefined) {
+        startPitch = "A0";
+    } else if (!/\d$/.test(startPitch)) {
+        startPitch += "0";
+    }
+    if (offset === undefined) {
+        offset = 0;
+    }
 
     let n = 0;
     let pitchNumber;
     if (i < 0) {
-        while (i < 0) {
-            i += 12;
-            n += 1; // Count octave bump ups.
-        }
-
         if (temperament === "equal") {
+            while (i < 0) {
+                i += 12;
+                n += 1; // Count octave bump ups.
+            }
+
             return [
                 PITCHES[(i + PITCHES.indexOf("A")) % 12],
                 Math.floor((i + PITCHES.indexOf("A")) / 12) - n
@@ -4040,11 +4061,12 @@ const numberToPitch = (i, temperament, startPitch, offset, activity) => {
         }
     }
 
+    const temperamentDefinition = TEMPERAMENT[temperament];
     let interval;
     if (isCustomTemperament(temperament)) {
         // The index may be outside of the octave.
         // Ensure the temperament exists in TEMPERAMENT before accessing it
-        if (!TEMPERAMENT[temperament] || !TEMPERAMENT[temperament]["pitchNumber"]) {
+        if (!temperamentDefinition || !temperamentDefinition["pitchNumber"]) {
             // Fallback to equal temperament if custom temperament is not found
             if (activity && activity.errorMsg) {
                 activity.errorMsg(
@@ -4054,19 +4076,22 @@ const numberToPitch = (i, temperament, startPitch, offset, activity) => {
             }
             temperament = "equal";
         }
-        const octaveLength = TEMPERAMENT[temperament]["pitchNumber"];
-        const pitchIdx = pitchNumber % octaveLength;
+        const octaveLength = getTemperamentPitchNumber(temperament);
+        const pitchIdx = ((pitchNumber % octaveLength) + octaveLength) % octaveLength;
         const octaveFactor = Math.floor(pitchNumber / octaveLength);
 
         pitchNumber = pitchIdx + "";
         if (TEMPERAMENT[temperament][pitchNumber] === undefined) {
             // If custom temperament is not defined, then it will
-            // store equal temperament notes.
-            for (let j = 0; j < 12; j++) {
+            // store notes from the active temperament's interval table.
+            const sourceTemperament = TEMPERAMENT[temperament].interval
+                ? TEMPERAMENT[temperament]
+                : TEMPERAMENT.equal;
+            for (let j = 0; j < octaveLength; j++) {
                 const number = "" + j;
-                interval = TEMPERAMENT["equal"]["interval"][j];
+                interval = sourceTemperament.interval[j] || sourceTemperament.interval[0];
                 TEMPERAMENT[temperament][number] = [
-                    Math.pow(2, j / 12),
+                    Math.pow(getOctaveRatio(), j / octaveLength),
                     getNoteFromInterval(startPitch, interval)[0],
                     getNoteFromInterval(startPitch, interval)[1]
                 ];
@@ -4082,8 +4107,13 @@ const numberToPitch = (i, temperament, startPitch, offset, activity) => {
             return [TEMPERAMENT[temperament][pitchNumber][1], o];
         }
     } else {
-        interval = TEMPERAMENT[temperament]["interval"][pitchNumber];
-        return getNoteFromInterval(startPitch, interval);
+        const octaveLength = getTemperamentPitchNumber(temperament);
+        const pitchIdx = ((pitchNumber % octaveLength) + octaveLength) % octaveLength;
+        const octaveFactor = Math.floor(pitchNumber / octaveLength);
+        const sourceTemperament = TEMPERAMENT[temperament] || TEMPERAMENT.equal;
+        interval = sourceTemperament.interval[pitchIdx] || sourceTemperament.interval[0];
+        const note = getNoteFromInterval(startPitch, interval);
+        return [note[0], note[1] + octaveFactor];
     }
 };
 
@@ -5059,9 +5089,14 @@ const _getStepSize = (keySignature, pitch, direction, transposition, temperament
     if (temperament === undefined) {
         temperament = "equal";
     }
-    if (isCustomTemperament(temperament)) {
-        //Scalar = Semitone for custom Temperament.
-        return transposition;
+    const temperamentDefinition = getTemperament(temperament);
+    if (!temperamentDefinition) {
+        return 0;
+    }
+    if (isCustomTemperament(temperament) || getTemperamentPitchNumber(temperament) !== 12) {
+        // Scalar steps map directly to temperament steps outside 12EDO.
+        const step = typeof transposition === "number" && transposition !== 0 ? transposition : 1;
+        return direction === "down" ? -Math.abs(step) : Math.abs(step);
     }
 
     let thisPitch = pitch;
@@ -6469,6 +6504,7 @@ if (typeof module !== "undefined" && module.exports) {
         getTemperamentsList,
         getTemperament,
         getTemperamentKeys,
+        getTemperamentPitchNumber,
         addTemperamentToList,
         deleteTemperamentFromList,
         addTemperamentToDictionary,


### PR DESCRIPTION
Related to #7171
## PR Category

- [x] Bug Fix
- [x] Feature
- [x] Performance
- [x] Tests
- [ ] Documentation
This PR improves non-12 EDO temperament behavior during playback and pitch operations.

Functional changes:
- Pitch numbers now wrap according to the selected temperament length.
- Negative pitch numbers now work correctly in non-12 EDO temperaments.
- Scalar step now respects non-12 EDO temperaments.
- nth modal pitch now uses the active temperament length.
- Runtime scalar transposition now follows predefined non-12 EDO systems, not only custom temperaments.
- Invalid or unset temperament state now falls back safely instead of throwing errors.

Validation:
- 613 focused tests passed across music utilities, singer runtime, pitch actions, and interval actions.
- Formatting passed.
- Targeted lint passed with no errors.

Scope note:
This focuses on the core playback/runtime behavior needed for temperament support. 

Larger UI-focused proposal items, such as a full Temperament Visualizer Widget and broader import/export UX will be attempted in the future.
