### PR TITLE
fix: toggle play button icon during playback in LEGO Bricks

### DIFF
--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -286,6 +286,8 @@ function LegoWidget() {
         this.playButton = widgetWindow.addButton("play-button.svg", ICONSIZE, _("Play"));
         this.playButton.onclick = () => {
             this._playPhrase();
+            const img = this.playButton.querySelector("img");
+            if (img) img.src = "header-icons/stop-button.svg";
         };
 
         this.saveButton = widgetWindow.addButton("save-button.svg", ICONSIZE, _("Save"));

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -2423,6 +2423,9 @@ function LegoWidget() {
 
         this.activity.hideMsgs();
 
+        const img = this.playButton.querySelector("img");
+        if (img) img.src = "header-icons/play-button.svg";
+
         // Save final color segments for all lines
         if (this.scanningLines) {
             const now = performance.now();

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -285,9 +285,13 @@ function LegoWidget() {
         // Add control buttons in left sidebar
         this.playButton = widgetWindow.addButton("play-button.svg", ICONSIZE, _("Play"));
         this.playButton.onclick = () => {
-            this._playPhrase();
-            const img = this.playButton.querySelector("img");
-            if (img) img.src = "header-icons/stop-button.svg";
+            if (this.isPlaying) {
+                this._stopPlayback();
+            } else {
+                this._playPhrase();
+                const img = this.playButton.querySelector("img");
+                if (img) img.src = "header-icons/stop-button.svg";
+            }
         };
 
         this.saveButton = widgetWindow.addButton("save-button.svg", ICONSIZE, _("Save"));


### PR DESCRIPTION
## PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior

## Summary
Resolves #7455 — the play button icon in the LEGO Bricks 
widget did not toggle during playback.

## Changes
js/widgets/legobricks.js
- Added icon toggle to stop-button.svg in playButton.onclick 
  handler when playback starts
- Added icon revert to play-button.svg at the start of 
  _stopPlayback() when playback ends

## Test Results
Before: Play button icon remains ▶️ throughout playback
After: Icon toggles to ⏹️ during playback and reverts to ▶️ when done

## Checklist
- [x] All tests pass locally (npm test)
- [x] Lint clean (npm run lint)
- [x] Prettier clean (npx prettier --check .)
- [x] No new dependencies added