### PR TITLE
Hoist findBlockInstance temperament1 lookup out of per-block loop

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6080,6 +6080,24 @@ class Blocks {
             const totalBlocks = this._loadCounter;
             let bIndex = 0;
 
+            // Check once before chunking instead of on every block.
+            // Look in existing blocks and in the incoming batch.
+            if (!this.customTemperamentDefined) {
+                if (this.findBlockInstance("temperament1")) {
+                    this.customTemperamentDefined = true;
+                } else {
+                    for (let b = 0; b < blockObjs.length; b++) {
+                        const name = typeof blockObjs[b][1] === "object"
+                            ? blockObjs[b][1][0]
+                            : blockObjs[b][1];
+                        if (name === "temperament1") {
+                            this.customTemperamentDefined = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
             const processChunk = () => {
                 const chunkEnd = Math.min(bIndex + CHUNK_SIZE, totalBlocks);
                 for (let b = bIndex; b < chunkEnd; b++) {
@@ -6143,10 +6161,6 @@ class Blocks {
                 }
 
                 const that = this;
-
-                if (this.findBlockInstance("temperament1")) {
-                    this.customTemperamentDefined = true;
-                }
 
                 let postProcess;
                 /** A few special cases. */

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6087,9 +6087,10 @@ class Blocks {
                     this.customTemperamentDefined = true;
                 } else {
                     for (let b = 0; b < blockObjs.length; b++) {
-                        const name = typeof blockObjs[b][1] === "object"
-                            ? blockObjs[b][1][0]
-                            : blockObjs[b][1];
+                        const name =
+                            typeof blockObjs[b][1] === "object"
+                                ? blockObjs[b][1][0]
+                                : blockObjs[b][1];
                         if (name === "temperament1") {
                             this.customTemperamentDefined = true;
                             break;


### PR DESCRIPTION
## PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation

## Summary

Fixes #7289

`_processOneBlock` called `findBlockInstance("temperament1")` for every block during project load. Since `findBlockInstance` does a linear scan of `blockList`, and the list grows as blocks are added, a project with N blocks triggered O(N^2) string comparisons during import.

This patch moves the check to a single call in `loadNewBlocks` before the chunked loop begins. The pre-check scans both the existing `blockList` (via `findBlockInstance`) and the incoming `blockObjs` array (via a simple loop), so the result is identical but runs once instead of once per block.

## What changed

- Removed the `findBlockInstance("temperament1")` call from `_processOneBlock`.
- Added a one-time check in `loadNewBlocks` that covers both already-loaded blocks and the incoming batch.
- No behavioral change; `customTemperamentDefined` is set to `true` under exactly the same conditions as before.

## Test plan

- [x] Load a project that contains a `temperament1` block and verify custom temperament behavior works as before.
- [x] Load a project without `temperament1` and verify `customTemperamentDefined` remains `false`.
- [x] Time `loadNewBlocks` on a large project (2000+ blocks) and confirm measurable improvement.