### PR TITLE
refactor: use CSS token for Extras SVG background

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -13,7 +13,7 @@
    global
    _, last, FlowBlock, ValueBlock, LeftBlock, NOINPUTERRORMSG,
    NANERRORMSG, mixedNumber, TONEBPM, DEFAULTDELAY, Singer,
-   StackClampBlock, platformColor, StatusMatrix
+   StackClampBlock, StatusMatrix
 */
 
 /* exported setupExtrasBlocks */
@@ -192,7 +192,8 @@ function setupExtrasBlocks(activity) {
                         '" width="' +
                         logo.canvas.width +
                         '" fill="' +
-                        platformColor.background +
+                        (getComputedStyle(document.body).getPropertyValue("--bg").trim() ||
+                            "#ffffff") +
                         '"/> ' +
                         logo.svgOutput;
                 }


### PR DESCRIPTION
## Summary

Partially addresses #6606

Migrates `js/blocks/ExtrasBlocks.js` to read the SVG background fill colour from the existing `--bg` CSS custom property instead of using `platformColor.background`.

## Changes

### `js/blocks/ExtrasBlocks.js`

* Replaced:

  ```js
  platformColor.background
  ```

  with:

  ```js
  getComputedStyle(document.body)
      .getPropertyValue("--bg")
      .trim() || "#ffffff"
  ```
* Removed the now-unused `platformColor` global from the file

## Notes

* No new CSS tokens introduced
* No behavioural changes intended
* `SensorsBlocks.js` was intentionally left unchanged because it currently parses RGB-formatted values, while `--bg` resolves to hex values

## Validation

### Automated checks

* [x] `npx jest js/blocks --coverage=false`

  * 25 suites passed
  * 1040 tests passed
* [x] `npm run lint`

  * passes with existing repository warnings only
* [x] `grep -n "platformColor" js/blocks/ExtrasBlocks.js`

  * returns no results

### Manual verification

* [x] Verified `--bg` resolves correctly for dark theme (`#1d1d20`)
* [x] Verified `--bg` resolves correctly for light theme (`#ffffff`)
* [x] Verified theme changes propagate correctly via `themechange` event
* [x] Verified no runtime errors in browser console

## PR Category

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Performance
- [ ] Documentation

## Validation Screenshots

Combined validation screenshot includes:

1. `grep -n "platformColor" js/blocks/ExtrasBlocks.js`

   * confirms no remaining `platformColor` usage in `ExtrasBlocks.js`
   
2. `npx jest js/blocks --coverage=false`

   * verifies relevant block test suites pass successfully
   
<img width="1102" height="50" alt="Screenshot 2026-05-25 162303" src="https://github.com/user-attachments/assets/55a8e166-08ff-4d9b-b894-86bcc73c4288" />


<img width="653" height="193" alt="Screenshot 2026-05-25 162229" src="https://github.com/user-attachments/assets/39ad5a27-799b-4407-aad8-f3c31b5453c2" />

   
3. DevTools console verification

   * confirms `--bg` resolves correctly for:

     * dark theme → `#1d1d20`
     * light theme → `#ffffff`
   * verifies theme updates propagate correctly via `themechange` event
   
<img width="783" height="351" alt="Screenshot 2026-05-25 213736" src="https://github.com/user-attachments/assets/dd4bdf2b-7f32-489d-bb98-54d7cd2a4fa4" />