### PR TITLE
chore(eslint): disable eqeqeq rule and remove obsolete suppressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,7 +169,7 @@ export default [
             "semi": ["error", "always"],
             "no-duplicate-case": "error",
             "no-irregular-whitespace": "warn",
-            "eqeqeq": "warn",
+            "eqeqeq": "off",
             "no-dupe-keys": "error"
         }
     },

--- a/js/block.js
+++ b/js/block.js
@@ -3225,10 +3225,8 @@ class Block {
             that.blocks.raiseStackToTop(thisBlock);
 
             // And possibly the collapse button.
-            // eslint-disable-next-line eqeqeq
             if (that.collapseContainer != null) {
                 // Ensure the blocksContainer still exisits.
-                // eslint-disable-next-line eqeqeq
                 if (that.activity.blocksContainer != null) {
                     that.activity.blocksContainer.setChildIndex(
                         that.collapseContainer,
@@ -3260,7 +3258,6 @@ class Block {
             // mouse move event.
             _dragHasRest2 = false;
             let checkBlock = that.blocks.blockList[that.connections[1]];
-            // eslint-disable-next-line eqeqeq
             while (checkBlock != null) {
                 if (checkBlock?.name === "rest2") {
                     _dragHasRest2 = true;
@@ -3422,7 +3419,6 @@ class Block {
         this.container.on("mouseout", event => {
             // Ignore transient mouseout while actively dragging.
             if (that._dragPointerDown) {
-                // eslint-disable-next-line eqeqeq
                 if (that.blocks.longPressTimeout != null) {
                     clearTimeout(that.blocks.longPressTimeout);
                     that.blocks.longPressTimeout = null;

--- a/js/logo.js
+++ b/js/logo.js
@@ -468,7 +468,6 @@ class Logo {
                 for (let i = 0; i < n; i++) {
                     const obj = this.connectionStore[turtle][blk].pop();
                     this.blockList[obj[0]].connections[obj[1]] = obj[2];
-                    // eslint-disable-next-line eqeqeq
                     if (obj[2] != null) {
                         this.blockList[obj[2]].connections[0] = obj[0];
                     }
@@ -756,7 +755,6 @@ class Logo {
     parseArg(logo, turtle, blk, parentBlk, receivedArg) {
         const tur = logo.activity.turtles.ithTurtle(turtle);
 
-        // eslint-disable-next-line eqeqeq
         if (blk == null) {
             logo.activity.errorMsg(NOINPUTERRORMSG, parentBlk);
             return null;
@@ -807,7 +805,6 @@ class Logo {
                         logo.statusFields.push([blk, "dectofrac"]);
                     } else {
                         const cblk = currentBlock.connections[1];
-                        // eslint-disable-next-line eqeqeq
                         if (cblk == null) {
                             logo.activity.errorMsg(NOINPUTERRORMSG, blk);
                             currentBlock.value = 0;
@@ -884,7 +881,6 @@ class Logo {
         // already been added to notesPlayed
 
         // Don't split the note if we are already splitting the note
-        // eslint-disable-next-line eqeqeq
         if (split == undefined) split = true;
 
         const tur = this.activity.turtles.ithTurtle(turtle);
@@ -1034,7 +1030,6 @@ class Logo {
             }
         }
 
-        // eslint-disable-next-line eqeqeq
         if (parentLoopBlock == null) {
             // Flush the child flow
             turtle.queue.pop();
@@ -1044,7 +1039,6 @@ class Logo {
         // For while and until, we need to add any childflow from the parent to the queue
         if (parentLoopBlock.name === "while" || parentLoopBlock.name === "until") {
             const childFlow = this.deps.utils.last(parentLoopBlock.connections);
-            // eslint-disable-next-line eqeqeq
             if (childFlow != null) {
                 const queueBlock = new Queue(childFlow, 1, loopBlkIdx);
                 // We need to keep track of the parent block to the child flow so we can
@@ -1137,7 +1131,6 @@ class Logo {
         // on the next run.
         this.synth.disposeAllInstruments();
 
-        // eslint-disable-next-line eqeqeq
         if (this.cameraID != null) {
             this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
         }
@@ -1180,7 +1173,6 @@ class Logo {
             if (this.stepQueue[turtle].length > 0) {
                 if (
                     turtle in this._unhighlightStepQueue &&
-                    // eslint-disable-next-line eqeqeq
                     this._unhighlightStepQueue[turtle] != null
                 ) {
                     if (this.activity.blocks.visible) {
@@ -1190,7 +1182,6 @@ class Logo {
                 }
 
                 const blk = this.stepQueue[turtle].pop();
-                // eslint-disable-next-line eqeqeq
                 if (blk != null) {
                     this.runFromBlockNow(this, turtle, blk, 0, null);
                 }
@@ -1248,7 +1239,6 @@ class Logo {
         this._alreadyRunning = false;
         this._prematureRestart = false;
 
-        // eslint-disable-next-line eqeqeq
         if (this._lastNoteTimeout != null) {
             clearTimeout(this._lastNoteTimeout);
             this._lastNoteTimeout = null;
@@ -1399,7 +1389,6 @@ class Logo {
                 const c = this.blockList[this.activity.blocks.stackList[blk]].connections[1];
                 // Is there a block in the action clamp?
                 const b = this.blockList[this.activity.blocks.stackList[blk]].connections[2];
-                // eslint-disable-next-line eqeqeq
                 if (c != null && b != null) {
                     // Don't use an action block in the trash
                     if (!this.blockList[this.activity.blocks.stackList[blk]].trash) {
@@ -1451,7 +1440,6 @@ class Logo {
         */
         if (this.activity.turtles.turtleCount() === 0) {
             this.activity.errorMsg(NOACTIONERRORMSG, null, _("start"));
-            // eslint-disable-next-line eqeqeq
         } else if (startHere != null) {
             // If a block to start from was passed, find its associated
             // turtle, i.e., which turtle should we use?
@@ -1551,7 +1539,6 @@ class Logo {
      */
     runFromBlock(logo, turtle, blk, isflow, receivedArg) {
         this._runningBlock = blk;
-        // eslint-disable-next-line eqeqeq
         if (blk == null) return;
 
         this.receivedArg = receivedArg;
@@ -1762,7 +1749,6 @@ class Logo {
             }
 
             const queueBlock = new Queue(nextFlow, 1, blk, receivedArg);
-            // eslint-disable-next-line eqeqeq
             if (nextFlow != null) {
                 // This could be the last block.
                 tur.queue.push(queueBlock);
@@ -1859,7 +1845,6 @@ class Logo {
                 const blockName = currentBlock.name;
                 const label = blockLabels[blockName];
 
-                // eslint-disable-next-line eqeqeq
                 if (currentBlock.value == null) {
                     logo.activity.textMsg("null block value");
                 } else {
@@ -1884,7 +1869,6 @@ class Logo {
             if (blk in tur.endOfClampSignals) {
                 while (tur.endOfClampSignals[blk].length > 0) {
                     const signal = tur.endOfClampSignals[blk].pop();
-                    // eslint-disable-next-line eqeqeq
                     if (signal != null) {
                         logo.activity.stage.dispatchEvent(signal);
                     }
@@ -1899,7 +1883,6 @@ class Logo {
         }
 
         // If there is a child flow, queue it.
-        // eslint-disable-next-line eqeqeq
         if (childFlow != null) {
             let queueBlock;
             if (logo.blockList[blk].name === "doArg" || logo.blockList[blk].name === "nameddoArg") {
@@ -1910,7 +1893,6 @@ class Logo {
             // We need to keep track of the parent block to the child
             // flow so we can unhighlight the parent block after the
             // child flow completes.
-            // eslint-disable-next-line eqeqeq
             if (tur.parentFlowQueue != undefined) {
                 tur.parentFlowQueue.push(blk);
                 tur.queue.push(queueBlock);
@@ -1939,7 +1921,6 @@ class Logo {
             }
         }
 
-        // eslint-disable-next-line eqeqeq
         if (nextBlock != null) {
             if (parentBlk !== blk) {
                 // The wait block waits _waitTimes longer than other
@@ -1969,10 +1950,8 @@ class Logo {
             }
 
             if (
-                // eslint-disable-next-line eqeqeq
                 (tur.singer.backward.length > 0 && logo.blockList[blk].connections[0] == null) ||
                 (tur.singer.backward.length === 0 &&
-                    // eslint-disable-next-line eqeqeq
                     logo.deps.utils.last(logo.blockList[blk].connections) == null)
             ) {
                 if (!tur.singer.suppressOutput && tur.singer.justCounting.length === 0) {
@@ -2064,10 +2043,8 @@ class Logo {
                 for (const b in tur.endOfClampSignals) {
                     const signalsLength = tur.endOfClampSignals[b].length;
                     for (let i = 0; i < signalsLength; i++) {
-                        // eslint-disable-next-line eqeqeq
                         if (tur.endOfClampSignals[b][i] != null) {
                             if (
-                                // eslint-disable-next-line eqeqeq
                                 tur.butNotThese[b] == null ||
                                 tur.butNotThese[b].indexOf(i) === -1
                             ) {

--- a/js/palette.js
+++ b/js/palette.js
@@ -804,7 +804,6 @@ class Palettes {
 
     getPluginMacroExpansion(blkname, x, y) {
         const obj = this.pluginMacros[blkname];
-        // eslint-disable-next-line eqeqeq
         if (obj != null) {
             obj[0][2] = x;
             obj[0][3] = y;
@@ -992,7 +991,6 @@ class Palettes {
     }
 
     updatePalettes(showPalette) {
-        // eslint-disable-next-line eqeqeq
         if (showPalette != null) {
             // Show the action palette after adding/deleting new
             // nameddo blocks.
@@ -1340,7 +1338,6 @@ class PaletteModel {
                 "nameddoArg",
                 "namedcalcArg"
             ].indexOf(protoBlock.name) !== -1 &&
-            // eslint-disable-next-line eqeqeq
             label != null
         ) {
             if (getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -156,7 +156,6 @@ class Turtle {
      * (if they have not been already changed).
      */
     stopBlink() {
-        // eslint-disable-next-line eqeqeq
         if (this._blinkTimeout != null || !this._blinkFinished) {
             clearTimeout(this._blinkTimeout);
             this._blinkTimeout = null;
@@ -683,7 +682,6 @@ Turtle.TurtleModel = class {
 
         const startBlock = this._startBlock;
         // Use the name on the label of the start block
-        // eslint-disable-next-line eqeqeq
         if (startBlock != null) {
             startBlock.overrideName = this._name;
             startBlock.collapseText.text = this._name;
@@ -880,9 +878,7 @@ Turtle.TurtleView = class {
             this.container.hitArea = hitArea;
 
             const startBlock = this._startBlock;
-            // eslint-disable-next-line eqeqeq
             if (startBlock != null) {
-                // eslint-disable-next-line eqeqeq
                 if (this._decorationBitmap != null) {
                     startBlock.container.removeChild(this._decorationBitmap);
                 }
@@ -1033,7 +1029,6 @@ Turtle.TurtleView = class {
             this._createCache();
 
             const startBlock = this._startBlock;
-            // eslint-disable-next-line eqeqeq
             if (useTurtleArtwork && startBlock != null) {
                 startBlock.updateCache();
                 this._decorationBitmap = this._bitmap.clone();

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -655,7 +655,6 @@ function setupPitchActions(activity) {
         static deltaPitch(outType, turtle) {
             const tur = activity.turtles.ithTurtle(turtle);
 
-            // eslint-disable-next-line eqeqeq
             if (tur.singer.previousNotePlayed == null) {
                 return 0;
             } else {

--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -281,7 +281,6 @@ function setupRhythmActions(activity) {
                 if (tur.singer.tieCarryOver > 0) {
                     if (tur.singer.justCounting.length === 0) {
                         const lastNote = last(tur.singer.inNoteBlock);
-                        // eslint-disable-next-line eqeqeq
                         if (lastNote != null && lastNote in tur.singer.notePitches) {
                             // Remove the note from the Lilypond list
                             for (

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -179,6 +179,7 @@ class ProjectStorage {
         const savedjsonobj = await this.LocalStorage.getItem(key);
 
         //  prevent unnecessary crashing
+        if (savedjsonobj == null) throw new Error("Failed to save project data");
 
         // == null covers both null and undefined
     }

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -181,7 +181,6 @@ class ProjectStorage {
         //  prevent unnecessary crashing
 
         // == null covers both null and undefined
-        if (savedjsonobj == null) throw new Error("Failed to save project data"); // eslint-disable-line eqeqeq
     }
 
     async get(key) {


### PR DESCRIPTION
## Summary
Disables the ESLint `eqeqeq` rule project-wide and cleans up now-unused inline suppression comments. The Music Blocks codebase intentionally uses loose equality (`==` / `!=`) in many places; the 350+ warnings were noise, not actionable issues.

## Changes
- `eslint.config.mjs`: `"eqeqeq": "warn"` → `"eqeqeq": "off"`
- Removed 38 `// eslint-disable-* eqeqeq` comments from:
  - `js/block.js`
  - `js/logo.js`
  - `js/palette.js`
  - `js/turtle.js`
  - `js/turtleactions/PitchActions.js`
  - `js/turtleactions/RhythmActions.js`
  - `planet/js/ProjectStorage.js`

## Verification
- `npm run lint` — **0 errors, 0 warnings** 
- `npm test` — **154 suites, 5132 tests passing** 

## Screenshots: 

<img width="487" height="132" alt="Screenshot 2026-05-11 at 9 18 17 AM" src="https://github.com/user-attachments/assets/95bc8745-c949-4032-aa53-e5d42675d226" />

## Related
Fixes #7306 

## PR Category
- [x] Bug Fix
- [x] Feature