### PR TITLE
Refactor/tuner css tokens

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -1,3 +1,5 @@
+@import url("tokens.css");
+
 /* Theme DropDown Styling */
 
 #themedropdown {

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,52 @@
+/**
+ * MusicBlocks v3.4.1
+ *
+ * @author Walter Bender
+ *
+ * @copyright 2026 Walter Bender
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MusicBlocks Design Tokens
+ *
+ * Single source of truth for theme-aware CSS custom properties.
+ * Light-theme values are set on :root; dark and high-contrast
+ * values are overridden via body class.
+ *
+ * Usage in JS:
+ *   element.style.backgroundColor = "var(--mb-selector-bg)"
+ *
+ * Refs: js/utils/platformstyle.js (platformThemes)
+ */
+
+/* Light theme (default) */
+:root {
+    --mb-selector-bg: #8cc6ff;
+    --mb-selector-selected: #1a8cff;
+}
+
+/* Dark theme */
+body.dark {
+    --mb-selector-bg: #64b5f6;
+    --mb-selector-selected: #1e88e5;
+}
+
+/* High contrast theme */
+body.highcontrast {
+    --mb-selector-bg: #00ffff;
+    --mb-selector-selected: #00cccc;
+}

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -37,16 +37,19 @@
 :root {
     --mb-selector-bg: #8cc6ff;
     --mb-selector-selected: #1a8cff;
+    --mb-text-color: black;
 }
 
 /* Dark theme */
 body.dark {
     --mb-selector-bg: #64b5f6;
     --mb-selector-selected: #1e88e5;
+    --mb-text-color: #e2e2e2;
 }
 
 /* High contrast theme */
 body.highcontrast {
     --mb-selector-bg: #00ffff;
     --mb-selector-selected: #00cccc;
+    --mb-text-color: #ffffff;
 }

--- a/js/widgets/__tests__/tuner.test.js
+++ b/js/widgets/__tests__/tuner.test.js
@@ -20,9 +20,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-global.platformColor = {
-    selectorBackground: "#8bc34a"
+const cssTokens = {
+    "--mb-selector-bg": "#8bc34a",
+    "--mb-text-color": "#111111"
 };
+
+global.getComputedStyle = jest.fn().mockReturnValue({
+    getPropertyValue: property => cssTokens[property] || ""
+});
 
 const createMockElement = tagName => ({
     style: {},
@@ -37,6 +42,7 @@ const createMockElement = tagName => ({
 });
 
 global.document = {
+    body: {},
     createElement: jest.fn().mockImplementation(tagName => {
         const element = createMockElement(tagName);
         if (tagName === "canvas") {

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -33,6 +33,7 @@ class StatusMatrix {
         this.isOpen = true;
         this.isMaximized = false;
         this._cellScale = window.innerWidth / 1200;
+        const selectorBg = "var(--mb-selector-bg)";
         let iconSize = StatusMatrix.ICONSIZE * this._cellScale;
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "status", "status");
@@ -178,14 +179,14 @@ class StatusMatrix {
             b.textContent = str;
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
-            cell.style.backgroundColor = platformColor.selectorBackground;
+            cell.style.backgroundColor = selectorBg;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
                     continue;
                 }
                 cell = row.insertCell();
-                cell.style.backgroundColor = platformColor.selectorBackground;
+                cell.style.backgroundColor = selectorBg;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";
@@ -206,14 +207,14 @@ class StatusMatrix {
             b.textContent = label;
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
-            cell.style.backgroundColor = platformColor.selectorBackground;
+            cell.style.backgroundColor = selectorBg;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
                     continue;
                 }
                 cell = row.insertCell();
-                cell.style.backgroundColor = platformColor.selectorBackground;
+                cell.style.backgroundColor = selectorBg;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";

--- a/js/widgets/tuner.js
+++ b/js/widgets/tuner.js
@@ -99,13 +99,15 @@ function TunerDisplay(canvas, width, height) {
  * Updates the styles of mode toggle buttons based on current mode
  */
 TunerDisplay.prototype.updateButtonStyles = function () {
+    const selectorBg = getComputedStyle(document.body).getPropertyValue("--mb-selector-bg").trim();
+
     if (this.chromaticMode) {
-        this.chromaticButton.style.backgroundColor = platformColor.selectorBackground;
+        this.chromaticButton.style.backgroundColor = selectorBg;
         this.chromaticButton.querySelector("img").style.filter = "brightness(0) invert(1)";
         this.targetPitchButton.style.backgroundColor = "transparent";
         this.targetPitchButton.querySelector("img").style.filter = "none";
     } else {
-        this.targetPitchButton.style.backgroundColor = platformColor.selectorBackground;
+        this.targetPitchButton.style.backgroundColor = selectorBg;
         this.targetPitchButton.querySelector("img").style.filter = "brightness(0) invert(1)";
         this.chromaticButton.style.backgroundColor = "transparent";
         this.chromaticButton.querySelector("img").style.filter = "none";
@@ -132,6 +134,10 @@ TunerDisplay.prototype.draw = function () {
     const ctx = this.ctx;
     const width = this.width;
     const height = this.height;
+    const selectorBg =
+        getComputedStyle(document.body).getPropertyValue("--mb-selector-bg").trim() || "#e0e0e0";
+    const textColor =
+        getComputedStyle(document.body).getPropertyValue("--mb-text-color").trim() || "#000000";
 
     // Clear the canvas
     ctx.clearRect(0, 0, width, height);
@@ -143,11 +149,11 @@ TunerDisplay.prototype.draw = function () {
     const meterY = height - 80; // Base position of meter
 
     // Draw the tuning meter background
-    ctx.fillStyle = platformColor.selectorBackground || "#e0e0e0";
+    ctx.fillStyle = selectorBg;
     ctx.fillRect(meterX, meterY, meterWidth, meterHeight);
 
     // Draw the center line
-    ctx.fillStyle = platformColor.textColor || "#000000";
+    ctx.fillStyle = textColor;
     ctx.fillRect(meterX + meterWidth / 2 - 1, meterY, 2, meterHeight);
 
     // Draw the indicator
@@ -159,7 +165,7 @@ TunerDisplay.prototype.draw = function () {
     // Draw the note
     ctx.font = "bold 48px Arial";
     ctx.textAlign = "center";
-    ctx.fillStyle = platformColor.textColor || "#000000";
+    ctx.fillStyle = textColor;
     ctx.fillText(this.note, width / 2, height - 200); // Much lower position
 
     // Draw the cents deviation


### PR DESCRIPTION
## PR Category

## PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Depends on: [7364](https://github.com/sugarlabs/musicblocks/pull/7364)

Closes #6606 (partial)

## Summary

This PR continues the CSS token migration started in `refactor/status-css-tokens`.

### Changes

* Added `--mb-text-color` to `css/tokens.css` for light, dark, and high-contrast themes
* Updated `js/widgets/tuner.js` to read tuner selector/text colors from CSS custom properties via `getComputedStyle()`
* Updated tuner unit test setup to mock CSS token values instead of `platformColor`

This removes the tuner widget’s dependency on `platformColor` and allows tuner selector/text styling to follow the active theme dynamically.

## Verification

### Manual Verification

Verified CSS token resolution directly in the browser console:

<img width="917" height="222" alt="Screenshot 2026-05-16 131705" src="https://github.com/user-attachments/assets/52d0e11e-2a66-4fcc-a10b-21f5566e2571" />
<img width="741" height="237" alt="Screenshot 2026-05-16 131915" src="https://github.com/user-attachments/assets/cc2376f2-c048-46a2-940b-c220c82d4391" />
<img width="920" height="548" alt="Screenshot 2026-05-16 131926" src="https://github.com/user-attachments/assets/d0cd02b7-b017-4012-99ee-fba86c41f108" />

* Confirmed `js/widgets/tuner.js` no longer references `platformColor`
* Confirmed tuner source uses:

  * `--mb-selector-bg`
  * `--mb-text-color`
* Confirmed token values resolve correctly across:

  * light/default theme
  * dark theme
  * high-contrast theme

Example verification output:

* Light/default:

  * selectorBg: `#8cc6ff`
  * textColor: `black`
* Dark:

  * selectorBg: `#64b5f6`
  * textColor: `#e2e2e2`
* High contrast:

  * selectorBg: `#00ffff`
  * textColor: `#ffffff`

Confirmed no relevant browser console errors appeared during testing.

### Automated Verification

```bash
grep platformColor js/widgets/tuner.js
npx prettier --check css/tokens.css js/widgets/tuner.js js/widgets/__tests__/tuner.test.js
npm test
npm run lint
```
<img width="760" height="186" alt="Screenshot 2026-05-16 132650" src="https://github.com/user-attachments/assets/5acf451c-693d-449e-bfa7-f2657b6415eb" />

* `grep platformColor js/widgets/tuner.js` returns no matches
* `npm test` passed successfully
* `npm run lint` completed with existing repository warnings only; no new lint errors introduced

## Notes

This PR depends on the earlier token infrastructure introduced in `refactor/status-css-tokens`.

Once the earlier PR is merged, this PR can be rebased/retargeted cleanly onto `master`.
