### PR TITLE
feat: add IndexedDB storage layer infrastructure (PR 1)

### DIFF
--- a/js/utils/__tests__/storage.test.js
+++ b/js/utils/__tests__/storage.test.js
@@ -1,0 +1,236 @@
+const IndexedDBWrapper = require("../storage");
+require("fake-indexeddb/auto");
+
+// Polyfill structuredClone for JSDOM
+if (typeof global.structuredClone === "undefined") {
+    global.structuredClone = val =>
+        val === undefined ? undefined : JSON.parse(JSON.stringify(val));
+}
+
+describe("IndexedDBWrapper", () => {
+    let storageWrapper;
+    let mockLocalStorage;
+    let mockBroadcastChannelPostMessage;
+    let originalURLSearchParams;
+
+    beforeEach(() => {
+        originalURLSearchParams = global.URLSearchParams;
+
+        global.navigator = global.navigator || {};
+        global.navigator.storage = { persist: jest.fn().mockResolvedValue(true) };
+
+        // Mock localStorage properly in JSDOM
+        mockLocalStorage = {};
+        const localStorageMock = {
+            getItem: jest.fn(key =>
+                mockLocalStorage[key] !== undefined ? mockLocalStorage[key] : null
+            ),
+            setItem: jest.fn((key, value) => {
+                mockLocalStorage[key] = String(value);
+            }),
+            removeItem: jest.fn(key => {
+                delete mockLocalStorage[key];
+            }),
+            clear: jest.fn(() => {
+                mockLocalStorage = {};
+            }),
+            key: jest.fn(i => Object.keys(mockLocalStorage)[i]),
+            get length() {
+                return Object.keys(mockLocalStorage).length;
+            }
+        };
+        Object.defineProperty(window, "localStorage", {
+            value: localStorageMock,
+            writable: true
+        });
+        // Also map it to global for the tests
+        global.localStorage = window.localStorage;
+
+        // Mock BroadcastChannel
+        mockBroadcastChannelPostMessage = jest.fn();
+        global.BroadcastChannel = class {
+            constructor(name) {
+                this.name = name;
+                this.postMessage = mockBroadcastChannelPostMessage;
+            }
+        };
+
+        storageWrapper = new IndexedDBWrapper();
+    });
+
+    afterEach(async () => {
+        global.URLSearchParams = originalURLSearchParams;
+        // Close DB connections to avoid deleteDatabase deadlock
+        if (storageWrapper && storageWrapper.db) {
+            storageWrapper.db.close();
+        }
+        // Clean up the fake DB so tests don't leak state
+        await new Promise(resolve => {
+            const req = window.indexedDB.deleteDatabase("MusicBlocksDB");
+            req.onsuccess = resolve;
+            req.onerror = resolve;
+            req.onblocked = resolve;
+        });
+    });
+
+    test("migrates from localStorage to IndexedDB on first init", async () => {
+        global.localStorage.setItem("themePreference", "dark");
+        global.localStorage.setItem("beginnerMode", "false");
+
+        await storageWrapper.init();
+
+        // Check if cache populated correctly via Proxy
+        expect(storageWrapper.proxy.themePreference).toBe("dark");
+        expect(storageWrapper.proxy.beginnerMode).toBe("false");
+
+        // Verify data was actually saved to IDB
+        const idbVal = await storageWrapper.getItem("themePreference");
+        expect(idbVal).toBe("dark");
+
+        // Verify migration_v1_complete flag was set in IDB
+        const flagVal = await storageWrapper.getItem("migration_v1_complete");
+        expect(flagVal).toBe(true);
+    });
+
+    test("skips migration if migration_v1_complete flag is present", async () => {
+        // First setup IDB with flag
+        await storageWrapper.init();
+
+        // Put a stale value in localStorage
+        global.localStorage.setItem("themePreference", "stale_light");
+
+        // Re-init with new wrapper instance (simulating a fresh boot)
+        const newWrapper = new IndexedDBWrapper();
+        await newWrapper.init();
+
+        // Should NOT have migrated the stale value
+        expect(newWrapper.proxy.themePreference).toBeUndefined();
+
+        // Clean up connection
+        if (newWrapper.db) {
+            newWrapper.db.close();
+        }
+    });
+
+    test("does not cache heavy keys on startup", async () => {
+        global.localStorage.setItem("themePreference", "dark");
+        global.localStorage.setItem("SESSION123", "massive_data");
+        global.localStorage.setItem("localStorage:plugins", "massive_plugins");
+
+        await storageWrapper.init();
+
+        // Lightweight key should be cached and accessible synchronously via proxy
+        expect(storageWrapper.proxy.themePreference).toBe("dark");
+
+        // Heavy keys should NOT be in cache
+        expect(storageWrapper.proxy["SESSION123"]).toBeUndefined();
+        expect(storageWrapper.proxy["localStorage:plugins"]).toBeUndefined();
+
+        // But they SHOULD be in IndexedDB (can be accessed asynchronously)
+        expect(await storageWrapper.getItem("SESSION123")).toBe("massive_data");
+        expect(await storageWrapper.getItem("localStorage:plugins")).toBe("massive_plugins");
+    });
+
+    test("proxy set operation updates cache and triggers async write", async () => {
+        await storageWrapper.init();
+
+        // Write via proxy
+        storageWrapper.proxy.newPref = "testValue";
+
+        // Cache should be updated immediately
+        expect(storageWrapper.proxy.newPref).toBe("testValue");
+
+        // Allow async writes to flush
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // IndexedDB should be updated
+        expect(await storageWrapper.getItem("newPref")).toBe("testValue");
+
+        // BroadcastChannel should have been notified
+        expect(mockBroadcastChannelPostMessage).toHaveBeenCalledWith({
+            action: "set",
+            key: "newPref",
+            value: "testValue"
+        });
+    });
+
+    test("proxy delete operation updates cache and triggers async remove", async () => {
+        await storageWrapper.init();
+        storageWrapper.proxy.toBeDeleted = "value";
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Delete via proxy
+        delete storageWrapper.proxy.toBeDeleted;
+
+        // Cache should be empty
+        expect(storageWrapper.proxy.toBeDeleted).toBeUndefined();
+
+        // Allow async writes to flush
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // IndexedDB should be empty for this key
+        expect(await storageWrapper.getItem("toBeDeleted")).toBeUndefined();
+
+        // BroadcastChannel should have been notified
+        expect(mockBroadcastChannelPostMessage).toHaveBeenCalledWith({
+            action: "remove",
+            key: "toBeDeleted",
+            value: undefined
+        });
+    });
+
+    test("clear empties cache and IndexedDB, broadcasts clear", async () => {
+        await storageWrapper.init();
+        storageWrapper.proxy.item1 = "1";
+        storageWrapper.proxy.item2 = "2";
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        await storageWrapper.clear();
+
+        expect(storageWrapper.proxy.item1).toBeUndefined();
+        expect(await storageWrapper.getItem("item2")).toBeUndefined();
+
+        expect(mockBroadcastChannelPostMessage).toHaveBeenCalledWith({
+            action: "clear",
+            key: undefined,
+            value: undefined
+        });
+    });
+
+    test("broadcast events update local cache", async () => {
+        await storageWrapper.init();
+
+        // Simulate receiving a broadcast from another tab
+        storageWrapper._handleBroadcast({
+            data: { action: "set", key: "crossTabKey", value: "synced!" }
+        });
+
+        // Proxy should immediately reflect the change
+        expect(storageWrapper.proxy.crossTabKey).toBe("synced!");
+
+        storageWrapper._handleBroadcast({
+            data: { action: "remove", key: "crossTabKey" }
+        });
+
+        expect(storageWrapper.proxy.crossTabKey).toBeUndefined();
+    });
+
+    test("falls back to localStorage if disableIndexedDB=true URL param is present", async () => {
+        // Mock URLSearchParams to return our custom param
+        global.URLSearchParams = jest.fn(() => ({
+            get: key => (key === "disableIndexedDB" ? "true" : null)
+        }));
+
+        const fallbackWrapper = new IndexedDBWrapper();
+        global.localStorage.setItem("fallbackKey", "fallbackValue");
+
+        await fallbackWrapper.init();
+
+        expect(fallbackWrapper.isFallback).toBe(true);
+        expect(fallbackWrapper.proxy.fallbackKey).toBe("fallbackValue");
+
+        // Proxy writes should go directly to localStorage
+        fallbackWrapper.proxy.newFallbackKey = "test";
+        expect(global.localStorage.setItem).toHaveBeenCalledWith("newFallbackKey", "test");
+    });
+});

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,0 +1,334 @@
+// Copyright (c) 2024 Yash Khandelwal
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+
+/* global ErrorHandler */
+
+class IndexedDBWrapper {
+    constructor() {
+        this.dbName = "MusicBlocksDB";
+        this.dbVersion = 1;
+        this.storeName = "keyval";
+        this.db = null;
+        this._cache = {};
+        this._channel = null;
+        this.isFallback = false;
+
+        // Ensure we handle private browsing restrictions gracefully
+        if (typeof BroadcastChannel !== "undefined") {
+            try {
+                this._channel = new BroadcastChannel("musicblocks_storage_sync");
+                this._channel.onmessage = this._handleBroadcast.bind(this);
+            } catch (e) {
+                console.warn("BroadcastChannel restricted", e);
+            }
+        }
+
+        // The proxy allows synchronous access to preferences (this.storage.themePreference)
+        // while routing methods to the wrapper and writes to IndexedDB
+        this.proxy = new Proxy(this, {
+            get: (target, prop) => {
+                if (prop in target) {
+                    if (typeof target[prop] === "function") {
+                        return target[prop].bind(target);
+                    }
+                    return target[prop];
+                }
+                return target._cache[prop];
+            },
+            set: (target, prop, value) => {
+                // Prevent overriding internal class properties
+                if (prop in target && typeof target[prop] !== "undefined") {
+                    target[prop] = value;
+                    return true;
+                }
+
+                target._cache[prop] = value;
+                // Fire async write, swallow unhandled rejections to prevent crashing
+                target.setItem(prop, value).catch(e => {
+                    console.error("Async write failed for", prop, e);
+                });
+                return true;
+            },
+            deleteProperty: (target, prop) => {
+                delete target._cache[prop];
+                target.removeItem(prop).catch(e => {
+                    console.error("Async remove failed for", prop, e);
+                });
+                return true;
+            }
+        });
+    }
+
+    _handleBroadcast(event) {
+        if (!event.data) return;
+        const { action, key, value } = event.data;
+        if (action === "set") {
+            this._cache[key] = value;
+        } else if (action === "remove") {
+            delete this._cache[key];
+        } else if (action === "clear") {
+            this._cache = {};
+        }
+    }
+
+    _broadcast(action, key, value) {
+        if (this._channel) {
+            this._channel.postMessage({ action, key, value });
+        }
+    }
+
+    async init() {
+        // Feature flag / fallback override
+        let urlParams = null;
+        try {
+            urlParams = new URLSearchParams(window.location.search);
+        } catch (e) {
+            // Ignore URL parsing errors
+        }
+
+        const disableIndexedDB =
+            (urlParams && urlParams.get("disableIndexedDB") === "true") ||
+            (typeof localStorage !== "undefined" &&
+                localStorage.getItem("disableIndexedDB") === "true");
+
+        if (disableIndexedDB || !window.indexedDB) {
+            this.isFallback = true;
+            this._loadFallbackCache();
+            return;
+        }
+
+        if (navigator.storage && navigator.storage.persist) {
+            try {
+                await navigator.storage.persist();
+            } catch (e) {
+                console.warn("Storage persistence denied", e);
+            }
+        }
+
+        return new Promise((resolve, reject) => {
+            const request = window.indexedDB.open(this.dbName, this.dbVersion);
+
+            request.onerror = event => {
+                console.error("IndexedDB blocked/failed. Falling back.", event);
+                this.isFallback = true;
+                this._loadFallbackCache();
+                resolve(); // Resolve anyway so app can boot
+            };
+
+            request.onupgradeneeded = event => {
+                const db = event.target.result;
+                if (event.oldVersion < 1) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+
+            request.onsuccess = async event => {
+                this.db = event.target.result;
+
+                try {
+                    await this._migrateAndPopulateCache();
+                } catch (e) {
+                    console.error("Migration/Cache population failed", e);
+                    if (typeof ErrorHandler !== "undefined") {
+                        ErrorHandler.recoverable(e, { operation: "indexeddb_init" });
+                    }
+                }
+
+                resolve();
+            };
+        });
+    }
+
+    _loadFallbackCache() {
+        if (typeof localStorage !== "undefined") {
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                this._cache[key] = localStorage.getItem(key);
+            }
+        }
+    }
+
+    _isHeavyKey(key) {
+        return (
+            key.startsWith("SESSION") ||
+            key === "macros" ||
+            key === "localStorage:plugins" ||
+            key === "custommode"
+        );
+    }
+
+    async _migrateAndPopulateCache() {
+        return new Promise((resolve, reject) => {
+            const transaction = this.db.transaction([this.storeName], "readwrite");
+            const store = transaction.objectStore(this.storeName);
+
+            let migrationNeeded = true;
+
+            const getFlagRequest = store.get("migration_v1_complete");
+
+            getFlagRequest.onsuccess = () => {
+                if (getFlagRequest.result === true) {
+                    migrationNeeded = false;
+                }
+
+                if (migrationNeeded && typeof localStorage !== "undefined") {
+                    try {
+                        for (let i = 0; i < localStorage.length; i++) {
+                            const key = localStorage.key(i);
+                            if (key !== "disableIndexedDB") {
+                                const val = localStorage.getItem(key);
+                                store.put(val, key);
+                            }
+                        }
+                        store.put(true, "migration_v1_complete");
+                    } catch (err) {
+                        console.error("Migration crash:", err);
+                    }
+                }
+
+                const cursorRequest = store.openCursor();
+                cursorRequest.onsuccess = e => {
+                    const cursor = e.target.result;
+                    if (cursor) {
+                        if (!this._isHeavyKey(cursor.key)) {
+                            this._cache[cursor.key] = cursor.value;
+                        }
+                        cursor.continue();
+                    }
+                };
+                cursorRequest.onerror = e => {
+                    console.error("Cursor error", e);
+                };
+            };
+            getFlagRequest.onerror = e => {
+                console.error("getFlagRequest error", e);
+            };
+
+            transaction.oncomplete = () => {
+                resolve();
+            };
+
+            transaction.onerror = e => {
+                console.error("Transaction error", e.target.error);
+                reject(e.target.error);
+            };
+        });
+    }
+
+    async getItem(key) {
+        // Fast path for lightweight keys that are already cached
+        if (key in this._cache) {
+            return this._cache[key];
+        }
+
+        if (this.isFallback) {
+            return typeof localStorage !== "undefined" ? localStorage.getItem(key) : undefined;
+        }
+
+        return new Promise((resolve, reject) => {
+            if (!this.db) return resolve(undefined);
+
+            const transaction = this.db.transaction([this.storeName], "readonly");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(key);
+
+            request.onsuccess = () => {
+                resolve(request.result);
+            };
+
+            request.onerror = e => {
+                console.error("IndexedDB getItem failed", e);
+                resolve(undefined);
+            };
+        });
+    }
+
+    async setItem(key, value) {
+        if (!this._isHeavyKey(key)) {
+            this._cache[key] = value;
+        }
+
+        this._broadcast("set", key, value);
+
+        if (this.isFallback) {
+            if (typeof localStorage !== "undefined") {
+                localStorage.setItem(key, value);
+            }
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            if (!this.db) return resolve();
+
+            const transaction = this.db.transaction([this.storeName], "readwrite");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.put(value, key);
+
+            request.onsuccess = () => resolve();
+            request.onerror = e => {
+                console.error("IndexedDB setItem failed", e);
+                reject(e.target.error);
+            };
+        });
+    }
+
+    async removeItem(key) {
+        delete this._cache[key];
+        this._broadcast("remove", key);
+
+        if (this.isFallback) {
+            if (typeof localStorage !== "undefined") {
+                localStorage.removeItem(key);
+            }
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            if (!this.db) return resolve();
+
+            const transaction = this.db.transaction([this.storeName], "readwrite");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.delete(key);
+
+            request.onsuccess = () => resolve();
+            request.onerror = e => {
+                console.error("IndexedDB removeItem failed", e);
+                reject(e.target.error);
+            };
+        });
+    }
+
+    async clear() {
+        this._cache = {};
+        this._broadcast("clear");
+
+        if (this.isFallback) {
+            if (typeof localStorage !== "undefined") {
+                localStorage.clear();
+            }
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            if (!this.db) return resolve();
+
+            const transaction = this.db.transaction([this.storeName], "readwrite");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.clear();
+
+            request.onsuccess = () => resolve();
+            request.onerror = e => {
+                console.error("IndexedDB clear failed", e);
+                reject(e.target.error);
+            };
+        });
+    }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = IndexedDBWrapper;
+}


### PR DESCRIPTION

MusicBlocks currently relies on `localStorage` for persisting user settings and session data. However, browsers enforce a strict 5MB limit on `localStorage`. When users accumulate large amounts of playground data, they hit this quota.

### What this PR1 covers
This is the first of two PRs to migrate our storage layer from `localStorage` to `IndexedDB` to completely bypass the browser limits. This PR focuses *exclusively* on the underlying infrastructure and contains no integration into the active codebase.
* **`IndexedDBWrapper` Class (`js/utils/storage.js`)**: A new storage adapter that mimics the synchronous nature of `localStorage` while backing data asynchronously into IndexedDB.
* **Atomic Migration**: Built-in logic to safely and atomically migrate all existing user data from `localStorage` to `IndexedDB` on the very first boot.
* **Synchronous Proxy**: Uses a JavaScript `Proxy` to cache lightweight keys (like user preferences) so they can still be read/written synchronously by the rest of the app, preventing massive refactors.
* **Heavy Payload Handling**: Bypasses the synchronous cache for massive data blobs (like `SESSION` data), handling them purely asynchronously to preserve RAM and prevent UI thread blocking.
* **Cross-Tab Syncing**: Implements `BroadcastChannel` so that storage updates in one tab instantly propagate to the in-memory caches of other open tabs.
* **Comprehensive Test Suite (`js/utils/__tests__/storage.test.js`)**: Fully passing Jest tests covering migration logic, proxy behavior, fallback behavior, and cross-tab syncing.

**What the next PR will cover (PR 2 - Integration)**
The follow-up PR will wire it into the actual application workflow:
1. **`loader.js` Integration**: Halting the boot sequence to `await` the initialization and migration of the `IndexedDBWrapper`.
2. **`activity.js` Refactor**: Swapping `this.storage` to use the new wrapper, and refactoring the synchronous reads/writes of heavy `SESSION` objects to use `async/await`.
3. **End-to-End Verification**: Fixing the language switcher bug and verifying it correctly handles massive playground sessions without hitting quota errors.


- [x] Feature