### PR TITLE
fix: align doMod error messages with the rest of MathUtility

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -224,7 +224,12 @@ function setupNumberBlocks(activity) {
             try {
                 return MathUtility.doMod(a, b);
             } catch (e) {
-                handleMathError(logo, e, blk);
+                logo.stopTurtle = true;
+                if (e.message === "NanError") {
+                    activity.errorMsg(NANERRORMSG, blk);
+                } else if (e.message === "DivByZeroError") {
+                    activity.errorMsg(ZERODIVIDEERRORMSG, blk);
+                }
                 return 0;
             }
         }

--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -130,7 +130,11 @@ describe("MathUtility", () => {
         });
 
         test("throws error for invalid inputs", () => {
-            expect(() => MathUtility.doMod("a", 3)).toThrow("Invalid number input");
+            expect(() => MathUtility.doMod("a", 3)).toThrow("NanError");
+        });
+
+        test("throws DivByZeroError when divisor is zero", () => {
+            expect(() => MathUtility.doMod(5, 0)).toThrow("DivByZeroError");
         });
 
         // Edge case tests
@@ -159,7 +163,7 @@ describe("MathUtility", () => {
         });
 
         test("throws error when second arg is string", () => {
-            expect(() => MathUtility.doMod(10, "a")).toThrow("Invalid number input");
+            expect(() => MathUtility.doMod(10, "a")).toThrow("NanError");
         });
     });
 

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -130,11 +130,11 @@ class MathUtility {
     static doMod(a, b) {
         if (typeof a === "number" && typeof b === "number") {
             if (Number(b) === 0) {
-                throw new Error("Division by zero");
+                throw new Error("DivByZeroError");
             }
             return Number(a) % Number(b);
         } else {
-            throw new Error("Invalid number input");
+            throw new Error("NanError");
         }
     }
 


### PR DESCRIPTION
## Description

`MathUtility.doMod` was throwing two non-standard error strings that didn't match anything else in the codebase:

- When the divisor is `0`, it threw `"Division by zero"` but the JSDoc for the same function says it should throw `"DivByZeroError"`, and `doDivide` (which does the same guard) throws `"DivByZeroError"`.
- When a non-number argument is passed, it threw `"Invalid number input"` but every other method in the class (`doSqrt`, `doMinus`, `doMultiply`, `doDivide`) throws `"NanError"`.

Because of this, the `ModBlock` catch handler in `NumberBlocks.js` was silently calling the generic `handleMathError` which always shows a NaN message even when the real cause was a division by zero. Users would see the wrong error message in the UI.


## Changes

**`js/utils/mathutils.js`**
- `doMod`: change `"Division by zero"` → `"DivByZeroError"`
- `doMod`: change `"Invalid number input"` → `"NanError"`

**`js/blocks/NumberBlocks.js`**
- `ModBlock` catch block: replace the generic `handleMathError` call with explicit checks for `"NanError"` and `"DivByZeroError"`, matching the pattern already used by `DivideBlock` 

**`js/utils/__tests__/mathutils.test.js`**
- Update two existing test assertions to expect `"NanError"` instead of the now-removed `"Invalid number input"`
- Add a new test: `doMod(5, 0)` throws `"DivByZeroError"`, mirroring the equivalent test already present for `doDivide`


## PR Category

-   [x] Bug Fix 
-   [x] Tests 


Note: `js/widgets/__tests__/aidebugger.test.js` has a pre-existing failure (1 test) unrelated to this PR. 