### PR TITLE
refactor: cleanup exporters.js AMD module export and require path

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -120,7 +120,7 @@ let MYDEFINES = [
     "activity/rubrics",
     "activity/macros",
     "activity/SaveInterface",
-    "activity/exporters",
+
     "activity/recorder",
     "utils/musicutils",
     "utils/synthutils",
@@ -232,6 +232,8 @@ const doAnalyzeProject = function () {
 /**
  * Represents an activity in the application.
  */
+
+let exporters;
 
 class Activity {
     /**
@@ -1359,14 +1361,14 @@ class Activity {
          * @returns {SVG} returns SVG of blocks
          */
         this.printBlockSVG = () => {
-            return require("activity/exporters").printBlockSVG(this);
+            return exporters.printBlockSVG(this);
         };
 
         /**
          * @returns {PNG} returns PNG of block artwork
          */
         this.printBlockPNG = async () => {
-            return require("activity/exporters").printBlockPNG(this);
+            return exporters.printBlockPNG(this);
         };
 
         const midiImportBlocks = midi => {
@@ -8775,7 +8777,8 @@ class Activity {
 const activity = new Activity();
 
 // Execute initialization once all RequireJS modules are loaded AND DOM is ready
-define(["domReady!"].concat(MYDEFINES), doc => {
+define(["domReady!", "activity/exporters"].concat(MYDEFINES), (doc, exportersModule) => {
+    exporters = exportersModule;
     const initialize = () => {
         // Defensive check for multiple critical globals that may be delayed
         // due to 'defer' execution timing variances.

--- a/js/activity.js
+++ b/js/activity.js
@@ -120,7 +120,7 @@ let MYDEFINES = [
     "activity/rubrics",
     "activity/macros",
     "activity/SaveInterface",
-    "activity/activity/exporters",
+    "activity/exporters",
     "activity/recorder",
     "utils/musicutils",
     "utils/synthutils",
@@ -1355,15 +1355,18 @@ class Activity {
             this.sendAllToTrash(true, true);
         };
 
+        /**
+         * @returns {SVG} returns SVG of blocks
+         */
         this.printBlockSVG = () => {
-            return window.printBlockSVG(this);
+            return require("activity/exporters").printBlockSVG(this);
         };
 
         /**
          * @returns {PNG} returns PNG of block artwork
          */
         this.printBlockPNG = async () => {
-            return window.printBlockPNG(this);
+            return require("activity/exporters").printBlockPNG(this);
         };
 
         const midiImportBlocks = midi => {

--- a/js/activity/exporters.js
+++ b/js/activity/exporters.js
@@ -11,9 +11,8 @@
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
 /* global DOMParser, XMLSerializer, SPECIALINPUTS, _, INLINECOLLAPSIBLES, EXPANDBUTTON, COLLAPSEBUTTON, TURTLESVG, FILLCOLORS, STROKECOLORS */
-/* exported extractSVGInner, printBlockSVG, printBlockPNG */
 
-window.extractSVGInner = svgString => {
+const extractSVGInner = svgString => {
     const parser = new DOMParser();
     const doc = parser.parseFromString(svgString, "image/svg+xml");
     const svgEl = doc.querySelector("svg");
@@ -27,8 +26,11 @@ window.extractSVGInner = svgString => {
     return svgEl.innerHTML;
 };
 
-window.printBlockSVG = activity => {
-    activity.blocks.activeBlock = null;
+/**
+ * @param {object} activity - The Activity instance.
+ * @returns {string} encoded SVG string of all visible blocks
+ */
+const printBlockSVG = activity => {
     let startCounter = 0;
     const svgParts = [];
     let xMax = 0;
@@ -68,7 +70,7 @@ window.printBlockSVG = activity => {
         );
 
         if (!SPECIALINPUTS.includes(activity.blocks.blockList[i].name)) {
-            svgParts.push(window.extractSVGInner(rawSVG));
+            svgParts.push(extractSVGInner(rawSVG));
         } else {
             // Safer SVG manipulation using DOM instead of string splitting
             const parser = new DOMParser();
@@ -181,8 +183,12 @@ window.printBlockSVG = activity => {
     );
 };
 
-window.printBlockPNG = async activity => {
-    const svgContent = window.printBlockSVG(activity);
+/**
+ * @param {object} activity - The Activity instance.
+ * @returns {Promise<string>} PNG data URL of the block artwork
+ */
+const printBlockPNG = async activity => {
+    const svgContent = printBlockSVG(activity);
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
     const parser = new DOMParser();
@@ -212,10 +218,11 @@ window.printBlockPNG = async activity => {
     });
 };
 
-if (typeof module !== "undefined" && module.exports) {
-    module.exports = {
-        extractSVGInner: window.extractSVGInner,
-        printBlockSVG: window.printBlockSVG,
-        printBlockPNG: window.printBlockPNG
-    };
+if (typeof define === "function" && define.amd) {
+    define(function () {
+        return { extractSVGInner, printBlockSVG, printBlockPNG };
+    });
+} else if (typeof module !== "undefined" && module.exports) {
+    // Jest / Node environment
+    module.exports = { extractSVGInner, printBlockSVG, printBlockPNG };
 }

--- a/js/loader.js
+++ b/js/loader.js
@@ -160,6 +160,7 @@ requirejs.config({
         "widgets": "js/widgets",
         "activity": "js",
         "activity/recorder": "js/activity/recorder",
+        "activity/exporters": "js/activity/exporters",
         "easeljs.min": "lib/easeljs.min",
         "tweenjs.min": "lib/tweenjs.min",
         "prefixfree.min": "lib/prefixfree.min",


### PR DESCRIPTION
# Description
This is a small, focused follow-up PR addressing the maintainer feedback from the previously merged `exporters.js` extraction (#7508). It corrects architectural inconsistencies without modifying any SVG/PNG rendering behavior.

## Changes Made
1. **Proper RequireJS Module Export**: `js/activity/exporters.js` has been refactored to use the standard AMD `define()` pattern (similar to `recorder.js`), removing top-level `window` pollution.
2. **Module Path Cleanup**: 
   - Added an explicit alias for `"activity/exporters": "js/activity/exporters"` in `loader.js`.
   - Replaced the brittle `"activity/activity/exporters"` dependency in `activity.js` with the correct `"activity/exporters"`.
3. **Redundant Assignment Removed**: Removed an unnecessary `activeBlock = null` execution from the exporter that didn't affect the generated file.

## Verification
- Linting ran cleanly on all modified files.
- `npm test` passes completely (0 regressions).
- Backward compatibility preserved: the SVG and PNG generation logic remains functionally untouched. 
-[x] Documentation
