### PR TITLE
fix: retry timeout failures in RequestManager instead of returning immediately

### DIFF
--- a/planet/js/RequestManager.js
+++ b/planet/js/RequestManager.js
@@ -179,8 +179,8 @@ class RequestManager {
                 this.timeoutMs
             );
 
-            // Check if the result indicates a failure that should be retried
-            if (result && result.success === false && result.error === "ERROR_CONNECTION_FAILURE") {
+            // Check if the result indicates a transient failure that should be retried
+            if (this._isRetryableFailure(result)) {
                 if (attempt < this.maxRetries) {
                     this.stats.retries++;
 
@@ -228,24 +228,30 @@ class RequestManager {
     }
 
     /**
-     * Converts callback-based request to Promise
+     * Checks whether a failed response represents a transient error worth retrying.
+     * @private
+     * @param {Object} result - The response object
+     * @returns {boolean}
+     */
+    _isRetryableFailure(result) {
+        if (!result || result.success !== false) return false;
+        const retryableErrors = ["ERROR_CONNECTION_FAILURE", "REQUEST_TIMEOUT"];
+        return retryableErrors.includes(result.error);
+    }
+
+    /**
+     * Converts callback-based request to Promise.
+     * Timeout is handled exclusively by _withTimeout to avoid duplicate
+     * timers racing against each other.
      * @private
      */
-    // Add 30s timeout inside _promisifyRequest
-
     _promisifyRequest(requestFn) {
         return new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                resolve({ success: false, error: "REQUEST_TIMEOUT" });
-            }, this.timeoutMs);
-
             try {
                 requestFn(result => {
-                    clearTimeout(timeout);
                     resolve(result);
                 });
             } catch (error) {
-                clearTimeout(timeout);
                 reject(error);
             }
         });
@@ -260,11 +266,9 @@ class RequestManager {
     _withTimeout(promise, timeoutMs) {
         let timeoutId;
 
-        const timeoutPromise = new Promise((_, reject) => {
+        const timeoutPromise = new Promise(resolve => {
             timeoutId = setTimeout(() => {
-                const error = new Error(`Request timeout after ${timeoutMs}ms`);
-                error.name = "TimeoutError";
-                reject(error);
+                resolve({ success: false, error: "REQUEST_TIMEOUT" });
             }, timeoutMs);
         });
 

--- a/planet/js/__tests__/RequestManager.test.js
+++ b/planet/js/__tests__/RequestManager.test.js
@@ -168,11 +168,58 @@ describe("RequestManager", () => {
             expect(result.success).toBe(false);
         });
 
-        it("should use configured timeout in the callback wrapper", async () => {
+        it("should retry on request timeout", async () => {
+            let attempts = 0;
+            const mockRequestFn = jest.fn(callback => {
+                attempts++;
+                if (attempts < 2) {
+                    // Never call back — will time out
+                } else {
+                    callback({ success: true, data: "recovered" });
+                }
+            });
+
+            const rm = new RequestManager({
+                timeoutMs: 50,
+                maxRetries: 3,
+                baseRetryDelay: 10,
+                minDelay: 0
+            });
+
+            const result = await rm.throttledRequest({ action: "test" }, mockRequestFn);
+
+            expect(result.success).toBe(true);
+            expect(result.data).toBe("recovered");
+            expect(attempts).toBe(2);
+            expect(rm.getStats().retries).toBeGreaterThanOrEqual(1);
+        }, 10000);
+
+        it("should fail with REQUEST_TIMEOUT after exhausting retries", async () => {
+            const mockRequestFn = jest.fn(() => {
+                // Never call back — always times out
+            });
+
+            const rm = new RequestManager({
+                timeoutMs: 50,
+                maxRetries: 2,
+                baseRetryDelay: 10,
+                minDelay: 0
+            });
+
+            const result = await rm.throttledRequest({ action: "test" }, mockRequestFn);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toBe("REQUEST_TIMEOUT");
+            expect(rm.getStats().failures).toBe(1);
+            expect(rm.getStats().retries).toBe(2);
+        }, 10000);
+
+        it("should resolve timeout from _withTimeout", async () => {
             jest.useFakeTimers();
 
             const rm = new RequestManager({ timeoutMs: 25 });
-            const promise = rm._promisifyRequest(() => {});
+            const neverResolves = new Promise(() => {});
+            const promise = rm._withTimeout(neverResolves, 25);
 
             jest.advanceTimersByTime(25);
 


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary

Fixes #7339

`_executeWithRetry()` only retried `ERROR_CONNECTION_FAILURE` responses. Timeouts were resolved (not rejected) by the internal `_promisifyRequest()` timer as `{ success: false, error: "REQUEST_TIMEOUT" }`, which did not match the retry condition — so timeout failures were returned to callers immediately with zero retries, regardless of the `maxRetries` setting.

This made the retry/backoff layer ineffective against the most common transient failure mode on slow or unstable networks.

## Changes

- **Extract `_isRetryableFailure()`** to centralise the retry decision. Both `ERROR_CONNECTION_FAILURE` and `REQUEST_TIMEOUT` are now retryable.
- **Remove duplicate timeout in `_promisifyRequest()`** — timeout is now handled exclusively by `_withTimeout()`, eliminating a race between two independent timers using the same duration.
- **Change `_withTimeout()` to resolve on timeout** so the result flows through the standard retry path instead of falling into the catch block with a different shape.
- **Add 3 regression tests**: timeout-then-recovery, exhausted retries on persistent timeout, and `_withTimeout` resolve shape verification.

## Test plan

- [x] All 19 `RequestManager.test.js` tests pass (was 16, added 3)
- [x] `npx jest planet/js/__tests__/RequestManager.test.js` — green
- [x] Lint and prettier pass via pre-commit hooks
- [ ] Manual verification: throttle network in DevTools, trigger Planet API calls, confirm retry log messages appear for slow responses