### PR TITLE
fix(palette): cancel hover timeout on click to prevent double-click needed to open palette

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -1084,6 +1084,7 @@ class Palettes {
                 this._hideMenus();
                 this.activity.showSearchWidget();
             } else {
+                this._clearPendingMenuOpen();
                 this.showPalette(name);
             }
         };


### PR DESCRIPTION
Fixes: #7495

### Problem
When a palette (e.g. Meter) is open and the user clicks a different palette 
(e.g. Ornament), the new palette does not open on the first click — a second 
click is required.

### Root Cause
`_loadPaletteButtonHandler` sets a 400ms hover timeout via `_menuOpenTimeout` 
on `onmouseover` that calls `showPalette`. When the user moves the mouse from 
one palette row to another and clicks, the hover timeout from the mouseover 
fires and calls `_hideMenus`, racing with the click handler which also calls 
`showPalette`. The net result is the first click only closes the open palette 
without opening the new one.

The `onmouseout` handler already calls `_clearPendingMenuOpen()` to cancel 
the timeout, but `onclick` did not — leaving the race condition open.

#### PR category
- [x] Bug Fix

### Fix
Add `this._clearPendingMenuOpen()` at the top of the `onclick` else-branch in 
`_loadPaletteButtonHandler`, consistent with how `onmouseout` already handles it.

### Files Changed
- `js/palette.js` — one line added in `_loadPaletteButtonHandler`
