### PR TITLE
fix: resolve block input click issue on browser zoom

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3302,7 +3302,15 @@ class Block {
             }
 
             if (window.hasMouse) {
-                moved = true;
+                const movedDx = Math.abs(
+                    event.stageX / that.activity.getStageScale() - that.original.x
+                );
+                const movedDy = Math.abs(
+                    event.stageY / that.activity.getStageScale() - that.original.y
+                );
+                if (movedDx + movedDy > 5) {
+                    moved = true;
+                }
             } else {
                 // Make it easier to select text on mobile.
                 setTimeout(() => {


### PR DESCRIPTION
### Description:
Fixes an issue where users were unable to input values (e.g. text, numbers, pie menus) when clicking on block arguments while the browser was zoomed in (e.g., using `ctrl` and `+` / `-`).

The issue was caused by sub-pixel DOM-to-Canvas coordinate interpolation inside EaselJS when the browser `devicePixelRatio` wasn't an integer. When the user clicked on a block, the minuscule coordinate shifts fired a microscopic `pressmove` event. The previous logic immediately flagged any mouse `pressmove` as a drag operation (`moved = true`), which overrode the `click` handler and prevented the input widget from opening.

This PR adds a 5-pixel tolerance threshold to the `pressmove` handler. The mouse must now demonstrably move beyond this threshold before `moved = true` is set. This cleanly absorbs coordinate jitters from browser zoom and normalizes block input behavior. 

fixes #7412 

### Testing
1. Drag an interactive block (e.g., `number`, `text`, or an `action` block) into the workspace.
2. Change your browser zoom to a non-standard level (e.g., 125%, 150%, or 90%).
3. Click the block's argument to input a value.
4. Verify that the input widget (number pad, pie menu, text box) successfully opens and accepts input.

### Screenshots
**125%**
<img width="1464" height="769" alt="Screenshot 2026-05-23 at 7 08 03 PM" src="https://github.com/user-attachments/assets/e49d78a5-a31d-4703-8c8a-284e949ae895" />
**150%**
<img width="1461" height="747" alt="Screenshot 2026-05-23 at 7 08 27 PM" src="https://github.com/user-attachments/assets/c3029035-edfe-42bc-8041-c60d88722081" />


#### PR category
- [x] Bug Fix

