### PR TITLE
test: add test coverage for _parse_pitch_string and export it

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -33,6 +33,7 @@ const {
     nthDegreeToPitch,
     getInterval,
     _calculate_pitch_number,
+    _parse_pitch_string,
     _getStepSize,
     reducedFraction,
     toFraction,
@@ -2875,6 +2876,87 @@ describe("normalization and pitch parsing extras", () => {
         });
         expect(getPitchInfo({})).toBe(global.INVALIDPITCH);
         expect(_calculate_pitch_number("C", 4, 2)).toBe(58);
+    });
+});
+
+describe("_parse_pitch_string", () => {
+    describe("plain notes without accidentals", () => {
+        it("parses a simple natural note", () => {
+            expect(_parse_pitch_string("C4")).toEqual(["C", 4]);
+        });
+
+        it("parses uppercase note letters", () => {
+            expect(_parse_pitch_string("G5")).toEqual(["G", 5]);
+        });
+
+        it("parses lowercase note letters (normalizes to uppercase)", () => {
+            expect(_parse_pitch_string("a4")).toEqual(["A", 4]);
+        });
+
+        it("handles octave 0", () => {
+            expect(_parse_pitch_string("C0")).toEqual(["C", 0]);
+        });
+
+        it("handles a high octave", () => {
+            expect(_parse_pitch_string("B9")).toEqual(["B", 9]);
+        });
+
+        it("handles negative octave", () => {
+            expect(_parse_pitch_string("C-1")).toEqual(["C", -1]);
+        });
+    });
+
+    describe("single accidentals", () => {
+        it("parses ASCII sharp (#)", () => {
+            expect(_parse_pitch_string("C#4")).toEqual(["C♯", 4]);
+        });
+
+        it("parses ASCII flat (b)", () => {
+            expect(_parse_pitch_string("Ab4")).toEqual(["A♭", 4]);
+        });
+
+        it("parses Unicode sharp (♯)", () => {
+            expect(_parse_pitch_string("F♯3")).toEqual(["F♯", 3]);
+        });
+
+        it("parses Unicode flat (♭)", () => {
+            expect(_parse_pitch_string("B♭2")).toEqual(["B♭", 2]);
+        });
+    });
+
+    describe("double accidentals", () => {
+        it("parses double-sharp textual (x)", () => {
+            expect(_parse_pitch_string("Cx4")).toEqual(["C𝄪", 4]);
+        });
+
+        it("parses double-sharp Unicode (𝄪)", () => {
+            expect(_parse_pitch_string("D𝄪4")).toEqual(["D𝄪", 4]);
+        });
+
+        it("parses double-flat Unicode (𝄫)", () => {
+            expect(_parse_pitch_string("E𝄫3")).toEqual(["E𝄫", 3]);
+        });
+
+        it("parses two ASCII sharps summing to double-sharp", () => {
+            expect(_parse_pitch_string("C##4")).toEqual(["C𝄪", 4]);
+        });
+
+        it("parses two ASCII flats summing to double-flat", () => {
+            expect(_parse_pitch_string("Abb4")).toEqual(["A𝄫", 4]);
+        });
+    });
+
+    describe("cancelling accidentals", () => {
+        it("sharp and flat cancel out to a natural note", () => {
+            expect(_parse_pitch_string("C#b4")).toEqual(["C", 4]);
+        });
+    });
+
+    describe("fallback path — no octave digit", () => {
+        it("falls back to octave 4 for a bare note name", () => {
+            const result = _parse_pitch_string("C#");
+            expect(result[1]).toBe(4);
+        });
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6462,6 +6462,7 @@ if (typeof module !== "undefined" && module.exports) {
         nthDegreeToPitch,
         getInterval,
         _calculate_pitch_number,
+        _parse_pitch_string,
         _getStepSize,
         reducedFraction,
         toFraction,


### PR DESCRIPTION
## Description

`_parse_pitch_string` is a utility function in `musicutils.js` that parses pitch strings like `"C#4"`, `"F𝄪5"`, or `"Abb3"` into a normalized `[noteName, octave]` pair. It handles plain natural notes, single and double 
accidentals in both ASCII and Unicode, mixed accidentals that cancel out, and a fallback path for strings without an octave digit.

It is called in two places inside `getNote()` - one of the most critical functions in the file but had zero test coverage and was not exported, making it impossible to test directly.


## Related Issue

No related issue - this PR adds missing test coverage identified through code analysis.


## PR Category

-   [x] Tests - Adds or updates test coverage


## Changes Made

- `js/utils/musicutils.js`: add `_parse_pitch_string` to the `module.exports` block, alongside its companion `_calculate_pitch_number` which is already exported
- `js/utils/__tests__/musicutils.test.js`: import `_parse_pitch_string` and  add a new `describe` block with 17 test cases covering all input branches - plain notes, uppercase/lowercase normalization, negative octaves, all 7 accidental character types, double accidentals via repeated ASCII, cancelling accidentals, and the fallback path


## Testing Performed

- Ran `npm test -- --testPathPattern="musicutils"` - all 17 new tests pass
- Ran full test suite `npm test` no regressions introduced


## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [x] I have enabled **"Allow edits from maintainers"**


Note: one pre-existing failure exists in js/widgets/__tests__/aidebugger.test.js (unrelated to this PR).

## Additional Notes for Reviewers

No production code logic was changed -the only source change is adding `_parse_pitch_string` to the exports. All 17 test cases were verified against the actual function output before writing the assertions.