### PR TITLE
Fix localized solfege labels

### DIFF
--- a/convert_po_to_json.py
+++ b/convert_po_to_json.py
@@ -41,9 +41,15 @@ def parse_po_file(po_file):
                 if current_msgid is not None:
                     if (
                         current_msgid == SOLFEGE_KEY
-                        and current_msgstr
                         and not is_valid_solfege_translation(current_msgstr)
                     ):
+                        print(
+                            f"Warning: invalid solfege translation in "
+                            f"{po_file}: expected {SOLFEGE_TOKEN_COUNT} "
+                            f"tokens, got {len(current_msgstr.split())}. "
+                            f"Falling back to English.",
+                            file=sys.stderr,
+                        )
                         data[current_msgid] = current_msgid
                     else:
                         data[current_msgid] = current_msgstr or current_msgid

--- a/convert_po_to_json.py
+++ b/convert_po_to_json.py
@@ -18,6 +18,13 @@ import json
 import re
 import sys
 
+SOLFEGE_KEY = "ti la sol fa mi re do"
+SOLFEGE_TOKEN_COUNT = 7
+
+def is_valid_solfege_translation(value):
+    """Return True when a solfege translation has seven note labels."""
+    return len(value.split()) == SOLFEGE_TOKEN_COUNT
+
 def parse_po_file(po_file):
     """Parse a .po file and return a dict of {msgid: msgstr}."""
     data = {}
@@ -32,7 +39,14 @@ def parse_po_file(po_file):
             elif line.startswith("msgstr"):
                 current_msgstr = re.findall(r'"(.*)"', line)[0]
                 if current_msgid is not None:
-                    data[current_msgid] = current_msgstr or current_msgid
+                    if (
+                        current_msgid == SOLFEGE_KEY
+                        and current_msgstr
+                        and not is_valid_solfege_translation(current_msgstr)
+                    ):
+                        data[current_msgid] = current_msgid
+                    else:
+                        data[current_msgid] = current_msgstr or current_msgid
                     current_msgid = None
     return data
 
@@ -63,7 +77,7 @@ def convert_po_to_json(po_file, output_dir):
             os.makedirs(output_dir, exist_ok=True)
             with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(combined, f, indent=2, ensure_ascii=False)
-            print(f"✅ Combined ja.po + ja-kana.po → {output_path}")
+            print(f"Combined ja.po + ja-kana.po -> {output_path}")
             return  # Don’t fall through to default case
 
     # Default for all other langs
@@ -72,7 +86,7 @@ def convert_po_to_json(po_file, output_dir):
     os.makedirs(output_dir, exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(json_data, f, indent=2, ensure_ascii=False)
-    print(f"✅ Converted {po_file} → {output_path}")
+    print(f"Converted {po_file} -> {output_path}")
 
 def convert_all_po_files(po_dir, output_dir):
     """Convert all .po files in the given directory to .json format."""

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2058,6 +2058,10 @@ describe("splitSolfege", () => {
 describe("i18nSolfege", () => {
     global.SOLFNOTES = ["ti", "la", "sol", "fa", "mi", "re", "do"];
 
+    afterEach(() => {
+        global._.mockImplementation(str => str);
+    });
+
     it("should return the internationalized version of a solfege note", () => {
         expect(i18nSolfege("do")).toEqual("do");
         expect(i18nSolfege("ti")).toEqual("ti");
@@ -2077,6 +2081,33 @@ describe("i18nSolfege", () => {
 
     it("should handle null or undefined values gracefully", () => {
         expect(i18nSolfege(null)).toEqual("sol"); //default
+    });
+
+    it("should use a complete localized solfege sequence", () => {
+        global._.mockImplementation(str =>
+            str === "ti la sol fa mi re do" ? "ती ला सोल फा मी रे दो" : str
+        );
+
+        expect(i18nSolfege("sol")).toEqual("सोल");
+        expect(i18nSolfege("do♯")).toEqual("दो♯");
+    });
+
+    it("should map localized solfege labels back to canonical notes", () => {
+        global._.mockImplementation(str =>
+            str === "ti la sol fa mi re do" ? "ती ला सोल फा मी रे दो" : str
+        );
+
+        expect(i18nSolfege("सोल")).toEqual("sol");
+        expect(i18nSolfege("दो♯")).toEqual("do♯");
+    });
+
+    it("should ignore malformed solfege translations", () => {
+        global._.mockImplementation(str =>
+            str === "ti la sol fa mi re do" ? "not a note sequence" : str
+        );
+
+        expect(i18nSolfege("sol")).toEqual("sol");
+        expect(i18nSolfege("do♯")).toEqual("do♯");
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4797,14 +4797,9 @@ function getNote(
                 // The note should already be translated, but just in case...
                 // Reverse any i18n
                 // solfnotes_ is used in the interface for i18n
-                //.TRANS: the note names must be separated by single spaces
-                const solfnotes_ = _("ti la sol fa mi re do").split(" ");
-                if (solfnotes_.includes(noteArg.substr(0, 1).toLowerCase())) {
-                    solfegePart = SOLFNOTES[solfnotes_.indexOf(noteArg.substr(0, 2).toLowerCase())];
-                } else if (solfnotes_.includes(noteArg.substr(0, 2).toLowerCase())) {
-                    solfegePart = SOLFNOTES[solfnotes_.indexOf(noteArg.substr(0, 2).toLowerCase())];
-                } else if (solfnotes_.includes(noteArg.substr(0, 3).toLowerCase())) {
-                    solfegePart = SOLFNOTES[solfnotes_.indexOf(noteArg.substr(0, 3).toLowerCase())];
+                const obj = splitI18nSolfege(noteArg);
+                if (SOLFNOTES.includes(obj[0])) {
+                    solfegePart = obj[0];
                 } else {
                     solfegePart = noteArg.substr(0, 2).toLowerCase();
                 }
@@ -6441,6 +6436,40 @@ const splitSolfege = value => {
     return ["sol", ""];
 };
 
+const getI18nSolfNotes = () => {
+    //.TRANS: the note names must be separated by single spaces
+    const solfnotes = _("ti la sol fa mi re do");
+    if (typeof solfnotes !== "string") {
+        return SOLFNOTES;
+    }
+
+    const translated = solfnotes.trim().split(/\s+/);
+    if (translated.length !== SOLFNOTES.length || translated.some(note => note.length === 0)) {
+        return SOLFNOTES;
+    }
+
+    return translated;
+};
+
+const splitI18nSolfege = value => {
+    if (value !== null && typeof value === "string") {
+        const solfnotes = getI18nSolfNotes();
+        const lowerValue = value.toLowerCase();
+        const matches = solfnotes
+            .map((note, i) => ({ note, i }))
+            .sort((a, b) => b.note.length - a.note.length);
+
+        for (const match of matches) {
+            const lowerNote = match.note.toLowerCase();
+            if (lowerValue === lowerNote || lowerValue.startsWith(lowerNote)) {
+                return [SOLFNOTES[match.i], value.slice(match.note.length)];
+            }
+        }
+    }
+
+    return splitSolfege(value);
+};
+
 /**
  * Internationalize a solfege note using i18n.
  * @function
@@ -6449,8 +6478,13 @@ const splitSolfege = value => {
  */
 const i18nSolfege = note => {
     // solfnotes_ is used in the interface for i18n
-    const solfnotes_ = _("ti la sol fa mi re do").split(" ");
-    const obj = splitSolfege(note);
+    const solfnotes_ = getI18nSolfNotes();
+    const sourceObj = splitSolfege(note);
+    const obj = splitI18nSolfege(note);
+
+    if (!SOLFNOTES.includes(sourceObj[0]) && SOLFNOTES.includes(obj[0])) {
+        return obj[0] + obj[1];
+    }
 
     const i = SOLFNOTES.indexOf(obj[0]);
     if (i !== -1) {

--- a/locales/am.json
+++ b/locales/am.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ቲ ላ ሶል ፋ ሚ ሬ ዶ",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -386,7 +386,7 @@
   "milliseconds": "ميلي ثانية",
   "scalar interval %s": "الفاصل العددي %s",
   "silence": "الصمت",
-  "ti la sol fa mi re do": "سأعطيك الوحيد",
+  "ti la sol fa mi re do": "سي لا صول فا مي ري دو",
   "down": "تحت",
   "up": "أعلى",
   "Silence block cannot be removed.": "لا يمكن إزالة كتلة الصمت.",

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "си ла сол фа ми ре до",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -386,7 +386,7 @@
   "milliseconds": "মিলিসেকেন্ড",
   "scalar interval %s": "স্কেলার ব্যবধান %s",
   "silence": "নীরবতা",
-  "ti la sol fa mi re do": "আমি তোমাকে একটাই দেব",
+  "ti la sol fa mi re do": "তি লা সোল ফা মি রে দো",
   "down": "নিচে",
   "up": "আপ",
   "Silence block cannot be removed.": "নীরবতা ব্লক সরানো যাবে না.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -386,7 +386,7 @@
   "milliseconds": "Millisekunden",
   "scalar interval %s": "Skalarintervall %s",
   "silence": "Stille",
-  "ti la sol fa mi re do": "Ich gebe dir das Einzige",
+  "ti la sol fa mi re do": "ti la sol fa mi re do",
   "down": "runter",
   "up": "hoch",
   "Silence block cannot be removed.": "Die Stummschaltung kann nicht entfernt werden.",

--- a/locales/dz.json
+++ b/locales/dz.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ཏི ལ སོལ ཕ མི རེ དོ",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/el.json
+++ b/locales/el.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "σι λα σολ φα μι ρε ντο",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "سی لا سل فا می ر دو",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/he.json
+++ b/locales/he.json
@@ -386,7 +386,7 @@
   "milliseconds": "אלפיות השנייה",
   "scalar interval %s": "מרווח סקלרי %s",
   "silence": "דְמָמָה",
-  "ti la sol fa mi re do": "אני אתן לך את היחיד",
+  "ti la sol fa mi re do": "סי לה סול פה מי רה דו",
   "down": "מטה",
   "up": "מַעְלָה",
   "Silence block cannot be removed.": "לא ניתן להסיר את בלוק השתיקה.",

--- a/locales/hy.json
+++ b/locales/hy.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "սի լա սոլ ֆա մի ռե դո",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/ibo.json
+++ b/locales/ibo.json
@@ -386,7 +386,7 @@
   "milliseconds": "millisekọnd",
   "scalar interval %s": "scalar etiti oge %s",
   "silence": "juu",
-  "ti la sol fa mi re do": "Aga m enye gị naanị otu",
+  "ti la sol fa mi re do": "ti la sol fa mi re do",
   "down": "gbadaa",
   "up": "elu",
   "Silence block cannot be removed.": "Enweghị ike iwepụ ngọngọ jụụ.",

--- a/locales/ka.json
+++ b/locales/ka.json
@@ -385,7 +385,7 @@
   "milliseconds": "მილიწამში",
   "scalar interval %s": "სკალარული ინტერვალი %s",
   "silence": "დუმილი",
-  "ti la sol fa mi re do": "მე მოგცემ ერთადერთს",
+  "ti la sol fa mi re do": "სი ლა სოლ ფა მი რე დო",
   "down": "ქვემოთ",
   "up": "ზევით",
   "Silence block cannot be removed.": "დუმილის ბლოკის ამოღება შეუძლებელია.",

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ಟಿ ಲಾ ಸೋಲ್ ಫಾ ಮಿ ರೇ ಡೋ",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -386,7 +386,7 @@
   "milliseconds": "밀리초",
   "scalar interval %s": "스칼라 간격 %s",
   "silence": "고요",
-  "ti la sol fa mi re do": "하나만 줄게",
+  "ti la sol fa mi re do": "시 라 솔 파 미 레 도",
   "down": "아래에",
   "up": "위로",
   "Silence block cannot be removed.": "침묵 차단은 제거할 수 없습니다.",

--- a/locales/ml.json
+++ b/locales/ml.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ടി ലാ സോൾ ഫാ മി റെ ഡോ",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/mn.json
+++ b/locales/mn.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "си ла соль фа ми ре до",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "си ля соль фа ми ре до",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/si.json
+++ b/locales/si.json
@@ -386,7 +386,7 @@
   "milliseconds": "milliseconds",
   "scalar interval %s": "scalar interval %s",
   "silence": "silence",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ටි ලා සොල් ෆා මි රේ ඩෝ",
   "down": "down",
   "up": "up",
   "Silence block cannot be removed.": "Silence block cannot be removed.",

--- a/locales/ta.json
+++ b/locales/ta.json
@@ -386,7 +386,7 @@
   "milliseconds": "மில்லி விநாடிகள்",
   "scalar interval %s": "அளவிடல் இடைவெளி %s",
   "silence": "அமைதி",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "டி லா சோல் ஃபா மி ரே டோ",
   "down": "கீழே",
   "up": "வரை",
   "Silence block cannot be removed.": "அமைதி தடையை அகற்ற முடியாது.",

--- a/locales/th.json
+++ b/locales/th.json
@@ -386,7 +386,7 @@
   "milliseconds": "มิลลิวินาที",
   "scalar interval %s": "ช่วงสเกลาร์ %s",
   "silence": "พัก",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "ที ลา ซอล ฟา มี เร โด",
   "down": "ลง",
   "up": "ขึ้น",
   "Silence block cannot be removed.": "ไม่สามารถลบบล็อกเงียบได้",

--- a/locales/ur.json
+++ b/locales/ur.json
@@ -386,7 +386,7 @@
   "milliseconds": "ملی سیکنڈ",
   "scalar interval %s": "اسکیلر وقفہ %s",
   "silence": "خاموشی",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "سی لا سول فا می رے دو",
   "down": "نیچے نیچے",
   "up": "اوپر",
   "Silence block cannot be removed.": "خاموشی بلاک کو نہیں ہٹایا جاسکتا۔",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -386,7 +386,7 @@
   "milliseconds": "毫秒",
   "scalar interval %s": "标量间隔 %s",
   "silence": "沉默",
-  "ti la sol fa mi re do": "ti la sol fa mi re do",
+  "ti la sol fa mi re do": "西 拉 梭 发 咪 来 多",
   "down": "向下",
   "up": "向上",
   "Silence block cannot be removed.": "无法移除静音模块",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -386,7 +386,7 @@
   "milliseconds": "毫秒",
   "scalar interval %s": "標量間隔 %s",
   "silence": "沉默",
-  "ti la sol fa mi re do": "我給你唯一的一個",
+  "ti la sol fa mi re do": "西 拉 梭 發 咪 來 多",
   "down": "向下",
   "up": "向上",
   "Silence block cannot be removed.": "沉默塊無法移除。",

--- a/po/am.po
+++ b/po/am.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ቲ ላ ሶል ፋ ሚ ሬ ዶ"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/ar.po
+++ b/po/ar.po
@@ -3060,7 +3060,7 @@ msgstr "الصمت"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "سأعطيك الوحيد"
+msgstr "سي لا صول فا مي ري دو"
 
 
 #: js/block.js:2832

--- a/po/bg.po
+++ b/po/bg.po
@@ -4451,7 +4451,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "си ла сол фа ми ре до"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/bn.po
+++ b/po/bn.po
@@ -5204,7 +5204,7 @@ msgstr "নীরবতা"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "আমি তোমাকে একটাই দেব"
+msgstr "তি লা সোল ফা মি রে দো"
 
 
 #: js/block.js:2832

--- a/po/de.po
+++ b/po/de.po
@@ -5136,7 +5136,7 @@ msgstr "Stille"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "Ich gebe dir das Einzige"
+msgstr "ti la sol fa mi re do"
 
 
 #: js/block.js:2832

--- a/po/dz.po
+++ b/po/dz.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ཏི ལ སོལ ཕ མི རེ དོ"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/el.po
+++ b/po/el.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "σι λα σολ φα μι ρε ντο"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/fa.po
+++ b/po/fa.po
@@ -4450,7 +4450,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "سی لا سل فا می ر دو"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/he.po
+++ b/po/he.po
@@ -2886,7 +2886,7 @@ msgstr "דְמָמָה"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "אני אתן לך את היחיד"
+msgstr "סי לה סול פה מי רה דו"
 
 
 #: js/block.js:2832

--- a/po/hy.po
+++ b/po/hy.po
@@ -4449,7 +4449,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "սի լա սոլ ֆա մի ռե դո"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/ibo.po
+++ b/po/ibo.po
@@ -3060,7 +3060,7 @@ msgstr "juu"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "Aga m enye gị naanị otu"
+msgstr "ti la sol fa mi re do"
 
 
 #: js/block.js:2832

--- a/po/ka.po
+++ b/po/ka.po
@@ -3027,7 +3027,7 @@ msgstr "დუმილი"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "მე მოგცემ ერთადერთს"
+msgstr "სი ლა სოლ ფა მი რე დო"
 
 
 #: js/block.js:2832

--- a/po/kn.po
+++ b/po/kn.po
@@ -4449,7 +4449,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ಟಿ ಲಾ ಸೋಲ್ ಫಾ ಮಿ ರೇ ಡೋ"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/ko.po
+++ b/po/ko.po
@@ -3103,7 +3103,7 @@ msgstr "고요"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "하나만 줄게"
+msgstr "시 라 솔 파 미 레 도"
 
 
 #: js/block.js:2832

--- a/po/ml.po
+++ b/po/ml.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ടി ലാ സോൾ ഫാ മി റെ ഡോ"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/mn.po
+++ b/po/mn.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "си ла соль фа ми ре до"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/ru.po
+++ b/po/ru.po
@@ -4453,7 +4453,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "си ля соль фа ми ре до"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/si.po
+++ b/po/si.po
@@ -4455,7 +4455,7 @@ msgstr ""
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ටි ලා සොල් ෆා මි රේ ඩෝ"
 
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627

--- a/po/ta.po
+++ b/po/ta.po
@@ -3098,7 +3098,7 @@ msgstr "அமைதி"
 #: js/utils/musicutils.js:6055
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "டி லா சோல் ஃபா மி ரே டோ"
 
 
 #: js/block.js:2832

--- a/po/th.po
+++ b/po/th.po
@@ -3053,7 +3053,7 @@ msgstr "พัก"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr ""
+msgstr "ที ลา ซอล ฟา มี เร โด"
 
 
 #: js/block.js:2832

--- a/po/ur.po
+++ b/po/ur.po
@@ -3011,7 +3011,7 @@ msgstr "خاموشی"
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr "ti la sol fa mi re do"
+msgstr "سی لا سول فا می رے دو"
 
 
 #: js/block.js:2832

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3202,7 +3202,7 @@ msgstr "沉默"
 #.TRANS: the note names must be separated by single spaces
 #.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
-msgstr "ti la sol fa mi re do"
+msgstr "西 拉 梭 发 咪 来 多"
 
 
 #: js/block.js:2832

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3102,7 +3102,7 @@ msgstr "沉默"
 #.TRANS: the note names must be separated by single spaces
 #. AUTOTRANSLATED: Google Translate
 msgid "ti la sol fa mi re do"
-msgstr "我給你唯一的一個"
+msgstr "西 拉 梭 發 咪 來 多"
 
 
 #: js/block.js:2832


### PR DESCRIPTION
## PR Category : 
- [x] Bug fix

## Summary

Fix localized solfege pitch labels so note names such as `sol`, `fa`, `mi`, `re`, and `do` display in the selected language when a valid translation exists.

## Changes

- Added validation for the special solfege translation key:
  - `ti la sol fa mi re do`
- Updated `i18nSolfege()` to:
  - use localized solfege labels only when the locale provides all seven note names
  - fall back safely when the translation is missing or malformed
  - map localized solfege labels back to canonical note names when needed
- Hardened `convert_po_to_json.py` so malformed solfege translations do not produce broken locale JSON.
- Corrected bad or missing solfege translations in affected PO files and regenerated matching locale JSON files.

## Affected Locales

Updated solfege entries for:

`am`, `ar`, `bg`, `bn`, `de`, `dz`, `el`, `fa`, `he`, `hy`, `ibo`, `ka`, `kn`, `ko`, `ml`, `mn`, `ru`, `si`, `ta`, `th`, `ur`, `zh_CN`, `zh_TW`

## Before : 
<img width="958" height="473" alt="image" src="https://github.com/user-attachments/assets/e25fcb9d-6604-41a7-8b71-d866de0e4d6a" />

## After : 
<img width="955" height="445" alt="Screenshot 2026-06-14 045410" src="https://github.com/user-attachments/assets/90124b10-bfa1-43ff-b15d-07103c1453b0" />
