### PR TITLE
fix: Restore accessibility focus states across palette and global inputs

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -236,7 +236,7 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
     margin-left: 8px;
 }
 
-#search:focus {
+#search:focus:not(:focus-visible) {
     border-color: #4da6ff;
     box-shadow: 0 4px 12px rgba(77, 166, 255, 0.2);
     outline: none;

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ input[type="range"] {
   width: 250px;
 }
 
-input[type="range"]:focus {
+input[type="range"]:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -2231,9 +2231,15 @@ describe("Palettes Class", () => {
             jest.useFakeTimers();
 
             const row = {};
+            const focusedClasses = new Set(["palette-keyboard-hover"]);
             const focused = {
-                style: { backgroundColor: platformColor.hoverColor },
-                dataset: { keyboardFocus: "true" }
+                classList: {
+                    add: (...args) => args.forEach(c => focusedClasses.add(c)),
+                    remove: (...args) => args.forEach(c => focusedClasses.delete(c)),
+                    contains: c => focusedClasses.has(c)
+                },
+                dataset: { keyboardFocus: "true" },
+                hasAttribute: jest.fn(() => false)
             };
             const paletteElement = { blur: jest.fn() };
             const hideMenu = jest.fn();
@@ -2265,7 +2271,7 @@ describe("Palettes Class", () => {
             expect(hideMenu).toHaveBeenCalled();
             expect(hideMenusSpy).toHaveBeenCalled();
             expect(showSpy).not.toHaveBeenCalled();
-            expect(focused.style.backgroundColor).toBe(platformColor.paletteBackground);
+            expect(focused.classList.contains("palette-keyboard-hover")).toBe(false);
             expect(focused.dataset.keyboardFocus).toBeUndefined();
             expect(palettes._keyboardNavActive).toBe(false);
             expect(palettes._navSection).toBe("type");

--- a/js/palette.js
+++ b/js/palette.js
@@ -452,14 +452,14 @@ class Palettes {
         } else if (this._navSection === "search" && blockRows.length > 0) {
             const searchRow = blockRows[0];
             if (searchRow) {
-                searchRow.style.backgroundColor = platformColor.hoverColor;
+                searchRow.classList.add("palette-keyboard-hover");
                 searchRow.dataset.keyboardFocus = "true";
                 searchRow.tabIndex = 0;
                 searchRow.focus({ preventScroll: true });
             }
         } else if (this._navSection === "blocks" && blockRows[this._navBlockIndex]) {
             const row = blockRows[this._navBlockIndex];
-            row.style.backgroundColor = platformColor.hoverColor;
+            row.classList.add("palette-keyboard-hover");
             row.dataset.keyboardFocus = "true";
             row.tabIndex = 0;
             row.focus({ preventScroll: true });
@@ -468,7 +468,7 @@ class Palettes {
             const paletteBlocks = this._getPaletteBlocks();
             if (paletteBlocks[this._navPaletteBlockIndex]) {
                 const blockRow = paletteBlocks[this._navPaletteBlockIndex];
-                blockRow.style.backgroundColor = platformColor.hoverColor;
+                blockRow.classList.add("palette-keyboard-hover");
                 blockRow.dataset.keyboardFocus = "true";
                 blockRow.tabIndex = 0;
                 blockRow.focus({ preventScroll: true });
@@ -484,7 +484,7 @@ class Palettes {
     _clearKeyboardFocus() {
         const focused = document.querySelectorAll('[data-keyboard-focus="true"]');
         focused.forEach(el => {
-            el.style.backgroundColor = platformColor.paletteBackground;
+            el.classList.remove("palette-keyboard-hover");
             delete el.dataset.keyboardFocus;
             if (typeof el.hasAttribute === "function" && el.hasAttribute("tabindex")) {
                 el.tabIndex = -1;

--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -715,6 +715,7 @@ describe("AIDebuggerWidget", () => {
             debuggerWidget.messageInput = document.createElement("input");
             debuggerWidget._sendToBackend = jest.fn();
             debuggerWidget._updateMessageCount = jest.fn();
+            debuggerWidget._consentGiven = true;
         });
 
         test("does nothing with empty input", () => {
@@ -739,6 +740,15 @@ describe("AIDebuggerWidget", () => {
             expect(debuggerWidget.messageInput.value).toBe("");
             expect(debuggerWidget._isProcessing).toBe(true);
             expect(debuggerWidget._sendToBackend).toHaveBeenCalledWith("Hello AI");
+        });
+
+        test("does not send message and shows consent banner if consent not given", () => {
+            debuggerWidget._consentGiven = false;
+            debuggerWidget._showConsentBanner = jest.fn();
+            debuggerWidget.messageInput.value = "Hello AI";
+            debuggerWidget._sendMessage();
+            expect(debuggerWidget.chatHistory).toHaveLength(0);
+            expect(debuggerWidget._showConsentBanner).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
**Problem**

Two accessibility issues prevent keyboard users from seeing focus indicators:

1. **Palette keyboard navigation** applies hover highlights using inline `style.backgroundColor` assignments tied to `platformColor.hoverColor`. This couples visual state to JS-driven color values, making highlights impossible to theme via CSS.

2. **Global `outline: none` overrides** on `#search:focus` ([activities.css:239](file:///d:/C4GT/musicblocks/css/activities.css#L239)) and `input[type="range"]:focus` ([style.css:12](file:///d:/C4GT/musicblocks/css/style.css#L12)) suppress the `*:focus-visible` outline ring for keyboard users, violating WCAG 2.4.7 (Focus Visible).

addresses #6606 

**Solution**

**Commit 1** — Replace the 4 inline `style.backgroundColor` assignments in `_updateKeyboardFocus` and `_clearKeyboardFocus` with `classList.add/remove("palette-keyboard-hover")`. This decouples the keyboard focus highlight from hardcoded JS color values, enabling theming through CSS:

```css
.palette-keyboard-hover {
    background-color: var(--color-state-hover);
}
```

**Commit 2** — Narrow the blanket `:focus { outline: none }` rules to `:focus:not(:focus-visible)` so that:
- Mouse/touch clicks still suppress the outline (no visual regression)
- Keyboard `Tab` focus preserves the `2px solid #0066ff` outline from the global `*:focus-visible` rule

### Changes

| File | Change |
|---|---|
| `js/palette.js` | 4 lines: `style.backgroundColor` → `classList.add/remove("palette-keyboard-hover")` in `_updateKeyboardFocus` and `_clearKeyboardFocus` |
| `css/activities.css` | `#search:focus` → `#search:focus:not(:focus-visible)` |
| `css/style.css` | `input[type="range"]:focus` → `input[type="range"]:focus:not(:focus-visible)` |

## PR Category
- [x] Bug Fix 
- [ ] Feature
- [ ] Performance
- [ ] Tests 
- [ ] Documentation


### Testing

- `npm test` — 5187/5187 passing
- `npm run lint` — 0 errors
- `npx prettier --check` — all modified files formatted

### Browser Testing Required

1. Run `npm run serve:dev`
2. Open `http://127.0.0.1:3000`
3. **Palette keyboard nav**: Press `Tab` to focus the palette → use arrow keys → verify a visible highlight follows the focused row
4. **Search input**: Click the search icon → `Tab` into the search box → verify a blue outline ring appears around it
5. **Range sliders**: Open any widget with a slider (e.g., Tempo) → `Tab` to the slider → verify a blue outline ring appears
6. **Mouse clicks**: Click the search box and sliders → verify **no** outline ring appears (clean mouse UX preserved)

---

### Upstream Test Regression Fixes
- Fixed `js/widgets/__tests__/aidebugger.test.js` where the `_sendMessage` unit tests failed because of a recent upstream master commit `d7e16bc81` introducing a consent flow check. The tests have been updated to mock `_consentGiven = true` and assert on the correct behavior when consent is not granted.

---