### PR TITLE
fix: prevent Infinity from division by zero in Neighbor ornament

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -144,9 +144,16 @@ function setupRhythmActions(activity) {
                         );
 
                         const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
-                        tur.singer.neighborArgCurrentBeat.push(
-                            tur.singer.beatFactor * (1 / nextBeat)
-                        );
+                        if (nextBeat <= 0 || !isFinite(nextBeat)) {
+                            activity.errorMsg(
+                                _("Neighbor note value is too large for the current note duration."),
+                                blk
+                            );
+                        } else {
+                            tur.singer.neighborArgCurrentBeat.push(
+                                tur.singer.beatFactor * (1 / nextBeat)
+                            );
+                        }
                     }
 
                     Singer.processNote(


### PR DESCRIPTION
## Description

In the Neighbor ornament handler, `nextBeat` is computed as `1/noteBeatValue - 2*neighborNoteValue`. When the neighbor note value is large enough relative to the note beat value, `nextBeat` becomes zero or negative, causing `1/nextBeat` to produce `Infinity` or `-Infinity`. This silently corrupts audio timing downstream.

Added a guard that validates `nextBeat` before use and shows a user-facing error message instead of propagating an invalid value.

## Related Issue

This PR fixes #6982

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/turtleactions/RhythmActions.js:146–153`: Added guard checking `nextBeat <= 0 || !isFinite(nextBeat)` before pushing to `neighborArgCurrentBeat`; shows `activity.errorMsg()` when invalid

## Testing Performed

- Set Neighbor note value ≥ half the current note value and run → user sees error message instead of silent `Infinity` corruption
- Valid neighbor note values continue to work as expected

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced