### PR TITLE
Fix/replace amp img

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,11 +353,12 @@
                         <div id="load-container">
                             <div id="load-content">
                                 <p id="messageText"></p>
-                                <amp-img
+                                <img
                                     id="loading-image"
                                     src="images/loading.gif"
                                     alt="Loading..."
-                                ></amp-img>
+                                    loading="lazy"
+                                />
                             </div>
                         </div>
                     </div>
@@ -541,8 +542,8 @@
                                 "
                                 data-position="bottom"
                             >
-                                <amp-img alt="MusicBlocks Logo" width="100%" src="images/logo.svg">
-                                </amp-img>
+                                <img alt="MusicBlocks Logo" width="100%" src="images/logo.svg" loading="lazy">
+                                </img>
                             </div>
                             <ul class="main left">
                                 <li>


### PR DESCRIPTION
### What is the current behavior?
The `index.html` file uses `<amp-img>` tags for the site logo and the loading spinner. However, the required Accelerated Mobile Pages (AMP) JavaScript runtime is not loaded anywhere in the document `<head>`. Because of this missing dependency, the browser parses these tags as an `HTMLUnknownElement`, resulting in invalid HTML that relies purely on fallback browser error-handling to render the images.

###  What is the new behavior?
This PR replaces the two instances of `<amp-img>` with standard, native HTML5 `<img>` tags. 

### Technical Details:
* Swapped `<amp-img>` to `<img>` for valid DOM parsing.
* Added the native `loading="lazy"` attribute to both images. This preserves the performance and lazy-loading benefits that the original AMP implementation was attempting to provide, but without requiring external libraries.
* Maintained all existing attributes (`id`, `src`, `alt`, `style`, `width`). Zero application logic or CSS was altered.

###  Checklist
- [x] Performance