### PR TITLE
fix: Typo accidetalFlat -> accidentalFlat in sampler.js

### DIFF
--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -1039,13 +1039,13 @@ function SampleWidget() {
                     tunerContainer.style.marginTop = "100px";
                 }
 
-                const accidetalFlat = document.createElement("img");
-                accidetalFlat.setAttribute("src", "header-icons/accidental-flat.svg");
-                accidetalFlat.style.height = 40 + "px";
-                accidetalFlat.style.width = 40 + "px";
-                accidetalFlat.style.marginTop = "auto";
+                const accidentalFlat = document.createElement("img");
+                accidentalFlat.setAttribute("src", "header-icons/accidental-flat.svg");
+                accidentalFlat.style.height = 40 + "px";
+                accidentalFlat.style.width = 40 + "px";
+                accidentalFlat.style.marginTop = "auto";
 
-                tunerContainer.appendChild(accidetalFlat);
+                tunerContainer.appendChild(accidentalFlat);
 
                 const tunerSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
                 tunerSvg.style.width = 350 + "px";


### PR DESCRIPTION
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

### Description
This PR fixes a minor typo in the variable name `accidetalFlat` within `js/widgets/sampler.js`. 

### Changes Made
- **js/widgets/sampler.js**: Renamed all instances of the misspelled variable `accidetalFlat` to `accidentalFlat` for clarity and correctness.

### Why This Matters
- Typo fixes are non-controversial and improve the overall readability and quality of the codebase.
- Clear variable naming helps prevent confusion for future contributors.

### Verification
- [x] Replaced `accidetalFlat` with `accidentalFlat`.
- [x] Checked formatting consistency.
