### PR TITLE
fix: allow Tab navigation on focusable DOM elements (#6608)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3263,9 +3263,16 @@ class Activity {
             // const BACKSPACE = 8;
             const TAB = 9;
             if (event.keyCode === TAB) {
-                // Prevent browser from grabbing TAB key
-                event.preventDefault();
-                return false;
+                const active = document.activeElement;
+                const isCanvasOrBody =
+                    active === document.body ||
+                    active === document.getElementById("canvas") ||
+                    active === document.getElementById("myCanvas");
+                if (isCanvasOrBody) {
+                    event.preventDefault();
+                    return false;
+                }
+                return;
             }
             const ESC = 27;
             // const ALT = 18;


### PR DESCRIPTION
##  Description

Fixes a global keyboard trap in `js/activity.js` where every Tab keypress
was unconditionally intercepted via `event.preventDefault()`, regardless
of where focus currently was. This blocked keyboard-only and screen
reader users from navigating to any focusable element (toolbar buttons,
widget inputs, etc.) via Tab.

The fix only suppresses Tab when focus is on the canvas or `body` (where
there is nothing meaningful to tab to). When focus is on a real DOM
element, Tab now passes through and navigates normally.

##  Related Issue

Part of #6608

##  Type of Change

- [x]  Accessibility Enhancement
- [x]  Bug Fix

##  Testing Performed

1. Loaded the app, pressed Tab repeatedly — focus now moves through
   toolbar buttons and other focusable elements in order.
2. Confirmed Tab is still suppressed when focus is on the canvas/body
   (no regression in canvas interaction).
3. Confirmed no console errors introduced.

##  PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts