### PR TITLE
fix: correct glide duration calculation for glissando

### DIFF
--- a/js/blocks/OrnamentBlocks.js
+++ b/js/blocks/OrnamentBlocks.js
@@ -396,10 +396,6 @@ function setupOrnamentBlocks(activity) {
          * @returns {number[]} - The result of the block execution.
          */
         flow(args, logo, turtle, blk) {
-            // TODO: Duration should be the sum of all the notes (like
-            // in a tie). If we set the synth portamento and use
-            // setNote for all but the first note, it should produce a
-            // glissando.
             if (args[1] === undefined) {
                 // Nothing to do.
                 return;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -491,11 +491,16 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = logo.boxes !== null ? deepClone(logo.boxes) : undefined;
+        const saveBoxes =
+            logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
+                ? deepClone(logo.turtleHeaps[turtle])
+                : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined;
+            logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
+                ? deepClone(logo.turtleDicts[turtle])
+                : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -546,17 +551,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes === undefined) {
+        if (saveBoxes === undefined || saveBoxes === null) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps === undefined) {
+        if (saveTurtleHeaps === undefined || saveTurtleHeaps === null) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts === undefined) {
+        if (saveTurtleDicts === undefined || saveTurtleDicts === null) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -605,11 +610,16 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: logo.boxes !== null ? deepClone(logo.boxes) : undefined,
+            boxes:
+                logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+                logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
+                    ? deepClone(logo.turtleHeaps[turtle])
+                    : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined,
+                logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
+                    ? deepClone(logo.turtleDicts[turtle])
+                    : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -666,11 +676,16 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = saveState.boxes !== null ? saveState.boxes : {};
+        activity.logo.boxes =
+            saveState.boxes !== null && saveState.boxes !== undefined ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps !== null ? saveState.turtleHeaps : {};
+            saveState.turtleHeaps !== null && saveState.turtleHeaps !== undefined
+                ? saveState.turtleHeaps
+                : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts !== null ? saveState.turtleDicts : {};
+            saveState.turtleDicts !== null && saveState.turtleDicts !== undefined
+                ? saveState.turtleDicts
+                : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1865,9 +1880,9 @@ class Singer {
             // 8->4->4->4->8
             // TESTME: Could behave weirdly with tie.
             if (tur.singer.swing.length > 0) {
-                /** @deprecated */
-                // newswing2 takes the target as an argument
-                if (last(tur.singer.swingTarget) === null) {
+                // Deprecated swing path; newswing2 takes the target as an argument.
+                const swingTargetLast = last(tur.singer.swingTarget);
+                if (swingTargetLast === null || swingTargetLast === undefined) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -491,17 +491,14 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-	// eslint-disable-next-line eqeqeq
-        const saveBoxes =
-            logo.boxes != null ? deepClone(logo.boxes) : undefined;
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
+        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
+        // eslint-disable-next-line eqeqeq
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle])
-                : undefined;
-	// eslint-disable-next-line eqeqeq
+            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+        // eslint-disable-next-line eqeqeq
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle])
-                : undefined;
+            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -552,19 +549,19 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
         if (saveBoxes == null) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
         if (saveTurtleHeaps == null) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
         if (saveTurtleDicts == null) {
             logo.turtleDicts = {};
         } else {
@@ -614,19 +611,14 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-	    // eslint-disable-next-line eqeqeq
-            boxes:
-                logo.boxes != null ? deepClone(logo.boxes) : undefined,
-	    // eslint-disable-next-line eqeqeq
+            // eslint-disable-next-line eqeqeq
+            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
+            // eslint-disable-next-line eqeqeq
             turtleHeaps:
-                logo.turtleHeaps[turtle] != null
-                    ? deepClone(logo.turtleHeaps[turtle])
-                    : undefined,
-	    // eslint-disable-next-line eqeqeq
+                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+            // eslint-disable-next-line eqeqeq
             turtleDicts:
-                logo.turtleDicts[turtle] != null
-                    ? deepClone(logo.turtleDicts[turtle])
-                    : undefined,
+                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -683,19 +675,14 @@ class Singer {
             penState: saveState.penState
         });
 
-	// eslint-disable-next-line eqeqeq
-        activity.logo.boxes =
-            saveState.boxes != null ? saveState.boxes : {};
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
+        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
+        // eslint-disable-next-line eqeqeq
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps != null
-                ? saveState.turtleHeaps
-                : {};
-	// eslint-disable-next-line eqeqeq
+            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
+        // eslint-disable-next-line eqeqeq
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts != null
-                ? saveState.turtleDicts
-                : {};
+            saveState.turtleDicts != null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1892,7 +1879,7 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 // Deprecated swing path; newswing2 takes the target as an argument.
                 const swingTargetLast = last(tur.singer.swingTarget);
-		// eslint-disable-next-line eqeqeq
+                // eslint-disable-next-line eqeqeq
                 if (swingTargetLast == null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
@@ -2632,7 +2619,7 @@ class Singer {
 
         tur.singer.pushedNote = false;
 
-	// eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq
         if (callback != null) {
             callback();
         }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -491,11 +491,11 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
-        const saveBoxes = logo.boxes != null ? deepClone(logo.boxes) : undefined;
+        const saveBoxes = logo.boxes !== null ? deepClone(logo.boxes) : undefined;
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
+            logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined;
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined;
+            logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined;
         // .. and the turtle state
         const saveX = tur.x;
         const saveY = tur.y;
@@ -546,17 +546,17 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes == undefined) {
+        if (saveBoxes === undefined) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps == undefined) {
+        if (saveTurtleHeaps === undefined) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts == undefined) {
+        if (saveTurtleDicts === undefined) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -605,11 +605,11 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
-            boxes: logo.boxes != null ? deepClone(logo.boxes) : undefined,
+            boxes: logo.boxes !== null ? deepClone(logo.boxes) : undefined,
             turtleHeaps:
-                logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
+                logo.turtleHeaps[turtle] !== null ? deepClone(logo.turtleHeaps[turtle]) : undefined,
             turtleDicts:
-                logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle]) : undefined,
+                logo.turtleDicts[turtle] !== null ? deepClone(logo.turtleDicts[turtle]) : undefined,
             x: tur.x,
             y: tur.y,
             color: tur.painter.color,
@@ -666,11 +666,11 @@ class Singer {
             penState: saveState.penState
         });
 
-        activity.logo.boxes = saveState.boxes != null ? saveState.boxes : {};
+        activity.logo.boxes = saveState.boxes !== null ? saveState.boxes : {};
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps != null ? saveState.turtleHeaps : {};
+            saveState.turtleHeaps !== null ? saveState.turtleHeaps : {};
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts != null ? saveState.turtleDicts : {};
+            saveState.turtleDicts !== null ? saveState.turtleDicts : {};
 
         tur.painter.doPenUp();
         tur.painter.doSetXY(saveState.x, saveState.y);
@@ -1070,7 +1070,7 @@ class Singer {
                 for (let i = 0, len = transpositionRatios.length; i < len; i++) {
                     ratio *= transpositionRatios[i];
                 }
-                if (ratio != 1) {
+                if (ratio !== 1) {
                     const hertz = getCachedPitchToFrequency(
                         noteObj[0],
                         noteObj[1],
@@ -1867,7 +1867,7 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 /** @deprecated */
                 // newswing2 takes the target as an argument
-                if (last(tur.singer.swingTarget) == null) {
+                if (last(tur.singer.swingTarget) === null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }
@@ -2355,7 +2355,7 @@ class Singer {
                                                     } else {
                                                         // trigger first note for entire duration of the glissando
                                                         const beatValueOverride =
-                                                            bpmFactor / tur.singer.glideOverride;
+                                                            bpmFactor * tur.singer.glideOverride;
                                                         activity.logo.synth.trigger(
                                                             turtle,
                                                             notes[d],

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -491,15 +491,16 @@ class Singer {
         const saveSuppressStatus = tur.singer.suppressOutput;
 
         // We need to save the state of the boxes and heap although there is a potential of a boxes collision with other turtles
+	// eslint-disable-next-line eqeqeq
         const saveBoxes =
-            logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined;
+            logo.boxes != null ? deepClone(logo.boxes) : undefined;
+	// eslint-disable-next-line eqeqeq
         const saveTurtleHeaps =
-            logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
-                ? deepClone(logo.turtleHeaps[turtle])
+            logo.turtleHeaps[turtle] != null ? deepClone(logo.turtleHeaps[turtle])
                 : undefined;
+	// eslint-disable-next-line eqeqeq
         const saveTurtleDicts =
-            logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
-                ? deepClone(logo.turtleDicts[turtle])
+            logo.turtleDicts[turtle] != null ? deepClone(logo.turtleDicts[turtle])
                 : undefined;
         // .. and the turtle state
         const saveX = tur.x;
@@ -551,17 +552,20 @@ class Singer {
         tur.singer.tallyNotes = saveTallyNotes;
 
         // Restore previous state
-        if (saveBoxes === undefined || saveBoxes === null) {
+	// eslint-disable-next-line eqeqeq
+        if (saveBoxes == null) {
             logo.boxes = {};
         } else {
             logo.boxes = saveBoxes;
         }
-        if (saveTurtleHeaps === undefined || saveTurtleHeaps === null) {
+	// eslint-disable-next-line eqeqeq
+        if (saveTurtleHeaps == null) {
             logo.turtleHeaps = {};
         } else {
             logo.turtleHeaps[turtle] = saveTurtleHeaps;
         }
-        if (saveTurtleDicts === undefined || saveTurtleDicts === null) {
+	// eslint-disable-next-line eqeqeq
+        if (saveTurtleDicts == null) {
             logo.turtleDicts = {};
         } else {
             logo.turtleDicts[turtle] = saveTurtleDicts;
@@ -610,14 +614,17 @@ class Singer {
 
         const saveState = {
             suppressOutput: tur.singer.suppressOutput,
+	    // eslint-disable-next-line eqeqeq
             boxes:
-                logo.boxes !== null && logo.boxes !== undefined ? deepClone(logo.boxes) : undefined,
+                logo.boxes != null ? deepClone(logo.boxes) : undefined,
+	    // eslint-disable-next-line eqeqeq
             turtleHeaps:
-                logo.turtleHeaps[turtle] !== null && logo.turtleHeaps[turtle] !== undefined
+                logo.turtleHeaps[turtle] != null
                     ? deepClone(logo.turtleHeaps[turtle])
                     : undefined,
+	    // eslint-disable-next-line eqeqeq
             turtleDicts:
-                logo.turtleDicts[turtle] !== null && logo.turtleDicts[turtle] !== undefined
+                logo.turtleDicts[turtle] != null
                     ? deepClone(logo.turtleDicts[turtle])
                     : undefined,
             x: tur.x,
@@ -676,14 +683,17 @@ class Singer {
             penState: saveState.penState
         });
 
+	// eslint-disable-next-line eqeqeq
         activity.logo.boxes =
-            saveState.boxes !== null && saveState.boxes !== undefined ? saveState.boxes : {};
+            saveState.boxes != null ? saveState.boxes : {};
+	// eslint-disable-next-line eqeqeq
         activity.logo.turtleHeaps[turtle] =
-            saveState.turtleHeaps !== null && saveState.turtleHeaps !== undefined
+            saveState.turtleHeaps != null
                 ? saveState.turtleHeaps
                 : {};
+	// eslint-disable-next-line eqeqeq
         activity.logo.turtleDicts[turtle] =
-            saveState.turtleDicts !== null && saveState.turtleDicts !== undefined
+            saveState.turtleDicts != null
                 ? saveState.turtleDicts
                 : {};
 
@@ -1882,7 +1892,8 @@ class Singer {
             if (tur.singer.swing.length > 0) {
                 // Deprecated swing path; newswing2 takes the target as an argument.
                 const swingTargetLast = last(tur.singer.swingTarget);
-                if (swingTargetLast === null || swingTargetLast === undefined) {
+		// eslint-disable-next-line eqeqeq
+                if (swingTargetLast == null) {
                     // When we start a swing we need to keep track of the initial beat value
                     tur.singer.swingTarget[tur.singer.swingTarget.length - 1] = noteBeatValue;
                 }
@@ -2621,7 +2632,8 @@ class Singer {
 
         tur.singer.pushedNote = false;
 
-        if (callback !== undefined && callback !== null) {
+	// eslint-disable-next-line eqeqeq
+        if (callback != null) {
             callback();
         }
 


### PR DESCRIPTION
### Issue:
The Glide block (used to create a smooth pitch slide between notes, like a glissando) was playing the first note for the wrong amount of time. I tested it by when i put few notes inside a glide block (as shown in the screenshot), the synth is supposed to hold the first note open for the entire combined duration of all the notes, while smoothly sliding through each pitch. Instead, it was holding the note for the mathematical inverse of that duration, so for a short glide it held too long, and the audio would bleed out way past where it should have ended, as shown in the screen recordings. To fix this i used `/` instead of `*`.

<img width="498" height="530" alt="Screenshot 2026-05-15 001535" src="https://github.com/user-attachments/assets/833f2aa0-d529-45dd-81f1-7a53c8acc11d" />

### Changes:
`js/turtle-singer.js` -> just a single change, used `/` instead of `*`(line 2358), others are lint fixes.
`js/blocks/OrnamentBlocks.js` -> removed a TODO comment that described this exact bug(from where i got to know about this bug).

### Screen Recordings:
After:

https://github.com/user-attachments/assets/0a42d94f-1c29-4cbe-ab35-7117173d7618


Before:

https://github.com/user-attachments/assets/2a7e85e6-94de-4c35-8df0-53be3e954002


### PR Category:
- [x] Bug Fix