### PR TITLE
fix: add Chore/Refactor category to PR template and ci check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -25,6 +25,7 @@ This PR fixes #
 -   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
 -   [ ] Tests — Adds or updates test coverage
 -   [ ] Documentation — Updates to docs, comments, or README
+-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
 
 ## Changes Made
 

--- a/.github/workflows/pr-category-check.yml
+++ b/.github/workflows/pr-category-check.yml
@@ -64,6 +64,13 @@ jobs:
                 displayName: 'Documentation',
                 pattern: /-\s*\[x\]\s*Documentation/i,
               },
+              {
+                label: 'chore',
+                color: 'A0AEC0',
+                description: 'Maintenance, refactoring, or tooling with no behavior change',
+                displayName: 'Chore / Refactor',
+                pattern: /-\s*\[x\]\s*Chore/i,
+              },
             ];
 
             const checkedCategories = categories.filter(cat => cat.pattern.test(prBody));


### PR DESCRIPTION
### Summary
`pr-category-check.yml` has exactly 5 categories: Bug Fix, Feature, Performance, tests, Doc. There is no Chore/Refactor category. This means cleanups, like i tried to do in #7356 has no correct category to check - contributors are forced to pick a misleading one. So, this pr adds a Chore / Refactor category.

### PR Category
- [x] Bug Fix
