### PR TITLE
perf: reduce redundant lookups in Logo execution engine

### DIFF
--- a/js/blocks/FlowBlocks.js
+++ b/js/blocks/FlowBlocks.js
@@ -242,7 +242,7 @@ function setupFlowBlocks(activity) {
                             for (let i = 0; i < n; i++) {
                                 const obj = logo.connectionStore[turtle][blk].pop();
                                 activity.blocks.blockList[obj[0]].connections[obj[1]] = obj[2];
-                                if (obj[2] != null) {
+                                if (obj[2] !== null && obj[2] !== undefined) {
                                     activity.blocks.blockList[obj[2]].connections[0] = obj[0];
                                 }
                             }
@@ -271,19 +271,20 @@ function setupFlowBlocks(activity) {
                 try {
                     // Check to see if another turtle has already disconnected these blocks
                     const otherTurtle = __lookForOtherTurtles(blk, turtle);
-                    if (otherTurtle != null) {
+                    if (otherTurtle !== null && otherTurtle !== undefined) {
                         // Copy the connections and queue the blocks
                         logo.connectionStore[turtle][blk] = [];
-                        for (let i = logo.connectionStore[otherTurtle][blk].length; i > 0; i--) {
-                            const obj = [
-                                logo.connectionStore[otherTurtle][blk][i - 1][0],
-                                logo.connectionStore[otherTurtle][blk][i - 1][1],
-                                logo.connectionStore[otherTurtle][blk][i - 1][2]
-                            ];
+                        const otherStore = logo.connectionStore[otherTurtle][blk];
+                        const otherLength = otherStore.length;
+                        const blockList = activity.blocks.blockList;
+                        for (let i = otherLength; i > 0; i--) {
+                            const otherItem = otherStore[i - 1];
+                            const obj = [otherItem[0], otherItem[1], otherItem[2]];
                             logo.connectionStore[turtle][blk].push(obj);
                             let child = obj[0];
-                            if (activity.blocks.blockList[child].name === "hidden") {
-                                child = activity.blocks.blockList[child].connections[0];
+                            const childBlk = blockList[child];
+                            if (childBlk.name === "hidden") {
+                                child = childBlk.connections[0];
                             }
 
                             const queueBlock = new Queue(child, factor, blk, receivedArg);
@@ -291,15 +292,18 @@ function setupFlowBlocks(activity) {
                             tur.queue.push(queueBlock);
                         }
                     } else {
+                        const blockList = activity.blocks.blockList;
                         let child = activity.blocks.findBottomBlock(args[1]);
+                        // eslint-disable-next-line eqeqeq
                         while (child != blk) {
-                            if (activity.blocks.blockList[child].name !== "hidden") {
+                            const childBlk = blockList[child];
+                            if (childBlk.name !== "hidden") {
                                 const queueBlock = new Queue(child, factor, blk, receivedArg);
                                 tur.parentFlowQueue.push(blk);
                                 tur.queue.push(queueBlock);
                             }
 
-                            child = activity.blocks.blockList[child].connections[0];
+                            child = childBlk.connections[0];
                         }
 
                         // Break the connections between blocks in the clamp so
@@ -307,35 +311,37 @@ function setupFlowBlocks(activity) {
                         // run
                         logo.connectionStore[turtle][blk] = [];
                         child = args[1];
-                        while (child != null) {
-                            const lastConnection =
-                                activity.blocks.blockList[child].connections.length - 1;
-                            const nextBlk =
-                                activity.blocks.blockList[child].connections[lastConnection];
+                        while (child !== null && child !== undefined) {
+                            const childBlk = blockList[child];
+                            const childConnections = childBlk.connections;
+                            const lastConnection = childConnections.length - 1;
+                            const nextBlk = childConnections[lastConnection];
                             // Don't disconnect a hidden block from its parent
                             if (
-                                nextBlk != null &&
-                                activity.blocks.blockList[nextBlk].name === "hidden"
+                                nextBlk !== null &&
+                                nextBlk !== undefined &&
+                                blockList[nextBlk].name === "hidden"
                             ) {
+                                const nextBlkObj = blockList[nextBlk];
                                 logo.connectionStore[turtle][blk].push([
                                     nextBlk,
                                     1,
-                                    activity.blocks.blockList[nextBlk].connections[1]
+                                    nextBlkObj.connections[1]
                                 ]);
-                                child = activity.blocks.blockList[nextBlk].connections[1];
-                                activity.blocks.blockList[nextBlk].connections[1] = null;
+                                child = nextBlkObj.connections[1];
+                                nextBlkObj.connections[1] = null;
                             } else {
                                 logo.connectionStore[turtle][blk].push([
                                     child,
                                     lastConnection,
                                     nextBlk
                                 ]);
-                                activity.blocks.blockList[child].connections[lastConnection] = null;
+                                childConnections[lastConnection] = null;
                                 child = nextBlk;
                             }
 
-                            if (child != null) {
-                                activity.blocks.blockList[child].connections[0] = null;
+                            if (child !== null && child !== undefined) {
+                                blockList[child].connections[0] = null;
                             }
                         }
                     }
@@ -395,9 +401,9 @@ function setupFlowBlocks(activity) {
                 return;
             }
 
-            const i = logo.switchCases[turtle][switchBlk].length;
-            // logo.switchCases[turtle][switchBlk].push(["__default__", args[0]]);
-            logo.switchCases[turtle][switchBlk][i - 1].push(["__default__", args[0]]);
+            const cases = logo.switchCases[turtle][switchBlk];
+            const i = cases.length;
+            cases[i - 1].push(["__default__", args[0]]);
         }
     }
 
@@ -452,9 +458,9 @@ function setupFlowBlocks(activity) {
                 return;
             }
 
-            const i = logo.switchCases[turtle][switchBlk].length;
-            // logo.switchCases[turtle][switchBlk].push([args[0], args[1]]);
-            logo.switchCases[turtle][switchBlk][i - 1].push([args[0], args[1]]);
+            const cases = logo.switchCases[turtle][switchBlk];
+            const i = cases.length;
+            cases[i - 1].push([args[0], args[1]]);
         }
     }
 
@@ -514,11 +520,12 @@ function setupFlowBlocks(activity) {
             const tur = activity.turtles.ithTurtle(turtle);
 
             // Push the current switch block and create an empty case for it
+            const casesForTurtle = logo.switchCases[turtle];
             logo.switchBlocks[turtle].push(blk);
-            if (blk in logo.switchCases[turtle]) {
-                logo.switchCases[turtle][blk].push([]);
+            if (blk in casesForTurtle) {
+                casesForTurtle[blk].push([]);
             } else {
-                logo.switchCases[turtle][blk] = [[]];
+                casesForTurtle[blk] = [[]];
             }
 
             // Set up the listener for the switch block
@@ -532,30 +539,34 @@ function setupFlowBlocks(activity) {
                 // Run the cases here.
                 let switchCase;
                 const argBlk = activity.blocks.blockList[switchBlk].connections[1];
-                if (argBlk == null) {
+                if (argBlk === null || argBlk === undefined) {
                     switchCase = "__default__";
                 } else {
                     switchCase = logo.parseArg(logo, turtle, argBlk, logo.receivedArg);
                 }
 
                 let caseFlow = null;
-                for (let i = 0; i < last(logo.switchCases[turtle][switchBlk]).length; i++) {
-                    if (last(logo.switchCases[turtle][switchBlk])[i][0] === switchCase) {
-                        caseFlow = last(logo.switchCases[turtle][switchBlk])[i][1];
+                const switchCases = logo.switchCases[turtle][switchBlk];
+                const activeCases = last(switchCases);
+                const activeCasesLength = activeCases.length;
+                for (let i = 0; i < activeCasesLength; i++) {
+                    const currentCase = activeCases[i];
+                    if (currentCase[0] === switchCase) {
+                        caseFlow = currentCase[1];
                         break;
-                    } else if (last(logo.switchCases[turtle][switchBlk])[i][0] === "__default__") {
-                        caseFlow = last(logo.switchCases[turtle][switchBlk])[i][1];
+                    } else if (currentCase[0] === "__default__") {
+                        caseFlow = currentCase[1];
                     }
                 }
 
-                if (caseFlow != null) {
+                if (caseFlow !== null && caseFlow !== undefined) {
                     const queueBlock = new Queue(caseFlow, 1, switchBlk, null);
                     tur.parentFlowQueue.push(switchBlk);
                     tur.queue.push(queueBlock);
                 }
 
                 // Clean up afterward.
-                logo.switchCases[turtle][switchBlk].pop();
+                switchCases.pop();
                 logo.switchBlocks[turtle].pop();
             };
 
@@ -656,8 +667,9 @@ function setupFlowBlocks(activity) {
             logo.doBreak(tur);
 
             // Since we pop the queue, we need to unhighlight our parent
-            const parentBlk = activity.blocks.blockList[blk].connections[0];
-            if (parentBlk != null) {
+            const connections = activity.blocks.blockList[blk].connections;
+            const parentBlk = connections[0];
+            if (parentBlk !== null && parentBlk !== undefined) {
                 if (!tur.singer.suppressOutput && tur.singer.justCounting.length === 0) {
                     tur.unhighlightQueue.push(parentBlk);
                 }
@@ -707,25 +719,28 @@ function setupFlowBlocks(activity) {
             if (args.length !== 1) return;
 
             const tur = activity.turtles.ithTurtle(turtle);
+            const queue = tur.queue;
+            const parentFlowQueue = tur.parentFlowQueue;
 
             if (!args[0]) {
                 // Requeue.
-                const parentBlk = activity.blocks.blockList[blk].connections[0];
+                const connections = activity.blocks.blockList[blk].connections;
+                const parentBlk = connections[0];
                 const queueBlock = new Queue(blk, 1, parentBlk);
-                tur.parentFlowQueue.push(parentBlk);
-                tur.queue.push(queueBlock);
+                parentFlowQueue.push(parentBlk);
+                queue.push(queueBlock);
                 tur.doWait(0.05);
             } else {
                 // Since a wait-for block was requeued each
                 // time, we need to flush the queue of all but
                 // the last one, otherwise the child of the
                 // while block is executed multiple times.
-                const queueLength = tur.queue.length;
+                const queueLength = queue.length;
                 let kept_one = false;
                 for (let i = queueLength - 1; i > 0; i--) {
-                    if (tur.queue[i].parentBlk === blk) {
+                    if (queue[i].parentBlk === blk) {
                         if (kept_one) {
-                            tur.queue.pop();
+                            queue.pop();
                         } else {
                             kept_one = true;
                         }
@@ -733,11 +748,12 @@ function setupFlowBlocks(activity) {
                 }
 
                 // We need to reset the turtle time
+                const currentTime = Date.now();
                 if (logo.firstNoteTime === null) {
-                    logo.firstNoteTime = new Date().getTime();
+                    logo.firstNoteTime = currentTime;
                 }
 
-                const elapsedTime = (new Date().getTime() - this.firstNoteTime) / 1000;
+                const elapsedTime = (currentTime - this.firstNoteTime) / 1000;
                 tur.singer.turtleTime = elapsedTime;
                 tur.singer.previousTurtleTime = elapsedTime;
             }
@@ -790,31 +806,34 @@ function setupFlowBlocks(activity) {
             if (args.length !== 2) return;
 
             const tur = activity.turtles.ithTurtle(turtle);
+            const queue = tur.queue;
+            const parentFlowQueue = tur.parentFlowQueue;
 
             if (!args[0]) {
                 // We will add the outflow of the until block
                 // each time through, so we pop it off so as
                 // to not accumulate multiple copies.
-                const queueLength = tur.queue.length;
+                const queueLength = queue.length;
                 if (queueLength > 0) {
-                    if (tur.queue[queueLength - 1].parentBlk === blk) {
-                        tur.queue.pop();
+                    if (queue[queueLength - 1].parentBlk === blk) {
+                        queue.pop();
                     }
                 }
                 // Requeue
-                const parentBlk = activity.blocks.blockList[blk].connections[0];
+                const connections = activity.blocks.blockList[blk].connections;
+                const parentBlk = connections[0];
                 const queueBlock = new Queue(blk, 1, parentBlk);
-                tur.parentFlowQueue.push(parentBlk);
-                tur.queue.push(queueBlock);
+                parentFlowQueue.push(parentBlk);
+                queue.push(queueBlock);
             } else {
                 // Since an until block was requeued each
                 // time, we need to flush the queue of all but
                 // the last one, otherwise the child of the
                 // until block is executed multiple times.
-                const queueLength = tur.queue.length;
+                const queueLength = queue.length;
                 for (let i = queueLength - 1; i > 0; i--) {
-                    if (tur.queue[i].parentBlk === blk) {
-                        tur.queue.pop();
+                    if (queue[i].parentBlk === blk) {
+                        queue.pop();
                     }
                 }
             }
@@ -873,22 +892,25 @@ function setupFlowBlocks(activity) {
             if (args.length !== 2) return;
 
             const tur = activity.turtles.ithTurtle(turtle);
+            const queue = tur.queue;
+            const parentFlowQueue = tur.parentFlowQueue;
 
             if (args[0]) {
                 // We will add the outflow of the while block
                 // each time through, so we pop it off so as
                 // to not accumulate multiple copies.
-                const queueLength = tur.queue.length;
+                const queueLength = queue.length;
                 if (queueLength > 0) {
-                    if (tur.queue[queueLength - 1].parentBlk === blk) {
-                        tur.queue.pop();
+                    if (queue[queueLength - 1].parentBlk === blk) {
+                        queue.pop();
                     }
                 }
 
-                const parentBlk = activity.blocks.blockList[blk].connections[0];
+                const connections = activity.blocks.blockList[blk].connections;
+                const parentBlk = connections[0];
                 const queueBlock = new Queue(blk, 1, parentBlk);
-                tur.parentFlowQueue.push(parentBlk);
-                tur.queue.push(queueBlock);
+                parentFlowQueue.push(parentBlk);
+                queue.push(queueBlock);
 
                 // and queue the interior child flow.
                 return [args[1], 1];
@@ -897,10 +919,10 @@ function setupFlowBlocks(activity) {
                 // we need to flush the queue of all but the
                 // last one, otherwise the child of the while
                 // block is executed multiple times.
-                const queueLength = tur.queue.length;
+                const queueLength = queue.length;
                 for (let i = queueLength - 1; i > 0; i--) {
-                    if (tur.queue[i].parentBlk === blk) {
-                        tur.queue.pop();
+                    if (queue[i].parentBlk === blk) {
+                        queue.pop();
                     }
                 }
             }
@@ -1169,15 +1191,11 @@ function setupFlowBlocks(activity) {
          * @param {number} blk - The block number.
          */
         arg(logo, turtle, blk) {
-            if (
-                logo.inStatusMatrix &&
-                activity.blocks.blockList[activity.blocks.blockList[blk].connections[0]].name ===
-                    "print"
-            ) {
+            const blockList = activity.blocks.blockList;
+            if (logo.inStatusMatrix && blockList[blockList[blk].connections[0]].name === "print") {
                 logo.statusFields.push([blk, "duplicate"]);
             } else {
-                activity.blocks.blockList[blk].value =
-                    activity.turtles.ithTurtle(turtle).singer.duplicateFactor;
+                blockList[blk].value = activity.turtles.ithTurtle(turtle).singer.duplicateFactor;
             }
         }
     }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1672,37 +1672,37 @@ class Logo {
 
         // Sometimes we don't want to unwind the entire queue.
         if (queueStart === undefined) queueStart = 0;
+        const currentBlock = logo.blockList[blk];
+        const blockName = currentBlock.name;
+        const proto = currentBlock.protoblock;
+        const connections = currentBlock.connections;
+        const lastConnection = logo.deps.utils.last(connections);
 
         /*
-        ===========================================================================
-        (1) Evaluate any arguments (beginning with connection[1]).
-        ===========================================================================
-        */
+===========================================================================
+(1) Evaluate any arguments (beginning with connection[1]).
+===========================================================================
+*/
+        const tur = logo.activity.turtles.ithTurtle(turtle);
         const args = [];
-        if (logo.blockList[blk].protoblock.args > 0) {
-            for (let i = 1; i <= logo.blockList[blk].protoblock.args; i++) {
-                if (logo.blockList[blk].protoblock.dockTypes[i] === "in") {
-                    if (logo.blockList[blk].connections[i] === null) {
+
+        if (proto.args > 0) {
+            for (let i = 1; i <= proto.args; i++) {
+                if (proto.dockTypes[i] === "in") {
+                    if (connections[i] === null) {
                         // console.debug("skipping inflow args");
                     } else {
-                        args.push(logo.blockList[blk].connections[i]);
+                        args.push(connections[i]);
                     }
                 } else {
-                    args.push(
-                        logo.parseArg(
-                            logo,
-                            turtle,
-                            logo.blockList[blk].connections[i],
-                            blk,
-                            receivedArg
-                        )
-                    );
+                    args.push(logo.parseArg(logo, turtle, connections[i], blk, receivedArg));
                 }
+
                 if (
-                    logo.activity.turtles.ithTurtle(turtle).singer.inNoteBlock.length > 0 &&
-                    logo.blockList[blk].connections[i] !== undefined &&
-                    logo.blockList[logo.blockList[blk].connections[i]] !== undefined &&
-                    logo.blockList[logo.blockList[blk].connections[i]].name === "currentpitch"
+                    tur.singer.inNoteBlock.length > 0 &&
+                    connections[i] !== undefined &&
+                    logo.blockList[connections[i]] !== undefined &&
+                    logo.blockList[connections[i]].name === "currentpitch"
                 ) {
                     // Re-eval this arg after note block ends to
                     // ensure that the current pitch is uptodate.
@@ -1716,30 +1716,24 @@ class Logo {
         (2) Run function associated with the block.
         ===========================================================================
         */
-        const tur = logo.activity.turtles.ithTurtle(turtle);
 
         let nextFlow = null;
-        if (!logo.blockList[blk].isValueBlock()) {
+        if (!currentBlock.isValueBlock()) {
             // nextFlow remains null for value blocks.
 
             // All flow blocks have a last connection (nextFlow), but
             // it can be null (i.e., end of a flow).
             if (tur.singer.backward.length > 0) {
-                // We only run backwards in the "first generation" children.
-                const c =
-                    logo.blockList[logo.deps.utils.last(tur.singer.backward)].name === "backward"
-                        ? 1
-                        : 2;
+                const lastBackward = logo.deps.utils.last(tur.singer.backward);
+                const backwardBlock = logo.blockList[lastBackward];
+                const backwardConnections = backwardBlock.connections;
 
-                if (
-                    !logo.activity.blocks.sameGeneration(
-                        logo.blockList[logo.deps.utils.last(tur.singer.backward)].connections[c],
-                        blk
-                    )
-                ) {
-                    nextFlow = logo.deps.utils.last(logo.blockList[blk].connections);
+                const c = backwardBlock.name === "backward" ? 1 : 2;
+
+                if (!logo.activity.blocks.sameGeneration(backwardConnections[c], blk)) {
+                    nextFlow = lastConnection;
                 } else {
-                    nextFlow = logo.blockList[blk].connections[0];
+                    nextFlow = connections[0];
                     if (
                         nextFlow !== null &&
                         (logo.blockList[nextFlow].name === "action" ||
@@ -1748,31 +1742,24 @@ class Logo {
                         nextFlow = null;
                     } else {
                         if (
-                            !logo.activity.blocks.sameGeneration(
-                                logo.blockList[logo.deps.utils.last(tur.singer.backward)]
-                                    .connections[c],
-                                nextFlow
-                            )
+                            !logo.activity.blocks.sameGeneration(backwardConnections[c], nextFlow)
                         ) {
-                            nextFlow = logo.deps.utils.last(logo.blockList[blk].connections);
+                            nextFlow = lastConnection;
                         } else {
-                            nextFlow = logo.blockList[blk].connections[0];
+                            nextFlow = connections[0];
                         }
                     }
                 }
             } else {
-                nextFlow = logo.deps.utils.last(logo.blockList[blk].connections);
+                nextFlow = lastConnection;
             }
 
             if (nextFlow === -1) {
                 nextFlow = null;
             }
 
-            const queueBlock = new Queue(nextFlow, 1, blk, receivedArg);
-            // eslint-disable-next-line eqeqeq
-            if (nextFlow != null) {
-                // This could be the last block.
-                tur.queue.push(queueBlock);
+            if (nextFlow !== null && nextFlow !== undefined) {
+                tur.queue.push(new Queue(nextFlow, 1, blk, receivedArg));
             }
         }
 
@@ -1801,7 +1788,6 @@ class Logo {
             }
         }
 
-        const currentBlock = logo.blockList[blk];
         if (!currentBlock.isArgBlock()) {
             let res = null;
             // Is it a plugin?
@@ -1820,15 +1806,7 @@ class Logo {
                 // Clamp blocks will return the child flow.
                 res = logo.pluginReturnValue;
             } else {
-                res = currentBlock.protoblock.flow(
-                    args,
-                    logo,
-                    turtle,
-                    blk,
-                    receivedArg,
-                    actionArgs,
-                    isflow
-                );
+                res = proto.flow(args, logo, turtle, blk, receivedArg, actionArgs, isflow);
             }
 
             if (res) {
@@ -1847,14 +1825,10 @@ class Logo {
             if (
                 // If it's an arg block, print its value.
                 currentBlock.isArgBlock() ||
-                ["anyout", "numberout", "textout", "booleanout"].includes(
-                    currentBlock.protoblock.dockTypes[0]
-                )
+                ["anyout", "numberout", "textout", "booleanout"].includes(proto.dockTypes[0])
             ) {
                 args.push(logo.parseArg(logo, turtle, blk, logo.receivedArg));
 
-                // Use label prefix for screen dimension blocks to clarify the display is informational
-                // Labels wrapped with _() for internationalization
                 const blockLabels = {
                     width: _("width"),
                     height: _("height"),
@@ -1863,19 +1837,19 @@ class Logo {
                     toppos: _("top (screen)"),
                     bottompos: _("bottom (screen)")
                 };
-                const blockName = currentBlock.name;
-                const label = blockLabels[blockName];
 
-                // eslint-disable-next-line eqeqeq
-                if (currentBlock.value == null) {
+                const label = blockLabels[blockName];
+                const blockValue = currentBlock.value;
+
+                if (blockValue === null || blockValue === undefined) {
                     logo.activity.textMsg("null block value");
                 } else {
-                    const value = currentBlock.value.toString();
+                    const value = blockValue.toString();
                     const displayText = label ? label + ": " + value : value;
                     logo.activity.textMsg(displayText);
                 }
             } else {
-                logo.activity.errorMsg("I do not know how to " + currentBlock.name + ".", blk);
+                logo.activity.errorMsg("I do not know how to " + blockName + ".", blk);
             }
 
             logo.stopTurtle = true;
@@ -1909,7 +1883,7 @@ class Logo {
         // eslint-disable-next-line eqeqeq
         if (childFlow != null) {
             let queueBlock;
-            if (logo.blockList[blk].name === "doArg" || logo.blockList[blk].name === "nameddoArg") {
+            if (blockName === "doArg" || blockName === "nameddoArg") {
                 queueBlock = new Queue(childFlow, childFlowCount, blk, actionArgs);
             } else {
                 queueBlock = new Queue(childFlow, childFlowCount, blk, receivedArg);
@@ -1932,17 +1906,16 @@ class Logo {
 
         // Run the last flow in the queue.
         if (tur.queue.length > queueStart) {
-            nextBlock = logo.deps.utils.last(tur.queue).blk;
-            parentBlk = logo.deps.utils.last(tur.queue).parentBlk;
-            passArg = logo.deps.utils.last(tur.queue).args;
+            const lastQueue = logo.deps.utils.last(tur.queue);
 
-            // Since the forever block starts at -1, it will never === 1.
-            if (logo.deps.utils.last(tur.queue).count === 1) {
-                // Finished child so pop it off the queue.
+            nextBlock = lastQueue.blk;
+            parentBlk = lastQueue.parentBlk;
+            passArg = lastQueue.args;
+
+            if (lastQueue.count === 1) {
                 tur.queue.pop();
             } else {
-                // Decrement the counter for repeating the flow.
-                logo.deps.utils.last(tur.queue).count -= 1;
+                lastQueue.count--;
             }
         }
 
@@ -1977,10 +1950,10 @@ class Logo {
 
             if (
                 // eslint-disable-next-line eqeqeq
-                (tur.singer.backward.length > 0 && logo.blockList[blk].connections[0] == null) ||
+                (tur.singer.backward.length > 0 && connections[0] == null) ||
                 (tur.singer.backward.length === 0 &&
                     // eslint-disable-next-line eqeqeq
-                    logo.deps.utils.last(logo.blockList[blk].connections) == null)
+                    lastConnection == null)
             ) {
                 if (!tur.singer.suppressOutput && tur.singer.justCounting.length === 0) {
                     // If we are at the end of the child flow, queue
@@ -1988,13 +1961,13 @@ class Logo {
                     // flow.
                     if (tur.unhighlightQueue === undefined) {
                         // console.debug("cannot find highlight queue for turtle " + turtle);
-                    } else if (
-                        tur.parentFlowQueue.length > 0 &&
-                        tur.queue.length > 0 &&
-                        logo.deps.utils.last(tur.queue).parentBlk !==
-                            logo.deps.utils.last(tur.parentFlowQueue)
-                    ) {
-                        tur.unhighlightQueue.push(logo.deps.utils.last(tur.parentFlowQueue));
+                    } else if (tur.parentFlowQueue.length > 0 && tur.queue.length > 0) {
+                        const lastQueue = logo.deps.utils.last(tur.queue);
+                        const lastParentFlow = logo.deps.utils.last(tur.parentFlowQueue);
+
+                        if (lastQueue.parentBlk !== lastParentFlow) {
+                            tur.unhighlightQueue.push(lastParentFlow);
+                        }
                     } else if (tur.unhighlightQueue.length > 0) {
                         // The child flow is finally complete, so unhighlight.
                         logo._timerManager.setGuardedTimeout(


### PR DESCRIPTION
## Overview

While profiling `crabcanon-plot.html` using Chrome DevTools Performance, I observed that `Logo.runFromBlockNow()` consistently appeared as one of the dominant hotspots in the interpreter execution path, accounting for roughly **65–70% of the captured call-tree time** during local profiling.

This PR is the **first optimization pass** targeting the Logo execution engine. It focuses on reducing interpreter overhead through safe micro-optimizations, including caching frequently accessed references and eliminating redundant property lookups, while preserving existing behavior.

The execution engine remains an area for further optimization, and this PR establishes an initial set of improvements for that hot path.

## Changes

### `js/logo.js`
- Cached frequently accessed objects and nested properties.
- Reduced repeated property dereferences.
- Cached repeated `last(...)` lookups.
- Simplified repeated access patterns in the execution hot path.

### `js/blocks/FlowBlocks.js`
- Cached frequently accessed references (`queue`, `parentFlowQueue`, `connections`, `blockList`).
- Reduced repeated nested property lookups in flow-control execution paths.
- Replaced `new Date().getTime()` with `Date.now()`.
- Applied similar micro-optimizations across `WaitFor`, `Until`, `While`, `Break`, `Duplicate`, and related flow blocks.

## Profiling

The screenshots below show representative local profiling captures before and after this optimization pass.

> **Note:** These are individual profiling observations from Chrome DevTools and are intended to illustrate the targeted hotspot. They are **not** presented as rigorous benchmark results.

As an initial optimization pass, this PR reduces the representative local profiling time of Logo.runFromBlockNow() from approximately 1315 ms to 1098 ms during CrabCanon execution by reducing redundant lookups in the interpreter hot path.

## Testing

- Ran Prettier on modified files.
- Ran the full test suite (**5531 tests passed**).
- Verified Crab Canon playback after the changes.

No functional or behavioral changes are intended.

## PR Category

- [x] Performance
