### PR TITLE
fix: remove duplicate isSafeUrl from ActionBlocks.js, use centralized utility

### DIFF
--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -13,7 +13,7 @@
 global
 
 FlowBlock, LeftBlock, FlowClampBlock, StackClampBlock, ValueBlock,
-Queue, NOACTIONERRORMSG, NOINPUTERRORMSG
+Queue, NOACTIONERRORMSG, NOINPUTERRORMSG, isSafeUrl
 */
 
 /* exported setupActionBlocks */
@@ -100,14 +100,6 @@ function setupActionBlocks(activity) {
      * @class
      * @extends FlowBlock
      */
-    function isSafeUrl(urlString) {
-        try {
-            const parsed = new URL(urlString);
-            return parsed.protocol === "http:" || parsed.protocol === "https:";
-        } catch (e) {
-            return false;
-        }
-    }
     class ReturnToURLBlock extends FlowBlock {
         /**
          * Constructor for the ReturnToURLBlock class.

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -113,6 +113,7 @@ global.FlowClampBlock = FlowClampBlock;
 global.StackClampBlock = StackClampBlock;
 global.LeftBlock = LeftBlock;
 global.ValueBlock = ValueBlock;
+global.isSafeUrl = require("../../utils/utils-logic").isSafeUrl;
 
 describe("ActionBlocks", () => {
     let activity;


### PR DESCRIPTION
## Description

`js/blocks/ActionBlocks.js` contained a local copy of `isSafeUrl()` that duplicated the canonical implementation in `js/utils/utils-logic.js`. This creates a maintenance and security consistency problem: future improvements or security fixes applied to the centralized utility in `utils-logic.js` will silently not apply to `ActionBlocks.js`, allowing different parts of the application to enforce different URL safety rules.

Removed the duplicate local function and declared `isSafeUrl` in the `/* global */` comment block so ESLint resolves it correctly from `utils-logic.js`, which declares it as `var` (global scope).

## Related Issue

This PR fixes #7384

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/blocks/ActionBlocks.js:103–110`: Removed local `isSafeUrl` function definition
- `js/blocks/ActionBlocks.js:15`: Added `isSafeUrl` to `/* global */` comment so ESLint resolves it from `utils-logic.js`

## Testing Performed

- `npm run lint` — no undefined variable warning for `isSafeUrl` at line 185
- Return to URL block still validates URLs via the centralized `isSafeUrl` from `utils-logic.js`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced