### PR TITLE
fix: guard against numeric noteArg in getNote() to prevent crash with…

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4352,10 +4352,10 @@ function getNote(
                 if (offset === -1) {
                     console.debug(
                         "WARNING: Key " +
-                            myKeySignature +
-                            " not found in " +
-                            thisScale +
-                            ". Using default of C"
+                        myKeySignature +
+                        " not found in " +
+                        thisScale +
+                        ". Using default of C"
                     );
                     offset = 0;
                     thisScale = NOTESSHARP;
@@ -4386,6 +4386,7 @@ function getNote(
             }
 
             let solfegePart;
+            noteArg = String(noteArg);
             if (halfSteps.includes(noteArg.substr(0, 1).toLowerCase())) {
                 solfegePart = noteArg.substr(0, 1).toLowerCase();
             } else if (halfSteps.includes(noteArg.substr(0, 2).toLowerCase())) {
@@ -4398,6 +4399,7 @@ function getNote(
                 // solfnotes_ is used in the interface for i18n
                 //.TRANS: the note names must be separated by single spaces
                 const solfnotes_ = _("ti la sol fa mi re do").split(" ");
+
                 if (solfnotes_.includes(noteArg.substr(0, 1).toLowerCase())) {
                     solfegePart = SOLFNOTES[solfnotes_.indexOf(noteArg.substr(0, 2).toLowerCase())];
                 } else if (solfnotes_.includes(noteArg.substr(0, 2).toLowerCase())) {


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Related Issue
Closes #7171

## Problem
When a custom temperament is active, pitch blocks pass integer step 
indices to `getNote()`. The function calls `.substr()` on `noteArg` 
assuming it is always a string, causing:
`TypeError: noteArg.substr is not a function`

## Fix
Added `noteArg = String(noteArg)` before the first `.substr()` call 
in the solfege resolution block, ensuring numeric inputs are safely 
converted to strings before any string operations.

## Files Changed
- `js/utils/musicutils.js`

## Testing
- All existing tests pass with no regressions