### PR TITLE
perf: reduce idle canvas re-rendering

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -545,10 +545,7 @@ class Activity {
                 if (this.stage) {
                     const hasActiveTweens = createjs.Tween.hasActiveTweens();
                     const hasActiveGifs = this.gifAnimator && this.gifAnimator.getActiveCount() > 0;
-                    const isInteracting =
-                        this.isDragging ||
-                        this.isSelecting ||
-                        (this.blocks && this.blocks.dragGroup !== null);
+                    const isInteracting = this.isDragging || this.isSelecting;
 
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
                         this.stage.update();


### PR DESCRIPTION
## Summary

While profiling Music Blocks, I observed continuous canvas updates during idle state. Investigation traced this behavior to the `blocks.dragGroup !== null` condition being included in the interaction check inside the render loop.

This change removes the `dragGroup` check from `isInteracting` and relies on the existing `isDragging` and `isSelecting` flags to determine active user interaction.

## Motivation

The render loop continued treating the stage as interactive even when no drag operation was actively in progress, resulting in unnecessary idle canvas updates.

## Validation

<img width="483" height="270" alt="image" src="https://github.com/user-attachments/assets/1cb37189-417d-4410-bd73-99c05345574c" />


* Verified block dragging behavior manually
* Verified project execution behavior
* Ran Prettier
* Ran ESLint successfully
* Ran full test suite successfully (165/165 suites, 5431/5431 tests passed)

## Change

```js
const isInteracting = this.isDragging || this.isSelecting;
```

removing:

```js
(this.blocks && this.blocks.dragGroup !== null)
```

from the interaction check used by the render loop.

## PR Category
- [ ] Bug Fix
- [ ] Feature
- [x] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
