### PR TITLE
fix: guard against TypeError when _loadStart is not a function in new…

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -155,6 +155,15 @@ describe("PlanetInterface", () => {
         expect(mockActivity._loadStart).toHaveBeenCalled();
         expect(planetInterface.saveLocally).toHaveBeenCalled();
     });
+    test("newProject does not throw when _loadStart is not a function", () => {
+        const activityWithout = { ...mockActivity, _loadStart: undefined };
+        const pi = new PlanetInterface(activityWithout);
+        jest.spyOn(pi, "closePlanet").mockImplementation(() => {});
+        jest.spyOn(pi, "initialiseNewProject").mockImplementation(() => {});
+        jest.spyOn(pi, "saveLocally").mockImplementation(() => {});
+        expect(() => pi.newProject()).not.toThrow();
+        expect(pi.saveLocally).toHaveBeenCalled();
+    });
     test("onConverterLoad sets window.Converter", () => {
         planetInterface.planet = { Converter: "mockConverter" };
         planetInterface.onConverterLoad();

--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -156,7 +156,7 @@ describe("PlanetInterface", () => {
         expect(planetInterface.saveLocally).toHaveBeenCalled();
     });
     test("newProject does not throw when _loadStart is not a function", () => {
-        const activityWithout = { ...mockActivity, _loadStart: undefined };
+        const activityWithout = { ...mockActivity, _loadStart: "not a function" };
         const pi = new PlanetInterface(activityWithout);
         jest.spyOn(pi, "closePlanet").mockImplementation(() => {});
         jest.spyOn(pi, "initialiseNewProject").mockImplementation(() => {});

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -199,7 +199,9 @@ class PlanetInterface {
         this.newProject = () => {
             this.closePlanet();
             this.initialiseNewProject();
-            this.activity._loadStart();
+            if (typeof this.activity._loadStart === "function") {
+                this.activity._loadStart();
+            }
             this.saveLocally();
         };
 


### PR DESCRIPTION
Fixes #6185

## Problem
`PlanetInterface.newProject()` calls `this.activity._loadStart()` 
directly, but `_loadStart` does not exist on the activity object, 
causing an Uncaught TypeError in the console when clicking the 
"+" button in the Planet interface.

## Fix
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Testing
- Reproduced the bug locally on localhost:3000
- Clicked Planet → "+" button → TypeError no longer appears in console
- Added a new test case to planetInterface.test.js
- All 35 tests passing