### PR TITLE
fix: resolve canvas pie menu rendering bug on fallback

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -733,7 +733,14 @@ class Activity {
             wheel.sliceInitPathCustom = wheel.slicePathCustom;
             wheel.clickModeRotate = false;
             const wheelItems = this.helpfulWheelItems.filter(ele => ele.display);
-            wheel.initWheel(wheelItems.map(ele => ele.icon));
+            wheel.initWheel(wheelItems.map(ele => _(ele.label)));
+
+            wheelItems.forEach((ele, i) => {
+                if (ele.icon) {
+                    wheel.navItems[i].setTitle(ele.icon);
+                }
+            });
+
             wheel.createWheel();
 
             wheel.navItems[0].selected = false;
@@ -7025,6 +7032,7 @@ class Activity {
          * These menu items are on the canvas, not the toolbar.
          */
         this._setupPaletteMenu = () => {
+            this.helpfulWheelItems = [];
             const btnSize = this.cellSize;
             const createButton = (icon, label, action) => {
                 const button = this._makeButton(icon, label, x, y, btnSize, 0);


### PR DESCRIPTION
**Description**
Resolves a regression where the canvas context menu (Helpful Wheel) failed to render correctly when SVG image loads failed (e.g., over `file://` protocol or strict environments). This updates the `wheelnav` initialization to safely fall back to text labels.

**Fixes**
- Closes #7362

**Changes**
1. **Fallback text initialization:** `_displayHelpfulWheel` now initializes the `wheelnav` slices using translated text labels (`_(ele.label)`) as primary titles to guarantee rendering if an icon is missing. 
2. **Dynamic icon assignment:** Iterates over the items *before* `createWheel()` and uses `wheel.navItems[i].setTitle(ele.icon)` so the original SVGs are still correctly prioritized for rendering and hover interactions do not break the visuals.
3. **Array reset cleanup:** Safely clears `this.helpfulWheelItems` at the top of `_setupPaletteMenu()` to prevent potential ghost items/duplicate menus if the UI recalculates on window resizes.

**PR Category**
- [x] Bug Fix
