### PR TITLE
fix: restore adjustDocks guard and trim clamp cleanup

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -230,4 +230,56 @@ describe("Blocks Foundation", () => {
             expect(blocks._expandablesList).toEqual([1]);
         });
     });
+
+    describe("Stack Cleanup And Dock Adjustment", () => {
+        it("should expand clamps once after adjusting all queued docks", () => {
+            const blocks = new Blocks(mockActivity);
+            const callOrder = [];
+
+            blocks._checkArgClampBlocks = [];
+            blocks._checkTwoArgBlocks = [];
+            blocks._adjustTheseDocks = [11, 17, 23];
+            blocks._adjustTheseStacks = [];
+            blocks.adjustDocks = jest.fn(blk => {
+                callOrder.push(`dock:${blk}`);
+            });
+            blocks._expandClamps = jest.fn(() => {
+                callOrder.push("expand");
+            });
+
+            blocks._cleanupStacks();
+
+            expect(blocks.adjustDocks).toHaveBeenCalledTimes(3);
+            expect(blocks._expandClamps).toHaveBeenCalledTimes(1);
+            expect(callOrder).toEqual(["dock:11", "dock:17", "dock:23", "expand"]);
+        });
+
+        it("should stop recursive adjustDocks cycles without overflowing the stack", () => {
+            const blocks = new Blocks(mockActivity);
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+            const makeDockBlock = (connections, x, y) => ({
+                name: "flow",
+                connections,
+                docks: [
+                    [0, 0],
+                    [0, 20]
+                ],
+                container: { x, y },
+                isTwoArgBooleanBlock: jest.fn().mockReturnValue(false),
+                isInlineCollapsible: jest.fn().mockReturnValue(false),
+                collapsed: false
+            });
+
+            blocks.blockList = [makeDockBlock([null, 1], 0, 0), makeDockBlock([0, 0], 0, 20)];
+            blocks._moveBlock = jest.fn();
+
+            expect(() => blocks.adjustDocks(0, true)).not.toThrow();
+            expect(blocks._moveBlock).toHaveBeenCalled();
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringContaining("Infinite loop encountered while adjusting docks")
+            );
+
+            debugSpy.mockRestore();
+        });
+    });
 });

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1178,7 +1178,7 @@ class Blocks {
 
                 if (c > 0) {
                     /** Recurse on connected blocks. */
-                    this.adjustDocks(cblk, true);
+                    this.adjustDocks(cblk);
                 }
             }
 
@@ -7049,8 +7049,9 @@ class Blocks {
             for (let blk = 0; blk < this._adjustTheseDocks.length; blk++) {
                 this.adjustDocks(this._adjustTheseDocks[blk], true);
                 /** blockBlocks._expandTwoArgs(); */
-                this._expandClamps();
             }
+
+            this._expandClamps();
 
             for (let blk = 0; blk < this._adjustTheseStacks.length; blk++) {
                 this.raiseStackToTop(this._adjustTheseStacks[blk]);


### PR DESCRIPTION
### Summary
This PR fixes two issues in `js/blocks.js`:

- restore the `adjustDocks()` infinite-loop guard by preserving `_loopCounter` across recursive calls
- run `_expandClamps()` once after `_cleanupStacks()` finishes adjusting queued docks instead of once per dock target
- add focused regression tests for both behaviors in `js/__tests__/blocks.test.js`

### Why
The recursive `adjustDocks(cblk, true)` call reset the loop counter on every step, which broke the malformed-data guard and could allow recursive dock cycles to run until stack overflow.

At the same time, `_cleanupStacks()` was calling `_expandClamps()` inside the `_adjustTheseDocks` loop, which repeated full clamp discovery and canvas refresh work for every queued dock adjustment during load.


### Tests
Added regression coverage for:

- `_cleanupStacks()` only expanding clamps once after all queued dock adjustments
- `adjustDocks()` stopping recursive cycles without overflowing the stack

### Testing
- `npm run lint`
- `npx prettier --check js/blocks.js js/__tests__/blocks.test.js`
- `npm test`

### PR Category
- [x] Performance
- [x] Tests
