### PR TITLE
fix(#7187): prevent null bounds crash during autosave thumbnail caching

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -7848,8 +7848,9 @@ class Activity {
 
             img.onload = () => {
                 const bitmap = new createjs.Bitmap(img);
-                const bounds = bitmap.getBounds();
-                bitmap.cache(bounds.x, bounds.y, bounds.width, bounds.height);
+                const width = img.naturalWidth || img.width || 320;
+                const height = img.naturalHeight || img.height || 240;
+                bitmap.cache(0, 0, width, height);
                 try {
                     that.storage["SESSIONIMAGE" + p] = bitmap.bitmapCache.getCacheDataURL();
                 } catch (e) {


### PR DESCRIPTION
## Description

During auto-save thumbnail generation, `createjs.Bitmap.getBounds()` occasionally returns `null` because the `Image` object is still being parsed or loaded by `createjs`. This causes a crash (`TypeError: Cannot read properties of null (reading 'x')`) when attempting to cache the bitmap.

## Related Issue

This PR fixes #7187

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   Replaced the reliance on `bitmap.getBounds()` with native `img.naturalWidth` / `img.naturalHeight` (with fallbacks to `img.width` and fallback literals `320`/`240`) when caching the bitmap for the auto-save thumbnail in `js/activity.js`.

## Testing Performed

-   Tested the auto-save process to ensure no console errors are thrown when the image data is cached.
-   Ran `npm run lint` and `npx prettier --check .` with no errors.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

Using the native image dimensions directly avoids the race condition/timing issue where `createjs` hasn't yet computed the bounds of the newly instantiated `Bitmap`. This guarantees that `cache()` is always called with valid numbers instead of throwing a `TypeError`.
