### PR TITLE
fix: toggle play button icon during playback in Pitch Staircase

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -162,7 +162,12 @@ class PitchStaircase {
             playCell.onclick = () => {
                 const i = playCell.getAttribute("id");
                 const stepCell = this._stepTables[i].rows[0].cells[1];
+                playCell.innerHTML = `&nbsp;&nbsp;<img src="header-icons/pause-button.svg" title="pause" alt="pause" height="${PitchStaircase.BUTTONSIZE}" width="${PitchStaircase.BUTTONSIZE}">`;
                 this._playOne(stepCell);
+                setTimeout(() => {
+                    playCell.innerHTML = `&nbsp;&nbsp;<img src="header-icons/play-button.svg" title="play" alt="play" height="${PitchStaircase.BUTTONSIZE}" width="${PitchStaircase.BUTTONSIZE}">`;
+                }, 1000);
+                
             };
         }
     }


### PR DESCRIPTION
## Problem
In the Pitch Staircase widget, the play button icon does not toggle during playback. The audio plays correctly but the button icon remains as ▶️ instead of changing to ⏸️.

## Fix
Added icon toggle logic to playCell.onclick handler in pitchstaircase.js:
- Icon changes to pause-button.svg when playback starts
- Icon reverts to play-button.svg after playback completes (1 second)

## Related Issue
Closes #7453

## Category
[ ]Bug Fix

<img width="811" height="662" alt="image" src="https://github.com/user-attachments/assets/7128aa87-6bd5-43ac-a5c8-866895f7f3a8" />
