### PR TITLE
Add tooltip for truncated project titles in Planet

### DIFF
--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -150,6 +150,7 @@ class GlobalCard {
             tagcontainer.appendChild(chip);
         }
 
+        // set project title text and tooltip
         const titleEl = frag.getElementById(`global-project-title-${this.id}`);
         titleEl.textContent = this.ProjectData.ProjectName;
         titleEl.title = this.ProjectData.ProjectName;

--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -150,10 +150,9 @@ class GlobalCard {
             tagcontainer.appendChild(chip);
         }
 
-        // set title text
-        frag.getElementById(`global-project-title-${this.id}`).textContent =
-            this.ProjectData.ProjectName;
-
+        const titleEl = frag.getElementById(`global-project-title-${this.id}`);
+        titleEl.textContent = this.ProjectData.ProjectName;
+        titleEl.title = this.ProjectData.ProjectName;
         // set number of likes
         frag.getElementById(`global-project-likes-${this.id}`).textContent =
             this.ProjectData.ProjectLikes.toString();


### PR DESCRIPTION
## PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
This PR adds a UI enhancement feature that displays the full project title in a tooltip when hovering over truncated project titles in Planet cards.


## Changes

* Added a `title` attribute to project title elements
* Users can now view the full project name on hover
* Existing layout and truncation behavior remain unchanged

## Before

Project titles were truncated with no way to view the complete project name.

<img width="1355" height="609" alt="WhatsApp Image 2026-05-14 at 1 34 50 PM" src="https://github.com/user-attachments/assets/7231878d-e09d-4ec4-a259-0f018c04cd0a" />


## After

Hovering over a truncated project title now displays the full project name in a tooltip.
<img width="1918" height="915" alt="Screenshot 2026-05-14 163456" src="https://github.com/user-attachments/assets/cf40029c-7e6e-44d5-ac27-b7a409cb15fb" />


