### PR TITLE
fix: guard block.artwork null in _renderTrashView before encoding

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4189,7 +4189,9 @@ class Activity {
                 listItem.classList.add("trash-item");
 
                 const svgData = block.artwork;
-                const encodedData = "data:image/svg+xml;utf8," + encodeURIComponent(svgData);
+                const encodedData = svgData
+                    ? "data:image/svg+xml;utf8," + encodeURIComponent(svgData)
+                    : "";
 
                 const img = document.createElement("img");
                 img.src = encodedData;


### PR DESCRIPTION
## Description

`_renderTrashView()` in `js/activity.js` passes `block.artwork` directly to `encodeURIComponent()` without checking if it is `null`. Since `block.artwork` is initialized as `null` and populated asynchronously by `generateArtwork()`, moving a block to trash before artwork generation completes produces a broken `data:image/svg+xml;utf8,null` image source, resulting in a broken thumbnail in the Trash panel.

Added a ternary guard: if `block.artwork` is null, the encoded data falls back to an empty string, leaving the image with no src (blank) rather than an invalid URL.

## Related Issue

This PR fixes #7359

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/activity.js:4167–4168`: Replaced direct `encodeURIComponent(svgData)` with a ternary that returns `""` when `svgData` is null

## Testing Performed

- Move a block to trash quickly before artwork loads → img src is `""` instead of `"data:image/svg+xml;utf8,null"`
- Move a block to trash after artwork loads → thumbnail displays correctly as before

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced