### PR TITLE
Fix help widget outside-click minimize behavior

### DIFF
--- a/js/__tests__/widgetWindows.test.js
+++ b/js/__tests__/widgetWindows.test.js
@@ -39,4 +39,24 @@ describe("widgetWindows outside-click behavior", () => {
         expect(win._rollButton.classList.contains("plus")).toBe(true);
         expect(window.widgetWindows.focused).toBeNull();
     });
+
+    test("does not minimize the focused window when clicking inside it", () => {
+        const win = window.widgetWindows.windowFor({}, "help", "help", false);
+        win.takeFocus();
+        win._rollButton = document.createElement("div");
+
+        const rollupSpy = jest.spyOn(win, "_rollup").mockImplementation(() => {
+            win._rolled = true;
+            return win;
+        });
+
+        window.widgetWindows._handleGlobalMouseDown({
+            target: win._frame,
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn()
+        });
+
+        expect(rollupSpy).not.toHaveBeenCalled();
+        expect(window.widgetWindows.focused).toBe(win);
+    });
 });

--- a/js/__tests__/widgetWindows.test.js
+++ b/js/__tests__/widgetWindows.test.js
@@ -1,0 +1,42 @@
+describe("widgetWindows outside-click behavior", () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML =
+            '<div id="floatingWindows"></div><canvas id="myCanvas"></canvas><nav></nav>';
+
+        global.docById = jest.fn(id => document.getElementById(id));
+        global._ = msg => msg;
+        global.ManagedTimer = function () {
+            this.clearAll = jest.fn();
+        };
+
+        window.widgetWindows = undefined;
+        require("../widgets/widgetWindows.js");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    test("minimizes the focused window when clicking outside all open windows", () => {
+        const win = window.widgetWindows.windowFor({}, "help", "help", false);
+        win.takeFocus();
+        win._rollButton = document.createElement("div");
+
+        const rollupSpy = jest.spyOn(win, "_rollup").mockImplementation(() => {
+            win._rolled = true;
+            return win;
+        });
+
+        window.widgetWindows._handleGlobalMouseDown({
+            target: document.body,
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn()
+        });
+
+        expect(rollupSpy).toHaveBeenCalledTimes(1);
+        expect(win._rollButton.classList.contains("plus")).toBe(true);
+        expect(window.widgetWindows.focused).toBeNull();
+    });
+});

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -119,6 +119,18 @@ window.widgetWindows = {
         }
 
         if (!focusedAny) {
+            const previouslyFocused = this.focused;
+
+            if (previouslyFocused && !previouslyFocused._rolled) {
+                previouslyFocused._rollup();
+                if (previouslyFocused._rollButton) {
+                    previouslyFocused._rollButton.classList.add("plus");
+                }
+                previouslyFocused._frame.style.width = "auto";
+                previouslyFocused._frame.style.height = "auto";
+                previouslyFocused._frame.style.minHeight = "0px";
+            }
+
             this.focused = null;
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes the help widget minimize behavior when the user clicks outside the panel to improve UX.



## Previously
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/3901da20-ea7f-42ff-b2ef-1f06869dc703" />



### What changed
- Clicking anywhere outside the help window now minimizes/rolls up the widget.
- The rolled-up state now uses the same visual behavior as the normal minimize control, including the visible plus/minimize indicator.
- Added a regression test to ensure outside-click minimize behavior remains working.


## After-change

https://github.com/user-attachments/assets/19ee78c8-1f31-49c3-80da-74770eeb4e1b



Ran `npx jest js/__tests__/widgetWindows.test.js --runInBand --coverage=false` for verification.

## Category 
- [x] Feature 
  