### PR TITLE
test: fix LocalCard debounce timer regression in renameProject test

### DIFF
--- a/planet/js/__tests__/LocalCard.test.js
+++ b/planet/js/__tests__/LocalCard.test.js
@@ -220,14 +220,17 @@ describe("LocalCard", () => {
         });
 
         it("should call renameProject when the name input changes", () => {
+            jest.useFakeTimers();
             const card = prepareCard("p11");
             card.render();
 
             const input = document.getElementById("local-project-input-p11");
             input.value = "New Name";
             input.dispatchEvent(new Event("input"));
+            jest.advanceTimersByTime(400);
 
             expect(planet.ProjectStorage.renameProject).toHaveBeenCalledWith("p11", "New Name");
+            jest.useRealTimers();
         });
 
         it("should show the cloud icon and call forceAddToCache when PublishedData exists", () => {


### PR DESCRIPTION
## Summary

This fixes a failing `LocalCard.test.js` test that surfaced on upstream master after the debounce optimization added in #7292.

The rename input listener in `LocalCard.js` now delays `Planet.ProjectStorage.renameProject()` using a `400ms` debounce timer to reduce repeated IndexedDB writes while typing. However, the existing test still expected the callback to execute synchronously immediately after dispatching the `input` event.

Because of that, the assertion now runs before the debounced callback executes, causing the upstream test failure:

```txt
Expected: "p11", "New Name"
Received calls: 0
```

## Changes

* Added `jest.useFakeTimers()`
* Advanced timers using `jest.advanceTimersByTime(400)`
* Restored real timers after assertion

## Why this fix

The production behavior is correct after the debounce optimization. The issue was the test still assuming synchronous execution.

This update aligns the test with the current debounced rename behavior and restores passing CI on upstream master.

## PR Category

- [x] Tests
