### PR TITLE
fix: correct duplicate-check and sync deletion in temperament list helpers

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2360,8 +2360,11 @@ const getTemperamentKeys = () => {
  * @returns {void}
  */
 const addTemperamentToList = newEntry => {
+    if (newEntry[1] in PreDefinedTemperaments) {
+        return;
+    }
     for (let i = 0; i < TEMPERAMENTS.length; i++) {
-        if (PreDefinedTemperaments[i] === newEntry) {
+        if (TEMPERAMENTS[i][1] === newEntry[1]) {
             return;
         }
     }
@@ -2376,6 +2379,10 @@ const addTemperamentToList = newEntry => {
  */
 const deleteTemperamentFromList = oldEntry => {
     delete TEMPERAMENT[oldEntry];
+    const idx = TEMPERAMENTS.findIndex(t => t[1] === oldEntry);
+    if (idx !== -1) {
+        TEMPERAMENTS.splice(idx, 1);
+    }
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes two bugs in \js/utils/musicutils.js\ related to temperament list management, directly relevant to the temperament refactor tracked in #7171.

**Bug 1 — \ddTemperamentToList\ (wrong duplicate guard)**
The loop used \PreDefinedTemperaments[i]\ where \i\ is a numeric index. Since \PreDefinedTemperaments\ is keyed by string names (\equal\, \equal5\, …), \PreDefinedTemperaments[0]\ is always \undefined\. The guard never fired, allowing predefined or duplicate temperaments to be added repeatedly.

**Fix:** Check \
ewEntry[1] in PreDefinedTemperaments\ first, then scan \TEMPERAMENTS\ by identifier \[1]\ for duplicates.

**Bug 2 — \deleteTemperamentFromList\ (TEMPERAMENTS array not updated)**
The function deleted the entry from the \TEMPERAMENT\ dictionary but never removed it from the \TEMPERAMENTS\ display array. Deleted temperaments kept appearing in UI dropdowns.

**Fix:** After deleting from \TEMPERAMENT\, find and splice the entry out of \TEMPERAMENTS\ by matching on the identifier field.

## Test plan
- [ ] Add a custom temperament → confirm it appears once in the list
- [ ] Try adding the same temperament again → confirm no duplicate appears
- [ ] Try adding a predefined temperament (e.g. \equal\) → confirm it is rejected
- [ ] Delete a custom temperament → confirm it disappears from the dropdown immediately

Relates to #7171
