### PR TITLE
fix: implement true glissando for Glide block (Related to #7257)

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -2002,7 +2002,8 @@ class Singer {
 
                 // Use the beatValue of the first note in the group
                 // since there can only be one.
-                const portamento = tur.singer.glide.length > 0 ? last(tur.singer.glide) : 0;
+                const portamento =
+                    tur.singer.glide.length > 0 ? bpmFactor * last(tur.singer.glide) : 0;
 
                 let beatValue = bpmFactor / noteBeatValue;
                 if (tur.singer.staccato.length > 0) {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1942,10 +1942,10 @@ function Synth() {
                     if (setNote !== undefined && setNote) {
                         if (this._instrumentEpoch !== epoch) return;
                         if (synth.oscillator !== undefined) {
-                            synth.setNote(notes);
+                            synth.setNote(notes, Tone.now() + future);
                         } else if (synth.voices !== undefined) {
                             for (let i = 0; i < synth.voices.length; i++) {
-                                synth.voices[i].setNote(notes);
+                                synth.voices[i].setNote(notes, Tone.now() + future);
                             }
                         }
                     } else {


### PR DESCRIPTION
## Description
This PR resolves the broken glissando behavior in the `Glide` block and fulfills the `TODO` comment previously left in `OrnamentBlocks.js`. 

Previously, the `Glide` block played nested notes as distinct, disconnected pitches. This PR fixes the duration calculations and audio scheduling to correctly interface with Tone.js's native portamento feature, resulting in a smooth, continuous pitch slide (a true glissando).

*(Note: In addition to the glissando fix, 14 preexisting `eqeqeq` lint warnings in `js/turtle-singer.js` were fixed to satisfy the `husky` pre-commit hooks).*

## Related Issue
This PR fixes #7257

## PR Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README

## Changes Made
- **`js/turtle-singer.js`**: Fixed duration calculation bug. The glissando duration `tur.singer.glideOverride` is now properly multiplied by `bpmFactor` instead of dividing it. Applied the same tempo-scaling fix to the `portamento` variable. Fixed 14 loose equality `==` / `!=` warnings.
- **`js/utils/synthutils.js`**: Passed the scheduled audio time (`Tone.now() + future`) to the `synth.setNote()` calls so pitch changes are correctly synced in the audio graph.
- **`js/blocks/OrnamentBlocks.js`**: Removed the outdated `TODO` comment regarding the lack of glissando support.

## Testing Performed
- Started local server and tested the `Glide` block using multiple internal `Note` blocks.
- Verified that synthesized instruments (e.g., `sine`, `electronic synth`) now slide smoothly in pitch rather than playing discrete notes.
- Verified that the `npm run lint` and `npx prettier --check .` hooks pass successfully.

