### PR TITLE
fix: reset _circularCanvas and _circularView on widget close

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -615,6 +615,8 @@ class RhythmRuler {
             this._playingOne = false;
             this._playingAll = false;
             this.activity.hideMsgs();
+            this._circularCanvas = null;
+            this._circularView = false;
 
             this.widgetWindow.destroy();
         };


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Fixes #7449

## Problem
On second open of Rhythm Maker widget, clicking Circular Ruler showed a blank widget.

## Root Cause
The onclose handler did not reset:
 `_circularCanvas` — stale detached DOM reference caused canvas to never re-initialize
-`_circularView` — boolean stayed `true`, so clicking circle button toggled it to `false`, preventing circular view from showing

## Fix
Reset both variables in the onclose handler:
 `this._circularCanvas = null;`
`this._circularView = false;`

## Testing
1. Open Rhythm Maker widget.
2. Click Circular Ruler first time, it works.
3. Close widget, reopen.
4. Click Circular Ruler again and it  works correctly.