### PR TITLE
refactor: migrate phrasemaker inline colour reads to CSS tokens

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,131 @@
+/*
+ * MusicBlocks Design Tokens
+ * Single source of truth for theme colours used across CSS files.
+ *
+ * Canvas/block colours (paletteColors, wheel colours, pie-menu colours)
+ * are intentionally excluded — they are drawn by CreateJS on <canvas>
+ * and must remain in js/utils/platformstyle.js.
+ *
+ * Usage in CSS:  background-color: var(--color-bg);
+ * Usage in JS:   getComputedStyle(document.body).getPropertyValue('--color-bg').trim()
+ */
+
+/* Light theme — values from platformThemes.light */
+:root {
+    --color-bg:                  #f9f9f9;
+    --color-panel-bg:            #f5f5f5;
+    --color-palette-bg:          #ffffff;
+    --color-palette-selected:    #f3f3f3;
+    --color-fg:                  #666666;
+    --color-text:                #000000;
+    --color-palette-text:        #666666;
+    --color-border:              #cccccc;
+    --color-rule:                #e2e2e2;
+    --color-accent:              #2196f3;
+    --color-heading:             #0066ff;
+    --color-blue-button:         #0066ff;
+    --color-blue-button-hover:   #023a76;
+    --color-blue-button-text:    #ffffff;
+    --color-hover:               #e0e0e0;
+    --color-header:              #4da6ff;
+    --color-header-aux:          #1a8cff;
+    --color-header-sub:          #8cc6ff;
+    --color-palette-label-bg:    #8cc6ff;
+    --color-palette-label-sel:   #1a8cff;
+    --color-widget-bg:           #cccccc;
+    --color-widget-button:       #8cc6ff;
+    --color-selector-bg:         #8cc6ff;
+    --color-selector-sel:        #1a8cff;
+    --color-orange:              #e37a00;
+    --color-disconnected:        #c4c4c4;
+    --color-trash:               #c0c0c0;
+    --color-trash-border:        #808080;
+    --color-trash-active:        #ff0000;
+    --color-ruler-highlight:     #ffbf00;
+    --color-stop-icon:           #ea174c;
+    --color-rhythm-cell:         #c8c8c8;
+    --color-label:               #a0a0a0;
+    --color-lyrics-label-bg:     #ff2b77;
+    --color-lyrics-input-bg:     #ff6ea1;
+    --color-tuplet-bg:           #c0c0c0;
+}
+
+/* Dark theme — values from platformThemes.dark */
+body.dark {
+    --color-bg:                  #303030;
+    --color-panel-bg:            #1c1c1c;
+    --color-palette-bg:          #1c1c1c;
+    --color-palette-selected:    #1e1e1e;
+    --color-fg:                  #e8e8e8;
+    --color-text:                #e2e2e2;
+    --color-palette-text:        #bdbdbd;
+    --color-border:              #000000;
+    --color-rule:                #303030;
+    --color-accent:              #3fe0d1;
+    --color-heading:             #0066ff;
+    --color-blue-button:         #0066ff;
+    --color-blue-button-hover:   #023a76;
+    --color-blue-button-text:    #ffffff;
+    --color-hover:               #808080;
+    --color-header:              #1e88e5;
+    --color-header-aux:          #1976d2;
+    --color-header-sub:          #64b5f6;
+    --color-palette-label-bg:    #022363;
+    --color-palette-label-sel:   #01143b;
+    --color-widget-bg:           #454545;
+    --color-widget-button:       #225a91;
+    --color-selector-bg:         #64b5f6;
+    --color-selector-sel:        #1e88e5;
+    --color-orange:              #fb8c00;
+    --color-disconnected:        #5c5c5c;
+    --color-trash:               #757575;
+    --color-trash-border:        #424242;
+    --color-trash-active:        #e53935;
+    --color-ruler-highlight:     #ffeb3b;
+    --color-stop-icon:           #d50000;
+    --color-rhythm-cell:         #303030;
+    --color-label:               #bdbdbd;
+    --color-lyrics-label-bg:     #c7225d;
+    --color-lyrics-input-bg:     #d15a84;
+    --color-tuplet-bg:           #424242;
+}
+
+/* High contrast theme — values from platformThemes.highcontrast */
+body.highcontrast {
+    --color-bg:                  #000000;
+    --color-panel-bg:            #000000;
+    --color-palette-bg:          #000000;
+    --color-palette-selected:    #111111;
+    --color-fg:                  #ffffff;
+    --color-text:                #ffffff;
+    --color-palette-text:        #ffffff;
+    --color-border:              #ffffff;
+    --color-rule:                #ffffff;
+    --color-accent:              #00ffff;
+    --color-heading:             #ffff00;
+    --color-blue-button:         #00ffff;
+    --color-blue-button-hover:   #00cccc;
+    --color-blue-button-text:    #000000;
+    --color-hover:               #666666;
+    --color-header:              #00ffff;
+    --color-header-aux:          #00cccc;
+    --color-header-sub:          #00ffff;
+    --color-palette-label-bg:    #000080;
+    --color-palette-label-sel:   #0000ff;
+    --color-widget-bg:           #000000;
+    --color-widget-button:       #00ffff;
+    --color-selector-bg:         #00ffff;
+    --color-selector-sel:        #00cccc;
+    --color-orange:              #ff8800;
+    --color-disconnected:        #666666;
+    --color-trash:               #ffffff;
+    --color-trash-border:        #ffffff;
+    --color-trash-active:        #ff0000;
+    --color-ruler-highlight:     #ffff00;
+    --color-stop-icon:           #ff0000;
+    --color-rhythm-cell:         #333333;
+    --color-label:               #ffffff;
+    --color-lyrics-label-bg:     #ff00ff;
+    --color-lyrics-input-bg:     #ff66ff;
+    --color-tuplet-bg:           #333333;
+}

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -858,7 +858,9 @@ class PhraseMaker {
             cell.style.position = "sticky";
             cell.style.left = "1.2px";
             cell.style.zIndex = "1";
-            cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-lyrics-label-bg")
+                .trim();
             cell.style.textAlign = "center";
             cell.textContent = "";
             const penImg = document.createElement("img");
@@ -875,7 +877,9 @@ class PhraseMaker {
             cell.style.position = "sticky";
             cell.style.left = "1.2px";
             cell.style.zIndex = "1";
-            cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-lyrics-label-bg")
+                .trim();
             cell.style.textAlign = "center";
             cell.textContent = "Lyrics";
 
@@ -899,7 +903,9 @@ class PhraseMaker {
                 inputCell.style.width = this._noteWidth(noteValue) + "px";
                 inputCell.style.minWidth = inputCell.style.width;
                 inputCell.style.maxWidth = inputCell.style.width;
-                inputCell.style.backgroundColor = this.platformColor.lyricsInputBackground;
+                inputCell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-lyrics-input-bg")
+                    .trim();
                 inputCell.style.fontFamily = "sans-serif";
                 inputCell.style.cursor = "default";
                 inputCell.style.borderSpacing = "1px 1px";
@@ -925,15 +931,21 @@ class PhraseMaker {
                 lyricsInput.style.padding = "0";
                 lyricsInput.style.border = "none";
                 lyricsInput.style.borderRadius = "6px";
-                lyricsInput.style.backgroundColor = this.platformColor.lyricsInputBackground;
+                lyricsInput.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-lyrics-input-bg")
+                    .trim();
 
                 inputCell.appendChild(lyricsInput);
                 inputCell.addEventListener("mouseover", event => {
-                    event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                    event.target.style.backgroundColor = getComputedStyle(document.body)
+                        .getPropertyValue("--color-selector-sel")
+                        .trim();
                 });
 
                 inputCell.addEventListener("mouseout", event => {
-                    event.target.style.backgroundColor = this.platformColor.lyricsInputBackground;
+                    event.target.style.backgroundColor = getComputedStyle(document.body)
+                        .getPropertyValue("--color-lyrics-input-bg")
+                        .trim();
                 });
                 lyricsInput.addEventListener("focus", () => (this.activity.isInputON = true));
                 lyricsInput.addEventListener("blur", () => (this.activity.isInputON = false));
@@ -978,7 +990,9 @@ class PhraseMaker {
             Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
         this._noteValueLabel.style.minWidth = this._noteValueLabel.style.width;
         this._noteValueLabel.style.maxWidth = this._noteValueLabel.style.width;
-        this._noteValueLabel.style.backgroundColor = this.platformColor.labelColor;
+        this._noteValueLabel.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-label")
+            .trim();
 
         // Create tables to store individual note values.
         tempTable = document.createElement("table");
@@ -2908,7 +2922,9 @@ class PhraseMaker {
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
             labelCell.style.minWidth = labelCell.style.width;
             labelCell.style.maxWidth = labelCell.style.width;
-            labelCell.style.backgroundColor = this.platformColor.labelColor;
+            labelCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-label")
+                .trim();
 
             labelCell = this._tupletValueLabel;
             labelCell.textContent = this._("tuplet value");
@@ -2917,7 +2933,9 @@ class PhraseMaker {
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
             labelCell.style.minWidth = labelCell.style.width;
             labelCell.style.maxWidth = labelCell.style.width;
-            labelCell.style.backgroundColor = this.platformColor.labelColor;
+            labelCell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-label")
+                .trim();
 
             // Fill in the columns in the tuplet note value row up to
             // where the tuplet begins.
@@ -2925,14 +2943,18 @@ class PhraseMaker {
             valueRow = this._tupletValueRow;
             for (let i = 0; i < firstRow.cells.length; i++) {
                 cell = noteRow.insertCell();
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-tuplet-bg")
+                    .trim();
                 cell.style.width = firstRow.cells[i].style.width;
                 cell.style.minWidth = firstRow.cells[i].style.minWidth;
                 cell.style.maxWidth = firstRow.cells[i].style.maxWidth;
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
 
                 cell = valueRow.insertCell();
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-tuplet-bg")
+                    .trim();
                 cell.style.width = firstRow.cells[i].style.width;
                 cell.style.minWidth = firstRow.cells[i].style.minWidth;
                 cell.style.maxWidth = firstRow.cells[i].style.maxWidth;
@@ -2953,7 +2975,9 @@ class PhraseMaker {
             cell = noteRow.insertCell(-1);
             numerator = 32 / param[1][i];
             thisNoteValue = 1 / (numerator / (totalNoteInterval / tupletTimeFactor));
-            cell.style.backgroundColor = this.platformColor.tupletBackground;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-tuplet-bg")
+                .trim();
             cell.style.width = this._noteWidth(thisNoteValue) + "px";
             cell.style.minWidth = cell.style.width;
             cell.style.maxWidth = cell.style.width;
@@ -3024,7 +3048,9 @@ class PhraseMaker {
 
                 cell.onmouseover = event => {
                     if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                        event.target.style.backgroundColor = getComputedStyle(document.body)
+                            .getPropertyValue("--color-selector-sel")
+                            .trim();
                     }
                 };
 
@@ -3048,7 +3074,9 @@ class PhraseMaker {
         cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
         cell.style.textAlign = "center";
         cell.textContent = tupletValue;
-        cell.style.backgroundColor = this.platformColor.tupletBackground;
+        cell.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-tuplet-bg")
+            .trim();
         cell.style.borderLeft = barStyle;
 
         // And a span in the note value column too.
@@ -3078,7 +3106,9 @@ class PhraseMaker {
                 if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
             }
         }
-        cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
+        cell.style.backgroundColor = getComputedStyle(document.body)
+            .getPropertyValue("--color-rhythm-cell")
+            .trim();
         cell.style.borderLeft = barStyle;
         this._matrixHasTuplets = true;
 
@@ -3164,7 +3194,9 @@ class PhraseMaker {
 
                 cell.addEventListener("mouseover", event => {
                     if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                        event.target.style.backgroundColor = getComputedStyle(document.body)
+                            .getPropertyValue("--color-selector-sel")
+                            .trim();
                     }
                 });
 
@@ -3201,8 +3233,12 @@ class PhraseMaker {
                     if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
                 }
             }
-            cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
-            cell.style.color = this.platformColor.textColor;
+            cell.style.backgroundColor = getComputedStyle(document.body)
+                .getPropertyValue("--color-rhythm-cell")
+                .trim();
+            cell.style.color = getComputedStyle(document.body)
+                .getPropertyValue("--color-text")
+                .trim();
             cell.setAttribute("alt", noteValue);
             cell.style.borderLeft = barStyle;
 
@@ -3216,7 +3252,9 @@ class PhraseMaker {
                 cell.style.maxWidth = cell.style.width;
                 cell.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-tuplet-bg")
+                    .trim();
                 cell.style.borderLeft = barStyle;
 
                 row = this._tupletValueRow;
@@ -3226,7 +3264,9 @@ class PhraseMaker {
                 cell.style.maxWidth = cell.style.width;
                 cell.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.style.backgroundColor = getComputedStyle(document.body)
+                    .getPropertyValue("--color-tuplet-bg")
+                    .trim();
                 cell.style.borderLeft = barStyle;
             }
 


### PR DESCRIPTION
Part of #6606
depends on #7238

phrasemaker.js had 20 inline platformColor style assignments. Four of
the needed tokens were missing from css/tokens.css so they have been
added alongside the migration.

backgroundColor !== 'black' guards are intentionally untouched as they
track note state.

69/69 phrasemaker tests pass.

## PR Category
- [x] Feature