### PR TITLE
fix: guard against numeric noteArg in getNote()

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4549,8 +4549,8 @@ function getNote(
     temperament
 ) {
     if (typeof noteArg === "number") {
-    noteArg = noteArg.toString();
-}
+        noteArg = noteArg.toString();
+    }
     if (temperament === undefined) {
         temperament = "equal";
     }
@@ -6474,9 +6474,7 @@ const getNumNote = (value, delta, temperament) => {
     let num = value + delta;
 
     const octaveSize =
-        temperament &&
-        TEMPERAMENT[temperament] &&
-        TEMPERAMENT[temperament]["pitchNumber"]
+        temperament && TEMPERAMENT[temperament] && TEMPERAMENT[temperament]["pitchNumber"]
             ? TEMPERAMENT[temperament]["pitchNumber"]
             : 12;
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4548,6 +4548,9 @@ function getNote(
     errorMsg,
     temperament
 ) {
+    if (typeof noteArg === "number") {
+    noteArg = noteArg.toString();
+}
     if (temperament === undefined) {
         temperament = "equal";
     }


### PR DESCRIPTION
## Problem
When a custom temperament is active, pitch blocks pass integer step indices to getNote(). The function internally calls .substr() assuming a string argument, causing a crash:
TypeError: noteArg.substr is not a function

## Fix
Added a type guard at the entry of getNote() in musicutils.js to convert numeric noteArg to string before processing.

## Category
- [x] Bug Fix