### PR TITLE
harden StringHelper XSS regression coverage

### DIFF
--- a/planet/js/StringHelper.js
+++ b/planet/js/StringHelper.js
@@ -91,11 +91,118 @@ class StringHelper {
             const elem = document.getElementById(obj[0]);
 
             if (elem) {
-                if (this.strings[i].length === 3) elem.setAttribute(obj[2], obj[1]);
-                else elem.innerHTML += obj[1];
+                if (this.strings[i].length === 3) {
+                    elem.setAttribute(obj[2], obj[1]);
+                } else if (HTML_ALLOWED_IDS.has(obj[0])) {
+                    elem.innerHTML = elem.innerHTML + sanitizeAllowedHTML(obj[1]);
+                } else {
+                    elem.textContent = (elem.textContent || "") + obj[1];
+                }
             }
         }
     }
+}
+
+// SECURITY: Only allow IDs here when the localized string intentionally
+// contains HTML and has been reviewed for safe rendering.
+const HTML_ALLOWED_IDS = new Set([
+    "deleter-confirm",
+    "deleter-paragraph",
+    "projectviewer-report-conduct"
+]);
+
+const HTML_ALLOWED_TAGS = new Set(["A", "BR", "EM", "I", "SPAN", "STRONG"]);
+
+const HTML_ALLOWED_ATTRIBUTES = {
+    A: new Set(["href"]),
+    SPAN: new Set(["id"])
+};
+
+function isSafeUrl(urlString) {
+    if (!urlString || typeof urlString !== "string") return false;
+
+    try {
+        let decodedUrl = urlString.trim();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(decodedUrl, "text/html");
+        decodedUrl = (doc.body.textContent || "").trim();
+
+        // eslint-disable-next-line no-control-regex
+        decodedUrl = decodedUrl.replace(/[\u0000-\u0020\u007F]/g, "");
+
+        const parsed = new URL(decodedUrl);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch (e) {
+        return false;
+    }
+}
+
+function sanitizeAllowedHTML(htmlString) {
+    const input = document.createElement("template");
+    input.innerHTML = htmlString;
+
+    const output = document.createElement("template");
+
+    const appendSanitizedNode = (sourceNode, targetParent) => {
+        if (sourceNode.nodeType === Node.TEXT_NODE) {
+            targetParent.appendChild(document.createTextNode(sourceNode.textContent || ""));
+            return;
+        }
+
+        if (sourceNode.nodeType !== Node.ELEMENT_NODE) {
+            return;
+        }
+
+        const tagName = sourceNode.tagName.toUpperCase();
+
+        if (!HTML_ALLOWED_TAGS.has(tagName)) {
+            for (const child of Array.from(sourceNode.childNodes)) {
+                appendSanitizedNode(child, targetParent);
+            }
+            return;
+        }
+
+        const cleanElement = document.createElement(tagName.toLowerCase());
+
+        for (const attr of Array.from(sourceNode.attributes)) {
+            const attrName = attr.name.toLowerCase();
+            const attrValue = attr.value;
+            const allowedAttributes = HTML_ALLOWED_ATTRIBUTES[tagName] || new Set();
+
+            if (attrName.startsWith("on") || !allowedAttributes.has(attrName)) {
+                continue;
+            }
+
+            if (tagName === "SPAN" && attrName === "id") {
+                if (attrValue !== "deleter-title" && attrValue !== "deleter-name") {
+                    continue;
+                }
+            }
+
+            if (tagName === "A" && attrName === "href") {
+                if (!isSafeUrl(attrValue)) {
+                    continue;
+                }
+
+                cleanElement.setAttribute("target", "_blank");
+                cleanElement.setAttribute("rel", "noopener noreferrer");
+            }
+
+            cleanElement.setAttribute(attr.name, attrValue);
+        }
+
+        for (const child of Array.from(sourceNode.childNodes)) {
+            appendSanitizedNode(child, cleanElement);
+        }
+
+        targetParent.appendChild(cleanElement);
+    };
+
+    for (const child of Array.from(input.content.childNodes)) {
+        appendSanitizedNode(child, output.content);
+    }
+
+    return output.innerHTML;
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/planet/js/__tests__/StringHelper.test.js
+++ b/planet/js/__tests__/StringHelper.test.js
@@ -51,14 +51,14 @@ describe("StringHelper", () => {
             expect(lastStringTurtle[1]).toBe("Open in Turtle Blocks");
         });
 
-        it("should init and append innerHTML to elements matching id", () => {
+        it("should init and append textContent to elements matching id", () => {
             document.body.innerHTML = '<div id="logo-container">Initial</div>';
             const helperObj = new StringHelper({ IsMusicBlocks: true });
 
             helperObj.init();
 
             const elem = document.getElementById("logo-container");
-            expect(elem.innerHTML).toBe("InitialPlanet");
+            expect(elem.textContent).toBe("InitialPlanet");
         });
 
         it("should init and set attribute if property is provided", () => {
@@ -138,18 +138,18 @@ describe("StringHelper", () => {
         });
 
         describe("init() improvements", () => {
-            it("should set innerHTML for elements without a third property", () => {
+            it("should set textContent for elements without a third property", () => {
                 document.body.innerHTML = '<div id="logo-container"></div>';
                 helper.init();
                 const elem = document.getElementById("logo-container");
-                expect(elem.innerHTML).toBe("Planet");
+                expect(elem.textContent).toBe("Planet");
             });
 
-            it("should append to existing innerHTML", () => {
+            it("should append to existing textContent", () => {
                 document.body.innerHTML = '<div id="logo-container">Prefix</div>';
                 helper.init();
                 const elem = document.getElementById("logo-container");
-                expect(elem.innerHTML).toBe("PrefixPlanet");
+                expect(elem.textContent).toBe("PrefixPlanet");
             });
 
             it("should set placeholder attribute for search input", () => {
@@ -163,8 +163,8 @@ describe("StringHelper", () => {
                 document.body.innerHTML =
                     '<div id="logo-container"></div><div id="localtitle"></div>';
                 helper.init();
-                expect(document.getElementById("logo-container").innerHTML).toBe("Planet");
-                expect(document.getElementById("localtitle").innerHTML).toBe("My Projects");
+                expect(document.getElementById("logo-container").textContent).toBe("Planet");
+                expect(document.getElementById("localtitle").textContent).toBe("My Projects");
             });
 
             it("should process all strings entries when all elements exist", () => {
@@ -181,8 +181,14 @@ describe("StringHelper", () => {
                     const elem = document.getElementById(entry[0]);
                     if (entry.length === 3) {
                         expect(elem.getAttribute(entry[2])).toBe(entry[1]);
+                    } else if (entry[0] === "deleter-confirm") {
+                        expect(elem.innerHTML).toContain('<span id="deleter-title"></span>');
+                    } else if (entry[0] === "deleter-paragraph") {
+                        expect(elem.innerHTML).toContain('<span id="deleter-name"></span>');
+                    } else if (entry[0] === "projectviewer-report-conduct") {
+                        expect(elem.innerHTML).toContain("<a ");
                     } else {
-                        expect(elem.innerHTML).toContain(entry[1]);
+                        expect(elem.textContent).toContain(entry[1]);
                     }
                 }
             });
@@ -199,8 +205,8 @@ describe("StringHelper", () => {
                 helper.init();
                 helper.init();
                 const elem = document.getElementById("local-tab");
-                // innerHTML is appended, so calling init twice doubles the text
-                expect(elem.innerHTML).toBe("LocalLocal");
+                // textContent is appended, so calling init twice doubles the text
+                expect(elem.textContent).toBe("LocalLocal");
             });
 
             it("should set data-tooltip for report-project and download-file entries", () => {
@@ -220,19 +226,78 @@ describe("StringHelper", () => {
                 ).toBe("Download as File");
             });
 
-            it("should inject sort option labels via innerHTML", () => {
+            it("should render sort option labels as plain text", () => {
                 document.body.innerHTML =
                     '<div id="option-recent"></div>' +
                     '<div id="option-liked"></div>' +
                     '<div id="option-downloaded"></div>' +
                     '<div id="option-alphabetical"></div>';
                 helper.init();
-                expect(document.getElementById("option-recent").innerHTML).toBe("Most recent");
-                expect(document.getElementById("option-liked").innerHTML).toBe("Most liked");
-                expect(document.getElementById("option-downloaded").innerHTML).toBe(
+                expect(document.getElementById("option-recent").textContent).toBe("Most recent");
+                expect(document.getElementById("option-liked").textContent).toBe("Most liked");
+                expect(document.getElementById("option-downloaded").textContent).toBe(
                     "Most downloaded"
                 );
-                expect(document.getElementById("option-alphabetical").innerHTML).toBe("A-Z");
+                expect(document.getElementById("option-alphabetical").textContent).toBe("A-Z");
+            });
+
+            it("should preserve safe HTML only for allowlisted strings", () => {
+                document.body.innerHTML =
+                    '<div id="deleter-confirm"></div>' +
+                    '<div id="projectviewer-report-conduct"></div>';
+
+                helper.init();
+
+                expect(document.getElementById("deleter-confirm").innerHTML).toContain(
+                    '<span id="deleter-title"></span>'
+                );
+                const reportLink = document
+                    .getElementById("projectviewer-report-conduct")
+                    .querySelector("a");
+                const reportElem = document.getElementById("projectviewer-report-conduct");
+
+                expect(reportElem.querySelector("script")).toBe(null);
+                expect(reportElem.querySelector("[onclick]")).toBe(null);
+                expect(reportElem.querySelector('a[href^="javascript:"]')).toBe(null);
+                expect(reportLink.getAttribute("href")).toBe(
+                    "https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md"
+                );
+                expect(reportLink.getAttribute("target")).toBe("_blank");
+                expect(reportLink.getAttribute("rel")).toBe("noopener noreferrer");
+            });
+
+            it("should strip unsafe HTML from allowlisted localization strings", () => {
+                document.body.innerHTML = '<div id="projectviewer-report-conduct"></div>';
+                helper.strings = [
+                    [
+                        "projectviewer-report-conduct",
+                        '<a href="javascript:alert(1)" onclick="alert(2)">Report</a><script>alert(3)</script>'
+                    ]
+                ];
+
+                helper.init();
+
+                const elem = document.getElementById("projectviewer-report-conduct");
+                expect(elem.querySelector("script")).toBe(null);
+                expect(elem.querySelector("[onclick]")).toBe(null);
+                expect(elem.querySelector('a[href^="javascript:"]')).toBe(null);
+                expect(elem.textContent).toContain("Report");
+                expect(elem.textContent).toContain("alert(3)");
+            });
+
+            it("should render non-allowlisted HTML as plain text", () => {
+                document.body.innerHTML = '<div id="logo-container"></div>';
+
+                helper.strings = [["logo-container", "<img src=x onerror=alert(1)>"]];
+
+                helper.init();
+
+                const elem = document.getElementById("logo-container");
+
+                expect(elem.querySelector("img")).toBe(null);
+                expect(elem.querySelector("script")).toBe(null);
+                expect(elem.querySelector("[onerror]")).toBe(null);
+                expect(elem.textContent).toContain("<img");
             });
         });
     });

--- a/planet/js/__tests__/helper.test.js
+++ b/planet/js/__tests__/helper.test.js
@@ -53,6 +53,7 @@ setupHelperDOM();
 const {
     getCookie,
     setCookie,
+    toggleText,
     toggleExpandable,
     hideOnClickOutside,
     updateCheckboxes
@@ -163,6 +164,32 @@ describe("helper.js", () => {
 
             toggleExpandable("toggle", "cls");
             expect(el.className).toBe("cls open");
+        });
+    });
+
+    describe("toggleText", () => {
+        it("should toggle the visible text without parsing HTML", () => {
+            document.body.innerHTML = '<div id="view-more-chips">Show more tags ▼</div>';
+
+            toggleText("view-more-chips", "Show more tags ▼", "Show fewer tags ▲");
+            expect(document.getElementById("view-more-chips").textContent).toBe(
+                "Show fewer tags ▲"
+            );
+
+            toggleText("view-more-chips", "Show more tags ▼", "Show fewer tags ▲");
+            expect(document.getElementById("view-more-chips").textContent).toBe("Show more tags ▼");
+        });
+
+        it("should not interpret malicious HTML when toggling text", () => {
+            document.body.innerHTML = '<div id="view-more-chips"></div>';
+            const el = document.getElementById("view-more-chips");
+
+            el.textContent = "Show more tags ▼<img src=x onerror=alert(1)>";
+
+            toggleText("view-more-chips", "Show more tags ▼", "Show fewer tags ▲");
+
+            expect(el.querySelector("img")).toBe(null);
+            expect(el.textContent).toBe("Show fewer tags ▲<img src=x onerror=alert(1)>");
         });
     });
 

--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -79,11 +79,12 @@ function toggleSearch(on) {
 function toggleText(id, a, b) {
     const el = document.getElementById(id);
 
-    const prevHTML = el.innerHTML;
-    const updatedHTML = prevHTML.includes(a) ? prevHTML.replace(a, b) : prevHTML.replace(b, a);
+    const currentText = el.textContent || "";
+    const updatedText = currentText.includes(a)
+        ? currentText.replace(a, b)
+        : currentText.replace(b, a);
 
-    el.innerHTML = "";
-    el.insertAdjacentHTML("afterbegin", updatedHTML);
+    el.textContent = updatedText;
 }
 
 function toggleExpandable(id, c) {
@@ -157,6 +158,7 @@ if (typeof module !== "undefined" && module.exports) {
         debounce,
         getCookie,
         setCookie,
+        toggleText,
         toggleExpandable,
         hideOnClickOutside,
         updateCheckboxes


### PR DESCRIPTION

This PR improves a few DOM rendering paths to reduce unnecessary HTML parsing and make the UI rendering safer, while keeping the existing behavior unchanged.

## What was changed

#### helper.js

* Replaced the `innerHTML`-based text toggle with `textContent`
* This removes unnecessary HTML parsing for the “Show more tags” toggle
* Added regression tests to confirm HTML-like input is treated as plain text and not rendered as DOM

#### StringHelper.js

* Normal localized strings now render with `textContent`
* Only a very small allowlist of reviewed strings can render HTML
* Added scoped sanitization for those allowlisted HTML strings
* Dangerous content such as:

  * `<script>` tags
  * inline event handlers (`onclick`, `onerror`, etc.)
  * `javascript:` URLs
    is removed before rendering

### Tests added

Added/updated tests to verify:

* plain text rendering still works correctly
* allowlisted HTML still renders correctly
* malicious HTML is not interpreted by the browser
* unsafe attributes and script tags are stripped
* non-allowlisted HTML remains inert text



### Result

This reduces unnecessary DOM parser exposure and improves defense-in-depth without introducing breaking behavior or changing the intended user experience. 

## existing test failure

#### - js/widgets/__tests__/aidebugger.test.js:736:48

## PR category
- [x] bug fix