### PR TITLE
fix: reject zero and negative ratio inputs in Pitch Staircase

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -204,7 +204,7 @@ class PitchStaircase {
         if (isNaN(inputNum1) || Number(inputNum1) <= 0) {
             inputNum1 = 3;
         } else {
-            inputNum1 = Math.abs(Math.floor(inputNum1));
+            inputNum1 = Math.floor(inputNum1);
         }
 
         this._musicRatio1.value = inputNum1;
@@ -213,7 +213,7 @@ class PitchStaircase {
         if (isNaN(inputNum2) || Number(inputNum2) <= 0) {
             inputNum2 = 2;
         } else {
-            inputNum2 = Math.abs(Math.floor(inputNum2));
+            inputNum2 = Math.floor(inputNum2);
         }
 
         this._musicRatio2.value = inputNum2;

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -201,7 +201,7 @@ class PitchStaircase {
     _dissectStair(event) {
         let inputNum1 = this._musicRatio1.value;
 
-        if (isNaN(inputNum1)) {
+        if (isNaN(inputNum1) || Number(inputNum1) <= 0) {
             inputNum1 = 3;
         } else {
             inputNum1 = Math.abs(Math.floor(inputNum1));
@@ -210,7 +210,7 @@ class PitchStaircase {
         this._musicRatio1.value = inputNum1;
         let inputNum2 = this._musicRatio2.value;
 
-        if (isNaN(inputNum2)) {
+        if (isNaN(inputNum2) || Number(inputNum2) <= 0) {
             inputNum2 = 2;
         } else {
             inputNum2 = Math.abs(Math.floor(inputNum2));


### PR DESCRIPTION
## Description

The Pitch Staircase widget only guarded ratio inputs with `isNaN()`. Since `isNaN(0)` returns `false`, a ratio of `0` passed validation and caused division by zero, producing `Infinity` or `NaN` frequencies that propagated silently through the staircase computation.

Extended the guard to also reject values ≤ 0, ensuring only positive ratios are accepted.

## Related Issue

This PR fixes #7058

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/widgets/pitchstaircase.js:204`: Extended `inputNum1` guard from `isNaN(inputNum1)` to `isNaN(inputNum1) || Number(inputNum1) <= 0`
- `js/widgets/pitchstaircase.js:210`: Same guard applied to `inputNum2`

## Testing Performed

- Entered `0` in ratio numerator field → falls back to default value `3` instead of producing `Infinity`
- Entered `0` in ratio denominator field → falls back to default value `2` instead of `NaN`
- Entered negative values → correctly rejected and replaced with defaults
- Valid positive ratios continue to work as expected

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced