### PR TITLE
style/fix: Maintain code quality and security standards in base64Utils & jseditor

### DIFF
--- a/js/base64Utils.js
+++ b/js/base64Utils.js
@@ -22,6 +22,8 @@
  * @module base64Utils
  */
 
+/* exported base64Encode, base64Decode */
+
 /**
  * Encodes a string to Base64 format.
  * @param {string} str - The string to encode.

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -374,7 +374,7 @@ class JSEditor {
         helpBtn.style.fontSize = "2rem";
         helpBtn.style.background = "#2196f3";
         helpBtn.style.cursor = "pointer";
-        helpBtn.innerHTML = "help_outline";
+        helpBtn.textContent = "help_outline";
         helpBtn.onclick = this._toggleHelp.bind(this);
         menuLeft.appendChild(helpBtn);
         generateTooltip(helpBtn, _("Help"));
@@ -387,7 +387,7 @@ class JSEditor {
         generateBtn.style.fontSize = "2rem";
         generateBtn.style.background = "#2196f3";
         generateBtn.style.cursor = "pointer";
-        generateBtn.innerHTML = "autorenew";
+        generateBtn.textContent = "autorenew";
         generateBtn.onclick = this._generateCode.bind(this);
         menuLeft.appendChild(generateBtn);
         generateTooltip(generateBtn, _("Reset Code"));
@@ -400,7 +400,7 @@ class JSEditor {
         runBtn.style.fontSize = "2rem";
         runBtn.style.background = "#2196f3";
         runBtn.style.cursor = "pointer";
-        runBtn.innerHTML = "play_arrow";
+        runBtn.textContent = "play_arrow";
         runBtn.onclick = this._runCode.bind(this);
         menuLeft.appendChild(runBtn);
         menubar.appendChild(menuLeft);
@@ -414,7 +414,7 @@ class JSEditor {
         convertBtn.style.fontSize = "2rem";
         convertBtn.style.background = "#2196f3";
         convertBtn.style.cursor = "pointer";
-        convertBtn.innerHTML = "transform";
+        convertBtn.textContent = "transform";
         convertBtn.onclick = this._codeToBlocks.bind(this);
         menuLeft.appendChild(convertBtn);
         menubar.appendChild(menuLeft);
@@ -435,7 +435,7 @@ class JSEditor {
         styleBtn.style.fontSize = "2rem";
         styleBtn.style.background = "#2196f3";
         styleBtn.style.cursor = "pointer";
-        styleBtn.innerHTML = "invert_colors";
+        styleBtn.textContent = "invert_colors";
         styleBtn.onclick = this._changeStyle.bind(this);
         menuRight.appendChild(styleBtn);
         menubar.appendChild(menuRight);
@@ -549,7 +549,7 @@ class JSEditor {
         arrowBtn.style.cursor = "pointer";
         arrowBtn.style.lineHeight = "0.75rem";
         arrowBtn.style.marginLeft = "0";
-        arrowBtn.innerHTML = "keyboard_arrow_down";
+        arrowBtn.textContent = "keyboard_arrow_down";
         arrowBtn.onclick = this._toggleConsole.bind(this);
         consolelabel.appendChild(arrowBtn);
         generateTooltip(arrowBtn, _("Toggle Console"), "left");


### PR DESCRIPTION
## Description
This PR addresses two minor but important standard violations.
**1. `base64Utils.js` - Missing `/* exported */` comment**
- `base64Encode` and `base64Decode` are globally available functions but lacked the `/* exported */` annotation.
- Added `/* exported base64Encode, base64Decode */` to satisfy `AGENTS.md §6`.

**2. `jseditor.js` - Security: Replaced `innerHTML` with `textContent`**
- Material Icons icon names (like `help_outline`, `autorenew`, `play_arrow`) were being inserted using `innerHTML`.
- Replaced 6 instances of `innerHTML` with `textContent` as these are static strings that do not need HTML parsing. This adheres to the security patterns required by `AGENTS.md`.

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation
- [ ] CI/CD

## Changes Made
- `js/base64Utils.js`: Added missing `/* exported */` comment.
- `js/widgets/jseditor.js`: Replaced `innerHTML` with `textContent` for 6 buttons.

## Verification
- Linting and Prettier checks pass successfully.
- Icons in JSEditor still render properly.
