### PR TITLE
test(utils): add escapeHTML and unescapeHTML coverage

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -92,7 +92,9 @@ const {
     closeWidgets,
     closeBlkWidgets,
     resolveObject,
-    importMembers
+    importMembers,
+    escapeHTML,
+    unescapeHTML
 } = require("../utils.js");
 
 describe("Utility Functions (logic-only)", () => {
@@ -795,6 +797,84 @@ describe("Utility Functions (logic-only)", () => {
         it("should return original string if no placeholders exist", () => {
             const result = format("Hello world", { name: "User" });
             expect(result).toBe("Hello world");
+        });
+    });
+
+    describe("escapeHTML()", () => {
+        it("escapes < to &lt;", () => {
+            expect(escapeHTML("<")).toBe("&lt;");
+        });
+
+        it("escapes > to &gt;", () => {
+            expect(escapeHTML(">")).toBe("&gt;");
+        });
+
+        it("escapes & to &amp;", () => {
+            expect(escapeHTML("&")).toBe("&amp;");
+        });
+
+        it("escapes double quotes to &quot;", () => {
+            expect(escapeHTML('"')).toBe("&quot;");
+        });
+
+        it("escapes single quotes to &#039;", () => {
+            expect(escapeHTML("'")).toBe("&#039;");
+        });
+
+        it("escapes multiple characters in one string", () => {
+            expect(escapeHTML('<script>alert("xss")</script>')).toBe(
+                "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"
+            );
+        });
+
+        it("handles non-string input by converting to string", () => {
+            expect(escapeHTML(123)).toBe("123");
+            expect(escapeHTML(null)).toBe("null");
+            expect(escapeHTML(undefined)).toBe("undefined");
+        });
+
+        it("returns empty string for empty input", () => {
+            expect(escapeHTML("")).toBe("");
+        });
+
+        it("returns string unchanged if no special characters", () => {
+            expect(escapeHTML("Hello World")).toBe("Hello World");
+            expect(escapeHTML("abc123")).toBe("abc123");
+        });
+    });
+
+    describe("unescapeHTML()", () => {
+        it("reverses escapeHTML for all entities", () => {
+            const original = '<div class="test">it\'s</div>';
+            expect(unescapeHTML(escapeHTML(original))).toBe(original);
+        });
+
+        it("unescapes &lt; to <", () => {
+            expect(unescapeHTML("&lt;")).toBe("<");
+        });
+
+        it("unescapes &gt; to >", () => {
+            expect(unescapeHTML("&gt;")).toBe(">");
+        });
+
+        it("unescapes &amp; to &", () => {
+            expect(unescapeHTML("&amp;")).toBe("&");
+        });
+
+        it("unescapes &quot; to double quote", () => {
+            expect(unescapeHTML("&quot;")).toBe('"');
+        });
+
+        it("unescapes &#039; to single quote", () => {
+            expect(unescapeHTML("&#039;")).toBe("'");
+        });
+
+        it("passes through plain text unchanged", () => {
+            expect(unescapeHTML("Hello World")).toBe("Hello World");
+        });
+
+        it("returns empty string for empty input", () => {
+            expect(unescapeHTML("")).toBe("");
         });
     });
 });

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -2099,6 +2099,7 @@ if (typeof module !== "undefined" && module.exports) {
         closeBlkWidgets,
         resolveObject,
         importMembers,
-        escapeHTML
+        escapeHTML,
+        unescapeHTML
     };
 }


### PR DESCRIPTION
## Summary
Adds comprehensive Jest test coverage for `escapeHTML()` and `unescapeHTML()` utility functions in `js/utils/utils.js`.

## PR Category
- [x] Tests

## Changes
- **9 new tests** for `escapeHTML()`:
  - Individual entity escaping (`<`, `>`, `&`, `"`, `'`)
  - Multiple characters in one string
  - Non-string input (number, null, undefined)
  - Empty string handling
  - Plain text passthrough

- **8 new tests** for `unescapeHTML()`:
  - Round-trip verification with `escapeHTML`
  - Individual entity unescaping
  - Plain text passthrough
  - Empty string handling

- **Bug fix**: Added `unescapeHTML` to the main `module.exports` export object in `js/utils/utils.js` (was missing despite being exported individually earlier in the file)

## Files Modified
| File | Change |
|------|--------|
| `js/utils/__tests__/utils.test.js` | Added 17 tests + imports |
| `js/utils/utils.js` | Added `unescapeHTML` to `module.exports` |

## Verification
- `npm test -- --testPathPattern="utils.test"` — **841 tests passing**
- `npm run lint` — no new errors

## Notes
This is a test-only change with zero impact on runtime behavior. The export fix is required for the tests to load the function in Node.js/Jest.