### PR TITLE
fix: correct pitch block placeholder restoration when slots are empty

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1314,19 +1314,24 @@ class Blocks {
                 cblk = this.blockList[parentblk].connections[2];
                 if (cblk == null) {
                     /**
-                     * Adjust Docks
-                     * @param - args - arguments
-                     * @public
-                     * @returns {void}
+                     * Restore the octave (number) placeholder for the pitch block's
+                     * second argument slot. Capture the future block index now so the
+                     * postProcess closure references the correct entry even when the
+                     * name-slot restoration below also appends a block.
                      */
+                    const octaveBlkIdx = this.blockList.length;
                     const postProcess = args => {
                         const parentblk = args[0];
                         const oldBlock = args[1];
-                        const blk = this.blockList.length - 1;
+                        const blk = args[2];
 
                         this.blockList[parentblk].connections[2] = blk;
 
-                        const octave = this.blockList[oldBlock].value;
+                        // Use the removed block's value only when it is a number;
+                        // if a name block was placed in the octave slot fall back
+                        // to the default octave of 4.
+                        const rawOctave = this.blockList[oldBlock].value;
+                        const octave = typeof rawOctave === "number" ? rawOctave : 4;
                         this.blockList[blk].value = octave;
 
                         this.blockList[blk].text.text = octave.toString();
@@ -1340,23 +1345,24 @@ class Blocks {
 
                     this._makeNewBlockWithConnections("number", 0, [parentblk], postProcess, [
                         parentblk,
-                        oldBlock
+                        oldBlock,
+                        octaveBlkIdx
                     ]);
                 }
 
                 const oblk = this.blockList[parentblk].connections[1];
                 if (oblk == null) {
                     /**
-                     * Adjust Docks
-                     * @param - args - arguments
-                     * @public
-                     * @returns {void}
+                     * Restore the name (solfege/notename/etc.) placeholder for the
+                     * pitch block's first argument slot. Capture the future block index
+                     * now so the postProcess closure is immune to the list growing
+                     * further before execution.
                      */
+                    const nameBlkIdx = this.blockList.length;
                     const postProcess = args => {
                         const parentblk = args[0];
                         const value = args[1];
-
-                        const blk = this.blockList.length - 1;
+                        const blk = args[2];
 
                         this.blockList[parentblk].connections[1] = blk;
 
@@ -1381,6 +1387,10 @@ class Blocks {
                         this.adjustDocks(parentblk, true);
                     };
 
+                    // When the removed block was itself in the name slot, mirror its
+                    // type in the replacement placeholder (e.g. notename → notename,
+                    // eastindiansolfege → eastindiansolfege). When the block came from
+                    // the octave slot (a number), fall back to the default "solfege".
                     let newBlockName = "solfege";
                     let newBlockValue = "sol";
                     switch (this.blockList[oldBlock].name) {
@@ -1402,7 +1412,8 @@ class Blocks {
 
                     this._makeNewBlockWithConnections(newBlockName, 0, [parentblk], postProcess, [
                         parentblk,
-                        newBlockValue
+                        newBlockValue,
+                        nameBlkIdx
                     ]);
                 }
             } else if (this.blockList[parentblk].name === "storein") {


### PR DESCRIPTION
**The Problem:**

When removing blocks from a Pitch block (especially when placing a name block in the octave slot and then removing it), the workspace was restoring the wrong type of placeholder (e.g., placing a name block in the octave slot). This happened because the system was losing track of the exact placeholders it was creating when multiple slots were empty at the same time.

**The Solution:**

- **Fixed Placeholder Tracking:** Updated the system's memory to capture the exact position of a new placeholder *before* it gets created. This guarantees that the correct placeholder type (Name vs. Number) is assigned to the correct slot, even if multiple slots are empty.

- **Added Safety Fallback:** Added a safeguard for the octave slot. If a user removes a non-number block (like a name block) from the octave slot, the system now recognizes it and safely defaults to an octave of `4`, rather than breaking or copying incorrect text values.


**Video:**

https://github.com/user-attachments/assets/769ee7ec-122f-4f6c-9494-72fade580c74



- [x] Bug Fix