### PR TITLE
fix: cancel pending hover timeout on palette click to prevent double-click requirement

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -1084,6 +1084,7 @@ class Palettes {
                 this._hideMenus();
                 this.activity.showSearchWidget();
             } else {
+                this._clearPendingMenuOpen();
                 this.showPalette(name);
             }
         };


### PR DESCRIPTION
## Description

When a palette flyout is open and the user clicks a different palette button, the new palette requires a double-click to open. Root cause is a race condition in `_loadPaletteButtonHandler`:

1. `onmouseover` schedules a 400ms timeout to call `showPalette(name)`
2. `onclick` calls `showPalette(name)` immediately — opening the clicked palette
3. The pending hover timeout fires, calling `_hideMenus`, which closes the palette that was just opened
4. User must click again to re-open it

Added `this._clearPendingMenuOpen()` inside `onclick` before `showPalette` to cancel any pending hover timeout, eliminating the race.

## Related Issue

This PR fixes #7495

## PR Category

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation Update

## Changes Made

- `js/palette.js:1086`: Added `this._clearPendingMenuOpen()` call inside `row.onclick` before `this.showPalette(name)`

## Testing Performed

- Open palette A → immediately click palette B → palette B opens on first click without needing double-click
- Hover over a palette (hover-open after timeout) → behavior unchanged

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced