### PR TITLE
Add unit tests for inactivity tracking and auto-saving

### DIFF
--- a/js/activity/__tests__/idle-watcher.test.js
+++ b/js/activity/__tests__/idle-watcher.test.js
@@ -56,6 +56,7 @@ describe("setupActivityIdleWatcher", () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
         jest.useRealTimers();
         delete global.createjs;
         delete global.debugLog;
@@ -163,6 +164,57 @@ describe("setupActivityIdleWatcher", () => {
             expect(mockActivity.isAppIdle).toBe(false);
             expect(global.createjs.Ticker.framerate).toBe(60);
             expect(mockActivity.stageDirty).toBe(true);
+        });
+
+        it("does not accumulate listeners or intervals when called twice", () => {
+            setupActivityIdleWatcher(mockActivity);
+            mockActivity._initIdleWatcher();
+
+            const firstListenerCount = mockActivity.addEventListener.mock.calls.length;
+            const firstInterval = mockActivity._idleWatcherInterval;
+
+            const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+            // Call _initIdleWatcher again (double init)
+            mockActivity._initIdleWatcher();
+
+            // The old interval should have been cleared by _stopIdleWatcher
+            expect(clearIntervalSpy).toHaveBeenCalledWith(firstInterval);
+
+            // Listeners should be re-added, not accumulated
+            // The second init should have removed old listeners then added new ones
+            expect(mockActivity.removeEventListener).toHaveBeenCalledWith(
+                window,
+                "mousemove",
+                expect.any(Function)
+            );
+            expect(mockActivity.removeEventListener).toHaveBeenCalledWith(
+                window,
+                "mousedown",
+                expect.any(Function)
+            );
+            expect(mockActivity.removeEventListener).toHaveBeenCalledWith(
+                window,
+                "keydown",
+                expect.any(Function)
+            );
+            expect(mockActivity.removeEventListener).toHaveBeenCalledWith(
+                window,
+                "touchstart",
+                expect.any(Function)
+            );
+            expect(mockActivity.removeEventListener).toHaveBeenCalledWith(
+                window,
+                "wheel",
+                expect.any(Function)
+            );
+
+            // New interval should be a different handle
+            expect(mockActivity._idleWatcherInterval).not.toBe(firstInterval);
+
+            // addEventListener should have been called same number of times each init
+            // (5 listeners per init, so 10 total)
+            expect(mockActivity.addEventListener).toHaveBeenCalledTimes(firstListenerCount * 2);
         });
     });
 

--- a/js/activity/__tests__/idle-watcher.test.js
+++ b/js/activity/__tests__/idle-watcher.test.js
@@ -162,6 +162,7 @@ describe("setupActivityIdleWatcher", () => {
 
             expect(mockActivity.isAppIdle).toBe(false);
             expect(global.createjs.Ticker.framerate).toBe(60);
+            expect(mockActivity.stageDirty).toBe(true);
         });
     });
 
@@ -239,6 +240,17 @@ describe("setupActivityIdleWatcher", () => {
             expect(global.ErrorHandler.recoverable).toHaveBeenCalledWith(testError, {
                 operation: "autoSave"
             });
+        });
+
+        it("does not throw when saveLocally is null", () => {
+            setupActivityIdleWatcher(mockActivity);
+            mockActivity.saveLocally = null;
+            mockActivity._initAutoSave();
+
+            jest.advanceTimersByTime(5 * 60 * 1000);
+
+            // Should not crash and ErrorHandler should not be called
+            expect(global.ErrorHandler.recoverable).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `idle-watcher.js` module. It verifies the inactivity tracking and auto-saving logic, ensuring proper initialization, teardown without memory leaks, and edge case coverage (like correct framerate dropping to save battery and restoring on activity).

## PR Category

-   [ ] Bug Fix - Fixes a bug or incorrect behavior
-   [ ] Feature - Adds new functionality
-   [ ] Performance - Improves performance (load time, memory, rendering, etc.)
-   [x] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README
-   [ ] Chore / Refactor - Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD - Changes to CI/CD workflows and automation

## Changes Made

-   Created `js/activity/__tests__/idle-watcher.test.js` to cover `_initIdleWatcher`, `_stopIdleWatcher`, `_initAutoSave`, and `_stopAutoSave`.
-   Mocked dependencies like `createjs`, `setInterval`, and global `window` events.
-   Validated framerate throttling (dropping from 60 fps to 1 fps on idle).
-   Validated wake-up logic on user activity or when music starts playing.
-   Validated logic to prevent memory leaks from duplicate interval setups and event listeners.

## Testing Performed

-   Ran `npx jest js/activity/__tests__/idle-watcher.test.js` locally.
-   Verified that all 13 test cases pass successfully with proper assertions.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The tests cover all edge cases mentioned in the issue requirements, including double initialization safety and threshold timings.
