### PR TITLE
Fix: Resolve redundant callbacks and missing payloads in HttpRequest

### DIFF
--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -300,17 +300,26 @@ function HttpRequest(url, loadCallback, userCallback) {
         req.onload = () => {
             if ((req.status >= 200 && req.status < 300) || this.localmode) {
                 if (typeof this.handler === "function") this.handler();
-                if (typeof this.userCallback === "function")
+                if (typeof this.userCallback === "function") {
                     this.userCallback(true, req.responseText);
+                }
             } else {
-                if (typeof this.userCallback === "function")
+                if (typeof this.handler === "function") this.handler();
+                if (typeof this.userCallback === "function") {
                     this.userCallback(false, `Error: ${req.status}`);
+                }
             }
         };
 
         req.onerror = () => {
-            if (typeof this.userCallback === "function") this.userCallback(false, "network error");
+            if (typeof this.handler === "function") this.handler();
+            if (typeof this.userCallback === "function") {
+                this.userCallback(false, "network error");
+            }
         };
+
+        req.onabort = req.onerror;
+        req.ontimeout = req.onerror;
 
         req.send("");
     } catch (e) {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -288,31 +288,38 @@ let httpPost = async (projectName, data) => {
  * @param {function} [userCallback] - An optional user-defined callback function.
  */
 function HttpRequest(url, loadCallback, userCallback) {
-    // userCallback is an optional callback-handler.
     const req = (this.request = new XMLHttpRequest());
     this.handler = loadCallback;
     this.url = url;
     this.localmode = Boolean(self.location.href.search(/^file:/i) === 0);
     this.userCallback = userCallback;
 
-    const objref = this;
     try {
         req.open("GET", url);
 
-        req.onreadystatechange = () => {
-            objref.handler();
+        req.onload = () => {
+            if ((req.status >= 200 && req.status < 300) || this.localmode) {
+                if (typeof this.handler === "function") this.handler();
+                if (typeof this.userCallback === "function")
+                    this.userCallback(true, req.responseText);
+            } else {
+                if (typeof this.userCallback === "function")
+                    this.userCallback(false, `Error: ${req.status}`);
+            }
+        };
+
+        req.onerror = () => {
+            if (typeof this.userCallback === "function") this.userCallback(false, "network error");
         };
 
         req.send("");
     } catch (e) {
         if (self.console) {
-            console.debug("Failed to load resource from " + url + ": Network error.");
-
-            console.debug(e);
+            console.debug("Failed to load resource from " + url + ": Network error.", e);
         }
 
-        if (typeof userCallback === "function") {
-            userCallback(false, "network error");
+        if (typeof this.userCallback === "function") {
+            this.userCallback(false, "network error");
         }
 
         this.request = this.handler = this.userCallback = null;


### PR DESCRIPTION
**Summary**
Refactors the legacy `HttpRequest` constructor to use `onload` and `onerror` instead of `onreadystatechange`. This prevents callbacks from firing multiple times per request and fixes a bug where `userCallback` was ignored on success.

Eliminates wasteful, redundant executions of `loadCallback` (which previously fired on ready states 1, 2, 3, and 4) and ensures successful network payloads are actually passed back to the requesting function.

## Category 
- [x] Bug Fix