### PR TITLE
docs: add test:coverage script and coverage guide section

### DIFF
--- a/js/guide_addingtest.md
+++ b/js/guide_addingtest.md
@@ -1,28 +1,28 @@
-# Test Suite Guidelines  
+# Test Suite Guidelines
 
-The Music Blocks repository follows a structured approach for testing using **Jest**. All tests should be placed inside the `_tests_` directory to ensure consistency and maintainability.  
+The Music Blocks repository follows a structured approach for testing using **Jest**. All tests should be placed inside the `_tests_` directory to ensure consistency and maintainability.
 
-## 🛠 Setting Up the Test Environment  
+## 🛠 Setting Up the Test Environment
 
-Before running or writing tests, ensure that dependencies are installed:  
+Before running or writing tests, ensure that dependencies are installed:
 
 ```sh
 npm install
-```  
+```
 
-To run the test suite, use:  
+To run the test suite, use:
 
 ```sh
 npm test
-```  
+```
 
-For running tests with detailed logs:  
+For running tests with detailed logs:
 
 ```sh
 npm test -- --verbose
-```  
+```
 
-## 📂 Directory Structure  
+## 📂 Directory Structure
 
 ```
 /musicblocks
@@ -32,82 +32,140 @@ npm test -- --verbose
 │── jest.config.js      # Jest configuration (try not to edit this)
 │── package.json        # Project dependencies
 │── js/guide_test.md    # This guide
-```  
+```
 
-## 📌 Key Guidelines Before Writing Tests  
+## 📌 Key Guidelines Before Writing Tests
 
-### ✅ General Rules  
-- All test files **must be placed inside the `_tests_` folder of the respective directory**.  
-- Follow the naming convention: **`<filename>.test.js`**.  
-- Ensure **100% function coverage** when adding tests.  
+### ✅ General Rules
+
+- All test files **must be placed inside the `_tests_` folder of the respective directory**.
+- Follow the naming convention: **`<filename>.test.js`**.
+- Ensure **100% function coverage** when adding tests.
 - **Mock dependencies** where necessary to isolate unit tests.
-- **Whenever a function is added or its functionality is changed, ensure that the corresponding test cases are added, updated, or refactored.** This ensures that the test suite remains accurate and reliable.  
+- **Whenever a function is added or its functionality is changed, ensure that the corresponding test cases are added, updated, or refactored.** This ensures that the test suite remains accurate and reliable.
 
-### 🔄 Import/Export Conventions  
-- The Music Blocks repository **strictly follows `const` for imports and exports**.  
-- **For CommonJS (`require/module.exports`)**, use:  
+### 🔄 Import/Export Conventions
 
-  ```js
-  const { functionName } = require('../src/file.js');
-  ```  
+- The Music Blocks repository **strictly follows `const` for imports and exports**.
+- **For CommonJS (`require/module.exports`)**, use:
 
-  Ensure `file.js` contains:  
+    ```js
+    const { functionName } = require("../src/file.js");
+    ```
 
-  ```js
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { functionName };
-  }
-  ```  
+    Ensure `file.js` contains:
 
-### 📑 Writing Tests  
-- Use `describe` blocks to group related tests.  
-- Use `test` or `it` for defining test cases.  
-- Use **Jest matchers** like `toBe`, `toEqual`, `toHaveBeenCalled`.  
+    ```js
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = { functionName };
+    }
+    ```
 
-#### 🔹 Example Test Structure:  
+### 📑 Writing Tests
+
+- Use `describe` blocks to group related tests.
+- Use `test` or `it` for defining test cases.
+- Use **Jest matchers** like `toBe`, `toEqual`, `toHaveBeenCalled`.
+
+#### 🔹 Example Test Structure:
 
 ```js
-const { myFunction } = require('../src/myFile.js');
+const { myFunction } = require("../src/myFile.js");
 
-describe('My Function Tests', () => {
-    test('should return expected output', () => {
-        expect(myFunction()).toBe('expectedValue');
+describe("My Function Tests", () => {
+    test("should return expected output", () => {
+        expect(myFunction()).toBe("expectedValue");
     });
 });
-```  
+```
 
-## 🛑 Common Mistakes to Avoid  
+## 🛑 Common Mistakes to Avoid
+
 ❌ Making changes in the root file.  
 ❌ Modifying `jest.config.js` unnecessarily.  
 ❌ Placing test files **outside** `_tests_` (always keep them inside).  
 ❌ Using `var` or `let` for imports (always use `const`).  
 ❌ Forgetting to mock dependencies when needed.  
-❌ Not handling async tests properly (use `async/await` or `done`). 
+❌ Not handling async tests properly (use `async/await` or `done`).
 ❌ **Neglecting to update or refactor test cases when adding or modifying functions.**
 
-## 🚀 Running Specific Tests  
-To run a specific test file:  
+## 🚀 Running Specific Tests
+
+To run a specific test file:
 
 ```sh
 npm test _tests_/filename.test.js
-```  
+```
 
-To watch tests while coding:  
+To watch tests while coding:
 
 ```sh
 npm test -- --watch
-```  
+```
 
-## 🔄 Updating Snapshots  
-If using Jest snapshots, update them with:  
+## 🔄 Updating Snapshots
+
+If using Jest snapshots, update them with:
 
 ```sh
 npm test -- -u
-```  
+```
 
-## 🎯 Contribution Guidelines  
-- Ensure all tests pass before creating a PR.  
-- Maintain code readability and add comments where needed.  
-- Adhere to the **import/export conventions** stated above.  
+## Code Coverage
+
+### Running Coverage Locally
+
+To generate a coverage report, run:
+
+```sh
+npm run test:coverage
+```
+
+This executes `jest --coverage`, which collects coverage data according to the settings in `jest.config.js`.
+
+### Where Reports Are Generated
+
+After the command finishes, reports are written to the `coverage/` directory at the project root. The configured reporters (`jest.config.js` → `coverageReporters`) produce:
+
+| Reporter       | Output                                              |
+| -------------- | --------------------------------------------------- |
+| `text-summary` | One-line summary printed to the terminal            |
+| `text`         | Per-file table printed to the terminal              |
+| `lcov`         | `coverage/lcov-report/index.html` (browsable)       |
+| `json-summary` | `coverage/coverage-summary.json` (machine-readable) |
+
+Open `coverage/lcov-report/index.html` in a browser to explore line-by-line coverage.
+
+> **Note:** The `coverage/` directory is listed in `.gitignore` and should never be committed.
+
+### Current Threshold Policy
+
+The `coverageThreshold` in `jest.config.js` enforces minimum global coverage. If any metric drops below its threshold, `jest --coverage` exits with a non-zero code and the CI build fails.
+
+| Metric     | Minimum |
+| ---------- | ------- |
+| Statements | 34 %    |
+| Branches   | 29 %    |
+| Functions  | 41 %    |
+| Lines      | 34 %    |
+
+These thresholds are intentionally kept as a ratchet — they should only go **up** as new tests are added, never down.
+
+### How CI Posts Coverage on PRs
+
+The GitHub Actions workflow (`.github/workflows/pr-jest-tests.yml`) runs on every pull request:
+
+1. Checks out the PR head commit and runs `npm test -- --coverage`.
+2. Reads `coverage/coverage-summary.json` to extract per-metric percentages.
+3. Posts a comment on the PR with the coverage summary and pass/fail status.
+4. If any test fails, the comment lists the failing test files.
+
+You can check the latest coverage numbers directly in the PR comment without downloading the CI logs.
+
+## 🎯 Contribution Guidelines
+
+- Ensure all tests pass before creating a PR.
+- Maintain code readability and add comments where needed.
+- Adhere to the **import/export conventions** stated above.
 - **Do not merge** without proper test coverage.
 - **Always update or refactor test cases when adding or modifying functions to ensure the test suite remains accurate and reliable.**

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "dev": "cross-env NODE_ENV=development nodemon index.js",
         "prod": "cross-env NODE_ENV=production node index.js",
         "test": "jest",
+        "test:coverage": "jest --coverage",
         "cypress:run": "cypress run",
         "electron": "electron .",
         "dist": "electron-builder"


### PR DESCRIPTION
# Add test:coverage script and coverage guide section

## What

This PR adds a dedicated `npm run test:coverage` script and documents the full coverage workflow in the existing test guide (`js/guide_addingtest.md`).

---

## Why

Contributors currently have no single command to run coverage locally and no documentation explaining:

- where reports are generated
- what the enforced thresholds are
- how CI surfaces coverage on pull requests

This creates friction for new contributors trying to understand and improve test coverage.

---

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `"test:coverage": "jest --coverage"` script |
| `js/guide_addingtest.md` | Add **Code Coverage** section |

---

## Guide Section Covers

### Running coverage locally

```bash
npm run test:coverage
```

### Where reports are generated -coverage/ directory breakdown:

text-summary → terminal one-liner
text → per-file table in terminal
lcov → coverage/lcov-report/index.html (browsable)
json-summary → coverage/coverage-summary.json (machine-readable)

### Current threshold policy from jest.config.js:
Statements: 34%
Branches: 29%
Functions: 41%
Lines: 34%

### How CI posts coverage on PRs - .github/workflows/pr-jest-tests.yml workflow behavior
Testing
npm run test:coverage runs successfully (154 suites, 5123 tests passed)
coverage/ directory generated with all expected reports
npx prettier --check package.json js/guide_addingtest.md passes
No functional code changes documentation and script only

- [x] Documentation
