### PR TITLE
fix: stop Rhythm Ruler audio on project switch by invoking onclose in closeWidgets

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -428,6 +428,7 @@ describe("Utility Functions (logic-only)", () => {
     describe("closeWidgets()", () => {
         beforeEach(() => {
             window.widgetWindows = {
+                openWindows: { RhythmRuler: {}, PhraseMarker: {} },
                 hideAllWindows: jest.fn(),
                 hideWindow: jest.fn(),
                 closeWindow: jest.fn()
@@ -435,7 +436,13 @@ describe("Utility Functions (logic-only)", () => {
         });
         it("calls window.widgetWindows.hideAllWindows", () => {
             closeWidgets();
-            expect(window.widgetWindows.hideAllWindows).toHaveBeenCalled();
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("RhythmRuler");
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("PhraseMarker");
+            expect(window.widgetWindows.hideAllWindows).not.toHaveBeenCalled();
+        });
+        it("does not throw when openWindows is empty", () => {
+            window.widgetWindows.openWindows = {};
+            expect(() => closeWidgets()).not.toThrow();
         });
     });
     describe("closeBlkWidgets()", () => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1414,7 +1414,8 @@ let delayExecution = duration => {
  * @returns {void}
  */
 function closeWidgets() {
-    window.widgetWindows.hideAllWindows();
+    const names = Object.keys(window.widgetWindows.openWindows);
+    names.forEach(name => window.widgetWindows.closeWindow(name));
 }
 
 /**


### PR DESCRIPTION
PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Fixes #7559

## Problem
When the Rhythm Ruler widget is playing and the user switches to another
project or creates a new project, the audio continues playing in the
background. It only stops when the Rhythm Ruler widget is manually reopened.

## Root Cause
`closeWidgets()` in `js/utils/utils.js` called `hideAllWindows()` on
project switch, which only sets `display:none` on widget frames without
invoking their `onclose` callbacks. This meant the Rhythm Ruler's internal
timer loop kept running with `_playing = true`, continuously triggering
synth sounds even though the widget was no longer visible.

## Fix
Changed `closeWidgets()` to iterate over all open widgets and call
`closeWindow()` for each, which routes through `win.close() → onclose()`,
allowing proper cleanup of audio timers.

```js
// Before
function closeWidgets() {
    window.widgetWindows.hideAllWindows();
}

// After
function closeWidgets() {
    const names = Object.keys(window.widgetWindows.openWindows);
    names.forEach(name => window.widgetWindows.closeWindow(name));
}
```

## Testing
1. Open Rhythm Ruler widget.
2. Click Play to start the rhythm.
3. Without closing the widget, click New Project.
4. Audio stops immediately which confirmed fix works