### PR TITLE
docs: add missing license header to p5-adapter.js and fix file description in oscilloscope.js

### DIFF
--- a/js/p5-adapter.js
+++ b/js/p5-adapter.js
@@ -1,3 +1,25 @@
+/**
+ * MusicBlocks v3.4.1
+ *
+ * @author Music Blocks Contributors
+ *
+ * @copyright 2025 Music Blocks Contributors
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /* global define, window */
 define(["p5.min"], function (p5) {
     console.log("p5-adapter: p5 loaded");

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -1,8 +1,8 @@
 /**
- * @file This contains the prototype of the JavaScript Editor Widget.
+ * @file This contains the prototype of the Oscilloscope Widget.
  * @author Saksham Mrig
  *
- * @copyright 2020 Saksham Mirg
+ * @copyright 2020 Saksham Mrig
  *
  * @license
  * This program is free software; you can redistribute it and/or modify it under the terms of the


### PR DESCRIPTION
## PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation
- [ ] CI/CD

## Description
This PR addresses two documentation compliance issues in the codebase:

1. **Missing AGPL license header** in `p5-adapter.js` - as explicitly required by `CONTRIBUTING.md` and `AGENTS.md` (Section 4: *"New files need the AGPL license header"*), every source file must include the standard license block. This file was missing it entirely.

2. **Inaccurate `@file` description** in `oscilloscope.js` - a copy-paste error from `jseditor.js` caused the file header to incorrectly describe this as the *"JavaScript Editor Widget"* instead of the *"Oscilloscope Widget"*. An author name typo (`Mirg` → `Mrig`) in the `@copyright` line is also corrected.

## Changes Made
- **`js/p5-adapter.js`**: Added the required AGPL-3.0-or-later license header block above the existing `/* global */` directive.
- **`js/widgets/oscilloscope.js`**: Fixed the `@file` tag from *"JavaScript Editor Widget"* → *"Oscilloscope Widget"* and corrected the `@copyright` typo *"Saksham Mirg"* → *"Saksham Mrig"*.

## Why This Matters
- Ensures full license compliance across all source files as mandated by project guidelines.
- Corrects misleading documentation that could confuse contributors navigating the widget codebase.
- Maintains consistency and accuracy in file-level JSDoc annotations.

## Verification
- [x] No functional code changes - documentation only.
- [x] Ran `npm run lint` and resolved any issues.
- [x] Ran `npx prettier --check .` to ensure formatting consistency.
- [x] Verified unit tests passing with `npm test`.

