### PR TITLE
Fix ReferenceError in Arpeggio Widget Test Suite

### DIFF
--- a/js/widgets/__tests__/arpeggio.test.js
+++ b/js/widgets/__tests__/arpeggio.test.js
@@ -36,6 +36,7 @@ global.keySignatureToMode = jest.fn(() => ["C", "major"]);
 global.getModeNumbers = jest.fn(() => "0 2 4 5 7 9 11");
 global.getTemperament = jest.fn(() => ({ pitchNumber: 12 }));
 global.normalizeNoteAccidentals = jest.fn(note => note);
+global.DEFAULTVOICE = "electronic synth";
 
 describe("Arpeggio Widget", () => {
     let arpeggio;


### PR DESCRIPTION
## fix: define missing DEFAULTVOICE global in arpeggio test suite

### Summary
This PR resolves a blocking `ReferenceError: DEFAULTVOICE is not defined` in the `arpeggio.test.js` suite. 

### Problem
The `Arpeggio` widget's `trigger` method depends on the `DEFAULTVOICE` global constant for audio feedback during grid interactions. This global was missing in the Jest environment, causing 6 tests to fail.

### Solution
Added `global.DEFAULTVOICE = "electronic synth";` to the test setup in `js/widgets/__tests__/arpeggio.test.js`.

### Verification
- `js/widgets/__tests__/arpeggio.test.js`: PASS (20/20)

- [x] Bug Fix
