### PR TITLE
fix: _codeToBlocks swallowed AST conversion errors

### DIFF
--- a/js/widgets/__tests__/jseditor.test.js
+++ b/js/widgets/__tests__/jseditor.test.js
@@ -556,7 +556,7 @@ describe("JSEditor", () => {
             global.ast2blocklist_config = undefined;
             window.ast2blocklist_config_ready = Promise.reject(new Error("network failed"));
 
-            await editor._codeToBlocks();
+            await expect(editor._codeToBlocks()).rejects.toThrow();
 
             expect(consoleEl.textContent).toContain(
                 "JavaScript block conversion is unavailable because its configuration file failed to load."

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -1005,6 +1005,7 @@ class JSEditor {
                 "message" in e ? e.message : e.prefix + this._code.substring(e.start, e.end),
                 "red"
             );
+            throw e;
         }
     }
 


### PR DESCRIPTION
Previously_`codeToBlocks` caught and swallowed internal conversion exceptions without re-throwing them. as a result when block conversion failed `_runCode `incorrectly assumed the code executed successfully and proceeded to play it, rather than throwing a Sandbox Error.

- [x] Bug Fix