### PR TITLE
fix: resolve PitchStaircase audio continuing after close and silence on reopen

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -33,52 +33,42 @@ global.SYNTHSVG = "<svg>SVGWIDTH XSCALE STOKEWIDTH</svg>";
 global.DEFAULTVOICE = "electronic synth";
 global.frequencyToPitch = jest.fn(f => ["A", "", 4]);
 global.base64Encode = jest.fn(s => s);
+global.PREVIEWVOLUME = 0.5;
+global.normalizeNoteAccidentals = jest.fn(n => n);
 
-global.window = {
-    innerWidth: 1200,
-    btoa: jest.fn(s => s),
-    widgetWindows: {
-        windowFor: jest.fn().mockReturnValue({
-            clear: jest.fn(),
-            show: jest.fn(),
-            addButton: jest.fn().mockReturnValue({ onclick: null }),
-            addInputButton: jest.fn().mockReturnValue({
-                value: "3",
-                addEventListener: jest.fn()
-            }),
-            getWidgetBody: jest.fn().mockReturnValue({
-                appendChild: jest.fn(),
-                append: jest.fn(),
+window.innerWidth = 1200;
+window.btoa = jest.fn(s => s);
+window.widgetWindows = {
+    windowFor: jest.fn().mockReturnValue({
+        clear: jest.fn(),
+        show: jest.fn(),
+        addButton: jest.fn().mockReturnValue({ onclick: null }),
+        addInputButton: jest.fn().mockReturnValue({
+            value: "3",
+            addEventListener: jest.fn()
+        }),
+        addDivider: jest.fn(),
+        getWidgetBody: jest.fn().mockReturnValue({
+            appendChild: jest.fn(),
+            append: jest.fn(),
+            style: {}
+        }),
+        sendToCenter: jest.fn(),
+        onclose: null,
+        onmaximize: null,
+        destroy: jest.fn()
+    })
+};
+
+if (typeof document !== "undefined") {
+    jest.spyOn(document, "getElementsByClassName").mockImplementation(() => {
+        return [
+            {
                 style: {}
-            }),
-            sendToCenter: jest.fn(),
-            onclose: null,
-            onmaximize: null,
-            destroy: jest.fn()
-        })
-    }
-};
-
-global.document = {
-    createElement: jest.fn(() => ({
-        style: {},
-        innerHTML: "",
-        appendChild: jest.fn(),
-        append: jest.fn(),
-        setAttribute: jest.fn(),
-        addEventListener: jest.fn(),
-        insertRow: jest.fn(() => ({
-            insertCell: jest.fn(() => ({
-                style: {},
-                innerHTML: "",
-                appendChild: jest.fn(),
-                setAttribute: jest.fn(),
-                addEventListener: jest.fn(),
-                className: ""
-            }))
-        }))
-    }))
-};
+            }
+        ];
+    });
+}
 
 describe("PitchStaircase Widget", () => {
     let psc;
@@ -275,6 +265,122 @@ describe("PitchStaircase Widget", () => {
             psc._makeStairs = jest.fn();
             psc._refresh();
             expect(psc._makeStairs).toHaveBeenCalledWith(true);
+        });
+    });
+
+    // --- init and close behavior Tests ---
+    describe("init and close behavior", () => {
+        let mockActivity;
+
+        beforeEach(() => {
+            mockActivity = {
+                logo: {
+                    synth: {
+                        setMasterVolume: jest.fn(),
+                        stop: jest.fn()
+                    }
+                },
+                textMsg: jest.fn(),
+                palettes: {
+                    dict: {}
+                }
+            };
+        });
+
+        test("should set master volume to PREVIEWVOLUME and clear/show widget window on init", () => {
+            psc.init(mockActivity);
+
+            expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalledWith(
+                global.PREVIEWVOLUME
+            );
+            expect(psc.closed).toBe(false);
+            expect(window.widgetWindows.windowFor).toHaveBeenCalledWith(
+                psc,
+                "pitch staircase",
+                "pitch staircase",
+                true
+            );
+        });
+
+        test("should stop synth, set closed to true, and restore master volume to PREVIEWVOLUME on close", () => {
+            psc.init(mockActivity);
+
+            const widgetWindow = window.widgetWindows.windowFor();
+            expect(widgetWindow.onclose).toBeDefined();
+
+            // Clear calls from init
+            mockActivity.logo.synth.setMasterVolume.mockClear();
+
+            widgetWindow.onclose();
+
+            expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
+            expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalledWith(
+                global.PREVIEWVOLUME
+            );
+            expect(psc.closed).toBe(true);
+            expect(widgetWindow.destroy).toHaveBeenCalled();
+        });
+    });
+
+    // --- _playNext closed guard Tests ---
+    describe("_playNext closed guard", () => {
+        test("should not trigger synth when closed is true inside _playNext setTimeout", () => {
+            jest.useFakeTimers();
+
+            // Set up stairs and stepTables so we don't throw TypeError when accessing them
+            psc.Stairs = [["A", "", 220.0]];
+            const mockCell = { classList: { add: jest.fn(), remove: jest.fn() } };
+            const mockRow = { cells: [null, mockCell] };
+            psc._stepTables = [{ rows: [mockRow] }];
+
+            psc.activity = {
+                logo: {
+                    synth: {
+                        trigger: jest.fn()
+                    }
+                }
+            };
+
+            // Call _playNext with index 0 and next 1
+            psc.closed = false;
+            psc._playNext(0, 1);
+
+            // Now close the widget before the timeout fires
+            psc.closed = true;
+
+            // Fast-forward time so the setTimeout callback runs
+            jest.advanceTimersByTime(1000);
+
+            // Assert trigger was not called
+            expect(psc.activity.logo.synth.trigger).not.toHaveBeenCalled();
+
+            jest.useRealTimers();
+        });
+
+        test("should trigger synth when closed is false inside _playNext setTimeout", () => {
+            jest.useFakeTimers();
+
+            psc.Stairs = [["A", "", 220.0]];
+            const mockCell = { classList: { add: jest.fn(), remove: jest.fn() } };
+            const mockRow = { cells: [null, mockCell] };
+            psc._stepTables = [{ rows: [mockRow] }];
+
+            psc.activity = {
+                logo: {
+                    synth: {
+                        trigger: jest.fn()
+                    }
+                }
+            };
+
+            psc.closed = false;
+            psc._playNext(0, 1);
+
+            jest.advanceTimersByTime(1000);
+
+            expect(psc.activity.logo.synth.trigger).toHaveBeenCalled();
+
+            jest.useRealTimers();
         });
     });
 });

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
-   normalizeNoteAccidentals
+   normalizeNoteAccidentals, PREVIEWVOLUME
  */
 
 /*
@@ -27,6 +27,8 @@
         _
     - js/utils/platformstyle.js
         platformColor
+    - js/logoconstants.js
+        PREVIEWVOLUME
 */
 /* exported PitchStaircase */
 
@@ -391,6 +393,7 @@ class PitchStaircase {
         const pscTableCell = previousRowNumber >= 0 ? this._stepTables[previousRowNumber] : null;
 
         setTimeout(() => {
+            if (this.closed) return;
             if (pscTableCell !== null && pscTableCell !== undefined) {
                 const stepCell = pscTableCell.rows[0].cells[1];
                 stepCell.classList.remove("active");
@@ -626,12 +629,14 @@ class PitchStaircase {
         widgetWindow.clear();
         widgetWindow.show();
         widgetWindow.onclose = () => {
-            this.activity.logo.synth.setMasterVolume(0);
             this.closed = true;
+            this.activity.logo.synth.stop();
+            this.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
             widgetWindow.destroy();
         };
 
         this.closed = false;
+        this.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
 
         widgetWindow.addButton("play-chord.svg", PitchStaircase.ICONSIZE, _("Play chord")).onclick =
             () => {


### PR DESCRIPTION
Related to #7515 #7550

**What**
Fixes audio continuing in the background after PitchStaircase widget is 
closed, and complete silence bug when the widget is reopened.

**Why**
`onclose` called `setMasterVolume(0)` to silence audio — but this 
permanently set the global master volume to 0 and never restored it. 
Reopening the widget produced complete silence. Already-queued `setTimeout` 
callbacks in `_playNext` also re-triggered notes after close.

**Changes**
`js/widgets/pitchstaircase.js`
- Added `PREVIEWVOLUME` to global declarations
- Call `synth.setMasterVolume(PREVIEWVOLUME)` in `init()` to restore volume on every open
- Replace `setMasterVolume(0)` in `onclose` with `synth.stop()` + `synth.setMasterVolume(PREVIEWVOLUME)`
- Added `if (this.closed) return` guard inside `setTimeout` callback in `_playNext`

**Testing**
- `npm run lint` → 0 errors
- `npm test` → 5636 tests, all pass
- Added `_playNext closed guard` suite in `pitchstaircase.test.js`

**Category**
- [x] Bug Fix
