### PR TITLE
refactor(oscilloscope): replace platformColor background with CSS token

### DIFF
--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -73,6 +73,13 @@ class Oscilloscope {
         // UI state
         this.zoomFactor = 40.0;
         this.verticalOffset = 0;
+        this._bgColor =
+            getComputedStyle(document.body).getPropertyValue("--bg").trim() || "#ffffff";
+        this._onThemeChange = () => {
+            this._bgColor =
+                getComputedStyle(document.body).getPropertyValue("--bg").trim() || "#ffffff";
+        };
+        document.body.addEventListener("themechange", this._onThemeChange);
 
         // Zoom buttons
         const zoomInButton = widgetWindow.addButton("", Oscilloscope.ICONSIZE, _("Zoom In"));
@@ -182,6 +189,7 @@ class Oscilloscope {
         this._stopAnimation();
 
         document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        document.body.removeEventListener("themechange", this._onThemeChange);
 
         this.drawVisualIDs = {};
         this._canvasState = {};
@@ -248,8 +256,7 @@ class Oscilloscope {
             const dataArray = analyser.getValue();
             const bufferLength = dataArray.length;
 
-            ctx.fillStyle =
-                getComputedStyle(document.body).getPropertyValue("--bg").trim() || "#ffffff";
+            ctx.fillStyle = this._bgColor;
             ctx.fillRect(0, 0, state.width, state.height);
             ctx.lineWidth = 2;
             ctx.strokeStyle = state.turtle.painter._canvasColor;

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -248,7 +248,8 @@ class Oscilloscope {
             const dataArray = analyser.getValue();
             const bufferLength = dataArray.length;
 
-            ctx.fillStyle = platformColor.background || "#FFFFFF";
+            ctx.fillStyle =
+                getComputedStyle(document.body).getPropertyValue("--bg").trim() || "#ffffff";
             ctx.fillRect(0, 0, state.width, state.height);
             ctx.lineWidth = 2;
             ctx.strokeStyle = state.turtle.painter._canvasColor;


### PR DESCRIPTION
## Summary

This PR migrates `js/widgets/oscilloscope.js` to read the canvas background color from the existing `--bg` CSS custom property instead of the legacy `platformColor.background` object.

No behavioral changes intended.

---

## Changes

### js/widgets/oscilloscope.js

* Replaced the Oscilloscope canvas background color lookup with:

  * `getComputedStyle(document.body).getPropertyValue("--bg")`
* Removed the remaining `platformColor` dependency from the widget.


---

## Validation

### Automated checks

* `npx jest js/widgets/__tests__/oscilloscope.test.js --coverage=false` ✅

  * 51 tests passed

* `npm run lint` ✅

  * passes with existing repository warnings only

* `npm test` ✅

  * 156 suites passed
  * 5187 tests passed

### Browser validation

Verified in DevTools console that:

* no `platformColor` dependency remains
* Oscilloscope reads the `--bg` CSS token correctly
* theme values resolve properly across themes

Validation screenshot attached :
<img width="901" height="381" alt="Screenshot 2026-05-19 123532" src="https://github.com/user-attachments/assets/e1af5046-ed27-473f-8dec-b20747983a09" />

---

## PR Category


- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Issue

Partially addresses #6606
