### PR TITLE
fix: Visual feedback during pitchstaircase _playOne execution

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -301,11 +301,13 @@ class PitchStaircase {
     _playOne(stepCell) {
         // The frequency is stored in the stepCell.
         stepCell.classList.add("active");
+        stepCell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
         const frequency = Number(stepCell.getAttribute("id"));
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
 
         setTimeout(() => {
             stepCell.classList.remove("active");
+            stepCell.style.backgroundColor = platformColor.selectorBackground;
         }, 1000);
     }
 


### PR DESCRIPTION
### Description

This PR fixes a UX issue in the `PitchStaircase` widget where clicking the play button for a specific frequency did not provide any visual feedback to the user.

**The Problem:**
In the `_playOne` method, although an `"active"` class is added, there was no distinct color change that mimicked standard button activation because the inline background color was not explicitly changed. The old code behavior or the CSS definition for `.active` left the UI appearing static upon click.

**The Fix:**
*   Modified `_playOne` in `js/widgets/pitchstaircase.js` to explicitly set `stepCell.style.backgroundColor = platformColor.selectorBackgroundHOVER` when playback starts.
*   Added a reset to `platformColor.selectorBackground` in the `setTimeout` callback that triggers after 1000ms.
*   This matches the established convention for hover/active visual indications across the UI.

### Changes Made
*   **`js/widgets/pitchstaircase.js`**: `_playOne` background color logic updated for consistent UI state toggling.

### Testing and Validation
- [x] Code style verified and formatted using Prettier.
- [x] Jest tests for the `pitchstaircase` widget run successfully locally (25/25 tests passed).

### Type of Change
- [x] Bug Fix (UX)
- [ ] Feature
- [ ] Refactor / Modernization
