### PR TITLE
Fixed status widget label handling in console.

### DIFF
--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -165,13 +165,20 @@ class StatusMatrix {
                         label = label.value;
                     }
                     break;
-                default:
-                    label =
-                        this.activity.blocks.blockList[statusField[0]].protoblock.staticLabels[0];
+                default: {
+                    const block = this.activity.blocks.blockList[statusField[0]];
+                    label = block?.protoblock?.staticLabels?.[0] || "";
                     break;
+                }
             }
-            let str = label;
-            str = label.charAt(0).toUpperCase() + label.slice(1);
+
+            let str = "";
+            if (typeof label === "string" && label.length > 0) {
+                str = label.charAt(0).toUpperCase() + label.slice(1);
+            } else {
+                str = "";
+            }
+
             // console.log(str);
             cell.textContent = "\u00A0";
             const b = document.createElement("b");


### PR DESCRIPTION
Fixed a widget bug where the status threw console errors and displayed missing or blank field labels. The code was trying to load a null.charAt(0) which is not possible, instead it was assuming a string. The widget correctly initializes and render labels now. Didn't see an error in my console later regarding the same.