### PR TITLE
fix: bpmFactor operator precedence in WaitBlock and NoteBlock

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -399,7 +399,7 @@ function setupExtrasBlocks(activity) {
 
             if (args.length === 1) {
                 const bpmFactor =
-                    TONEBPM / tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM;
+                    TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
                 const noteBeatValue = bpmFactor / (1 / args[0]);
                 tur.singer.previousTurtleTime = tur.singer.turtleTime;

--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -140,7 +140,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 // polyphonic rhythms.
                 if (logo.rhythmRulerMeasure === null) {
                     logo.rhythmRulerMeasure = arg0 * arg1;
-                } else if (logo.rhythmRulerMeasure != arg0 * arg1) {
+                } else if (logo.rhythmRulerMeasure !== arg0 * arg1) {
                     activity.textMsg(_("polyphonic rhythm"));
                 }
 
@@ -182,7 +182,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                 const bpmFactor =
                     TONEBPM / (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
-                const beatValue = bpmFactor == null ? 1 : bpmFactor / noteBeatValue;
+                const beatValue = bpmFactor === null ? 1 : bpmFactor / noteBeatValue;
 
                 let __callback;
 
@@ -738,9 +738,8 @@ function setupRhythmBlockPaletteBlocks(activity) {
                     tur.singer.inNoteBlock.push(blk);
 
                     const bpmFactor =
-                        TONEBPM / tur.singer.bpm.length > 0
-                            ? last(tur.singer.bpm)
-                            : Singer.masterBPM;
+                        TONEBPM /
+                        (tur.singer.bpm.length > 0 ? last(tur.singer.bpm) : Singer.masterBPM);
 
                     let timeout = 0;
                     let beatValue;


### PR DESCRIPTION
Fixes #7416

## PR Category

- [x] Bug Fix

**Description**

Two places in the codebase compute `bpmFactor` with incorrect operator precedence. The intent is:

```js
TONEBPM / (bpm.length > 0 ? last(bpm) : Singer.masterBPM)
```
But due to / binding tighter than > in JavaScript, it was evaluating as:
```
(TONEBPM / bpm.length) > 0 ? last(bpm) : Singer.masterBPM
```
Since TONEBPM is 240, the condition is always true. When the bpm stack is empty, last([]) returns undefined, making bpmFactor undefined and downstream timing calculations produce NaN.

## Changes Made

- js/blocks/ExtrasBlocks.js line 402 : fixed parentheses in WaitBlock
- js/blocks/RhythmBlockPaletteBlocks.js lines 183 and 741: fixed parentheses, also fixed two pre-existing ==/!= ESLint warnings in the same file

## Testing Performed

- npm test : 153 suites, 5094 tests pass
- npm run lint:  0 errors
- npx prettier --check js/blocks/ExtrasBlocks.js js/blocks/RhythmBlockPaletteBlocks.js — all files pass