### PR TITLE
feat(firefox): warn when unusually large canvas may impact rendering performance

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -370,8 +370,23 @@ class Activity {
         this.stageDirty = false;
         this._renderLoopRafId = null;
         this._renderLoopRunning = false;
+        this.firefoxWarningShown = false;
 
         this.themes = ["light", "dark", "highcontrast"];
+
+        if (navigator.userAgent.includes("Firefox")) {
+            let lastPixelRatio = window.devicePixelRatio;
+
+            setInterval(() => {
+                if (window.devicePixelRatio !== lastPixelRatio) {
+                    lastPixelRatio = window.devicePixelRatio;
+
+                    if (typeof this._onResize === "function") {
+                        this._onResize(false);
+                    }
+                }
+            }, 1000);
+        }
         try {
             // Detect system theme preference (using same logic as ThemeBox)
             const getSystemTheme = () => {
@@ -3637,6 +3652,33 @@ class Activity {
 
             this.stage.canvas.width = w;
             this.stage.canvas.height = h;
+
+            // Firefox large canvas warning
+            const isFirefox = navigator.userAgent.includes("Firefox");
+            const canvasArea = w * h;
+            const FIREFOX_CANVAS_THRESHOLD = 4000000;
+            const warningMsg = _(
+                "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%."
+            );
+
+            if (isFirefox) {
+                if (canvasArea > FIREFOX_CANVAS_THRESHOLD) {
+                    const isShown = this.printText && this.printText.classList.contains("show");
+                    const hasMsg =
+                        this.printTextContent && this.printTextContent.textContent === warningMsg;
+
+                    // Re-show if not shown or if message was overwritten/hidden
+                    if (!this.firefoxWarningShown || !isShown || !hasMsg) {
+                        this.firefoxWarningShown = true;
+                        this.textMsg(warningMsg, 1000000);
+                    }
+                } else if (this.firefoxWarningShown) {
+                    if (this.printTextContent && this.printTextContent.textContent === warningMsg) {
+                        this.hidePrintText();
+                    }
+                    this.firefoxWarningShown = false;
+                }
+            }
 
             this.turtles.doScale(w, h, this.turtleBlocksScale);
 


### PR DESCRIPTION
## Overview

This PR adds a Firefox-specific performance warning when Music Blocks detects an unusually large canvas that may negatively impact rendering performance.

Rather than attempting to detect the browser zoom level directly, the implementation monitors the resulting canvas dimensions and displays a warning only when the canvas exceeds a conservative threshold associated with degraded rendering performance.

---

## Problem

During the Firefox performance investigation, profiling showed that rendering performance degrades significantly when the canvas becomes unusually large. In these cases, Firefox spends substantially more time compositing the canvas, resulting in slower turtle animation and reduced responsiveness.

Although browser zoom cannot be reliably detected, its effect can be observed through the resulting canvas dimensions. Extremely large canvases require Firefox to manage a much larger pixel buffer (approximately 6.3 million pixels in the investigated stress-test scenario), increasing rendering cost.

---

## Solution

- Adds a Firefox-specific warning when the canvas area exceeds a conservative threshold.
- Detects the rendering artifact (large canvas) instead of attempting to detect browser zoom.
- Reuses the existing `textMsg()` notification system without introducing new UI components.
- Re-evaluates the canvas size whenever Firefox zoom changes affect the viewport.
- Automatically dismisses the warning once the canvas returns below the configured threshold.
- Recommends resetting browser zoom to **100% (Ctrl+0)** for the best experience.

---

## Threshold Selection

The warning threshold is set to **4,000,000 pixels**.

This value was chosen to:

- Avoid unnecessary warnings during typical usage.
- Detect unusually large canvases that are more likely to impact Firefox rendering performance.
- Capture the stress-test scenario observed during profiling, where the canvas reached approximately **6.3 million pixels** and rendering performance degraded significantly.

---

## Implementation Details

- Added Firefox-specific warning state to the `Activity` class.
- Added a lightweight Firefox zoom-change sentinel to re-evaluate canvas size when browser zoom changes.
- Integrated canvas-area evaluation into `_onResize()`.
- Reused the existing notification system (`textMsg()`).
- Automatically hides the warning when the canvas size returns below the configured threshold.

---

## PR Category

- [x] Performance
- [ ] Bug Fix
- [ ] Feature
- [ ] Tests
- [ ] Documentation

---

## Validation

- [x] Verified manually in Firefox.
- [x] Warning appears only when the canvas exceeds the configured threshold.
- [x] Warning automatically disappears when the canvas returns below the threshold.
- [x] No behavior changes for non-Firefox browsers.
- [x] `npm test`
- [x] `npm run lint`
- [x] `npx prettier --write js/activity.js`