### PR TITLE
docs: fix minor typos in contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,7 +308,7 @@ Feel free. But, please don't spam :p.
    any satisfactory answer, then ask it in a comment. If it is a general
    question about Music Blocks, please use the new
    [discussions](https://github.com/sugarlabs/musicblocks/discussions)
-   tab on top the the repository, or the _Sugar-dev Devel
+   tab on top of the repository, or the _Sugar-dev Devel
    <[sugar-devel@lists.sugarlabs.org](mailto:sugar-devel@lists.sugarlabs.org)>_
    mailing list. We also have a
    [matrix channel](https://matrix.to/#/#music-blocks:matrix.org).

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ server using npm
     npm run dev
     ```
 
-6. You should see a message `Serving HTTP on 127.0.0.1 port 3000
+5. You should see a message `Serving HTTP on 127.0.0.1 port 3000
 (http://127.0.0.1:3000/) ...` since the HTTP Server is set to start
 listening on port 3000.
 
-7. Open your favorite browser and visit `localhost:3000` or `127.0.0.1:3000`.
+6. Open your favorite browser and visit `localhost:3000` or `127.0.0.1:3000`.
 
 **NOTE:** _Use `ctrl + c` or `cmd + c` to quit the HTTP Server to avoid
 `socket.error:[Errno 48]`_.


### PR DESCRIPTION
## Summary

This PR fixes minor typos in the contribution documentation.

## Changes

* Corrected duplicate word: "top the the repository" → "top of the repository" in `CONTRIBUTING.md`
* Fixed incorrect step numbering in README setup instructions

## Notes

No functional changes. Documentation-only fix.

## PR Category
- [x] Documentation
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests

## Checklist

* [x] I have read and followed the project's code of conduct.
* [x] I have searched for similar issues before creating this one.
* [x] I have provided all necessary information.
* [x] I am willing to contribute to the resolution of this issue.
