### PR TITLE
Add lesson-plans/ directory with template and beginner lesson (#6607)

### DIFF
--- a/lesson-plans/README.md
+++ b/lesson-plans/README.md
@@ -1,0 +1,21 @@
+# Music Blocks Lesson Plans
+
+This directory contains ready-to-use lesson plans for Music Blocks. Each lesson plan is written in Markdown and follows the template in `TEMPLATE.md`.
+
+## Available Plans
+
+| Level | Lesson | Description |
+|---|---|---|
+| Beginner | [Pitch and Rhythm with the Pitch-Time Matrix](beginner-pitch-rhythm.md) | Grades 3-6. Create a melody using the Pitch-Time Matrix, change note durations, add drum tracks. |
+
+## Planned
+
+Additional lessons for intermediate (loops, actions, ABA composition) and advanced (conditionals, transposition, scales) levels are in progress.
+
+## Template
+
+The [TEMPLATE.md](TEMPLATE.md) file provides a reusable structure for creating new lesson plans. Each plan includes learning objectives (music and computational thinking), step-by-step instructions naming specific blocks and widgets, assessment criteria, and extension activities.
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../CONTRIBUTING.md) for how to contribute. New lesson plans should follow `TEMPLATE.md` and reference specific Music Blocks blocks and widgets by name.

--- a/lesson-plans/TEMPLATE.md
+++ b/lesson-plans/TEMPLATE.md
@@ -1,0 +1,82 @@
+# Music Blocks Lesson Plan Template
+
+Use this template to create new lesson plans for Music Blocks. Each lesson plan is a Markdown file placed in the `lesson-plans/` directory.
+
+---
+
+## Lesson Plan: [Title]
+
+**Target Audience:** [Grade/Age level]  
+**Duration:** [Number] class periods (approx. [minutes] minutes each)  
+**Music Blocks Version:** [Required version if any]
+
+### Overview
+
+A 2-3 sentence summary of what students will do and learn.
+
+### Learning Objectives
+
+**Music Objectives:**
+- Objective 1 (e.g., Identify note values: whole, half, quarter)
+- Objective 2
+
+**Computational Thinking Objectives:**
+- Objective 1 (e.g., Understand sequences as ordered note series)
+- Objective 2
+
+### Prerequisites
+
+- Prerequisite skill or knowledge 1
+- Prerequisite skill or knowledge 2
+- *(None for beginner plans)*
+
+### Materials & Music Blocks Widgets
+
+- [Music Blocks App](https://musicblocks.sugarlabs.org/) — run live or locally
+- **Widgets:** [Widget names: Pitch-Time Matrix, Rhythm Maker, etc.]
+- **Key Blocks:** [Block names: Note Value, Pitch, Repeat, Action, etc.]
+- Optional: Printed reference card, headphones
+
+### Step-by-Step Instructions
+
+**Step 1: [Title]**
+- Detailed instruction referencing specific blocks/widgets
+- Screenshot reference or widget link
+
+**Step 2: [Title]**
+- Instruction continues
+
+**Step 3: [Title]**
+- Instruction continues
+
+*(Continue as needed)*
+
+### Discussion Prompts
+
+- Prompt 1: What happens when you change [parameter]?
+- Prompt 2: How would you make this pattern repeat?
+- Prompt 3: Can you create a variation using different note values?
+
+### Assessment Criteria
+
+| Criteria | Beginning (1) | Developing (2) | Proficient (3) | Exemplary (4) |
+|---|---|---|---|---|
+| Criterion 1 | Description | Description | Description | Description |
+| Criterion 2 | Description | Description | Description | Description |
+| Criterion 3 | Description | Description | Description | Description |
+
+### Extension Activities
+
+- Extension idea 1: [Description]
+- Extension idea 2: [Description]
+- Self-directed challenge: [Challenge description]
+
+### Reference Links
+
+- [WhyMusicBlocks.md](https://github.com/sugarlabs/musicblocks/blob/master/WhyMusicBlocks.md)
+- [Music Blocks Guide](https://github.com/sugarlabs/musicblocks/tree/master/guide)
+- [Sample Lesson: Sakura Melody](https://musicblocks.net/2026/03/24/sakura-melody/)
+
+---
+
+*This template is part of the Music Blocks lesson-plans/ directory. See lesson-plans/README.md for the complete index.*

--- a/lesson-plans/beginner-pitch-rhythm.md
+++ b/lesson-plans/beginner-pitch-rhythm.md
@@ -1,0 +1,111 @@
+# Beginner Lesson: Exploring Pitch and Rhythm with the Pitch-Time Matrix
+
+**Target Audience:** Grades 3–6 (ages 8–12)  
+**Duration:** 1–2 class periods (45–90 minutes)  
+**Music Blocks Version:** Latest stable (browser version at musicblocks.sugarlabs.org)
+
+## Overview
+
+Students explore the relationship between pitch (how high or low a note sounds) and rhythm (how long or short a note lasts) using Music Blocks' Pitch-Time Matrix widget. They will create a short melody by placing notes on a grid, play it back, and experiment with changes.
+
+## Learning Objectives
+
+**Music Objectives:**
+- Identify that pitch increases vertically and time advances horizontally in the Pitch-Time Matrix
+- Recognize whole notes, half notes, and quarter notes by their visual duration
+- Create and play back a simple 4-measure melody
+
+**Computational Thinking Objectives:**
+- Understand the grid as a coordinate system (pitch = y-axis, time = x-axis)
+- Recognize that a sequence of notes forms a program that Music Blocks executes
+- Predict the output of a sequence before running it
+
+## Prerequisites
+
+- None. This is a beginner-friendly lesson.
+
+## Materials & Music Blocks Widgets
+
+- [Music Blocks (browser)](https://musicblocks.sugarlabs.org/) — no installation needed
+- **Widget:** Pitch-Time Matrix
+- **Key Blocks:** Note Value block, Pitch block, Drum block, Play button
+- Optional: Headphones, printed grid worksheet
+
+## Step-by-Step Instructions
+
+### Step 1: Open Music Blocks and Start a New Project
+
+1. Go to https://musicblocks.sugarlabs.org/ in your browser.
+2. Click "New Project" (or the default project loads automatically).
+3. Look for the **Pitch-Time Matrix** widget in the center of the screen — it looks like a grid with note names on the left and time divisions along the top.
+
+### Step 2: Place Your First Notes
+
+1. In the Pitch-Time Matrix, click on a block in one of the first four columns.
+2. You will see a colored rectangle appear — this is a **note block**.
+3. Try clicking different rows. Notice how higher rows produce higher-pitched sounds.
+4. Place notes in 4 consecutive columns to create a short melody.
+
+**Teacher tip:** Encourage students to place notes in different rows so their melody has shape, rather than all notes on the same row.
+
+### Step 3: Listen to Your Melody
+
+1. Find the **Play** button (triangle icon) above or beside the matrix.
+2. Click Play to hear your melody.
+3. Discuss: How did the pitch change as notes moved higher or lower?
+
+### Step 4: Change Note Durations
+
+1. Click on a note you placed. A properties menu appears.
+2. Look for the **Note Value** parameter — this controls how long the note sounds.
+3. Try changing the value:
+   - **1** = whole note (longest)
+   - **1/2** = half note
+   - **1/4** = quarter note
+   - **1/8** = eighth note (shortest)
+4. Play your melody again. How does it sound different?
+
+### Step 5: Add Rhythm with a Drum Track
+
+1. Below the Pitch-Time Matrix, find the **Drum** row or switch to the Rhythm Maker widget.
+2. Click in the drum row to add drum hits at specific beats.
+3. Play your melody with the drum track together.
+
+### Step 6: Experiment and Share
+
+1. Make one change to your melody (change a pitch, duration, or add notes).
+2. Predict what it will sound like before pressing Play.
+3. Play and compare your prediction with the result.
+4. Optional: Save your project using the **Save** option and share with a partner.
+
+## Discussion Prompts
+
+- What happened when you placed all notes on the same row? How did it sound compared to notes on different rows?
+- What changed when you made a note longer (whole note) vs. shorter (eighth note)?
+- Can you find the **Repeat** block? What do you think it does?
+- How is the Music Blocks grid like a map or graph you've seen in other subjects?
+
+## Assessment Criteria
+
+| Criteria | Beginning (1) | Developing (2) | Proficient (3) | Exemplary (4) |
+|---|---|---|---|---|
+| Note placement | Places 1–3 random notes | Places 4+ notes but all same row | Places 4+ notes across 2+ rows | Places 8+ notes creating a recognisable melody shape |
+| Duration awareness | Does not change note values | Changes one note value | Uses 2+ different note values | Uses 3+ different values with intentional rhythmic effect |
+| Playback & prediction | Plays melody | Plays and describes what they hear | Predicts effect before changing notes | Predicts correctly and explains reasoning |
+
+## Extension Activities
+
+- **Partner remix:** Exchange melody projects with a partner. Add two new notes to their melody and explain your choice.
+- **Pattern challenge:** Create a 4-note pattern that repeats. Then change the last note. How does the feeling change?
+- **Nature sounds:** Try to imitate a familiar sound (doorbell, bird call, raindrops) using 3–5 notes.
+- **Cross-curricular:** Draw your melody as a line graph. Does the graph look like the melody sounds?
+
+## Reference Links
+
+- [Pitch-Time Matrix documentation](https://github.com/sugarlabs/musicblocks/blob/master/guide/README.md)
+- [WhyMusicBlocks.md — Music & Programming Concepts](https://github.com/sugarlabs/musicblocks/blob/master/WhyMusicBlocks.md)
+- [Example: Sakura Melody](https://musicblocks.net/2026/03/24/sakura-melody/)
+
+---
+
+*Part of Music Blocks lesson-plans/. Beginner level.*


### PR DESCRIPTION
Small PR for #6607 — lesson-plans/ directory with a template and one beginner lesson. Gets the format in front of reviewers before expanding.

Three files:
- lesson-plans/README.md — index
- lesson-plans/TEMPLATE.md — reusable template with objectives, step-by-step, rubric, extensions
- lesson-plans/beginner-pitch-rhythm.md — Pitch-Time Matrix lesson for grades 3-6, no Music Blocks experience needed

The template follows the programming-vs-music concept mapping from WhyMusicBlocks.md. Discussion prompts are open-ended the way that doc uses them. Each step references a specific block or widget so a teacher can find it without digging through menus.

Next batch would add intermediate lessons and the root README link, but I want to make sure the template works first.

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation