### PR TITLE
refactor(turtles): replace platformColor background and ruleColor wit…

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -1,3 +1,5 @@
+@import url("tokens.css");
+
 /* Theme DropDown Styling */
 
 #themedropdown {

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,49 @@
+/**
+ * MusicBlocks v3.6.2
+ *
+ * @author Walter Bender
+ *
+ * @copyright 2026 Walter Bender
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MusicBlocks Design Tokens
+ *
+ * Single source of truth for theme-aware CSS custom properties.
+ * Light-theme values are set on :root; dark and high-contrast
+ * values are overridden via body class.
+ *
+ * Usage in JS:
+ *   getComputedStyle(document.body).getPropertyValue("--mb-rule-color").trim()
+ *
+ * Refs: js/utils/platformstyle.js (platformThemes)
+ */
+
+/* Light theme (default) */
+:root {
+    --mb-rule-color: #e2e2e2;
+}
+
+/* Dark theme */
+body.dark {
+    --mb-rule-color: #303030;
+}
+
+/* High contrast theme */
+body.highcontrast {
+    --mb-rule-color: #ffffff;
+}

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -17,7 +17,7 @@
  */
 
 /*
-   global createjs, platformColor, last, importMembers, setupRhythmActions, setupMeterActions,
+   global createjs, last, importMembers, setupRhythmActions, setupMeterActions,
    setupPitchActions, setupIntervalsActions, setupToneActions, setupOrnamentActions,
    setupVolumeActions, setupDrumActions, setupDictActions, _, Turtle, TURTLESVG, METRONOMESVG,
    FILLCOLORS, STROKECOLORS, getMunsellColor, DEFAULTVALUE, DEFAULTCHROMA,
@@ -29,6 +29,11 @@
 
 // What is the scale factor when stage is shrunk?
 const CONTAINERSCALEFACTOR = 4;
+const DEFAULTBACKGROUND = "#ffffff";
+const DEFAULTRULECOLOR = "#e2e2e2";
+
+const getThemeColor = (token, fallback) =>
+    getComputedStyle(document.body).getPropertyValue(token).trim() || fallback;
 
 /**
  * Class for managing all the turtles.
@@ -649,7 +654,7 @@ Turtles.TurtlesView = class {
         this.expand = null; // Function to expand the canvas
 
         // canvas background color
-        this._backgroundColor = platformColor.background;
+        this._backgroundColor = getThemeColor("--bg", DEFAULTBACKGROUND);
 
         this._locked = false; // whether the canvas is locked
         this._queue = []; // temporarily stores [w, h, scale]
@@ -758,7 +763,9 @@ Turtles.TurtlesView = class {
      */
     setBackgroundColor(index) {
         const color =
-            index === -1 ? platformColor.background : this.getTurtle(index).painter.canvasColor;
+            index === -1
+                ? getThemeColor("--bg", DEFAULTBACKGROUND)
+                : this.getTurtle(index).painter.canvasColor;
         this._backgroundColor = color;
         this.makeBackground();
         this.activity.refreshCanvas();
@@ -1241,7 +1248,10 @@ Turtles.TurtlesView = class {
                             .replace("X", 10)
                             .replace("DY", dy)
                             .replace("DX", dx)
-                            .replace("stroke_color", platformColor.ruleColor)
+                            .replace(
+                                "stroke_color",
+                                getThemeColor("--mb-rule-color", DEFAULTRULECOLOR)
+                            )
                             .replace("fill_color", this._backgroundColor)
                             .replace("STROKE", 20)
                     )
@@ -1280,7 +1290,10 @@ Turtles.TurtlesView = class {
                             .replace("X", 10 / CONTAINERSCALEFACTOR)
                             .replace("DY", dy)
                             .replace("DX", dx)
-                            .replace("stroke_color", platformColor.ruleColor)
+                            .replace(
+                                "stroke_color",
+                                getThemeColor("--mb-rule-color", DEFAULTRULECOLOR)
+                            )
                             .replace("fill_color", this._backgroundColor)
                             .replace("STROKE", 20 / CONTAINERSCALEFACTOR)
                     )


### PR DESCRIPTION
## Summary

This PR migrates `js/turtles.js` away from the legacy `platformColor`
object and replaces background/rule color reads with CSS custom
property lookups via `getComputedStyle()`.

It also introduces a new `--mb-rule-color` token for light, dark,
and high-contrast themes.

No behavioral changes intended.

---

## Changes

### css/tokens.css

Added:

* `--mb-rule-color`

for:

* light theme
* dark theme
* high-contrast theme

### css/themes.css

* imports `tokens.css`

### js/turtles.js

Replaced:

* `platformColor.background`
* `platformColor.ruleColor`

with CSS token lookups using:

* `--bg`
* `--mb-rule-color`

Also removed the remaining `platformColor`
dependency from the file.

A small fallback helper was added so tests and
non-loaded CSS environments preserve the existing
default colors.

---

## Validation

### Verification

Confirmed that:

* `js/turtles.js` no longer references `platformColor`
* turtles now read theme values from CSS custom properties
* token values resolve correctly across themes

### Terminal checks

* `npx prettier --check css/tokens.css css/themes.css js/turtles.js`

  * all matched files use Prettier code style

* `npm run lint`

  * passes with existing repository warnings only

* `npm test`

  * 159/160 suites passed
  * remaining failure is the existing unrelated
    `js/widgets/__tests__/aidebugger.test.js`

Attached screenshots include:

* verification showing removal of `platformColor` references
* scoped diff/stat summary
* token definitions and `themes.css` import   
<img width="429" height="322" alt="Screenshot 2026-05-21 175502" src="https://github.com/user-attachments/assets/d669501b-8074-48fa-b310-d91be466eb46" />

<img width="924" height="50" alt="Screenshot 2026-05-21 175727" src="https://github.com/user-attachments/assets/ca12d8e6-26cf-490f-bbbf-6bf339009602" />

<img width="949" height="113" alt="Screenshot 2026-05-21 175716" src="https://github.com/user-attachments/assets/c86e36c6-27a9-4222-afe7-b093b4b52f59" />

<img width="939" height="189" alt="Screenshot 2026-05-21 175946" src="https://github.com/user-attachments/assets/6c656731-f4be-40b2-a1e7-3f2628ebdf0b" />

## PR Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation


---


## Issue

Partially addresses #6606
