### PR TITLE
fix(test): remove obsolete console.log assertion in DictActions tests

### DIFF
--- a/js/turtleactions/__tests__/DictActions.test.js
+++ b/js/turtleactions/__tests__/DictActions.test.js
@@ -285,13 +285,6 @@ describe("setupDictActions", () => {
             Turtle.DictActions.setValue("newDict", "key", "value", turtle);
             expect(activity.logo.turtleDicts[turtle].newDict.key).toBe("value");
         });
-
-        it("should log to console when setting a value", () => {
-            console.log = jest.fn();
-            activity.logo.turtleDicts[turtle] = {};
-            Turtle.DictActions.setValue("testDict", "key", "value", turtle);
-            expect(console.log).toHaveBeenCalled();
-        });
     });
 
     describe("getValue", () => {


### PR DESCRIPTION
## Summary

This PR removes an obsolete `console.log` assertion from `DictActions.setValue` tests.

The debug logging inside `setValue()` was removed in a previous cleanup PR, but one test was still asserting that `console.log` should be called, which now causes the test suite to fail.

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Changes

- Removed the outdated test:
  - `should log to console when setting a value`
- Kept the existing behavior-focused tests that already validate:
  - dictionary creation
  - turtleDict initialization
  - value assignment behavior

## Why this change

The removed assertion was testing debug logging rather than actual functionality. Since the implementation no longer logs to the console, the test became obsolete and caused failures on the current master branch.

The remaining tests already provide proper coverage for the functional behavior of `setValue()`.

## Testing

```bash
npx jest js/turtleactions/__tests__/DictActions.test.js --runInBand