### PR TITLE
Fix thumbnail not saving due to getBounds() returning null

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7839,13 +7839,26 @@ class Activity {
             );
 
             img.onload = () => {
-                const bitmap = new createjs.Bitmap(img);
-                const bounds = bitmap.getBounds();
-                bitmap.cache(bounds.x, bounds.y, bounds.width, bounds.height);
+                // FIX: createjs.Bitmap.getBounds() returns null for any Bitmap
+                // not added to a live EaselJS stage → TypeError: null.x crash.
+                // doSVG() returns "" on blank canvas → naturalWidth = 0 → guaranteed crash.
+                // Fix: use img.naturalWidth directly + plain offscreen canvas (no EaselJS needed).
                 try {
-                    that.storage["SESSIONIMAGE" + p] = bitmap.bitmapCache.getCacheDataURL();
+                    if (!img.naturalWidth || !img.naturalHeight) {
+                        // Blank canvas — doSVG() returned empty string, nothing to thumbnail.
+                        // SESSION<p> JSON was already saved above, so this is safe to skip.
+                        return;
+                    }
+
+                    const w = img.naturalWidth;
+                    const h = img.naturalHeight;
+                    const offscreen = document.createElement("canvas");
+                    offscreen.width = w;
+                    offscreen.height = h;
+                    offscreen.getContext("2d").drawImage(img, 0, 0);
+                    this.storage["SESSIONIMAGE" + p] = offscreen.toDataURL("image/png");
                 } catch (e) {
-                    console.error(e);
+                    console.error("[saveLocally] Thumbnail save failed:", e);
                 }
             };
 


### PR DESCRIPTION
## What this fixes

I noticed that project thumbnails were not being saved in localStorage
during auto-save. The project data was saving correctly, but the thumbnail
(SESSIONIMAGE) was missing.

Related Issue
This PR fixes https://github.com/sugarlabs/musicblocks/issues/7187

## Root cause

The code was using createjs.Bitmap.getBounds() on an image that was not
attached to a stage. In this case, getBounds() returns null, which caused
a runtime error when accessing bounds.x.

Because of this, thumbnail generation failed.

## What I changed

- Removed use of createjs.Bitmap and getBounds()
- Used an offscreen canvas instead
- Used img.naturalWidth / naturalHeight for dimensions
- Added a check for blank canvas case

## Result

- No more runtime error in console
- Thumbnail is saved correctly
- Auto-save works as expected


## PR Category

* [x] Bug Fix
* [ ] Feature
* [ ] Performance
* [ ] Tests
* [ ] Documentation

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run npm run lint and npx prettier --check . with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; this only affects the PR branch, not your fork).
