### PR TITLE
fix: average two-finger touch deltas to fix scroll direction bug

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2859,26 +2859,36 @@ class Activity {
                 "touchmove",
                 event => {
                     if (event.touches.length === 2) {
+                        let totalDeltaY = 0;
+                        let totalDeltaX = 0;
+                        let count = 0;
+
                         for (let i = 0; i < 2; i++) {
                             const touchY = event.touches[i].clientY;
                             const touchX = event.touches[i].clientX;
 
                             if (initialTouches[i][0] !== null && initialTouches[i][1] !== null) {
-                                const deltaY = touchY - initialTouches[i][0];
-                                const deltaX = touchX - initialTouches[i][1];
+                                totalDeltaY += touchY - initialTouches[i][0];
+                                totalDeltaX += touchX - initialTouches[i][1];
+                                count++;
+                            }
 
-                                if (deltaY !== 0) {
-                                    closeAnyOpenMenusAndLabels();
-                                    that.blocksContainer.y -= deltaY;
-                                }
+                            initialTouches[i][0] = touchY;
+                            initialTouches[i][1] = touchX;
+                        }
 
-                                if (that.scrollBlockContainer && deltaX !== 0) {
-                                    closeAnyOpenMenusAndLabels();
-                                    that.blocksContainer.x -= deltaX;
-                                }
+                        if (count > 0) {
+                            const avgDeltaY = totalDeltaY / count;
+                            const avgDeltaX = totalDeltaX / count;
 
-                                initialTouches[i][0] = touchY;
-                                initialTouches[i][1] = touchX;
+                            if (avgDeltaY !== 0) {
+                                closeAnyOpenMenusAndLabels();
+                                that.blocksContainer.y -= avgDeltaY;
+                            }
+
+                            if (that.scrollBlockContainer && avgDeltaX !== 0) {
+                                closeAnyOpenMenusAndLabels();
+                                that.blocksContainer.x -= avgDeltaX;
                             }
                         }
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Summary

Two-finger scrolling in the blocks workspace now uses the average movement of both touches instead of applying each finger's movement independently.

Previously, the touch handler updated the workspace position for each finger separately. This could cause amplified scrolling, jitter, or inconsistent movement when the two fingers moved slightly differently during a scroll gesture.

This fix updates the touchmove handler in js/activity.js to calculate the average X and Y deltas across both active touches before applying the movement to the blocks container. As a result, two-finger scrolling behaves more smoothly and predictably on touch devices.

## Test Plan

- [ ]  Open Music Blocks on a touch-enabled device (or Chrome DevTools with touch emulation enabled)

- [ ]  Place two fingers on the workspace and perform vertical scrolling

- [ ]  Verify the workspace moves smoothly without exaggerated movement

- [ ] Perform horizontal two-finger scrolling (when horizontal scrolling is enabled)

- [ ] Verify scrolling remains responsive and follows finger movement correctly

- [ ] Confirm no regressions in existing touch interactions

Fixes #4096

