### PR TITLE
Add @fileoverview docstring to minify.js

### DIFF
--- a/js/js-export/minify.js
+++ b/js/js-export/minify.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview This script reads the ast2blocks.json file, parses it, and minifies it to ast2blocks.min.json for deployment.
+ */
 const fs = require("fs");
 
 const jsonContent = fs.readFileSync("ast2blocks.json", "utf8");


### PR DESCRIPTION
## Problem Background
The `minify.js` script in `js/js-export/` lacked documentation comments, which reduced code readability and made it harder for contributors to understand its purpose and usage.

## Changes
Added a `@fileoverview` docstring at the beginning of the file to clearly describe the script's functionality: reading `ast2blocks.json`, parsing its content, and minifying it to `ast2blocks.min.json` for deployment. This aligns with JSDoc standards and improves maintainability.

## Verification
- Review the modified file to confirm the comment is correctly placed and accurately describes the script.
- Ensure no functional changes by running the script (if applicable) to verify that it still produces the expected output without errors.