### PR TITLE
blocks: Add missing radix parameter to parseInt calls

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -696,7 +696,10 @@ function setupEnsembleBlocks(activity) {
                     if (thisTurtle.singer.lastNotePlayed !== null) {
                         const len = thisTurtle.singer.lastNotePlayed[0].length;
                         const pitch = thisTurtle.singer.lastNotePlayed[0].slice(0, len - 1);
-                        const octave = parseInt(thisTurtle.singer.lastNotePlayed[0].slice(len - 1), 10);
+                        const octave = parseInt(
+                            thisTurtle.singer.lastNotePlayed[0].slice(len - 1),
+                            10
+                        );
 
                         obj = [pitch, octave];
                     } else if (thisTurtle.singer.notePitches.length > 0) {

--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -696,7 +696,7 @@ function setupEnsembleBlocks(activity) {
                     if (thisTurtle.singer.lastNotePlayed !== null) {
                         const len = thisTurtle.singer.lastNotePlayed[0].length;
                         const pitch = thisTurtle.singer.lastNotePlayed[0].slice(0, len - 1);
-                        const octave = parseInt(thisTurtle.singer.lastNotePlayed[0].slice(len - 1));
+                        const octave = parseInt(thisTurtle.singer.lastNotePlayed[0].slice(len - 1), 10);
 
                         obj = [pitch, octave];
                     } else if (thisTurtle.singer.notePitches.length > 0) {
@@ -735,7 +735,7 @@ function setupEnsembleBlocks(activity) {
                 if (tur.singer.lastNotePlayed !== null) {
                     const len = tur.singer.lastNotePlayed[0].length;
                     const pitch = tur.singer.lastNotePlayed[0].slice(0, len - 1);
-                    const octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1));
+                    const octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1), 10);
                     obj = [pitch, octave];
                 } else if (tur.singer.notePitches.length > 0) {
                     obj = getNote(

--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -41,7 +41,7 @@ function setupNumberBlocks(activity) {
     const toInteger = (logo, value, blk) => {
         if (typeof value === "string") {
             try {
-                return parseInt(value);
+                return parseInt(value, 10);
             } catch (e) {
                 logo.stopTurtle = true;
                 activity.errorMsg(NANERRORMSG, blk);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -302,7 +302,7 @@ function setupPitchBlocks(activity) {
                     if (typeof tur.singer.lastNotePlayed[0] === "string") {
                         const len = tur.singer.lastNotePlayed[0].length;
                         const pitch = tur.singer.lastNotePlayed[0].slice(0, len - 1);
-                        const octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1));
+                        const octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1), 10);
                         obj = [pitch, octave];
                     } else {
                         // Hertz?

--- a/js/blocks/SensorsBlocks.js
+++ b/js/blocks/SensorsBlocks.js
@@ -558,7 +558,7 @@ function setupSensorsBlocks(activity) {
 
             const obj = colorString.split("(")[1].split(",");
             const component = Number(obj[this.colorIndex]);
-            return parseInt(component / 2.55);
+            return parseInt(component / 2.55, 10);
         }
     }
 

--- a/js/blocks/__tests__/EnsembleBlocks.test.js
+++ b/js/blocks/__tests__/EnsembleBlocks.test.js
@@ -199,12 +199,12 @@ describe("setupEnsembleBlocks", () => {
             turtleList: [0, 1, 2],
             ithTurtle: jest.fn(i => {
                 if (i && typeof i === "object" && i.singer) return i;
-                const index = typeof i === "string" ? parseInt(i) : i;
+                const index = typeof i === "string" ? parseInt(i, 10) : i;
                 return mockTurtles[index];
             }),
             getTurtle: jest.fn(i => {
                 if (i && typeof i === "object" && i.singer) return i;
-                const index = typeof i === "string" ? parseInt(i) : i;
+                const index = typeof i === "string" ? parseInt(i, 10) : i;
                 return mockTurtles[index];
             }),
             getTurtleCount: jest.fn(() => 3),

--- a/js/blocks/__tests__/MediaBlocks.test.js
+++ b/js/blocks/__tests__/MediaBlocks.test.js
@@ -126,7 +126,7 @@ global.NANERRORMSG = "Not a number";
 
 global.toFixed2 = val => Number(val).toFixed(2);
 
-global.calcOctave = (currentOctave, val, lastNote, noteValue) => currentOctave + parseInt(val);
+global.calcOctave = (currentOctave, val, lastNote, noteValue) => currentOctave + parseInt(val, 10);
 global.pitchToFrequency = (note, octave, cents, keySig) => 440;
 global.doStopVideoCam = jest.fn();
 

--- a/js/blocks/__tests__/NumberBlocks.test.js
+++ b/js/blocks/__tests__/NumberBlocks.test.js
@@ -154,7 +154,7 @@ global.MathUtility = {
     doMinus: (a, b) => Number(a) - Number(b)
 };
 
-global.calcOctave = (currentOctave, val, lastNote, noteValue) => currentOctave + parseInt(val);
+global.calcOctave = (currentOctave, val, lastNote, noteValue) => currentOctave + parseInt(val, 10);
 
 global.toFixed2 = val => Number(val).toFixed(2);
 

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -185,7 +185,7 @@ class Tempo {
                 if (this._firstClickTime === null) {
                     this._firstClickTime = d.getTime();
                 } else {
-                    newBPM = parseInt((60 * 1000) / (d.getTime() - this._firstClickTime));
+                    newBPM = parseInt((60 * 1000) / (d.getTime() - this._firstClickTime), 10);
                     if (newBPM > 29 && newBPM < 1001) {
                         this.BPMs[id] = newBPM;
                         this._updateBPM(id);


### PR DESCRIPTION
### Description

This PR addresses a logical correctness issue by adding the missing radix parameter (`10`) to several `parseInt()` calls across the codebase, primarily focusing on `js/blocks/` and the `tempo` widget.

Using `parseInt()` without a radix parameter is a well-known JavaScript footgun, as it can cause strings with leading zeros to be incorrectly parsed as octals. This change explicitly enforces base-10 parsing, ensuring predictable behavior, adhering to JavaScript best practices, and fulfilling ESLint `radix` rules.

### Changes Made
*   **`js/blocks/NumberBlocks.js`**: Added radix `10` to `parseInt(value, 10)` in the `toInteger()` method.
*   **`js/blocks/EnsembleBlocks.js`**: Enforced base-10 parsing during octave extraction.
*   **`js/blocks/PitchBlocks.js`**: Enforced base-10 parsing during octave extraction.
*   **`js/blocks/SensorsBlocks.js`**: Added radix `10` to color component parsing.
*   **`js/widgets/tempo.js`**: Added radix `10` when parsing the calculated BPM from click intervals.
*   **Test Files**: Updated `EnsembleBlocks.test.js`, `MediaBlocks.test.js`, and `NumberBlocks.test.js` to ensure the mock implementations and assertions align with the radix implementation.

### Testing and Validation
- [x] `npm test` runs successfully without any regressions.
- [x] Pre-commit hooks triggered successfully.
- [x] Verified that all modified blocks and tempo calculations function exactly as expected using base-10 parsing.

### Type of Change
- [x] Bug Fix (Logical correctness)
- [ ] Feature
- [x] Code Quality / Refactor
