### PR TITLE
ci: add timeout-minutes to workflows

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -18,6 +18,7 @@ jobs:
     rebase:
         name: Auto-rebase all open PRs onto latest master
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -19,6 +19,7 @@ jobs:
     check:
         name: Detect merge conflicts
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: eps1lon/actions-label-merge-conflict@v3
               with:

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -14,6 +14,7 @@ jobs:
   lighthouse:
     name: Lighthouse Performance Audit (${{ matrix.preset }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,6 +11,7 @@ jobs:
     lint:
         name: Lint and format-check changed JS files
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         strategy:
             matrix:

--- a/.github/workflows/po-to-json-validation.yml
+++ b/.github/workflows/po-to-json-validation.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   convert-and-verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-category-check.yml
+++ b/.github/workflows/pr-category-check.yml
@@ -19,6 +19,7 @@ jobs:
   check-pr-category:
     name: Validate PR Category & Auto-Label
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check categories and apply labels
         uses: actions/github-script@v7

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   security-scans:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
Fix: #7323

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Adds `timeout-minutes: 30` to 9 GitHub Actions workflows that were missing explicit timeouts. This prevents indefinite runner hangs and unnecessary CI minute consumption.

## Problem
GitHub Actions defaults to a **6-hour timeout** when `timeout-minutes` is not specified. If any step hangs (e.g., `npm install` on a slow network, `lighthouse-ci` getting stuck, or `auto-rebase` hitting a conflict loop), the runner stays occupied for hours before GitHub kills it.

## Changes
Added `timeout-minutes: 30` to the following workflows:

| Workflow | Job Name 
|----------|----------|
| `auto-rebase.yml` | Auto-rebase all open PRs | 
| `conflict-check.yml` | Detect merge conflicts | 
| `lighthouse-ci.yml` | Lighthouse Performance Audit |
| `linter.yml` | Lint and format-check changed JS files | 
| `node.js.yml` | Smoke Test build |
| `po-to-json-validation.yml` | Convert PO to JSON and verify changes | 
| `pr-category-check.yml` | Validate PR Category & Auto-Label | 
| `security_scan.yml` | Security Scans | 
| `stale.yml` | Close stale pull requests | 

Already had timeout (unchanged):
- `pr-jest-tests.yml` — `timeout-minutes: 30`
- `pr-cypress-e2e.yml` — `timeout-minutes: 30`

## Verification
- [x] Confirm all modified workflows have `timeout-minutes: 30` in the job definition
- [x] Confirm no syntax errors in YAML (can validate with `actionlint` or GitHub UI)

## Why 30 minutes?
This is a generous but reasonable default for this project's workflows:
- `npm ci` + `npm test` usually completes in ~2-5 minutes
- `lighthouse-ci` with full audit takes ~5-10 minutes
- `auto-rebase` with multiple PRs may take ~10-15 minutes
- 30 minutes provides 2-3x headroom while still failing fast on true hangs

---

**No source code changes. CI infrastructure improvement only.**