### PR TITLE
feat: load ABC as assignment target and score student output

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,7 @@
         <script src="lib/astring.min.js" defer></script>
         <script src="js/utils/mb-dialog.js" defer></script>
         <script src="js/svgAssetSelector.js" defer></script>
+        <script src="js/assignmentChecker.js" defer></script>
         <script src="lib/acorn.min.js" defer></script>
         <script src="env.js" defer></script>
 
@@ -412,6 +413,7 @@
                             accept=".mp3, .wav"
                             tabindex="-1"
                         />
+                        <input class="file" type="file" id="myOpenAssignment" accept=".abc" tabindex="-1" />
                         <input class="file" type="file" id="myOpenAll" tabindex="-1" />
                     </div>
                 </div>
@@ -809,6 +811,31 @@
                                             role="button"
                                             tabindex="0"
                                             ><i class="material-icons md-48">merge_type</i></a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            id="loadAssignmentIcon"
+                                            class="tooltipped"
+                                            data-position="bottom"
+                                            data-delay="10"
+                                            data-tooltip="Load Assignment"
+                                            role="button"
+                                            tabindex="0"
+                                            ><i class="material-icons md-48">assignment</i></a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            id="checkAssignmentIcon"
+                                            class="tooltipped"
+                                            data-position="bottom"
+                                            data-delay="10"
+                                            data-tooltip="Check Assignment"
+                                            role="button"
+                                            tabindex="0"
+                                            style="display: none"
+                                            ><i class="material-icons md-48">assignment_turned_in</i></a
                                         >
                                     </li>
                                     <li>

--- a/js/activity.js
+++ b/js/activity.js
@@ -52,7 +52,7 @@ try {
    SHARP, FLAT, buildScale, TREBLE_F, TREBLE_G, GIFAnimator,
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
-   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
+   SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS, compareAssignment, saveAbcOutput,
    unescapeHTML
  */
 
@@ -456,6 +456,20 @@ class Activity {
             this.pluginChooser = document.getElementById("myOpenPlugin");
             // The file chooser for all files
             this.allFilesChooser = document.getElementById("myOpenAll");
+            this.assignmentChooser = document.getElementById("myOpenAssignment");
+            this._assignmentTarget = null;
+            this.assignmentChooser.onchange = event => {
+                const file = event.target.files[0];
+                if (!file) return;
+                const reader = new FileReader();
+                reader.onload = e => {
+                    this._assignmentTarget = e.target.result;
+                    document.getElementById("checkAssignmentIcon").style.display = "block";
+                    this.textMsg(_("Assignment loaded."));
+                };
+                reader.readAsText(file);
+                this.assignmentChooser.value = "";
+            };
             this.auxToolbar = document.getElementById("aux-toolbar");
             // Error message containers
             this.errorText = document.getElementById("errorText");
@@ -2200,8 +2214,30 @@ class Activity {
         };
 
         /*
+         * Loads an ABC file as an assignment target without converting to blocks.
+         */
+        const doLoadAssignment = () => {
+            this.assignmentChooser.click();
+        };
+
+        /*
+         * Compares the student's current project against the loaded assignment.
+         */
+        const doCheckAssignment = async () => {
+            const activity = globalActivity;
+            if (!activity._assignmentTarget) return;
+            await lazyLoad(["activity/abc"]);
+            const studentABC = window.saveAbcOutput(activity);
+            const result = window.compareAssignment(activity._assignmentTarget, studentABC);
+            activity.textMsg(
+                result.score + "% — " + result.matched + "/" + result.total + " notes matched"
+            );
+        };
+
+        /*
          * Runs Music Blocks at a slower rate
          */
+
         const doSlowButton = activity => {
             activity.runMode = "slow";
             activity._doSlowButton();
@@ -8343,6 +8379,8 @@ class Activity {
             this.toolbar.renderRunStepIcon(doStepButton);
             this.toolbar.renderThemeSelectIcon(this.themeBox, this.themes);
             this.toolbar.renderMergeIcon(_doMergeLoad);
+            document.getElementById("loadAssignmentIcon").onclick = doLoadAssignment;
+            document.getElementById("checkAssignmentIcon").onclick = doCheckAssignment;
             this.toolbar.renderRestoreIcon(restoreTrash);
             if (_THIS_IS_MUSIC_BLOCKS_) {
                 this.toolbar.renderChooseKeyIcon(chooseKeyMenu);


### PR DESCRIPTION
Addresses part of #1106
Depends on #7248

The existing ABC import calls parseABC which converts the file into
blocks — wrong for assignments since the student would see the answer.

Adds a separate load path via a new aux toolbar button (clipboard icon).
The file is stored as _assignmentTarget without touching parseABC. A
second button (hidden until an assignment is loaded) calls saveAbcOutput
on whatever the student has built, runs it through compareAssignment from
#7248, and shows the score.

WAV based assignments and a teacher export flow are out of scope here.

## PR Category
- [x] Feature


Before 
<img width="1673" height="883" alt="Screenshot From 2026-05-18 23-52-51" src="https://github.com/user-attachments/assets/8abf0b3b-0117-4c8f-bdc3-ec6ae30cad15" />


After
<img width="1679" height="935" alt="Screenshot From 2026-05-10 19-22-10" src="https://github.com/user-attachments/assets/8c02d0fc-d6e3-4da7-a184-49c82ce8e321" />
