### PR TITLE
fix: replace mouse-only handlers with Pointer Events in widgets

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1003,7 +1003,10 @@ describe("PhraseMaker Widget", () => {
                         removeEventListener: jest.fn(),
                         getAttribute: jest.fn(() => 1)
                     }
-                ]
+                ],
+                parentElement: {
+                    addEventListener: jest.fn()
+                }
             }
         ];
 

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -553,8 +553,7 @@ describe("TemperamentWidget basic tests", () => {
                 appendChild: jest.fn(),
                 setAttribute: jest.fn(),
                 style: {},
-                onmouseover: jest.fn(),
-                onmouseout: jest.fn()
+                addEventListener: jest.fn()
             })),
             append: jest.fn()
         }));

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -347,16 +347,18 @@ class Arpeggio {
 
             cell.setAttribute("id", i + "," + arpeggioIdx); // row,column
 
-            cell.onmouseover = () => {
+            // Use Pointer Events so hover feedback works on touch and stylus too.
+            cell.style.touchAction = "manipulation";
+            cell.addEventListener("pointerenter", () => {
                 if (cell.style.backgroundColor !== "black") {
                     cell.style.backgroundColor = platformColor.selectorSelected;
                 }
-            };
-            cell.onmouseout = () => {
+            });
+            cell.addEventListener("pointerleave", () => {
                 if (cell.style.backgroundColor !== "black") {
                     cell.style.backgroundColor = platformColor.selectorBackground;
                 }
-            };
+            });
         }
 
         const arpeggioNoteTable = docById("arpeggioNoteTable");

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1501,53 +1501,56 @@ function MusicKeyboard(activity) {
             };
         }
 
-        let row, isMouseDown;
+        let row;
         for (let i = 0; i < this.layout.length; i++) {
-            // The buttons get added to the embedded table.
             row = docById("mkb" + i);
             for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
-                // Give each clickable cell a unique id
                 cell.setAttribute("id", i + ":" + j);
-
-                isMouseDown = false;
-
-                cell.onmousedown = e => {
-                    cell = e.target;
-                    isMouseDown = true;
-                    const obj = cell.id.split(":");
-                    // i = Number(obj[0]);
-                    const j = Number(obj[1]);
-                    if (cell.style.backgroundColor === "black") {
-                        cell.style.backgroundColor = cell.getAttribute("cellColor");
-                        this._setNotes(j, false);
-                    } else {
-                        cell.style.backgroundColor = "black";
-                        this._setNotes(j, true);
-                    }
-                };
-
-                cell.onmouseover = () => {
-                    // let obj, i, j;
-                    // obj = cell.id.split(":");
-                    // i = Number(obj[0]);
-                    // j = Number(obj[1]);
-                    if (isMouseDown) {
-                        if (cell.style.backgroundColor === "black") {
-                            cell.style.backgroundColor = cell.getAttribute("cellColor");
-                            this._setNotes(j, false);
-                        } else {
-                            cell.style.backgroundColor = "black";
-                            this._setNotes(j, true);
-                        }
-                    }
-                };
-
-                cell.onmouseup = function () {
-                    isMouseDown = false;
-                };
+                // Prevent scroll during drag so touch drag-paint works.
+                cell.style.touchAction = "none";
             }
         }
+
+        // Pointer Events on the shared table handle both mouse drag-paint and
+        // touch drag-paint (elementFromPoint resolves the cell under the finger).
+        const mkbTable = docById("mkbTable");
+        let isPointerDown = false;
+        let lastDragCell = null;
+
+        const __toggleDragCell = target => {
+            const targetCell = target.closest("td");
+            if (!targetCell || !targetCell.id || !targetCell.id.includes(":")) return;
+            if (targetCell === lastDragCell) return;
+            lastDragCell = targetCell;
+            const j = Number(targetCell.id.split(":")[1]);
+            if (targetCell.style.backgroundColor === "black") {
+                targetCell.style.backgroundColor = targetCell.getAttribute("cellColor");
+                this._setNotes(j, false);
+            } else {
+                targetCell.style.backgroundColor = "black";
+                this._setNotes(j, true);
+            }
+        };
+
+        mkbTable.addEventListener("pointerdown", e => {
+            isPointerDown = true;
+            lastDragCell = null;
+            __toggleDragCell(e.target);
+        });
+
+        mkbTable.addEventListener("pointermove", e => {
+            if (!isPointerDown) return;
+            const el = document.elementFromPoint(e.clientX, e.clientY);
+            if (el) __toggleDragCell(el);
+        });
+
+        const __endDrag = () => {
+            isPointerDown = false;
+            lastDragCell = null;
+        };
+        mkbTable.addEventListener("pointerup", __endDrag);
+        mkbTable.addEventListener("pointercancel", __endDrag);
     };
 
     /**

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -3027,17 +3027,18 @@ class PhraseMaker {
                 cell.style.backgroundColor = cellColor;
                 cell.style.borderLeft = i === 0 ? barStyle : "1px solid #ccc";
 
-                cell.onmouseover = event => {
+                // Use Pointer Events so hover feedback works on touch and stylus too.
+                cell.style.touchAction = "manipulation";
+                cell.addEventListener("pointerenter", event => {
                     if (event.target.style.backgroundColor !== "black") {
                         event.target.style.backgroundColor = this.platformColor.selectorSelected;
                     }
-                };
-
-                cell.onmouseout = event => {
+                });
+                cell.addEventListener("pointerleave", event => {
                     if (event.target.style.backgroundColor !== "black") {
                         event.target.style.backgroundColor = event.target.getAttribute("cellColor");
                     }
-                };
+                });
             }
         }
 
@@ -4113,51 +4114,58 @@ class PhraseMaker {
             }
         }
 
-        let isMouseDown;
+        // Tag all cells with row/column indices; Pointer Events on the inner table
+        // enable touch drag-paint via elementFromPoint.
         for (let i = 0; i < rowCount; i++) {
-            // The buttons get added to the embedded table.
             row = this._rows[i];
             for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
-                // Give each clickable cell a unique id
                 cell.setAttribute("data-i", i);
                 cell.setAttribute("data-j", j);
-
-                isMouseDown = false;
-
-                cell.onmousedown = evt => {
-                    isMouseDown = true;
-                    const i = Number(evt.target.getAttribute("data-i"));
-                    const j = Number(evt.target.getAttribute("data-j"));
-                    if (evt.target.style.backgroundColor === "black") {
-                        evt.target.style.backgroundColor = evt.target.getAttribute("cellColor");
-                        this._notesToPlay[j][0] = ["R"];
-                        if (!this._noteBlocks) this._setNotes(j, i, false);
-                    } else {
-                        evt.target.style.backgroundColor = "black";
-                        if (!this._noteBlocks) this._setNotes(j, i, true);
-                    }
-                };
-
-                cell.onmouseover = evt => {
-                    const i = Number(evt.target.getAttribute("data-i"));
-                    const j = Number(evt.target.getAttribute("data-j"));
-                    if (isMouseDown) {
-                        if (evt.target.style.backgroundColor === "black") {
-                            evt.target.style.backgroundColor = evt.target.getAttribute("cellColor");
-                            this._notesToPlay[j][0] = ["R"];
-                            if (!this._noteBlocks) this._setNotes(j, i, false);
-                        } else {
-                            evt.target.style.backgroundColor = "black";
-                            if (!this._noteBlocks) this._setNotes(j, i, true);
-                        }
-                    }
-                };
-
-                cell.onmouseup = () => {
-                    isMouseDown = false;
-                };
+                cell.style.touchAction = "none";
             }
+        }
+
+        let isPointerDown = false;
+        let lastDragCell = null;
+
+        const __togglePMCell = target => {
+            const targetCell = target.closest("td[data-i]");
+            if (!targetCell || targetCell === lastDragCell) return;
+            lastDragCell = targetCell;
+            const i = Number(targetCell.getAttribute("data-i"));
+            const j = Number(targetCell.getAttribute("data-j"));
+            if (targetCell.style.backgroundColor === "black") {
+                targetCell.style.backgroundColor = targetCell.getAttribute("cellColor");
+                this._notesToPlay[j][0] = ["R"];
+                if (!this._noteBlocks) this._setNotes(j, i, false);
+            } else {
+                targetCell.style.backgroundColor = "black";
+                if (!this._noteBlocks) this._setNotes(j, i, true);
+            }
+        };
+
+        const __endPMDrag = () => {
+            isPointerDown = false;
+            lastDragCell = null;
+        };
+
+        for (let i = 0; i < rowCount; i++) {
+            // Attach listeners to the inner table (parent of the row) so that
+            // pointermove has a container to fire on during touch drag.
+            const innerTable = this._rows[i].parentElement;
+            innerTable.addEventListener("pointerdown", e => {
+                isPointerDown = true;
+                lastDragCell = null;
+                __togglePMCell(e.target);
+            });
+            innerTable.addEventListener("pointermove", e => {
+                if (!isPointerDown) return;
+                const el = document.elementFromPoint(e.clientX, e.clientY);
+                if (el) __togglePMCell(el);
+            });
+            innerTable.addEventListener("pointerup", __endPMDrag);
+            innerTable.addEventListener("pointercancel", __endPMDrag);
         }
 
         // Mark any cells found in the blockMap from previous

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -478,16 +478,18 @@ class PitchDrumMatrix {
             cell.style.border = "2px solid white";
             cell.style.borderRadius = "10px";
 
-            cell.onmouseover = () => {
+            // Use Pointer Events so hover feedback works on touch and stylus too.
+            cell.style.touchAction = "manipulation";
+            cell.addEventListener("pointerenter", () => {
                 if (cell.style.backgroundColor !== "black") {
                     cell.style.backgroundColor = platformColor.selectorSelected;
                 }
-            };
-            cell.onmouseout = () => {
+            });
+            cell.addEventListener("pointerleave", () => {
                 if (cell.style.backgroundColor !== "black") {
                     cell.style.backgroundColor = platformColor.selectorBackground;
                 }
-            };
+            });
 
             cell.setAttribute("id", i + "," + drumIdx); // row,column
         }
@@ -549,7 +551,8 @@ class PitchDrumMatrix {
 
                 drumCell = drumRow.cells[j];
 
-                cell.onclick = e => {
+                cell.style.touchAction = "manipulation";
+                cell.addEventListener("click", e => {
                     const currCell = e.target;
                     const rowcol = currCell.id.split(",");
                     if (currCell.style.backgroundColor === "black") {
@@ -559,7 +562,7 @@ class PitchDrumMatrix {
                         currCell.style.backgroundColor = "black";
                         this._setCellPitchDrum(rowcol[1], rowcol[0], true);
                     }
-                };
+                });
             }
         }
 

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -81,14 +81,14 @@ class PitchStaircase {
         cell.style.minHeight = cell.style.height;
         cell.style.maxHeight = cell.style.height;
         cell.style.backgroundColor = platformColor.selectorBackground;
-
-        cell.onmouseover = () => {
+        // Use Pointer Events so hover feedback works on touch and stylus too.
+        cell.style.touchAction = "manipulation";
+        cell.addEventListener("pointerenter", () => {
             cell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
-        };
-
-        cell.onmouseout = () => {
+        });
+        cell.addEventListener("pointerleave", () => {
             cell.style.backgroundColor = platformColor.selectorBackground;
-        };
+        });
 
         return cell;
     }
@@ -162,15 +162,16 @@ class PitchStaircase {
             stepCell.style.backgroundRepeat = "no-repeat";
             stepCell.style.backgroundPosition = "center center";
 
+            stepCell.style.touchAction = "manipulation";
             stepCell.addEventListener("click", event => {
                 this._dissectStair(event);
             });
 
-            playCell.onclick = () => {
+            playCell.addEventListener("pointerdown", () => {
                 const i = playCell.getAttribute("id");
                 const stepCell = this._stepTables[i].rows[0].cells[1];
                 this._playOne(stepCell);
-            };
+            });
         }
     }
 

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -164,13 +164,14 @@ function TemperamentWidget() {
         cell.style.maxHeight = cell.style.height;
         cell.style.backgroundColor = platformColor.selectorBackground;
 
-        cell.onmouseover = function () {
+        // Use Pointer Events so hover feedback works on touch and stylus too.
+        cell.style.touchAction = "manipulation";
+        cell.addEventListener("pointerenter", function () {
             this.style.backgroundColor = platformColor.selectorBackgroundHOVER;
-        };
-
-        cell.onmouseout = function () {
+        });
+        cell.addEventListener("pointerleave", function () {
             this.style.backgroundColor = platformColor.selectorBackground;
-        };
+        });
 
         return cell;
     };
@@ -807,20 +808,17 @@ function TemperamentWidget() {
             notesCell[i][0].style.backgroundColor = platformColor.selectorBackground;
             notesCell[i][0].style.textAlign = "center";
 
-            notesCell[i][0].onmouseover = function () {
+            notesCell[i][0].style.touchAction = "manipulation";
+            notesCell[i][0].addEventListener("pointerenter", function () {
                 this.style.backgroundColor = platformColor.selectorBackgroundHOVER;
-            };
-
-            notesCell[i][0].onmouseout = function () {
+            });
+            notesCell[i][0].addEventListener("pointerleave", function () {
                 this.style.backgroundColor = platformColor.selectorBackground;
-            };
+            });
 
             const playImage = docById("play_" + i);
 
-            playImage.onmouseover = function () {
-                this.style.cursor = "pointer";
-            };
-
+            playImage.style.cursor = "pointer";
             playImage.onclick = function (event) {
                 that.playNote(event.target.dataset.id);
             };
@@ -1050,9 +1048,7 @@ function TemperamentWidget() {
 
         addDivision(false);
 
-        divAppend.onmouseover = function () {
-            this.style.cursor = "pointer";
-        };
+        divAppend.style.cursor = "pointer";
 
         let pitchNumber = this.pitchNumber;
         let pitchNumber1 = Number(docById("octaveIn").value);
@@ -1271,9 +1267,7 @@ function TemperamentWidget() {
 
         addButtons(false);
 
-        divAppend.onmouseover = function () {
-            this.style.cursor = "pointer";
-        };
+        divAppend.style.cursor = "pointer";
 
         divAppend.onclick = function (event) {
             const input1 = docById("ratioIn").value;
@@ -1618,9 +1612,7 @@ function TemperamentWidget() {
         divAppend.style.overflow = "auto";
         arbitraryEdit.append(divAppend);
 
-        divAppend.onmouseover = function () {
-            this.style.cursor = "pointer";
-        };
+        divAppend.style.cursor = "pointer";
 
         divAppend.onclick = function () {
             that.ratios = that.tempRatios1.slice();
@@ -1824,9 +1816,7 @@ function TemperamentWidget() {
         divAppend.style.overflow = "auto";
         octaveSpaceEdit.append(divAppend);
 
-        divAppend.onmouseover = function () {
-            this.style.cursor = "pointer";
-        };
+        divAppend.style.cursor = "pointer";
 
         divAppend.onclick = function () {
             const startRatio = docById("startNote").value;


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Summary

Replaces legacy `onmouseover`/`onmouseout` event properties with the Pointer Events API across several widgets, enabling touch and stylus input on mobile devices.

### Changes

| Widget | What changed |
|---|---|
| `arpeggio.js` | `onmouseover`/`onmouseout` → `pointerenter`/`pointerleave` + `touch-action: manipulation` |
| `pitchdrummatrix.js` | Same hover fix; `onclick` → `addEventListener("click")` + `touch-action: manipulation` |
| `pitchstaircase.js` | Same hover fix; `playCell.onclick` → `pointerdown` for immediate response on tap |
| `phrasemaker.js` (tuplet row) | `onmouseover`/`onmouseout` → `pointerenter`/`pointerleave` |
| `temperament.js` | Hover cells use `pointerenter`/`pointerleave`; cursor-only `onmouseover` handlers replaced with `element.style.cursor = "pointer"` |
| `musickeyboard.js` (note grid) | Drag-paint rewritten with `pointerdown`/`pointermove`/`pointerup` on the shared `mkbTable`; `elementFromPoint` resolves the cell under a touch, enabling touch drag-paint. Also fixes a pre-existing bug where the drag-paint closure read the wrong `cell` variable. |
| `phrasemaker.js` (note grid) | Same drag-paint rewrite using `pointermove` on each inner table row |

### Why Pointer Events?

The Pointer Events API is a single unified model covering mouse, touch, and stylus input. Replacing `onmouseover`/`onmouseout` with `pointerenter`/`pointerleave` means hover feedback now works on touchscreens. The drag-paint rewrite using `elementFromPoint` is the only reliable cross-cell touch-drag mechanism because during a touch drag `pointermove` fires on the element where the touch **started**, not on whatever element is currently under the finger.

### Test plan

- [x] All existing tests pass (`npm test`)
- [ ] Open Arpeggio widget on mobile → tap a cell → hover highlight appears and disappears correctly
- [ ] Open Music Keyboard widget → drag across note cells with a finger → each cell toggles once
- [ ] Open Phrase Maker widget → drag across note cells on touch → cells toggle correctly
- [ ] Open Pitch Staircase → tap play button → note plays immediately (no 300 ms delay)
- [ ] Open Temperament widget → tapping rows highlights them correctly on touch

Closes part of #6603 (DMP 2026 widget touch support)