### PR TITLE
fix: guard against uninitialized note arrays in playRest

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -194,7 +194,10 @@ function setupRhythmActions(activity) {
         static playRest(turtle) {
             const tur = activity.turtles.ithTurtle(turtle);
 
-            if (tur.singer.inNoteBlock.length > 0) {
+            if (
+                tur.singer.inNoteBlock.length > 0 &&
+                tur.singer.notePitches[last(tur.singer.inNoteBlock)] !== undefined
+            ) {
                 tur.singer.notePitches[last(tur.singer.inNoteBlock)].push("rest");
                 tur.singer.noteOctaves[last(tur.singer.inNoteBlock)].push(4);
                 tur.singer.noteCents[last(tur.singer.inNoteBlock)].push(0);


### PR DESCRIPTION
## Summary

`RhythmActions.playRest()` only checked that `inNoteBlock` is non-empty before pushing rest data into the note arrays (`notePitches`, `noteOctaves`, `noteCents`, `noteHertz`, `noteBeatValues`). These are plain objects (`{}`) in `turtle-singer.js` and only get per-block entries when `clearNoteParams` is called for that block ID. If that initialization was skipped for the active block ID, the key returns `undefined`, and the subsequent `.push()` throws:

TypeError: Cannot read properties of undefined (reading 'push')



This crashes music playback silently with no user-visible feedback.

## Fix

Added a guard to verify that `notePitches[last(inNoteBlock)]` is not `undefined` before pushing rest data. This follows the same pattern already used in `getNoteValue()` in the same file (lines 444-468).

### Before:
```js
if (tur.singer.inNoteBlock.length > 0) {
```

### After:

```
if (
    tur.singer.inNoteBlock.length > 0 &&
    tur.singer.notePitches[last(tur.singer.inNoteBlock)] !== undefined
) {
```

PR Category
 - [x] Bug Fix
Fixes #7425