### PR TITLE
fix: add touch long-press to trigger context pie menu on mobile

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3485,6 +3485,31 @@ class Block {
             _dragHasRest2 = false;
             moved = false;
         });
+        // Touch long-press to open context menu
+        this.container.on("touchstart", () => {
+            that.blocks.mouseDownTime = new Date().getTime();
+            that.blocks.longPressTimeout = setTimeout(() => {
+                that.blocks.activeBlock = thisBlock;
+                that._triggerLongPress = true;
+                that.blocks.triggerLongPress();
+            }, LONGPRESSTIME);
+        });
+
+        this.container.on("touchmove", () => {
+            if (that.blocks.longPressTimeout !== null) {
+                clearTimeout(that.blocks.longPressTimeout);
+                that.blocks.longPressTimeout = null;
+                that.blocks.clearLongPress();
+            }
+        });
+
+        this.container.on("touchend", () => {
+            if (that.blocks.longPressTimeout !== null) {
+                clearTimeout(that.blocks.longPressTimeout);
+                that.blocks.longPressTimeout = null;
+                that.blocks.clearLongPress();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary
Long-pressing a block on touch/mobile devices now opens the pie 
context menu, matching the right-click behavior on desktop.

The existing long-press timeout was only wired to `mousedown`, 
which touch browsers do not fire. This fix adds `touchstart`, 
`touchmove`, and `touchend` handlers to `_loadEventHandlers()` 
in `js/block.js` so the 1500ms timer fires correctly on touch devices.
If the finger moves before the timeout, the long press is cancelled.

## Test Plan
- [ ] Open MusicBlocks in Chrome DevTools with touch emulation enabled
- [ ] Long press any block for 1.5 seconds without moving
- [ ] Pie context menu should appear
- [ ] Moving finger during hold should cancel the menu

Fixes #4096