### PR TITLE
test(musickeyboard): cover row, layout, and note-editing helpers

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -362,13 +362,14 @@ describe("MusicKeyboard core logic", () => {
                 20: { connections: [10, null] }
             };
             const sendStackToTrash = jest.fn();
+            const adjustDocks = jest.fn();
             const refreshCanvas = jest.fn();
-            keyboard.blockNo = 10;
+            keyboard.blockNo = 2;
             keyboard.activity = {
                 blocks: {
                     blockList,
                     sendStackToTrash,
-                    adjustDocks: jest.fn(),
+                    adjustDocks,
                     clampBlocksToCheck: []
                 },
                 refreshCanvas
@@ -380,7 +381,8 @@ describe("MusicKeyboard core logic", () => {
             expect(blockList[20].connections[0]).toBe(2);
             expect(blockList[10].connections[2]).toBeNull();
             expect(sendStackToTrash).toHaveBeenCalledWith(blockList[10]);
-            expect(keyboard.activity.blocks.clampBlocksToCheck).toEqual([[10, 0]]);
+            expect(adjustDocks).toHaveBeenCalledWith(2, true);
+            expect(keyboard.activity.blocks.clampBlocksToCheck).toEqual([[2, 0]]);
             expect(refreshCanvas).toHaveBeenCalled();
         });
     });

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -153,3 +153,235 @@ describe("MusicKeyboard add-row submenu", () => {
         ]);
     });
 });
+
+describe("MusicKeyboard core logic", () => {
+    let savedNoteToFrequency;
+    let savedLast;
+    let savedEighthNoteWidth;
+    let savedDocById;
+    let savedBeginnerMode;
+
+    beforeEach(() => {
+        savedNoteToFrequency = global.noteToFrequency;
+        savedLast = global.last;
+        savedEighthNoteWidth = global.EIGHTHNOTEWIDTH;
+        savedDocById = global.docById;
+        savedBeginnerMode = global.beginnerMode;
+
+        global.noteToFrequency = jest.fn(name => ({ do4: 261, sol4: 392 })[name] ?? 0);
+        global.last = array => array[array.length - 1];
+        global.EIGHTHNOTEWIDTH = 24;
+        global.docById = jest.fn(() => ({ getAttribute: () => "0.5" }));
+        global.beginnerMode = "false";
+    });
+
+    afterEach(() => {
+        global.noteToFrequency = savedNoteToFrequency;
+        global.last = savedLast;
+        global.EIGHTHNOTEWIDTH = savedEighthNoteWidth;
+        global.docById = savedDocById;
+        global.beginnerMode = savedBeginnerMode;
+    });
+
+    describe("addRowBlock", () => {
+        test("appends a row block", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._rowBlocks = [];
+
+            keyboard.addRowBlock(5);
+
+            expect(keyboard._rowBlocks).toEqual([5]);
+        });
+
+        test("offsets duplicate row blocks to keep them unique", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._rowBlocks = [5];
+
+            keyboard.addRowBlock(5);
+
+            expect(keyboard._rowBlocks).toEqual([5, 1000005]);
+        });
+    });
+
+    describe("_noteWidth", () => {
+        test("scales the width by the note value and cell scale", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._cellScale = 1;
+
+            expect(keyboard._noteWidth(0.25)).toBe(48);
+        });
+
+        test("never returns less than the minimum width", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._cellScale = 1;
+
+            expect(keyboard._noteWidth(0.001)).toBe(15);
+        });
+    });
+
+    describe("clearBlocks", () => {
+        test("resets the note names and octaves", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard.noteNames = ["do", "re"];
+            keyboard.octaves = [4, 4];
+
+            keyboard.clearBlocks();
+
+            expect(keyboard.noteNames).toEqual([]);
+            expect(keyboard.octaves).toEqual([]);
+        });
+    });
+
+    describe("_sortLayout", () => {
+        test("orders pitches by frequency and pushes hertz rows to the end", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard.activity = {
+                turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+            };
+            keyboard.keyboardShown = true;
+            keyboard._createKeyboard = jest.fn();
+            keyboard._removePitchBlock = jest.fn();
+            keyboard.layout = [
+                { noteName: "sol", noteOctave: 4, blockNumber: 3 },
+                { noteName: "hertz", noteOctave: 440, blockNumber: 5 },
+                { noteName: "do", noteOctave: 4, blockNumber: 1 }
+            ];
+
+            keyboard._sortLayout();
+
+            expect(keyboard.layout.map(item => item.noteName)).toEqual(["do", "sol", "hertz"]);
+            expect(keyboard._createKeyboard).toHaveBeenCalled();
+            expect(keyboard._removePitchBlock).not.toHaveBeenCalled();
+        });
+
+        test("removes a duplicate pitch and rebuilds the table when hidden", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard.activity = {
+                turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+            };
+            keyboard.keyboardShown = false;
+            keyboard._createTable = jest.fn();
+            keyboard._removePitchBlock = jest.fn();
+            keyboard.layout = [
+                { noteName: "do", noteOctave: 4, blockNumber: 1 },
+                { noteName: "do", noteOctave: 4, blockNumber: 2 }
+            ];
+
+            keyboard._sortLayout();
+
+            expect(keyboard.layout).toHaveLength(1);
+            expect(keyboard._removePitchBlock).toHaveBeenCalledWith(2);
+            expect(keyboard._createTable).toHaveBeenCalled();
+        });
+    });
+
+    describe("_updateDuration", () => {
+        test("rounds the matching note duration to the nearest eighth", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._createTable = jest.fn();
+            keyboard._notesPlayed = [
+                { startTime: 0, duration: 1 },
+                { startTime: 100, duration: 1 }
+            ];
+
+            keyboard._updateDuration(0, [1, 4]);
+
+            expect(keyboard._notesPlayed[0].duration).toBe(0.25);
+            expect(keyboard._notesPlayed[1].duration).toBe(1);
+            expect(keyboard._createTable).toHaveBeenCalled();
+        });
+    });
+
+    describe("_addNotes", () => {
+        test("appends divided copies and shifts later notes forward", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._createTable = jest.fn();
+            keyboard._notesPlayed = [
+                { startTime: 0, duration: 1, noteOctave: "do4" },
+                { startTime: 100, duration: 1, noteOctave: "re4" }
+            ];
+
+            keyboard._addNotes("cell0", 0, 2);
+
+            expect(keyboard._notesPlayed).toHaveLength(4);
+            expect(keyboard._notesPlayed.map(note => note.startTime)).toEqual([
+                0, 1000, 2000, 1100
+            ]);
+            expect(keyboard._createTable).toHaveBeenCalled();
+        });
+    });
+
+    describe("_deleteNotes", () => {
+        test("removes every note sharing the given start time", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._createTable = jest.fn();
+            keyboard._notesPlayed = [
+                { startTime: 0, duration: 1 },
+                { startTime: 100, duration: 1 }
+            ];
+
+            keyboard._deleteNotes(0);
+
+            expect(keyboard._notesPlayed).toHaveLength(1);
+            expect(keyboard._notesPlayed[0].startTime).toBe(100);
+            expect(keyboard._createTable).toHaveBeenCalled();
+        });
+    });
+
+    describe("_divideNotes", () => {
+        test("splits a note into equal shorter notes", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._createTable = jest.fn();
+            keyboard._notesPlayed = [{ startTime: 0, duration: 1, noteOctave: "do4" }];
+
+            keyboard._divideNotes(0, 2);
+
+            expect(keyboard._notesPlayed).toHaveLength(2);
+            expect(keyboard._notesPlayed.map(note => note.duration)).toEqual([0.5, 0.5]);
+            expect(keyboard._notesPlayed.map(note => note.startTime)).toEqual([0, 500]);
+        });
+
+        test("leaves the note untouched when the division is too short", () => {
+            const keyboard = new MusicKeyboard({});
+            keyboard._createTable = jest.fn();
+            keyboard._notesPlayed = [{ startTime: 0, duration: 1, noteOctave: "do4" }];
+
+            keyboard._divideNotes(0, 100);
+
+            expect(keyboard._notesPlayed).toHaveLength(1);
+            expect(keyboard._notesPlayed[0].duration).toBe(1);
+        });
+    });
+
+    describe("_removePitchBlock", () => {
+        test("splices the block out of its connection chain and trashes it", () => {
+            const keyboard = new MusicKeyboard({});
+            const blockList = {
+                10: { connections: [2, 99, 20] },
+                2: { name: "musickeyboard", connections: [0, 10] },
+                20: { connections: [10, null] }
+            };
+            const sendStackToTrash = jest.fn();
+            const refreshCanvas = jest.fn();
+            keyboard.blockNo = 10;
+            keyboard.activity = {
+                blocks: {
+                    blockList,
+                    sendStackToTrash,
+                    adjustDocks: jest.fn(),
+                    clampBlocksToCheck: []
+                },
+                refreshCanvas
+            };
+
+            keyboard._removePitchBlock(10);
+
+            expect(blockList[2].connections[1]).toBe(20);
+            expect(blockList[20].connections[0]).toBe(2);
+            expect(blockList[10].connections[2]).toBeNull();
+            expect(sendStackToTrash).toHaveBeenCalledWith(blockList[10]);
+            expect(keyboard.activity.blocks.clampBlocksToCheck).toEqual([[10, 0]]);
+            expect(refreshCanvas).toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Extends the `MusicKeyboard` widget test suite. `musickeyboard.js` is the lowest-covered widget file; this PR adds focused tests for its self-contained helper methods, raising statement coverage from ~9% to ~15% and function coverage from ~5% to ~18% as part of the ongoing Music Blocks maintenance / test-completion effort.

## Related Issue

Not tied to a specific issue — general test-coverage improvement for the `musickeyboard` widget.

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `addRowBlock` — appending and the unique-offset path for duplicate row blocks.
-   `_noteWidth` — note-value/cell-scale scaling and the minimum-width clamp.
-   `clearBlocks` — note-name and octave reset.
-   `_sortLayout` — frequency ordering with hertz rows pushed last, plus duplicate-pitch removal that triggers `_removePitchBlock` and a table rebuild.
-   `_removePitchBlock` — connection-chain splicing and stack trashing.
-   `_updateDuration`, `_addNotes`, `_deleteNotes`, `_divideNotes` — the `_notesPlayed` transforms, including the later-note shift and the too-short-to-divide guard.

## Testing Performed

-   `npm run lint` — passes.
-   `npx prettier --check` on the modified file — passes.
-   `npm test` for the widget — 17 tests pass.
-   Coverage for `musickeyboard.js`: statements 9% -> 15%, functions 5% -> 18%.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
