### PR TITLE
fix: show Home toolbar tooltip as “Home” only

### DIFF
--- a/css/play-only-mode.css
+++ b/css/play-only-mode.css
@@ -58,8 +58,7 @@
 }
 
 /* Ensure Home button is always visible in this container */
-.play-only #Home\ \[HOME\],
-.play-only [id="Home [HOME]"] {
+.play-only #Home {
     display: flex !important;
 }
 

--- a/index.html
+++ b/index.html
@@ -1370,7 +1370,7 @@
                 function togglePlayOnlyMode() {
                     const isSmallScreen = window.innerWidth < 768 || window.innerHeight < 600;
                     const body = document.body;
-                    const homeButton = document.getElementById("Home [HOME]");
+                    const homeButton = document.getElementById("Home");
                     const buttonContainer = document.getElementById("buttoncontainerBOTTOM");
 
                     if (isSmallScreen) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -7026,16 +7026,12 @@ class Activity {
             ButtonHolder.style.display = "block";
             document.body.appendChild(ButtonHolder);
 
-            this.homeButtonContainer = createButton(
-                GOHOMEFADEDBUTTON,
-                _("Home") + " [" + _("Home").toUpperCase() + "]",
-                findBlocks
-            );
+            this.homeButtonContainer = createButton(GOHOMEFADEDBUTTON, _("Home"), findBlocks);
             this.boundary.hide();
 
-            if (!this.helpfulWheelItems.find(ele => ele.label === "Home [HOME]"))
+            if (!this.helpfulWheelItems.find(ele => ele.label === "Home"))
                 this.helpfulWheelItems.push({
-                    label: "Home [HOME]",
+                    label: "Home",
                     icon:
                         "imgsrc:data:image/svg+xml;base64," +
                         window.btoa(base64Encode(GOHOMEFADEDBUTTON)),


### PR DESCRIPTION
### Summary
Align the toolbar Home control with the other icons.

Before:
<img width="330" height="119" alt="Screenshot 2026-05-13 204525" src="https://github.com/user-attachments/assets/1803c14a-746c-44e3-a3a5-29121c30df20" />


After:
<img width="325" height="131" alt="Screenshot 2026-05-13 204339" src="https://github.com/user-attachments/assets/2242afec-89ff-4799-a093-0d52eb98507b" />

### PR Category: 
- [x] Bug Fix