### PR TITLE
Debounce local project rename to avoid repeated full DB writes

### DIFF
--- a/planet/js/LocalCard.js
+++ b/planet/js/LocalCard.js
@@ -27,6 +27,7 @@ class LocalCard {
         this.PlaceholderTBImage = "images/tbgraphic.png";
         this.id = null;
         this.ProjectData = null;
+        this._renameTimers = {};
         this.CopySuffix = `(${_("Copy")})`;
 
         this.renderData = `
@@ -143,7 +144,13 @@ class LocalCard {
         // set input modify listener
 
         frag.getElementById(`local-project-input-${this.id}`).addEventListener("input", evt => {
-            Planet.ProjectStorage.renameProject(this.id, evt.target.value);
+            const projectId = this.id;
+            const newName = evt.target.value;
+            clearTimeout(this._renameTimers[projectId]);
+            this._renameTimers[projectId] = setTimeout(() => {
+                Planet.ProjectStorage.renameProject(projectId, newName);
+                delete this._renameTimers[projectId];
+            }, 400);
         });
 
         // set delete button listener


### PR DESCRIPTION
## PR Category

- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation

## Summary

Fixes #7291

The `input` event listener on the local project title field calls `Planet.ProjectStorage.renameProject()` on every keystroke. Since `renameProject` triggers a full `save()` cycle (read entire DB, write backup, write primary), this causes repeated heavy IndexedDB operations while the user is still typing.

This patch adds a 400ms debounce so the database write only fires once after the user stops typing.

## What changed

- Added a `_renameTimers` map to `LocalCard` to track pending debounce timers per project.
- Replaced the direct `renameProject` call in the `input` handler with a debounced version.
- Each new keystroke clears the previous timer and starts a fresh 400ms delay.
- The timer entry is cleaned up after the write completes.

## Test plan

- [x] Rename a local project and confirm the new name persists after refreshing.
- [x] Type quickly and confirm that only one IndexedDB write occurs (visible in DevTools Application tab).
- [x] Rename multiple projects in quick succession and confirm each saves correctly.
- [x] Delete a project mid-rename and confirm no errors from orphaned timers.