### PR TITLE
chore: introduce CSS design token system

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -12,6 +12,7 @@
 }
 */
 
+@import url("tokens.css");
 @import url("play-only-mode.css");
 
 *:focus:not(:focus-visible) {

--- a/css/themes.css
+++ b/css/themes.css
@@ -64,11 +64,11 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 /* Dark Mode */
 
 .dark .blue {
-    background-color: #022363 !important;
+    background-color: var(--color-palette-label-bg) !important;
 }
 
 .dark #canvas {
-    background-color: #1c1c1c !important;
+    background-color: var(--color-panel-bg) !important;
 }
 
 .dark .blue.darken-1 {
@@ -81,7 +81,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 .dark .wfbtItem {
-    background-color: #225a91;
+    background-color: var(--color-widget-button);
 }
 
 .dark #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
@@ -126,7 +126,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark #search,
 .dark #helpfulSearch,
 .dark .ui-autocomplete {
-    background-color: #1c1c1c !important;
+    background-color: var(--color-panel-bg) !important;
     color: #fff !important;
     border-color: #444 !important;
 }
@@ -167,7 +167,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 .dark .dropdown-content li > a {
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
     color: #3fe0d1;
 }
 
@@ -189,25 +189,25 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 .dark .dropdown-content {
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
 }
 
 .dark .modalBox {
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
 }
 
 .dark .modal-message {
     color: #e2e2e2;
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
 }
 
 .dark #newdropdown {
     border: #000000;
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
 }
 
 .dark #newdropdown li {
-    background-color: #1c1c1c;
+    background-color: var(--color-panel-bg);
 }
 
 .dark #newdropdown li:hover {
@@ -219,7 +219,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 body {
-    --border: #cccccc;
+    --border: var(--color-border);
     --bg: #ffffff;
     --fg: #666666;
     --panel-bg: #f5f5f5;

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,119 @@
+/*
+ * MusicBlocks Design Tokens
+ * Single source of truth for theme colours used across CSS files.
+ *
+ * Canvas/block colours (paletteColors, wheel colours, pie-menu colours)
+ * are intentionally excluded — they are drawn by CreateJS on <canvas>
+ * and must remain in js/utils/platformstyle.js.
+ *
+ * Usage in CSS:  background-color: var(--color-bg);
+ * Usage in JS:   getComputedStyle(document.body).getPropertyValue('--color-bg').trim()
+ */
+
+/* Light theme — values from platformThemes.light */
+:root {
+    --color-bg:                  #f9f9f9;
+    --color-panel-bg:            #f5f5f5;
+    --color-palette-bg:          #ffffff;
+    --color-palette-selected:    #f3f3f3;
+    --color-fg:                  #666666;
+    --color-text:                #000000;
+    --color-palette-text:        #666666;
+    --color-border:              #cccccc;
+    --color-rule:                #e2e2e2;
+    --color-accent:              #2196f3;
+    --color-heading:             #0066ff;
+    --color-blue-button:         #0066ff;
+    --color-blue-button-hover:   #023a76;
+    --color-blue-button-text:    #ffffff;
+    --color-hover:               #e0e0e0;
+    --color-header:              #4da6ff;
+    --color-header-aux:          #1a8cff;
+    --color-header-sub:          #8cc6ff;
+    --color-palette-label-bg:    #8cc6ff;
+    --color-palette-label-sel:   #1a8cff;
+    --color-widget-bg:           #cccccc;
+    --color-widget-button:       #8cc6ff;
+    --color-selector-bg:         #8cc6ff;
+    --color-selector-sel:        #1a8cff;
+    --color-orange:              #e37a00;
+    --color-disconnected:        #c4c4c4;
+    --color-trash:               #c0c0c0;
+    --color-trash-border:        #808080;
+    --color-trash-active:        #ff0000;
+    --color-ruler-highlight:     #ffbf00;
+    --color-stop-icon:           #ea174c;
+    --color-rhythm-cell:         #c8c8c8;
+}
+
+/* Dark theme — values from platformThemes.dark */
+body.dark {
+    --color-bg:                  #303030;
+    --color-panel-bg:            #1c1c1c;
+    --color-palette-bg:          #1c1c1c;
+    --color-palette-selected:    #1e1e1e;
+    --color-fg:                  #e8e8e8;
+    --color-text:                #e2e2e2;
+    --color-palette-text:        #bdbdbd;
+    --color-border:              #000000;
+    --color-rule:                #303030;
+    --color-accent:              #3fe0d1;
+    --color-heading:             #0066ff;
+    --color-blue-button:         #0066ff;
+    --color-blue-button-hover:   #023a76;
+    --color-blue-button-text:    #ffffff;
+    --color-hover:               #808080;
+    --color-header:              #1e88e5;
+    --color-header-aux:          #1976d2;
+    --color-header-sub:          #64b5f6;
+    --color-palette-label-bg:    #022363;
+    --color-palette-label-sel:   #01143b;
+    --color-widget-bg:           #454545;
+    --color-widget-button:       #225a91;
+    --color-selector-bg:         #64b5f6;
+    --color-selector-sel:        #1e88e5;
+    --color-orange:              #fb8c00;
+    --color-disconnected:        #5c5c5c;
+    --color-trash:               #757575;
+    --color-trash-border:        #424242;
+    --color-trash-active:        #e53935;
+    --color-ruler-highlight:     #ffeb3b;
+    --color-stop-icon:           #d50000;
+    --color-rhythm-cell:         #303030;
+}
+
+/* High contrast theme — values from platformThemes.highcontrast */
+body.highcontrast {
+    --color-bg:                  #000000;
+    --color-panel-bg:            #000000;
+    --color-palette-bg:          #000000;
+    --color-palette-selected:    #111111;
+    --color-fg:                  #ffffff;
+    --color-text:                #ffffff;
+    --color-palette-text:        #ffffff;
+    --color-border:              #ffffff;
+    --color-rule:                #ffffff;
+    --color-accent:              #00ffff;
+    --color-heading:             #ffff00;
+    --color-blue-button:         #00ffff;
+    --color-blue-button-hover:   #00cccc;
+    --color-blue-button-text:    #000000;
+    --color-hover:               #666666;
+    --color-header:              #00ffff;
+    --color-header-aux:          #00cccc;
+    --color-header-sub:          #00ffff;
+    --color-palette-label-bg:    #000080;
+    --color-palette-label-sel:   #0000ff;
+    --color-widget-bg:           #000000;
+    --color-widget-button:       #00ffff;
+    --color-selector-bg:         #00ffff;
+    --color-selector-sel:        #00cccc;
+    --color-orange:              #ff8800;
+    --color-disconnected:        #666666;
+    --color-trash:               #ffffff;
+    --color-trash-border:        #ffffff;
+    --color-trash-active:        #ff0000;
+    --color-ruler-highlight:     #ffff00;
+    --color-stop-icon:           #ff0000;
+    --color-rhythm-cell:         #333333;
+}

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -353,7 +353,9 @@ function MusicKeyboard(activity) {
             }
 
             if (ele !== null && ele !== undefined) {
-                ele.style.backgroundColor = platformColor.orange;
+                ele.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-orange")
+                    .trim();
                 temp1[id] = ele.getAttribute("alt").split("__")[0];
                 if (temp1[id] === "hertz") {
                     temp2[id] = parseInt(ele.getAttribute("alt").split("__")[1]);
@@ -563,7 +565,9 @@ function MusicKeyboard(activity) {
         const __startNote = element => {
             startDate = new Date();
             startTime = startDate.getTime(); // Milliseconds();
-            element.style.backgroundColor = platformColor.orange;
+            element.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-orange")
+                .trim();
             this.activity.logo.synth.trigger(
                 0,
                 this.noteMapper[element.id],
@@ -814,7 +818,9 @@ function MusicKeyboard(activity) {
             } else {
                 // Turn on metronome
                 this.metronomeON = true;
-                this.tickButton.style.background = platformColor.orange;
+                this.tickButton.style.background = getComputedStyle(document.body)
+                    .getPropertyValue("--color-orange")
+                    .trim();
 
                 const winBody = document.getElementsByClassName("wfbWidget")[0];
                 const countdownContainer = document.createElement("div");
@@ -948,7 +954,9 @@ function MusicKeyboard(activity) {
 
             if (!this.keyboardShown) {
                 cell = docById("cells-0");
-                cell.style.backgroundColor = platformColor.selectorBackground;
+                cell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-selector-bg")
+                    .trim();
             }
 
             this._stopOrCloseClicked = false;
@@ -997,7 +1005,9 @@ function MusicKeyboard(activity) {
 
                 if (!this.keyboardShown) {
                     cell = docById("cells-" + counter);
-                    cell.style.backgroundColor = platformColor.selectorBackground;
+                    cell.style.backgroundColor = getComputedStyle(document.body)
+                        .getPropertyValue("--color-selector-bg")
+                        .trim();
                 }
 
                 if (this.keyboardShown && selectedNotes[counter - 1].objId[0] !== null) {
@@ -3411,7 +3421,9 @@ function MusicKeyboard(activity) {
         const __startNote = (event, element) => {
             if (!element) return;
             startTime = event.timeStamp; // Milliseconds();
-            element.style.backgroundColor = platformColor.orange;
+            element.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-orange")
+                .trim();
             this.activity.logo.synth.trigger(
                 0,
                 this.noteMapper[element.id],


### PR DESCRIPTION
Closes part of #6606

Introduces css/tokens.css as a single source of truth for theme colours
across light, dark, and high-contrast themes. Values sourced directly
from platformThemes in platformstyle.js — no visual changes.

- css/tokens.css: 96 custom properties covering all three themes
- css/activities.css: imports tokens.css
- css/themes.css: hardcoded #1c1c1c, #022363, #225a91 replaced with token references
- js/widgets/musickeyboard.js: platformColor.orange and platformColor.selectorBackground
  replaced with getComputedStyle token reads

Canvas/wheel colours stay in platformstyle.js (CreateJS territory).
Key state checks (backgroundColor === 'black') left untouched to avoid
breaking note-tracking logic.

All 154 Jest tests pass.

## PR Category
- [x] Feature