### PR TITLE
fix: replace innerHTML with textContent for static text in modewidget.js and jseditor.js

### DIFF
--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -538,7 +538,7 @@ class JSEditor {
         consolelabel.style.background = "white";
         consolelabel.style.display = "flex";
         consolelabel.style.justifyContent = "space-between";
-        consolelabel.innerHTML = "&nbsp;&nbsp;&nbsp;&nbsp;CONSOLE";
+        consolelabel.textContent = "\u00a0\u00a0\u00a0\u00a0CONSOLE";
         this._editor.appendChild(consolelabel);
 
         const arrowBtn = document.createElement("span");

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -193,7 +193,7 @@ class ModeWidget {
         const row = table.insertRow();
         const cell = row.insertCell();
         // cell.colSpan = 18;
-        cell.innerHTML = "&nbsp;";
+        cell.textContent = "\u00a0";
         cell.style.backgroundColor = platformColor.selectorBackground;
 
         // Set current mode in pie menu.


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## Description
This PR addresses security and code quality improvements by replacing `innerHTML` with `textContent` for rendering static UI text in `modewidget.js` and `jseditor.js`.

As outlined in `AGENTS.md` (Section 4: Prefer textContent over innerHTML), using `innerHTML` to inject static text strings is an anti-pattern. This PR ensures we follow the project's security and DOM manipulation guidelines.

## Changes Made
- **`js/widgets/modewidget.js`**: Replaced `innerHTML` with `textContent` for setting the static non-breaking space `&nbsp;` on line 196. The Unicode character `\u00a0` is used for the exact same visual result without HTML parsing.
- **`js/widgets/jseditor.js`**: Replaced `innerHTML` with `textContent` for the `CONSOLE` label text, replacing the `&nbsp;` HTML entities with the Unicode `\u00a0` non-breaking space characters.
- **Code Formatting**: Verified changes using `eslint` and `npx prettier --write` as required.

## Why This Matters
- Prevents unnecessary HTML parsing for static strings.
- Adheres strictly to the guidelines established in `AGENTS.md`.
- Improves overall code security and maintains cleaner DOM injection practices.

## Verification
- [x] Replaced instances of `innerHTML` with `textContent` where applicable.
- [x] Ran `npm run lint` and resolved any issues.
- [x] Ran `npx prettier --check .` to ensure formatting consistency.
- [x] Verified unit tests passing with `npm test`.
