### PR TITLE
fix: correct duplicate-check and sync deletion in temperament list helpers

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2360,8 +2360,11 @@ const getTemperamentKeys = () => {
  * @returns {void}
  */
 const addTemperamentToList = newEntry => {
+    if (newEntry[1] in PreDefinedTemperaments) {
+        return;
+    }
     for (let i = 0; i < TEMPERAMENTS.length; i++) {
-        if (PreDefinedTemperaments[i] === newEntry) {
+        if (TEMPERAMENTS[i][1] === newEntry[1]) {
             return;
         }
     }
@@ -2376,6 +2379,10 @@ const addTemperamentToList = newEntry => {
  */
 const deleteTemperamentFromList = oldEntry => {
     delete TEMPERAMENT[oldEntry];
+    const idx = TEMPERAMENTS.findIndex(t => t[1] === oldEntry);
+    if (idx !== -1) {
+        TEMPERAMENTS.splice(idx, 1);
+    }
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes two bugs in `js/utils/musicutils.js` related to temperament list management, directly relevant to the temperament refactor in #7171.

**Bug 1 — `addTemperamentToList` (wrong duplicate guard)**
The loop used `PreDefinedTemperaments[i]` where `i` is a numeric index. Since `PreDefinedTemperaments` is keyed by string names (`equal`, `equal5`), `PreDefinedTemperaments[0]` is always `undefined`. The guard never fired, allowing predefined or duplicate temperaments to be added repeatedly.

**Bug 2 — `deleteTemperamentFromList` (TEMPERAMENTS array not updated)**
The function deleted the entry from the `TEMPERAMENT` dictionary but never removed it from the `TEMPERAMENTS` display array. Deleted temperaments kept appearing in UI dropdowns.

## Related Issue

This PR fixes #7171

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README

## Changes Made

-   Fixed `addTemperamentToList`: checks `newEntry[1] in PreDefinedTemperaments` and scans `TEMPERAMENTS` by identifier to prevent duplicates
-   Fixed `deleteTemperamentFromList`: splices the entry out of `TEMPERAMENTS` display array after deleting from `TEMPERAMENT` dict

## Testing Performed

-   Add a custom temperament → appears once in the list
-   Add same temperament again → no duplicate appears
-   Add a predefined temperament (`equal`) → rejected correctly
-   Delete a custom temperament → disappears from dropdown immediately

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project coding style guidelines.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Both bugs are in the temperament list helper functions and directly impact the custom temperament workflow being refactored in #7171.

---

Thank you for contributing to our project! We appreciate your help in improving it.
