### PR TITLE
fix: make widget window controls keyboard accessible

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -242,6 +242,56 @@ describe("widgetWindows", () => {
         });
     });
 
+    describe("window control keyboard handling", () => {
+        test("Enter activates the close button", () => {
+            const win = createTestWindow();
+            const closeButton = win._drag.querySelector(".close");
+            const spy = jest.fn();
+            win.onclose = spy;
+
+            closeButton.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: "Enter",
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        test("Space activates the roll-up button", () => {
+            const win = createTestWindow();
+
+            win._rollButton.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: " ",
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+
+            expect(win._rolled).toBe(true);
+            expect(win._rollButton.classList.contains("plus")).toBe(true);
+        });
+
+        test("Enter activates the maximize button", () => {
+            const win = createTestWindow();
+            const maxminButton = win._nonclosebuttons.querySelector(".wftMaxmin");
+
+            maxminButton.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: "Enter",
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+
+            expect(win._maximized).toBe(true);
+            expect(win._maxminIcon.getAttribute("src")).toBe("header-icons/icon-contract.svg");
+        });
+    });
+
     describe("addButton", () => {
         test("returns a div element with wfbtItem class", () => {
             const win = createTestWindow();

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -196,6 +196,16 @@ class WidgetWindow {
 
     /**
      * @private
+     * @param {KeyboardEvent} e
+     * @param {Function} handler
+     */
+    _handleButtonKeydown(e, handler) {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        handler(e);
+    }
+
+    /**
+     * @private
      * @returns {void}
      */
     _createUIelements() {
@@ -220,11 +230,13 @@ class WidgetWindow {
         closeButton.setAttribute("role", "button");
         closeButton.setAttribute("aria-label", _("Close window"));
         closeButton.setAttribute("tabindex", "0");
-        closeButton.onclick = e => {
+        const closeWindow = e => {
             this.onclose();
             e.preventDefault();
             e.stopPropagation();
         };
+        closeButton.onclick = closeWindow;
+        closeButton.onkeydown = e => this._handleButtonKeydown(e, closeWindow);
 
         this._nonclose = this._create("div", "nonclose", this._drag);
         this._nonclose.style.display = "flex";
@@ -268,7 +280,7 @@ class WidgetWindow {
         rollButton.setAttribute("role", "button");
         rollButton.setAttribute("aria-label", _("Roll up window"));
         rollButton.setAttribute("tabindex", "0");
-        rollButton.onclick = e => {
+        const toggleRollup = e => {
             if (this._rolled) {
                 this.unroll();
             } else {
@@ -282,13 +294,15 @@ class WidgetWindow {
             e.preventDefault();
             e.stopPropagation();
         };
+        rollButton.onclick = toggleRollup;
+        rollButton.onkeydown = e => this._handleButtonKeydown(e, toggleRollup);
 
         if (this._fullscreenEnabled) {
             const maxminButton = this._create("div", "wftButton wftMaxmin", this._nonclosebuttons);
             maxminButton.setAttribute("role", "button");
             maxminButton.setAttribute("aria-label", _("Maximize window"));
             maxminButton.setAttribute("tabindex", "0");
-            maxminButton.onclick = e => {
+            const toggleMaximize = e => {
                 if (this._maximized) {
                     this._restore();
                     this.sendToCenter();
@@ -300,6 +314,8 @@ class WidgetWindow {
                 e.preventDefault();
                 e.stopImmediatePropagation();
             };
+            maxminButton.onclick = toggleMaximize;
+            maxminButton.onkeydown = e => this._handleButtonKeydown(e, toggleMaximize);
             this._maxminIcon = this._create("img", undefined, maxminButton);
             this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
         }


### PR DESCRIPTION
## Summary
This PR makes the widget window controls keyboard-accessible.

Changes made:
- Added a `_handleButtonKeydown` helper in `WidgetWindow`
- Connected the close button to activate on `Enter` and `Space`
- Connected the roll-up/minimize button to activate on `Enter` and `Space`
- Connected the maximize/restore button to activate on `Enter` and `Space`
- Added Jest tests covering keyboard activation for close, roll-up, and maximize controls

## Why
The widget window controls are implemented as `div` elements with `role="button"` and `tabindex="0"`. This makes them focusable and exposes them as buttons to assistive technologies, but they previously only responded to mouse clicks. Custom button-like elements should also support keyboard activation with `Enter` and `Space`.

## Testing
- `npx.cmd jest js/widgets/__tests__/widgetWindows.test.js --runInBand --coverage=false`
- `npx.cmd prettier --check js/widgets/widgetWindows.js js/widgets/__tests__/widgetWindows.test.js`
- `npm.cmd run lint`

### PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation