### PR TITLE
refactor(status): replace platformColor.selectorBackground with CSS t…

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -1,3 +1,5 @@
+@import url("tokens.css");
+
 /* Theme DropDown Styling */
 
 #themedropdown {

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,52 @@
+/**
+ * MusicBlocks v3.4.1
+ *
+ * @author Walter Bender
+ *
+ * @copyright 2026 Walter Bender
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MusicBlocks Design Tokens
+ *
+ * Single source of truth for theme-aware CSS custom properties.
+ * Light-theme values are set on :root; dark and high-contrast
+ * values are overridden via body class.
+ *
+ * Usage in JS:
+ *   element.style.backgroundColor = "var(--mb-selector-bg)"
+ *
+ * Refs: js/utils/platformstyle.js (platformThemes)
+ */
+
+/* Light theme (default) */
+:root {
+    --mb-selector-bg: #8cc6ff;
+    --mb-selector-selected: #1a8cff;
+}
+
+/* Dark theme */
+body.dark {
+    --mb-selector-bg: #64b5f6;
+    --mb-selector-selected: #1e88e5;
+}
+
+/* High contrast theme */
+body.highcontrast {
+    --mb-selector-bg: #00ffff;
+    --mb-selector-selected: #00cccc;
+}

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -33,6 +33,7 @@ class StatusMatrix {
         this.isOpen = true;
         this.isMaximized = false;
         this._cellScale = window.innerWidth / 1200;
+        const selectorBg = "var(--mb-selector-bg)";
         let iconSize = StatusMatrix.ICONSIZE * this._cellScale;
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "status", "status");
@@ -178,14 +179,14 @@ class StatusMatrix {
             b.textContent = str;
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
-            cell.style.backgroundColor = platformColor.selectorBackground;
+            cell.style.backgroundColor = selectorBg;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
                     continue;
                 }
                 cell = row.insertCell();
-                cell.style.backgroundColor = platformColor.selectorBackground;
+                cell.style.backgroundColor = selectorBg;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";
@@ -206,14 +207,14 @@ class StatusMatrix {
             b.textContent = label;
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
-            cell.style.backgroundColor = platformColor.selectorBackground;
+            cell.style.backgroundColor = selectorBg;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
                     continue;
                 }
                 cell = row.insertCell();
-                cell.style.backgroundColor = platformColor.selectorBackground;
+                cell.style.backgroundColor = selectorBg;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";


### PR DESCRIPTION
## PR Category
- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

Closes #6606 (partial)

Introduces `css/tokens.css` as an initial CSS custom-property design token file for Music Blocks.

## Changes

* Added `--mb-selector-bg` and `--mb-selector-selected` tokens for light, dark, and high-contrast themes
* Imported `tokens.css` from `css/themes.css`
* Updated the Status widget to use `var(--mb-selector-bg)` instead of `platformColor.selectorBackground`

This removes the Status widget’s direct dependency on the JS `platformColor.selectorBackground` value and allows the row background to follow the active body theme class dynamically.

## Manual Verification

* Ran the app locally
* Opened the Status widget
* Verified live theme updates by toggling body theme classes directly from the browser console:

```js
document.body.classList.remove("light", "dark", "highcontrast");
document.body.classList.add("dark");
```

```js
document.body.classList.remove("light", "dark", "highcontrast");
document.body.classList.add("highcontrast");
```

* Confirmed the Status widget row backgrounds updated immediately without requiring a page reload
* Verified active theme state using:

```js
document.body.classList.contains("dark");
document.body.className;
```

* Confirmed no relevant browser console errors appeared

## Automated Verification

```bash
npx prettier --check css/tokens.css css/themes.css js/widgets/status.js
npm run lint
npm test
```

* `npm run lint` completed with existing repository warnings only; no new lint errors introduced
* `npm test` passed successfully (156 suites, 5187 tests)
<img width="1026" height="310" alt="Screenshot 2026-05-16 092633" src="https://github.com/user-attachments/assets/e2307d4c-3858-4b55-bfd8-aa0cb16b1cd5" />


## Screenshots / Recording

Attached:

* Status widget in light/default theme
* Status widget in dark theme
* Status widget in high-contrast theme

https://github.com/user-attachments/assets/3f4a1f12-fb3c-4c87-b1bd-93c92e814a28



## Notes

The working tree already contained unrelated generated `dist/` changes, which were intentionally excluded from this PR.

## **Files Included**

* `css/tokens.css`
* `css/themes.css`
* `js/widgets/status.js`
