### PR TITLE
docs: fix broken Testing Guide link in test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_contribution.md
+++ b/.github/ISSUE_TEMPLATE/test_contribution.md
@@ -23,10 +23,10 @@ assignees: ""
 -   [ ] I have read and followed the project's code of conduct.
 -   [ ] I have checked that no existing tests cover this area.
 -   [ ] I have checked that there is no open PR for the tests I am submitting.
--   [ ] I have reviewed [docs/TESTING.md](docs/TESTING.md) for testing patterns.
+-   [ ] I have reviewed [Docs/TESTING.md](blob/master/Docs/TESTING.md) for testing patterns.
 
 ---
 
-📚 See [Testing Guide](docs/TESTING.md) for how to write block tests.
+📚 See [Testing Guide](blob/master/Docs/TESTING.md) for how to write block tests.
 
 🙋🏾🙋🏼 Questions: [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org).


### PR DESCRIPTION
## Summary

Fixes the broken Testing Guide link in the Test Contribution issue template.

The previous relative link did not resolve correctly when the template was rendered on GitHub, making it difficult for contributors to access the testing documentation.

## Changes

* Update the Testing Guide link in the Test Contribution issue template
* Point the link to the correct `Docs/TESTING.md` location on GitHub

## Testing

* Verified that the updated link opens the Testing Guide successfully from the rendered issue template

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation