### PR TITLE
fix(musicutils): correct octave check for "ti" in getNumNote

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2030,6 +2030,12 @@ describe("getNumNote", () => {
 
         expect(getNumNote(13, 1)).toEqual(["do♯", 2]);
     });
+
+    it("should decrement octave for 'ti' note", () => {
+        expect(getNumNote(0, 0)).toEqual(["ti", 0]);
+        expect(getNumNote(12, 0)).toEqual(["ti", 1]);
+        expect(getNumNote(0, 12)).toEqual(["ti", 1]);
+    });
 });
 
 describe("calcOctave", () => {


### PR DESCRIPTION
## Description

`getNumNote` in `musicutils.js` converts a numeric pitch value into a solfege note name and octave. When the resulting note is `"ti"`, the octave should be decremented by 1 -- this is a standard musical convention since `"ti"` sits at the boundary between octaves in the solfege system.

The existing check was:

```js
if (note[num] === "ti") {
    octave -= 1;
}
```

Here `note` is a string like `"ti"` and `num` is the modulo result (0–11). `note[num]` indexes a **character** from the string at position `num` but since `"ti"` is only 2 characters long, `note[num]` is `undefined` for any `num >= 2`. For `num === 0` (the only case where `"ti"` can appear, since `NOTESTABLE[0] === "ti"`), `note[0]` gives `"t"`, not `"ti"`. So this condition is **always false** and the octave decrement never fires.

As a result, every call to `getNumNote` that produces a `"ti"` note returns an octave that is 1 too high.

The fix is a one-character change: `note[num]` → `note`.


## Related Issue

No related issue -- bug identified through code analysis.


## PR Category

- [x] Bug Fix 


## Changes Made

- `js/utils/musicutils.js`: change `note[num] === "ti"` to `note === "ti"` in `getNumNote`
- `js/utils/__tests__/musicutils.test.js`: add 3 test assertions covering the `"ti"` octave decrement path, which had zero coverage


## Testing Performed

- Ran `npm test -- musicutils` - all tests pass
- Ran full test suite `npm test` - no regressions introduced


## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**