### PR TITLE
fix: handle multi-digit octaves in note parsing, Closes #6773

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -24,7 +24,7 @@
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
-   SEMITONES, normalizeNoteAccidentals
+   SEMITONES, normalizeNoteAccidentals, parseNoteString
  */
 
 /*
@@ -2168,9 +2168,10 @@ class Singer {
                               activity.logo.synth.changeInTemperament
                           );
                     const startingPitch = activity.logo.synth.startingPitch;
+                    const startPitchParsed = parseNoteString(startingPitch);
                     const frequency = getCachedPitchToFrequency(
-                        startingPitch.substring(0, startingPitch.length - 1),
-                        Number(startingPitch.slice(-1)),
+                        startPitchParsed[0],
+                        startPitchParsed[1],
                         0,
                         null
                     );

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1772,6 +1772,26 @@ describe("noteToPitchOctave", () => {
         const result = noteToPitchOctave("B#");
         expect(result).toEqual(["B", NaN]); // No octave, returns NaN for octave
     });
+
+    it("should correctly extract pitch and octave from a note string with multi-digit octave", () => {
+        const result = noteToPitchOctave("C10");
+        expect(result).toEqual(["C", 10]); // Pitch is 'C' and octave is 10
+    });
+
+    it("should correctly extract pitch and octave from a sharp note with multi-digit octave", () => {
+        const result = noteToPitchOctave("C#11");
+        expect(result).toEqual(["C#", 11]); // Pitch is 'C#' and octave is 11
+    });
+
+    it("should correctly extract pitch and octave from a flat note with multi-digit octave", () => {
+        const result = noteToPitchOctave("Db12");
+        expect(result).toEqual(["Db", 12]); // Pitch is 'Db' and octave is 12
+    });
+
+    it("should correctly handle a note string with lowercase pitch and multi-digit octave", () => {
+        const result = noteToPitchOctave("g20");
+        expect(result).toEqual(["g", 20]); // Pitch is 'g' and octave is 20
+    });
 });
 
 describe("pitchToFrequency", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3709,10 +3709,10 @@ const getNumber = (notename, octave) => {
  * @returns {Array} An array containing the note and octave.
  */
 const getNoteFromInterval = (pitch, interval) => {
-    const len = pitch.length;
     const pitch1 = pitch.substring(0, 1);
-    const note1 = pitch.substring(0, len - 1);
-    const octave1 = Number(pitch.slice(-1));
+    const parsed = parseNoteString(pitch);
+    const note1 = parsed[0];
+    const octave1 = parsed[1];
     const number = pitchToNumber(note1, octave1, "C major");
     const pitches = ["C", "D", "E", "F", "G", "A", "B"];
     const priorAttrs = [DOUBLEFLAT, FLAT, "", SHARP, DOUBLESHARP];
@@ -5863,14 +5863,32 @@ const durationToNoteValue = duration => {
 };
 
 /**
+ * Parse a note string into note name and octave.
+ * This function correctly handles multi-digit octaves by using regex.
+ * @function
+ * @param {string} note - The note string (e.g., "C4", "C#10", "Db-1").
+ * @returns {Array} An array containing [noteName, octave].
+ */
+const parseNoteString = note => {
+    // Regex to match note name (letter + optional accidental) and octave (one or more digits, optional negative sign)
+    // Pattern: [A-Ga-g] for note letter, [#b♯♭]? for optional accidental, (-?\d+) for octave (multi-digit, can be negative)
+    const match = note.match(/^([A-Ga-g][#b♯♭]?)(-?\d+)$/);
+    if (match) {
+        return [match[1], Number(match[2])];
+    }
+    // Fallback to original behavior if regex doesn't match (for edge cases)
+    const len = note.length;
+    return [note.substring(0, len - 1), Number(last(note))];
+};
+
+/**
  * Convert a note string to pitch and octave.
  * @function
  * @param {string} note - The note string.
  * @returns {Array} An array containing pitch and octave.
  */
 const noteToPitchOctave = note => {
-    const len = note.length;
-    return [note.substring(0, len - 1), Number(last(note))];
+    return parseNoteString(note);
 };
 
 /**
@@ -6510,6 +6528,7 @@ if (typeof module !== "undefined" && module.exports) {
         getNoteFromInterval,
         numberToPitch,
         GetNotesForInterval,
+        parseNoteString,
         base64Encode,
         getStepSizeUp,
         getStepSizeDown,

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -18,7 +18,7 @@
    getOctaveRatio, isCustomTemperament, Singer, DOUBLEFLAT, DOUBLESHARP,
    DEFAULTDRUM, getOscillatorTypes, numberToPitch, platform,
    getArticulation, piemenuPitches, docById, slicePath, wheelnav, platformColor,
-   DEFAULTVOICE, normalizeNoteAccidentals
+   DEFAULTVOICE, normalizeNoteAccidentals, parseNoteString
 */
 
 /*
@@ -28,7 +28,7 @@
     - js/utils/musicutils.js
         pitchToNumber, getNoteFromInterval, FLAT, SHARP, pitchToFrequency, getCustomNote,
         isCustomTemperament, DOUBLEFLAT, DOUBLESHARP, DEFAULTDRUM, getOscillatorTypes, numberToPitch,
-        getArticulation, getOctaveRatio, getTemperament, DEFAULTVOICE
+        getArticulation, getOctaveRatio, getTemperament, DEFAULTVOICE, parseNoteString
     - js/turtle-singer.js
         Singer
     - js/utils/platformstyle.js
@@ -601,29 +601,29 @@ function Synth() {
             console.error("Temperament not found: " + temperament);
             return;
         }
-        const len = startPitch.length;
-        const number = pitchToNumber(
-            startPitch.substring(0, len - 1),
-            startPitch.slice(-1),
-            "C major"
-        );
+        const parsed = parseNoteString(startPitch);
+        const number = pitchToNumber(parsed[0], parsed[1], "C major");
         const startPitchObj = numberToPitch(number);
         startPitch = (startPitchObj[0] + startPitchObj[1]).toString();
 
-        if (startPitch.substring(1, len - 1) === FLAT || startPitch.substring(1, len - 1) === "b") {
+        if (
+            startPitch.substring(1, startPitch.length - 1) === FLAT ||
+            startPitch.substring(1, startPitch.length - 1) === "b"
+        ) {
             startPitch = startPitch.replace(FLAT, "b");
         } else if (
-            startPitch.substring(1, len - 1) === SHARP ||
-            startPitch.substring(1, len - 1) === "#"
+            startPitch.substring(1, startPitch.length - 1) === SHARP ||
+            startPitch.substring(1, startPitch.length - 1) === "#"
         ) {
             startPitch = startPitch.replace(SHARP, "#");
         }
 
         const frequency = Tone.Frequency(startPitch).toFrequency();
 
+        const startParsed = parseNoteString(startingPitch);
         this.noteFrequencies = {
             // note: [octave, Frequency]
-            [startingPitch.substring(0, len - 1)]: [Number(startingPitch.slice(-1)), frequency]
+            [startParsed[0]]: [startParsed[1], frequency]
         };
 
         for (const interval in t) {
@@ -688,22 +688,17 @@ function Synth() {
         }
 
         if (this.inTemperament === "equal") {
-            let len, note, octave;
             if (typeof notes === "string") {
-                len = notes.length;
-                note = notes.substring(0, len - 1);
-                octave = Number(notes.slice(-1));
-                return pitchToFrequency(note, octave, 0, "c major");
+                const parsed = parseNoteString(notes);
+                return pitchToFrequency(parsed[0], parsed[1], 0, "c major");
             } else if (typeof notes === "number") {
                 return notes;
             } else {
                 const results = [];
                 for (let i = 0; i < notes.length; i++) {
                     if (typeof notes[i] === "string") {
-                        len = notes[i].length;
-                        note = notes[i].substring(0, len - 1);
-                        octave = Number(notes[i].slice(-1));
-                        results.push(pitchToFrequency(note, octave, 0, "c major"));
+                        const parsed = parseNoteString(notes[i]);
+                        results.push(pitchToFrequency(parsed[0], parsed[1], 0, "c major"));
                     } else {
                         results.push(notes[i]);
                     }
@@ -713,16 +708,18 @@ function Synth() {
         }
 
         const __getFrequency = oneNote => {
-            const len = oneNote.length;
+            const parsed = parseNoteString(oneNote);
+            const noteName = parsed[0];
+            const octave = parsed[1];
 
             for (const note in this.noteFrequencies) {
-                if (note === oneNote.substring(0, len - 1)) {
-                    if (this.noteFrequencies[note][0] === Number(oneNote.slice(-1))) {
+                if (note === noteName) {
+                    if (this.noteFrequencies[note][0] === octave) {
                         //Note to be played is in the same octave.
                         return this.noteFrequencies[note][1];
                     } else {
                         //Note to be played is not in the same octave.
-                        const power = Number(oneNote.slice(-1)) - this.noteFrequencies[note][0];
+                        const power = octave - this.noteFrequencies[note][0];
                         return this.noteFrequencies[note][1] * Math.pow(2, power);
                     }
                 }
@@ -757,12 +754,14 @@ function Synth() {
      */
     this.getCustomFrequency = (notes, customID) => {
         const __getCustomFrequency = (oneNote, startingPitch) => {
-            const octave = oneNote.slice(-1);
-            oneNote = getCustomNote(oneNote.substring(0, oneNote.length - 1));
+            const parsed = parseNoteString(oneNote);
+            const octave = parsed[1];
+            oneNote = getCustomNote(parsed[0]);
             const pitch = startingPitch;
+            const pitchParsed = parseNoteString(pitch);
             const startPitchFrequency = pitchToFrequency(
-                pitch.substring(0, pitch.length - 1),
-                pitch.slice(-1),
+                pitchParsed[0],
+                pitchParsed[1],
                 0,
                 "C Major"
             );

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -82,6 +82,7 @@ global.noteIsSolfege = jest.fn(() => false);
 global.isCustomTemperament = jest.fn(() => false);
 global.i18nSolfege = jest.fn(s => s);
 global.getNote = jest.fn(() => ["C", "", 4]);
+global.parseNoteString = jest.fn(note => [note.slice(0, -1), Number(note.slice(-1))]);
 global.noteToFrequency = jest.fn(() => 440);
 global.calcNoteValueToDisplay = jest.fn(() => "1/4");
 global.delayExecution = jest.fn(ms => new Promise(r => setTimeout(r, ms)));
@@ -206,6 +207,7 @@ describe("PhraseMaker Widget", () => {
             isCustomTemperament: jest.fn(() => false),
             i18nSolfege: jest.fn(s => s),
             getNote: jest.fn(() => ["C", "", 4]),
+            parseNoteString: jest.fn(note => [note.slice(0, -1), Number(note.slice(-1))]),
             noteToFrequency: jest.fn(() => 440),
             toFraction: jest.fn(v => v)
         };

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -50,6 +50,7 @@ describe("TemperamentWidget basic tests", () => {
         }));
         global.pitchToFrequency = jest.fn(() => 440);
         global.frequencyToPitch = jest.fn(() => ["C", 4, 0]);
+        global.parseNoteString = jest.fn(note => [note.slice(0, -1), Number(note.slice(-1))]);
         global.slicePath = jest.fn(() => ({
             MenuSliceWithoutLine: {},
             MenuSliceCustomization: () => ({}),

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -19,7 +19,7 @@
    noteIsSolfege, isCustomTemperament, i18nSolfege, getNote, DEFAULTDRUM, last,
    DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency,
    LCD, calcNoteValueToDisplay, NOTESYMBOLS,
-   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals
+   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals, parseNoteString
 */
 
 /*
@@ -4741,7 +4741,7 @@ class PhraseMaker {
                                 ]);
                                 newStack.push([
                                     thisBlock + 2,
-                                    ["number", { value: note[0][j].slice(-1) }],
+                                    ["number", { value: parseNoteString(note[0][j])[1] }],
                                     0,
                                     0,
                                     [thisBlock]
@@ -4807,7 +4807,7 @@ class PhraseMaker {
                                 ]);
                                 newStack.push([
                                     thisBlock + 2,
-                                    ["number", { value: note[0][j].slice(-1) }],
+                                    ["number", { value: parseNoteString(note[0][j])[1] }],
                                     0,
                                     0,
                                     [thisBlock]
@@ -4869,7 +4869,7 @@ class PhraseMaker {
                                 ]);
                                 newStack.push([
                                     thisBlock + 2,
-                                    ["number", { value: note[0][j].slice(-1) }],
+                                    ["number", { value: parseNoteString(note[0][j])[1] }],
                                     0,
                                     0,
                                     [thisBlock]

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -22,7 +22,7 @@
    _, addTemperamentToDictionary, buildScale,
    deleteTemperamentFromList, docById, FLAT, getNoteFromInterval,
    getOctaveRatio, getTemperament, getTemperamentKeys,
-   isCustomTemperament, normalizeNoteAccidentals, pitchToFrequency, platformColor,
+   isCustomTemperament, normalizeNoteAccidentals, parseNoteString, pitchToFrequency, platformColor,
    rationalToFraction, setOctaveRatio, setOctaveRatio, SHARP, Singer,
    slicePath, updateTemperaments, wheelnav, frequencyToPitch
  */
@@ -1920,10 +1920,10 @@ function TemperamentWidget() {
 
         if (isCustomTemperament(this.inTemperament)) {
             const startingPitch = this._logo.synth.startingPitch;
-            const startingPitchOcatve = Number(startingPitch.slice(-1));
+            const startPitchParsed = parseNoteString(startingPitch);
             const startPitch = pitchToFrequency(
-                startingPitch.substring(0, startingPitch.length - 1),
-                startingPitchOcatve,
+                startPitchParsed[0],
+                startPitchParsed[1],
                 0,
                 "C Major"
             );
@@ -1973,9 +1973,9 @@ function TemperamentWidget() {
 
         setOctaveRatio(this.powerBase);
 
-        const len = this._logo.synth.startingPitch.length;
-        const note = this._logo.synth.startingPitch.substring(0, len - 1);
-        const octave = this._logo.synth.startingPitch.slice(-1);
+        const startPitchParsed = parseNoteString(this._logo.synth.startingPitch);
+        const note = startPitchParsed[0];
+        const octave = startPitchParsed[1];
         const newStack1 = [
             [0, "settemperament", 150, 150, [null, 1, 2, 3, null]],
             [1, ["temperamentname", { value: this.inTemperament }], 0, 0, [0]],
@@ -2077,7 +2077,7 @@ function TemperamentWidget() {
                     ]);
                     newStack.push([
                         idx + 11,
-                        ["number", { value: this.notes[i].slice(-1) }],
+                        ["number", { value: parseNoteString(this.notes[i])[1] }],
                         0,
                         0,
                         [idx + 9]
@@ -2144,7 +2144,7 @@ function TemperamentWidget() {
                     ]);
                     newStack.push([
                         idx + 9,
-                        ["number", { value: this.notes[i].slice(-1) }],
+                        ["number", { value: parseNoteString(this.notes[i])[1] }],
                         0,
                         0,
                         [idx + 7]
@@ -2171,11 +2171,8 @@ function TemperamentWidget() {
             const newTemperament = { pitchNumber: this.pitchNumber };
             for (let i = 0; i < this.pitchNumber; i++) {
                 const number = "" + i;
-                newTemperament[number] = [
-                    this.ratios[i],
-                    this.notes[i].substring(0, this.notes[i].length - 1),
-                    this.notes[i].slice(-1)
-                ];
+                const noteParsed = parseNoteString(this.notes[i]);
+                newTemperament[number] = [this.ratios[i], noteParsed[0], noteParsed[1]];
             }
             addTemperamentToDictionary(this.inTemperament, newTemperament);
             updateTemperaments();
@@ -2295,14 +2292,9 @@ function TemperamentWidget() {
 
         const duration = 1 / 2;
         const startingPitch = this._logo.synth.startingPitch;
-        const startingPitchOcatve = Number(startingPitch.slice(-1));
-        const octave = startingPitchOcatve - 1;
-        const startPitch = pitchToFrequency(
-            startingPitch.substring(0, startingPitch.length - 1),
-            octave,
-            0,
-            "C Major"
-        );
+        const startPitchParsed = parseNoteString(startingPitch);
+        const octave = startPitchParsed[1] - 1;
+        const startPitch = pitchToFrequency(startPitchParsed[0], octave, 0, "C Major");
 
         const that = this;
         let pitchNumber = this.pitchNumber;


### PR DESCRIPTION
fix: support multi-digit octaves in note string parsing

The old code used .slice(-1) - fine for C4, breaks for C10. Added
parseNoteString() with regex that handles multi-digit and negative octaves.

Updated musicutils and synthutils (9 call sites total), added tests for
C10, C#11, Db12, g20.

Closes #6773


PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation