### PR TITLE
Fix restored trash blocks missing blockArt regeneration

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1378,6 +1378,14 @@ class Activity {
                     ? this.blocks.blockCollapseArt[i]
                     : this.blocks.blockArt[i];
 
+                // Defensive guard: blockArt may be undefined if a block was restored
+                // from trash and regenerateArtwork() has not yet completed (it is
+                // asynchronous). Skip this block rather than injecting <parsererror>
+                // into the SVG output.
+                if (!rawSVG) {
+                    continue;
+                }
+
                 if (this.blocks.blockList[i].isCollapsible()) {
                     svgParts.push("<g>");
                 }
@@ -4512,9 +4520,20 @@ class Activity {
                 this.blocks.blockList[blk].trash = false;
                 this.blocks.moveBlockRelative(blk, dx, dy);
 
+                const block = this.blocks.blockList[blk];
+
+                // Re-populate blocks.blockArt[blk] if it was deleted on trash.
+                // sendStackToTrash() and sendAllToTrash() both delete blockArt[blk]
+                // to free memory. Without regeneration, printBlockSVG() receives
+                // undefined here, passes it to DOMParser.parseFromString(undefined),
+                // and injects a <parsererror> node into every Save Block Artwork
+                // export (activity.js ~line 1394).
+                if (!this.blocks.blockArt[blk]) {
+                    block.regenerateArtwork(block.isCollapsible());
+                }
+
                 // Re-cache the container if it was uncached to save
                 // memory in sendStackToTrash().
-                const block = this.blocks.blockList[blk];
                 if (block.container && !block.container.bitmapCache) {
                     block.container.cache(
                         0,
@@ -4526,7 +4545,6 @@ class Activity {
 
                 this.blocks.blockList[blk].show();
             }
-
             this.blocks.raiseStackToTop(blockId);
             const restoredBlock = this.blocks.blockList[blockId];
 


### PR DESCRIPTION
## Description

When a block stack is moved to trash, `sendStackToTrash()` deletes the corresponding `blocks.blockArt[blk]` and `blocks.blockCollapseArt[blk]` entries to free memory.

However, `_restoreTrashById()` restores the blocks visually without regenerating the deleted artwork cache. As a result, restored blocks retain undefined `blockArt` entries.

Later, during `Save → Save Block Artwork`, `printBlockSVG()` attempts to parse these undefined SVG strings using:

```js
DOMParser.parseFromString(undefined, "image/svg+xml")
```

This injects `<parsererror>` XML nodes into the exported SVG output and can corrupt SVG/PNG exports.

## Related Issue

Fixes #7254


## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Changes Made

* Added artwork regeneration inside `_restoreTrashById()`
* Re-populated missing `blocks.blockArt[blk]` entries using:

  ```js
  block.regenerateArtwork(block.isCollapsible());
  ```
* Added a defensive null guard in `printBlockSVG()` to skip undefined SVG entries instead of injecting malformed XML into exports

## Testing Performed

* Created and deleted block stacks
* Restored blocks from trash
* Exported artwork using:

  * Save → Save Block Artwork
* Verified:

  * No `<parsererror>` nodes appear in exported SVG
  * SVG exports remain valid after trash/restore cycle
  * PNG exports render correctly
* Ran:

  * `npm run lint`
  * `npx prettier --check .`

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run npm run lint and npx prettier --check . with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits from maintainers".

## Additional Notes for Reviewers

This bug was caused by a cache invalidation mismatch:

* `sendStackToTrash()` deletes `blockArt` entries
* `_restoreTrashById()` restored visibility/state but never regenerated artwork

The added regeneration step restores the invariant that every visible non-trash block must have a valid `blockArt` entry before export.
