### PR TITLE
fix: translate default parameter block labels at display layer for i18n

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4034,12 +4034,15 @@ class Activity {
 
                     if (uniqueName !== actionArg) {
                         actionArg.value = uniqueName;
+                        const translatedName = _(uniqueName);
                         label =
-                            uniqueName.length > 8 ? uniqueName.substr(0, 7) + "..." : uniqueName;
+                            translatedName.length > 8
+                                ? translatedName.substr(0, 7) + "..."
+                                : translatedName;
                         actionArg.text.text = label;
 
                         if (actionArg.label !== null) {
-                            actionArg.label.value = uniqueName;
+                            actionArg.label.value = translatedName;
                         }
                         actionArg.container.updateCache();
                         for (let b = 0; b < this.blocks.dragGroup.length; b++) {
@@ -4052,10 +4055,11 @@ class Activity {
                             ) {
                                 me.privateData = uniqueName;
                                 me.value = uniqueName;
+                                const translatedMeName = _(uniqueName);
                                 label =
-                                    uniqueName.length > 8
-                                        ? uniqueName.substr(0, 7) + "..."
-                                        : uniqueName;
+                                    translatedMeName.length > 8
+                                        ? translatedMeName.substr(0, 7) + "..."
+                                        : translatedMeName;
                                 me.text.text = label;
                                 me.overrideName = label;
                                 me.regenerateArtwork();

--- a/js/block.js
+++ b/js/block.js
@@ -1549,7 +1549,7 @@ class Block {
                 label = _(this.value);
             } else {
                 if (this.value !== null) {
-                    label = this.value.toString();
+                    label = _(this.value.toString());
                 } else {
                     label = "???";
                 }
@@ -4812,7 +4812,7 @@ class Block {
         } else if (this.name === "modename") {
             label = this.value + " " + getModeNumbers(this.value);
         } else {
-            label = this.value.toString();
+            label = _(this.value.toString());
         }
 
         if (!WIDENAMES.includes(this.name) && getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {
@@ -4853,7 +4853,7 @@ class Block {
 
                     // eslint-disable-next-line no-case-declarations
                     const metadata = this.blocks.actionMetadata(c);
-                    if (oldValue === _("action")) {
+                    if (oldValue === _("action") || oldValue === "action") {
                         this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                         this.blocks.setActionProtoVisibility(false);
                     }
@@ -4863,7 +4863,7 @@ class Block {
                     const blockPalette = this.blocks.palettes.dict["action"];
                     for (let blk = 0; blk < blockPalette.protoList.length; blk++) {
                         const block = blockPalette.protoList[blk];
-                        if (oldValue === _("action")) {
+                        if (oldValue === _("action") || oldValue === "action") {
                             if (block.name === "nameddo" && block.defaults.length === 0) {
                                 block.hidden = true;
                             }
@@ -4874,7 +4874,7 @@ class Block {
                         }
                     }
 
-                    if (oldValue === _("action")) {
+                    if (oldValue === _("action") || oldValue === "action") {
                         this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                         this.blocks.setActionProtoVisibility(false);
                     }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2821,7 +2821,7 @@ class Blocks {
                     } else if (typeof myBlock.value !== "string") {
                         label = myBlock.value.toString();
                     } else {
-                        label = myBlock.value;
+                        label = _(myBlock.value);
                     }
                     break;
             }
@@ -3435,7 +3435,8 @@ class Blocks {
                         }
                         break;
                     default:
-                        that.blockList[thisBlock].text.text = value;
+                        that.blockList[thisBlock].text.text =
+                            value !== null && value !== undefined ? _(value.toString()) : value;
                         break;
                 }
 
@@ -3701,7 +3702,7 @@ class Blocks {
                 if (myBlock.name === "action") {
                     /** Make sure we don't make two actions with the same name. */
                     value = this.findUniqueActionName(_("action"));
-                    if (value !== _("action")) {
+                    if (value !== _("action") && value !== "action") {
                         const metadata = this.actionMetadata(blk);
                         this.newNameddoBlock(value, metadata.hasReturn, metadata.hasArgs);
                         /** this.activity.palettes.hide(); */
@@ -3719,7 +3720,7 @@ class Blocks {
                             const b = args[0];
                             const v = args[1];
                             that.blockList[b].value = v;
-                            let l = value.toString();
+                            let l = _(value.toString());
                             if (
                                 !WIDENAMES.includes(that.blockList[b].name) &&
                                 getTextWidth(l, "bold 20pt Sans") > TEXTWIDTH
@@ -3746,7 +3747,7 @@ class Blocks {
                         const b = args[0];
                         const v = args[1];
                         that.blockList[b].value = v;
-                        let l = v.toString();
+                        let l = _(v.toString());
                         if (
                             !WIDENAMES.includes(that.blockList[b].name) &&
                             getTextWidth(l, "bold 20pt Sans") > TEXTWIDTH
@@ -3952,7 +3953,7 @@ class Blocks {
          */
         this.findUniqueActionName = (name, actionBlk) => {
             /** If we have a stack named 'action', make the protoblock visible. */
-            if (name === _("action")) {
+            if (name === _("action") || name === "action") {
                 this.setActionProtoVisibility(true);
             }
 
@@ -4551,7 +4552,7 @@ class Blocks {
          * @returns boolean
          */
         this.newNameddoBlock = (name, hasReturn, hasArgs) => {
-            if (name === _("action")) {
+            if (name === _("action") || name === "action") {
                 /** 'action' already has its associated palette entries. */
                 return false;
             }
@@ -5751,7 +5752,7 @@ class Blocks {
                 }
 
                 /** If we have a stack named 'action', make the protoblock visible. */
-                if (name === _("action")) {
+                if (name === _("action") || name === "action") {
                     this.setActionProtoVisibility(true);
                 }
 
@@ -6964,7 +6965,11 @@ class Blocks {
                 if (!this.blockList[blk].trash && this.blockList[blk].name === "action") {
                     const myBlock = this.blockList[blk];
                     const c = myBlock.connections[1];
-                    if (c != null && this.blockList[c].value !== _("action")) {
+                    if (
+                        c != null &&
+                        this.blockList[c].value !== _("action") &&
+                        this.blockList[c].value !== "action"
+                    ) {
                         const metadata = this.actionMetadata(blk);
                         if (
                             this.newNameddoBlock(

--- a/js/palette.js
+++ b/js/palette.js
@@ -1313,7 +1313,7 @@ class PaletteModel {
                             label = `${_("store in")} ${block.staticLabels[0]}`;
                         }
                     } else {
-                        label = block.defaults[0];
+                        label = _(block.defaults[0]);
                     }
                 } else if (protoBlock.staticLabels.length > 0) {
                     label = protoBlock.staticLabels[0];


### PR DESCRIPTION
# PR Category : 
- [x] Bug fix
# Description

This PR fixes a localization issue where default parameter blocks (specifically `"action"` and `"custom"`) were not being translated into other languages when the application loaded or when blocks were rendered on the canvas. 

The fix is designed to translate strings strictly at the **display/rendering layer**, ensuring that the internal block values remain in English. This preserves cross-language project compatibility so that saved projects can still be loaded and run correctly regardless of the user's current locale.

## Changes

### 1. `js/activity.js`
- Translated display labels for dynamically spawned parameter blocks in `updateParameterBlock()`.
- Handled visual length-clipping using the translated string rather than the raw English key.

### 2. `js/block.js`
- Translated labels inside `updateLabel()`.
- Allowed comparisons against both the raw English string and the translated string (`oldValue === _("action") || oldValue === "action"`) to correctly identify actions when updating block states.

### 3. `js/blocks.js`
- Added translation wrappers in the default fallback case of `updateBlockText()`.
- Extended action comparisons (`"action"`) to check both raw and translated strings.
- Added localization handling when assigning visual text for new blocks dynamically spawned on the canvas.

### 4. `js/palette.js`
- Ensured visual labels in the SVG-rendered palette items are wrapped in translation helpers (`_()`) during palette creation in `makeBlockInfo()`.

## Before : 
 
<img width="955" height="478" alt="image" src="https://github.com/user-attachments/assets/d934afea-fe85-4b7b-98f5-63e57c5a8c73" />

## After : 
<img width="1918" height="951" alt="image" src="https://github.com/user-attachments/assets/3fec5a77-aea8-4d10-9e73-8ea43c48eb8d" />


## Verification Results

- Formatted all modified files with Prettier.
- Ran the Jest test suite: **All 5,491 tests passed successfully**.
