### PR TITLE
fix(#7216): remove inline sr-only styles breaking textMsg visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,17 +266,6 @@
                 tabindex="-1"
                 aria-live="polite"
                 role="status"
-                style="
-                    position: absolute;
-                    width: 1px;
-                    height: 1px;
-                    padding: 0;
-                    margin: -1px;
-                    overflow: hidden;
-                    clip: rect(0 0 0 0);
-                    white-space: nowrap;
-                    border: 0;
-                "
             >
                 <div class="contentWrapper">
                     <span id="printTextContent"></span>
@@ -294,17 +283,6 @@
                 tabindex="-1"
                 aria-live="assertive"
                 role="alert"
-                style="
-                    position: absolute;
-                    width: 1px;
-                    height: 1px;
-                    padding: 0;
-                    margin: -1px;
-                    overflow: hidden;
-                    clip: rect(0 0 0 0);
-                    white-space: nowrap;
-                    border: 0;
-                "
             >
                 <div class="contentWrapper">
                     <span id="errorTextContent"></span>


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

- PR #6637 added inline sr-only styles (`width:1px; height:1px; clip:rect(0 0 0 0)`) to `#printText` and `#errorText` for accessibility
- These inline styles have higher specificity than the `.show` CSS class, so both containers stay clipped at 1x1px even when shown — making print block output and error messages invisible
- Removed the inline styles; `.popupMsg` already hides via `visibility:hidden` and `aria-live` works correctly with that approach. ARIA attributes are preserved.

## Test Plan

- [x] Drag a **print** block from Extras palette → click Run → message appears on screen
- [x] Trigger an error (e.g. divide by zero) → error message appears on screen
- [x] Screen reader announces messages correctly (aria-live attributes preserved)
- [x] All existing Jest tests pass (pre-existing `LocalCard.test.js` failure is on master)

Fixes #7216