### PR TITLE
fix(security): deduplicate isSafeUrl utility in ActionBlocks

### DIFF
--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -20,12 +20,20 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* global NOACTIONERRORMSG, NOINPUTERRORMSG */
+/* global NOACTIONERRORMSG, NOINPUTERRORMSG, isSafeUrl */
 const { setupActionBlocks } = jest.requireActual("../ActionBlocks");
 
 global._ = s => s;
 global.NOACTIONERRORMSG = "NO ACTION";
 global.NOINPUTERRORMSG = "NO_INPUT";
+global.isSafeUrl = function (urlString) {
+    try {
+        const parsed = new URL(urlString);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch (e) {
+        return false;
+    }
+};
 global.Queue = class Queue {
     constructor(child, factor, parentBlk, receivedArg) {
         this.child = child;


### PR DESCRIPTION
Closes #7384.

isSafeUrl was defined twice -- once in utils.js (canonical) and again 
as a local copy in ActionBlocks.js. Both were identical, but duplicated 
security utilities drift silently. A fix to utils.js wouldn't 
automatically apply to the copy in ActionBlocks.js.

Changes:
- Removed the 8-line duplicate from ActionBlocks.js
- Added isSafeUrl to the existing /* global */ ESLint comment at the 
  top of ActionBlocks.js (it comes from utils.js via index.html)
- Added global.isSafeUrl mock to ActionBlocks.test.js so the 
  ReturnToURLBlock tests don't crash in Node where index.html isn't loaded

All tests pass. Pre-existing aidebugger.test.js failure on master is 
unrelated.

## PR Category
- [x] Bug Fix
- [ ] Performance
- [ ] Feature
- [ ] Tests
- [ ] Documentation