### PR TITLE
Fix local storage bug on Reflection API error

### DIFF
--- a/js/widgets/__tests__/reflection.test.js
+++ b/js/widgets/__tests__/reflection.test.js
@@ -450,6 +450,14 @@ describe("ReflectionMatrix", () => {
             expect(reflection.saveReport).toHaveBeenCalledWith({ response: "Analysis body" });
         });
 
+        test("generateAnalysis catches errors", async () => {
+            global.fetch.mockRejectedValue(new Error("Net Error"));
+
+            const data = await reflection.generateAnalysis();
+
+            expect(data).toEqual({ error: "Failed to send message" });
+        });
+
         test("sendMessage skips if input is empty", () => {
             reflection.input.value = "   ";
             reflection.sendMessage();

--- a/js/widgets/__tests__/reflection.test.js
+++ b/js/widgets/__tests__/reflection.test.js
@@ -451,11 +451,15 @@ describe("ReflectionMatrix", () => {
         });
 
         test("generateAnalysis catches errors", async () => {
+            const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
             global.fetch.mockRejectedValue(new Error("Net Error"));
 
             const data = await reflection.generateAnalysis();
 
             expect(data).toEqual({ error: "Failed to send message" });
+            expect(consoleSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
         });
 
         test("sendMessage skips if input is empty", () => {

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -567,8 +567,10 @@ class ReflectionMatrix {
         this.hideTypingIndicator();
         if (data) {
             this.botReplyDiv(data, false, true);
+            if (!data.error) {
+                await this.saveReport(data);
+            }
         }
-        await this.saveReport(data);
     }
 
     /**

--- a/js/widgets/reflection.js
+++ b/js/widgets/reflection.js
@@ -567,6 +567,9 @@ class ReflectionMatrix {
         this.hideTypingIndicator();
         if (data) {
             this.botReplyDiv(data, false, true);
+            // Expected errors in data.error:
+            // 1. Server-side errors returned by the API (e.g., 500s or rate limits).
+            // 2. Network failures caught by generateAnalysis().
             if (!data.error) {
                 await this.saveReport(data);
             }


### PR DESCRIPTION
### Summary
This PR fixes a bug where network failures during `generateAnalysis` would inadvertently corrupt the user's local storage, and introduces unit test coverage to ensure the API's error-handling contract is maintained.

### What Changed
1. **Unit Test (`reflection.test.js`)**: Added a test specifically simulating a rejected `fetch` promise during `generateAnalysis`. It asserts that the application gracefully catches the exception and returns the correct fallback object `{ error: "Failed to send message" }`.
2. **Test Polish**: Mocked `console.error` during the new unit test to suppress the expected error log and keep the test suite's terminal output clean.

- [x] Bug Fix