### PR TITLE
fix: clear LEGO Bricks scanning status message

### DIFF
--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -2415,6 +2415,8 @@ function LegoWidget() {
     this._stopPlayback = function () {
         this.isPlaying = false;
 
+        this.activity.hideMsgs();
+
         // Save final color segments for all lines
         if (this.scanningLines) {
             const now = performance.now();


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

Fixes #7504

## Problem

When an image scan is started in the LEGO Bricks widget, the status message:

"Scanning image with vertical lines..."

is displayed while scanning is in progress.

After scanning completes, the message remains visible instead of being cleared. The message can also remain visible when the widget is closed during scanning.

## Root Cause

The scanning status message is displayed using `activity.textMsg()`, but it is never cleared when playback/scanning stops.

## Fix

Clear the status message in `_stopPlayback()` by calling:

`this.activity.hideMsgs();`

## Testing

1. Open LEGO Bricks widget.
2. Upload an image.
3. Start scanning.
4. Verify the message appears during scanning.
5. Wait for scanning to complete.
6. Verify the message disappears.
7. Close the widget during scanning.
8. Verify the message is cleared.
9. Verify scanning and audio playback continue to work correctly.
