### PR TITLE
fix: replace zero-delay setTimeout with requestAnimationFrame for UI-sync calls

### DIFF
--- a/js/palette.js
+++ b/js/palette.js
@@ -1579,9 +1579,9 @@ class Palette {
             this._outsideClickListener = null;
         };
         // Delay attachment to avoid capturing the opening click
-        setTimeout(() => {
+        requestAnimationFrame(() => {
             document.addEventListener("click", this._outsideClickListener);
-        }, 0);
+        });
     }
 
     _hideMenuItems() {

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -76,7 +76,7 @@ class HelpWidget {
         window.requestAnimationFrame(() => this._setup(useActiveBlock, 0));
 
         // Position center
-        setTimeout(this.widgetWindow.sendToCenter, 50);
+        requestAnimationFrame(() => this.widgetWindow.sendToCenter());
     }
 
     /**


### PR DESCRIPTION
## Category

- [x] Performance

## Summary

Replaces two `setTimeout` calls with `requestAnimationFrame` where the delay is zero or semantically a frame-sync operation, not a timed delay.

| File | Before | After |
|------|--------|-------|
| `js/palette.js:1569` | `setTimeout(fn, 0)` | `requestAnimationFrame(fn)` |
| `js/widgets/help.js:79` | `setTimeout(sendToCenter, 50)` | `requestAnimationFrame(() => sendToCenter())` |

**Why these two only:**
- All other `setTimeout` calls in the codebase use intentional fixed delays (200ms resize debounce, 400ms hover UX, 500ms animation) — replacing those would break timing.
- `palette.js:1569` is a zero-delay defer to skip the current click event — textbook rAF use-case.
- `help.js:79` is inconsistent with `activity.js:6652` which already uses `requestAnimationFrame` for the same `sendToCenter()` call.

The main render loop already uses rAF (`_startRenderLoop` / `_stopRenderLoop`).

## Test plan

- [ ] `npm run lint` — no errors
- [ ] `npx prettier --check js/palette.js js/widgets/help.js` — no errors
- [ ] `npm test` — all tests pass
- [ ] Open a palette → click outside → palette dismisses correctly
- [ ] Open Help widget → widget centers on screen

Closes #7153