### PR TITLE
Improve Planet search behavior and disable infinite scroll

### DIFF
--- a/planet/js/GlobalPlanet.js
+++ b/planet/js/GlobalPlanet.js
@@ -11,9 +11,8 @@
 
 /*
    global
-
-   _, GlobalTag, GlobalCard, jQuery, currentUserScrollPos:true,
-   maxScrollPos:true, ProjectViewer, debounce
+_, GlobalTag, GlobalCard, jQuery, currentUserScrollPos:true,
+   maxScrollPos:true, ProjectViewer
 */
 /*
    exported
@@ -571,30 +570,32 @@ class GlobalPlanet {
                 }
             });
 
-            const debouncedfunction = debounce(this.search.bind(this), 250);
-
-            document.getElementById("global-search").addEventListener("input", evt => {
-                this.searchString = document.getElementById("global-search").value;
-                debouncedfunction();
+            document.getElementById("global-search").addEventListener("keydown", evt => {
+                if (evt.key === "Enter") {
+                    this.searchString = document.getElementById("global-search").value;
+                    this.search();
+                }
             });
 
-            document.getElementById("global-search-2").addEventListener("input", evt => {
-                this.searchString = document.getElementById("global-search-2").value;
-                debouncedfunction();
+            document.getElementById("global-search-2").addEventListener("keydown", evt => {
+                if (evt.key === "Enter") {
+                    this.searchString = document.getElementById("global-search-2").value;
+                    this.search();
+                }
             });
 
             document.getElementById("search-close").addEventListener("click", evt => {
                 document.getElementById("global-search").value = "";
                 this.searchString = "";
                 document.getElementById("search-close").style.display = "none";
-                debouncedfunction();
+                this.search();
             });
 
             document.getElementById("search-close-2").addEventListener("click", evt => {
                 document.getElementById("global-search-2").value = "";
                 this.searchString = "";
                 document.getElementById("search-close-2").style.display = "none";
-                debouncedfunction();
+                this.search();
             });
 
             document.getElementById("global-tab").addEventListener("click", evt => {
@@ -606,22 +607,8 @@ class GlobalPlanet {
                 // document.getElementById("two_header").style.display = "none";
             });
 
-            document.body.onscroll = () => {
-                const currentUserScrollPos =
-                    window.pageYOffset || document.documentElement.scrollTop;
-
-                const maxScrollPos = Math.max(
-                    document.body.scrollHeight,
-                    document.body.offsetHeight,
-                    document.documentElement.clientHeight,
-                    document.documentElement.scrollHeight,
-                    document.documentElement.offsetHeight
-                );
-
-                if ((currentUserScrollPos / maxScrollPos) * 100 >= 75 && this.loadButtonShown)
-                    this.loadMoreProjects();
-            };
-
+            // Infinite scroll disabled - server overload prevention
+            document.body.onscroll = null;
             this.ProjectViewer = new ProjectViewer(Planet);
             this.ProjectViewer.init();
         }


### PR DESCRIPTION
## Description

This PR reduces unnecessary requests sent to the Planet server.

### Changes

* Trigger searches only when the user presses **Enter** instead of on every keystroke.
* Update the search-clear ("x") buttons to refresh results without relying on the removed debounced search handler.
* Disable infinite scrolling so additional projects are loaded only through the existing **Load More Projects** workflow.

### Verification

* Verified that typing in the search box no longer generates repeated search requests.
* Verified that a search request is sent when Enter is pressed.
* Verified that scrolling to the bottom no longer triggers automatic project-fetch requests.

### Issue

Planet performance: excessive server requests caused by aggressive search behavior and infinite scrolling.

### Screenshots

* Before: 
<img width="1600" height="785" alt="WhatsApp Image 2026-06-09 at 7 20 08 PM" src="https://github.com/user-attachments/assets/dc02fdd1-097d-4e8f-bfcc-bf0fff1a2546" />


* After: 
<img width="1600" height="684" alt="WhatsApp Image 2026-06-10 at 12 05 59 AM" src="https://github.com/user-attachments/assets/0f1011dd-2ed8-4704-af65-9d9aece63f66" />


## PR Category
- [X] Bug Fix
- [x] Performance

