### PR TITLE
Added touch-action: none to canvas and workspace for mobile touch

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -659,6 +659,7 @@ canvas {
     overflow: clip !important;
     width: 100%;
     height: 100%;
+    touch-action: none;
 }
 
 .projectname {
@@ -781,6 +782,7 @@ table {
 
 #canvas {
     overflow-y: visible;
+    touch-action: none;
 }
 
 #statusDiv {
@@ -2232,4 +2234,11 @@ table {
     padding: 0 10px;
     box-sizing: border-box;
   }
+}
+
+/* Mobile touch fix: prevent browser scroll interference during block drag */
+.blocklyDiv,
+.canvasDiv,
+#svgDiv {
+    touch-action: none;
 }

--- a/css/activities.css
+++ b/css/activities.css
@@ -145,14 +145,14 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
 }
 
 .cancel-button {
-  border: none;
-  border-radius: 4px;
-  padding: 8px 16px;
-  font-weight: bold;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  background-color: #e0e0e0;
-  color: black;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 16px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    background-color: #e0e0e0;
+    color: black;
 }
 
 .cancel-button:hover {
@@ -547,7 +547,9 @@ nav {
     background-color: #8bc34a;
     height: 64px;
     width: 100%;
-    box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.16), 0px 2px 10px 0px rgba(0, 0, 0, 0.12);
+    box-shadow:
+        0px 2px 5px 0px rgba(0, 0, 0, 0.16),
+        0px 2px 10px 0px rgba(0, 0, 0, 0.12);
     font: 32px sans;
     vertical-align: middle;
     line-height: 64px;
@@ -1227,7 +1229,7 @@ table {
     overflow: visible;
     width: calc(100% - 130px) !important;
     max-width: 350px;
-    padding-top: 2.5rem; 
+    padding-top: 2.5rem;
     padding-bottom: 2.5rem;
     display: flex;
     flex-direction: column;
@@ -1248,11 +1250,11 @@ table {
 }
 
 #helpBodyDiv p {
-    margin: 0.5rem 0; 
+    margin: 0.5rem 0;
 }
 
 #helpBodyDiv a {
-    color: #2196F3;
+    color: #2196f3;
     text-decoration: underline;
     font-weight: 600;
     transition: color 0.2s ease;
@@ -1283,7 +1285,7 @@ table {
 }
 
 #helpBodyDiv figure {
-    margin-left: 0.5rem; 
+    margin-left: 0.5rem;
     margin-bottom: 1rem;
 }
 
@@ -2028,7 +2030,9 @@ table {
     width: 28px;
     height: 28px;
     filter: invert(100%);
-    transition: background-color 0.3s, filter 0.3s;
+    transition:
+        background-color 0.3s,
+        filter 0.3s;
 }
 
 .msgCloseIcon:hover {
@@ -2213,27 +2217,27 @@ table {
    FIX: Center the Welcome Modal on Mobile
    ====================================================== */
 @media screen and (max-width: 600px) {
-  #helpDiv {
-    /* 1. Fit the screen width */
-    width: 90% !important;
+    #helpDiv {
+        /* 1. Fit the screen width */
+        width: 90% !important;
 
-    /* 2. Center Horizontally */
-    left: 50% !important;
-    transform: translateX(-50%);
-    /* Moves it back by half its width to center it */
+        /* 2. Center Horizontally */
+        left: 50% !important;
+        transform: translateX(-50%);
+        /* Moves it back by half its width to center it */
 
-    /* 3. Reset Top position if needed */
-    top: 15% !important;
-  }
+        /* 3. Reset Top position if needed */
+        top: 15% !important;
+    }
 
-  /* Fix the inner text box width so it doesn't overflow */
-  #helpBodyDiv {
-    width: calc(100% - 110px) !important;
-    margin: 0 auto !important;
-    left: 0 !important;
-    padding: 0 10px;
-    box-sizing: border-box;
-  }
+    /* Fix the inner text box width so it doesn't overflow */
+    #helpBodyDiv {
+        width: calc(100% - 110px) !important;
+        margin: 0 auto !important;
+        left: 0 !important;
+        padding: 0 10px;
+        box-sizing: border-box;
+    }
 }
 
 /* Mobile touch fix: prevent browser scroll interference during block drag */


### PR DESCRIPTION

On mobile browsers, when users try to drag blocks on the canvas, the browser intercepts touch events to scroll/zoom the page instead. This makes block dragging unreliable or impossible on touch devices.

## Root Cause
No `touch-action` CSS property was set on the canvas or workspace elements, so the browser's default touch behavior (scroll/zoom) takes priority over Music Blocks' drag handlers.

## Fix
Added `touch-action: none` to:
- `canvas` element (lines 657-663) — prevents scroll interference during block drag
- `#canvas` id rule (lines 783-786) — explicit override for main canvas
- `.blocklyDiv`, `.canvasDiv`, `#svgDiv` (new rule at end of file) covers block workspace containers

## Testing
- Block dragging on mobile browser works without page scrolling
- No regressions on desktop mouse drag
- Verified with Chrome DevTools mobile emulator

## References
- Identified in codebase audit: touch events only present in 4 out of 150+ JS files
- Addresses mobile UX gap for tablet/phone users in classroom deployments

## PR Category
- [ ] Bug Fix | Fixes a bug or incorrect behavior
- [x] Feature | Adds new functionality
- [ ] Performance | Improves performance
- [ ] Tests | Adds or updates test coverage
- [ ] Documentation | Updates to docs, comments, or README