### PR TITLE
fix: correct 5 double-accidental entries in FIXEDSOLFEGE1

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2195,7 +2195,7 @@ describe("calcOctave", () => {
         "ti"
     ];
     global.FIXEDSOLFEGE1 = {
-        "do𝄫": "B",
+        "do𝄫": "B" + FLAT,
         "do♭": "C" + FLAT,
         "do": "C",
         "do♯": "C" + SHARP,
@@ -2209,13 +2209,13 @@ describe("calcOctave", () => {
         "mi♭": "E" + FLAT,
         "mi": "E",
         "mi♯": "E" + SHARP,
-        "mi𝄪": "G",
+        "mi𝄪": "F" + SHARP,
         "fa𝄫": "E" + FLAT,
         "fa♭": "F" + FLAT,
         "fa": "F",
         "fa♯": "F" + SHARP,
-        "fa𝄪": "G" + SHARP,
-        "sol𝄫": "E",
+        "fa𝄪": "G",
+        "sol𝄫": "F",
         "sol♭": "G" + FLAT,
         "sol": "G",
         "sol♯": "G" + SHARP,
@@ -2229,7 +2229,7 @@ describe("calcOctave", () => {
         "ti♭": "B" + FLAT,
         "ti": "B",
         "ti♯": "B" + SHARP,
-        "ti𝄪": "C",
+        "ti𝄪": "C" + SHARP,
         "R": _("rest")
     };
 
@@ -2312,7 +2312,7 @@ describe("convertFromSolfege", () => {
     const SHARP = "♯";
     const FLAT = "♭";
     global.FIXEDSOLFEGE1 = {
-        "do𝄫": "B",
+        "do𝄫": "B" + FLAT,
         "do♭": "C" + FLAT,
         "do": "C",
         "do♯": "C" + SHARP,
@@ -2326,13 +2326,13 @@ describe("convertFromSolfege", () => {
         "mi♭": "E" + FLAT,
         "mi": "E",
         "mi♯": "E" + SHARP,
-        "mi𝄪": "G",
+        "mi𝄪": "F" + SHARP,
         "fa𝄫": "E" + FLAT,
         "fa♭": "F" + FLAT,
         "fa": "F",
         "fa♯": "F" + SHARP,
-        "fa𝄪": "G" + SHARP,
-        "sol𝄫": "E",
+        "fa𝄪": "G",
+        "sol𝄫": "F",
         "sol♭": "G" + FLAT,
         "sol": "G",
         "sol♯": "G" + SHARP,
@@ -2346,12 +2346,12 @@ describe("convertFromSolfege", () => {
         "ti♭": "B" + FLAT,
         "ti": "B",
         "ti♯": "B" + SHARP,
-        "ti𝄪": "C",
+        "ti𝄪": "C" + SHARP,
         "R": _("rest")
     };
     global.EQUIVALENTNATURALS = { "E♯": "F", "B♯": "C", "C♭": "B", "F♭": "E" };
     const testCases = [
-        { input: "do𝄫", expected: "B" },
+        { input: "do𝄫", expected: "B" + FLAT },
         { input: "do♭", expected: "B" },
         { input: "do♯", expected: "C♯" },
         { input: "re♯", expected: "D♯" },

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -640,7 +640,7 @@ const FIXEDSOLFEGE = {
  * @constant {Object.<string, string>}
  */
 const FIXEDSOLFEGE1 = {
-    "do𝄫": "B",
+    "do𝄫": "B" + FLAT,
     "do♭": "C" + FLAT,
     "do": "C",
     "do♯": "C" + SHARP,
@@ -654,13 +654,13 @@ const FIXEDSOLFEGE1 = {
     "mi♭": "E" + FLAT,
     "mi": "E",
     "mi♯": "E" + SHARP,
-    "mi𝄪": "G",
+    "mi𝄪": "F" + SHARP,
     "fa𝄫": "E" + FLAT,
     "fa♭": "F" + FLAT,
     "fa": "F",
     "fa♯": "F" + SHARP,
-    "fa𝄪": "G" + SHARP,
-    "sol𝄫": "E",
+    "fa𝄪": "G",
+    "sol𝄫": "F",
     "sol♭": "G" + FLAT,
     "sol": "G",
     "sol♯": "G" + SHARP,
@@ -674,7 +674,7 @@ const FIXEDSOLFEGE1 = {
     "ti♭": "B" + FLAT,
     "ti": "B",
     "ti♯": "B" + SHARP,
-    "ti𝄪": "C",
+    "ti𝄪": "C" + SHARP,
     "R": _("rest")
 };
 


### PR DESCRIPTION
- [x] Bug Fix
- [x] Feature
- [ ] Performance
- [x] Tests
- [x] Documentation
- [ ] CI/CD
## Summary

Fix five incorrect double-accidental mappings in `FIXEDSOLFEGE1`.

The following entries were off by one semitone:

| Solfege | Previous | Correct |
|----------|----------|----------|
| do𝄫 | B | B♭ |
| mi𝄪 | G | F♯ |
| fa𝄪 | G♯ | G |
| sol𝄫 | E | F |
| ti𝄪 | C | C♯ |

The remaining double-accidental mappings were verified and required no changes.

## Testing

- Updated `musicutils.test.js` mirror tables (both copies)
- Updated `convertFromSolfege` test expectation for `do𝄫`
- All tests passing (`394/394`)

## Impact

This fixes incorrect pitch conversion when double-accidental solfege is processed through:

- `pitchToNumber`
- `calcOctave`
- `convertFromSolfege`
- Music keyboard note generation

Previously these inputs could produce an audible note one semitone away from the intended pitch.

### Reviewer Notes

* This PR only corrects five incorrect double-accidental mappings in the `FIXEDSOLFEGE1` lookup table.
* No conversion logic, APIs, UI components, or data structures were modified.
* The change is isolated and does not conflict with any ongoing mentorship projects or active feature-development work.
* Existing test coverage was updated to match the corrected mappings.
* All tests pass (`394/394`).
* The remaining double-accidental entries were manually verified and found to be correct.
* This fix addresses an audible correctness issue where certain double-accidental solfege inputs could be converted to notes one semitone away from the intended pitch.
