### PR TITLE
fix: guard against null when setting theme-color meta content

### DIFF
--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -538,7 +538,8 @@ if (platformThemes[activeTheme]) {
     window.platformColor = platformThemes["light"];
 }
 
-document.querySelector("meta[name=theme-color]").content = platformColor.header;
+const _themeMeta = document.querySelector("meta[name=theme-color]");
+if (_themeMeta) _themeMeta.content = platformColor.header;
 
 /**
  * @public


### PR DESCRIPTION
## Description

`document.querySelector("meta[name=theme-color]")` returns `null` when the tag is absent (e.g. custom hosts, test harnesses, or stripped HTML). Accessing `.content` on `null` throws a `TypeError` and crashes the styling initialization. Added a null guard before the assignment.

## Related Issue

This PR fixes #7072

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/utils/platformstyle.js:541`: Extracted `querySelector` result into a variable and wrapped `.content` assignment in a null check

## Testing Performed

- Temporarily removed `<meta name="theme-color">` from index.html and loaded the app — no crash occurs
- Normal environments with the meta tag present continue to work as before

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced