### PR TITLE
refactor: use CSS tokens in sampler canvas

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -1976,7 +1976,8 @@ function SampleWidget() {
                 (this.pitchAnalysers[turtleIdx] && (this.running || resized))
             ) {
                 this.drawVisualIDs[turtleIdx] = requestAnimationFrame(draw);
-                canvasCtx.fillStyle = platformColor.background || "#FFFFFF";
+                canvasCtx.fillStyle =
+                    getComputedStyle(document.body).getPropertyValue("--bg").trim() || "#ffffff";
                 canvasCtx.font = "10px Verdana";
                 this.verticalOffset = -canvas.height / 4;
                 this.zoomFactor = 40.0;
@@ -1987,7 +1988,8 @@ function SampleWidget() {
                     //.TRANS: The sound sample that the user uploads.
                     oscText = this.sampleName !== "" ? this.sampleName : _("sample");
                 }
-                canvasCtx.fillStyle = platformColor.textColor || "#000000";
+                canvasCtx.fillStyle =
+                    getComputedStyle(document.body).getPropertyValue("--fg").trim() || "#000000";
                 //.TRANS: The reference tone is a sound used for comparison.
                 canvasCtx.fillText(_("reference tone"), 10, 10);
                 canvasCtx.fillText(oscText, 10, canvas.height / 2 + 10);


### PR DESCRIPTION
## Summary

This PR migrates the waveform canvas drawing in `js/widgets/sampler.js`
to read background and foreground colours from existing CSS custom
properties instead of the legacy `platformColor` object.

Specifically:

* `platformColor.background` → `--bg`
* waveform canvas `platformColor.textColor` → `--fg`

No behavioral changes intended.

---

## Changes

### js/widgets/sampler.js

Replaced:

* `platformColor.background`
* waveform canvas `platformColor.textColor`

with:

* `getComputedStyle(document.body).getPropertyValue("--bg")`
* `getComputedStyle(document.body).getPropertyValue("--fg")`

Both tokens already exist in `css/themes.css`, so no new tokens or theme changes were introduced.

---

## Validation

### Verification

Confirmed that:

* the migrated canvas colour calls now read from CSS tokens
* no targeted `platformColor` waveform canvas references remain
* waveform rendering behavior remains unchanged

### Automated checks

* `npx prettier --check js/widgets/sampler.js` ✅
* `npm run lint` ✅

  * passes with existing repository warnings only

### Test status

* `npm test` currently has an unrelated existing failure in
  `js/widgets/__tests__/aidebugger.test.js`

Validation screenshots attached:
<img width="1464" height="138" alt="Screenshot 2026-05-20 135149" src="https://github.com/user-attachments/assets/4f2913a2-94ac-4ada-a6ad-dd83065fd10e" />

<img width="1032" height="52" alt="Screenshot 2026-05-20 135115" src="https://github.com/user-attachments/assets/27b089be-cee1-4699-af3c-5fbf8f81fc73" />

---

## PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

---

## Issue

Partially addresses #6606

