### PR TITLE
fix: resolve uncaught exception swallowing in Cypress and fix exposed block.js null crash

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -1,15 +1,7 @@
 /* global Cypress, cy, before */
 
 Cypress.on("uncaught:exception", err => {
-    const ignored = [
-        "ResizeObserver loop limit exceeded",
-        "Cannot read properties of undefined",
-        "Cannot read properties of null",
-        "Cannot set properties of null",
-        "Cannot set properties of undefined",
-        "_ is not defined",
-        "Permissions check failed"
-    ];
+    const ignored = ["ResizeObserver loop limit exceeded"];
     return !ignored.some(msg => err.message.includes(msg));
 });
 

--- a/js/block.js
+++ b/js/block.js
@@ -682,7 +682,7 @@ class Block {
             }
 
             // and hide the unhighlighted collapsed artwork...
-            if (this.collapseBlockBitmap !== null) {
+            if (this.collapseBlockBitmap) {
                 this.collapseBlockBitmap.visible = false;
             }
 
@@ -712,15 +712,15 @@ class Block {
             if (this.isCollapsible()) {
                 // There could be a race condition when making a
                 // new action block.
-                if (this.collapseText !== null) {
+                if (this.collapseText) {
                     this.collapseText.visible = false;
                 }
 
-                if (this.collapseBlockBitmap !== null) {
+                if (this.collapseBlockBitmap) {
                     this.collapseBlockBitmap.visible = false;
                 }
 
-                if (this.highlightCollapseBlockBitmap !== null) {
+                if (this.highlightCollapseBlockBitmap) {
                     this.highlightCollapseBlockBitmap.visible = false;
                 }
             }
@@ -1641,9 +1641,9 @@ class Block {
             that.activity.refreshCanvas();
             that.blocks.cleanupAfterLoad(that.name);
             if (that.trash) {
-                that.collapseText.visible = false;
-                that.collapseButtonBitmap.visible = false;
-                that.expandButtonBitmap.visible = false;
+                if (that.collapseText) that.collapseText.visible = false;
+                if (that.collapseButtonBitmap) that.collapseButtonBitmap.visible = false;
+                if (that.expandButtonBitmap) that.expandButtonBitmap.visible = false;
             }
         };
 
@@ -1694,7 +1694,7 @@ class Block {
                         that.protoblock.scale / 3;
 
                 that.container.addChild(that.expandButtonBitmap);
-                that.expandButtonBitmap.visible = that.collapsed;
+                if (that.expandButtonBitmap) that.expandButtonBitmap.visible = that.collapsed;
 
                 that.expandButtonBitmap.x = 2 * that.protoblock.scale;
                 if (that.isInlineCollapsible()) {
@@ -1721,7 +1721,8 @@ class Block {
             that.highlightCollapseBlockBitmap = bitmap;
             that.highlightCollapseBlockBitmap.name = "highlight_collapse_" + thisBlock;
             that.container.addChild(that.highlightCollapseBlockBitmap);
-            that.highlightCollapseBlockBitmap.visible = false;
+            if (that.highlightCollapseBlockBitmap)
+                that.highlightCollapseBlockBitmap.visible = false;
 
             if (that.collapseText === null) {
                 const fontSize = 10 * that.protoblock.scale;
@@ -1880,7 +1881,7 @@ class Block {
             }
 
             that._positionCollapseLabel(that.protoblock.scale);
-            that.collapseText.visible = that.collapsed;
+            if (that.collapseText) that.collapseText.visible = that.collapsed;
             that._ensureDecorationOnTop();
 
             // Save the collapsed block artwork for export.
@@ -1904,7 +1905,7 @@ class Block {
             that.collapseBlockBitmap = bitmap;
             that.collapseBlockBitmap.name = "collapse_" + thisBlock;
             that.container.addChild(that.collapseBlockBitmap);
-            that.collapseBlockBitmap.visible = that.collapsed;
+            if (that.collapseBlockBitmap) that.collapseBlockBitmap.visible = that.collapsed;
             that.activity.refreshCanvas();
 
             const artwork = that.collapseArtwork;
@@ -1936,10 +1937,10 @@ class Block {
         this.container.visible = false;
         if (this.isCollapsible()) {
             // Sometimes these fields are not set.
-            if (this.collapseText !== null) {
+            if (this.collapseText) {
                 this.collapseText.visible = false;
             }
-            if (this.expandButtonBitmap !== null) {
+            if (this.expandButtonBitmap) {
                 this.expandButtonBitmap.visible = false;
             }
             if (this.collapseButtonBitmap !== null) {
@@ -1999,13 +2000,14 @@ class Block {
             this.container.visible = true;
             if (this.isCollapsible()) {
                 if (this.collapsed) {
-                    this.bitmap.visible = false;
-                    this.highlightBitmap.visible = false;
-                    this.collapseBlockBitmap.visible = true;
-                    this.highlightCollapseBlockBitmap.visible = false;
-                    this.collapseText.visible = true;
-                    this.expandButtonBitmap.visible = true;
-                    this.collapseButtonBitmap.visible = false;
+                    if (this.bitmap) this.bitmap.visible = false;
+                    if (this.highlightBitmap) this.highlightBitmap.visible = false;
+                    if (this.collapseBlockBitmap) this.collapseBlockBitmap.visible = true;
+                    if (this.highlightCollapseBlockBitmap)
+                        this.highlightCollapseBlockBitmap.visible = false;
+                    if (this.collapseText) this.collapseText.visible = true;
+                    if (this.expandButtonBitmap) this.expandButtonBitmap.visible = true;
+                    if (this.collapseButtonBitmap) this.collapseButtonBitmap.visible = false;
                     if (this.disconnectedBitmap !== null) {
                         this.disconnectedBitmap.visible = false;
                     }
@@ -2032,11 +2034,12 @@ class Block {
                         this.disconnectedHighlightBitmap.visible = false;
                     }
 
-                    this.collapseBlockBitmap.visible = false;
-                    this.highlightCollapseBlockBitmap.visible = false;
-                    this.collapseText.visible = false;
-                    this.expandButtonBitmap.visible = false;
-                    this.collapseButtonBitmap.visible = true;
+                    if (this.collapseBlockBitmap) this.collapseBlockBitmap.visible = false;
+                    if (this.highlightCollapseBlockBitmap)
+                        this.highlightCollapseBlockBitmap.visible = false;
+                    if (this.collapseText) this.collapseText.visible = false;
+                    if (this.expandButtonBitmap) this.expandButtonBitmap.visible = false;
+                    if (this.collapseButtonBitmap) this.collapseButtonBitmap.visible = true;
                 }
             } else {
                 // If the block is disconnected, use the disconnected bitmap.
@@ -2426,13 +2429,13 @@ class Block {
         this.collapsed = !isCollapsed;
 
         // These are the buttons to collapse/expand the stack.
-        this.collapseButtonBitmap.visible = isCollapsed;
-        this.expandButtonBitmap.visible = !isCollapsed;
+        if (this.collapseButtonBitmap) this.collapseButtonBitmap.visible = isCollapsed;
+        if (this.expandButtonBitmap) this.expandButtonBitmap.visible = !isCollapsed;
 
         // These are the collapse-state bitmaps.
-        this.collapseBlockBitmap.visible = !isCollapsed;
-        this.highlightCollapseBlockBitmap.visible = false;
-        this.collapseText.visible = !isCollapsed;
+        if (this.collapseBlockBitmap) this.collapseBlockBitmap.visible = !isCollapsed;
+        if (this.highlightCollapseBlockBitmap) this.highlightCollapseBlockBitmap.visible = false;
+        if (this.collapseText) this.collapseText.visible = !isCollapsed;
 
         if (this.isInlineCollapsible() && this.collapseText.visible) {
             switch (this.name) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3890,8 +3890,8 @@ class Blocks {
 
             const myBlock = this.blockList[blk];
             /** If this happens, something is really broken. */
-            if (myBlock === null) {
-                console.debug("null block encountered... this is bad. " + blk);
+            if (!myBlock) {
+                console.debug("null or undefined block encountered... this is bad. " + blk);
                 return;
             }
 

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -521,11 +521,17 @@ class ToolbarUI {
             onclick(this.activity);
             handleClick();
             stopIcon.style.color = this.stopIconColorWhenPlaying;
-            saveButton.disabled = true;
-            saveButtonAdvanced.disabled = true;
-            saveButton.className = "grey-text inactiveLink";
-            saveButtonAdvanced.className = "grey-text inactiveLink";
-            recordButton.className = "grey-text inactiveLink";
+            if (saveButton) {
+                saveButton.disabled = true;
+                saveButton.className = "grey-text inactiveLink";
+            }
+            if (saveButtonAdvanced) {
+                saveButtonAdvanced.disabled = true;
+                saveButtonAdvanced.className = "grey-text inactiveLink";
+            }
+            if (recordButton) {
+                recordButton.className = "grey-text inactiveLink";
+            }
             isPlayIconRunning = true;
             play_button_debounce_timeout = setTimeout(function () {
                 handleClick();
@@ -559,11 +565,17 @@ class ToolbarUI {
         stopIcon.onclick = () => {
             onclick(this.activity);
             stopIcon.style.color = "white";
-            saveButton.disabled = false;
-            saveButtonAdvanced.disabled = false;
-            saveButton.className = "";
-            saveButtonAdvanced.className = "";
-            recordButton.className = "";
+            if (saveButton) {
+                saveButton.disabled = false;
+                saveButton.className = "";
+            }
+            if (saveButtonAdvanced) {
+                saveButtonAdvanced.disabled = false;
+                saveButtonAdvanced.className = "";
+            }
+            if (recordButton) {
+                recordButton.className = "";
+            }
         };
     }
 
@@ -1028,7 +1040,7 @@ class ToolbarUI {
         this._cleanupRecordDropdownListeners();
 
         if (hideIn.includes(browser)) {
-            Record.classList.add("hide");
+            if (Record) Record.classList.add("hide");
             if (RecordDropdownArrow) RecordDropdownArrow.classList.add("hide");
             return;
         }
@@ -1705,13 +1717,16 @@ class ToolbarUI {
 
             // Set up click handlers for each language
             languages.forEach(lang => {
-                docById(lang).onclick = () => {
-                    // Update highlight to newly selected language
-                    updateSelectedLanguageHighlight(lang);
+                const elem = docById(lang);
+                if (elem) {
+                    elem.onclick = () => {
+                        // Update highlight to newly selected language
+                        updateSelectedLanguageHighlight(lang);
 
-                    // Call the original language change handler
-                    languageBox[`${lang}_onclick`](this.activity);
-                };
+                        // Call the original language change handler
+                        languageBox[`${lang}_onclick`](this.activity);
+                    };
+                }
             });
         };
     }


### PR DESCRIPTION
The global exception handler in cypress/e2e/main.cy.js was ignoring 
broad error strings including "Cannot read properties of undefined" 
and "Cannot read properties of null", masking real application crashes.

Changes:
- Refactored handler to only ignore "ResizeObserver loop limit exceeded" 
  (known benign Cypress layout noise)
- Fixed exposed crash in js/block.js: added null guards for 
  collapseBlockBitmap, highlightCollapseBlockBitmap, collapseText, 
  and expandButtonBitmap before accessing .visible
- All 22 Cypress tests pass with the stricter handler

PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation