### PR TITLE
perf: optimize block drag performance

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3404,8 +3404,6 @@ class Block {
                 }
             }
 
-            that._setDragGroupTrashHoverScale(overTrash, dx, dy);
-
             // Single deferred checkBounds + single canvas refresh per frame
             that.blocks.scheduleCheckBounds();
             that._setDragGroupTrashHoverScale(overTrash, dx, dy);


### PR DESCRIPTION
## Description
This PR removes redundant O(N) tween applications that were occurring repeatedly during block `pressmove` events in the `blocks` workspace.

### Changes
- Removed the redundant call to `_setDragGroupTrashHoverScale` in `js/block.js` prior to bounds scheduling.
- Eliminates heavy `createjs.Tween` recalculations on every `pressmove` event during block dragging over the trashcan.

### Motivation
Improves UI responsiveness and minimizes redundant Canvas updates by preventing overlapping tweens during the heaviest user interaction states.

### PR Category
- [x] Performance