### PR TITLE
feat: add CSS design token system (WIP - activities.css audit complete )

### DIFF
--- a/audit-notes.md
+++ b/audit-notes.md
@@ -1,0 +1,107 @@
+# Design Token Audit
+
+This document tracks all hardcoded color values found across styling
+sources, as part of the CSS design token migration.
+
+## Status
+
+| File                        | Audited        | Tokens Mapped  |
+| --------------------------- | -------------- | -------------- |
+| css/activities.css          | ✅ Done        | ✅ Done        |
+| css/themes.css              | 🔄 In progress | 🔄 In progress |
+| js/utils/platformstyle.js   | ⏳ Pending     | ⏳ Pending     |
+| dist/css/windows.css        | ⏳ Pending     | ⏳ Pending     |
+| planet/css/planetThemes.css | ⏳ Pending     | ⏳ Pending     |
+
+## css/activities.css
+
+| LINE | VALUE     | CONTEXT                        | TOKEN                                |
+| ---- | --------- | ------------------------------ | ------------------------------------ |
+| 22   | #0066ff   | focus ring outline             | --color-blue-btn                     |
+| 28   | #fff      | search box bg (light)          | --color-dialogue-box                 |
+| 29   | #000      | search text (light)            | --color-text                         |
+| 33   | #ddd      | autocomplete hover             | --color-hover                        |
+| 37   | #f9f9f9   | search div bg (light)          | --color-background                   |
+| 42   | #000000   | ui-menu bg (highcontrast)      | --color-background                   |
+| 43   | #ffffff   | ui-menu border (highcontrast)  | --color-rule                         |
+| 47   | #ffffff   | menu item text (highcontrast)  | --color-text                         |
+| 52   | #333333   | menu item hover (highcontrast) | --color-hover                        |
+| 53   | #00ffff   | menu hover text (highcontrast) | --color-blue-btn                     |
+| 58   | #fff      | newdropdown bg                 | --color-dialogue-box                 |
+| 59   | #cccccc   | newdropdown border             | --color-rule                         |
+| 60   | #000000   | newdropdown text               | --color-text                         |
+| 91   | #0066ff   | new-project-title color        | --color-blue-btn                     |
+| 107  | #fff      | modalBox bg                    | --color-dialogue-box                 |
+| 115  | #0066ff   | modal-title color              | --color-blue-btn                     |
+| 137  | #0066ff   | confirm button bg              | --color-blue-btn                     |
+| 144  | #023a76   | confirm button hover bg        | --color-blue-btn-hover               |
+| 154  | #e0e0e0   | cancel button bg               | --color-cancel-btn                   |
+| 159  | #afafaf   | cancel button hover bg         | --color-cancel-btn-hover             |
+| 181  | #fefefe   | modal-content bg               | --color-dialogue-box                 |
+| 191  | #ccc      | block-count-dropdown border    | --color-rule                         |
+| 193  | #dedededd | block-count-dropdown bg        | --color-hover                        |
+| 211  | #aaa      | close button color             | --color-label                        |
+| 230  | #ffffff   | search input bg                | --color-dialogue-box                 |
+| 231  | #03a9f4   | search input border            | --color-header                       |
+| 240  | #4da6ff   | search focus border            | --color-aux                          |
+| 252  | #f0f0f0   | helpfulSearchDiv bg            | --color-background                   |
+| 254  | #ccc      | helpfulSearchDiv border        | --color-rule                         |
+| 286  | #87cefa   | trash-view border              | --color-sub                          |
+| 301  | #2196f3   | button-container bg            | --color-header                       |
+| 304  | #d9d9d9   | button-container border-bottom | --color-rule                         |
+| 315  | #d9d9d9   | trash-item hover bg            | --color-rule                         |
+| 350  | #87cefa   | ui-menu border                 | --color-sub                          |
+| 381  | #d0d3d4   | ui-id-1 hover bg               | --color-cancel-btn                   |
+| 385  | #d0d3d4   | ui-state-focus bg              | --color-cancel-btn                   |
+| 400  | #92b5c8   | myProgress bg                  | --color-aux                          |
+| 407  | #ffffff   | myBar bg                       | --color-dialogue-box                 |
+| 429  | #fff      | load-container bg              | --color-dialogue-box                 |
+| 483  | #444      | popdown-palette h3 border      | --color-rule                         |
+| 515  | #4682b4   | div.back bg                    | --color-header                       |
+| 547  | #8bc34a   | nav bg                         | --color-header                       |
+| 638  | #96d3f3   | thumbnail bg                   | --color-highlight ← NEW TOKEN        |
+| 651  | #fff      | planet-iframe bg               | --color-dialogue-box                 |
+| 682  | #92b5c8   | body bg                        | --color-aux                          |
+| 700  | #88e20a   | select bg                      | --color-active-indicator ← NEW TOKEN |
+| 710  | #fff      | input.input bg                 | --color-dialogue-box                 |
+| 721  | #ff5942   | input.text bg                  | --color-input-text ← NEW TOKEN       |
+| 731  | #c96df3   | input.boolean bg               | --color-input-boolean ← NEW TOKEN    |
+| 742  | #ff5293   | input.number bg                | --color-input-number ← NEW TOKEN     |
+| 754  | #8cc6ff   | input.musicratio bg            | --color-sub                          |
+| 766  | #8cc6ff   | input.BPMInput bg              | --color-sub                          |
+| 1163 | #2196f3   | top-wrapper bg                 | --color-header                       |
+| 1168 | #fff      | top-wrapper color              | --color-dialogue-box                 |
+| 1253 | #2196F3   | helpBodyDiv link color         | --color-header                       |
+| 1260 | #2b8be5   | helpBodyDiv link hover         | --color-aux                          |
+| 1399 | #8cc6ff   | timbreName input bg            | --color-sub                          |
+| 1456 | #8cc6ff   | popupMsg bg                    | --color-sub                          |
+| 1592 | #000031   | slider thumb shadow            | --color-shadow ← NEW TOKEN           |
+| 1593 | #00001e   | slider thumb border            | --color-shadow                       |
+| 1603 | #000031   | slider thumb shadow (moz)      | --color-shadow                       |
+| 1604 | #00001e   | slider thumb border (moz)      | --color-shadow                       |
+| 1652 | #4caf50   | progressBar bg                 | --color-active-indicator             |
+| 1690 | #90c100   | btn bg                         | --color-active-indicator             |
+| 1694 | #90c100   | btn border                     | --color-active-indicator             |
+| 1702 | #fff      | circle text color              | --color-dialogue-box                 |
+| 1705 | #000      | circle bg                      | --color-text                         |
+| 1726 | #c8c8c8   | rangeslidervalue bg            | --color-rhythm-cell                  |
+| 1786 | #222      | slider label color             | --color-text                         |
+| 1787 | #555      | slider label text-shadow       | --color-label                        |
+| 1800 | #222      | same as above                  | --color-text                         |
+| 1801 | #555      | same as above                  | --color-label                        |
+| 1814 | #222      | same as above                  | --color-text                         |
+| 1815 | #555      | same as above                  | --color-label                        |
+| 1903 | #f2f2f2   | chooseKeyDiv bg                | --color-background                   |
+| 1919 | #f2f2f2   | movable bg                     | --color-background                   |
+| 1963 | #8cc6ff   | popupMsg bg                    | --color-sub                          |
+| 2004 | #000000   | errorText color                | --color-text                         |
+| 2075 | #000      | link color                     | --color-text                         |
+| 2079 | #033cd2   | color-change fill              | --color-blue-btn                     |
+| 2080 | #78e600   | color-change stroke            | --color-active-indicator             |
+| 2089 | #1e88e5   | persistentNotification bg      | --color-header                       |
+| 2113 | #ccc      | chatLog border                 | --color-rule                         |
+| 2136 | #dfdfdf   | message-container bg           | --color-hover                        |
+| 2137 | #000      | message-container text         | --color-text                         |
+| 2149 | #dcf8c6   | user message bg                | --color-chat-user ← NEW TOKEN        |
+| 2154 | #ff0000   | lego-brick bg                  | --color-trash-active                 |
+| 2155 | #880000   | lego-brick border              | --color-trash-active                 |

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,188 @@
+/* ============================================
+   css/tokens.css
+   
+   Single source of truth for all theme colors.
+   
+   Usage:
+     color: var(--color-text);
+     background: var(--color-background);
+   
+   To add a new token:
+     1. Add it under :root for the light value
+     2. Add the dark override under body.dark
+     3. Add the highcontrast override under body.highcontrast
+   ============================================ */
+
+/* ── LIGHT THEME (default) ── */
+:root,
+body.light {
+    /* Text */
+    --color-text: black;
+    --color-block-text: #282828;
+    --color-label: #a0a0a0;
+
+    /* Backgrounds */
+    --color-background: #f9f9f9;
+    --color-dialogue-box: #ffffff;
+    --color-hover: #e0e0e0;
+
+    /* Buttons */
+    --color-blue-btn: #0066ff;
+    --color-blue-btn-hover: #023a76;
+    --color-cancel-btn: #e0e0e0;
+    --color-cancel-btn-hover: #afafaf;
+
+    /* Borders / Rules */
+    --color-rule: #e2e2e2;
+
+    /* Header / Nav */
+    --color-header: #2196f3;
+    --color-aux: #1a8cff;
+    --color-sub: #8cc6ff;
+
+    /* Palette */
+    --color-palette-bg: #ffffff;
+    --color-palette-selected: #f3f3f3;
+    --color-palette-label-bg: #8cc6ff;
+    --color-palette-label-selected: #1a8cff;
+    --color-palette-text: #666666;
+
+    /* Widget */
+    --color-widget-bg: #cccccc;
+    --color-widget-btn: #8cc6ff;
+    --color-widget-btn-select: #c8c8c8;
+
+    /* Selector */
+    --color-selector-bg: #8cc6ff;
+    --color-selector-selected: #1a8cff;
+
+    /* Trash */
+    --color-trash: #c0c0c0;
+    --color-trash-border: #808080;
+    --color-trash-active: #ff0000;
+
+    /* Misc */
+    --color-ruler-highlight: #ffbf00;
+    --color-rhythm-cell: #c8c8c8;
+    --color-stop-icon: #ea174c;
+    --color-hit-area: #ffffff;
+    --color-orange: #e37a00;
+    --color-disconnected: #c4c4c4;
+
+    /* Block input types */
+    --color-input-text: #ff5942;
+    --color-input-boolean: #c96df3;
+    --color-input-number: #ff5293;
+
+    /* Misc UI */
+    --color-highlight: #96d3f3;
+    --color-active-indicator: #88e20a;
+    --color-shadow: #000031;
+    --color-chat-user: #dcf8c6;
+}
+
+/* ── DARK THEME ── */
+body.dark {
+    /* Text */
+    --color-text: #e2e2e2;
+    --color-block-text: #ffffff;
+    --color-label: #bdbdbd;
+
+    /* Backgrounds */
+    --color-background: #303030;
+    --color-dialogue-box: #1c1c1c;
+    --color-hover: #808080;
+
+    /* Header / Nav */
+    --color-header: #1e88e5;
+    --color-aux: #1976d2;
+    --color-sub: #64b5f6;
+
+    /* Borders */
+    --color-rule: #303030;
+
+    /* Palette */
+    --color-palette-bg: #1c1c1c;
+    --color-palette-selected: #1e1e1e;
+    --color-palette-label-bg: #022363;
+    --color-palette-label-selected: #01143b;
+    --color-palette-text: #bdbdbd;
+
+    /* Widget */
+    --color-widget-bg: #454545;
+    --color-widget-btn: #225a91;
+    --color-widget-btn-select: #979797;
+
+    /* Selector */
+    --color-selector-bg: #64b5f6;
+    --color-selector-selected: #1e88e5;
+
+    /* Trash */
+    --color-trash: #757575;
+    --color-trash-border: #424242;
+    --color-trash-active: #e53935;
+
+    /* Misc */
+    --color-ruler-highlight: #ffeb3b;
+    --color-rhythm-cell: #303030;
+    --color-stop-icon: #d50000;
+    --color-hit-area: #121212;
+    --color-orange: #fb8c00;
+    --color-disconnected: #5c5c5c;
+}
+
+/* ── HIGH CONTRAST THEME ── */
+body.highcontrast {
+    /* Text */
+    --color-text: #ffffff;
+    --color-block-text: #000000;
+    --color-label: #ffffff;
+
+    /* Backgrounds */
+    --color-background: #000000;
+    --color-dialogue-box: #000000;
+    --color-hover: #666666;
+
+    /* Buttons */
+    --color-blue-btn: #00ffff;
+    --color-blue-btn-hover: #00cccc;
+    --color-cancel-btn: #ffffff;
+    --color-cancel-btn-hover: #cccccc;
+
+    /* Header */
+    --color-header: #00ffff;
+    --color-aux: #00cccc;
+    --color-sub: #00ffff;
+
+    /* Borders */
+    --color-rule: #ffffff;
+
+    /* Palette */
+    --color-palette-bg: #000000;
+    --color-palette-selected: #111111;
+    --color-palette-label-bg: #000080;
+    --color-palette-label-selected: #0000ff;
+    --color-palette-text: #ffffff;
+
+    /* Widget */
+    --color-widget-bg: #000000;
+    --color-widget-btn: #00ffff;
+    --color-widget-btn-select: #ffffff;
+
+    /* Selector */
+    --color-selector-bg: #00ffff;
+    --color-selector-selected: #00cccc;
+
+    /* Trash */
+    --color-trash: #ffffff;
+    --color-trash-border: #ffffff;
+    --color-trash-active: #ff0000;
+
+    /* Misc */
+    --color-ruler-highlight: #ffff00;
+    --color-rhythm-cell: #333333;
+    --color-stop-icon: #ff0000;
+    --color-hit-area: #000000;
+    --color-orange: #ff8800;
+    --color-disconnected: #666666;
+}

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
                 this.rel = 'stylesheet';
             "
         />
+        <link rel="stylesheet" href="css/tokens.css" />
         <!-- NOTE: The exact query-string URL here must be listed in sw.js `precacheFiles`.
          If you change `?v=fixed` (or remove/add a query param), update sw.js so offline still works. -->
         <link
@@ -115,7 +116,10 @@
             rel="preload"
             href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css"
             as="style"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript
             ><link
@@ -136,7 +140,10 @@
             as="style"
             integrity="sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07"
             crossorigin="anonymous"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript
             ><link
@@ -178,7 +185,10 @@
             rel="preload"
             href="css/themes.css?v=fixed"
             as="style"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript><link rel="stylesheet" href="css/themes.css?v=fixed" /></noscript>
         <script>
@@ -260,13 +270,7 @@
             ></canvas>
 
             <!--hidden at the beginning whilst everything loads-->
-            <div
-                class="popupMsg"
-                id="printText"
-                tabindex="-1"
-                aria-live="polite"
-                role="status"
-            >
+            <div class="popupMsg" id="printText" tabindex="-1" aria-live="polite" role="status">
                 <div class="contentWrapper">
                     <span id="printTextContent"></span>
                     <img
@@ -277,13 +281,7 @@
                     />
                 </div>
             </div>
-            <div
-                class="popupMsg"
-                id="errorText"
-                tabindex="-1"
-                aria-live="assertive"
-                role="alert"
-            >
+            <div class="popupMsg" id="errorText" tabindex="-1" aria-live="assertive" role="alert">
                 <div class="contentWrapper">
                     <span id="errorTextContent"></span>
                     <img
@@ -1169,7 +1167,10 @@
                             e.preventDefault(); // prevent default <a> behavior
                             const selectedLang = this.id; // ID corresponds to language code
                             const currentLang = readStorage("languagePreference");
-                            if (currentLang !== selectedLang && writeStorage("languagePreference", selectedLang)) {
+                            if (
+                                currentLang !== selectedLang &&
+                                writeStorage("languagePreference", selectedLang)
+                            ) {
                                 location.reload(); // automatically reload
                             }
                         });
@@ -1306,7 +1307,7 @@
 
                 iconCode.textContent = isFullscreen ? "\ue5d1" : "\ue5d0";
 
-                if (fullScreenBtn && typeof _ === 'function') {
+                if (fullScreenBtn && typeof _ === "function") {
                     var tooltipText = isFullscreen ? _("Exit Fullscreen") : _("Enter Fullscreen");
                     fullScreenBtn.setAttribute("data-tooltip", tooltipText);
                     if (window.jQuery) {


### PR DESCRIPTION
## PR Category
- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation

## Summary

Closes #6606 (partial)

Started working on the design token modernisation for MusicBlocks. This is the first step — audited `css/activities.css` and introduced `css/tokens.css` as the centralized CSS custom property token file covering light, dark, and highcontrast themes.

## Changes

- Audit css/activities.css and map all hardcoded hex values to token names
- Added `css/tokens.css` with CSS custom properties for all three themes (`body.light`, `body.dark`, `body.highcontrast`)
- Linked `css/tokens.css` in `index.html` as a blocking stylesheet
- Added `audit-notes.md` documenting all hardcoded hex values found in `css/activities.css` mapped to their token names

## Next Steps

- Replace all hardcoded hex values in `css/activities.css` with `var(--token-name)` references
- Audit and migrate `css/themes.css`, `dist/css/windows.css`, `js/utils/platformstyle.js`, `planet/css/planetThemes.css`
- Fix theme switching to work without page reload by replacing `location.reload()` with body class toggle
- Refactor inline `element.style.*` color assignments in widget JS files
- Accessibility fixes — restore focus indicators and verify WCAG AA contrast

--- 

### Testing

```
Test Suites: 151 passed, 1 failed, 152 total  
Tests:       5003 passed, 1 failed, 5004 total  
```

--- 

### Checklist

* ✔ Code follows the project's style guidelines
* ✔ Self-review of code completed
* ✔ Changes generate no new warnings
* ✔ Commit message follows conventional commit format
* ✔ Issue linked and addressed

---

### Thank You