### PR TITLE
test: add async playback regression coverage for aiwidget

### DIFF
--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -739,11 +739,15 @@ describe("AIWidget Instance", () => {
             })
         }));
         aiWidget = new AIWidget();
-        aiWidget.pause = jest.fn();
-        aiWidget.isMoving = true;
+        const pauseSpy = jest.fn();
+
+        aiWidget.pause = pauseSpy;
         aiWidget.init(mockActivity);
+        pauseSpy.mockClear();
+        aiWidget.isMoving = true;
         playButton.onclick();
-        expect(aiWidget.pause).toHaveBeenCalled();
+
+        expect(pauseSpy).toHaveBeenCalledTimes(1);
         expect(aiWidget.isMoving).toBe(false);
     });
 
@@ -800,12 +804,15 @@ describe("AIWidget Instance", () => {
         aiWidget._playSample = jest.fn();
         aiWidget._endPlaying = jest.fn();
         const promise = aiWidget._waitAndPlaySample();
-        jest.runAllTimers();
+
+        expect(aiWidget._playSample).not.toHaveBeenCalled();
+        expect(aiWidget._endPlaying).not.toHaveBeenCalled();
+
+        jest.runOnlyPendingTimers();
         const result = await promise;
-        expect(aiWidget._playSample).toHaveBeenCalled();
-        expect(aiWidget._endPlaying).toHaveBeenCalled();
+        expect(aiWidget._playSample).toHaveBeenCalledTimes(1);
+        expect(aiWidget._endPlaying).toHaveBeenCalledTimes(1);
         expect(result).toBe("played");
-        jest.useRealTimers();
     });
 
     it("should pause playback after sample duration ends", async () => {
@@ -814,11 +821,14 @@ describe("AIWidget Instance", () => {
         aiWidget.pause = jest.fn();
         aiWidget.sampleLength = 1500;
         const promise = aiWidget._waitAndEndPlaying();
-        jest.runAllTimers();
+
+        expect(aiWidget.pause).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1499);
+        expect(aiWidget.pause).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
         const result = await promise;
-        expect(aiWidget.pause).toHaveBeenCalled();
+        expect(aiWidget.pause).toHaveBeenCalledTimes(1);
         expect(result).toBe("ended");
-        jest.useRealTimers();
     });
 
     it("should delegate delayed playback to waitAndPlaySample", async () => {

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -156,6 +156,10 @@ describe("AIWidget Instance", () => {
     let aiWidget;
     let mockActivity;
     let originalFetch;
+    let originalCustomSamples;
+    let originalInstruments;
+    let originalToneAnalyser;
+    let originalWindowFor;
 
     beforeEach(() => {
         mockActivity = {
@@ -208,10 +212,25 @@ describe("AIWidget Instance", () => {
         // Since aiwidget.js uses wheelnav as a global if present
         global.wheelnav = jest.fn();
         originalFetch = global.fetch;
+
+        originalCustomSamples = global.CUSTOMSAMPLES;
+        originalInstruments = global.instruments;
+        originalToneAnalyser = global.Tone?.Analyser;
+        originalWindowFor = global.window?.widgetWindows?.windowFor;
     });
 
     afterEach(() => {
         global.fetch = originalFetch;
+        global.CUSTOMSAMPLES = originalCustomSamples;
+        global.instruments = originalInstruments;
+
+        if (global.Tone) {
+            global.Tone.Analyser = originalToneAnalyser;
+        }
+
+        if (global.window?.widgetWindows) {
+            global.window.widgetWindows.windowFor = originalWindowFor;
+        }
         jest.restoreAllMocks();
         jest.useRealTimers();
     });

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -704,4 +704,179 @@ describe("AIWidget Instance", () => {
             expect(labels).toContain("V: 1 Line 2");
         });
     });
+
+    it("should pause playback when play button is clicked while already moving", () => {
+        let playButton;
+        global.window.widgetWindows.windowFor = jest.fn(() => ({
+            clear: jest.fn(),
+            show: jest.fn(),
+            destroy: jest.fn(),
+            sendToCenter: jest.fn(),
+            isMaximized: jest.fn(() => false),
+            getWidgetFrame: jest.fn(() => ({
+                getBoundingClientRect: jest.fn(() => ({
+                    width: 800,
+                    height: 600
+                }))
+            })),
+            getWidgetBody: jest.fn(() => {
+                const div = document.createElement("div");
+                div.getBoundingClientRect = jest.fn(() => ({
+                    width: 800,
+                    height: 600
+                }));
+                return div;
+            }),
+            addButton: jest.fn(iconName => {
+                const button = {
+                    onclick: null,
+                    innerHTML: ""
+                };
+                if (iconName === "play-button.svg") {
+                    playButton = button;
+                }
+                return button;
+            })
+        }));
+        aiWidget = new AIWidget();
+        aiWidget.pause = jest.fn();
+        aiWidget.isMoving = true;
+        aiWidget.init(mockActivity);
+        playButton.onclick();
+        expect(aiWidget.pause).toHaveBeenCalled();
+        expect(aiWidget.isMoving).toBe(false);
+    });
+
+    it("should not add duplicate custom samples", () => {
+        aiWidget = new AIWidget();
+        global.CUSTOMSAMPLES = [["Piano", "existing-data"]];
+        aiWidget.sampleName = "Piano";
+        aiWidget.sampleData = "new-data";
+        aiWidget._addSample();
+        expect(CUSTOMSAMPLES.length).toBe(1);
+        expect(CUSTOMSAMPLES[0][1]).toBe("existing-data");
+    });
+
+    it("should add new custom samples when sample name is unique", () => {
+        aiWidget = new AIWidget();
+        global.CUSTOMSAMPLES = [];
+        aiWidget.sampleName = "Flute";
+        aiWidget.sampleData = "flute-data";
+        aiWidget._addSample();
+        expect(CUSTOMSAMPLES).toContainEqual(["Flute", "flute-data"]);
+    });
+
+    it("should trigger sample playback when sample name exists", () => {
+        const triggerMock = jest.fn();
+        aiWidget = new AIWidget();
+        aiWidget.activity = mockActivity;
+        aiWidget.activity.logo.synth = {
+            trigger: triggerMock
+        };
+        aiWidget.reconnectSynthsToAnalyser = jest.fn();
+        aiWidget.sampleName = "Piano";
+        aiWidget.originalSampleName = "Piano";
+        aiWidget.sampleLength = 2000;
+        aiWidget._playSample();
+        expect(aiWidget.reconnectSynthsToAnalyser).toHaveBeenCalled();
+        expect(triggerMock).toHaveBeenCalled();
+    });
+
+    it("should not trigger playback when sample name is empty", () => {
+        const triggerMock = jest.fn();
+        aiWidget = new AIWidget();
+        aiWidget.activity = mockActivity;
+        aiWidget.activity.logo.synth = {
+            trigger: triggerMock
+        };
+        aiWidget.sampleName = "";
+        aiWidget._playSample();
+        expect(triggerMock).not.toHaveBeenCalled();
+    });
+
+    it("should play and end sample playback after wait time", async () => {
+        jest.useFakeTimers();
+        aiWidget = new AIWidget();
+        aiWidget._playSample = jest.fn();
+        aiWidget._endPlaying = jest.fn();
+        const promise = aiWidget._waitAndPlaySample();
+        jest.runAllTimers();
+        const result = await promise;
+        expect(aiWidget._playSample).toHaveBeenCalled();
+        expect(aiWidget._endPlaying).toHaveBeenCalled();
+        expect(result).toBe("played");
+        jest.useRealTimers();
+    });
+
+    it("should pause playback after sample duration ends", async () => {
+        jest.useFakeTimers();
+        aiWidget = new AIWidget();
+        aiWidget.pause = jest.fn();
+        aiWidget.sampleLength = 1500;
+        const promise = aiWidget._waitAndEndPlaying();
+        jest.runAllTimers();
+        const result = await promise;
+        expect(aiWidget.pause).toHaveBeenCalled();
+        expect(result).toBe("ended");
+        jest.useRealTimers();
+    });
+
+    it("should delegate delayed playback to waitAndPlaySample", async () => {
+        aiWidget = new AIWidget();
+        aiWidget._waitAndPlaySample = jest.fn(() => Promise.resolve("played"));
+        await aiWidget._playDelayedSample();
+        expect(aiWidget._waitAndPlaySample).toHaveBeenCalled();
+    });
+
+    it("should delegate ending playback to waitAndEndPlaying", async () => {
+        aiWidget = new AIWidget();
+        aiWidget._waitAndEndPlaying = jest.fn(() => Promise.resolve("ended"));
+        await aiWidget._endPlaying();
+        expect(aiWidget._waitAndEndPlaying).toHaveBeenCalled();
+    });
+
+    it("should reconnect reference sample synth to analyser 0", () => {
+        const disconnectMock = jest.fn();
+        const connectMock = jest.fn();
+        global.instruments = [
+            {
+                [REFERENCESAMPLE]: {
+                    disconnect: disconnectMock,
+                    connect: connectMock
+                }
+            }
+        ];
+        global.Tone.Analyser = jest.fn(() => ({}));
+        aiWidget = new AIWidget();
+        aiWidget.pitchAnalysers = {
+            0: {},
+            1: {}
+        };
+        aiWidget.reconnectSynthsToAnalyser();
+        expect(disconnectMock).toHaveBeenCalled();
+        expect(connectMock).toHaveBeenCalledWith(aiWidget.pitchAnalysers[0]);
+    });
+
+    it("should reconnect custom sample synth to analyser 1", () => {
+        const disconnectMock = jest.fn();
+        const connectMock = jest.fn();
+        global.instruments = [
+            {
+                customsample_Piano: {
+                    disconnect: disconnectMock,
+                    connect: connectMock
+                }
+            }
+        ];
+        global.Tone.Analyser = jest.fn(() => ({}));
+        aiWidget = new AIWidget();
+        aiWidget.originalSampleName = "Piano";
+        aiWidget.pitchAnalysers = {
+            0: {},
+            1: {}
+        };
+        aiWidget.reconnectSynthsToAnalyser();
+        expect(disconnectMock).toHaveBeenCalled();
+        expect(connectMock).toHaveBeenCalledWith(aiWidget.pitchAnalysers[1]);
+    });
 });

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -827,7 +827,13 @@ describe("AIWidget Instance", () => {
         expect(aiWidget._playSample).not.toHaveBeenCalled();
         expect(aiWidget._endPlaying).not.toHaveBeenCalled();
 
-        jest.runOnlyPendingTimers();
+        jest.advanceTimersByTime(499);
+
+        expect(aiWidget._playSample).not.toHaveBeenCalled();
+        expect(aiWidget._endPlaying).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+
         const result = await promise;
         expect(aiWidget._playSample).toHaveBeenCalledTimes(1);
         expect(aiWidget._endPlaying).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Adds regression-focused tests for async playback sequencing and analyser-routing flows in `js/widgets/aiwidget.js`.

This PR focuses on deterministic playback behavior, async lifecycle sequencing, and synth/analyser routing paths that are more prone to regressions during future playback or audio-runtime changes.

## Covered regression scenarios

The added tests validate:

* delayed sample playback execution,
* async playback completion behavior,
* playback lifecycle delegation flows,
* custom sample playback guards,
* reference sample analyser routing,
* and custom sample analyser routing behavior.

## Why these tests

`aiwidget.js` coordinates:

* async playback sequencing,
* synth routing,
* analyser connections,
* and playback lifecycle behavior.

These execution paths are more regression-prone because they combine async timing behavior with runtime synth/analyser coordination.

The added tests focus on:

* deterministic async execution,
* playback lifecycle consistency,
* runtime routing correctness,
* and contributor-facing reliability improvements.

This PR intentionally targets async playback and analyser-routing execution paths instead of broad coverage expansion across the entire file.

Additional targeted regression coverage for remaining `aiwidget.js` execution paths can continue incrementally in follow-up PRs to keep testing changes maintainable and focused.

## Testing

```bash
npm test
```

Closes #7440

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation