### PR TITLE
fix(tests): set consent state explicitly in AIDebuggerWidget test

### DIFF
--- a/js/widgets/__tests__/aidebugger.test.js
+++ b/js/widgets/__tests__/aidebugger.test.js
@@ -732,6 +732,7 @@ describe("AIDebuggerWidget", () => {
         });
 
         test("shows consent banner and does not send message if consent not given", () => {
+            debuggerWidget._consentGiven = false;
             debuggerWidget.messageInput.value = "Hello AI";
             debuggerWidget._showConsentBanner = jest.fn();
             debuggerWidget._sendMessage();


### PR DESCRIPTION
fixes #7458
## Summary

This PR fixes a failing npm test in js/widgets/__tests__/aidebugger.test.js.

The test assumes that user consent has not been granted, but the consent state is not explicitly initialized. As a result, the test can fail depending on the widget state.

## Changes

* Explicitly set debuggerWidget._consentGiven = false in the consent handling test.
* Ensure the test accurately reflects the intended scenario where consent has not been granted.

## Result

The npm test suite passes consistently and the consent handling test correctly validates the expected behavior.
<img width="443" height="133" alt="Screenshot 2026-06-02 at 2 35 41 AM" src="https://github.com/user-attachments/assets/ef4767d1-ab95-4e5c-8c3e-8be33f219868" />

## PR Category

- [x] Bug Fix
- [x] Tests

