### PR TITLE
feat: add WhatsApp share button to GlobalCard share card

### DIFF
--- a/planet/css/style.css
+++ b/planet/css/style.css
@@ -523,3 +523,16 @@ a {
 	font-size: 16px;
 	outline: none;
 }
+
+/* Social share button in share card */
+.share-social-btn {
+	display: inline-block;
+	margin-left: 8px;
+	vertical-align: middle;
+	color: #555;
+	cursor: pointer;
+}
+
+.share-social-btn:hover {
+	color: #25D366;
+}

--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -72,6 +72,9 @@ class GlobalCard {
                                             <a class="copyshareurl tooltipped" data-clipboard-text="https://musicblocks.sugarlabs.org/index.html?id={ID}&run=True" data-delay="50" data-tooltip="${_(
                                                 "Copy link to clipboard"
                                             )}"><i class="material-icons"alt="Copy!">file_copy</i></a>
+                                            <a class="share-social-btn tooltipped" id="global-whatsapp-share-{ID}" data-position="bottom" data-delay="50" data-tooltip="${_(
+                                                "Share on WhatsApp"
+                                            )}" target="_blank" rel="noopener noreferrer"><i class="material-icons">chat</i></a>
                                             <div class="shareurl-advanced" id="global-advanced-{ID}"> 
                                                     <div class="shareurltitle">${_("Flags")}</div> 
                                                     <div><input type="checkbox" name="run" id="global-checkboxrun-{ID}" checked><label for="global-checkboxrun-{ID}">${_(
@@ -198,6 +201,15 @@ class GlobalCard {
                 );
             } else s.style.display = "none";
         });
+
+        // set WhatsApp share link
+        const shareInput = frag.querySelector(`#global-sharebox-${this.id} input[type=text]`);
+        const shareUrl = shareInput
+            ? shareInput.getAttribute("data-originalurl") + "&run=True"
+            : `https://musicblocks.sugarlabs.org/index.html?id=${this.id}&run=True`;
+        const whatsappText = _("Check out this Music Blocks project!") + " " + shareUrl;
+        frag.getElementById(`global-whatsapp-share-${this.id}`).href =
+            `https://api.whatsapp.com/send?text=${encodeURIComponent(whatsappText)}`;
 
         // set share checkbox listener
 


### PR DESCRIPTION
## Description
Adds a WhatsApp share button to the Planet Global project cards, placed next to the existing copy-link icon inside the share card. When clicked, it opens WhatsApp with a pre-filled message containing the project URL.

## Related Issue
Related to #6604

## PR Category
- [x] Feature — Adds new functionality

## Changes Made
- **`planet/js/GlobalCard.js`** — Added WhatsApp share `<a>` element to the share card HTML template and WhatsApp URL construction logic in `render()`
- **`planet/css/style.css`** — Appended `.share-social-btn` styles (no reformatting of existing CSS)

## Design Decisions
- Uses existing `material-icons` (`chat` icon) — no external SVGs or assets needed
- Share URL is built from the existing `data-originalurl` attribute with `encodeURIComponent` for safety
- Link opens in new tab with `target="_blank" rel="noopener noreferrer"` for security
- Share text is wrapped in `_()` for i18n support
- No helper.js refactoring, no test files, no i18n JSON changes — intentionally minimal

## Testing Performed
- `npm run lint` — 0 errors (warnings are pre-existing in codebase)
- `npm test` — all 5123 tests pass across 154 suites
- lint-staged pre-commit hook (eslint + prettier) passed on commit

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled "Allow edits from maintainers".

## Note
This is an intentionally small (XS-sized) PR focused solely on adding WhatsApp sharing. Additional social platforms and embed features from #6604 are out of scope and can be follow-up PRs.
