### PR TITLE
feat: add docs media check CI and bot comment workflow

### DIFF
--- a/.github/workflows/docs-media-check.yml
+++ b/.github/workflows/docs-media-check.yml
@@ -1,0 +1,53 @@
+name: Docs Media Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-media:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Check for doc file changes
+        id: doc-changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const docFiles = files.data.filter(f =>
+              f.filename.startsWith('docs/') ||
+              f.filename.startsWith('Docs/') ||
+              f.filename.endsWith('.md') ||
+              f.filename.endsWith('.md') ||
+              f.filename.endsWith('.mdx')
+            );
+
+            core.setOutput('has_doc_changes', docFiles.length > 0 ? 'true' : 'false');
+
+      - name: Check PR body for media
+        if: steps.doc-changes.outputs.has_doc_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            const hasImage = /!\[.*?\]\(.*?\)|<img\s[^>]*src=/i.test(body);
+            const hasVideo = /https:\/\/user-images\.githubusercontent\.com\/.*\.(mp4|gif|webm)/i.test(body);
+            const hasMedia = hasImage || hasVideo;
+
+            if (!hasMedia) {
+              core.setFailed(
+                'Documentation changes detected, but no screenshot or video attachment was found in the PR description.\n' +
+                'Please attach proof of local verification before merging.'
+              );
+            } else {
+              console.log('Media attachment found. Check passed.');
+            }

--- a/.github/workflows/docs-pr-bot.yml
+++ b/.github/workflows/docs-pr-bot.yml
@@ -1,0 +1,64 @@
+name: Docs PR Bot
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  comment-on-docs-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Check for doc file changes
+        id: doc-changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const docFiles = files.data.filter(f =>
+              f.filename.startsWith('docs/') ||
+              f.filename.startsWith('Docs/') ||
+              f.filename.endsWith('.md') ||
+              f.filename.endsWith('.mdx')
+            );
+
+            core.setOutput('has_doc_changes', docFiles.length > 0 ? 'true' : 'false');
+
+      - name: Post bot comment
+        if: steps.doc-changes.outputs.has_doc_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `## 📸 Documentation PR — Media Required
+
+            Thanks for contributing documentation updates!
+
+            Please attach a **screenshot or short screen recording** showing the documentation running locally.
+            This helps reviewers verify the changes quickly and ensures docs were tested before submission.
+
+            ### How to attach media:
+            \`\`\`markdown
+            ## Screenshot
+            <img width="1200" alt="docs-preview" src="YOUR_IMAGE_URL" />
+
+            ## Video
+            https://user-images.githubusercontent.com/your-video.mp4
+            \`\`\`
+
+            You can drag and drop images/videos directly into the PR description box on GitHub.
+
+            > ⚠️ The CI check will **block merging** until valid media is detected in the PR description.
+
+            📚 See [contributing instructions](https://github.com/sugarlabs/musicblocks/blob/master/README.md) for local setup help.`
+            });


### PR DESCRIPTION
## PR Category
- [x] Feature

## Summary
Closes #7270

Adds automated CI enforcement requiring contributors to attach a screenshot 
or screen recording whenever a PR contains documentation changes.

## Problem
Documentation PRs can currently be merged without any proof the changes 
were run or verified locally. As AI-assisted contributions grow, this 
increases the risk of broken or untested docs being merged, and forces 
maintainers to manually verify every docs PR.

## Solution
Two GitHub Actions workflows:

**1. `docs-media-check.yml`** — CI check that blocks merging if a docs PR 
has no screenshot or video in the description. Triggers on PR open, edit, 
synchronize, and reopen.

**2. `docs-pr-bot.yml`** — Bot that automatically comments on docs PRs 
explaining the requirement and showing contributors exactly how to attach 
media.

## Files Changed
- `.github/workflows/docs-media-check.yml`
- `.github/workflows/docs-pr-bot.yml`

## How It Works
- Detects changes to `docs/`, `Docs/`, `*.md`, `*.mdx`
- Scans PR description for image tags (`![...]()`, `<img src=...>`) or 
  GitHub video URLs (`.mp4`, `.gif`, `.webm`)
- Fails CI with a clear message if no media is found
- Passes silently if only source code files are changed
- Bot comment appears automatically on all docs PRs

## Acceptance Tests
- [x] A PR modifying only source code does not require media attachments
- [x] A PR modifying `.md`/`.mdx`/`docs/` files without media fails CI
- [x] A PR with a valid screenshot or video attachment passes CI
- [x] Bot comment appears automatically on documentation-related PRs
- [x] Merge is blocked until the CI check passes
- [x] Contributors receive clear guidance when the check fails