### PR TITLE
fix(js/blocks): prevent potential infinite loop in _deletePitchBlocks & safe JSON Parsing

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1470,21 +1470,18 @@ class Blocks {
             let c = this.blockList[thisBlock].connections[0];
             if (c === null) {
                 console.debug("Silence block was not inside a note block");
+                return;
             }
 
             let counter = 0;
 
-            while (true) {
+            while (c !== null) {
                 if (NOTEBLOCKS.includes(this.blockList[c].name)) {
                     break;
                 }
 
                 thisBlock = c;
                 c = this.blockList[c].connections[0];
-                if (c === null) {
-                    console.debug("Silence block was not inside a note block");
-                    break;
-                }
 
                 counter += 1;
                 if (counter > this.blockList.length) {

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -36,6 +36,14 @@ global.platformColor = {
 };
 global.DEFAULTVOICE = "piano";
 global.last = arr => arr[arr.length - 1];
+global.safeJSONParse = (data, fallback = null) => {
+    if (typeof data !== "string" || !data) return fallback;
+    try {
+        return JSON.parse(data);
+    } catch (e) {
+        return fallback;
+    }
+};
 
 // Mock utils
 global.docById = jest.fn().mockImplementation(id => ({

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -14,7 +14,7 @@
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
-   normalizeNoteAccidentals,
+   normalizeNoteAccidentals, safeJSONParse,
  */
 
 /*
@@ -785,7 +785,10 @@ class ModeWidget {
      */
     _undo() {
         if (this._undoStack.length > 0) {
-            const prevState = JSON.parse(this._undoStack.pop());
+            const prevState = safeJSONParse(this._undoStack.pop(), null);
+            if (prevState === null) {
+                return;
+            }
             for (let i = 0; i < 12; i++) {
                 this._selectedNotes[i] = prevState[i];
             }


### PR DESCRIPTION
## Summary
This PR addresses two critical stability issues:

1. **Infinite loop guard in `_deletePitchBlocks`** (`js/blocks.js`):
   - Replaced `while(true)` with `while(c !== null)` for explicit loop control
   - Added early return when the initial connection is null, preventing null pointer access
   - The existing `counter` guard remains as a secondary safety net for circular references

2. **Safe JSON parsing in ModeWidget undo** (`js/widgets/modewidget.js`):
   - Replaced unprotected `JSON.parse` with the project's existing `safeJSONParse` utility
   - Returns gracefully when undo stack data is corrupted instead of throwing
   - Added `safeJSONParse` mock to `modewidget.test.js`

## Verification
- `npm test` — 154 suites, 5132 tests passing
- `npm run lint` — no new errors introduced (pre-existing `eqeqeq` warnings in `js/blocks.js` are unrelated to this change)

## PR Category
- [x] Bug Fix