### PR TITLE
fix: resolve failing AI Debugger _sendMessage test and add consent fallback test

### DIFF
--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -730,8 +730,18 @@ describe("AIDebuggerWidget", () => {
             expect(debuggerWidget.chatHistory).toHaveLength(0);
         });
 
+        test("shows consent banner and does not send message if consent not given", () => {
+            debuggerWidget.messageInput.value = "Hello AI";
+            debuggerWidget._showConsentBanner = jest.fn();
+            debuggerWidget._sendMessage();
+            expect(debuggerWidget.chatHistory).toHaveLength(0);
+            expect(debuggerWidget._showConsentBanner).toHaveBeenCalled();
+            expect(debuggerWidget._sendToBackend).not.toHaveBeenCalled();
+        });
+
         test("sends message and clears input", () => {
             debuggerWidget.messageInput.value = "Hello AI";
+            debuggerWidget._consentGiven = true;
             debuggerWidget._sendMessage();
             expect(debuggerWidget.chatHistory).toHaveLength(1);
             expect(debuggerWidget.chatHistory[0].type).toBe("user");


### PR DESCRIPTION
### Summary

This PR fixes a failing test in the AI Debugger widget test suite (`js/widgets/__tests__/aidebugger.test.js`) and improves test coverage around user consent handling.

### Testing

- Ran npm test locally. All 5349 tests pass successfully.
- Verified that chatHistory behaves exactly as expected both before and after user consent is mocked.

### Category
- [x] Bug Fix

Thanks!