### PR TITLE
fix: stop custom mode widget audio and close window on block deletion

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7314,7 +7314,7 @@ class Blocks {
                 }
 
                 const title = this.blockList[blk].protoblock.staticLabels[0];
-                closeBlkWidgets(_(title), title);
+                closeBlkWidgets(_(title));
                 this.activity.refreshCanvas();
             }
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7314,7 +7314,7 @@ class Blocks {
                 }
 
                 const title = this.blockList[blk].protoblock.staticLabels[0];
-                closeBlkWidgets(_(title));
+                closeBlkWidgets(_(title), title);
                 this.activity.refreshCanvas();
             }
 

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -642,7 +642,7 @@ describe("Utility Functions (logic-only)", () => {
                 "custom mode": { close: jest.fn() }
             };
 
-            closeBlkWidgets("custom mode", "custom mode");
+            closeBlkWidgets("custom mode");
 
             expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
         });
@@ -652,7 +652,7 @@ describe("Utility Functions (logic-only)", () => {
                 "pitch drum": { close: jest.fn() }
             };
 
-            closeBlkWidgets("pitch-drum mapper", "pitch-drum mapper");
+            closeBlkWidgets("pitch-drum mapper");
 
             expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("pitch drum");
         });
@@ -665,7 +665,7 @@ describe("Utility Functions (logic-only)", () => {
 
             document.getElementsByClassName = jest.fn(() => [mockElement]);
 
-            closeBlkWidgets("custom mode", "custom mode");
+            closeBlkWidgets("custom mode");
 
             expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
         });

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -622,7 +622,8 @@ describe("Utility Functions (logic-only)", () => {
             window.widgetWindows = {
                 hideAllWindows: jest.fn(),
                 hideWindow: jest.fn(),
-                closeWindow: jest.fn()
+                closeWindow: jest.fn(),
+                openWindows: {}
             };
         });
 
@@ -634,6 +635,39 @@ describe("Utility Functions (logic-only)", () => {
             closeBlkWidgets("TestWidget");
 
             expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("TestWidget");
+        });
+
+        it("closes widget directly using key lookup from openWindows", () => {
+            window.widgetWindows.openWindows = {
+                "custom mode": { close: jest.fn() }
+            };
+
+            closeBlkWidgets("custom mode", "custom mode");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
+        });
+
+        it("closes widget using mapped key", () => {
+            window.widgetWindows.openWindows = {
+                "pitch drum": { close: jest.fn() }
+            };
+
+            closeBlkWidgets("pitch-drum mapper", "pitch-drum mapper");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("pitch drum");
+        });
+
+        it("closes widget by matching element ID when display title changes", () => {
+            const mockElement = {
+                innerHTML: "C MAJOR",
+                id: "custom modeWidgetID"
+            };
+
+            document.getElementsByClassName = jest.fn(() => [mockElement]);
+
+            closeBlkWidgets("custom mode", "custom mode");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
         });
 
         it("does nothing if no match found", () => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1421,13 +1421,54 @@ function closeWidgets() {
  * Closes a specific widget by its name.
  *
  * @param {string} name - The name of the widget to be closed.
+ * @param {string} [key] - Optional key associated with the widget window.
  * @returns {void}
  */
-let closeBlkWidgets = name => {
+let closeBlkWidgets = (name, key) => {
+    let searchKey = key || name;
+
+    const KEY_MAPPING = {
+        "pitch-drum mapper": "pitch drum",
+        "custom mode": "custom mode",
+        "tempo": "tempo",
+        "arpeggio": "arpeggio",
+        "timbre": "timbre",
+        "sampler": "sampler",
+        "rhythm maker": "rhythm maker",
+        "oscilloscope": "oscilloscope",
+        "temperament": "temperament",
+        "meter": "meter"
+    };
+
+    if (KEY_MAPPING[searchKey]) {
+        searchKey = KEY_MAPPING[searchKey];
+    }
+
+    if (
+        window.widgetWindows &&
+        window.widgetWindows.openWindows &&
+        window.widgetWindows.openWindows[searchKey]
+    ) {
+        window.widgetWindows.closeWindow(searchKey);
+        return;
+    }
+
     const widgetTitle = document.getElementsByClassName("wftTitle");
     for (let i = 0; i < widgetTitle.length; i++) {
-        if (widgetTitle[i].innerHTML === name) {
-            window.widgetWindows.closeWindow(widgetTitle[i].innerHTML);
+        const titleEl = widgetTitle[i];
+        if (
+            titleEl.innerHTML === name ||
+            titleEl.id === `${searchKey}WidgetID` ||
+            (key && titleEl.id === `${key}WidgetID`) ||
+            (KEY_MAPPING[key] && titleEl.id === `${KEY_MAPPING[key]}WidgetID`)
+        ) {
+            const winKey =
+                titleEl.id && typeof titleEl.id === "string"
+                    ? titleEl.id.replace("WidgetID", "")
+                    : key || name;
+            if (window.widgetWindows && typeof window.widgetWindows.closeWindow === "function") {
+                window.widgetWindows.closeWindow(winKey);
+            }
             break;
         }
     }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1421,11 +1421,10 @@ function closeWidgets() {
  * Closes a specific widget by its name.
  *
  * @param {string} name - The name of the widget to be closed.
- * @param {string} [key] - Optional key associated with the widget window.
  * @returns {void}
  */
-let closeBlkWidgets = (name, key) => {
-    let searchKey = key || name;
+let closeBlkWidgets = name => {
+    let searchKey = name;
 
     const KEY_MAPPING = {
         "pitch-drum mapper": "pitch drum",
@@ -1440,8 +1439,12 @@ let closeBlkWidgets = (name, key) => {
         "meter": "meter"
     };
 
-    if (KEY_MAPPING[searchKey]) {
-        searchKey = KEY_MAPPING[searchKey];
+    for (const origKey in KEY_MAPPING) {
+        const translated = typeof _ === "function" ? _(origKey) : origKey;
+        if (name === translated) {
+            searchKey = KEY_MAPPING[origKey];
+            break;
+        }
     }
 
     if (
@@ -1456,16 +1459,11 @@ let closeBlkWidgets = (name, key) => {
     const widgetTitle = document.getElementsByClassName("wftTitle");
     for (let i = 0; i < widgetTitle.length; i++) {
         const titleEl = widgetTitle[i];
-        if (
-            titleEl.innerHTML === name ||
-            titleEl.id === `${searchKey}WidgetID` ||
-            (key && titleEl.id === `${key}WidgetID`) ||
-            (KEY_MAPPING[key] && titleEl.id === `${KEY_MAPPING[key]}WidgetID`)
-        ) {
+        if (titleEl.innerHTML === name || titleEl.id === `${searchKey}WidgetID`) {
             const winKey =
                 titleEl.id && typeof titleEl.id === "string"
                     ? titleEl.id.replace("WidgetID", "")
-                    : key || name;
+                    : searchKey;
             if (window.widgetWindows && typeof window.widgetWindows.closeWindow === "function") {
                 window.widgetWindows.closeWindow(winKey);
             }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1426,6 +1426,16 @@ function closeWidgets() {
 let closeBlkWidgets = name => {
     let searchKey = name;
 
+    // NOTE: This mapping only works for widgets that never set their own
+    // `blockNo` property (e.g. ModeWidget). window.widgetWindows.windowFor()
+    // keys a widget's window by `widget.blockNo` if that property is set to
+    // anything other than undefined (including null) — otherwise it falls
+    // back to the `saveAs` or `title` argument. Widgets like PhraseMaker set
+    // `this.blockNo` in their constructor, so they are keyed by blockNo, not
+    // by name, and will NOT be found via this KEY_MAPPING lookup. Adding such
+    // widgets here would silently do nothing. Before adding a new entry,
+    // verify the target widget's windowFor() call and confirm it does not
+    // rely on blockNo for its window key.
     const KEY_MAPPING = {
         "pitch-drum mapper": "pitch drum",
         "custom mode": "custom mode",

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -370,4 +370,16 @@ describe("ModeWidget", () => {
         expect(modeWidget._locked).toBe(false);
         jest.useRealTimers();
     });
+
+    test("onclose handler should stop synth and reset lock state", () => {
+        const widgetWindow = window.widgetWindows.windowFor();
+
+        modeWidget._locked = true;
+
+        // Trigger onclose
+        widgetWindow.onclose();
+
+        expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
+        expect(modeWidget._locked).toBe(false);
+    });
 });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -121,6 +121,10 @@ class ModeWidget {
                 this._timeouts = [];
             }
             this._playing = false;
+            if (this.logo && this.logo.synth) {
+                this.logo.synth.stop();
+            }
+            this._locked = false;
             this.hideMsgs();
             this.widgetWindow.destroy();
         };


### PR DESCRIPTION
## Description

When a `custom mode` block is deleted from the canvas using the radial menu ("Move to trash"), the widget stays open and audio keeps playing.

The deletion flow calls `closeBlkWidgets(_(title))` in `js/blocks.js`, which searches for a widget window by matching the localized block name against the window's visible title. However, `ModeWidget` dynamically updates its title from `"custom mode"` to the active key/mode name (e.g. `"C MAJOR"`) after opening — so no match is found, the widget is never closed, and `synth.stop()` is never called.

## Fix

- **js/utils/utils.js** — Modified `closeBlkWidgets(name)` to implement a reverse-translation lookup mapping (comparing the passed name against translations of known widget keys). If matched, we resolve the canonical key (e.g., `"custom mode"`) and use direct key lookup (`window.widgetWindows.openWindows[key]`) or fallback element ID matching (`titleEl.id === key + "WidgetID"`) to close it. 
- **js/widgets/modewidget.js** — Added `this.logo.synth.stop()` and `this._locked = false` to the `onclose` handler so audio always stops regardless of how the widget is dismissed.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Testing Performed

- Manually verified: trash the block → widget closes and audio stops
- `npm test` — all 5,536 tests passed (added 4 new tests covering mapped keys, ID matching, and audio stopping onclose)
- `npm run lint` — 0 errors
- `npx prettier --check .` on modified files — passed
