### PR TITLE
refactor: Modernize codebase with e.key and Math.hypot

### DIFF
--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -584,4 +584,44 @@ describe("MathUtility", () => {
             expect(MathUtility.doPlus(true, true)).toBe(2);
         });
     });
+
+    describe("doCalculateDistance", () => {
+        test("returns 0 when both points are the same", () => {
+            expect(MathUtility.doCalculateDistance(3, 4, 3, 4)).toBe(0);
+        });
+
+        test("calculates distance for a 3-4-5 right triangle", () => {
+            expect(MathUtility.doCalculateDistance(0, 0, 3, 4)).toBe(5);
+        });
+
+        test("calculates distance along the x-axis", () => {
+            expect(MathUtility.doCalculateDistance(0, 0, 10, 0)).toBe(10);
+        });
+
+        test("calculates distance along the y-axis", () => {
+            expect(MathUtility.doCalculateDistance(0, 0, 0, 7)).toBe(7);
+        });
+
+        test("handles negative coordinates", () => {
+            expect(MathUtility.doCalculateDistance(-3, -4, 0, 0)).toBe(5);
+        });
+
+        test("is commutative (order of points does not matter)", () => {
+            const d1 = MathUtility.doCalculateDistance(1, 2, 4, 6);
+            const d2 = MathUtility.doCalculateDistance(4, 6, 1, 2);
+            expect(d1).toBe(d2);
+        });
+
+        test("calculates correct distance for floating-point coordinates", () => {
+            expect(MathUtility.doCalculateDistance(1.5, 2.5, 4.5, 6.5)).toBeCloseTo(5, 5);
+        });
+
+        test("throws NanError for non-numeric x1", () => {
+            expect(() => MathUtility.doCalculateDistance("a", 0, 3, 4)).toThrow("NanError");
+        });
+
+        test("throws NanError for non-numeric y2", () => {
+            expect(() => MathUtility.doCalculateDistance(0, 0, 3, "b")).toThrow("NanError");
+        });
+    });
 });

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -254,7 +254,7 @@ class MathUtility {
                 return 0;
             }
 
-            return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2));
+            return Math.hypot(x1 - x2, y1 - y2);
         } else {
             throw new Error("NanError");
         }

--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -523,10 +523,10 @@ describe("Tempo Widget", () => {
                 call => call[0] === "keyup"
             );
             const keyupHandler = keyupCall[1];
-            keyupHandler({ keyCode: 13 });
+            keyupHandler({ key: "Enter" });
             expect(useBPMSpy).toHaveBeenCalledTimes(1);
             expect(useBPMSpy).toHaveBeenCalledWith(0);
-            keyupHandler({ keyCode: 32 });
+            keyupHandler({ key: "Space" });
             expect(useBPMSpy).toHaveBeenCalledTimes(1);
         });
     });

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -205,7 +205,7 @@ class Tempo {
             this.BPMInputs[i].addEventListener(
                 "keyup",
                 (id => e => {
-                    if (e.keyCode === 13) {
+                    if (e.key === "Enter") {
                         this._useBPM(id);
                     }
                 })(i)


### PR DESCRIPTION
### Description

This PR combines two surgical modernization and refactoring fixes to improve the readability, stability, and future-proofing of the codebase.

1. **Replaced deprecated `e.keyCode` with `e.key`** in `tempo.js`. 
   `KeyboardEvent.keyCode` is deprecated by MDN and may be removed from browsers in the future. Using `e.key` is the modern standard, making the code more readable and future-proof. This was the only occurrence of `keyCode` in the entire `js/widgets/` directory.

2. **Replaced `Math.pow` and `Math.sqrt` with `Math.hypot`** in `mathutils.js`.
   The `doCalculateDistance` function now uses `Math.hypot(x1 - x2, y1 - y2)`. `Math.hypot` is a modern JavaScript feature that is not only more idiomatic and concise but also mathematically more stable (it internally avoids numerical overflow or underflow issues with very large or very small coordinates).

### Changes Made
*   **`js/widgets/tempo.js`**: `if (e.keyCode === 13)` replaced with `if (e.key === "Enter")`.
*   **`js/utils/mathutils.js`**: Replaced standard distance formula `Math.sqrt(Math.pow(..., 2) + Math.pow(..., 2))` with `Math.hypot(..., ...)`.

### Testing and Validation
- [x] Code style verified and formatted using Prettier.
- [x] Tests run successfully locally.
- [x] Tested both `tempo` inputs and Euclidean distance calculations, ensuring functionally identical results with modern APIs.

### Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor / Modernization
