### PR TITLE
test: add negative assertion to validate debounce delay in LocalCard test

### DIFF
--- a/planet/js/__tests__/LocalCard.test.js
+++ b/planet/js/__tests__/LocalCard.test.js
@@ -219,7 +219,7 @@ describe("LocalCard", () => {
             expect(planet.LocalPlanet.Publisher.open).toHaveBeenCalledWith("p10");
         });
 
-        it("should call renameProject when the name input changes", () => {
+        it("should call renameProject when the name input changes (after debounce)", () => {
             jest.useFakeTimers();
             const card = prepareCard("p11");
             card.render();
@@ -227,6 +227,9 @@ describe("LocalCard", () => {
             const input = document.getElementById("local-project-input-p11");
             input.value = "New Name";
             input.dispatchEvent(new Event("input"));
+
+            expect(planet.ProjectStorage.renameProject).not.toHaveBeenCalled();
+
             jest.advanceTimersByTime(400);
 
             expect(planet.ProjectStorage.renameProject).toHaveBeenCalledWith("p11", "New Name");


### PR DESCRIPTION
With #7365 merged to resolve the basic timer regression, this PR adds a negative assertion (`not.toHaveBeenCalled()`) before the clock is advanced. 

Without this check, the test would still pass even if the debounce mechanism gets broken in the future and runs synchronously. This ensures we actually verify the delay itself.

## PR Category
- [x] Tests
- [ ] Bug Fix
- [ ] Performance
- [ ] Documentation