### PR TITLE
fix(musicutils): correct typo in convertFactor - 0.675 should be 0.625 (5/8)

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2257,7 +2257,7 @@ describe("convertFactor", () => {
         { input: 0.4375, expected: "4.." },
         { input: 0.5, expected: "2" },
         { input: 0.5625, expected: "2 16" },
-        { input: 0.675, expected: "2 8" },
+        { input: 0.625, expected: "2 8" },
         { input: 0.6875, expected: "2 8 16" },
         { input: 0.75, expected: "2." },
         { input: 0.8125, expected: "2 4 16" },
@@ -2274,6 +2274,7 @@ describe("convertFactor", () => {
 
     it("should return null for unknown factors", () => {
         expect(convertFactor(0)).toBeNull();
+        expect(convertFactor(0.675)).toBeNull();
         expect(convertFactor("string")).toBeNull(); // Non-numeric input
     });
 });

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6471,9 +6471,7 @@ const getNumNote = (value, delta, temperament) => {
     let num = value + delta;
 
     const octaveSize =
-        temperament &&
-        TEMPERAMENT[temperament] &&
-        TEMPERAMENT[temperament]["pitchNumber"]
+        temperament && TEMPERAMENT[temperament] && TEMPERAMENT[temperament]["pitchNumber"]
             ? TEMPERAMENT[temperament]["pitchNumber"]
             : 12;
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6674,7 +6674,7 @@ const convertFactor = factor => {
             return "2";
         case 0.5625: // 9/16
             return "2 16";
-        case 0.675: // 5/8
+        case 0.625: // 5/8
             return "2 8";
         case 0.6875: // 11/16
             return "2 8 16";


### PR DESCRIPTION
## Description

`convertFactor` in `musicutils.js` maps beat duration values to their LilyPond string representations. The case for 5/8 contained a typo:

```js
case 0.675: // 5/8    ← wrong, 0.675 is not a valid musical fraction
    return "2 8";
```

The correct value for 5/8 is `0.625`, not `0.675`. As a result:

- `convertFactor(0.625)` fell through to `default` and returned `null`
- In `notation.js`, a `null` return silently **drops** the tempo or pickup marking in LilyPond export for any project using a 5/8 beat value - the notation is exported without the correct tempo/pickup
- `0.675` is unreachable in practice since no standard musical computation produces it

The existing test also contained the same typo and was therefore passing against the wrong value.


## Related Issue

No related issue — bug identified through code analysis.

## PR Category

- [x] Bug Fix 


## Changes Made

- `js/utils/musicutils.js`: change `case 0.675` to `case 0.625`
- `js/utils/__tests__/musicutils.test.js`: update test input from `0.675` to `0.625`, and add `convertFactor(0.675)` to the `null` test to confirm it is not a valid factor


## Testing Performed

- Ran `npm test -- musicutils` - all tests pass
- Ran full test suite `npm test` - no regressions introduced
- Note: one pre-existing failure in  `js/widgets/__tests__/aidebugger.test.js` (unrelated to this PR)

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**