### PR TITLE
fix: correct convertFactor typo 0.675 to 0.625 for 5/8

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2384,7 +2384,7 @@ describe("convertFactor", () => {
         { input: 0.4375, expected: "4.." },
         { input: 0.5, expected: "2" },
         { input: 0.5625, expected: "2 16" },
-        { input: 0.675, expected: "2 8" },
+        { input: 0.625, expected: "2 8" },
         { input: 0.6875, expected: "2 8 16" },
         { input: 0.75, expected: "2." },
         { input: 0.8125, expected: "2 4 16" },

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6731,7 +6731,7 @@ const convertFactor = factor => {
             return "2";
         case 0.5625: // 9/16
             return "2 16";
-        case 0.675: // 5/8
+        case 0.625: // 5/8
             return "2 8";
         case 0.6875: // 11/16
             return "2 8 16";


### PR DESCRIPTION
## Labels

- [x] Bug fix
- [ ] New feature
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Refactoring

## Reviewer Notes

- Corrects an incorrect `5/8` subdivision value (`0.675` → `0.625`).
- The previous value corresponded to `27/40`, not a valid `5/8` musical subdivision.
- Updated the corresponding test mirror.
- No APIs, UI components, or data structures were modified.
- Does not conflict with ongoing mentorship projects or active feature-development work.
- All tests pass.