### PR TITLE
fix: replace innerHTML with textContent in sampler.js and pitchslider.js

### DIFF
--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -132,7 +132,7 @@ class PitchSlider {
             const freqLabel = document.createElement("div");
             freqLabel.className = "wfbtItem";
             toolBarDiv.appendChild(freqLabel);
-            freqLabel.innerHTML = `<label>${parseFloat(this.frequencies[id].toFixed(2))}</label>`;
+            freqLabel.textContent = parseFloat(this.frequencies[id].toFixed(2));
 
             this.sliders[id] = slider;
             const changeFreq = () => {
@@ -141,9 +141,7 @@ class PitchSlider {
                     this.frequencies[id],
                     Tone.now() + 0.05
                 );
-                freqLabel.innerHTML = `<label>${parseFloat(
-                    this.frequencies[id].toFixed(2)
-                )}</label>`;
+                freqLabel.textContent = parseFloat(this.frequencies[id].toFixed(2));
             };
 
             slider.oninput = () => {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -660,7 +660,7 @@ function SampleWidget() {
             container.style.gap = "20px";
 
             const h1 = document.createElement("h1");
-            h1.innerHTML = "AI Sample Generation";
+            h1.textContent = "AI Sample Generation";
             h1.style.fontSize = "40px";
             h1.style.marginTop = "0";
             h1.style.marginBottom = "0px";
@@ -699,7 +699,7 @@ function SampleWidget() {
             submit.style.borderRadius = "10px";
             submit.style.border = "none";
             submit.style.cursor = "pointer";
-            submit.innerHTML = "Submit";
+            submit.textContent = "Submit";
             submit.onclick = async function () {
                 submit.disabled = true;
                 const prompt = textArea.value;
@@ -745,7 +745,7 @@ function SampleWidget() {
             preview.style.borderRadius = "10px";
             preview.style.border = "none";
             preview.style.cursor = "pointer";
-            preview.innerHTML = "Preview";
+            preview.textContent = "Preview";
             preview.disabled = true;
             preview.onclick = () => {
                 if (that.audioPreview) {
@@ -773,7 +773,7 @@ function SampleWidget() {
             save.style.borderRadius = "10px";
             save.style.border = "none";
             save.style.cursor = "pointer";
-            save.innerHTML = "Save";
+            save.textContent = "Save";
             save.disabled = true;
             save.onclick = function () {
                 const audioURL = `http://13.61.94.100:8000/save`;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## Description
This PR addresses security and code quality improvements by replacing `innerHTML` with `textContent` for rendering static UI text in `sampler.js` and `pitchslider.js`. 

As outlined in `AGENTS.md` (Section 4: Prefer `textContent` over `innerHTML`), using `innerHTML` to inject static text strings is an anti-pattern. This PR ensures we follow the project's security and DOM manipulation guidelines.

## Changes Made
* **`js/widgets/sampler.js`**: Replaced `innerHTML` with `textContent` for static UI elements including "AI Sample Generation", "Submit", "Preview", and "Save" buttons.
* **`js/widgets/pitchslider.js`**: Replaced `innerHTML` with `textContent` for setting the `freqLabel` display text, removing unnecessary inline `<label>` injections.
* **Code Formatting**: Verified changes using `eslint` and `npx prettier --write` as required.

## Why This Matters
* Prevents unnecessary HTML parsing for static strings.
* Adheres strictly to the guidelines established in `AGENTS.md`.
* Improves overall code security and maintains cleaner DOM injection practices.

## Verification
* [x] Replaced instances of `innerHTML` with `textContent` where applicable.
* [x] Ran `npm run lint` and resolved any issues.
* [x] Ran `npx prettier --check .` to ensure formatting consistency.
* [x] Verified unit tests passing with `npm test`.
