### PR TITLE
fix: update interval selection when interval type changes without number

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3179,6 +3179,7 @@ const piemenuIntervals = (block, selectedInterval) => {
             )
         ) + "px";
 
+    let isInitialized = false;
     // Add function to each main menu for show/hide sub menus
     // TODO: Add all tabs to each interval
     const __setupAction = (i, activeTabs) => {
@@ -3193,6 +3194,10 @@ const piemenuIntervals = (block, selectedInterval) => {
                         that._intervalWheel.navItems[l * 8 + j].navItem.show();
                     }
                 }
+            }
+            if (isInitialized) {
+                that._intervalWheel.navigateWheel(i * 8 + activeTabs[0] - 1);
+                __selectionChanged();
             }
         };
     };
@@ -3227,6 +3232,7 @@ const piemenuIntervals = (block, selectedInterval) => {
     } else {
         block._intervalWheel.navigateWheel(INTERVALS[i][2][0] - 1);
     }
+    isInitialized = true;
 
     const __exitMenu = () => {
         that._piemenuExitTime = new Date().getTime();

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3195,7 +3195,7 @@ const piemenuIntervals = (block, selectedInterval) => {
                     }
                 }
             }
-            if (isInitialized) {
+            if (isInitialized && activeTabs.length > 0) {
                 that._intervalWheel.navigateWheel(i * 8 + activeTabs[0] - 1);
                 __selectionChanged();
             }


### PR DESCRIPTION
fixes. #7471 
## Summary
Fixes an issue in the interval pie menu where selecting an interval type updated the visible number tabs but did not update the selected interval state.

## New Behaviou
r

When an interval type is selected, the pie menu automatically navigates to the first valid interval number for that type and updates the interval state immediately.

Example:

text perfect 5 
click major 
block becomes major 2 

The block value now stays synchronized with the user's interval-type selection.

## Changes

- Added interval-type selection handling after initialization.
- Automatically navigates to the first valid interval number for the selected interval type.
- Triggers interval state synchronization via __selectionChanged().
- Prevents stale interval values when changing interval categories.

### PR Category
- [x]  Bug Fix


## BEFORE:



https://github.com/user-attachments/assets/d0b26a5e-9f51-46bf-8335-7c362ab4c041



## AFTER:

https://github.com/user-attachments/assets/e5c6ef09-3aaa-4845-92d7-70d164ef2d80

