### PR TITLE
fix: replace leftover debug console.log calls with console.warn

### DIFF
--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -1063,7 +1063,9 @@ function setupIntervalsBlocks(activity) {
                 if (intervalName in INTERVALVALUES) {
                     r = INTERVALVALUES[intervalName][2];
                 } else {
-                    console.warn(`[IntervalsBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`);
+                    console.warn(
+                        `[IntervalsBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`
+                    );
                     r = 1;
                 }
             }

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -1063,7 +1063,7 @@ function setupIntervalsBlocks(activity) {
                 if (intervalName in INTERVALVALUES) {
                     r = INTERVALVALUES[intervalName][2];
                 } else {
-                    console.log("could not find " + intervalName + " in INTERVALVALUES");
+                    console.warn(`[IntervalsBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`);
                     r = 1;
                 }
             }

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -1192,7 +1192,9 @@ function setupPitchBlocks(activity) {
                 if (intervalName in INTERVALVALUES) {
                     r = INTERVALVALUES[intervalName][2];
                 } else {
-                    console.warn(`[PitchBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`);
+                    console.warn(
+                        `[PitchBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`
+                    );
                     r = 1;
                 }
             }

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -1192,7 +1192,7 @@ function setupPitchBlocks(activity) {
                 if (intervalName in INTERVALVALUES) {
                     r = INTERVALVALUES[intervalName][2];
                 } else {
-                    console.log("could not find " + intervalName + " in INTERVALVALUES");
+                    console.warn(`[PitchBlocks] Interval name not found in INTERVALVALUES: "${intervalName}"`);
                     r = 1;
                 }
             }

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -435,7 +435,7 @@ describe("setupPitchBlocks", () => {
     describe("Transposition Blocks", () => {
         it("SetRatioTranspositionBlock", () => {
             const block = createdBlocks["setratio"];
-            const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+            const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
             activity.blocks.blockList[10].connections[1] = 20;
 


### PR DESCRIPTION
## What this PR does

Three production code paths used `console.log` for unexpected or error conditions, inconsistent with the rest of the codebase which uses `console.warn` for non-fatal warnings (see `logo.js`, `themebox.js`, `activity.js`, `turtle.js`).

- `js/turtleactions/DictActions.js` — `setValue()` was logging the entire turtle dictionary object on every write. This is a debug trace with no user value and leaks internal state to the browser console in production.
  Removed entirely.

- `js/blocks/PitchBlocks.js` — unrecognised interval name was logged with `console.log`. Changed to `console.warn` with a descriptive prefix and the actual value for easier debugging.

- `js/blocks/IntervalsBlocks.js` — identical issue to PitchBlocks. Same fix.

Tests updated to reflect the changes:
- `DictActions.test.js` — replaced the console.log assertion with a behavioural check (verifies the value is actually stored correctly)
- `PitchBlocks.test.js` — updated spy from `console.log` to `console.warn`

Note: `arpeggio.test.js` has 6 pre-existing failures unrelated to this PR (`DEFAULTVOICE is not defined` in the test environment).

## Files changed
- `js/turtleactions/DictActions.js`
- `js/blocks/PitchBlocks.js`
- `js/blocks/IntervalsBlocks.js`
- `js/turtleactions/__tests__/DictActions.test.js`
- `js/blocks/__tests__/PitchBlocks.test.js`

## PR Category
- [x] Bug Fix