### PR TITLE
fix: keep neighbor beat arrays in sync when note value is too large

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -139,17 +139,18 @@ function setupRhythmActions(activity) {
 
                 if (tur.singer.inNoteBlock.length > 0) {
                     if (tur.singer.inNeighbor.length > 0) {
-                        tur.singer.neighborArgBeat.push(
-                            tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
-                        );
-
                         const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
                         if (nextBeat <= 0 || !isFinite(nextBeat)) {
                             activity.errorMsg(
-                                _("Neighbor note value is too large for the current note duration."),
+                                _(
+                                    "Neighbor note value is too large for the current note duration."
+                                ),
                                 blk
                             );
                         } else {
+                            tur.singer.neighborArgBeat.push(
+                                tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
+                            );
                             tur.singer.neighborArgCurrentBeat.push(
                                 tur.singer.beatFactor * (1 / nextBeat)
                             );

--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -551,4 +551,29 @@ describe("setupRhythmActions", () => {
 
         expect(targetTurtle.singer.multipleVoices).toBe(true);
     });
+    it("pushes to both neighbor beat arrays when nextBeat is valid", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = 0.25;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1, jest.fn());
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(targetTurtle.singer.neighborArgBeat).toEqual([4]);
+        expect(targetTurtle.singer.neighborArgCurrentBeat).toEqual([2]);
+    });
+    it("keeps neighbor beat arrays in sync when nextBeat is invalid", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = 1;
+        activity.errorMsg = jest.fn();
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1, jest.fn());
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(activity.errorMsg).toHaveBeenCalled();
+        expect(targetTurtle.singer.neighborArgBeat.length).toBe(
+            targetTurtle.singer.neighborArgCurrentBeat.length
+        );
+    });
 });


### PR DESCRIPTION
## Description

While reviewing #7533 I noticed the new division-by-zero guard returns before pushing to `neighborArgCurrentBeat`, but `neighborArgBeat` is still pushed unconditionally just above it. The two arrays are meant to stay paired — `turtle-singer.js` reads them together via `last()`:

```js
neighborArgBeat        = bpmFactor / last(tur.singer.neighborArgBeat);
neighborArgCurrentBeat = bpmFactor / last(tur.singer.neighborArgCurrentBeat);
```

So when the guard fires, `neighborArgBeat` gets a new element while `neighborArgCurrentBeat` does not. On the next neighbor note this reads a stale value off `neighborArgCurrentBeat`, and when the guarded note is the first neighbor note `last([])` is `undefined`, giving `bpmFactor / undefined = NaN`.

This moves the `neighborArgBeat` push into the same valid-`nextBeat` branch so both arrays grow together or not at all.

## Related Issue

Follow-up to #7533, which fixed the crash but left the two arrays able to desync.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Moved `neighborArgBeat.push()` inside the `else` branch in `RhythmActions.js` so it only runs when `nextBeat` is valid, alongside `neighborArgCurrentBeat.push()`.
-   Added two tests in `RhythmActions.test.js`: one asserting both arrays are pushed on the valid path, one asserting they stay the same length when the guard fires.

## Testing Performed

-   `npx jest js/turtleactions/__tests__/RhythmActions.test.js` — 30/30 pass. The new "in sync when invalid" test fails on current master and passes with this change.
-   `npx prettier --check` on both files — clean.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.
