### PR TITLE
fix: correct major blues scale interval sum to 12 semitones

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1643,7 +1643,7 @@ const PITCH_COLLECTIONS = {
     },
     6: {
         "minor blues": [3, 2, 1, 1, 3, 2],
-        "major blues": [2, 1, 1, 3, 2, 2],
+        "major blues": [2, 1, 1, 3, 2, 3],
         "whole tone": [2, 2, 2, 2, 2, 2]
     },
     5: {


### PR DESCRIPTION
## PR Category

- [x] Documentation
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] CI/CD

## Summary

Fixes an incorrect interval definition in `PITCH_COLLECTIONS` that caused the scale to span only 11 semitones instead of a complete octave.

## Problem

The final interval in the scale was defined as `2` semitones:

```js
[2,1,1,3,2,2]
```

However, the interval from A (pitch class 9) to the octave C (pitch class 12) is **3 semitones**, not 2.

As a result:

* The intervals summed to **11 semitones** instead of 12.
* Scale generation terminated on **B** rather than returning to the octave **C**.
* This made the scale internally inconsistent with the expected pitch collection definition.

## Fix

Updated the final interval from `2` to `3` semitones so the scale correctly spans a full octave.

Before:

```js
[2,1,1,3,2,2] // total = 11
```

After:

```js
[2,1,1,3,2,3] // total = 12
```

## Impact

* Restores correct octave completion.
* Ensures generated notes match the intended scale structure.
* Aligns this pitch collection with all other entries in `PITCH_COLLECTIONS`, which correctly sum to 12 semitones.

## Note for Reviewers

This is a data-correction change only. No logic was modified.

The issue can be verified by summing the interval sequence and observing that the previous definition produced an 11-semitone span, whereas all other scale definitions in `PITCH_COLLECTIONS` represent a complete 12-semitone octave.
