### PR TITLE
fix: improve dark mode search and autocomplete visibility

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -108,3 +108,17 @@ body.highcontrast {
     border-radius: 3px;
     padding: 2px;
 }
+
+/* Fix search autocomplete dropdown text in dark mode */
+body.dark #ui-id-1 .ui-menu-item-wrapper,
+body.dark #ui-id-1 a {
+    color: #e8e8e8 !important;
+}
+
+body.dark #ui-id-1 {
+    background-color: #1d1d20 !important;
+}
+
+body.dark #ui-id-1 .ui-menu-item {
+    background-color: #1d1d20 !important;
+}

--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -112,13 +112,13 @@ body.highcontrast {
 /* Fix search autocomplete dropdown text in dark mode */
 body.dark #ui-id-1 .ui-menu-item-wrapper,
 body.dark #ui-id-1 a {
-    color: #e8e8e8 !important;
+    color: var(--color-text-primary) !important;
 }
 
 body.dark #ui-id-1 {
-    background-color: #1d1d20 !important;
+    background-color: var(--color-bg-primary) !important;
 }
 
 body.dark #ui-id-1 .ui-menu-item {
-    background-color: #1d1d20 !important;
+    background-color: var(--color-bg-primary) !important;
 }

--- a/css/themes.css
+++ b/css/themes.css
@@ -125,9 +125,9 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 
 .dark #search,
 .dark #helpfulSearch {
-    color: white !important;
-    -webkit-text-fill-color: white !important;
-    caret-color: white !important;
+    color: var(--color-text-primary) !important;
+    -webkit-text-fill-color: var(--color-text-primary) !important;
+    caret-color: var(--color-text-primary) !important;
 }
 .dark .ui-autocomplete {
     background-color: var(--color-bg-primary) !important;
@@ -150,14 +150,9 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-menu-item:hover,
 .dark .ui-autocomplete .ui-menu-item:hover a,
 .dark .ui-autocomplete .ui-menu-item:hover .ui-menu-item-wrapper,
-.dark .ui-autocomplete .ui-state-focus,
-.dark .ui-autocomplete .ui-state-active {
-    background-color: var(--color-bg-tertiary) !important;
-    color: var(--color-text-inverse) !important;
-}
 .dark .ui-menu-item-wrapper.ui-state-active,
 .dark .ui-menu-item-wrapper.ui-state-focus {
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
 }
 
 .dark #helpfulSearchDiv {

--- a/css/themes.css
+++ b/css/themes.css
@@ -124,7 +124,11 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 .dark #search,
-.dark #helpfulSearch,
+.dark #helpfulSearch {
+    color: white !important;
+    -webkit-text-fill-color: white !important;
+    caret-color: white !important;
+}
 .dark .ui-autocomplete {
     background-color: var(--color-bg-primary) !important;
     color: var(--color-text-inverse) !important;
@@ -134,7 +138,10 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 /* Ensure all text inside autocomplete items is white */
 .dark .ui-autocomplete .ui-menu-item,
 .dark .ui-autocomplete .ui-menu-item a,
-.dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
+.dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper,
+.dark .ui-autocomplete .ui-menu-item span,
+.dark .ui-autocomplete .ui-menu-item b,
+.dark .ui-autocomplete .ui-menu-item strong {
     color: var(--color-text-inverse) !important;
     background-color: transparent !important;
 }
@@ -147,6 +154,10 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-state-active {
     background-color: var(--color-bg-tertiary) !important;
     color: var(--color-text-inverse) !important;
+}
+.dark .ui-menu-item-wrapper.ui-state-active,
+.dark .ui-menu-item-wrapper.ui-state-focus {
+    color: #ffffff !important;
 }
 
 .dark #helpfulSearchDiv {

--- a/js/palette.js
+++ b/js/palette.js
@@ -490,11 +490,7 @@ class Palettes {
     _clearKeyboardFocus() {
         const focused = document.querySelectorAll('[data-keyboard-focus="true"]');
         focused.forEach(el => {
-            if (el.classList && el.classList.contains("ui-menu-item")) {
-                el.style.backgroundColor = "";
-            } else {
-                el.style.backgroundColor = platformColor.paletteBackground;
-            }
+            el.style.backgroundColor = platformColor.paletteBackground;
             delete el.dataset.keyboardFocus;
             if (typeof el.hasAttribute === "function" && el.hasAttribute("tabindex")) {
                 el.tabIndex = -1;

--- a/js/palette.js
+++ b/js/palette.js
@@ -490,7 +490,11 @@ class Palettes {
     _clearKeyboardFocus() {
         const focused = document.querySelectorAll('[data-keyboard-focus="true"]');
         focused.forEach(el => {
-            el.style.backgroundColor = platformColor.paletteBackground;
+            if (el.classList.contains("ui-menu-item")) {
+                el.style.backgroundColor = "";
+            } else {
+                el.style.backgroundColor = platformColor.paletteBackground;
+            }
             delete el.dataset.keyboardFocus;
             if (typeof el.hasAttribute === "function" && el.hasAttribute("tabindex")) {
                 el.tabIndex = -1;

--- a/js/palette.js
+++ b/js/palette.js
@@ -490,7 +490,7 @@ class Palettes {
     _clearKeyboardFocus() {
         const focused = document.querySelectorAll('[data-keyboard-focus="true"]');
         focused.forEach(el => {
-            if (el.classList.contains("ui-menu-item")) {
+            if (el.classList && el.classList.contains("ui-menu-item")) {
                 el.style.backgroundColor = "";
             } else {
                 el.style.backgroundColor = platformColor.paletteBackground;


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

Fixes #7589

## Problem

When switching to dark mode in Music Blocks, the search widget has visibility issues:

1. Text typed into the search input is difficult or impossible to see while typing.
2. Autocomplete suggestions can appear with poor contrast, making block names hard to read.

This makes searching for blocks significantly harder in dark mode.

## Root Cause

The search widget and autocomplete dropdown did not fully apply dark-mode text and background styling, resulting in poor contrast and reduced readability.

## Fix

### `css/darkmode.css`

* Added explicit dark-mode styling for autocomplete dropdown items.
* Ensured autocomplete text uses the appropriate theme text color.
* Applied dark-mode background styling to autocomplete results.

### `css/themes.css`

* Added dark-mode support for search input text rendering.
* Added `caret-color` and `-webkit-text-fill-color` so typed text remains visible while searching.
* Improved autocomplete item text visibility for dark mode.

## Testing

1. Open Music Blocks.
2. Switch to Dark Mode.
3. Open the palette search.
4. Type a block name (for example: `cal`).
5. Verify that:

   * Typed text is clearly visible.
   * Caret remains visible while typing.
   * Autocomplete suggestions are readable.
   * Hover and keyboard navigation continue to work correctly.

## Result

The search input and autocomplete dropdown are now fully readable and usable in dark mode while preserving existing functionality.
