### PR TITLE
fix: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22.x
                   cache: "npm"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"

--- a/.github/workflows/pr-cypress-e2e.yml
+++ b/.github/workflows/pr-cypress-e2e.yml
@@ -17,13 +17,14 @@ jobs:
   e2e:
     name: Run Cypress E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Run Jest Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: 
       pull-requests: write
       contents: read
@@ -26,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix

- Upgrade `actions/setup-node` from v4 to v5 across all workflows
- Add `30-minute` timeout to `Jest` and `Cypress` test workflows
- Prevents indefinite workflow runs and uses latest stable action versions
