### PR TITLE
fix: guard against null blockList[blk] in _blockFindTurtle

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -43,6 +43,7 @@ function getTargetTurtle(turtles, targetTurtle) {
 }
 
 function _blockFindTurtle(activity, turtle, blk, receivedArg) {
+    if (!activity.blocks.blockList[blk]) return null;
     const cblk = activity.blocks.blockList[blk].connections[1];
     if (cblk === null) {
         //Debug: connecting block not found, returning null
@@ -1070,7 +1071,7 @@ function setupEnsembleBlocks(activity) {
             const tur = activity.turtles.ithTurtle(activity.turtles.companionTurtle(turtle));
             const heading = tur.orientation;
             // Heading needs to be set to 0 when we update the graphic.
-            if (heading != 0) {
+            if (heading !== 0) {
                 tur.painter.doSetHeading(0);
             }
 
@@ -1094,7 +1095,7 @@ function setupEnsembleBlocks(activity) {
             );
 
             // Restore the heading.
-            if (heading != 0) {
+            if (heading !== 0) {
                 tur.painter.doSetHeading(heading);
             }
         }


### PR DESCRIPTION
### Description
Fixed a crash in _blockFindTurtle() in js/blocks/EnsembleBlocks.js. On line 46, the function directly accesses .connections[1] on blockList[blk] without first checking whether that block actually exists. If the block has been deleted or the reference is invalid, JavaScript throws a TypeError and the whole thing crashes before any of the existing null checks even get a chance to run.

The fix is a simple one-line guard at the very top of the function. If the block doesn't exist, we return null early and let the callers handle it gracefully, which they already do using if (thisTurtle) fallback logic.

I also fixed 2 small pre-existing ESLint warnings in the same file (!= to !==) that were blocking the pre-commit hook

### Related Issue
Fixes #7211

### PR Category
- [x] Bug Fix

### Changes Made
Added if (!activity.blocks.blockList[blk]) return null; as the first line of _blockFindTurtle() in js/blocks/EnsembleBlocks.js
Fixed 2 pre-existing != to !== ESLint warnings in the same file

### Checklist
- [x] I tested my changes locally
- [x] I ran ESLint and Prettier checks
- [x] I have enabled "Allow edits from maintainers"