### PR TITLE
fix: resolve synth initialization bug

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -484,8 +484,51 @@ class Logo {
      * @returns {void}
      */
     prepSynths() {
-        // Guard: Skip if synths already initialized
         if (this._synthsInitialized) {
+            // Ensure any newly added turtles (e.g., companion turtles) are
+            // initialized without disrupting existing turtles' runtime state.
+            for (const turtle in this.activity.turtles.turtleList) {
+                if (turtle in this.deps.instruments) {
+                    continue;
+                }
+
+                const tur = this.activity.turtles.ithTurtle(turtle);
+                this.deps.instruments[turtle] = {};
+                this.deps.instrumentsFilters[turtle] = {};
+                this.deps.instrumentsEffects[turtle] = {};
+
+                if (!(DEFAULTVOICE in this.deps.instruments[turtle])) {
+                    this.synth.createDefaultSynth(turtle);
+                }
+
+                for (const instrumentName in this.deps.instruments[0]) {
+                    if (!(instrumentName in this.deps.instruments[turtle])) {
+                        this.synth.loadSynth(turtle, instrumentName);
+
+                        if (instrumentName in this.deps.instrumentsFilters[0]) {
+                            this.deps.instrumentsFilters[turtle][instrumentName] =
+                                this.deps.instrumentsFilters[0][instrumentName];
+                        }
+
+                        if (instrumentName in this.deps.instrumentsEffects[0]) {
+                            this.deps.instrumentsEffects[turtle][instrumentName] =
+                                this.deps.instrumentsEffects[0][instrumentName];
+                        }
+                    }
+                }
+
+                tur.singer.synthVolume = {
+                    "electronic synth": [DEFAULTVOLUME],
+                    "noise1": [DEFAULTVOLUME],
+                    "noise2": [DEFAULTVOLUME],
+                    "noise3": [DEFAULTVOLUME]
+                };
+                tur.singer.synthVolume[DEFAULTVOICE] = [DEFAULTVOLUME];
+
+                for (const synth in tur.singer.synthVolume) {
+                    this.deps.Singer.setSynthVolume(this, turtle, synth, DEFAULTVOLUME);
+                }
+            }
             return;
         }
         this.synth.newTone();
@@ -1149,7 +1192,7 @@ class Logo {
         // and Web Audio nodes. They will be re-created by prepSynths()
         // on the next run.
         this.synth.disposeAllInstruments();
-        this._synthsInitialized = false; // Reset so synths are recreated on next run
+        this._synthsInitialized = false;
 
         // eslint-disable-next-line eqeqeq
         if (this.cameraID != null) {


### PR DESCRIPTION
## PR Category

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [ ] Performance


## Summary

Fixes #7641 by ensuring turtles created during execution are fully initialized even after synth initialization has already completed.

Previously, companion turtles created at runtime (e.g. via `MeterActions.onEveryBeatDo`) could be missing their `instrumentsEffects[turtle]` entry, resulting in:

```text
Cannot use 'in' operator to search for 'guitar' in undefined
```

at `turtle-singer.js:1409`.

## Root Cause

PR #7617 introduced a `_synthsInitialized` guard in `prepSynths()` to avoid reinitializing synths on subsequent calls. Once initialization completed, the guard returned immediately.

As a result, turtles created later during execution never received initialization for `instruments`, `instrumentsFilters`, `instrumentsEffects`, `synthVolume`, or their default synths. `MeterActions.onEveryBeatDo` is the execution path that creates these companion turtles and subsequently calls `prepSynths()`, exposing the issue.

## Fix

Instead of returning immediately when `_synthsInitialized` is `true`, `prepSynths()` now performs a lightweight pass over `turtleList` and initializes only turtles that do not already have entries.

For each newly created turtle, the following are initialized:

* `instruments[turtle]`
* `instrumentsFilters[turtle]`
* `instrumentsEffects[turtle]`
* `synthVolume`
* Default and previously loaded synths

Existing turtles are skipped if they have already been initialized, preserving the performance optimization introduced in #7617 while correctly handling turtles created during execution.

Additionally, a redundant inline comment was removed.

## Verification

* [X] `npm run lint`
* [X] `npx prettier --check js/logo.js`
* [X] All 168 test suites passed (5655 tests, 0 failures)
