### PR TITLE
fix: add missing cases 55 and 97 in oneHundredToFraction

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -170,7 +170,8 @@ describe("Utility Logic Functions", () => {
             expect(oneHundredToFraction(91)).toEqual([11, 12]);
             expect(oneHundredToFraction(96)).toEqual([31, 32]);
             expect(oneHundredToFraction(99)).toEqual([63, 64]);
-            expect(oneHundredToFraction(97)).toEqual([97, 100]);
+            expect(oneHundredToFraction(97)).toEqual([31, 32]);
+            expect(oneHundredToFraction(55)).toEqual([9, 16]);
         });
     });
 

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -528,7 +528,7 @@ describe("Utility Functions (logic-only)", () => {
         });
 
         it("handles default case", () => {
-            expect(oneHundredToFraction(97)).toEqual([97, 100]);
+            expect(oneHundredToFraction(97)).toEqual([31, 32]);
         });
     });
     describe("rationalSum()", () => {
@@ -615,7 +615,7 @@ describe("Utility Functions (logic-only)", () => {
         });
 
         it("handles default case", () => {
-            expect(oneHundredToFraction(97)).toEqual([97, 100]);
+            expect(oneHundredToFraction(97)).toEqual([31, 32]);
         });
     });
     describe("delayExecution()", () => {

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -455,6 +455,7 @@ var oneHundredToFraction = d => {
         case 53:
         case 54:
             return [17, 32];
+        case 55:
         case 56:
         case 57:
         case 58:
@@ -508,6 +509,7 @@ var oneHundredToFraction = d => {
         case 95:
             return [15, 16];
         case 96:
+        case 97:
         case 98:
             return [31, 32];
         case 99:


### PR DESCRIPTION
## Description

`oneHundredToFraction` in `js/utils/utils-logic.js` is missing two cases - `55` and `97`. When a user sets the vibrato frequency slider in the Timbre widget to either of these values, they get back a raw fraction like `[55, 100]` or `[97, 100]` instead of a proper musical fraction. Every other value in the range maps cleanly.

- `55` should return `[9, 16]` - it's closer to 0.5625 (distance 0.0125) than to `[17, 32]` (distance 0.0188)
- `97` should return `[31, 32]` - both its neighbours 96 and 98 already map there

There was also an existing test asserting `[97, 100]`, which was written against the broken behaviour.


## Related Issue

No related issue - bug identified through code analysis.


## PR Category

- [x] Bug Fix - Fixes a bug or incorrect behavior
- [x] Tests - Adds or updates test coverage


## Changes Made

- `js/utils/utils-logic.js`: add `case 55` mapping to `[9, 16]` and `case 97` mapping to `[31, 32]`
- `js/utils/__tests__/utils-logic.test.js`: fix existing wrong assertion for case 97 (`[97, 100]` → `[31, 32]`) and add a new test for case 55
- `js/utils/__tests__/utils.test.js`: fix two additional wrong assertions for case 97 (lines 531 and 618) also written against the buggy behaviour


## Testing Performed

- Ran `npm test -- --testPathPattern="utils"` — all 974 tests pass
- Ran full test suite `npm test` — no regressions introduced
- Note: one pre-existing failure exists in `js/widgets/__tests__/aidebugger.test.js` (unrelated to this PR)

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added & updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.