### PR TITLE
feat: add ABC assignment comparison utility

### DIFF
--- a/js/__tests__/assignmentChecker.test.js
+++ b/js/__tests__/assignmentChecker.test.js
@@ -9,8 +9,6 @@
  * (at your option) any later version.
  */
 
-"use strict";
-
 const { extractNotes, compareAssignment } = require("../assignmentChecker");
 
 // ABCJS is a browser library — mock parseOnly for Node/Jest

--- a/js/__tests__/assignmentChecker.test.js
+++ b/js/__tests__/assignmentChecker.test.js
@@ -129,3 +129,18 @@ describe("compareAssignment", () => {
         expect(compareAssignment("target", "student")).toEqual({ score: 0, matched: 0, total: 0 });
     });
 });
+
+describe("multi-tune behaviour", () => {
+    beforeEach(() => {
+        global.ABCJS.parseOnly.mockReset();
+    });
+
+    it("compares only the first tune when multiple tunes are present", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([0, 1, 2]), makeTune([5, 6, 7])])
+            .mockReturnValueOnce([makeTune([0, 1, 2])]);
+        const result = compareAssignment("target", "student");
+        expect(result.score).toBe(100);
+        expect(result.total).toBe(3);
+    });
+});

--- a/js/__tests__/assignmentChecker.test.js
+++ b/js/__tests__/assignmentChecker.test.js
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 Shivang Kumar Dubey
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+"use strict";
+
+const { extractNotes, compareAssignment } = require("../assignmentChecker");
+
+// ABCJS is a browser library — mock parseOnly for Node/Jest
+global.ABCJS = {
+    parseOnly: jest.fn()
+};
+
+const makeTune = pitches => ({
+    lines: [
+        {
+            staff: [
+                {
+                    voices: [
+                        [
+                            ...pitches.map(p => ({
+                                el_type: "note",
+                                pitches: [{ pitch: p }],
+                                duration: 0.25
+                            }))
+                        ]
+                    ]
+                }
+            ]
+        }
+    ]
+});
+
+describe("extractNotes", () => {
+    it("returns pitch integers from a tune", () => {
+        expect(extractNotes(makeTune([0, 1, 2]))).toEqual([0, 1, 2]);
+    });
+
+    it("returns empty array for tune with no notes", () => {
+        const tune = { lines: [{ staff: [{ voices: [[{ el_type: "bar" }]] }] }] };
+        expect(extractNotes(tune)).toEqual([]);
+    });
+
+    it("skips elements without pitches array", () => {
+        const tune = {
+            lines: [
+                {
+                    staff: [
+                        {
+                            voices: [
+                                [
+                                    { el_type: "note", pitches: [] },
+                                    { el_type: "note", pitches: [{ pitch: 3 }] }
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        expect(extractNotes(tune)).toEqual([3]);
+    });
+
+    it("handles empty lines", () => {
+        expect(extractNotes({ lines: [] })).toEqual([]);
+    });
+});
+
+describe("compareAssignment", () => {
+    beforeEach(() => {
+        global.ABCJS.parseOnly.mockReset();
+    });
+
+    it("returns 100 when all notes match", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([0, 1, 2])])
+            .mockReturnValueOnce([makeTune([0, 1, 2])]);
+        expect(compareAssignment("target", "student")).toEqual({
+            score: 100,
+            matched: 3,
+            total: 3
+        });
+    });
+
+    it("returns 0 when no notes match", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([0, 1, 2])])
+            .mockReturnValueOnce([makeTune([5, 6, 7])]);
+        const result = compareAssignment("target", "student");
+        expect(result.score).toBe(0);
+        expect(result.matched).toBe(0);
+    });
+
+    it("scores partial matches correctly", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([0, 1, 2, 3])])
+            .mockReturnValueOnce([makeTune([0, 1, 5, 6])]);
+        const result = compareAssignment("target", "student");
+        expect(result.matched).toBe(2);
+        expect(result.total).toBe(4);
+        expect(result.score).toBe(50);
+    });
+
+    it("handles student with more notes than target", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([0, 1])])
+            .mockReturnValueOnce([makeTune([0, 1, 2, 3])]);
+        const result = compareAssignment("target", "student");
+        expect(result.total).toBe(2);
+        expect(result.score).toBe(100);
+    });
+
+    it("returns zero score when target is empty", () => {
+        global.ABCJS.parseOnly
+            .mockReturnValueOnce([makeTune([])])
+            .mockReturnValueOnce([makeTune([0, 1])]);
+        expect(compareAssignment("target", "student")).toEqual({ score: 0, matched: 0, total: 0 });
+    });
+
+    it("returns zero score when parseOnly returns empty array", () => {
+        global.ABCJS.parseOnly.mockReturnValue([]);
+        expect(compareAssignment("target", "student")).toEqual({ score: 0, matched: 0, total: 0 });
+    });
+});

--- a/js/assignmentChecker.js
+++ b/js/assignmentChecker.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Shivang Kumar Dubey
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/* global ABCJS */
+/* exported extractNotes, compareAssignment */
+
+/**
+ * Extracts a flat array of pitch integers from a parsed ABCJS tune.
+ * Pitch integers are diatonic: 0 = C4, 1 = D4, 7 = C5, etc.
+ *
+ * @param {Object} tune - A single tune from ABCJS.parseOnly()
+ * @returns {number[]}
+ */
+function extractNotes(tune) {
+    const notes = [];
+    tune.lines?.forEach(line => {
+        line.staff?.forEach(staff => {
+            staff.voices?.forEach(voice => {
+                voice.forEach(element => {
+                    if (element.el_type === "note" && element.pitches?.length > 0) {
+                        notes.push(element.pitches[0].pitch);
+                    }
+                });
+            });
+        });
+    });
+    return notes;
+}
+
+/**
+ * Compares a student's ABC output against a target ABC string.
+ * Scores based on how many notes match in sequence (pitch only).
+ *
+ * @param {string} targetABC - The assignment target
+ * @param {string} studentABC - The student's current output
+ * @returns {{ score: number, matched: number, total: number }}
+ */
+function compareAssignment(targetABC, studentABC) {
+    const targetTunes = ABCJS.parseOnly(targetABC);
+    const studentTunes = ABCJS.parseOnly(studentABC);
+
+    if (!targetTunes.length || !studentTunes.length) {
+        return { score: 0, matched: 0, total: 0 };
+    }
+
+    const targetNotes = extractNotes(targetTunes[0]);
+    const studentNotes = extractNotes(studentTunes[0]);
+
+    if (targetNotes.length === 0) {
+        return { score: 0, matched: 0, total: 0 };
+    }
+
+    let matched = 0;
+    const len = Math.min(targetNotes.length, studentNotes.length);
+    for (let i = 0; i < len; i++) {
+        if (targetNotes[i] === studentNotes[i]) {
+            matched++;
+        }
+    }
+
+    return {
+        score: Math.round((matched / targetNotes.length) * 100),
+        matched,
+        total: targetNotes.length
+    };
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { extractNotes, compareAssignment };
+}

--- a/js/assignmentChecker.js
+++ b/js/assignmentChecker.js
@@ -37,6 +37,8 @@ function extractNotes(tune) {
 
 /**
  * Compares a student's ABC output against a target ABC string.
+ * Only the first tune in each file is compared; multi-tune ABC files are
+ * not fully supported (saveAbcOutput always produces a single tune).
  * Scores based on how many notes match in sequence (pitch only).
  *
  * @param {string} targetABC - The assignment target


### PR DESCRIPTION
Addresses part of #1106

saveAbcOutput() already produces ABC — this adds the comparison side.
extractNotes() extracts pitch sequences from a parsed ABCJS tunebook,
compareAssignment() returns a 0–100 score against a target.

## PR Category
- [x] Feature