### PR TITLE
fix: sanitize saved HTML image URLs

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -292,6 +292,23 @@ class SaveInterface {
      * @instance
      */
     prepareHTML() {
+        const sanitizeImageURL = value => {
+            if (value === null || value === undefined) return "";
+
+            const raw = String(value).trim();
+            if (raw === "") return "";
+
+            const lower = raw.toLowerCase();
+            if (lower.startsWith("data:")) {
+                return /^data:image\/[a-z0-9.+-]+;base64,[a-z0-9+/=\s]+$/i.test(raw) ? raw : "";
+            }
+
+            if (lower.startsWith("http://") || lower.startsWith("https://")) return raw;
+
+            if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) return "";
+            return raw;
+        };
+
         let file = this.htmlSaveTemplate;
         let description = _("No description provided");
         if (
@@ -316,7 +333,7 @@ class SaveInterface {
             .replace(/{{ project_description }}/g, escapeHTML(description))
             .replace(/{{ project_name }}/g, escapeHTML(name))
             .replace(/{{ data }}/g, escapeHTML(data))
-            .replace(/{{ project_image }}/g, escapeHTML(image));
+            .replace(/{{ project_image }}/g, escapeHTML(sanitizeImageURL(image)));
 
         return file;
     }

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -316,6 +316,61 @@ describe("save HTML methods", () => {
         expect(html).toContain("&lt;/script&gt;");
     });
 
+    it("should block unsafe project image URLs in prepareHTML", () => {
+        const unsafeImageActivity = {
+            beginnerMode: false,
+            PlanetInterface: {
+                getCurrentProjectName: jest.fn(() => "Mock Project"),
+                getCurrentProjectDescription: jest.fn(() => "Mock Description"),
+                getCurrentProjectImage: jest.fn(() => "javascript:alert(1)")
+            },
+            prepareExport: jest.fn(() => "Mock Exported Data")
+        };
+
+        const si = new SaveInterface(unsafeImageActivity);
+        const html = si.prepareHTML();
+
+        expect(html).toContain('src=""');
+        expect(html).not.toContain("javascript:alert(1)");
+    });
+
+    it("should reject non-image data URLs in prepareHTML", () => {
+        const dataUrlActivity = {
+            beginnerMode: false,
+            PlanetInterface: {
+                getCurrentProjectName: jest.fn(() => "Mock Project"),
+                getCurrentProjectDescription: jest.fn(() => "Mock Description"),
+                getCurrentProjectImage: jest.fn(() => "data:text/html;base64,PHNjcmlwdD4=")
+            },
+            prepareExport: jest.fn(() => "Mock Exported Data")
+        };
+
+        const si = new SaveInterface(dataUrlActivity);
+        const html = si.prepareHTML();
+
+        expect(html).toContain('src=""');
+        expect(html).not.toContain("data:text/html;base64,PHNjcmlwdD4=");
+    });
+
+    it("should allow valid image data URLs in prepareHTML", () => {
+        const validImageActivity = {
+            beginnerMode: false,
+            PlanetInterface: {
+                getCurrentProjectName: jest.fn(() => "Mock Project"),
+                getCurrentProjectDescription: jest.fn(() => "Mock Description"),
+                getCurrentProjectImage: jest.fn(
+                    () => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA"
+                )
+            },
+            prepareExport: jest.fn(() => "Mock Exported Data")
+        };
+
+        const si = new SaveInterface(validImageActivity);
+        const html = si.prepareHTML();
+
+        expect(html).toContain("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA");
+    });
+
     it("should compose exported page initialization with other load handlers", () => {
         const si = new SaveInterface({
             PlanetInterface: {


### PR DESCRIPTION
## PR Description
Hardens saved project HTML exports by sanitizing `project_image` URLs before they are inserted into the exported page.

## Changes
- allow safe `http`/`https` image URLs
- allow valid base64 `data:image/...` URLs
- reject unsafe schemes such as `javascript:`
- reject non-image `data:` URLs such as `data:text/html`
- add focused tests for blocked and allowed image URL cases

## Testing
- npm run lint
- npx prettier --check js/SaveInterface.js js/__tests__/SaveInterface.test.js
- npm test

## Manual verification
- ran Music Blocks locally
- confirmed the workspace loads correctly
- confirmed the save dropdown still opens normally after the change

## PR category
- [x] Bug Fix
- [x] Security