### PR TITLE
fix: resolve off-by-one in ModeWidget._clear() keeping tonic active

### DIFF
--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -268,13 +268,12 @@ describe("ModeWidget", () => {
         expect(modeWidget._selectedNotes[1]).toBe(false);
     });
 
-    test("should clear all notes except root", () => {
+    test("should clear all notes including root", () => {
         modeWidget._selectedNotes = Array(12).fill(true);
 
         modeWidget._clear();
 
-        expect(modeWidget._selectedNotes[0]).toBe(true);
-        for (let i = 1; i < 12; i++) {
+        for (let i = 0; i < 12; i++) {
             expect(modeWidget._selectedNotes[i]).toBe(false);
         }
     });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -822,7 +822,7 @@ class ModeWidget {
 
         this._saveState();
 
-        for (let i = 1; i < 12; i++) {
+        for (let i = 0; i < 12; i++) {
             this._selectedNotes[i] = false;
         }
 


### PR DESCRIPTION
### Description
This PR resolves a critical off-by-one bug in the Mode Widget where the `_clear()` method failed to deselect the root/tonic note (index `0`). 
Because `_selectedNotes[0]` was never cleared, a cascade of silent failures occurred whenever a user attempted to clear the widget to build a new mode from scratch:
- **Data Corruption:** The `_calculateMode()` logic would evaluate the single note as `[12]`, which `_save()` would blindly overwrite into `localStorage.custommode`, clobbering the user's legitimately saved custom modes.
- **Mislabeled Export:** Since `[12]` does not match any valid entry in `MUSICALMODES`, `_setModeName()` would blank the mode label, causing the generated `action` and `definemode` blocks to always incorrectly default to the name `"custom"`.
- **Broken Features:** The Rotate animations (`_rotateRight` / `_rotateLeft`) immediately abort if `_selectedNotes[0]` is true, meaning rotation was permanently broken after clicking Clear.
- **UI/UX:** The wheel retained a "ghost" selection, confusing users.
### PR Category
- [x] Bug fix (non-breaking change which fixes an issue)
### Changes Made
* **`js/widgets/modewidget.js`**: Updated the loop bounds in `_clear()` to initialize at `i = 0` instead of `i = 1`, ensuring all 12 note positions are properly deselected.
* **`js/widgets/__tests__/modewidget.test.js`**: Updated the `should clear all notes except root` test. The test was originally written to explicitly expect this broken behavior. It has been renamed to `should clear all notes including root` and updated to assert that `_selectedNotes[0]` evaluates to `false`.
### Testing Performed
- **Unit Tests:** Ran `npm test`. All 5,006 tests across 152 suites pass successfully.
- **Manual Verification:** Verified that clicking the **Clear** button now fully clears the wheel, rotation animations function normally, and custom modes can be saved without data corruption.