### PR TITLE
fix: use active Planet metadata for exports

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -155,9 +155,11 @@ class SaveInterface {
                 saveButton = "#saveButton";
             }
 
+            const planet = this.getPlanetInterface();
             if (
-                typeof this.PlanetInterface !== "undefined" &&
-                this.PlanetInterface.getTimeLastSaved() !== this.timeLastSaved
+                planet &&
+                typeof planet.getTimeLastSaved === "function" &&
+                planet.getTimeLastSaved() !== this.timeLastSaved
             ) {
                 event.preventDefault();
                 // Will trigger when exit/reload cancelled.
@@ -165,6 +167,14 @@ class SaveInterface {
                 return "";
             }
         });
+    }
+
+    getPlanetInterface(activity = this.activity) {
+        if (!activity) {
+            return this.PlanetInterface;
+        }
+
+        return activity.planet || activity.PlanetInterface || this.PlanetInterface;
     }
 
     showToast(message) {
@@ -224,11 +234,11 @@ class SaveInterface {
             this.showToast(message);
         };
         if (defaultfilename === undefined || defaultfilename === null) {
-            if (this.activity.PlanetInterface === undefined) {
-                defaultfilename = STR_MY_PROJECT;
-            } else {
-                defaultfilename = this.activity.PlanetInterface.getCurrentProjectName();
-            }
+            const planet = this.getPlanetInterface();
+            defaultfilename =
+                planet && typeof planet.getCurrentProjectName === "function"
+                    ? planet.getCurrentProjectName()
+                    : STR_MY_PROJECT;
 
             if (fileExt(defaultfilename) !== extension) {
                 defaultfilename += "." + extension;
@@ -311,22 +321,20 @@ class SaveInterface {
 
         let file = this.htmlSaveTemplate;
         let description = _("No description provided");
-        if (
-            this.activity.PlanetInterface &&
-            this.activity.PlanetInterface.getCurrentProjectDescription
-        ) {
-            description = this.activity.PlanetInterface.getCurrentProjectDescription();
+        const planet = this.getPlanetInterface();
+        if (planet && typeof planet.getCurrentProjectDescription === "function") {
+            description = planet.getCurrentProjectDescription();
         }
         // let author = '';
         // Currently we're using anonymous for authors - not storing names.
         let name = STR_MY_PROJECT;
-        if (this.activity.PlanetInterface && this.activity.PlanetInterface.getCurrentProjectName) {
-            name = this.activity.PlanetInterface.getCurrentProjectName();
+        if (planet && typeof planet.getCurrentProjectName === "function") {
+            name = planet.getCurrentProjectName();
         }
         const data = this.activity.prepareExport();
         let image = "";
-        if (this.activity.PlanetInterface && this.activity.PlanetInterface.getCurrentProjectImage) {
-            image = this.activity.PlanetInterface.getCurrentProjectImage();
+        if (planet && typeof planet.getCurrentProjectImage === "function") {
+            image = planet.getCurrentProjectImage();
         }
 
         file = file
@@ -371,11 +379,9 @@ class SaveInterface {
         setTimeout(() => {
             const html =
                 "data:text/plain;charset=utf-8," + encodeURIComponent(activity.save.prepareHTML());
-            if (activity.PlanetInterface !== undefined) {
-                activity.save.downloadURL(
-                    activity.PlanetInterface.getCurrentProjectName() + ".html",
-                    html
-                );
+            const planet = this.getPlanetInterface(activity);
+            if (planet && typeof planet.getCurrentProjectName === "function") {
+                activity.save.downloadURL(planet.getCurrentProjectName() + ".html", html);
             } else {
                 activity.save.downloadURL(STR_MY_PROJECT.replace(" ", "_") + ".html", html);
             }
@@ -719,8 +725,9 @@ class SaveInterface {
 
         const lyext = "ly";
         let filename = STR_MY_PROJECT;
-        if (activity.PlanetInterface !== undefined) {
-            filename = activity.PlanetInterface.getCurrentProjectName();
+        const planet = this.getPlanetInterface(activity);
+        if (planet && typeof planet.getCurrentProjectName === "function") {
+            filename = planet.getCurrentProjectName();
         }
 
         if (fileExt(filename) !== lyext) {
@@ -742,8 +749,8 @@ class SaveInterface {
         //.TRANS: Lilypond is a scripting language for generating sheet music
         docById("submitLilypond").textContent = _("Save as Lilypond");
         docById("fileName").value = filename;
-        if (activity.PlanetInterface !== undefined) {
-            docById("title").value = activity.PlanetInterface.getCurrentProjectName();
+        if (planet && typeof planet.getCurrentProjectName === "function") {
+            docById("title").value = planet.getCurrentProjectName();
         } else {
             //.TRANS: default project title when saving as Lilypond
             docById("title").value = STR_MY_PROJECT;

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -393,8 +393,6 @@ describe("save HTML methods", () => {
 
     it("should use the active Planet project metadata in prepareHTML", () => {
         const activity = {
-            htmlSaveTemplate:
-                "<html><body><h1>{{ project_name }}</h1><p>{{ project_description }}</p><img src='{{ project_image }}'/><div>{{ data }}</div></body></html>",
             prepareExport: jest.fn(() => "Mock Exported Data"),
             planet: {
                 getCurrentProjectName: jest.fn(() => "Planet Project"),

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -391,6 +391,25 @@ describe("save HTML methods", () => {
         expect(escapeHTML("&<>\"'")).toBe("&amp;&lt;&gt;&quot;&#039;");
     });
 
+    it("should use the active Planet project metadata in prepareHTML", () => {
+        const activity = {
+            htmlSaveTemplate:
+                "<html><body><h1>{{ project_name }}</h1><p>{{ project_description }}</p><img src='{{ project_image }}'/><div>{{ data }}</div></body></html>",
+            prepareExport: jest.fn(() => "Mock Exported Data"),
+            planet: {
+                getCurrentProjectName: jest.fn(() => "Planet Project"),
+                getCurrentProjectDescription: jest.fn(() => "Planet Description"),
+                getCurrentProjectImage: jest.fn(() => "planet-image.png")
+            }
+        };
+
+        const html = new SaveInterface(activity).prepareHTML();
+
+        expect(html).toContain("<title>Planet Project</title>");
+        expect(html).toContain("<p>Planet Description</p>");
+        expect(html).toContain('src="planet-image.png"');
+    });
+
     it("should handle missing project fields gracefully in prepareHTML", () => {
         const activity = {
             PlanetInterface: {
@@ -484,6 +503,26 @@ describe("save HTML methods", () => {
         expect(mockGetProjectName).toHaveBeenCalled();
         expect(mockDownloadURL).toHaveBeenCalledWith(
             "MockProject.html",
+            "data:text/plain;charset=utf-8,%3Chtml%3EMock%20HTML%3C%2Fhtml%3E"
+        );
+    });
+
+    it("should use the active Planet project name for HTML downloads without a prompt", () => {
+        const activity = {
+            save: {
+                prepareHTML: jest.fn(() => "<html>Mock HTML</html>"),
+                downloadURL: jest.fn()
+            },
+            planet: {
+                getCurrentProjectName: jest.fn(() => "Planet Project")
+            }
+        };
+
+        instance.saveHTMLNoPrompt(activity);
+        jest.runAllTimers();
+
+        expect(activity.save.downloadURL).toHaveBeenCalledWith(
+            "Planet Project.html",
             "data:text/plain;charset=utf-8,%3Chtml%3EMock%20HTML%3C%2Fhtml%3E"
         );
     });
@@ -871,6 +910,32 @@ describe("beforeunload warning", () => {
 
         expect(preventDefault).toHaveBeenCalled();
     });
+
+    it("should check the active Planet project save time before unloading", () => {
+        let savedHandler;
+
+        global.jQuery = jest.fn(() => ({
+            on: jest.fn((event, handler) => {
+                if (event === "beforeunload") {
+                    savedHandler = handler;
+                }
+            }),
+            trigger: jest.fn()
+        }));
+
+        const instance = new SaveInterface({
+            beginnerMode: false,
+            planet: {
+                getTimeLastSaved: () => 100
+            }
+        });
+        instance.timeLastSaved = 0;
+
+        const preventDefault = jest.fn();
+        savedHandler({ preventDefault });
+
+        expect(preventDefault).toHaveBeenCalled();
+    });
 });
 
 describe("saveLilypond Methods", () => {
@@ -1018,6 +1083,21 @@ describe("saveLilypond Methods", () => {
         expect(docById("fileName").value).toBe("Test Project.ly");
         expect(docById("title").value).toBe("Test Project");
         expect(docById("author").value).toBe("Custom Author");
+    });
+
+    it("should use the active Planet project name in Lilypond fields", () => {
+        const activity = {
+            ...mockActivity,
+            PlanetInterface: undefined,
+            planet: {
+                getCurrentProjectName: jest.fn(() => "Planet Score")
+            }
+        };
+
+        instance.saveLilypond(activity);
+
+        expect(docById("fileName").value).toBe("Planet Score.ly");
+        expect(docById("title").value).toBe("Planet Score");
     });
 
     it("should close the modal when close button is clicked", () => {

--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -742,7 +742,6 @@ describe("AIDebuggerWidget", () => {
         });
 
         test("sends message and clears input", () => {
-            debuggerWidget._consentGiven = true;
             debuggerWidget.messageInput.value = "Hello AI";
             debuggerWidget._consentGiven = true;
             debuggerWidget._sendMessage();

--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -742,6 +742,7 @@ describe("AIDebuggerWidget", () => {
         });
 
         test("sends message and clears input", () => {
+            debuggerWidget._consentGiven = true;
             debuggerWidget.messageInput.value = "Hello AI";
             debuggerWidget._consentGiven = true;
             debuggerWidget._sendMessage();


### PR DESCRIPTION
## Summary

Fixes #7409.

Projects opened from Planet keep their current metadata on `activity.planet`, but the export paths in `SaveInterface` were still reading the older `PlanetInterface` property. Because of that, HTML export, Lilypond defaults, and the unsaved-change check could fall back to `My Project` or stale metadata.

This updates `SaveInterface` to read from the active Planet adapter first, while keeping the old fallback for existing call sites.

## Changes

- Use one helper to find the active Planet interface.
- Use Planet-backed metadata for HTML export fields and no-prompt HTML filenames.
- Use the same project name for Lilypond filename/title defaults.
- Check the active Planet save timestamp before unload.
- Add regression coverage for the affected export paths.

## Testing

- `npx jest js/__tests__/SaveInterface.test.js js/__tests__/planetInterface.test.js --runInBand --coverage=false`
- `npx prettier --check js/SaveInterface.js js/__tests__/SaveInterface.test.js`
- `git diff --check`
- `npm run lint`

## PR Category

- [x] Bug Fix
- [x] Tests