### PR TITLE
fix: add missing switch cases to correct slider fractions

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -174,7 +174,8 @@ describe("Utility Logic Functions", () => {
             expect(oneHundredToFraction(91)).toEqual([11, 12]);
             expect(oneHundredToFraction(96)).toEqual([31, 32]);
             expect(oneHundredToFraction(99)).toEqual([63, 64]);
-            expect(oneHundredToFraction(97)).toEqual([97, 100]);
+            expect(oneHundredToFraction(55)).toEqual([9, 16]);
+            expect(oneHundredToFraction(97)).toEqual([31, 32]);
         });
     });
 

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -291,7 +291,8 @@ describe("Utility Functions (logic-only)", () => {
         });
 
         it("handles default case", () => {
-            expect(oneHundredToFraction(97)).toEqual([97, 100]);
+            expect(oneHundredToFraction(55)).toEqual([9, 16]);
+            expect(oneHundredToFraction(97)).toEqual([31, 32]);
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -455,6 +455,7 @@ var oneHundredToFraction = d => {
         case 53:
         case 54:
             return [17, 32];
+        case 55:
         case 56:
         case 57:
         case 58:
@@ -508,6 +509,7 @@ var oneHundredToFraction = d => {
         case 95:
             return [15, 16];
         case 96:
+        case 97:
         case 98:
             return [31, 32];
         case 99:


### PR DESCRIPTION
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD

### Description
This PR fixes a logical bug in the `oneHundredToFraction` utility function where certain slider positions were not mapped correctly due to missing switch cases. 

**The Problem:**
The `switch` statement skipped cases `55` and `97`. Because these cases were missing, inputs of `55` and `97` fell through to the `default` branch, returning mathematically imprecise fractions (`[55, 100]` and `[97, 100]`). 

**Why it matters:**
`oneHundredToFraction` maps the musical slider positions (0–100) to clean note durations. A gap means dragging the slider to position 55 or 97 would result in an ugly fractional display (`55/100` or `97/100`) instead of the correct, simplified fractions that neighboring positions produce.

**The Fix:**
- Mapped `case 55` to fall through to `[9, 16]` (consistent with neighboring cases 56-58).
- Mapped `case 97` to fall through to `[31, 32]` (consistent with neighboring cases 96 and 98).

### Testing Performed
- Updated the assertions in `utils-logic.test.js` to reflect the correct intended behavior for cases `55` and `97`.
- Ran all unit tests locally (`npm run test`) and verified full success.
