### PR TITLE
fix: restore hover colour in pitchstaircase cells

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -74,14 +74,20 @@ class PitchStaircase {
         cell.style.height = cell.style.width;
         cell.style.minHeight = cell.style.height;
         cell.style.maxHeight = cell.style.height;
-        cell.style.backgroundColor = platformColor.selectorBackground;
+        cell.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-selector-bg")
+            .trim();
 
         cell.onmouseover = () => {
-            cell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-sel")
+                .trim();
         };
 
         cell.onmouseout = () => {
-            cell.style.backgroundColor = platformColor.selectorBackground;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-bg")
+                .trim();
         };
 
         return cell;
@@ -135,7 +141,9 @@ class PitchStaircase {
             stepCell.style.minWidth = stepCell.style.width;
             stepCell.style.maxWidth = stepCell.style.width;
             stepCell.style.height = PitchStaircase.BUTTONSIZE + "px";
-            stepCell.style.backgroundColor = platformColor.selectorBackground;
+            stepCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-bg")
+                .trim();
 
             const cellWidth = Number(stepCell.style.width.replace(/px/, ""));
             const svgWidth = cellWidth.toString();
@@ -293,12 +301,16 @@ class PitchStaircase {
      */
     _playOne(stepCell) {
         // The frequency is stored in the stepCell.
-        stepCell.style.backgroundColor = platformColor.selectorBackground;
+        stepCell.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-selector-bg")
+            .trim();
         const frequency = Number(stepCell.getAttribute("id"));
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
 
         setTimeout(() => {
-            stepCell.style.backgroundColor = platformColor.selectorBackground;
+            stepCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-bg")
+                .trim();
         }, 1000);
     }
 
@@ -313,14 +325,18 @@ class PitchStaircase {
             const note = this.Stairs[i][0] + this.Stairs[i][1];
             pitchnotes.push(normalizeNoteAccidentals(note));
             const stepCell = this._stepTables[i].rows[0].cells[1];
-            stepCell.style.backgroundColor = platformColor.selectorBackground;
+            stepCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-bg")
+                .trim();
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         }
 
         setTimeout(() => {
             for (let i = 0; i < this.Stairs.length; i++) {
                 const stepCell = this._stepTables[i].rows[0].cells[1];
-                stepCell.style.backgroundColor = platformColor.selectorBackground;
+                stepCell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-selector-bg")
+                    .trim();
             }
         }, 1000);
     }
@@ -336,7 +352,9 @@ class PitchStaircase {
         pitchnotes.push(normalizeNoteAccidentals(note));
         const last = this.Stairs.length - 1;
         const stepCell = this._stepTables[last].rows[0].cells[1];
-        stepCell.style.backgroundColor = platformColor.selectorBackground;
+        stepCell.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-selector-bg")
+            .trim();
         this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         this._playNext(this.Stairs.length - 2, -1);
     }
@@ -354,7 +372,9 @@ class PitchStaircase {
             setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    stepCell.style.backgroundColor = getComputedStyle(document.body)
+                        .getPropertyValue("--color-selector-bg")
+                        .trim();
                 }
             }, 1000);
             return;
@@ -364,7 +384,9 @@ class PitchStaircase {
             setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    stepCell.style.backgroundColor = getComputedStyle(document.body)
+                        .getPropertyValue("--color-selector-bg")
+                        .trim();
                 }
             }, 1000);
 
@@ -384,11 +406,15 @@ class PitchStaircase {
         setTimeout(() => {
             if (pscTableCell !== null) {
                 const stepCell = pscTableCell.rows[0].cells[1];
-                stepCell.style.backgroundColor = platformColor.selectorBackground;
+                stepCell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-selector-bg")
+                    .trim();
             }
 
             const stepCell = this._stepTables[index].rows[0].cells[1];
-            stepCell.style.backgroundColor = platformColor.selectorBackground;
+            stepCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-selector-bg")
+                .trim();
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
             if (index < this.Stairs.length || index > -1) {
                 this._playNext(index + next, next);


### PR DESCRIPTION
Part of #6606
Depends on #7238

`platformColor.selectorBackgroundHOVER` does not exist in platformThemes —
hover on pitch staircase cells was silently setting backgroundColor to undefined.

Replaces both selector colour reads with getComputedStyle token lookups
using --color-selector-bg and --color-selector-sel from css/tokens.css.

## PR Category
- [x] Bug Fix