### PR TITLE
fix: replace unsafe innerHTML with createElement in sampler, PhraseMakerAudio, and aiwidget 

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -359,7 +359,6 @@ const PhraseMakerAudio = {
                         pm._("Play")
                     );
                     pm.playingNow = false;
-                    // Use createElement to safely update button icon
                     const playImg = document.createElement("img");
                     playImg.src = "header-icons/play-button.svg";
                     playImg.title = pm._("Play");

--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -359,14 +359,18 @@ const PhraseMakerAudio = {
                         pm._("Play")
                     );
                     pm.playingNow = false;
-                    pm._playButton.innerHTML = `&nbsp;&nbsp;<img 
-                    src="header-icons/play-button.svg" 
-                    title="${pm._("Play")}" 
-                    alt="${pm._("Play")}" 
-                    height="${pm.constructor.ICONSIZE}" 
-                    width="${pm.constructor.ICONSIZE}" 
-                    vertical-align="middle"
-                >&nbsp;&nbsp;`;
+                    // Use createElement to safely update button icon
+                    const playImg = document.createElement("img");
+                    playImg.src = "header-icons/play-button.svg";
+                    playImg.title = pm._("Play");
+                    playImg.alt = pm._("Play");
+                    playImg.height = pm.constructor.ICONSIZE;
+                    playImg.width = pm.constructor.ICONSIZE;
+                    playImg.style.verticalAlign = "middle";
+                    pm._playButton.textContent = "\u00A0\u00A0";
+                    pm._playButton.appendChild(playImg);
+                    const nbsp = document.createTextNode("\u00A0\u00A0");
+                    pm._playButton.appendChild(nbsp);
                 } else {
                     row = pm._noteValueRow;
                     cell = row.cells[pm._colIndex];

--- a/js/widgets/__tests__/PhraseMakerAudio.test.js
+++ b/js/widgets/__tests__/PhraseMakerAudio.test.js
@@ -104,7 +104,10 @@ describe("PhraseMakerAudio", () => {
             platformColor: { selectorBackground: "blue" },
             _noteValueRow: { cells: [] },
             _tupletNoteValueRow: { cells: [] },
-            _playButton: { innerHTML: "" },
+            _playButton: {
+                textContent: "",
+                appendChild: jest.fn()
+            },
             _: str => str,
             constructor: { ICONSIZE: 32 }
         };

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -749,7 +749,8 @@ describe("AIWidget Instance", () => {
             addButton: jest.fn(iconName => {
                 const button = {
                     onclick: null,
-                    innerHTML: ""
+                    textContent: "",
+                    appendChild: jest.fn()
                 };
                 if (iconName === "play-button.svg") {
                     playButton = button;
@@ -768,6 +769,9 @@ describe("AIWidget Instance", () => {
 
         expect(pauseSpy).toHaveBeenCalledTimes(1);
         expect(aiWidget.isMoving).toBe(false);
+        // Verify button was updated using appendChild instead of innerHTML
+        expect(playButton.textContent).toBe("");
+        expect(playButton.appendChild).toHaveBeenCalled();
     });
 
     it("should not add duplicate custom samples", () => {

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -769,7 +769,6 @@ describe("AIWidget Instance", () => {
 
         expect(pauseSpy).toHaveBeenCalledTimes(1);
         expect(aiWidget.isMoving).toBe(false);
-        // Verify button was updated using appendChild instead of innerHTML
         expect(playButton.textContent).toBe("");
         expect(playButton.appendChild).toHaveBeenCalled();
     });

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -128,7 +128,6 @@ function AIWidget() {
      * @returns {void}
      */
     this.resume = function () {
-        // Use createElement to safely update button icon
         const pauseImg = document.createElement("img");
         pauseImg.src = "header-icons/pause-button.svg";
         pauseImg.title = _("Pause");
@@ -768,7 +767,6 @@ function AIWidget() {
         this.playBtn.onclick = () => {
             if (this.isMoving) {
                 this.pause();
-                // Use createElement to safely update button icon
                 const playImg = document.createElement("img");
                 playImg.src = "header-icons/play-button.svg";
                 playImg.title = _("Play");

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -128,14 +128,16 @@ function AIWidget() {
      * @returns {void}
      */
     this.resume = function () {
-        this.playBtn.innerHTML = `<img
-                src="header-icons/pause-button.svg" 
-                title="${_("Pause")}" 
-                alt="${_("Pause")}" 
-                height="${ICONSIZE}" 
-                width="${ICONSIZE}" 
-                vertical-align="middle"
-            >`;
+        // Use createElement to safely update button icon
+        const pauseImg = document.createElement("img");
+        pauseImg.src = "header-icons/pause-button.svg";
+        pauseImg.title = _("Pause");
+        pauseImg.alt = _("Pause");
+        pauseImg.height = ICONSIZE;
+        pauseImg.width = ICONSIZE;
+        pauseImg.style.verticalAlign = "middle";
+        this.playBtn.textContent = "";
+        this.playBtn.appendChild(pauseImg);
         this.isMoving = true;
     };
 
@@ -766,14 +768,16 @@ function AIWidget() {
         this.playBtn.onclick = () => {
             if (this.isMoving) {
                 this.pause();
-                this.playBtn.innerHTML = `<img 
-                        src="header-icons/play-button.svg" 
-                        title="${_("Play")}" 
-                        alt="${_("Play")}" 
-                        height="${ICONSIZE}" 
-                        width="${ICONSIZE}"
-                        vertical-align="middle"
-                    >`;
+                // Use createElement to safely update button icon
+                const playImg = document.createElement("img");
+                playImg.src = "header-icons/play-button.svg";
+                playImg.title = _("Play");
+                playImg.alt = _("Play");
+                playImg.height = ICONSIZE;
+                playImg.width = ICONSIZE;
+                playImg.style.verticalAlign = "middle";
+                this.playBtn.textContent = "";
+                this.playBtn.appendChild(playImg);
                 this.isMoving = false;
             } else {
                 if (!(abcNotationSong === "")) {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -210,7 +210,6 @@ function SampleWidget() {
      * @returns {void}
      */
     this.pause = function () {
-        // Use createElement to safely update button icon
         const playImg = document.createElement("img");
         playImg.src = "header-icons/play-button.svg";
         playImg.title = _("Play");
@@ -228,7 +227,6 @@ function SampleWidget() {
      * @returns {void}
      */
     this.resume = function () {
-        // Use createElement to safely update button icon
         const pauseImg = document.createElement("img");
         pauseImg.src = "header-icons/pause-button.svg";
         pauseImg.title = _("Pause");
@@ -1883,8 +1881,6 @@ function SampleWidget() {
             width = this.widgetWindow.getWidgetBody().getBoundingClientRect().width;
             height = this.widgetWindow.getWidgetFrame().getBoundingClientRect().height - 70;
         }
-        // Note: Canvas elements don't have innerHTML - this line has no effect
-        // Keeping for compatibility, but canvas is cleared by makeCanvas() below
         // Cancel any existing RAF loop for this canvas before creating a new one
         // to prevent multiple concurrent draw loops accumulating on resize/maximize.
         if (this.drawVisualIDs[0]) {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -210,14 +210,16 @@ function SampleWidget() {
      * @returns {void}
      */
     this.pause = function () {
-        this.playBtn.innerHTML = `<img 
-                src="header-icons/play-button.svg" 
-                title="${_("Play")}" 
-                alt="${_("Play")}" 
-                height="${ICONSIZE}" 
-                width="${ICONSIZE}" 
-                vertical-align="middle"
-            >`;
+        // Use createElement to safely update button icon
+        const playImg = document.createElement("img");
+        playImg.src = "header-icons/play-button.svg";
+        playImg.title = _("Play");
+        playImg.alt = _("Play");
+        playImg.height = ICONSIZE;
+        playImg.width = ICONSIZE;
+        playImg.style.verticalAlign = "middle";
+        this.playBtn.textContent = "";
+        this.playBtn.appendChild(playImg);
         this.isMoving = false;
     };
 
@@ -226,14 +228,16 @@ function SampleWidget() {
      * @returns {void}
      */
     this.resume = function () {
-        this.playBtn.innerHTML = `<img 
-                src="header-icons/pause-button.svg" 
-                title="${_("Pause")}" 
-                alt="${_("Pause")}" 
-                height="${ICONSIZE}" 
-                width="${ICONSIZE}" 
-                vertical-align="middle"
-            >`;
+        // Use createElement to safely update button icon
+        const pauseImg = document.createElement("img");
+        pauseImg.src = "header-icons/pause-button.svg";
+        pauseImg.title = _("Pause");
+        pauseImg.alt = _("Pause");
+        pauseImg.height = ICONSIZE;
+        pauseImg.width = ICONSIZE;
+        pauseImg.style.verticalAlign = "middle";
+        this.playBtn.textContent = "";
+        this.playBtn.appendChild(pauseImg);
         this.isMoving = true;
     };
 
@@ -1879,7 +1883,8 @@ function SampleWidget() {
             width = this.widgetWindow.getWidgetBody().getBoundingClientRect().width;
             height = this.widgetWindow.getWidgetFrame().getBoundingClientRect().height - 70;
         }
-        document.getElementsByTagName("canvas")[0].innerHTML = "";
+        // Note: Canvas elements don't have innerHTML - this line has no effect
+        // Keeping for compatibility, but canvas is cleared by makeCanvas() below
         // Cancel any existing RAF loop for this canvas before creating a new one
         // to prevent multiple concurrent draw loops accumulating on resize/maximize.
         if (this.drawVisualIDs[0]) {


### PR DESCRIPTION
### Problem
XSS vulnerabilities from unsafe `innerHTML` usage. Using `innerHTML` parses HTML/JavaScript, creating security risks if dynamic content reaches these assignments.

### Changes
Fixed 7 instances across 3 files plus updated 2 test files:

**Widget Files:**
- **sampler.js** (3 fixes): Play/pause buttons use `createElement()` + `appendChild()`, removed ineffective canvas.innerHTML
- **PhraseMakerAudio.js** (1 fix): Play button uses `createElement()` + `appendChild()` with proper unicode nbsp
- **aiwidget.js** (2 fixes): Resume function and play button onclick use `createElement()` + `appendChild()`

**Test Files:**
- **aiwidget.test.js**: Updated mock to use `textContent` + `appendChild` instead of `innerHTML`
- **PhraseMakerAudio.test.js**: Updated `_playButton` mock to use `textContent` + `appendChild`

### Verified Using : 
npm run lint
npm test
npm test -- js/widgets/__tests__/sampler.test.js
npm test -- js/widgets/__tests__/PhraseMakerAudio.test.js
npm test -- js/widgets/__tests__/aiwidget.test.js

*This continues the similar kind of changes from PR but across different files: #7569*

## PR Category

- [x] Bug Fix