### PR TITLE
fix: add stale-while-revalidate to Planet cache and invalidate on report

### DIFF
--- a/planet/js/CacheManager.js
+++ b/planet/js/CacheManager.js
@@ -279,6 +279,52 @@ class CacheManager {
     }
 
     /**
+     * Invalidates all cached data for a specific project (metadata, data, thumbnail).
+     * Used when a project is reported, deleted, or known to be stale.
+     * @param {string} id - Project ID
+     * @returns {Promise<boolean>} - True if at least one entry was removed
+     */
+    async invalidateProject(id) {
+        if (!this.isInitialized) return false;
+
+        let removed = false;
+
+        for (const storeName of Object.values(this.STORES)) {
+            try {
+                const existing = await this._getFromStore(storeName, id);
+
+                if (existing) {
+                    await this._deleteFromStore(storeName, id);
+                    removed = true;
+                }
+            } catch (error) {
+                cacheDebugLog(`[CacheManager] Error invalidating ${id} from ${storeName}:`, error);
+            }
+        }
+
+        if (removed) {
+            cacheDebugLog(`[CacheManager] Invalidated project: ${id}`);
+        }
+
+        return removed;
+    }
+
+    /**
+     * Deletes a single entry from a store
+     * @private
+     */
+    _deleteFromStore(storeName, key) {
+        return new Promise((resolve, reject) => {
+            const transaction = this.db.transaction([storeName], "readwrite");
+            const store = transaction.objectStore(storeName);
+            const request = store.delete(key);
+
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
      * Clears all expired entries from all stores
      * @returns {Promise<number>} - Number of entries cleared
      */

--- a/planet/js/ServerInterface.js
+++ b/planet/js/ServerInterface.js
@@ -199,29 +199,42 @@ class ServerInterface {
     }
 
     /**
-     * Downloads full project data with caching support
+     * Downloads full project data with stale-while-revalidate caching.
+     * Returns cached data immediately if available, then revalidates
+     * from the server in the background to keep the cache fresh and
+     * respect any server-side moderation or deletion.
      */
     async downloadProject(ProjectID, callback) {
+        let servedFromCache = false;
+
         if (!this.disablePlanetCache) {
-            // Try cache first
             await this.initCache();
             const cached = await this.cacheManager.getProject(ProjectID);
 
             if (cached) {
                 console.debug("[ServerInterface] Returning cached project:", ProjectID);
                 callback({ success: true, data: cached });
-                return;
+                servedFromCache = true;
             }
         }
-        // Fetch from server
+
+        // Always revalidate from server (even on cache hit)
         const obj = { action: "downloadProject", ProjectID: ProjectID };
 
         this.throttledRequest(obj, async result => {
-            // Cache successful responses
-            if (!this.disablePlanetCache && result && result.success && result.data) {
-                await this.cacheManager.cacheProject(ProjectID, result.data);
+            if (!this.disablePlanetCache) {
+                if (result && result.success && result.data) {
+                    await this.cacheManager.cacheProject(ProjectID, result.data);
+                } else if (result && !result.success) {
+                    // Server says the project is gone or inaccessible — evict stale cache
+                    await this.cacheManager.invalidateProject(ProjectID);
+                }
             }
-            callback(result);
+
+            // Only call back if we didn't already serve from cache
+            if (!servedFromCache) {
+                callback(result);
+            }
         });
     }
 
@@ -234,9 +247,15 @@ class ServerInterface {
     }
 
     /**
-     * Reports a project (uses raw request - no caching for write operations)
+     * Reports a project and invalidates its local cache so a stale
+     * copy cannot be served after moderation.
      */
-    reportProject(ProjectID, Description, callback) {
+    async reportProject(ProjectID, Description, callback) {
+        if (!this.disablePlanetCache) {
+            await this.initCache();
+            await this.cacheManager.invalidateProject(ProjectID);
+        }
+
         const obj = { action: "reportProject", ProjectID: ProjectID, Description: Description };
         this.request(obj, callback);
     }

--- a/planet/js/__tests__/CacheManager.test.js
+++ b/planet/js/__tests__/CacheManager.test.js
@@ -551,6 +551,41 @@ describe("IndexedDB CacheManager integration", () => {
         });
     });
 
+    describe("invalidateProject", () => {
+        test("removes project data, metadata, and thumbnail for a given id", async () => {
+            await cacheManager.cacheMetadata("inv-1", { name: "Doomed" });
+            await cacheManager.cacheProject("inv-1", { data: "gone" });
+            await cacheManager.cacheThumbnail("inv-1", "data:image/png;base64,abc");
+
+            const removed = await cacheManager.invalidateProject("inv-1");
+
+            expect(removed).toBe(true);
+            expect(await cacheManager.getMetadata("inv-1")).toBeNull();
+            expect(await cacheManager.getProject("inv-1")).toBeNull();
+            expect(await cacheManager.getThumbnail("inv-1")).toBeNull();
+        });
+
+        test("returns false for a non-existent id", async () => {
+            const removed = await cacheManager.invalidateProject("no-such-id");
+            expect(removed).toBe(false);
+        });
+
+        test("does not affect other projects", async () => {
+            await cacheManager.cacheProject("keep", { data: "safe" });
+            await cacheManager.cacheProject("remove", { data: "bye" });
+
+            await cacheManager.invalidateProject("remove");
+
+            expect(await cacheManager.getProject("keep")).toEqual({ data: "safe" });
+            expect(await cacheManager.getProject("remove")).toBeNull();
+        });
+
+        test("returns false when not initialized", async () => {
+            const uninit = new CacheManager();
+            expect(await uninit.invalidateProject("x")).toBe(false);
+        });
+    });
+
     describe("updateLastAccessed", () => {
         test("getMetadata updates lastAccessed", async () => {
             const BASE = 1000;

--- a/planet/js/__tests__/ServerInterface.test.js
+++ b/planet/js/__tests__/ServerInterface.test.js
@@ -50,6 +50,7 @@ describe("ServerInterface", () => {
             cacheMetadata: jest.fn().mockResolvedValue(true),
             getProject: jest.fn().mockResolvedValue(null),
             cacheProject: jest.fn().mockResolvedValue(true),
+            invalidateProject: jest.fn().mockResolvedValue(true),
             clearAll: jest.fn().mockResolvedValue(true),
             clearExpired: jest.fn().mockResolvedValue(0),
             getStats: jest.fn().mockResolvedValue({
@@ -207,16 +208,18 @@ describe("ServerInterface", () => {
     });
 
     describe("downloadProject (project data caching)", () => {
-        it("should return cached project when available", async () => {
+        it("should return cached project immediately and still revalidate", async () => {
             const cachedProject = { blocks: [] };
             mockCacheManager.getProject.mockResolvedValueOnce(cachedProject);
             const callback = jest.fn();
 
             await server.downloadProject("p1", callback);
+            await new Promise(process.nextTick);
 
             expect(mockCacheManager.getProject).toHaveBeenCalledWith("p1");
             expect(callback).toHaveBeenCalledWith({ success: true, data: cachedProject });
-            expect(jQuery.ajax).not.toHaveBeenCalled();
+            // Stale-while-revalidate: server request is still made
+            expect(jQuery.ajax).toHaveBeenCalled();
         });
 
         it("should fetch from network and cache project when not cached", async () => {
@@ -237,6 +240,62 @@ describe("ServerInterface", () => {
         });
     });
 
+    describe("downloadProject stale-while-revalidate", () => {
+        it("should revalidate from server even on cache hit", async () => {
+            const cachedProject = { blocks: [1, 2] };
+            mockCacheManager.getProject.mockResolvedValueOnce(cachedProject);
+            const callback = jest.fn();
+
+            await server.downloadProject("p1", callback);
+            await new Promise(process.nextTick);
+
+            // Should have called back with cached data
+            expect(callback).toHaveBeenCalledWith({ success: true, data: cachedProject });
+
+            // Should still make a server request to revalidate
+            expect(jQuery.ajax).toHaveBeenCalled();
+        });
+
+        it("should invalidate cache when server says project is gone", async () => {
+            mockCacheManager.getProject.mockResolvedValueOnce({ blocks: [] });
+            const callback = jest.fn();
+
+            server.downloadProject("p-gone", callback);
+            await new Promise(process.nextTick);
+
+            // Simulate server returning failure (deleted/moderated)
+            const ajaxInstance = jQuery.ajax.mock.results[0].value;
+            ajaxInstance._done({ success: false, error: "PROJECT_NOT_FOUND" });
+            await new Promise(process.nextTick);
+
+            expect(mockCacheManager.invalidateProject).toHaveBeenCalledWith("p-gone");
+        });
+
+        it("should update cache when server returns fresh data", async () => {
+            mockCacheManager.getProject.mockResolvedValueOnce({ blocks: [1] });
+            const callback = jest.fn();
+
+            server.downloadProject("p-update", callback);
+            await new Promise(process.nextTick);
+
+            const freshData = { success: true, data: { blocks: [1, 2, 3] } };
+            const ajaxInstance = jQuery.ajax.mock.results[0].value;
+            ajaxInstance._done(freshData);
+            await new Promise(process.nextTick);
+
+            expect(mockCacheManager.cacheProject).toHaveBeenCalledWith("p-update", freshData.data);
+        });
+    });
+
+    describe("reportProject cache invalidation", () => {
+        it("should invalidate cache for the reported project", async () => {
+            const callback = jest.fn();
+            await server.reportProject("p-bad", "spam", callback);
+
+            expect(mockCacheManager.invalidateProject).toHaveBeenCalledWith("p-bad");
+        });
+    });
+
     describe("endpoint methods", () => {
         it("should call addProject using a direct request", () => {
             const callback = jest.fn();
@@ -248,9 +307,9 @@ describe("ServerInterface", () => {
             expect(sentData["api-key"]).toBe(server.APIKey);
         });
 
-        it("should call reportProject using a direct request", () => {
+        it("should call reportProject using a direct request", async () => {
             const callback = jest.fn();
-            server.reportProject("p1", "spam", callback);
+            await server.reportProject("p1", "spam", callback);
 
             const sentData = jQuery.ajax.mock.calls[0][0].data;
             expect(sentData.action).toBe("reportProject");


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary

Fixes #7341

`downloadProject()` previously returned cached project data for up to 7 days without ever contacting the server. A project that was deleted, updated, or moderated on the server would continue loading from the local IndexedDB cache with no revalidation or invalidation.

## Changes

**CacheManager (`planet/js/CacheManager.js`):**
- Add `invalidateProject(id)` — evicts all cached data (metadata, project data, thumbnail) for a specific project
- Add `_deleteFromStore()` helper for single-entry removal

**ServerInterface (`planet/js/ServerInterface.js`):**
- `downloadProject()` now uses **stale-while-revalidate**: returns cached data immediately for responsiveness, then revalidates from the server in the background. If the server returns a failure (project deleted/moderated), the stale cache entry is evicted via `invalidateProject()`
- `reportProject()` now invalidates the local cache for the reported project before sending the report, so the reporter cannot re-open a stale cached copy

## Test plan

- [x] 85 tests pass across `CacheManager.test.js` and `ServerInterface.test.js`
- [x] 4 new CacheManager tests: invalidation across stores, non-existent id, isolation from other projects, uninitialized state
- [x] 4 new ServerInterface tests: revalidation on cache hit, cache eviction on server failure, cache update on fresh data, report invalidation
- [x] 2 existing tests updated to match stale-while-revalidate behavior
- [x] Lint and prettier pass
- [ ] Manual: open a cached project, delete it via Planet admin, reopen — should see error after background revalidation