### PR TITLE
fix: add package.json overrides for babel, postcss, and ip-address CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,9 +1253,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8201,9 +8201,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -9724,9 +9724,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13540,9 +13540,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,10 @@
         "svgo": "^4.0.1",
         "@xmldom/xmldom": "^0.8.13",
         "@gulp-sourcemaps/identity-map": {
-            "postcss": "^8.4.31"
-        }
+            "postcss": "^8.5.10"
+        },
+        "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+        "ip-address": "^10.2.0"
     },
     "lint-staged": {
         "*.{js,mjs}": [


### PR DESCRIPTION
Adds package.json overrides for three CVEs with available fixes:

- @babel/plugin-transform-modules-systemjs to ^7.29.4 (High - arbitrary code execution, GHSA-fv7c-fp4j-7gwp)
- postcss to ^8.5.10 (Moderate - XSS in CSS stringify output, GHSA-qx2v-qp2m-jg93)
- ip-address to ^10.2.0 (Moderate - XSS in Address6 HTML methods, GHSA-v2v4-37r5-5v8g)

npm audit now reports 1 remaining vulnerability (materialize-css no fix available).

PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation