### PR TITLE
test: Migrate test assertions to support CSS class architecture

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -236,7 +236,7 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
     margin-left: 8px;
 }
 
-#search:focus {
+#search:focus:not(:focus-visible) {
     border-color: #4da6ff;
     box-shadow: 0 4px 12px rgba(77, 166, 255, 0.2);
     outline: none;

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ input[type="range"] {
   width: 250px;
 }
 
-input[type="range"]:focus {
+input[type="range"]:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/css/widgets/phrasemaker.css
+++ b/css/widgets/phrasemaker.css
@@ -1,0 +1,264 @@
+﻿/*
+ * PhraseMaker Widget ΓÇö Design Token Stylesheet
+ *
+ * Copyright (c) 2026 Music Blocks contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the The GNU Affero General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+ *
+ * This file replaces inline style assignments previously driven by
+ * the platformColor JavaScript object with semantic CSS classes that
+ * reference CSS Custom Properties (design tokens).
+ *
+ * Layout-only properties that depend on dynamic JS calculations
+ * (widths, heights based on _cellScale) remain in JavaScript.
+ */
+
+/* ===================================================================
+ * 1. Design Tokens (Light / Default Theme)
+ * =================================================================== */
+:root {
+    /* --- Row label backgrounds --- */
+    --pm-pitch-label-bg: #77c428;
+    --pm-drum-label-bg: #25c3c0;
+    --pm-graphics-label-bg: #728ff9;
+    --pm-lyrics-label-bg: #ff2b77;
+    --pm-lyrics-input-bg: #ff6ea1;
+
+    /* --- Grid cell backgrounds --- */
+    --pm-pitch-cell-bg: #7cd622;
+    --pm-drum-cell-bg: #3edcdd;
+    --pm-graphics-cell-bg: #92a9ff;
+
+    /* --- Bottom row / value cells --- */
+    --pm-rhythm-cell-bg: #c8c8c8;
+    --pm-tuplet-bg: #c0c0c0;
+    --pm-label-color: #a0a0a0;
+
+    /* --- Interactive states --- */
+    --pm-selector-selected: #1a8cff;
+    --pm-selector-bg: #8cc6ff;
+    --pm-cell-active: black;
+
+    /* --- Text --- */
+    --pm-text-color: black;
+
+    /* --- Borders --- */
+    --pm-border-bar: 3px solid #555;
+    --pm-border-cell: 1px solid #ccc;
+
+    /* --- Window body --- */
+    --pm-window-body-bg: #cccccc;
+}
+
+/* --- Dark Theme --- */
+body.dark {
+    --pm-pitch-label-bg: #2e7d32;
+    --pm-drum-label-bg: #00796b;
+    --pm-graphics-label-bg: #283593;
+    --pm-lyrics-label-bg: #c7225d;
+    --pm-lyrics-input-bg: #d15a84;
+
+    --pm-pitch-cell-bg: #4caf50;
+    --pm-drum-cell-bg: #00acc1;
+    --pm-graphics-cell-bg: #7986cb;
+
+    --pm-rhythm-cell-bg: #303030;
+    --pm-tuplet-bg: #424242;
+    --pm-label-color: #bdbdbd;
+
+    --pm-selector-selected: #1e88e5;
+    --pm-selector-bg: #64b5f6;
+    --pm-cell-active: black;
+
+    --pm-text-color: #e2e2e2;
+
+    --pm-border-bar: 3px solid #888;
+    --pm-border-cell: 1px solid #555;
+
+    --pm-window-body-bg: #454545;
+}
+
+/* --- High Contrast Theme --- */
+body.highcontrast {
+    --pm-pitch-label-bg: #00cc00;
+    --pm-drum-label-bg: #00cccc;
+    --pm-graphics-label-bg: #cc00cc;
+    --pm-lyrics-label-bg: #ff00ff;
+    --pm-lyrics-input-bg: #ff66ff;
+
+    --pm-pitch-cell-bg: #00ff00;
+    --pm-drum-cell-bg: #00ffff;
+    --pm-graphics-cell-bg: #ff00ff;
+
+    --pm-rhythm-cell-bg: #333333;
+    --pm-tuplet-bg: #333333;
+    --pm-label-color: #ffffff;
+
+    --pm-selector-selected: #00cccc;
+    --pm-selector-bg: #00ffff;
+    --pm-cell-active: black;
+
+    --pm-text-color: #ffffff;
+
+    --pm-border-bar: 3px solid #ffffff;
+    --pm-border-cell: 1px solid #666;
+
+    --pm-window-body-bg: #000000;
+}
+
+/* ===================================================================
+ * 2. Structural / Layout Classes
+ * =================================================================== */
+
+/* Sticky column cells (row labels on the left) */
+.pm-headcol {
+    position: sticky;
+    left: 1.2px;
+}
+
+.pm-labelcol {
+    position: sticky;
+}
+
+/* Bottom row (note value / tuplet labels) ΓÇö sticky at bottom */
+.pm-bottom-row {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+}
+
+.pm-bottom-cell {
+    position: sticky;
+    left: 1.2px;
+    z-index: 1;
+}
+
+/* Lyrics row */
+.pm-lyrics-row {
+    position: sticky;
+}
+
+/* ===================================================================
+ * 3. Color Classes ΓÇö Row Label Backgrounds
+ * =================================================================== */
+
+.pm-bg-pitch-label {
+    background-color: var(--pm-pitch-label-bg);
+}
+
+.pm-bg-drum-label {
+    background-color: var(--pm-drum-label-bg);
+}
+
+.pm-bg-graphics-label {
+    background-color: var(--pm-graphics-label-bg);
+}
+
+.pm-bg-lyrics-label {
+    background-color: var(--pm-lyrics-label-bg);
+    text-align: center;
+}
+
+/* ===================================================================
+ * 4. Color Classes ΓÇö Grid Cell Backgrounds
+ * =================================================================== */
+
+.pm-bg-pitch-cell {
+    background-color: var(--pm-pitch-cell-bg);
+}
+
+.pm-bg-drum-cell {
+    background-color: var(--pm-drum-cell-bg);
+}
+
+.pm-bg-graphics-cell {
+    background-color: var(--pm-graphics-cell-bg);
+}
+
+/* Note-value / bottom-row cells */
+.pm-bg-rhythm-cell {
+    background-color: var(--pm-rhythm-cell-bg);
+    color: var(--pm-text-color);
+}
+
+.pm-bg-tuplet {
+    background-color: var(--pm-tuplet-bg);
+}
+
+.pm-bg-label {
+    background-color: var(--pm-label-color);
+}
+
+/* Active / selected cell */
+.pm-cell-active {
+    background-color: var(--pm-cell-active);
+}
+
+/* ===================================================================
+ * 5. Color Classes ΓÇö Interactive States
+ * =================================================================== */
+
+.pm-bg-selector-selected {
+    background-color: var(--pm-selector-selected);
+}
+
+.pm-bg-selector {
+    background-color: var(--pm-selector-bg);
+}
+
+/* ===================================================================
+ * 6. Lyrics Input Styling
+ * =================================================================== */
+
+.pm-lyrics-input-cell {
+    background-color: var(--pm-lyrics-input-bg);
+    font-family: sans-serif;
+    cursor: default;
+    border-spacing: 1px 1px;
+    border-collapse: collapse;
+    box-sizing: border-box;
+    padding: 0;
+    border-radius: 6px;
+    border: none;
+}
+
+.pm-lyrics-input {
+    width: 100%;
+    font-size: inherit;
+    font-family: sans-serif;
+    cursor: default;
+    box-sizing: border-box;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background-color: var(--pm-lyrics-input-bg);
+}
+
+/* ===================================================================
+ * 7. Value Row Cell Styling
+ * =================================================================== */
+
+.pm-value-cell {
+    line-height: 60%;
+    text-align: center;
+}
+
+/* Grid note cells */
+.pm-note-cell {
+    border-radius: 6px;
+}
+
+/* ===================================================================
+ * 8. Window Body Background (used by PhraseMakerUI.js)
+ * =================================================================== */
+
+.pm-window-body-bg {
+    background: var(--pm-window-body-bg);
+}

--- a/index.html
+++ b/index.html
@@ -101,6 +101,15 @@
                 this.rel = 'stylesheet';
             "
         />
+        <link
+            rel="preload"
+            href="css/widgets/phrasemaker.css"
+            as="style"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
+        />
         <link rel="prefetch" as="video" href="loading-animation.webm" type="video/webm" />
         <link rel="prefetch" as="video" href="loading-animation.mp4" type="video/mp4" />
 
@@ -115,7 +124,10 @@
             rel="preload"
             href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css"
             as="style"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript
             ><link
@@ -136,7 +148,10 @@
             as="style"
             integrity="sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07"
             crossorigin="anonymous"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript
             ><link
@@ -178,7 +193,10 @@
             rel="preload"
             href="css/themes.css?v=fixed"
             as="style"
-            onload="this.onload=null;this.rel='stylesheet'"
+            onload="
+                this.onload = null;
+                this.rel = 'stylesheet';
+            "
         />
         <noscript><link rel="stylesheet" href="css/themes.css?v=fixed" /></noscript>
         <script>
@@ -1293,7 +1311,7 @@
 
                 iconCode.textContent = isFullscreen ? "\ue5d1" : "\ue5d0";
 
-                if (fullScreenBtn && typeof _ === 'function') {
+                if (fullScreenBtn && typeof _ === "function") {
                     var tooltipText = isFullscreen ? _("Exit Fullscreen") : _("Enter Fullscreen");
                     fullScreenBtn.setAttribute("data-tooltip", tooltipText);
                     if (window.jQuery) {

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -2231,9 +2231,15 @@ describe("Palettes Class", () => {
             jest.useFakeTimers();
 
             const row = {};
+            const focusedClasses = new Set(["palette-keyboard-hover"]);
             const focused = {
-                style: { backgroundColor: platformColor.hoverColor },
-                dataset: { keyboardFocus: "true" }
+                classList: {
+                    add: (...args) => args.forEach(c => focusedClasses.add(c)),
+                    remove: (...args) => args.forEach(c => focusedClasses.delete(c)),
+                    contains: c => focusedClasses.has(c)
+                },
+                dataset: { keyboardFocus: "true" },
+                hasAttribute: jest.fn(() => false)
             };
             const paletteElement = { blur: jest.fn() };
             const hideMenu = jest.fn();
@@ -2265,7 +2271,7 @@ describe("Palettes Class", () => {
             expect(hideMenu).toHaveBeenCalled();
             expect(hideMenusSpy).toHaveBeenCalled();
             expect(showSpy).not.toHaveBeenCalled();
-            expect(focused.style.backgroundColor).toBe(platformColor.paletteBackground);
+            expect(focused.classList.contains("palette-keyboard-hover")).toBe(false);
             expect(focused.dataset.keyboardFocus).toBeUndefined();
             expect(palettes._keyboardNavActive).toBe(false);
             expect(palettes._navSection).toBe("type");

--- a/js/palette.js
+++ b/js/palette.js
@@ -452,14 +452,14 @@ class Palettes {
         } else if (this._navSection === "search" && blockRows.length > 0) {
             const searchRow = blockRows[0];
             if (searchRow) {
-                searchRow.style.backgroundColor = platformColor.hoverColor;
+                searchRow.classList.add("palette-keyboard-hover");
                 searchRow.dataset.keyboardFocus = "true";
                 searchRow.tabIndex = 0;
                 searchRow.focus({ preventScroll: true });
             }
         } else if (this._navSection === "blocks" && blockRows[this._navBlockIndex]) {
             const row = blockRows[this._navBlockIndex];
-            row.style.backgroundColor = platformColor.hoverColor;
+            row.classList.add("palette-keyboard-hover");
             row.dataset.keyboardFocus = "true";
             row.tabIndex = 0;
             row.focus({ preventScroll: true });
@@ -468,7 +468,7 @@ class Palettes {
             const paletteBlocks = this._getPaletteBlocks();
             if (paletteBlocks[this._navPaletteBlockIndex]) {
                 const blockRow = paletteBlocks[this._navPaletteBlockIndex];
-                blockRow.style.backgroundColor = platformColor.hoverColor;
+                blockRow.classList.add("palette-keyboard-hover");
                 blockRow.dataset.keyboardFocus = "true";
                 blockRow.tabIndex = 0;
                 blockRow.focus({ preventScroll: true });
@@ -484,7 +484,7 @@ class Palettes {
     _clearKeyboardFocus() {
         const focused = document.querySelectorAll('[data-keyboard-focus="true"]');
         focused.forEach(el => {
-            el.style.backgroundColor = platformColor.paletteBackground;
+            el.classList.remove("palette-keyboard-hover");
             delete el.dataset.keyboardFocus;
             if (typeof el.hasAttribute === "function" && el.hasAttribute("tabindex")) {
                 el.tabIndex = -1;

--- a/js/widgets/PhraseMakerUI.js
+++ b/js/widgets/PhraseMakerUI.js
@@ -50,7 +50,7 @@ const PhraseMakerUI = {
                 wfWinBody.style.overflowX = totalWidth > maxWidth ? "auto" : "hidden";
                 wfWinBody.style.width = "-webkit-fill-available";
                 wfWinBody.style.height = "-webkit-fill-available";
-                wfWinBody.style.background = "#cccccc";
+                wfWinBody.classList.add("pm-window-body-bg");
             }
         }
     },
@@ -64,14 +64,16 @@ const PhraseMakerUI = {
         let cell;
         for (let i = 0; i < row.cells.length; i++) {
             cell = row.cells[i];
-            cell.style.backgroundColor = pm.platformColor.rhythmcellcolor;
+            cell.classList.remove("pm-bg-selector", "pm-bg-tuplet");
+            cell.classList.add("pm-bg-rhythm-cell");
         }
 
         if (pm._matrixHasTuplets) {
             row = pm._tupletNoteValueRow;
             for (let i = 0; i < row.cells.length; i++) {
                 cell = row.cells[i];
-                cell.style.backgroundColor = pm.platformColor.tupletBackground;
+                cell.classList.remove("pm-bg-selector", "pm-bg-rhythm-cell");
+                cell.classList.add("pm-bg-tuplet");
             }
         }
     },
@@ -128,7 +130,8 @@ const PhraseMakerUI = {
 
         const cell = pm._rows[rowIndex].cells[colIndex];
         if (cell) {
-            cell.style.backgroundColor = pm.platformColor.selectorBackground;
+            cell.classList.add("pm-bg-selector");
+            cell.classList.remove("pm-bg-rhythm-cell");
         }
     },
 
@@ -142,8 +145,9 @@ const PhraseMakerUI = {
         if (!pm._rows[rowIndex]) return;
 
         const cell = pm._rows[rowIndex].cells[colIndex];
-        if (cell && cell.style.backgroundColor === pm.platformColor.selectorBackground) {
-            cell.style.backgroundColor = pm.platformColor.rhythmcellcolor;
+        if (cell && cell.classList.contains("pm-bg-selector")) {
+            cell.classList.remove("pm-bg-selector");
+            cell.classList.add("pm-bg-rhythm-cell");
         }
     },
 
@@ -157,13 +161,13 @@ const PhraseMakerUI = {
         if (!cell) return;
 
         if (isActive) {
-            cell.style.backgroundColor = pm.platformColor.selectorBackground;
+            cell.classList.add("pm-bg-selector", "active");
+            cell.classList.remove("pm-bg-rhythm-cell");
             cell.textContent = "\u00a0\u2713"; // checkmark
-            cell.className = "active";
         } else {
-            cell.style.backgroundColor = pm.platformColor.rhythmcellcolor;
+            cell.classList.remove("pm-bg-selector", "active");
+            cell.classList.add("pm-bg-rhythm-cell");
             cell.textContent = "";
-            cell.className = "";
         }
     },
 

--- a/js/widgets/__tests__/PhraseMakerUI.test.js
+++ b/js/widgets/__tests__/PhraseMakerUI.test.js
@@ -192,7 +192,7 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.highlightCell(pm, 0, 0);
 
-            expect(cell.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(true);
         });
 
         test("does nothing when row does not exist", () => {
@@ -220,9 +220,9 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.highlightCell(pm, 1, 0);
 
-            expect(cell0.style.backgroundColor).toBe("");
-            expect(cell1.style.backgroundColor).toBe("rgb(139, 195, 74)");
-            expect(cell2.style.backgroundColor).toBe("");
+            expect(cell0.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell1.classList.contains("pm-bg-selector")).toBe(true);
+            expect(cell2.classList.contains("pm-bg-selector")).toBe(false);
         });
 
         test("highlights correct row in multi-row matrix", () => {
@@ -233,30 +233,33 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.highlightCell(pm, 0, 1);
 
-            expect(cell0.style.backgroundColor).toBe("");
-            expect(cell1.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(cell0.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell1.classList.contains("pm-bg-selector")).toBe(true);
         });
     });
 
     describe("unhighlightCell", () => {
-        test("resets highlighted cell to rhythmcellcolor", () => {
+        test("resets highlighted cell to rhythmcellcolor class", () => {
             const pm = createMockPM();
             const cell = createMockCell("#8bc34a");
+            cell.classList.add("pm-bg-selector");
             pm._rows = [{ cells: [cell] }];
 
             PhraseMakerUI.unhighlightCell(pm, 0, 0);
 
-            expect(cell.style.backgroundColor).toBe("rgb(255, 255, 255)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell.classList.contains("pm-bg-rhythm-cell")).toBe(true);
         });
 
-        test("does not change cell if not highlighted with selectorBackground", () => {
+        test("does not change cell if not highlighted with selector class", () => {
             const pm = createMockPM();
             const cell = createMockCell("#ff0000");
+            // cell does NOT have pm-bg-selector class
             pm._rows = [{ cells: [cell] }];
 
             PhraseMakerUI.unhighlightCell(pm, 0, 0);
 
-            expect(cell.style.backgroundColor).toBe("rgb(255, 0, 0)");
+            expect(cell.classList.contains("pm-bg-rhythm-cell")).toBe(false);
         });
 
         test("does nothing when row does not exist", () => {
@@ -277,12 +280,15 @@ describe("PhraseMakerUI", () => {
             const pm = createMockPM();
             const cell0 = createMockCell("#8bc34a");
             const cell1 = createMockCell("#8bc34a");
+            cell0.classList.add("pm-bg-selector");
+            cell1.classList.add("pm-bg-selector");
             pm._rows = [{ cells: [cell0, cell1] }];
 
             PhraseMakerUI.unhighlightCell(pm, 0, 0);
 
-            expect(cell0.style.backgroundColor).toBe("rgb(255, 255, 255)");
-            expect(cell1.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(cell0.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell0.classList.contains("pm-bg-rhythm-cell")).toBe(true);
+            expect(cell1.classList.contains("pm-bg-selector")).toBe(true);
         });
     });
 
@@ -293,7 +299,7 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.updateNoteCellVisual(pm, cell, true);
 
-            expect(cell.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(true);
         });
 
         test("sets active cell innerHTML to checkmark", () => {
@@ -305,13 +311,15 @@ describe("PhraseMakerUI", () => {
             expect(cell.textContent).toBe("\u00a0\u2713");
         });
 
-        test("sets inactive cell background to rhythmcellcolor", () => {
+        test("sets inactive cell to rhythmcellcolor class", () => {
             const pm = createMockPM();
             const cell = createMockCell("#8bc34a");
+            cell.classList.add("pm-bg-selector");
 
             PhraseMakerUI.updateNoteCellVisual(pm, cell, false);
 
-            expect(cell.style.backgroundColor).toBe("rgb(255, 255, 255)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell.classList.contains("pm-bg-rhythm-cell")).toBe(true);
         });
 
         test("clears inactive cell innerHTML", () => {
@@ -342,11 +350,12 @@ describe("PhraseMakerUI", () => {
             cell.innerHTML = "";
 
             PhraseMakerUI.updateNoteCellVisual(pm, cell, true);
-            expect(cell.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(true);
             expect(cell.textContent).toBe("\u00a0\u2713");
 
             PhraseMakerUI.updateNoteCellVisual(pm, cell, false);
-            expect(cell.style.backgroundColor).toBe("rgb(255, 255, 255)");
+            expect(cell.classList.contains("pm-bg-selector")).toBe(false);
+            expect(cell.classList.contains("pm-bg-rhythm-cell")).toBe(true);
             expect(cell.textContent).toBe("");
         });
     });
@@ -438,8 +447,8 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.resetMatrix(pm);
 
-            expect(cell0.style.backgroundColor).toBe("rgb(255, 255, 255)");
-            expect(cell1.style.backgroundColor).toBe("rgb(255, 255, 255)");
+            expect(cell0.classList.contains("pm-bg-rhythm-cell")).toBe(true);
+            expect(cell1.classList.contains("pm-bg-rhythm-cell")).toBe(true);
         });
 
         test("does not touch tuplet row when _matrixHasTuplets is false", () => {
@@ -451,7 +460,7 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.resetMatrix(pm);
 
-            expect(tupletCell.style.backgroundColor).toBe("rgb(139, 195, 74)");
+            expect(tupletCell.classList.contains("pm-bg-tuplet")).toBe(false);
         });
 
         test("resets tuplet row cells when _matrixHasTuplets is true", () => {
@@ -464,8 +473,8 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.resetMatrix(pm);
 
-            expect(tupletCell0.style.backgroundColor).toBe("rgb(224, 224, 224)");
-            expect(tupletCell1.style.backgroundColor).toBe("rgb(224, 224, 224)");
+            expect(tupletCell0.classList.contains("pm-bg-tuplet")).toBe(true);
+            expect(tupletCell1.classList.contains("pm-bg-tuplet")).toBe(true);
         });
 
         test("handles empty noteValueRow cells", () => {
@@ -494,8 +503,11 @@ describe("PhraseMakerUI", () => {
 
             PhraseMakerUI.resetMatrix(pm);
 
-            expect(noteCell.style.backgroundColor).toBe("rgb(255, 255, 255)");
-            expect(tupletCell.style.backgroundColor).toBe("rgb(224, 224, 224)");
+            expect(noteCell.classList.contains("pm-bg-rhythm-cell")).toBe(true);
+            expect(tupletCell.classList.contains("pm-bg-tuplet")).toBe(true);
+            // They should have different classes
+            expect(noteCell.classList.contains("pm-bg-tuplet")).toBe(false);
+            expect(tupletCell.classList.contains("pm-bg-rhythm-cell")).toBe(false);
         });
     });
 });

--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -715,6 +715,7 @@ describe("AIDebuggerWidget", () => {
             debuggerWidget.messageInput = document.createElement("input");
             debuggerWidget._sendToBackend = jest.fn();
             debuggerWidget._updateMessageCount = jest.fn();
+            debuggerWidget._consentGiven = true;
         });
 
         test("does nothing with empty input", () => {
@@ -739,6 +740,15 @@ describe("AIDebuggerWidget", () => {
             expect(debuggerWidget.messageInput.value).toBe("");
             expect(debuggerWidget._isProcessing).toBe(true);
             expect(debuggerWidget._sendToBackend).toHaveBeenCalledWith("Hello AI");
+        });
+
+        test("does not send message and shows consent banner if consent not given", () => {
+            debuggerWidget._consentGiven = false;
+            debuggerWidget._showConsentBanner = jest.fn();
+            debuggerWidget.messageInput.value = "Hello AI";
+            debuggerWidget._sendMessage();
+            expect(debuggerWidget.chatHistory).toHaveLength(0);
+            expect(debuggerWidget._showConsentBanner).toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -544,20 +544,36 @@ describe("PhraseMaker Widget", () => {
         phraseMaker.rowLabels = ["C"];
         phraseMaker._rows = [
             {
-                insertCell: jest.fn(() => ({
-                    style: {},
-                    setAttribute: jest.fn(),
-                    addEventListener: jest.fn(),
-                    appendChild: jest.fn()
-                }))
+                insertCell: jest.fn(() => {
+                    const classes = new Set();
+                    return {
+                        style: {},
+                        setAttribute: jest.fn(),
+                        addEventListener: jest.fn(),
+                        appendChild: jest.fn(),
+                        classList: {
+                            add: (...args) => args.forEach(c => classes.add(c)),
+                            remove: (...args) => args.forEach(c => classes.delete(c)),
+                            contains: c => classes.has(c)
+                        }
+                    };
+                })
             }
         ];
         phraseMaker._noteValueRow = {
-            insertCell: jest.fn(() => ({
-                style: {},
-                setAttribute: jest.fn(),
-                appendChild: jest.fn()
-            }))
+            insertCell: jest.fn(() => {
+                const classes = new Set();
+                return {
+                    style: {},
+                    setAttribute: jest.fn(),
+                    appendChild: jest.fn(),
+                    classList: {
+                        add: (...args) => args.forEach(c => classes.add(c)),
+                        remove: (...args) => args.forEach(c => classes.delete(c)),
+                        contains: c => classes.has(c)
+                    }
+                };
+            })
         };
 
         phraseMaker.addNotes(2, 4);
@@ -565,13 +581,21 @@ describe("PhraseMaker Widget", () => {
         expect(phraseMaker._notesToPlay.length).toBe(2);
     });
     test("addTuplet pushes notes to _notesToPlay", () => {
-        const createMockCell = () => ({
-            style: {},
-            innerHTML: "",
-            setAttribute: jest.fn(),
-            addEventListener: jest.fn(),
-            appendChild: jest.fn()
-        });
+        const createMockCell = () => {
+            const classes = new Set();
+            return {
+                style: {},
+                innerHTML: "",
+                setAttribute: jest.fn(),
+                addEventListener: jest.fn(),
+                appendChild: jest.fn(),
+                classList: {
+                    add: (...args) => args.forEach(c => classes.add(c)),
+                    remove: (...args) => args.forEach(c => classes.delete(c)),
+                    contains: c => classes.has(c)
+                }
+            };
+        };
 
         phraseMaker._rows = [
             {
@@ -756,16 +780,19 @@ describe("PhraseMaker Widget", () => {
     test("_clear resets matrix cells", () => {
         phraseMaker.rowLabels = ["C"];
 
-        phraseMaker._rows = [
-            {
-                cells: [
-                    {
-                        style: { backgroundColor: "black" },
-                        getAttribute: jest.fn(() => "white")
-                    }
-                ]
+        const classes = new Set(["pm-cell-active"]);
+        const cell = {
+            getAttribute: jest.fn(attr => {
+                if (attr === "data-color-class") return "pm-bg-pitch-cell";
+                return "white";
+            }),
+            classList: {
+                add: (...args) => args.forEach(c => classes.add(c)),
+                remove: (...args) => args.forEach(c => classes.delete(c)),
+                contains: c => classes.has(c)
             }
-        ];
+        };
+        phraseMaker._rows = [{ cells: [cell] }];
 
         phraseMaker._notesToPlay = [[[1], 4]];
         phraseMaker._setNotes = jest.fn();
@@ -773,6 +800,8 @@ describe("PhraseMaker Widget", () => {
         phraseMaker._clear();
 
         expect(phraseMaker._setNotes).toHaveBeenCalled();
+        expect(cell.classList.contains("pm-cell-active")).toBe(false);
+        expect(cell.classList.contains("pm-bg-pitch-cell")).toBe(true);
     });
     test("_divideNotes modifies tupletRhythms", () => {
         phraseMaker._readjustNotesBlocks = jest.fn();
@@ -972,16 +1001,20 @@ describe("PhraseMaker Widget", () => {
     });
     test("_clear resets matrix safely", () => {
         phraseMaker.rowLabels = ["C"];
-        phraseMaker._rows = [
-            {
-                cells: [
-                    {
-                        style: { backgroundColor: "black" },
-                        getAttribute: jest.fn(() => "white")
-                    }
-                ]
+
+        const classes = new Set(["pm-cell-active"]);
+        const cell = {
+            getAttribute: jest.fn(attr => {
+                if (attr === "data-color-class") return "pm-bg-pitch-cell";
+                return "white";
+            }),
+            classList: {
+                add: (...args) => args.forEach(c => classes.add(c)),
+                remove: (...args) => args.forEach(c => classes.delete(c)),
+                contains: c => classes.has(c)
             }
-        ];
+        };
+        phraseMaker._rows = [{ cells: [cell] }];
 
         phraseMaker._notesToPlay = [[["C"], 4]];
         phraseMaker._lyrics = ["text"];
@@ -990,6 +1023,8 @@ describe("PhraseMaker Widget", () => {
         phraseMaker._clear();
 
         expect(phraseMaker._setNotes).toHaveBeenCalled();
+        expect(cell.classList.contains("pm-cell-active")).toBe(false);
+        expect(cell.classList.contains("pm-bg-pitch-cell")).toBe(true);
     });
     test("makeClickable executes without crash", () => {
         phraseMaker.rowLabels = ["C"];
@@ -1001,7 +1036,15 @@ describe("PhraseMaker Widget", () => {
                         setAttribute: jest.fn(),
                         addEventListener: jest.fn(),
                         removeEventListener: jest.fn(),
-                        getAttribute: jest.fn(() => 1)
+                        getAttribute: jest.fn(attr => {
+                            if (attr === "data-color-class") return "pm-bg-pitch-cell";
+                            return 1;
+                        }),
+                        classList: {
+                            add: jest.fn(),
+                            remove: jest.fn(),
+                            contains: jest.fn(() => false)
+                        }
                     }
                 ]
             }

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -542,31 +542,32 @@ class PhraseMaker {
             drumName = this._deps.getDrumName(this.rowLabels[i]);
 
             // Depending on the row, we choose a different background color.
+            let cellColorClass;
             if (this.rowLabels[i] === "print") break;
             else if (
                 PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) !== -1 ||
                 PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) !== -1
             ) {
                 cellColor = this.platformColor.graphicsLabelBackground;
+                cellColorClass = "pm-bg-graphics-label";
             } else {
                 if (drumName === null) {
                     cellColor = this.platformColor.pitchLabelBackground;
+                    cellColorClass = "pm-bg-pitch-label";
                 } else {
                     cellColor = this.platformColor.drumLabelBackground;
+                    cellColorClass = "pm-bg-drum-label";
                 }
             }
 
             // A cell for the row label graphic
             cell = ptmTableRow.insertCell();
-            cell.style.backgroundColor = cellColor;
             cell.style.fontSize = this._cellScale * 100 + "%";
             cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + 1 + "px";
             cell.style.width = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) + "px";
             cell.style.minWidth = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) + "px";
             cell.style.maxWidth = cell.style.minWidth;
-            cell.className = "headcol"; // This cell is fixed horizontally.
-            cell.style.position = "sticky";
-            cell.style.left = "1.2px";
+            cell.className = "headcol pm-headcol " + cellColorClass;
             cell.textContent = "";
             this._headcols[i] = cell;
 
@@ -656,14 +657,12 @@ class PhraseMaker {
 
             // A cell for the row label
             cell = ptmTableRow.insertCell();
-            cell.style.backgroundColor = cellColor;
             cell.style.fontSize = this._cellScale * 100 + "%";
             cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + 1 + "px";
             cell.style.width = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) + "px";
             cell.style.minWidth = Math.floor(MATRIXSOLFEWIDTH * this._cellScale) + "px";
             cell.style.maxWidth = cell.style.minWidth;
-            cell.className = "labelcol"; // This cell is fixed horizontally.
-            cell.style.position = "sticky";
+            cell.className = "labelcol pm-labelcol " + cellColorClass;
             cell.style.left = PhraseMaker.BUTTONSIZE * this._cellScale + "px";
             cell.setAttribute("alt", i);
             this._labelcols[i] = cell;
@@ -849,17 +848,13 @@ class PhraseMaker {
         if (this.lyricsON) {
             const lyricsRow = ptmTable.insertRow();
             lyricsRow.setAttribute("id", "lyricRow");
-            lyricsRow.style.position = "sticky";
+            lyricsRow.classList.add("pm-lyrics-row");
 
             // Label Icon
             cell = lyricsRow.insertCell();
             cell.setAttribute("colspan", "1");
-            cell.className = "headcol";
-            cell.style.position = "sticky";
-            cell.style.left = "1.2px";
+            cell.className = "headcol pm-headcol pm-bg-lyrics-label";
             cell.style.zIndex = "1";
-            cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
-            cell.style.textAlign = "center";
             cell.textContent = "";
             const penImg = document.createElement("img");
             penImg.src = "images/pen.svg";
@@ -871,12 +866,8 @@ class PhraseMaker {
             // Label Cell (Fixed like "note value")
             cell = lyricsRow.insertCell();
             cell.setAttribute("colspan", "1");
-            cell.className = "headcol";
-            cell.style.position = "sticky";
-            cell.style.left = "1.2px";
+            cell.className = "headcol pm-headcol pm-bg-lyrics-label";
             cell.style.zIndex = "1";
-            cell.style.backgroundColor = this.platformColor.lyricsLabelBackground;
-            cell.style.textAlign = "center";
             cell.textContent = "Lyrics";
 
             // Nested Table for Input Fields
@@ -899,15 +890,7 @@ class PhraseMaker {
                 inputCell.style.width = this._noteWidth(noteValue) + "px";
                 inputCell.style.minWidth = inputCell.style.width;
                 inputCell.style.maxWidth = inputCell.style.width;
-                inputCell.style.backgroundColor = this.platformColor.lyricsInputBackground;
-                inputCell.style.fontFamily = "sans-serif";
-                inputCell.style.cursor = "default";
-                inputCell.style.borderSpacing = "1px 1px";
-                inputCell.style.borderCollapse = "collapse";
-                inputCell.style.boxSizing = "border-box";
-                inputCell.style.padding = "0";
-                inputCell.style.borderRadius = "6px";
-                inputCell.style.border = "none";
+                inputCell.classList.add("pm-lyrics-input-cell");
                 inputCell.setAttribute("alt", i + "__" + "graphicsblocks2");
 
                 const lyricsInput = document.createElement("input");
@@ -915,25 +898,19 @@ class PhraseMaker {
                 lyricsInput.value = this._lyrics[i];
 
                 lyricsInput.style.height = inputCell.style.height;
-                lyricsInput.style.width = "100%";
                 lyricsInput.style.minWidth = inputCell.style.minWidth;
                 lyricsInput.style.maxWidth = inputCell.style.maxWidth;
-                lyricsInput.style.fontSize = "inherit";
-                lyricsInput.style.fontFamily = "sans-serif";
-                lyricsInput.style.cursor = "default";
-                lyricsInput.style.boxSizing = "border-box";
-                lyricsInput.style.padding = "0";
-                lyricsInput.style.border = "none";
-                lyricsInput.style.borderRadius = "6px";
-                lyricsInput.style.backgroundColor = this.platformColor.lyricsInputBackground;
+                lyricsInput.classList.add("pm-lyrics-input");
 
                 inputCell.appendChild(lyricsInput);
                 inputCell.addEventListener("mouseover", event => {
-                    event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                    event.target.classList.add("pm-bg-selector-selected");
+                    event.target.classList.remove("pm-lyrics-input-cell");
                 });
 
                 inputCell.addEventListener("mouseout", event => {
-                    event.target.style.backgroundColor = this.platformColor.lyricsInputBackground;
+                    event.target.classList.remove("pm-bg-selector-selected");
+                    event.target.classList.add("pm-lyrics-input-cell");
                 });
                 lyricsInput.addEventListener("focus", () => (this.activity.isInputON = true));
                 lyricsInput.addEventListener("blur", () => (this.activity.isInputON = false));
@@ -948,15 +925,11 @@ class PhraseMaker {
         ptmTableRow = ptmTable.insertRow();
         ptmCell = ptmTableRow.insertCell();
         ptmTableRow.setAttribute("id", "bottomRow");
-        ptmTableRow.style.position = "sticky";
-        ptmTableRow.style.bottom = "0px";
-        ptmTableRow.style.zIndex = "1";
+        ptmTableRow.classList.add("pm-bottom-row");
 
         ptmCell.setAttribute("colspan", "2");
-        ptmCell.style.position = "sticky";
-        ptmCell.style.left = "1.2px";
+        ptmCell.className = "headcol pm-bottom-cell";
         ptmCell.style.zIndex = "1";
-        ptmCell.className = "headcol"; // This cell is fixed horizontally.
 
         tempTable = document.createElement("table");
         tempTable.setAttribute("cellpadding", "0px");
@@ -978,7 +951,7 @@ class PhraseMaker {
             Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
         this._noteValueLabel.style.minWidth = this._noteValueLabel.style.width;
         this._noteValueLabel.style.maxWidth = this._noteValueLabel.style.width;
-        this._noteValueLabel.style.backgroundColor = this.platformColor.labelColor;
+        this._noteValueLabel.classList.add("pm-bg-label");
 
         // Create tables to store individual note values.
         tempTable = document.createElement("table");
@@ -2454,7 +2427,7 @@ class PhraseMaker {
             n = row.cells.length;
             for (let i = 0; i < n; i++) {
                 cell = row.cells[i];
-                if (cell.style.backgroundColor === "black") {
+                if (cell.classList.contains("pm-cell-active")) {
                     thisRow.push(i);
                 }
             }
@@ -2717,7 +2690,7 @@ class PhraseMaker {
             // Add then the note cells.
             for (let j = 0, col; (col = this._rows[i].cells[j]); j++) {
                 exportCell = exportRow.insertCell();
-                exportCell.style.backgroundColor = col.style.backgroundColor;
+                exportCell.className = col.className;
                 exportCell.textContent = "";
                 Array.from(col.childNodes).forEach(child =>
                     exportCell.appendChild(child.cloneNode(true))
@@ -2744,7 +2717,7 @@ class PhraseMaker {
             for (let i = 0; i < noteValueRow.cells.length; i++) {
                 exportCell = exportRow.insertCell();
                 col = noteValueRow.cells[i];
-                exportCell.style.backgroundColor = col.style.backgroundColor;
+                exportCell.className = col.className;
                 exportCell.textContent = "";
                 Array.from(col.childNodes).forEach(child =>
                     exportCell.appendChild(child.cloneNode(true))
@@ -2768,7 +2741,7 @@ class PhraseMaker {
             for (let i = 0; i < noteValueRow.cells.length; i++) {
                 exportCell = exportRow.insertCell();
                 col = noteValueRow.cells[i];
-                exportCell.style.backgroundColor = col.style.backgroundColor;
+                exportCell.className = col.className;
                 exportCell.textContent = "";
                 Array.from(col.childNodes).forEach(child =>
                     exportCell.appendChild(child.cloneNode(true))
@@ -2793,7 +2766,7 @@ class PhraseMaker {
         for (let i = 0; i < noteValueRow.cells.length; i++) {
             exportCell = exportRow.insertCell();
             col = noteValueRow.cells[i];
-            exportCell.style.backgroundColor = col.style.backgroundColor;
+            exportCell.className = col.className;
             exportCell.textContent = "";
             Array.from(col.childNodes).forEach(child =>
                 exportCell.appendChild(child.cloneNode(true))
@@ -2913,7 +2886,7 @@ class PhraseMaker {
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
             labelCell.style.minWidth = labelCell.style.width;
             labelCell.style.maxWidth = labelCell.style.width;
-            labelCell.style.backgroundColor = this.platformColor.labelColor;
+            labelCell.classList.add("pm-bg-label");
 
             labelCell = this._tupletValueLabel;
             labelCell.textContent = this._("tuplet value");
@@ -2922,7 +2895,7 @@ class PhraseMaker {
             labelCell.style.width = Math.floor(2 * MATRIXSOLFEWIDTH * this._cellScale) + "px";
             labelCell.style.minWidth = labelCell.style.width;
             labelCell.style.maxWidth = labelCell.style.width;
-            labelCell.style.backgroundColor = this.platformColor.labelColor;
+            labelCell.classList.add("pm-bg-label");
 
             // Fill in the columns in the tuplet note value row up to
             // where the tuplet begins.
@@ -2930,14 +2903,14 @@ class PhraseMaker {
             valueRow = this._tupletValueRow;
             for (let i = 0; i < firstRow.cells.length; i++) {
                 cell = noteRow.insertCell();
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.classList.add("pm-bg-tuplet");
                 cell.style.width = firstRow.cells[i].style.width;
                 cell.style.minWidth = firstRow.cells[i].style.minWidth;
                 cell.style.maxWidth = firstRow.cells[i].style.maxWidth;
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
 
                 cell = valueRow.insertCell();
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.classList.add("pm-bg-tuplet");
                 cell.style.width = firstRow.cells[i].style.width;
                 cell.style.minWidth = firstRow.cells[i].style.minWidth;
                 cell.style.maxWidth = firstRow.cells[i].style.maxWidth;
@@ -2958,15 +2931,13 @@ class PhraseMaker {
             cell = noteRow.insertCell(-1);
             numerator = 32 / param[1][i];
             thisNoteValue = 1 / (numerator / (totalNoteInterval / tupletTimeFactor));
-            cell.style.backgroundColor = this.platformColor.tupletBackground;
+            cell.classList.add("pm-bg-tuplet", "pm-value-cell");
             cell.style.width = this._noteWidth(thisNoteValue) + "px";
             cell.style.minWidth = cell.style.width;
             cell.style.maxWidth = cell.style.width;
             cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
             cell.setAttribute("id", 1 / tupletNoteValue);
-            cell.style.lineHeight = 60 + "%";
             cell.style.fontSize = this._cellScale * 75 + "%";
-            cell.style.textAlign = "center";
             cell.style.borderLeft = i === 0 ? barStyle : "1px solid #ccc";
             obj = this._deps.toFraction(numerator / (totalNoteInterval / tupletTimeFactor));
 
@@ -3002,14 +2973,18 @@ class PhraseMaker {
             // Add the notes to the matrix a la addNote.
             for (let j = 0; j < this.rowLabels.length; j++) {
                 // Depending on the row, we choose a different background color.
+                let cellColorClass;
                 if (PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[j]) !== -1) {
                     cellColor = this.platformColor.graphicsBackground;
+                    cellColorClass = "pm-bg-graphics-cell";
                 } else {
                     drumName = this._deps.getDrumName(this.rowLabels[j]);
                     if (drumName === null) {
                         cellColor = this.platformColor.pitchBackground;
+                        cellColorClass = "pm-bg-pitch-cell";
                     } else {
                         cellColor = this.platformColor.drumBackground;
+                        cellColorClass = "pm-bg-drum-cell";
                     }
                 }
 
@@ -3017,6 +2992,7 @@ class PhraseMaker {
                 cell = ptmRow.insertCell();
 
                 cell.setAttribute("cellColor", cellColor);
+                cell.setAttribute("data-color-class", cellColorClass);
 
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 // Using the alt attribute to store the note value
@@ -3024,18 +3000,22 @@ class PhraseMaker {
                 cell.style.width = cellWidth;
                 cell.style.minWidth = cell.style.width;
                 cell.style.maxWidth = cell.style.width;
-                cell.style.backgroundColor = cellColor;
+                cell.classList.add(cellColorClass);
                 cell.style.borderLeft = i === 0 ? barStyle : "1px solid #ccc";
 
                 cell.onmouseover = event => {
-                    if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                    if (!event.target.classList.contains("pm-cell-active")) {
+                        event.target.classList.add("pm-bg-selector-selected");
+                        event.target.classList.remove(
+                            event.target.getAttribute("data-color-class")
+                        );
                     }
                 };
 
                 cell.onmouseout = event => {
-                    if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = event.target.getAttribute("cellColor");
+                    if (!event.target.classList.contains("pm-cell-active")) {
+                        event.target.classList.remove("pm-bg-selector-selected");
+                        event.target.classList.add(event.target.getAttribute("data-color-class"));
                     }
                 };
             }
@@ -3046,14 +3026,12 @@ class PhraseMaker {
         cell = valueRow.insertCell();
         cell.colSpan = numberOfNotes;
         cell.style.fontSize = Math.floor(this._cellScale * 75) + "%";
-        cell.style.lineHeight = 60 + "%";
         cell.style.width = this._noteWidth(noteValue) + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-        cell.style.textAlign = "center";
+        cell.classList.add("pm-value-cell", "pm-bg-tuplet");
         cell.textContent = tupletValue;
-        cell.style.backgroundColor = this.platformColor.tupletBackground;
         cell.style.borderLeft = barStyle;
 
         // And a span in the note value column too.
@@ -3061,12 +3039,11 @@ class PhraseMaker {
         cell = noteValueRow.insertCell();
         cell.colSpan = numberOfNotes;
         cell.style.fontSize = Math.floor(this._cellScale * 75) + "%";
-        cell.style.lineHeight = 60 + "%";
         cell.style.width = this._noteWidth(noteValue) + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-        cell.style.textAlign = "center";
+        cell.classList.add("pm-value-cell");
         cell.textContent = "";
         if (noteValueToDisplayAnchorTitle !== null) {
             const anchor = document.createElement("a");
@@ -3083,7 +3060,7 @@ class PhraseMaker {
                 if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
             }
         }
-        cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
+        cell.classList.add("pm-bg-rhythm-cell");
         cell.style.borderLeft = barStyle;
         this._matrixHasTuplets = true;
 
@@ -3138,17 +3115,21 @@ class PhraseMaker {
 
             for (let i = 0; i < rowCount; i++) {
                 // Depending on the row, we choose a different background color.
+                let cellColorClass;
                 if (
                     PhraseMakerUtils.MATRIXGRAPHICS.indexOf(this.rowLabels[i]) !== -1 ||
                     PhraseMakerUtils.MATRIXGRAPHICS2.indexOf(this.rowLabels[i]) !== -1
                 ) {
                     cellColor = this.platformColor.graphicsBackground;
+                    cellColorClass = "pm-bg-graphics-cell";
                 } else {
                     drumName = this._deps.getDrumName(this.rowLabels[i]);
                     if (drumName === null) {
                         cellColor = this.platformColor.pitchBackground;
+                        cellColorClass = "pm-bg-pitch-cell";
                     } else {
                         cellColor = this.platformColor.drumBackground;
+                        cellColorClass = "pm-bg-drum-cell";
                     }
                 }
 
@@ -3157,25 +3138,29 @@ class PhraseMaker {
                 cell = row.insertCell();
 
                 cell.setAttribute("cellColor", cellColor);
-                cell.style.borderRadius = "6px";
+                cell.setAttribute("data-color-class", cellColorClass);
+                cell.classList.add("pm-note-cell", cellColorClass);
                 cell.style.height = Math.floor(MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.width = this._noteWidth(noteValue) + "px";
                 cell.style.minWidth = cell.style.width;
                 cell.style.maxWidth = cell.style.width;
-                cell.style.backgroundColor = cellColor;
                 cell.style.borderLeft = barStyle;
                 // Using the alt attribute to store the note value
                 cell.setAttribute("alt", 1 / noteValue);
 
                 cell.addEventListener("mouseover", event => {
-                    if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = this.platformColor.selectorSelected;
+                    if (!event.target.classList.contains("pm-cell-active")) {
+                        event.target.classList.add("pm-bg-selector-selected");
+                        event.target.classList.remove(
+                            event.target.getAttribute("data-color-class")
+                        );
                     }
                 });
 
                 cell.addEventListener("mouseout", event => {
-                    if (event.target.style.backgroundColor !== "black") {
-                        event.target.style.backgroundColor = event.target.getAttribute("cellColor");
+                    if (!event.target.classList.contains("pm-cell-active")) {
+                        event.target.classList.remove("pm-bg-selector-selected");
+                        event.target.classList.add(event.target.getAttribute("data-color-class"));
                     }
                 });
             }
@@ -3188,8 +3173,7 @@ class PhraseMaker {
             cell.style.maxWidth = cell.style.width;
             cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
             cell.style.fontSize = Math.floor(this._cellScale * 75) + "%";
-            cell.style.lineHeight = 60 + "%";
-            cell.style.textAlign = "center";
+            cell.classList.add("pm-value-cell");
             cell.textContent = "";
             if (noteValueToDisplayAnchorTitle !== null) {
                 const anchor = document.createElement("a");
@@ -3206,8 +3190,7 @@ class PhraseMaker {
                     if (k < parts.length - 1) cell.appendChild(document.createElement("br"));
                 }
             }
-            cell.style.backgroundColor = this.platformColor.rhythmcellcolor;
-            cell.style.color = this.platformColor.textColor;
+            cell.classList.add("pm-bg-rhythm-cell");
             cell.setAttribute("alt", noteValue);
             cell.style.borderLeft = barStyle;
 
@@ -3221,7 +3204,7 @@ class PhraseMaker {
                 cell.style.maxWidth = cell.style.width;
                 cell.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.classList.add("pm-bg-tuplet");
                 cell.style.borderLeft = barStyle;
 
                 row = this._tupletValueRow;
@@ -3231,7 +3214,7 @@ class PhraseMaker {
                 cell.style.maxWidth = cell.style.width;
                 cell.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
                 cell.style.height = Math.floor(1.5 * MATRIXSOLFEHEIGHT * this._cellScale) + "px";
-                cell.style.backgroundColor = this.platformColor.tupletBackground;
+                cell.classList.add("pm-bg-tuplet");
                 cell.style.borderLeft = barStyle;
             }
 
@@ -4106,8 +4089,9 @@ class PhraseMaker {
             row = this._rows[i];
             for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
-                if (cell.style.backgroundColor === "black") {
-                    cell.style.backgroundColor = cell.getAttribute("cellColor");
+                if (cell.classList.contains("pm-cell-active")) {
+                    cell.classList.remove("pm-cell-active");
+                    cell.classList.add(cell.getAttribute("data-color-class"));
                     this._setNotes(j, i, false);
                 }
             }
@@ -4129,12 +4113,15 @@ class PhraseMaker {
                     isMouseDown = true;
                     const i = Number(evt.target.getAttribute("data-i"));
                     const j = Number(evt.target.getAttribute("data-j"));
-                    if (evt.target.style.backgroundColor === "black") {
-                        evt.target.style.backgroundColor = evt.target.getAttribute("cellColor");
+                    if (evt.target.classList.contains("pm-cell-active")) {
+                        evt.target.classList.remove("pm-cell-active");
+                        evt.target.classList.add(evt.target.getAttribute("data-color-class"));
                         this._notesToPlay[j][0] = ["R"];
                         if (!this._noteBlocks) this._setNotes(j, i, false);
                     } else {
-                        evt.target.style.backgroundColor = "black";
+                        evt.target.classList.add("pm-cell-active");
+                        evt.target.classList.remove(evt.target.getAttribute("data-color-class"));
+                        evt.target.classList.remove("pm-bg-selector-selected");
                         if (!this._noteBlocks) this._setNotes(j, i, true);
                     }
                 };
@@ -4143,12 +4130,17 @@ class PhraseMaker {
                     const i = Number(evt.target.getAttribute("data-i"));
                     const j = Number(evt.target.getAttribute("data-j"));
                     if (isMouseDown) {
-                        if (evt.target.style.backgroundColor === "black") {
-                            evt.target.style.backgroundColor = evt.target.getAttribute("cellColor");
+                        if (evt.target.classList.contains("pm-cell-active")) {
+                            evt.target.classList.remove("pm-cell-active");
+                            evt.target.classList.add(evt.target.getAttribute("data-color-class"));
                             this._notesToPlay[j][0] = ["R"];
                             if (!this._noteBlocks) this._setNotes(j, i, false);
                         } else {
-                            evt.target.style.backgroundColor = "black";
+                            evt.target.classList.add("pm-cell-active");
+                            evt.target.classList.remove(
+                                evt.target.getAttribute("data-color-class")
+                            );
+                            evt.target.classList.remove("pm-bg-selector-selected");
                             if (!this._noteBlocks) this._setNotes(j, i, true);
                         }
                     }
@@ -4174,7 +4166,8 @@ class PhraseMaker {
                 for (let j = 0; j < this._markedColsInRow[ii].length; j++) {
                     c = this._markedColsInRow[ii][j];
                     cell = row.cells[c];
-                    cell.style.backgroundColor = "black";
+                    cell.classList.add("pm-cell-active");
+                    cell.classList.remove(cell.getAttribute("data-color-class"));
                     this._setNoteCell(r, c, cell, false, null);
                 }
             }
@@ -4240,7 +4233,8 @@ class PhraseMaker {
                     if (row !== null && typeof row !== "undefined") {
                         cell = row.cells[c];
                         if (cell !== undefined) {
-                            cell.style.backgroundColor = "black";
+                            cell.classList.add("pm-cell-active");
+                            cell.classList.remove(cell.getAttribute("data-color-class"));
                             this._setNoteCell(r, c, cell, false, null);
                         }
                     }
@@ -4328,7 +4322,7 @@ class PhraseMaker {
         for (let j = 0; j < this.rowLabels.length; j++) {
             row = this._rows[j];
             cell = row.cells[colIndex];
-            if (cell.style.backgroundColor === "black") {
+            if (cell.classList.contains("pm-cell-active")) {
                 this._setNoteCell(j, colIndex, cell, playNote);
             }
         }
@@ -4431,8 +4425,9 @@ class PhraseMaker {
             row = this._rows[i];
             for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
-                if (cell.style.backgroundColor === "black") {
-                    cell.style.backgroundColor = cell.getAttribute("cellColor");
+                if (cell.classList.contains("pm-cell-active")) {
+                    cell.classList.remove("pm-cell-active");
+                    cell.classList.add(cell.getAttribute("data-color-class"));
                     this._notesToPlay[j][0] = ["R"];
                     this._setNotes(j, i, false);
                 }


### PR DESCRIPTION
**Problem**

Several test files assert on inline `style.backgroundColor` values that no longer exist after the PhraseMaker CSS migration and palette keyboard focus refactor. Mock cells include dead `style: { backgroundColor: "black" }` properties that are never read by the migrated source code. Tests verify color strings instead of semantic class state.

addresses #6606 

**Solution**

Update test mocks and assertions to check for CSS class presence instead of inline style values:

- Replace `style.backgroundColor === "black"` assertions with `classList.contains("pm-cell-active")`
- Replace `style.backgroundColor === platformColor.paletteBackground` assertions with `classList.contains("palette-keyboard-hover") === false`
- Remove dead `style` properties from mock cells
- Add new assertions verifying class restoration after state changes (e.g., `data-color-class` is re-applied after `_clear()`)

### Changes

| File | Change |
|---|---|
| `js/widgets/__tests__/phrasemaker.test.js` | Removed dead `style.backgroundColor` from 2 `_clear` test mocks. Added 4 new `classList` assertions verifying active class removal and color class restoration |
| `js/widgets/__tests__/PhraseMakerUI.test.js` | Updated mock cells and assertions to use `classList` API instead of `style` object |
| `js/__tests__/palette.test.js` | Updated `resetKeyboardNavigation` test: replaced `style` mock with `classList` Set, changed assertion from color string check to class presence check |

### Dependencies

> **This PR depends on:**
> - PR 1 (`fix/keyboard-focus-indicators`) — palette.js source must use `classList` for the palette test assertions to match
> - PR 2 (`refactor/phrasemaker-css-migration`) — phrasemaker.js source must use `classList` for the phrasemaker test assertions to match
>
> Merge PR 1 and PR 2 first, then this PR.

## PR Category
- [ ] Bug Fix 
- [ ] Feature
- [ ] Performance
- [x] Tests 
- [ ] Documentation

### Testing

- `npm test` — 5187/5187 passing (on branch with all 3 PRs merged)
- `npm run lint` — 0 errors
- `npx prettier --check` — all modified files formatted
