### PR TITLE
fix: surface zero-denominator in rationalSum as console.error

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -419,6 +419,22 @@ describe("Utility Functions (logic-only)", () => {
         it("handles negative + positive", () => {
             expect(rationalSum([-1, 3], [1, 3])).toEqual([0, 3]);
         });
+
+        describe("rationalSum zero denominator", () => {
+            it("logs error and returns [0,1] for zero first denominator", () => {
+                const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+                expect(rationalSum([1, 0], [2, 3])).toEqual([0, 1]);
+                expect(spy).toHaveBeenCalled();
+                spy.mockRestore();
+            });
+
+            it("logs error and returns [0,1] for zero second denominator", () => {
+                const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+                expect(rationalSum([2, 3], [1, 0])).toEqual([0, 1]);
+                expect(spy).toHaveBeenCalled();
+                spy.mockRestore();
+            });
+        });
     });
     describe("hexToRGB() without hash", () => {
         it("parses hex without #", () => {

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -313,12 +313,17 @@ var rationalSum = (a, b) => {
         typeof a[0] !== "number" ||
         typeof a[1] !== "number" ||
         typeof b[0] !== "number" ||
-        typeof b[1] !== "number" ||
-        a[1] === 0 ||
-        b[1] === 0
+        typeof b[1] !== "number"
     ) {
         if (typeof console !== "undefined") {
             console.warn("Invalid input passed to rationalSum:", a, b);
+        }
+        return [0, 1];
+    }
+
+    if (a[1] === 0 || b[1] === 0) {
+        if (typeof console !== "undefined") {
+            console.error("rationalSum: zero denominator — corrupted rhythm state", { a, b });
         }
         return [0, 1];
     }


### PR DESCRIPTION
## Description

`rationalSum` in `js/utils/utils-logic.js` previously lumped all invalid-input cases — including type/shape errors and zero-denominator arrays — into a single `console.warn`. A zero denominator inside a structurally valid `[num, denom]` array always indicates corrupted rhythm state (beat tracking, `notesPlayed` counter, `onEveryBeatDo` timing) — not a bad caller input. This distinction matters for debugging: `warn` suggests a recoverable quirk; `error` flags a programming bug that needs investigation.

## Related Issue

This PR fixes #7385

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Tests — Adds or updates test coverage

## Changes Made

-   `js/utils/utils-logic.js`: Split the single guard into two blocks — type/shape mismatches keep `console.warn`; zero-denominator now emits `console.error("rationalSum: zero denominator — corrupted rhythm state", { a, b })`
-   `js/utils/__tests__/utils.test.js`: Added two new tests covering zero-denominator in first and second argument, verifying `console.error` is called and `[0, 1]` is returned

## Testing Performed

-   Ran `npx jest --testPathPattern=utils.test.js` — all 84 tests pass (including 2 new)
-   Ran full suite `npx jest` — 5503 tests across 166 suites, all pass
-   Ran `npm run lint` — 0 errors
-   Ran `npx prettier --check .` — no formatting issues

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.