### PR TITLE
Fix: corrected the typo, giving error in console when clicked on "letter class" button in status, from widgets section.

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -4267,7 +4267,7 @@ class Block {
             let labels;
             if (this.activity.beginnerMode) {
                 values = this.protoblock.extraSearchTerms.slice(0, 6);
-                labels = this.protoblock.iemenuLabels.slice(0, 6);
+                labels = this.protoblock.piemenuLabels.slice(0, 6);
             } else {
                 values = this.protoblock.extraSearchTerms;
                 labels = this.protoblock.piemenuLabels;


### PR DESCRIPTION
A small typo was giving an error in console, this error was followed by the widget error, although it was fixed and now I can see the widgets getting popped up on the screen when pressed "letter class" button. 