### PR TITLE
Fix crash in _blockFindTurtle when block is missing

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -43,36 +43,37 @@ function getTargetTurtle(turtles, targetTurtle) {
 }
 
 function _blockFindTurtle(activity, turtle, blk, receivedArg) {
-    const block = activity.blocks.blockList[blk];
-
-    // Prevent crash if block is missing
-    if (!block || !block.connections) {
+    if (!activity.blocks.blockList[blk]) {
         return null;
     }
 
-    const cblk = block.connections[1];
+    const cblk = activity.blocks.blockList[blk].connections[1];
 
-    // No connected turtle block
-    if (cblk === null || cblk === undefined) {
+    if (cblk === null) {
         return null;
     }
 
-    const targetTurtle = activity.logo.parseArg(activity.logo, turtle, cblk, blk, receivedArg);
+    const targetTurtle = activity.logo.parseArg(
+        activity.logo,
+        turtle,
+        cblk,
+        blk,
+        receivedArg
+    );
 
-    // Invalid turtle name
     if (targetTurtle === null) {
         return null;
     }
 
     const targetTurtleId = getTargetTurtle(activity.turtles, targetTurtle);
 
-    // Turtle not found
     if (targetTurtleId === null) {
         return null;
     }
 
     return activity.turtles.getTurtle(targetTurtleId);
 }
+
 
 function setupEnsembleBlocks(activity) {
     // Extract common block setup logic
@@ -496,7 +497,7 @@ function setupEnsembleBlocks(activity) {
 
         flow(args, logo, turtle, blk, receivedArg, actionArgs, isflow) {
             const targetTurtle = getTargetTurtle(activity.turtles, args[0]);
-            if (targetTurtle !== null) {
+            if (targetTurtle != null) {
                 logo.runFromBlock(logo, targetTurtle, args[1], isflow, receivedArg);
             } else {
                 if (_THIS_IS_MUSIC_BLOCKS_) {
@@ -1084,7 +1085,7 @@ function setupEnsembleBlocks(activity) {
             const tur = activity.turtles.ithTurtle(activity.turtles.companionTurtle(turtle));
             const heading = tur.orientation;
             // Heading needs to be set to 0 when we update the graphic.
-            if (heading !== 0) {
+            if (heading != 0) {
                 tur.painter.doSetHeading(0);
             }
 
@@ -1108,7 +1109,7 @@ function setupEnsembleBlocks(activity) {
             );
 
             // Restore the heading.
-            if (heading !== 0) {
+            if (heading != 0) {
                 tur.painter.doSetHeading(heading);
             }
         }

--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -43,20 +43,34 @@ function getTargetTurtle(turtles, targetTurtle) {
 }
 
 function _blockFindTurtle(activity, turtle, blk, receivedArg) {
-    const cblk = activity.blocks.blockList[blk].connections[1];
-    if (cblk === null) {
-        //Debug: connecting block not found, returning null
+    const block = activity.blocks.blockList[blk];
+
+    // Prevent crash if block is missing
+    if (!block || !block.connections) {
         return null;
     }
+
+    const cblk = block.connections[1];
+
+    // No connected turtle block
+    if (cblk === null || cblk === undefined) {
+        return null;
+    }
+
     const targetTurtle = activity.logo.parseArg(activity.logo, turtle, cblk, blk, receivedArg);
+
+    // Invalid turtle name
     if (targetTurtle === null) {
-        //Debug: target turtleName from arg not found, returning null
         return null;
     }
+
     const targetTurtleId = getTargetTurtle(activity.turtles, targetTurtle);
+
+    // Turtle not found
     if (targetTurtleId === null) {
         return null;
     }
+
     return activity.turtles.getTurtle(targetTurtleId);
 }
 
@@ -1070,7 +1084,7 @@ function setupEnsembleBlocks(activity) {
             const tur = activity.turtles.ithTurtle(activity.turtles.companionTurtle(turtle));
             const heading = tur.orientation;
             // Heading needs to be set to 0 when we update the graphic.
-            if (heading != 0) {
+            if (heading !== 0) {
                 tur.painter.doSetHeading(0);
             }
 
@@ -1094,7 +1108,7 @@ function setupEnsembleBlocks(activity) {
             );
 
             // Restore the heading.
-            if (heading != 0) {
+            if (heading !== 0) {
                 tur.painter.doSetHeading(heading);
             }
         }


### PR DESCRIPTION
## PR Type

- [x] Bug Fix

## Description

Fixes a crash in `_blockFindTurtle()` when `activity.blocks.blockList[blk]` is null or undefined.

Previously, the function accessed:

```js
activity.blocks.blockList[blk].connections
```

without validating that the block existed, which could cause:

```js
TypeError: Cannot read properties of undefined (reading 'connections')
```

when referenced turtle blocks were deleted.

## Changes Made

* Added defensive checks for missing or invalid blocks
* Prevented crashes when referenced turtle blocks no longer exist
* Preserved existing behavior by returning `null` for invalid blocks

Fixes #7211
