### PR TITLE
Add area ownership governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,66 @@
+# Default owner for paths that do not have an area approver yet.
+* @walterbender
+
+# Blocks and runtime
+/js/blocks/ @ssz2605
+/js/js-export/ @ssz2605
+
+# Music and pedagogy
+/js/widgets/ @pikurasa
+/css/ @pikurasa
+/header-icons/ @pikurasa
+/js/turtleactions/ @pikurasa
+/lilypond/ @pikurasa
+/examples/ @pikurasa
+/lessonPlan/ @pikurasa
+/js/abc.js @pikurasa
+/js/lilypond.js @pikurasa
+/js/notation.js @pikurasa
+/js/turtle-singer.js @pikurasa
+/js/utils/musicutils.js @pikurasa
+/js/__tests__/abc.test.js @pikurasa
+/js/__tests__/lilypond.test.js @pikurasa
+/js/__tests__/notation.test.js @pikurasa
+/js/__tests__/turtle-singer.test.js @pikurasa
+/js/utils/__tests__/musicutils.test.js @pikurasa
+
+# Music block overrides. These rules come after the broader runtime rule.
+/js/blocks/DrumBlocks.js @pikurasa
+/js/blocks/EnsembleBlocks.js @pikurasa
+/js/blocks/IntervalsBlocks.js @pikurasa
+/js/blocks/MeterBlocks.js @pikurasa
+/js/blocks/OrnamentBlocks.js @pikurasa
+/js/blocks/PitchBlocks.js @pikurasa
+/js/blocks/RhythmBlockPaletteBlocks.js @pikurasa
+/js/blocks/RhythmBlocks.js @pikurasa
+/js/blocks/ToneBlocks.js @pikurasa
+/js/blocks/VolumeBlocks.js @pikurasa
+/js/blocks/__tests__/DrumBlocks*.test.js @pikurasa
+/js/blocks/__tests__/EnsembleBlocks*.test.js @pikurasa
+/js/blocks/__tests__/IntervalsBlocks*.test.js @pikurasa
+/js/blocks/__tests__/MeterBlocks*.test.js @pikurasa
+/js/blocks/__tests__/OrnamentBlocks*.test.js @pikurasa
+/js/blocks/__tests__/PitchBlocks*.test.js @pikurasa
+/js/blocks/__tests__/RhythmBlockPaletteBlocks*.test.js @pikurasa
+/js/blocks/__tests__/RhythmBlocks*.test.js @pikurasa
+/js/blocks/__tests__/ToneBlocks*.test.js @pikurasa
+/js/blocks/__tests__/VolumeBlocks*.test.js @pikurasa
+
+# Planet and project sharing
+/planet/ @zealot-zew
+/js/planetInterface.js @zealot-zew
+/js/SaveInterface.js @zealot-zew
+
+# Tests and CI infrastructure
+/.github/workflows/ @omsuneri @Ashutoshx7
+/.husky/ @omsuneri @Ashutoshx7
+/cypress/ @omsuneri @Ashutoshx7
+/cypress.config.js @omsuneri @Ashutoshx7
+/jest.config.js @omsuneri @Ashutoshx7
+/jest.setup.js @omsuneri @Ashutoshx7
+/eslint.config.mjs @omsuneri @Ashutoshx7
+
+# Ownership and governance
+/.github/CODEOWNERS @walterbender @pikurasa
+/GOVERNANCE.md @walterbender @pikurasa
+/MAINTAINERS.md @walterbender @pikurasa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,57 +1,47 @@
 # Default owner for paths that do not have an area approver yet.
 * @walterbender
 
+# General JavaScript fallback. More specific JavaScript rules below override
+# this for owned areas.
+/js/ @walterbender
+
 # Blocks and runtime
 /js/blocks/ @ssz2605
 /js/js-export/ @ssz2605
 
-# Music and pedagogy
-/js/widgets/ @pikurasa
-/css/ @pikurasa
-/header-icons/ @pikurasa
-/js/turtleactions/ @pikurasa
-/lilypond/ @pikurasa
-/examples/ @pikurasa
-/lessonPlan/ @pikurasa
-/js/abc.js @pikurasa
-/js/lilypond.js @pikurasa
-/js/notation.js @pikurasa
-/js/turtle-singer.js @pikurasa
-/js/utils/musicutils.js @pikurasa
-/js/__tests__/abc.test.js @pikurasa
-/js/__tests__/lilypond.test.js @pikurasa
-/js/__tests__/notation.test.js @pikurasa
-/js/__tests__/turtle-singer.test.js @pikurasa
-/js/utils/__tests__/musicutils.test.js @pikurasa
+# Music, pedagogy, and user-facing interface
+/js/widgets/ @walterbender @pikurasa
+/css/ @walterbender @pikurasa
+/header-icons/ @walterbender @pikurasa
+/js/turtleactions/ @walterbender @pikurasa
+/lilypond/ @walterbender @pikurasa
+/examples/ @walterbender @pikurasa
+/lessonPlan/ @walterbender @pikurasa
+/js/abc.js @walterbender @pikurasa
+/js/lilypond.js @walterbender @pikurasa
+/js/notation.js @walterbender @pikurasa
+/js/turtle-singer.js @walterbender @pikurasa
+/js/utils/musicutils.js @walterbender @pikurasa
 
 # Music block overrides. These rules come after the broader runtime rule.
-/js/blocks/DrumBlocks.js @pikurasa
-/js/blocks/EnsembleBlocks.js @pikurasa
-/js/blocks/IntervalsBlocks.js @pikurasa
-/js/blocks/MeterBlocks.js @pikurasa
-/js/blocks/OrnamentBlocks.js @pikurasa
-/js/blocks/PitchBlocks.js @pikurasa
-/js/blocks/RhythmBlockPaletteBlocks.js @pikurasa
-/js/blocks/RhythmBlocks.js @pikurasa
-/js/blocks/ToneBlocks.js @pikurasa
-/js/blocks/VolumeBlocks.js @pikurasa
-/js/blocks/__tests__/DrumBlocks*.test.js @pikurasa
-/js/blocks/__tests__/EnsembleBlocks*.test.js @pikurasa
-/js/blocks/__tests__/IntervalsBlocks*.test.js @pikurasa
-/js/blocks/__tests__/MeterBlocks*.test.js @pikurasa
-/js/blocks/__tests__/OrnamentBlocks*.test.js @pikurasa
-/js/blocks/__tests__/PitchBlocks*.test.js @pikurasa
-/js/blocks/__tests__/RhythmBlockPaletteBlocks*.test.js @pikurasa
-/js/blocks/__tests__/RhythmBlocks*.test.js @pikurasa
-/js/blocks/__tests__/ToneBlocks*.test.js @pikurasa
-/js/blocks/__tests__/VolumeBlocks*.test.js @pikurasa
+/js/blocks/DrumBlocks.js @walterbender @pikurasa
+/js/blocks/EnsembleBlocks.js @walterbender @pikurasa
+/js/blocks/IntervalsBlocks.js @walterbender @pikurasa
+/js/blocks/MeterBlocks.js @walterbender @pikurasa
+/js/blocks/OrnamentBlocks.js @walterbender @pikurasa
+/js/blocks/PitchBlocks.js @walterbender @pikurasa
+/js/blocks/RhythmBlockPaletteBlocks.js @walterbender @pikurasa
+/js/blocks/RhythmBlocks.js @walterbender @pikurasa
+/js/blocks/ToneBlocks.js @walterbender @pikurasa
+/js/blocks/VolumeBlocks.js @walterbender @pikurasa
 
 # Planet and project sharing
 /planet/ @zealot-zew
 /js/planetInterface.js @zealot-zew
 /js/SaveInterface.js @zealot-zew
 
-# Tests and CI infrastructure
+# Tests and CI infrastructure. These rules come after source rules so test
+# files do not fall back to Walter or Devin.
 /.github/workflows/ @omsuneri @Ashutoshx7
 /.husky/ @omsuneri @Ashutoshx7
 /cypress/ @omsuneri @Ashutoshx7
@@ -59,6 +49,20 @@
 /jest.config.js @omsuneri @Ashutoshx7
 /jest.setup.js @omsuneri @Ashutoshx7
 /eslint.config.mjs @omsuneri @Ashutoshx7
+/js/__tests__/ @omsuneri @Ashutoshx7
+/js/utils/__tests__/ @omsuneri @Ashutoshx7
+/js/widgets/__tests__/ @omsuneri @Ashutoshx7
+/js/turtleactions/__tests__/ @omsuneri @Ashutoshx7
+/js/blocks/__tests__/DrumBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/EnsembleBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/IntervalsBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/MeterBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/OrnamentBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/PitchBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/RhythmBlockPaletteBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/RhythmBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/ToneBlocks*.test.js @omsuneri @Ashutoshx7
+/js/blocks/__tests__/VolumeBlocks*.test.js @omsuneri @Ashutoshx7
 
 # Ownership and governance
 /.github/CODEOWNERS @walterbender @pikurasa

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,17 @@ Follow these steps when contributing:
 
 7.  Respond to review feedback and update your branch as needed.
 
+### Reviews and Area Ownership
+
+All reviews are welcome. Reviewing pull requests is a good way to help the
+project and learn from other contributors.
+
+Some parts of the project have Area Approvers. Their approval, or approval from
+a Project Maintainer, is required before a pull request can be merged.
+
+See [GOVERNANCE.md](GOVERNANCE.md) for the review flow and
+[MAINTAINERS.md](MAINTAINERS.md) for the current areas and maintainers.
+
 ### Keeping Your PR Up-to-Date
 
 Our CI automatically rebases your PR onto the latest `master` whenever

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,14 +61,26 @@ Project Maintainer.
 | Changed files | Requested review |
 | --- | --- |
 | `js/blocks/NumberBlocks.js` | Blocks & Runtime |
+| `js/blocks/__tests__/NumberBlocks.test.js` | Blocks & Runtime |
 | `js/widgets/tempo.js` | UI/UX & Accessibility |
+| `js/widgets/__tests__/tempo.test.js` | Tests & CI |
 | `planet/js/Publisher.js` | Planet & Project Sharing |
 | `.github/workflows/...` | Tests & CI |
 | `README.md` | Project Maintainer |
+| `js/widgets/tempo.js` and `js/widgets/__tests__/tempo.test.js` | UI/UX & Accessibility and Tests & CI |
 | `js/widgets/tempo.js` and `planet/js/Publisher.js` | UI/UX & Accessibility and Planet & Project Sharing |
 | `js/widgets/tempo.js` and `README.md` | UI/UX & Accessibility and Project Maintainer |
 
-Feature tests stay with the same area as the feature. Shared test setup and CI
+Feature tests stay with the same technical area when that area already has a
+clear code owner, such as Blocks & Runtime or Planet. This keeps source-and-test
+changes in those areas from needing an extra approval only because a matching
+test changed.
+
+Music and UI code paths request both code review and feedback on classroom
+use, music behavior, and child-facing UX.
+Tests in those paths go to Tests & CI, so test review is handled by people
+maintaining the project's test practice. Tests that would otherwise fall back
+to a Project Maintainer also go to Tests & CI. Shared test setup and CI
 infrastructure go to Tests & CI.
 
 | Situation | Approval needed for merge |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,109 @@
+# Governance
+
+Music Blocks uses area ownership so pull requests reach people who know the
+affected part of the project. This helps reviews move without requiring every
+decision to go through a single maintainer.
+
+Everyone is welcome to review, test, and ask questions on pull requests. Those
+reviews help the project and help contributors learn. To merge a pull request,
+GitHub needs an approval from the relevant Area Approver or a Project
+Maintainer, along with the required checks.
+
+## Roles
+
+### Project Maintainer
+
+Project Maintainers are responsible for the project as a whole. They appoint
+Area Approvers, resolve disagreements, and handle exceptions. They may review,
+merge, or close any pull request.
+
+### Area Approver
+
+Area Approvers are trusted contributors for a specific part of the project.
+Their approval is required before pull requests in that area can be merged.
+They may merge pull requests in their area and close routine stale,
+superseded, or out-of-scope pull requests with a short explanation.
+
+### Reviewer
+
+Reviewers are contributors with experience in an area. They review code, test
+changes, and help other contributors. Their feedback is useful even when they
+are not the person whose approval is required for merge.
+
+### Contributor
+
+Anyone may contribute. Contributors are encouraged to review pull requests,
+ask questions, and grow into Reviewer or Area Approver roles over time.
+
+## Pull Request Flow
+
+1. A contributor opens a focused pull request.
+2. GitHub requests reviews from the owners of the changed paths.
+3. Contributors review, test, and discuss the change.
+4. Required checks pass and the relevant Area Approver approves the pull
+   request.
+5. An Area Approver merges the pull request.
+
+Some pull requests affect more than one area. The relevant Area Approvers
+should review those changes. If one file spans multiple areas, its listed
+owner gives the required approval and asks the other expert for input when
+needed.
+
+If an Area Approver authored a pull request or is unavailable, a Project
+Maintainer may handle the pull request as an exception. The Project Maintainer
+should leave a short comment explaining the exception.
+
+Disagreements that cannot be resolved within an area should be brought to a
+Project Maintainer.
+
+## Routing Examples
+
+| Changed files | Requested review |
+| --- | --- |
+| `js/blocks/NumberBlocks.js` | Blocks & Runtime |
+| `js/widgets/tempo.js` | UI/UX & Accessibility |
+| `planet/js/Publisher.js` | Planet & Project Sharing |
+| `.github/workflows/...` | Tests & CI |
+| `README.md` | Project Maintainer |
+| `js/widgets/tempo.js` and `planet/js/Publisher.js` | UI/UX & Accessibility and Planet & Project Sharing |
+| `js/widgets/tempo.js` and `README.md` | UI/UX & Accessibility and Project Maintainer |
+
+Feature tests stay with the same area as the feature. Shared test setup and CI
+infrastructure go to Tests & CI.
+
+| Situation | Approval needed for merge |
+| --- | --- |
+| One area has one Area Approver | Approval from that Area Approver |
+| One area has more than one Area Approver | Approval from any one of them |
+| A pull request changes files from two areas | Approval from each affected area |
+| One file spans more than one area | Approval from its listed owner, with input from the other area when needed |
+
+## Role Growth and Changes
+
+Contributors may become Reviewers after making useful reviews or contributions
+in an area over time. Reviewers should understand the area well enough to help
+contributors and give practical feedback.
+
+Reviewers may become Area Approvers after showing sound judgment in an area and
+a willingness to help move pull requests forward. Area Approvers should
+understand how changes in their area affect the rest of the project.
+
+Role changes are made through a pull request that updates
+[MAINTAINERS.md](MAINTAINERS.md). Adding or removing an Area Approver also
+requires an update to [CODEOWNERS](.github/CODEOWNERS), and repository write
+access must be granted before the person is added to CODEOWNERS.
+
+A Project Maintainer approves role changes. It is fine for an area to start
+with one Area Approver, but important areas should grow toward at least two
+active Area Approvers when contributor capacity allows.
+
+Area Approvers should be reasonably responsive when available. If someone is no
+longer active in an area, they may move to emeritus status or be removed from
+CODEOWNERS. Emergency access removal may happen immediately and should be
+documented in a follow-up pull request.
+
+## GitHub Permissions
+
+GitHub write access applies to the whole repository. GitHub does not limit it
+to individual folders. Area Approvers should use merge and close permissions
+within their documented areas. Project Maintainers handle exceptions.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,11 +15,17 @@ pull request flow.
 
 | Area | GitHub handles | Responsibility |
 | --- | --- | --- |
-| Music & Pedagogy | [@pikurasa](https://github.com/pikurasa) | Music behavior, notation, examples, and classroom use |
-| UI/UX & Accessibility | [@pikurasa](https://github.com/pikurasa) | Widgets, layout, interaction design, and child-facing usability |
+| Music & Pedagogy | [@walterbender](https://github.com/walterbender), [@pikurasa](https://github.com/pikurasa) | Music behavior, notation, examples, and classroom use |
+| UI/UX & Accessibility | [@walterbender](https://github.com/walterbender), [@pikurasa](https://github.com/pikurasa) | Widgets, layout, interaction design, and child-facing usability |
 | Blocks & Runtime | [@ssz2605](https://github.com/ssz2605) | General block definitions and JavaScript export |
-| Tests & CI | [@omsuneri](https://github.com/omsuneri), [@Ashutoshx7](https://github.com/Ashutoshx7) | Shared test infrastructure and CI workflows |
+| Tests & CI | [@omsuneri](https://github.com/omsuneri), [@Ashutoshx7](https://github.com/Ashutoshx7) | Shared test infrastructure, CI workflows, and tests without a technical area owner |
 | Planet & Project Sharing | [@zealot-zew](https://github.com/zealot-zew) | Planet, publishing, and project-sharing flow |
+
+Music and UI paths request Walter and Devin together. This keeps Devin close to
+changes where music behavior, child-facing UX, and real classroom use matter,
+while Walter can handle code approval when needed. Tests in these paths are
+routed to Tests & CI so test review goes to the people maintaining the
+project's test practice.
 
 ## Reviewers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,40 @@
+# Maintainers
+
+This file lists the current Music Blocks maintainers, Area Approvers, and
+Reviewers. See [GOVERNANCE.md](GOVERNANCE.md) for role definitions and the
+pull request flow.
+
+## Project Maintainers
+
+| GitHub handle | Responsibility |
+| --- | --- |
+| [@walterbender](https://github.com/walterbender) | Project-wide maintenance |
+| [@pikurasa](https://github.com/pikurasa) | Project-wide maintenance |
+
+## Area Approvers
+
+| Area | GitHub handles | Responsibility |
+| --- | --- | --- |
+| Music & Pedagogy | [@pikurasa](https://github.com/pikurasa) | Music behavior, notation, examples, and classroom use |
+| UI/UX & Accessibility | [@pikurasa](https://github.com/pikurasa) | Widgets, layout, interaction design, and child-facing usability |
+| Blocks & Runtime | [@ssz2605](https://github.com/ssz2605) | General block definitions and JavaScript export |
+| Tests & CI | [@omsuneri](https://github.com/omsuneri), [@Ashutoshx7](https://github.com/Ashutoshx7) | Shared test infrastructure and CI workflows |
+| Planet & Project Sharing | [@zealot-zew](https://github.com/zealot-zew) | Planet, publishing, and project-sharing flow |
+
+## Reviewers
+
+| Area | GitHub handles |
+| --- | --- |
+| Docs, Lessons & i18n | [@stutijain2006](https://github.com/stutijain2006) |
+| Blocks & Runtime | [@vanshika2720](https://github.com/vanshika2720) |
+
+## Areas Without an Area Approver
+
+Project Maintainers currently handle:
+
+- Docs, Lessons & i18n
+- Plugins, Media & Assets
+- Release, Security & Infrastructure
+
+The project may add Area Approvers as contributors gain experience in these
+parts of the repository.


### PR DESCRIPTION
## Description

This is the first version of area ownership for Musicblocks.

The goal is to make PR routing clearer: when a change touches a known part of the project, GitHub should request review from people who understand that area. 
This helps review and merge work move beyond one person, while still keeping community review open for everyone.

NOTE: This PR only adds the structure. It does not turn on required CODEOWNER approval yet.

## PR Category
-   [x] Documentation: Updates to docs, comments, or README
-   [x] Chore / Refactor: Maintenance, cleanup, or refactoring with no behavior change