### PR TITLE
test(block): add regenerateArtwork edge case tests

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -259,5 +259,80 @@ describe("Block Foundation", () => {
                 expect(block.highlightBitmap.visible).toBe(false);
             });
         });
+
+        describe("regenerateArtwork()", () => {
+            it("should remove old bitmaps and call generateArtwork", () => {
+                block.bitmap = new global.createjs.Bitmap();
+                block.highlightBitmap = new global.createjs.Bitmap();
+                const generateSpy = jest
+                    .spyOn(block, "generateArtwork")
+                    .mockImplementation(() => {});
+
+                block.regenerateArtwork(false);
+
+                expect(block.container.removeChild).toHaveBeenCalledWith(block.bitmap);
+                expect(block.container.removeChild).toHaveBeenCalledWith(block.highlightBitmap);
+                expect(generateSpy).toHaveBeenCalledWith(false);
+                generateSpy.mockRestore();
+            });
+
+            it("should handle collapse artwork when collapse is true", () => {
+                block.bitmap = new global.createjs.Bitmap();
+                block.highlightBitmap = new global.createjs.Bitmap();
+                block.collapseBlockBitmap = new global.createjs.Bitmap();
+                block.collapseButtonBitmap = new global.createjs.Bitmap();
+                block.expandButtonBitmap = new global.createjs.Bitmap();
+                block.highlightCollapseBlockBitmap = new global.createjs.Bitmap();
+                const generateSpy = jest
+                    .spyOn(block, "generateArtwork")
+                    .mockImplementation(() => {});
+
+                block.regenerateArtwork(true);
+
+                expect(block.container.removeChild).toHaveBeenCalledWith(
+                    block.collapseButtonBitmap
+                );
+                expect(block.container.removeChild).toHaveBeenCalledWith(block.expandButtonBitmap);
+                expect(block.container.removeChild).toHaveBeenCalledWith(block.collapseBlockBitmap);
+                expect(block.container.removeChild).toHaveBeenCalledWith(
+                    block.highlightCollapseBlockBitmap
+                );
+                generateSpy.mockRestore();
+            });
+
+            it("should handle null bitmaps gracefully", () => {
+                block.bitmap = null;
+                block.highlightBitmap = null;
+                const generateSpy = jest
+                    .spyOn(block, "generateArtwork")
+                    .mockImplementation(() => {});
+
+                expect(() => block.regenerateArtwork(false)).not.toThrow();
+                expect(generateSpy).toHaveBeenCalledWith(false);
+                generateSpy.mockRestore();
+            });
+
+            it("should restore imageBitmap after regeneration", () => {
+                block.bitmap = new global.createjs.Bitmap();
+                block.highlightBitmap = new global.createjs.Bitmap();
+                const mockImage = { width: 50, height: 50 };
+                block.imageBitmap = { image: mockImage };
+                const generateSpy = jest
+                    .spyOn(block, "generateArtwork")
+                    .mockImplementation(() => {});
+                block._positionMedia = jest.fn();
+
+                block.regenerateArtwork(false);
+
+                expect(block.container.addChild).toHaveBeenCalledWith(block.imageBitmap);
+                expect(block._positionMedia).toHaveBeenCalledWith(
+                    block.imageBitmap,
+                    50,
+                    50,
+                    block.protoblock.scale
+                );
+                generateSpy.mockRestore();
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary
Adds test coverage for `Block.regenerateArtwork()` in `js/block.js`, covering SVG regeneration after collapse/expand and color changes.

## PR Category
- [x] Tests

| Test | Description |
|------|-------------|
| Basic regeneration | Removes bitmap and highlightBitmap, calls generateArtwork(false) |
| Collapse mode | Removes collapseButtonBitmap, expandButtonBitmap, collapseBlockBitmap, highlightCollapseBlockBitmap |
| Null bitmaps | Handles null bitmaps without throwing |
| imageBitmap restore | Temporarily removes and restores imageBitmap with correct positioning |

## Files Modified
- `js/__tests__/block.test.js` (+4 tests)

## Verification
- `npm test -- --testPathPattern="block.test"` — **20 tests passing**
- No source code changes — test-only addition