### PR TITLE
fix: Prevent whole-page zoom and implement pinch-to-zoom on blocks canvas

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2250,6 +2250,7 @@ class Activity {
                 [null, null],
                 [null, null]
             ]; // Array to track two fingers (Y and X coordinates)
+            let initialPinchDistance = null;
 
             /**
              * Handles touch start event on the canvas.
@@ -2263,10 +2264,15 @@ class Activity {
                             initialTouches[i][0] = event.touches[i].clientY;
                             initialTouches[i][1] = event.touches[i].clientX;
                         }
+                        const dx = event.touches[0].clientX - event.touches[1].clientX;
+                        const dy = event.touches[0].clientY - event.touches[1].clientY;
+                        initialPinchDistance = Math.hypot(dx, dy);
                     }
                 },
                 { passive: true }
             );
+
+            myCanvas.style.touchAction = "none";
 
             /**
              * Handles touch move event on the canvas.
@@ -2276,6 +2282,23 @@ class Activity {
                 "touchmove",
                 event => {
                     if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const dx = event.touches[0].clientX - event.touches[1].clientX;
+                        const dy = event.touches[0].clientY - event.touches[1].clientY;
+                        const currentPinchDistance = Math.hypot(dx, dy);
+
+                        if (initialPinchDistance !== null && !that.resizeDebounce) {
+                            const pinchDelta = currentPinchDistance - initialPinchDistance;
+                            if (Math.abs(pinchDelta) > 20) {
+                                if (pinchDelta > 0) {
+                                    doLargerBlocks(that);
+                                } else {
+                                    doSmallerBlocks(that);
+                                }
+                                initialPinchDistance = currentPinchDistance;
+                            }
+                        }
+
                         let totalDeltaY = 0;
                         let totalDeltaX = 0;
                         let count = 0;
@@ -2312,7 +2335,7 @@ class Activity {
                         that.refreshCanvas();
                     }
                 },
-                { passive: true }
+                { passive: false }
             );
 
             /**
@@ -2323,6 +2346,7 @@ class Activity {
                     initialTouches[i][0] = null;
                     initialTouches[i][1] = null;
                 }
+                initialPinchDistance = null;
             });
 
             /**


### PR DESCRIPTION
#### **What does this PR do?**
This PR implements native pinch-to-zoom functionality on the main blocks canvas for touch devices, making the workspace significantly more mobile-friendly. Crucially, it resolves a known issue where pinching on touch devices would scale the entire browser UI (menus, toolbars, etc.) instead of properly zooming the block elements on the canvas. 

#### **How was this implemented?**
1. Modified `_setupBlocksContainerEvents` in activity.js.
2. Changed the `touchmove` event listener options to `{ passive: false }` so that `event.preventDefault()` can be safely called to halt the browser's default pinch-to-zoom behavior on the viewport.
3. Implemented a Euclidean distance calculator (`Math.hypot`) between `event.touches[0]` and `event.touches[1]` to manage delta changes.
4. Triggers `doLargerBlocks()` and `doSmallerBlocks()` internally when fingers pinch inward or outward respectively.

#### **How to test / verify?**
1. Run `npm run dev` or `npm run serve:dev` locally.
2. DEMO:  [Link to Demo Video](https://drive.google.com/file/d/1JPPIZJ-F1Z5vmMYhxb7IcDxsWGVlOQV3/view?usp=sharing)
3. Pinch inward on the blocks canvas. The blocks should get smaller.
4. Pinch outward on the blocks canvas. The blocks should get larger.
5. Watch the top menus or toolbar. The actual browser page should **not** zoom.

#### **Checklist**
- [x] Bug Fix
- [x] I have read CONTRIBUTING.md.
- [x] I ran `npm run lint` and resolved all errors related to my changes.
- [x] I ran `npx prettier --check .` (Formatting passes).
- [x] I ran `npm test` and no tests were broken.
- [x] My changes are narrowly scoped to fixing this exact problem.
- [x] PR title follows conventional commits (`fix: ...`, `feat: ...`, etc.).