### PR TITLE
fix: add alt text to decorative palette icons, label close button (#6608)

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -169,6 +169,8 @@ describe("Palettes Class", () => {
                 this.height = 0;
                 this.style = {};
             }
+            setAttribute() {}
+            removeAttribute() {}
         };
 
         global.docById = jest.fn(id => {
@@ -2068,6 +2070,8 @@ describe("Palettes Class", () => {
                 constructor() {
                     this.src = "";
                 }
+                setAttribute() {}
+                removeAttribute() {}
             };
             const tr = {
                 children: MULTIPALETTES.map(() => ({

--- a/js/palette.js
+++ b/js/palette.js
@@ -61,6 +61,12 @@ const makePaletteIcons = (data, width, height) => {
 
     const img = new Image();
     img.src = src;
+    // Decorative icon: the parent element (palette tab, button, etc.)
+    // already carries an aria-label/role, so mark this image as
+    // presentational to avoid duplicate/empty announcements for
+    // screen reader users (WCAG 1.1.1 Non-text Content).
+    img.alt = "";
+    img.setAttribute("role", "presentation");
     if (width) img.width = width;
     if (height) img.height = height;
     return img;
@@ -1540,6 +1546,13 @@ class Palette {
                 this.palettes.cellSize,
                 this.palettes.cellSize
             );
+            // This icon is functional (closes the menu), not decorative,
+            // so override the default presentational/empty-alt markup
+            // applied in makePaletteIcons with a real accessible name.
+            closeImg.removeAttribute("role");
+            closeImg.alt = _("Close");
+            closeImg.setAttribute("role", "button");
+            closeImg.tabIndex = 0;
             closeImg.onclick = () => this.hideMenu();
             closeImg.onmouseover = () => (document.body.style.cursor = "pointer");
             closeImg.onmouseleave = () => (document.body.style.cursor = "default");


### PR DESCRIPTION
## Description

Addresses 13 critical `image-alt` violations found during the WCAG 2.1 AA
audit (#7510): palette category icons and other icons created via
`makePaletteIcons()` had no `alt` attribute, making them inaccessible to
screen readers.

- Icons created via `makePaletteIcons()` are now marked `alt=""` with
  `role="presentation"` by default, since their parent elements (palette
  tabs, buttons, rows) already carry an `aria-label`/`role`.
- The one exception is the palette menu's close button, whose wrapping
  span has no text or label — this icon is given an explicit
  `aria-label`-equivalent (`alt="Close"`), `role="button"`, and
  `tabIndex="0"` so it remains both visible and keyboard-accessible.

## Related Issue

Part of #6608

## Type of Change

- [x] Accessibility Enhancement
- [x] Bug Fix

## Testing Performed

1. Verified all 10 call sites of `makePaletteIcons()` have a labeled
   parent element before relying on the decorative default.
2. Confirmed the close button retains a visible/announced label after
   the change.
3. Loaded the app locally, opened palette menus, and confirmed icons
   and the close button still render and function correctly.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts