### PR TITLE
Fix/planet to title case utils logic dependency

### DIFF
--- a/planet/index.html
+++ b/planet/index.html
@@ -40,6 +40,7 @@
     <script type="text/javascript" src="js/Publisher.js"></script>
     <script type="text/javascript" src="js/LocalPlanet.js"></script>
 
+    <script type="text/javascript" src="../js/utils/utils-logic.js"></script>
     <script type="text/javascript" src="../js/utils/utils.js"></script>
     <script type="text/javascript" src="js/GlobalTag.js"></script>
     <script type="text/javascript" src="js/GlobalCard.js"></script>

--- a/planet/js/GlobalTag.js
+++ b/planet/js/GlobalTag.js
@@ -122,3 +122,7 @@ class GlobalTag {
         this.render();
     }
 }
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = GlobalTag;
+}

--- a/planet/js/__tests__/GlobalTag.test.js
+++ b/planet/js/__tests__/GlobalTag.test.js
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Regression tests for:
+ *   ReferenceError: toTitleCase is not defined
+ *
+ * After PR #7302/#7303/#7304 moved toTitleCase from js/utils/utils.js into
+ * js/utils/utils-logic.js, GlobalTag.render() started throwing a ReferenceError
+ * because planet/index.html did not load utils-logic.js before GlobalTag.js.
+ *
+ * Fix: planet/index.html now loads ../js/utils/utils-logic.js before
+ * ../js/utils/utils.js so that Object.assign(window, UtilsLogic) runs first,
+ * putting toTitleCase on window before GlobalTag.js is parsed.
+ *
+ * These tests mirror that load order in Jest: require utils-logic, assign its
+ * exports to global, then require GlobalTag — exactly as the browser does.
+ */
+
+// Replicate planet/index.html load order after the fix:
+//  1. utils-logic.js → Object.assign(window, UtilsLogic) makes toTitleCase global
+//  2. GlobalTag.js   → uses toTitleCase as a global
+const UtilsLogic = require("../../../js/utils/utils-logic");
+Object.assign(global, UtilsLogic);
+
+const GlobalTag = require("../GlobalTag");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function addChipContainer(id) {
+    const el = document.createElement("div");
+    el.id = id;
+    document.body.appendChild(el);
+    return el;
+}
+
+function makePlanet(tagName = "music", isDisplay = "1") {
+    return {
+        TagsManifest: { 1: { TagName: tagName, IsDisplayTag: isDisplay } },
+        GlobalPlanet: {
+            selectSpecialTag: jest.fn(),
+            refreshTagList: jest.fn()
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Regression: toTitleCase must be reachable when GlobalTag.render() runs
+// ---------------------------------------------------------------------------
+
+describe("GlobalTag – regression: toTitleCase dependency after utils modularization", () => {
+    beforeEach(() => {
+        addChipContainer("primarychips");
+        addChipContainer("morechips");
+        global._ = str => str; // identity stub for translation helper
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        delete global._;
+    });
+
+    it("toTitleCase is defined on global after loading utils-logic", () => {
+        expect(typeof global.toTitleCase).toBe("function");
+    });
+
+    it("toTitleCase capitalises the first letter of a string", () => {
+        expect(global.toTitleCase("hello")).toBe("Hello");
+    });
+
+    it("toTitleCase returns undefined for non-string input", () => {
+        expect(global.toTitleCase(123)).toBeUndefined();
+    });
+
+    it("toTitleCase returns empty string for empty input", () => {
+        expect(global.toTitleCase("")).toBe("");
+    });
+
+    it("GlobalTag.render() does not throw ReferenceError for toTitleCase", () => {
+        const tag = new GlobalTag(makePlanet("music"));
+        expect(() => tag.init({ id: 1 })).not.toThrow();
+    });
+
+    it("GlobalTag.render() sets textContent via toTitleCase", () => {
+        const tag = new GlobalTag(makePlanet("art"));
+        tag.init({ id: 1 });
+        // _ is identity stub, toTitleCase("art") === "Art"
+        expect(tag.tagElement.textContent).toBe("Art");
+    });
+
+    it("display tag is appended to #primarychips", () => {
+        const tag = new GlobalTag(makePlanet("game", "1"));
+        tag.init({ id: 1 });
+        expect(document.getElementById("primarychips").children.length).toBeGreaterThan(0);
+    });
+
+    it("non-display tag is appended to #morechips", () => {
+        const tag = new GlobalTag(makePlanet("sensors", "0"));
+        tag.init({ id: 1 });
+        expect(document.getElementById("morechips").children.length).toBeGreaterThan(0);
+    });
+
+    it("special tag render() also does not throw", () => {
+        const tag = new GlobalTag(makePlanet());
+        expect(() => tag.init({ name: "All Projects", func: jest.fn() })).not.toThrow();
+    });
+});


### PR DESCRIPTION
# fix: restore Planet bootstrap dependency for toTitleCase after utils modularization

## Description

This PR fixes a regression introduced during the utils modularization series (`#7302–#7304`) where Planet bootstrap paths could fail with:

```text
ReferenceError: toTitleCase is not defined
```

The issue occurred because `toTitleCase` was moved from:

```text
js/utils/utils.js
```

to:

```text
js/utils/utils-logic.js
```

However, the Planet bootstrap:

```text
planet/index.html
```

still loaded only:

```html
../js/utils/utils.js
```

and never loaded:

```html
../js/utils/utils-logic.js
```

Since `utils-logic.js` is responsible for exposing extracted utility helpers globally via:

```js
Object.assign(window, UtilsLogic)
```

the Planet runtime never received the global `toTitleCase` symbol before:

```text
GlobalTag.js
```

executed.

As a result:

```text
GlobalTag.render()
```

could throw:

```text
ReferenceError: toTitleCase is not defined
```

---

# Changes

## Bootstrap Fix

Updated:

```text
planet/index.html
```

to load:

```html
../js/utils/utils-logic.js
```

before:

```html
../js/utils/utils.js
```

This restores the expected global initialization order required by Planet runtime dependencies.

---

## GlobalTag CommonJS Compatibility

Updated:

```text
planet/js/GlobalTag.js
```

to include a guarded:

```js
module.exports
```

pattern matching existing Planet modules such as:

```text
CacheManager.js
```

This allows the file to be imported cleanly in Jest environments.

---

## Regression Test Coverage

Added:

```text
planet/js/__tests__/GlobalTag.test.js
```

with regression coverage for:

- Global availability of `toTitleCase`
- `GlobalTag.render()` no longer throwing
- Proper `textContent` formatting
- Display tag DOM insertion
- Non-display tag DOM insertion
- Special-tag rendering path

---

# Verification

```text
PASS planet/js/__tests__/GlobalTag.test.js

✓ toTitleCase is defined on global after loading utils-logic
✓ toTitleCase capitalises the first letter of a string
✓ toTitleCase returns undefined for non-string input
✓ toTitleCase returns empty string for empty input
✓ GlobalTag.render() does not throw ReferenceError for toTitleCase
✓ GlobalTag.render() sets textContent via toTitleCase
✓ display tag is appended to #primarychips
✓ non-display tag is appended to #morechips
✓ special tag render() also does not throw
```

- Tests: 9 passed
- Lint: no new errors
- Prettier: clean

---

# Why this is safe

This PR does not modify:
- Utility behavior
- Planet rendering logic
- Existing runtime functionality

It only restores the missing bootstrap dependency ordering required after the utils modularization refactor and adds regression coverage to prevent future bootstrap/load-order breakage.

- [x] Bug Fix

 ### After Fix
<img width="1468" height="298" alt="Screenshot 2026-05-15 at 6 50 45 PM" src="https://github.com/user-attachments/assets/19d25358-ddcd-437a-9571-c97ce8580c88" />
