### PR TITLE
feat: add docker compose support 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+    musicblocks:
+        container_name: musicblocks
+        build:
+            context: .
+            dockerfile: dockerfile
+        ports:
+            - "3000:3000"
+        volumes:
+            - .:/app
+            - musicblocks-node-modules:/app/node_modules
+        environment:
+            - NODE_ENV=development
+            - HOST=0.0.0.0
+
+volumes:
+    musicblocks-node-modules:

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,4 @@
-# First stage: Build stage
-FROM node:20-slim AS build
+FROM node:20-slim
 
 WORKDIR /app
 
@@ -9,19 +8,6 @@ RUN npm install
 
 COPY . .
 
-# Second stage: Final stage
-FROM node:20-slim
-
-RUN useradd -m appuser
-
-WORKDIR /app
-
-COPY --from=build /app /app
-
-USER appuser
-
 EXPOSE 3000
 
-ENV HOST=0.0.0.0
-
-CMD ["node", "index.js"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Related Issue
fixes #7284 

This PR adds `docker-compose.yml` to support a hot-reloading environment by mounting the local directory as a volume in the container, so file changes are reflected immediately without rebuilding the image.

Additionally, the existing `Dockerfile` is modified to switch to a single-step build from a multi-step build.

## PR Category
- [x] feature