### PR TITLE
ci: add DCO check workflow and document sign-off in CONTRIBUTING.md

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,20 @@
+name: DCO Check
+
+on:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+    pull-requests: write
+    statuses: write
+
+jobs:
+    dco:
+        name: DCO
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: thenets/action-dco@v0.2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,33 @@ If AI tools were used while preparing a pull request:
 AI tools should assist development, but they should not replace
 understanding of the codebase.
 
+### Developer Certificate of Origin (DCO)
+
+All commits must include a `Signed-off-by` line certifying that you
+wrote the contribution or have the right to submit it under the
+project's license.
+
+Add it automatically with the `-s` flag:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This appends the following line to your commit message:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+To add a sign-off to your most recent commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+A DCO status check runs on every pull request and will fail if any
+commit is missing the `Signed-off-by` line.
+
 ### Before You Push
 
 Run these commands locally before submitting a PR:


### PR DESCRIPTION
## Description

Adds DCO (Developer Certificate of Origin) enforcement via GitHub Actions and documents the sign-off process for contributors.

## Related Issue

This PR fixes #7565

## PR Category

-   [x] CI/CD — Changes to CI/CD workflows and automation
-   [x] Documentation — Updates to docs, comments, or README

## Changes Made

-   `.github/workflows/dco.yml`: New workflow using `thenets/action-dco@v0.2` — triggers on `pull_request_target` (opened, synchronize, reopened), posts a DCO status check on every PR
-   `CONTRIBUTING.md`: Added a **Developer Certificate of Origin (DCO)** section after the AI guidelines explaining `git commit -s` and `git commit --amend -s --no-edit`

## Testing Performed

-   All 5503 Jest tests pass locally
-   Workflow syntax validated — follows same patterns as existing workflows (`conflict-check.yml`, `stale.yml`)
-   Note: making DCO a *required* status check in branch protection requires maintainer/admin repo settings access — out of scope for this PR

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.