### PR TITLE
fix: correct activity reference in tempo widget and planet interface test

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -222,7 +222,7 @@ describe("PlanetInterface", () => {
         planetInterface.planet = { ProjectStorage: { saveLocally: jest.fn() } };
 
         return planetInterface.saveLocally().then(() => {
-            expect(mockActivity.stage.update).toHaveBeenCalledWith(undefined);
+            expect(mockActivity.stage.update).toHaveBeenCalled();
             expect(planetInterface.planet.ProjectStorage.saveLocally).toHaveBeenCalledWith(D, null);
         });
     });

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -461,7 +461,7 @@ class Tempo {
                 [5, ["vspace", {}], 0, 0, [0, null]]
             ];
             this.activity.blocks.loadNewBlocks(newStack);
-            activity.textMsg(_("New action block generated."), 3000);
+            this.activity.textMsg(_("New action block generated."), 3000);
         };
 
         if (this.widgetWindow && this.widgetWindow.timerManager) {


### PR DESCRIPTION
## Summary

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

**Before:** 

<img width="775" height="350" alt="Screenshot 2026-05-09 at 7 18 35 PM" src="https://github.com/user-attachments/assets/a5a50d0c-1699-42ad-888b-8eba9e66fbe4" />

**After:** 

<img width="664" height="209" alt="Screenshot 2026-05-09 at 7 17 29 PM" src="https://github.com/user-attachments/assets/3352e43c-9fb8-4a48-a212-788a4b028752" />


Fixed 6 failing tests caused by two issues:

### 1. Tempo Widget Bug (js/widgets/tempo.js:464)
- **Issue**: `activity.textMsg` referenced without `this.` in the `__save()` callback
- **Impact**: Caused `ReferenceError: activity is not defined` when saving tempo blocks
- **Fix**: Changed to `this.activity.textMsg` to properly reference the activity instance

### 2. Test Assertion Mismatch (js/__tests__/planetInterface.test.js:225)
- **Issue**: Test expected `stage.update()` to be called with `undefined` argument
- **Reality**: Implementation calls `stage.update()` without any arguments
- **Fix**: Updated test assertion to use `toHaveBeenCalled()` instead of `toHaveBeenCalledWith(undefined)`

## Changes

- `js/widgets/tempo.js`: Fixed activity reference in __save() callback
- `js/__tests__/planetInterface.test.js`: Corrected test assertion to match implementation

## Verification

- All 5064 tests now pass (previously 6 failing)
- `npm test` completes successfully
- No new linting issues introduced