### PR TITLE
fix: guard localStorage reads in turtledefs with try/catch fallback

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -320,7 +320,12 @@ const createDefaultStack = () => {
             [7, ["number", { value: 90 }], 0, 0, [6]]
         ];
     } else {
-        let language = localStorage.languagePreference;
+        let language;
+        try {
+            language = localStorage.languagePreference;
+        } catch (_e) {
+            language = undefined;
+        }
         if (language === undefined) {
             language = navigator.language;
         }
@@ -407,7 +412,12 @@ const createDefaultStack = () => {
 };
 
 const createHelpContent = activity => {
-    let language = localStorage.languagePreference;
+    let language;
+    try {
+        language = localStorage.languagePreference;
+    } catch (_e) {
+        language = undefined;
+    }
     if (language === undefined) {
         language = navigator.language;
     }


### PR DESCRIPTION
## Description

Guard unprotected localStorage reads in turtledefs initialization helpers to prevent SecurityError crashes in restricted browser contexts (privacy mode, extensions with strict storage policies).

## Related Issue

This PR fixes #7005

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- Wrap `localStorage.languagePreference` read at line 323 in try/catch
- Wrap `localStorage.languagePreference` read at line 410 in try/catch
- Fall back to `navigator.language` when storage unavailable
- Pattern matches existing theme preference guard elsewhere in codebase

## Testing Performed

- Block localStorage in browser DevTools → reload → no crash
- App initializes normally without storage access
- `npm run lint` passes (no new linting issues)
- `npm test` passes

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**

## Additional Notes for Reviewers

This fix prevents startup failures in restricted environments. The pattern used matches existing localStorage access guards (e.g., theme preference initialization in platformstyle.js).