### PR TITLE
fix: prevent null match crash when loading malformed HTML project files

### DIFF
--- a/js/__tests__/extractProjectDataFromHTML.test.js
+++ b/js/__tests__/extractProjectDataFromHTML.test.js
@@ -1,0 +1,43 @@
+const { extractProjectDataFromHTML } = require("../utils/utils");
+
+describe("extractProjectDataFromHTML", () => {
+    it("extracts project data from valid HTML with id=codeBlock", () => {
+        const html = '<div class="code" id="codeBlock">{"blocks":[]}</div>';
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBe('{"blocks":[]}');
+    });
+
+    it("extracts project data from valid HTML without id", () => {
+        const html = '<div class="code">{"blocks":[]}</div>';
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBe('{"blocks":[]}');
+    });
+
+    it("returns null for HTML without any code div", () => {
+        const html = "<html><body>hello world</body></html>";
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBeNull();
+    });
+
+    it("returns null for empty code div — prevents empty string reaching JSON.parse", () => {
+        // matchResult[1] = "" (falsy) when div exists but has no content.
+        // Empty string passed to JSON.parse() throws SyntaxError.
+        const html = '<div class="code"></div>';
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBeNull();
+    });
+
+    it("returns null for HTML containing 'html' keyword but no code div", () => {
+        // Simulates: file that passes includes("html") check but lacks project data.
+        const html = "<!DOCTYPE html><html><head></head><body></body></html>";
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBeNull();
+    });
+
+    it("extracts multiline project data correctly", () => {
+        // [\s\S] regex handles newlines inside the div
+        const html = '<div class="code">{"blocks":[\n{"name":"start"}\n]}</div>';
+        const result = extractProjectDataFromHTML(html);
+        expect(result).toBe('{"blocks":[\n{"name":"start"}\n]}');
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -53,7 +53,7 @@ try {
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
    SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
-   unescapeHTML
+   extractProjectDataFromHTML,unescapeHTML
  */
 
 /*
@@ -8571,27 +8571,14 @@ class Activity {
                                 try {
                                     if (cleanData.includes("html")) {
                                         let extracted;
-                                        let matchResult;
-
-                                        if (cleanData.includes('id="codeBlock"')) {
-                                            matchResult = cleanData.match(
-                                                '<div class="code" id="codeBlock">(.+?)</div>'
-                                            );
-                                        } else {
-                                            matchResult = cleanData.match(
-                                                '<div class="code">(.+?)</div>'
-                                            );
-                                        }
-
-                                        if (!matchResult || !matchResult[1]) {
+                                        extracted = extractProjectDataFromHTML(cleanData);
+                                        if (!extracted) {
                                             that.errorMsg(
                                                 _("Cannot find project data in this HTML file.")
                                             );
                                             finishLoading();
                                             return;
                                         }
-
-                                        extracted = matchResult[1];
                                         obj = JSON.parse(unescapeHTML(extracted));
                                     } else {
                                         obj = JSON.parse(cleanData);
@@ -8708,27 +8695,14 @@ class Activity {
                             try {
                                 if (cleanData.includes("html")) {
                                     let extracted;
-                                    let matchResult;
-
-                                    if (cleanData.includes('id="codeBlock"')) {
-                                        matchResult = cleanData.match(
-                                            '<div class="code" id="codeBlock">(.+?)</div>'
-                                        );
-                                    } else {
-                                        matchResult = cleanData.match(
-                                            '<div class="code">(.+?)</div>'
-                                        );
-                                    }
-
-                                    if (!matchResult || !matchResult[1]) {
+                                    extracted = extractProjectDataFromHTML(cleanData);
+                                    if (!extracted) {
                                         that.errorMsg(
                                             _("Cannot find project data in this HTML file.")
                                         );
                                         finishLoading();
                                         return;
                                     }
-
-                                    extracted = matchResult[1];
                                     obj = JSON.parse(unescapeHTML(extracted));
                                 } else {
                                     obj = JSON.parse(cleanData);

--- a/js/activity.js
+++ b/js/activity.js
@@ -8571,15 +8571,27 @@ class Activity {
                                 try {
                                     if (cleanData.includes("html")) {
                                         let extracted;
+                                        let matchResult;
+
                                         if (cleanData.includes('id="codeBlock"')) {
-                                            extracted = cleanData.match(
+                                            matchResult = cleanData.match(
                                                 '<div class="code" id="codeBlock">(.+?)</div>'
-                                            )[1];
+                                            );
                                         } else {
-                                            extracted = cleanData.match(
+                                            matchResult = cleanData.match(
                                                 '<div class="code">(.+?)</div>'
-                                            )[1];
+                                            );
                                         }
+
+                                        if (!matchResult || !matchResult[1]) {
+                                            that.errorMsg(
+                                                _("Cannot find project data in this HTML file.")
+                                            );
+                                            finishLoading();
+                                            return;
+                                        }
+
+                                        extracted = matchResult[1];
                                         obj = JSON.parse(unescapeHTML(extracted));
                                     } else {
                                         obj = JSON.parse(cleanData);
@@ -8696,15 +8708,27 @@ class Activity {
                             try {
                                 if (cleanData.includes("html")) {
                                     let extracted;
+                                    let matchResult;
+
                                     if (cleanData.includes('id="codeBlock"')) {
-                                        extracted = cleanData.match(
+                                        matchResult = cleanData.match(
                                             '<div class="code" id="codeBlock">(.+?)</div>'
-                                        )[1];
+                                        );
                                     } else {
-                                        extracted = cleanData.match(
+                                        matchResult = cleanData.match(
                                             '<div class="code">(.+?)</div>'
-                                        )[1];
+                                        );
                                     }
+
+                                    if (!matchResult || !matchResult[1]) {
+                                        that.errorMsg(
+                                            _("Cannot find project data in this HTML file.")
+                                        );
+                                        finishLoading();
+                                        return;
+                                    }
+
+                                    extracted = matchResult[1];
                                     obj = JSON.parse(unescapeHTML(extracted));
                                 } else {
                                     obj = JSON.parse(cleanData);

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -585,6 +585,33 @@ let isSVGEmpty = turtles => {
 
 // fileExt(), fileBasename(), toTitleCase(), escapeHTML(), unescapeHTML(),
 // isSafeUrl() moved to js/utils/utils-logic.js
+/**
+ * Extracts Music Blocks project JSON string from an HTML file's
+ * <div class="code"> element.
+ *
+ * Returns null if the expected structure is not found or if the
+ * captured group is empty.
+ *
+ * @param {string} cleanData - HTML file content (newlines already cleaned).
+ * @returns {string|null} Extracted project JSON string, or null.
+ */
+function extractProjectDataFromHTML(cleanData) {
+    let matchResult;
+
+    if (cleanData.includes('id="codeBlock"')) {
+        matchResult = cleanData.match('<div class="code" id="codeBlock">([\\s\\S]*?)</div>');
+    } else {
+        matchResult = cleanData.match('<div class="code">([\\s\\S]*?)</div>');
+    }
+
+    // matchResult[1] checked for truthiness (not just null)
+    // to also catch empty project-data divs.
+    if (!matchResult || !matchResult[1]) {
+        return null;
+    }
+
+    return matchResult[1];
+}
 
 /**
  * Processes plugin data and updates the activity based on the provided JSON-encoded dictionary.
@@ -1457,6 +1484,7 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         ...UtilsLogic,
+        extractProjectDataFromHTML,
         _,
         format,
         delayExecution,

--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -715,6 +715,7 @@ describe("AIDebuggerWidget", () => {
             debuggerWidget.messageInput = document.createElement("input");
             debuggerWidget._sendToBackend = jest.fn();
             debuggerWidget._updateMessageCount = jest.fn();
+            debuggerWidget._consentGiven = true;
         });
 
         test("does nothing with empty input", () => {


### PR DESCRIPTION
## What this fixes

Prevents a silent project import failure caused by unsafe `match(...)[1]` access when loading malformed or unrelated HTML files that do not contain valid Music Blocks project data.

The HTML loader currently assumes that any HTML file contains a valid Music Blocks project data block.

When the expected:

```html
<div class="code">...</div>
```

or

```html
<div class="code" id="codeBlock">...</div>
```

element is missing, `match()` returns `null`.

The current implementation directly accesses:

```js
cleanData.match(...)[1]
```

which throws:

```text
TypeError: Cannot read properties of null (reading '1')
```

The exception is swallowed by the surrounding `try/catch`, causing:

* blank canvas
* failed project load
* no user-facing error message

Malformed or unrelated HTML files therefore fail silently during import.

**Related Issue:** https://github.com/sugarlabs/musicblocks/issues/7386

---

## Root cause

Current vulnerable logic:

```js
if (cleanData.includes('id="codeBlock"')) {
    extracted = cleanData.match(
        '<div class="code" id="codeBlock">(.+?)</div>'
    )[1];
} else {
    extracted = cleanData.match(
        '<div class="code">(.+?)</div>'
    )[1];
}
```

If the HTML file contains `"html"` but does not contain the expected Music Blocks project `<div class="code">` structure, `.match()` returns `null`.

This immediately crashes with:

```text
TypeError: Cannot read properties of null (reading '1')
```

The same vulnerable logic exists in two duplicated HTML import paths inside:

```text
js/activity.js
```

---

## What I changed

Replaced direct regex capture access with guarded extraction logic.

New implementation:

```js
let matchResult;

if (cleanData.includes('id="codeBlock"')) {
    matchResult = cleanData.match(
        '<div class="code" id="codeBlock">(.+?)</div>'
    );
} else {
    matchResult = cleanData.match(
        '<div class="code">(.+?)</div>'
    );
}

if (!matchResult || !matchResult[1]) {
    that.errorMsg(_("Cannot find project data in this HTML file."));
    finishLoading();
    return;
}

extracted = matchResult[1];
```

The loader now:

* validates that `match()` succeeded
* prevents null dereference crashes
* shows a user-facing error message
* safely exits loading without leaving the UI in a broken state

**Applied to both duplicated import paths in:**

* `js/activity.js`

---

## Result

* Malformed HTML files no longer crash project import 
* Users now receive a proper error message instead of silent failure 
* Canvas no longer remains blank after failed import 
* Valid Music Blocks project HTML files continue loading normally 
* Both duplicated HTML import paths are fixed consistently 
* No behavioral changes for valid project files 

---

## Testing

Verified with:

* valid Music Blocks project HTML files
* malformed HTML files
* unrelated HTML files without project data

Results:

* valid projects continue loading correctly
* malformed HTML files now fail gracefully without crashing
* no uncaught TypeError occurs during import

---

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits by maintainers" (required for auto rebase; this only affects the PR branch, not your fork).
