### PR TITLE
fix: align Phaser base frequency defaults in Timbre widget

### DIFF
--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -2687,8 +2687,8 @@ class TimbreWidget {
                     docById("myRangeFx1").value = 3;
                     docById("myspanFx1").textContent = "3";
                     docById("sFx2").textContent = _("base frequency");
-                    docById("myRangeFx2").value = 1000;
-                    docById("myspanFx2").textContent = "1000";
+                    docById("myRangeFx2").value = 100;
+                    docById("myspanFx2").textContent = "100";
 
                     if (this.phaserEffect.length !== 0) {
                         blockValue = this.phaserEffect.length - 1;
@@ -2716,7 +2716,7 @@ class TimbreWidget {
                         this.phaserEffect.push(n);
                         this.phaserParams.push(5);
                         this.phaserParams.push(3);
-                        this.phaserParams.push(350);
+                        this.phaserParams.push(100);
 
                         await delayExecution(500);
                         this.clampConnection(n, 4, topOfClamp);


### PR DESCRIPTION
## Description

Three different default values existed for the Phaser effect's base frequency in the Timbre widget: the UI slider initialized to `1000`, the block creation used `100`, and the cached params stored `350`. This mismatch caused state desync on first open and after reopening the widget.

All three are now aligned to `100`, which matches the canonical default defined at block creation time.

## Related Issue

This PR fixes #6862

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/widgets/timbre.js`: Changed UI slider value from `1000` to `100`
- `js/widgets/timbre.js`: Changed slider display text from `"1000"` to `"100"`
- `js/widgets/timbre.js`: Changed `phaserParams.push(350)` to `phaserParams.push(100)`

## Testing Performed

- Open Timbre → Effects → Phaser → slider now initializes at `100`
- Create a block with Phaser effect → default value is `100`
- Close and reopen the widget → value remains `100` (no revert to stale cached value)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced