### PR TITLE
Fix companion turtles not cleared in sendAllToTrash

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4863,11 +4863,28 @@ class Activity {
                     this.blocks.trashStacks.push(blk);
                 }
 
-                if (myBlock.name === "start" || myBlock.name === "drum") {
-                    const turtle = myBlock.value;
-                    if (!myBlock.trash && turtle !== null) {
-                        this.turtles.getTurtle(turtle).inTrash = true;
-                        this.turtles.getTurtle(turtle).container.visible = false;
+                if (
+                    this.blocks.blockList[blk].name === "start" ||
+                    this.blocks.blockList[blk].name === "drum"
+                ) {
+                    const turtle = this.blocks.blockList[blk].value;
+
+                    if (!this.blocks.blockList[blk].trash && turtle !== null) {
+                        const primaryTurtle = this.turtles.getTurtle(turtle);
+
+                        primaryTurtle.inTrash = true;
+                        primaryTurtle.container.visible = false;
+
+                        const comp = primaryTurtle.companionTurtle;
+
+                        if (comp !== null && comp !== undefined) {
+                            const companionTurtle = this.turtles.getTurtle(comp);
+
+                            if (companionTurtle) {
+                                companionTurtle.inTrash = true;
+                                companionTurtle.container.visible = false;
+                            }
+                        }
                     }
                 } else if (myBlock.name === "action") {
                     if (!myBlock.trash) {


### PR DESCRIPTION
## Description

`sendAllToTrash()` clears the primary turtle for `start` and `drum` blocks, but it does not clear the associated `companionTurtle` created by `onEveryBeatDo`.

As a result, companion turtles from the previous project remain active after:

* New Project
* Project load
* Merge operations

This causes stale `onEveryBeatDo` callbacks from the old project to continue executing in the new session.

## Related Issue

Fixes #7220

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Changes Made

* Updated `sendAllToTrash()` in `js/activity.js`
* Added cleanup logic for companion turtles
* Marked companion turtles as:

  * `inTrash = true`
  * `container.visible = false`
* Mirrored the existing companion cleanup logic already used in `sendStackToTrash()` (`js/blocks.js`)

## Testing Performed

* Created a project using `onEveryBeatDo`
* Confirmed beat callbacks execute normally
* Clicked:

  * Stop
  * New Project
* Created a second unrelated project
* Verified:

  * No stale beat callbacks continue running
  * No ghost audio/events persist from the previous project
* Ran:

  * `npm run lint`
  * `npx prettier --check .`

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run npm run lint and npx prettier --check . with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits from maintainers".

## Additional Notes for Reviewers

This issue was caused by inconsistent turtle lifecycle handling between:

* `sendStackToTrash()` (`js/blocks.js`)
* `sendAllToTrash()` (`js/activity.js`)

`sendStackToTrash()` already handled companion turtles correctly, while `sendAllToTrash()` only trashed the primary turtle.

This change keeps both code paths behaviorally consistent and prevents stale runtime state from surviving project resets.
