### PR TITLE
Handle missing Planet local tab

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -22,6 +22,7 @@ global.platformColor = {
     header: "#8bc34a"
 };
 global._THIS_IS_MUSIC_BLOCKS_ = {};
+global._ = jest.fn(str => str);
 global.doSVG = jest.fn();
 
 const mockActivity = {
@@ -338,6 +339,7 @@ describe("PlanetInterface", () => {
         planetInterface.showPlanet();
 
         expect(console.error).toHaveBeenCalled();
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith("Planet view is not ready yet.");
     });
     test("saveLocally: non-empty SVG triggers image‑onload path", done => {
         doSVG.mockReturnValue("<svg/>");

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -93,9 +93,15 @@ class PlanetInterface {
             this.iframe.style.display = "block";
             this.iframe.style.zIndex = "9999";
             try {
-                this.iframe.contentWindow.document.getElementById("local-tab").click();
+                const localTab = this.iframe.contentWindow.document.getElementById("local-tab");
+                if (!localTab) {
+                    throw new Error("local-tab not found");
+                }
+
+                localTab.click();
             } catch (e) {
                 console.error(e);
+                this.activity.errorMsg(_("Planet view is not ready yet."));
             }
         };
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Fixes #7293 by making `PlanetInterface.showPlanet()` handle a missing Planet iframe local tab with visible user feedback.

## Changes
- Check that `#local-tab` exists before clicking it.
- Show an `activity.errorMsg(...)` message when the Planet view is not ready.
- Add regression coverage for the missing-tab path.

## Validation
- `npx jest js/__tests__/planetInterface.test.js --runInBand --coverage=false`
- `npx eslint js/planetInterface.js js/__tests__/planetInterface.test.js`
- `git diff --check`