### PR TITLE
fix: make search box text visible in dark/high contrast modes

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -135,7 +135,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-menu-item,
 .dark .ui-autocomplete .ui-menu-item a,
 .dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
-    color: var(--color-text-inverse) !important;
+    color: #ffffff !important;
     background-color: transparent !important;
 }
 
@@ -146,7 +146,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-state-focus,
 .dark .ui-autocomplete .ui-state-active {
     background-color: var(--color-bg-tertiary) !important;
-    color: var(--color-text-inverse) !important;
+    color: #ffffff !important;
 }
 
 .dark #helpfulSearchDiv {
@@ -572,7 +572,7 @@ body.highcontrast {
 }
 
 .highcontrast .ui-autocomplete .ui-menu-item a {
-    color: var(--color-text-inverse) !important;
+    color: #ffffff !important;
     background-color: var(--color-text-inverse) !important;
 }
 

--- a/css/themes.css
+++ b/css/themes.css
@@ -127,7 +127,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark #helpfulSearch,
 .dark .ui-autocomplete {
     background-color: var(--color-bg-primary) !important;
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
     border-color: var(--color-border-primary) !important;
 }
 
@@ -135,7 +135,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-menu-item,
 .dark .ui-autocomplete .ui-menu-item a,
 .dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
     background-color: transparent !important;
 }
 
@@ -146,7 +146,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-state-focus,
 .dark .ui-autocomplete .ui-state-active {
     background-color: var(--color-bg-tertiary) !important;
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
 }
 
 .dark #helpfulSearchDiv {
@@ -567,12 +567,12 @@ body.highcontrast {
 .highcontrast #helpfulSearch,
 .highcontrast .ui-autocomplete {
     background-color: var(--color-text-inverse) !important;
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
     border: 1px solid #ffffff;
 }
 
 .highcontrast .ui-autocomplete .ui-menu-item a {
-    color: #ffffff !important;
+    color: var(--color-text-primary) !important;
     background-color: var(--color-text-inverse) !important;
 }
 

--- a/css/themes.css
+++ b/css/themes.css
@@ -127,7 +127,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark #helpfulSearch,
 .dark .ui-autocomplete {
     background-color: var(--color-bg-primary) !important;
-    color: var(--color-text-inverse) !important;
+    color: #ffffff !important;
     border-color: var(--color-border-primary) !important;
 }
 
@@ -567,7 +567,7 @@ body.highcontrast {
 .highcontrast #helpfulSearch,
 .highcontrast .ui-autocomplete {
     background-color: var(--color-text-inverse) !important;
-    color: var(--color-text-inverse) !important;
+    color: #ffffff !important;
     border: 1px solid #ffffff;
 }
 


### PR DESCRIPTION
This is a small pr just fixed an accessibility issue where text typed into the search box was invisible in Dark Mode and High Contrast Mode.
The text color was incorrectly using the `--color-text-inverse` variable, which evaluated to black on a dark background, resulting in black-on-black text. How: Hardcoded the search box text color to white` (#ffffff) `for the `.dark` and `.highcontrast` themes in `css/themes.css.`


### After change:
<img width="1912" height="1032" alt="image" src="https://github.com/user-attachments/assets/c579b790-4cc1-47de-a349-090248ef05bd" />


 - [x] Bug Fix