### PR TITLE
fix: add missing radix parameter to parseInt calls across js/

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -114,19 +114,19 @@ class SaveInterface {
             '  var codeBlock = document.getElementById("codeBlock");' +
             '  var showHideButton = document.getElementById("showhide");' +
             '  showHideButton.addEventListener("click", function(e) {' +
-            '    e.preventDefault();' +
+            "    e.preventDefault();" +
             '    if (codeBlock.style.display === "none") {' +
             '      codeBlock.style.display = "flex";' +
             '      showHideButton.textContent = "' +
             STR_HIDE +
             '";' +
-            '    } else {' +
+            "    } else {" +
             '      codeBlock.style.display = "none";' +
             '      showHideButton.textContent = "' +
             STR_SHOW +
             '";' +
             "    }" +
-            '  });' +
+            "  });" +
             '  codeBlock.style.display = "none";' +
             '  showHideButton.textContent = "' +
             STR_SHOW +
@@ -424,7 +424,7 @@ class SaveInterface {
 
             Object.entries(data).forEach(([blockIndex, notes]) => {
                 const mainTrack = midi.addTrack();
-                mainTrack.name = `Track ${parseInt(blockIndex) + 1}`;
+                mainTrack.name = `Track ${parseInt(blockIndex, 10) + 1}`;
 
                 const trackMap = new Map();
                 let globalTime = 0;
@@ -438,7 +438,7 @@ class SaveInterface {
                         const drum = noteData.drum || false;
                         if (!trackMap.has(drum)) {
                             const drumTrack = midi.addTrack();
-                            drumTrack.name = `Track ${parseInt(blockIndex) + 1} - ${drum}`;
+                            drumTrack.name = `Track ${parseInt(blockIndex, 10) + 1} - ${drum}`;
                             drumTrack.channel = 9; // Drums must be on Channel 10
                             trackMap.set(drum, drumTrack);
                         }
@@ -459,7 +459,7 @@ class SaveInterface {
                         if (!trackMap.has(instrument)) {
                             const instrumentTrack = midi.addTrack();
                             instrumentTrack.name = `Track ${
-                                parseInt(blockIndex) + 1
+                                parseInt(blockIndex, 10) + 1
                             } - ${instrument}`;
                             instrumentTrack.instrument.number =
                                 Object.prototype.hasOwnProperty.call(instrumentMIDI, instrument)

--- a/js/activity.js
+++ b/js/activity.js
@@ -2340,9 +2340,6 @@ class Activity {
          */
         this.showSearchWidget = () => this.searchController.showSearchWidget();
 
-        /*
-         * Uses JQuery to add autocompleted search suggestions
-         */
         this.doSearch = () => this.searchController.doSearch();
 
         //To create a sampler widget
@@ -6284,7 +6281,7 @@ class Activity {
                                     getJSON(url).then(
                                         data => {
                                             const n = data.arg;
-                                            env.push(parseInt(n));
+                                            env.push(parseInt(n, 10));
                                         },
                                         () => {
                                             alert(

--- a/js/midi.js
+++ b/js/midi.js
@@ -237,7 +237,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
                             ],
                             [
                                 x + 2,
-                                ["number", { value: parseInt(name[name.length - 1]) }],
+                                ["number", { value: parseInt(name[name.length - 1], 10) }],
                                 0,
                                 0,
                                 [x]

--- a/js/mxml.js
+++ b/js/mxml.js
@@ -50,7 +50,7 @@ saveMxmlOutput = logo => {
 
     Object.keys(logo.notation.notationStaging).forEach(voice => {
         if (logo.notation.notationStaging[voice].length === 0) return;
-        voiceNum = parseInt(voice) + 1;
+        voiceNum = parseInt(voice, 10) + 1;
         add(`<score-part id="P${voiceNum}">`);
         indent++;
         add(`<part-name> Voice #${voiceNum} </part-name>`);
@@ -63,7 +63,7 @@ saveMxmlOutput = logo => {
 
     Object.keys(logo.notation.notationStaging).forEach(voice => {
         if (logo.notation.notationStaging[voice].length === 0) return;
-        voiceNum = parseInt(voice) + 1;
+        voiceNum = parseInt(voice, 10) + 1;
         indent++;
         add(`<part id="P${voiceNum}">`);
         indent++;
@@ -245,14 +245,14 @@ saveMxmlOutput = logo => {
     let mi = 1e5;
     for (let i = 0; i < res.length - 1; i++) {
         if ((res[i] === "P" || res[i] === "#") && "123456789".includes(res[i + 1])) {
-            mi = Math.min(mi, parseInt(res[i + 1]));
+            mi = Math.min(mi, parseInt(res[i + 1], 10));
         }
     }
 
     res = res.split("");
     for (let i = 0; i < res.length - 1; i++) {
         if ((res[i] === "P" || res[i] === "#") && "123456789".includes(res[i + 1])) {
-            res[i + 1] = parseInt(res[i + 1]) - mi + 1;
+            res[i + 1] = parseInt(res[i + 1], 10) - mi + 1;
         }
     }
     res = res.join("");

--- a/js/palette.js
+++ b/js/palette.js
@@ -588,7 +588,7 @@ class Palettes {
     deltaY(dy) {
         // Cache DOM element reference to avoid multiple lookups and forced reflow
         const palette = document.getElementById("palette");
-        const curr = parseInt(palette.style.top);
+        const curr = parseInt(palette.style.top, 10);
         palette.style.top = curr + dy + "px";
     }
 
@@ -1677,8 +1677,8 @@ class Palette {
                     img.onmouseup = null;
                     img.ontouchend = null;
 
-                    const x = parseInt(img.style.left);
-                    const y = parseInt(img.style.top);
+                    const x = parseInt(img.style.left, 10);
+                    const y = parseInt(img.style.top, 10);
 
                     img.style.position = posit;
                     img.style.zIndex = zInd;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4407,7 +4407,7 @@ const piemenuDissectNumber = widget => {
     // Determine wheel values based on beginner mode
     const wheelValues = isBeginnerMode ? [2, 3, 4] : [2, 3, 4, 5, 7];
 
-    const currentValue = parseInt(widget._dissectNumber.value) || 2;
+    const currentValue = parseInt(widget._dissectNumber.value, 10) || 2;
 
     // Show the wheel div
     showWheelDiv();
@@ -4511,7 +4511,7 @@ const piemenuDissectNumber = widget => {
 
     // Set up decrement button (-)
     exitWheel.navItems[1].navigateFunction = () => {
-        const currentVal = parseInt(widget._dissectNumber.value);
+        const currentVal = parseInt(widget._dissectNumber.value, 10);
         const currentIdx = wheelValues.indexOf(currentVal);
 
         // Move to previous value in the array, or stay at first
@@ -4523,7 +4523,7 @@ const piemenuDissectNumber = widget => {
 
     // Set up increment button (+)
     exitWheel.navItems[2].navigateFunction = () => {
-        const currentVal = parseInt(widget._dissectNumber.value);
+        const currentVal = parseInt(widget._dissectNumber.value, 10);
         const currentIdx = wheelValues.indexOf(currentVal);
 
         // Move to next value in the array, or stay at last

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -778,7 +778,7 @@ class Singer {
                     turtle,
                     note,
                     octave,
-                    parseInt(tur.singer.neighborStepPitch)
+                    parseInt(tur.singer.neighborStepPitch, 10)
                 );
                 if (tur.singer.transposition !== 0) {
                     noteObj2 = getNote(
@@ -796,7 +796,7 @@ class Singer {
                 noteObj2 = getNote(
                     note,
                     octave,
-                    tur.singer.transposition + parseInt(tur.singer.neighborStepPitch),
+                    tur.singer.transposition + parseInt(tur.singer.neighborStepPitch, 10),
                     tur.singer.keySignature,
                     tur.singer.movable,
                     null,
@@ -2213,7 +2213,7 @@ class Singer {
                         if (typeof notes[0] === "number") {
                             tur.singer.currentOctave = frequencyToPitch(notes[0])[1];
                         } else {
-                            tur.singer.currentOctave = parseInt(notes[0].slice(len - 1));
+                            tur.singer.currentOctave = parseInt(notes[0].slice(len - 1), 10);
                         }
                         tur.singer.currentCalculatedOctave = tur.singer.currentOctave;
 

--- a/js/turtleactions/DictActions.js
+++ b/js/turtleactions/DictActions.js
@@ -91,7 +91,7 @@ function setupDictActions(activity) {
                 if (targetTur.singer.lastNotePlayed !== null) {
                     const len = targetTur.singer.lastNotePlayed[0].length;
                     const pitch = targetTur.singer.lastNotePlayed[0].slice(0, len - 1);
-                    const octave = parseInt(targetTur.singer.lastNotePlayed[0].slice(len - 1));
+                    const octave = parseInt(targetTur.singer.lastNotePlayed[0].slice(len - 1), 10);
 
                     obj = [pitch, octave];
                 } else if (targetTur.singer.notePitches.length > 0) {

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -123,7 +123,8 @@ function setupPitchActions(activity) {
             } else {
                 pitchName = lastNotePlayed[0].slice(0, lastNotePlayed[0].length - 1);
                 octave = parseInt(
-                    lastNotePlayed[0].slice(lastNotePlayed[0].length - 1, lastNotePlayed[0].length)
+                    lastNotePlayed[0].slice(lastNotePlayed[0].length - 1, lastNotePlayed[0].length),
+                    10
                 );
             }
             if (tur.singer.inverted) {
@@ -661,13 +662,13 @@ function setupPitchActions(activity) {
             } else {
                 let len = tur.singer.previousNotePlayed[0].length;
                 let pitch = tur.singer.previousNotePlayed[0].slice(0, len - 1);
-                let octave = parseInt(tur.singer.previousNotePlayed[0].slice(len - 1));
+                let octave = parseInt(tur.singer.previousNotePlayed[0].slice(len - 1), 10);
                 let obj = [pitch, octave];
                 const previousValue = pitchToNumber(obj[0], obj[1], tur.singer.keySignature);
 
                 len = tur.singer.lastNotePlayed[0].length;
                 pitch = tur.singer.lastNotePlayed[0].slice(0, len - 1);
-                octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1));
+                octave = parseInt(tur.singer.lastNotePlayed[0].slice(len - 1), 10);
                 obj = [pitch, octave];
 
                 let delta = pitchToNumber(obj[0], obj[1], tur.singer.keySignature) - previousValue;

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3297,7 +3297,7 @@ const getTemperamentName = name => {
  * @returns {Array} An array containing the note, octave, and cents.
  */
 const noteToObj = note => {
-    let octave = parseInt(note.slice(note.length - 1));
+    let octave = parseInt(note.slice(note.length - 1), 10);
     if (isNaN(octave)) {
         octave = 4;
     } else {
@@ -4498,8 +4498,8 @@ const GetNotesForInterval = tur => {
             return { firstNote, secondNote: firstNote, octave };
         }
         secondNote = noteStatus[0][1].replace(/\d/g, "");
-        const octavea = parseInt(noteStatus[0][0].replace(/[^0-9]/g, ""));
-        const octaveb = parseInt(noteStatus[0][1].replace(/[^0-9]/g, ""));
+        const octavea = parseInt(noteStatus[0][0].replace(/[^0-9]/g, ""), 10);
+        const octaveb = parseInt(noteStatus[0][1].replace(/[^0-9]/g, ""), 10);
         octave = octaveb - octavea;
     } else if (notePitches) {
         const pitchBlk = notePitches[last(tur.singer.inNoteBlock)];
@@ -4606,7 +4606,10 @@ function getNote(
         // Could be mi#<sub>4</sub> (from matrix) or mi# (from note).
         if (noteArg.substr(-1) === ">") {
             // Read octave and solfege from HTML
-            octave = parseInt(noteArg.slice(noteArg.indexOf(">") + 1, noteArg.indexOf("/") - 1));
+            octave = parseInt(
+                noteArg.slice(noteArg.indexOf(">") + 1, noteArg.indexOf("/") - 1),
+                10
+            );
             noteArg = noteArg.substr(0, noteArg.indexOf("<"));
         }
         if (
@@ -6124,7 +6127,7 @@ const toFraction = d => {
             top += 1;
         } else {
             bot += 1;
-            top = parseInt(d * bot);
+            top = parseInt(d * bot, 10);
         }
         df = top / bot;
     }
@@ -6159,8 +6162,8 @@ const calcNoteValueToDisplay = (a, b) => {
     let value;
     let obj;
     let d0, d1;
-    if (parseInt(noteValue) < noteValue) {
-        noteValueToDisplay = parseInt(noteValue * 1.5);
+    if (parseInt(noteValue, 10) < noteValue) {
+        noteValueToDisplay = parseInt(noteValue * 1.5, 10);
         if (noteValueToDisplay in NSYMBOLS) {
             value = b / a; // * noteValueToDisplay;
             obj = toFraction(value);
@@ -6176,7 +6179,7 @@ const calcNoteValueToDisplay = (a, b) => {
                 NSYMBOLS[noteValueToDisplay] +
                 ".";
         } else {
-            noteValueToDisplay = parseInt(noteValue * 1.75);
+            noteValueToDisplay = parseInt(noteValue * 1.75, 10);
             if (noteValueToDisplay in NSYMBOLS) {
                 value = b / a; // * noteValueToDisplay;
                 obj = toFraction(value);
@@ -6677,7 +6680,7 @@ const calcOctaveInterval = arg => {
  * @returns {boolean} True if the value is an integer, false otherwise.
  */
 const isInt = value => {
-    return !isNaN(value) && parseInt(Number(value)) === value && !isNaN(parseInt(value, 10));
+    return !isNaN(value) && parseInt(Number(value), 10) === value && !isNaN(parseInt(value, 10));
 };
 
 /**

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -3063,7 +3063,7 @@ function Synth() {
                                                 const octave =
                                                     tempBlock._octavesWheel.navItems[i].title;
                                                 if (octave && !isNaN(octave)) {
-                                                    selectionState.octave = parseInt(octave);
+                                                    selectionState.octave = parseInt(octave, 10);
                                                     updateTargetNote();
                                                 }
                                             };
@@ -3128,7 +3128,7 @@ function Synth() {
                                         }
 
                                         // Adjust for octave (C4 is the reference octave)
-                                        const octaveDiff = parseInt(octave) - 4;
+                                        const octaveDiff = parseInt(octave, 10) - 4;
                                         freq *= Math.pow(2, octaveDiff);
 
                                         targetPitch.frequency = freq;
@@ -3672,7 +3672,7 @@ function Synth() {
 
         // Add event listener for slider changes
         slider.oninput = () => {
-            const value = parseInt(slider.value);
+            const value = parseInt(slider.value, 10);
             valueDisplay.textContent = (value >= 0 ? "+" : "") + value + "¢";
             this.centsValue = value;
             // Update tuner display if it exists

--- a/js/widgets/aidebugger.js
+++ b/js/widgets/aidebugger.js
@@ -511,7 +511,7 @@ function AIDebuggerWidget() {
         typingIndicators.forEach(indicator => {
             const animationId = indicator.getAttribute("data-animation-id");
             if (animationId) {
-                clearInterval(parseInt(animationId));
+                clearInterval(parseInt(animationId, 10));
             }
             indicator.remove();
         });

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -166,7 +166,7 @@ function AIWidget() {
      * @returns {void}
      */
     this._useOctave = function (o) {
-        this.octaveCenter = parseInt(o);
+        this.octaveCenter = parseInt(o, 10);
     };
 
     /**
@@ -230,7 +230,7 @@ function AIWidget() {
                             ],
                             [
                                 blockId + 4,
-                                ["text", { value: `Voice ${parseInt(lineId) + 1} ` }],
+                                ["text", { value: `Voice ${parseInt(lineId, 10) + 1} ` }],
                                 0,
                                 0,
                                 [blockId + 3]
@@ -372,7 +372,7 @@ function AIWidget() {
                             [
                                 "nameddo",
                                 {
-                                    value: `V: ${parseInt(lineId) + 1} Line ${
+                                    value: `V: ${parseInt(lineId, 10) + 1} Line ${
                                         baseBlocks.length + 1
                                     }`
                                 }
@@ -400,7 +400,7 @@ function AIWidget() {
                             [
                                 "text",
                                 {
-                                    value: `V: ${parseInt(lineId) + 1} Line ${
+                                    value: `V: ${parseInt(lineId, 10) + 1} Line ${
                                         baseBlocks.length + 1
                                     }`
                                 }

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -1084,7 +1084,7 @@ function LegoWidget() {
         if (!noteMatch) return null;
 
         const noteName = noteMatch[1];
-        const octave = parseInt(noteMatch[2]);
+        const octave = parseInt(noteMatch[2], 10);
 
         // Convert note name to solfege
         const noteToSolfege = {

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -356,7 +356,7 @@ function MusicKeyboard(activity) {
                 ele.style.backgroundColor = platformColor.orange;
                 temp1[id] = ele.getAttribute("alt").split("__")[0];
                 if (temp1[id] === "hertz") {
-                    temp2[id] = parseInt(ele.getAttribute("alt").split("__")[1]);
+                    temp2[id] = parseInt(ele.getAttribute("alt").split("__")[1], 10);
                 } else if (temp1[id] in FIXEDSOLFEGE1) {
                     temp2[id] =
                         FIXEDSOLFEGE1[temp1[id]].replace(SHARP, "#").replace(FLAT, "b") +
@@ -1443,7 +1443,7 @@ function MusicKeyboard(activity) {
         const start = docById("cells-" + colIndex).getAttribute("start");
 
         this._notesPlayed = this._notesPlayed.filter(function (ele) {
-            return ele.startTime !== parseInt(start);
+            return ele.startTime !== parseInt(start, 10);
         });
 
         // Look for each cell that is marked in this column.
@@ -1462,7 +1462,7 @@ function MusicKeyboard(activity) {
             ele = docById("cells-" + colIndex);
             dur = ele.getAttribute("dur");
             this._notesPlayed.push({
-                startTime: parseInt(start),
+                startTime: parseInt(start, 10),
                 noteOctave: "R",
                 objId: null,
                 duration: parseFloat(dur)
@@ -1500,7 +1500,7 @@ function MusicKeyboard(activity) {
 
         const ele = docById(j + ":" + colIndex);
         this._notesPlayed.push({
-            startTime: parseInt(start),
+            startTime: parseInt(start, 10),
             noteOctave: temp2,
             blockNumber: this.layout[n - j - 1].blockNumber,
             duration: parseFloat(ele.getAttribute("alt")),
@@ -2015,8 +2015,8 @@ function MusicKeyboard(activity) {
      * @param {number[]} duration - The new duration expressed as a fraction [numerator, denominator].
      */
     this._updateDuration = function (start, duration) {
-        start = parseInt(start);
-        duration = parseInt(duration[0]) / parseInt(duration[1]);
+        start = parseInt(start, 10);
+        duration = parseInt(duration[0], 10) / parseInt(duration[1], 10);
         const newduration = parseFloat((Math.round(duration * 8) / 8).toFixed(3));
         this._notesPlayed = this._notesPlayed.map(function (item) {
             if (item.startTime === start) {
@@ -2035,13 +2035,13 @@ function MusicKeyboard(activity) {
      * @param {number} divideNoteBy - The number of divisions to create from the note.
      */
     this._addNotes = function (cellId, start, divideNoteBy) {
-        start = parseInt(start);
+        start = parseInt(start, 10);
         const cell = docById(cellId);
         const dur = cell.getAttribute("dur");
 
         this._notesPlayed = this._notesPlayed.reduce(function (prevValue, curValue) {
             let oldcurValue, newcurValue;
-            if (parseInt(curValue.startTime) === start) {
+            if (parseInt(curValue.startTime, 10) === start) {
                 prevValue = prevValue.concat([curValue]);
                 oldcurValue = Object.assign({}, curValue);
                 for (let i = 0; i < divideNoteBy; i++) {
@@ -2052,7 +2052,7 @@ function MusicKeyboard(activity) {
                 }
 
                 return prevValue;
-            } else if (parseInt(curValue.startTime) > start) {
+            } else if (parseInt(curValue.startTime, 10) > start) {
                 curValue.startTime = curValue.startTime + dur * 1000 * divideNoteBy;
                 return prevValue.concat([curValue]);
             }
@@ -2068,10 +2068,10 @@ function MusicKeyboard(activity) {
      * @param {string} start - The start time of the notes to delete.
      */
     this._deleteNotes = function (start) {
-        start = parseInt(start);
+        start = parseInt(start, 10);
 
         this._notesPlayed = this._notesPlayed.filter(function (ele) {
-            return parseInt(ele.startTime) !== start;
+            return parseInt(ele.startTime, 10) !== start;
         });
 
         this._createTable();
@@ -2083,11 +2083,11 @@ function MusicKeyboard(activity) {
      * @param {number} divideNoteBy - The number of divisions to create from the note.
      */
     this._divideNotes = function (start, divideNoteBy) {
-        start = parseInt(start);
+        start = parseInt(start, 10);
 
         this._notesPlayed = this._notesPlayed.reduce(function (prevValue, curValue) {
             let newcurValue, newcurValue2, oldcurValue;
-            if (parseInt(curValue.startTime) === start) {
+            if (parseInt(curValue.startTime, 10) === start) {
                 if (beginnerMode === "true") {
                     if (curValue.duration / divideNoteBy < 0.125) {
                         return prevValue.concat([curValue]);
@@ -2105,7 +2105,8 @@ function MusicKeyboard(activity) {
                 for (let i = 0; i < divideNoteBy - 1; i++) {
                     newcurValue2 = Object.assign({}, oldcurValue);
                     newcurValue2.startTime = parseInt(
-                        newcurValue2.startTime + newcurValue2.duration * 1000
+                        newcurValue2.startTime + newcurValue2.duration * 1000,
+                        10
                     );
                     prevValue = prevValue.concat([newcurValue2]);
                     oldcurValue = newcurValue2;
@@ -2535,7 +2536,7 @@ function MusicKeyboard(activity) {
      * @param {string} condition - The condition that determines the type of submenu to create ('synthsblocks' or 'pitchblocks').
      */
     this._createColumnPieSubmenu = function (index, condition) {
-        index = parseInt(index);
+        index = parseInt(index, 10);
         const displayLayout = this.displayLayout || this.layout;
         const layoutItem = displayLayout[displayLayout.length - index - 1];
 
@@ -2745,7 +2746,7 @@ function MusicKeyboard(activity) {
                 this._pitchWheel.navItems[this._pitchWheel.selectedNavItemIndex].title;
             const argBlock = this.activity.blocks.blockList[block].connections[1];
             this.activity.blocks.blockList[argBlock].text.text = blockValue;
-            this.activity.blocks.blockList[argBlock].value = parseInt(blockValue);
+            this.activity.blocks.blockList[argBlock].value = parseInt(blockValue, 10);
 
             const z = this.activity.blocks.blockList[argBlock].container.children.length - 1;
             this.activity.blocks.blockList[argBlock].container.setChildIndex(
@@ -2755,15 +2756,15 @@ function MusicKeyboard(activity) {
             this.activity.blocks.blockList[argBlock].updateCache();
 
             const cell = docById("labelcol" + (displayLayout.length - index - 1));
-            displayLayout[index].noteOctave = parseInt(blockValue);
+            displayLayout[index].noteOctave = parseInt(blockValue, 10);
             if (this.layout[index]) {
-                this.layout[index].noteOctave = parseInt(blockValue);
+                this.layout[index].noteOctave = parseInt(blockValue, 10);
             }
             cell.textContent =
                 displayLayout[index].noteName + displayLayout[index].noteOctave.toString();
             this._notesPlayed.map(item => {
                 if (item.objId === displayLayout[index].blockNumber) {
-                    item.noteOctave = parseInt(blockValue);
+                    item.noteOctave = parseInt(blockValue, 10);
                 }
                 return item;
             });
@@ -3342,7 +3343,7 @@ function MusicKeyboard(activity) {
             return ans;
         };
         const actionGroupInterval = 50;
-        const actionGroups = parseInt(selectedNotes.length / actionGroupInterval) + 1;
+        const actionGroups = parseInt(selectedNotes.length / actionGroupInterval, 10) + 1;
 
         for (let actionGroup = 0; actionGroup < actionGroups; actionGroup++) {
             const currentSelectedNotes = selectedNotes.slice(

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -1508,8 +1508,8 @@ class PhraseMaker {
                 const newBlock = this.activity.blocks.blockList.length;
                 this.activity.blocks.loadNewBlocks([
                     [0, thisBlockName, 0, 0, [null, 1, 2, null]],
-                    [1, ["number", { value: parseInt(this.xblockValue[0]) }], 0, 0, [0]],
-                    [2, ["number", { value: parseInt(this.yblockValue[0]) }], 0, 0, [0]]
+                    [1, ["number", { value: parseInt(this.xblockValue[0], 10) }], 0, 0, [0]],
+                    [2, ["number", { value: parseInt(this.yblockValue[0], 10) }], 0, 0, [0]]
                 ]);
 
                 await this._deps.delayExecution(500);
@@ -1521,7 +1521,7 @@ class PhraseMaker {
                 // Just updating a block arg value
                 argBlock = this.activity.blocks.blockList[thisBlock].connections[1];
                 this.activity.blocks.blockList[argBlock].text.text = this.xblockValue[0];
-                this.activity.blocks.blockList[argBlock].value = parseInt(this.xblockValue[0]);
+                this.activity.blocks.blockList[argBlock].value = parseInt(this.xblockValue[0], 10);
 
                 z = this.activity.blocks.blockList[argBlock].container.children.length - 1;
                 this.activity.blocks.blockList[argBlock].container.setChildIndex(
@@ -1532,7 +1532,7 @@ class PhraseMaker {
 
                 argBlock = this.activity.blocks.blockList[thisBlock].connections[2];
                 this.activity.blocks.blockList[argBlock].text.text = this.yblockValue[0];
-                this.activity.blocks.blockList[argBlock].value = parseInt(this.yblockValue[0]);
+                this.activity.blocks.blockList[argBlock].value = parseInt(this.yblockValue[0], 10);
 
                 z = this.activity.blocks.blockList[argBlock].container.children.length - 1;
                 this.activity.blocks.blockList[argBlock].container.setChildIndex(
@@ -1544,8 +1544,8 @@ class PhraseMaker {
 
             // Update the stored values for this node.
             this.rowLabels[blockIndex] = thisBlockName;
-            this.rowArgs[blockIndex][0] = parseInt(this.xblockValue);
-            this.rowArgs[blockIndex][1] = parseInt(this.yblockValue);
+            this.rowArgs[blockIndex][0] = parseInt(this.xblockValue, 10);
+            this.rowArgs[blockIndex][1] = parseInt(this.yblockValue, 10);
 
             // Update the cell label.
             let blockLabel;
@@ -1817,7 +1817,7 @@ class PhraseMaker {
                 newBlock = this.activity.blocks.blockList.length;
                 this.activity.blocks.loadNewBlocks([
                     [0, thisBlockName, 0, 0, [null, 1, null]],
-                    [1, ["number", { value: parseInt(this.blockValue) }], 0, 0, [0]]
+                    [1, ["number", { value: parseInt(this.blockValue, 10) }], 0, 0, [0]]
                 ]);
 
                 await this._deps.delayExecution(500);
@@ -1829,7 +1829,7 @@ class PhraseMaker {
                 // Just updating a block arg value
                 argBlock = this.activity.blocks.blockList[thisBlock].connections[1];
                 this.activity.blocks.blockList[argBlock].text.text = this.blockValue;
-                this.activity.blocks.blockList[argBlock].value = parseInt(this.blockValue);
+                this.activity.blocks.blockList[argBlock].value = parseInt(this.blockValue, 10);
 
                 z = this.activity.blocks.blockList[argBlock].container.children.length - 1;
                 this.activity.blocks.blockList[argBlock].container.setChildIndex(
@@ -1841,7 +1841,7 @@ class PhraseMaker {
 
             // Update the stored values for this node.
             this.rowLabels[blockIndex] = thisBlockName;
-            this.rowArgs[blockIndex] = parseInt(this.blockValue);
+            this.rowArgs[blockIndex] = parseInt(this.blockValue, 10);
 
             // Update the cell label.
             let cell = this._headcols[blockIndex];
@@ -1929,7 +1929,7 @@ class PhraseMaker {
      * @param {boolean} sortedClose - Determines if the menu is sorted and closed.
      */
     _createColumnPieSubmenu(index, condition, sortedClose) {
-        index = parseInt(index);
+        index = parseInt(index, 10);
         this.docById("wheelDivptm").textContent = "";
         this.docById("wheelDivptm").style.display = "";
 
@@ -3635,9 +3635,9 @@ class PhraseMaker {
             this._blockMapHelper.push([this._colBlocks[i], [i]]);
         }
         for (let i = noteToDivide + 1; i < this.activity.logo.tupletRhythms.length; i++) {
-            this._blockMapHelper.push([this._colBlocks[i], [i + parseInt(notesToAdd)]]);
+            this._blockMapHelper.push([this._colBlocks[i], [i + parseInt(notesToAdd, 10)]]);
         }
-        for (let i = 0; i < parseInt(notesToAdd); i++) {
+        for (let i = 0; i < parseInt(notesToAdd, 10); i++) {
             this.activity.logo.tupletRhythms = this.activity.logo.tupletRhythms
                 .slice(0, noteToDivide + i + 1)
                 .concat(this.activity.logo.tupletRhythms.slice(noteToDivide + i));
@@ -3656,7 +3656,7 @@ class PhraseMaker {
         if (this.activity.logo.tupletRhythms.length === 1) {
             return;
         }
-        noteToDivide = parseInt(noteToDivide);
+        noteToDivide = parseInt(noteToDivide, 10);
         this._blockMapHelper = [];
         for (let i = 0; i < noteToDivide; i++) {
             this._blockMapHelper.push([this._colBlocks[i], [i]]);
@@ -3679,7 +3679,7 @@ class PhraseMaker {
      * @private
      */
     _divideNotes(noteToDivide, divideNoteBy) {
-        noteToDivide = parseInt(noteToDivide);
+        noteToDivide = parseInt(noteToDivide, 10);
         this._blockMapHelper = [];
         for (let i = 0; i < noteToDivide; i++) {
             this._blockMapHelper.push([this._colBlocks[i], [i]]);
@@ -3742,7 +3742,7 @@ class PhraseMaker {
             this._blockMapHelper.push([this._colBlocks[i], [j]]);
         }
         j++;
-        for (let i = parseInt(upCellId) + 1; i < this.activity.logo.tupletRhythms.length; i++) {
+        for (let i = parseInt(upCellId, 10) + 1; i < this.activity.logo.tupletRhythms.length; i++) {
             this._blockMapHelper.push([this._colBlocks[i], [j]]);
             j++;
         }
@@ -3761,7 +3761,7 @@ class PhraseMaker {
                     1 / newNote
                 ]
             ])
-            .concat(this.activity.logo.tupletRhythms.slice(parseInt(upCellId) + 1));
+            .concat(this.activity.logo.tupletRhythms.slice(parseInt(upCellId, 10) + 1));
 
         this._readjustNotesBlocks();
         this._syncMarkedBlocks();
@@ -3796,9 +3796,9 @@ class PhraseMaker {
      * @private
      */
     _updateTupletValue(noteToDivide, oldTupletValue, newTupletValue) {
-        noteToDivide = parseInt(noteToDivide);
-        oldTupletValue = parseInt(oldTupletValue);
-        newTupletValue = parseInt(newTupletValue);
+        noteToDivide = parseInt(noteToDivide, 10);
+        oldTupletValue = parseInt(oldTupletValue, 10);
+        newTupletValue = parseInt(newTupletValue, 10);
         this._blockMapHelper = [];
 
         let k = 0;
@@ -4038,7 +4038,7 @@ class PhraseMaker {
 
             this._menuWheel.navItems[3].navigateFunction = () => {
                 if (this.newNoteValue > 1) {
-                    this.newNoteValue = String(parseInt(this.newNoteValue) - 1);
+                    this.newNoteValue = String(parseInt(this.newNoteValue, 10) - 1);
                     this.docById("wheelnav-_exitWheel-title-1").children[0].textContent =
                         this.newNoteValue;
                     this._updateTupletValue(this, noteToDivide, tupletValue, this.newNoteValue);
@@ -4046,7 +4046,7 @@ class PhraseMaker {
             };
 
             this._menuWheel.navItems[9].navigateFunction = () => {
-                this.newNoteValue = String(parseInt(this.newNoteValue) + 1);
+                this.newNoteValue = String(parseInt(this.newNoteValue, 10) + 1);
                 this.docById("wheelnav-_exitWheel-title-1").children[0].textContent =
                     this.newNoteValue;
                 this._updateTupletValue(noteToDivide, tupletValue, this.newNoteValue);
@@ -4101,7 +4101,7 @@ class PhraseMaker {
                     const word = this.newNoteValue.split("/");
                     this._updateTuplet(
                         noteToDivide,
-                        parseInt(word[1]) / parseInt(word[0]),
+                        parseInt(word[1], 10) / parseInt(word[0], 10),
                         condition
                     );
                 }
@@ -4620,7 +4620,7 @@ class PhraseMaker {
             // which case we output 1 / (3 x 4) instead of 1 / 12.
             if (
                 this._outputAsTuplet[i][0] !== 1 &&
-                parseInt(this._outputAsTuplet[i][1]) === this._outputAsTuplet[i][1]
+                parseInt(this._outputAsTuplet[i][1], 10) === this._outputAsTuplet[i][1]
             ) {
                 // We don't reformat dotted tuplets since they are too complicated.
                 // We are adding 6 blocks: vspace, divide, number, multiply, number, number
@@ -4658,7 +4658,7 @@ class PhraseMaker {
                 // note value is saved as a fraction
                 newStack.push([idx + 2, "divide", 0, 0, [idx, idx + 3, idx + 4]]);
 
-                if (parseInt(note[1]) < note[1]) {
+                if (parseInt(note[1], 10) < note[1]) {
                     // dotted note
                     obj = this._deps.toFraction(note[1]);
                     newStack.push([idx + 3, ["number", { value: obj[1] }], 0, 0, [idx + 2]]);
@@ -4702,7 +4702,7 @@ class PhraseMaker {
                         }
                     }
 
-                    if (!isNaN(parseInt(note[0][j]))) {
+                    if (!isNaN(parseInt(note[0][j], 10))) {
                         obj = null;
                         drumName = null;
                     } else {
@@ -4728,7 +4728,7 @@ class PhraseMaker {
                         ]);
                         newStack.push([
                             thisBlock + 1,
-                            ["number", { value: parseInt(note[0][j]) }],
+                            ["number", { value: parseInt(note[0][j], 10) }],
                             0,
                             0,
                             [thisBlock]

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -705,7 +705,7 @@ class RhythmRuler {
             if (event.keyCode === 13 || event.key === "Enter") {
                 event.preventDefault();
                 event.stopPropagation();
-                const inputValue = parseInt(this._dissectNumber.value);
+                const inputValue = parseInt(this._dissectNumber.value, 10);
                 if (!isNaN(inputValue) && inputValue > 0) {
                     // Validate the input value - allow any number from 2 to 128
                     const validatedValue = Math.min(Math.max(inputValue, 2), 128);

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -265,7 +265,7 @@ function SampleWidget() {
      * @returns {void}
      */
     this._useOctave = function (o) {
-        this.octaveCenter = parseInt(o);
+        this.octaveCenter = parseInt(o, 10);
     };
 
     /**
@@ -1398,7 +1398,7 @@ function SampleWidget() {
 
                 // Add event listener for slider changes
                 slider.oninput = () => {
-                    const value = parseInt(slider.value);
+                    const value = parseInt(slider.value, 10);
                     this.centAdjustmentValue = value;
                     valueDisplay.textContent = (value >= 0 ? "+" : "") + value + "¢";
                     this.applyCentAdjustment(value);


### PR DESCRIPTION
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
## Summary

Add an explicit radix parameter (`10`) to all remaining `parseInt` calls in the `js/` directory that were missing it.

This follows the pattern established by PR #7579, which added explicit radix values to `parseInt` calls in `blocks/` and `widgets/tempo.js`.

## Changes

- Updated all remaining `parseInt(...)` calls in `js/` to `parseInt(..., 10)`
- Applied the change consistently across 18 files
- Fixed approximately 80 instances

## Rationale

While modern JavaScript engines (ES5+) default `parseInt` to base 10 for standard numeric strings, providing an explicit radix is a long-standing best practice because it:

- Makes the intended base explicit
- Prevents legacy octal/hexadecimal interpretation edge cases
- Improves code readability and maintainability
- Aligns with common linting and style-guide recommendations

## Note for Reviewers

- No functional changes
- No behavior changes expected
- Refactor/style consistency improvement only

## Testing

- Existing test suite passes
- Change is mechanical and does not alter parsing logic