### PR TITLE
test(rhythmruler): cover widget timer lifecycle helpers

### DIFF
--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -866,3 +866,163 @@ describe("RhythmRuler Widget", () => {
         });
     });
 });
+
+describe("RhythmRuler widget timer fallback (no ManagedTimer)", () => {
+    let rhythmRuler;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        rhythmRuler = new RhythmRuler();
+        rhythmRuler._timerManager = null;
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    describe("_setWidgetTimeout", () => {
+        it("tracks the timeout and runs the callback, then stops tracking it", () => {
+            const callback = jest.fn();
+
+            const id = rhythmRuler._setWidgetTimeout(callback, 100);
+            expect(rhythmRuler._activeTimeouts.has(id)).toBe(true);
+
+            jest.advanceTimersByTime(100);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(rhythmRuler._activeTimeouts.has(id)).toBe(false);
+        });
+    });
+
+    describe("_clearWidgetTimeout", () => {
+        it("returns false for null or undefined ids", () => {
+            expect(rhythmRuler._clearWidgetTimeout(null)).toBe(false);
+            expect(rhythmRuler._clearWidgetTimeout(undefined)).toBe(false);
+        });
+
+        it("cancels a tracked timeout before it fires", () => {
+            const callback = jest.fn();
+            const id = rhythmRuler._setWidgetTimeout(callback, 100);
+
+            expect(rhythmRuler._clearWidgetTimeout(id)).toBe(true);
+            expect(rhythmRuler._activeTimeouts.has(id)).toBe(false);
+
+            jest.advanceTimersByTime(100);
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it("returns false for an untracked id", () => {
+            expect(rhythmRuler._clearWidgetTimeout(999999)).toBe(false);
+        });
+    });
+
+    describe("_setWidgetInterval", () => {
+        it("tracks the interval and runs the callback repeatedly", () => {
+            const callback = jest.fn();
+
+            const id = rhythmRuler._setWidgetInterval(callback, 100);
+            expect(rhythmRuler._activeIntervals.has(id)).toBe(true);
+
+            jest.advanceTimersByTime(250);
+            expect(callback).toHaveBeenCalledTimes(2);
+
+            rhythmRuler._clearWidgetInterval(id);
+        });
+    });
+
+    describe("_clearWidgetInterval", () => {
+        it("returns false for null or undefined ids", () => {
+            expect(rhythmRuler._clearWidgetInterval(null)).toBe(false);
+            expect(rhythmRuler._clearWidgetInterval(undefined)).toBe(false);
+        });
+
+        it("cancels a tracked interval", () => {
+            const callback = jest.fn();
+            const id = rhythmRuler._setWidgetInterval(callback, 100);
+
+            expect(rhythmRuler._clearWidgetInterval(id)).toBe(true);
+            expect(rhythmRuler._activeIntervals.has(id)).toBe(false);
+
+            jest.advanceTimersByTime(300);
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it("returns false for an untracked id", () => {
+            expect(rhythmRuler._clearWidgetInterval(999999)).toBe(false);
+        });
+    });
+
+    describe("_clearWidgetTimers", () => {
+        it("cancels every tracked timer and returns the count", () => {
+            rhythmRuler._setWidgetTimeout(jest.fn(), 100);
+            rhythmRuler._setWidgetTimeout(jest.fn(), 200);
+            rhythmRuler._setWidgetInterval(jest.fn(), 100);
+
+            const count = rhythmRuler._clearWidgetTimers();
+
+            expect(count).toBe(3);
+            expect(rhythmRuler._activeTimeouts.size).toBe(0);
+            expect(rhythmRuler._activeIntervals.size).toBe(0);
+            expect(rhythmRuler._longPressBeep).toBeNull();
+        });
+    });
+});
+
+describe("RhythmRuler widget timer delegation (with ManagedTimer)", () => {
+    let rhythmRuler;
+
+    beforeEach(() => {
+        rhythmRuler = new RhythmRuler();
+    });
+
+    it("_setWidgetTimeout delegates to the timer manager", () => {
+        const callback = jest.fn();
+        rhythmRuler._timerManager = { setTimeout: jest.fn().mockReturnValue(42) };
+
+        expect(rhythmRuler._setWidgetTimeout(callback, 100)).toBe(42);
+        expect(rhythmRuler._timerManager.setTimeout).toHaveBeenCalledWith(callback, 100);
+    });
+
+    it("_setWidgetInterval delegates to the timer manager", () => {
+        const callback = jest.fn();
+        rhythmRuler._timerManager = { setInterval: jest.fn().mockReturnValue(7) };
+
+        expect(rhythmRuler._setWidgetInterval(callback, 100)).toBe(7);
+        expect(rhythmRuler._timerManager.setInterval).toHaveBeenCalledWith(callback, 100);
+    });
+
+    it("_clearWidgetTimers adds the manager count to the tracked timer count", () => {
+        rhythmRuler._timerManager = { clearAll: jest.fn().mockReturnValue(5) };
+        rhythmRuler._activeTimeouts.add(1);
+        rhythmRuler._activeIntervals.add(2);
+
+        expect(rhythmRuler._clearWidgetTimers()).toBe(7);
+    });
+
+    it("_clearWidgetTimeout returns true when the manager clears the timeout", () => {
+        rhythmRuler._timerManager = { clearTimeout: jest.fn().mockReturnValue(true) };
+
+        expect(rhythmRuler._clearWidgetTimeout(5)).toBe(true);
+        expect(rhythmRuler._timerManager.clearTimeout).toHaveBeenCalledWith(5);
+    });
+
+    it("_clearWidgetInterval returns true when the manager clears the interval", () => {
+        rhythmRuler._timerManager = { clearInterval: jest.fn().mockReturnValue(true) };
+
+        expect(rhythmRuler._clearWidgetInterval(5)).toBe(true);
+        expect(rhythmRuler._timerManager.clearInterval).toHaveBeenCalledWith(5);
+    });
+});
+
+describe("RhythmRuler _get_save_lock", () => {
+    it("returns the current save lock state", () => {
+        const rhythmRuler = new RhythmRuler();
+
+        rhythmRuler._save_lock = false;
+        expect(rhythmRuler._get_save_lock()).toBe(false);
+
+        rhythmRuler._save_lock = true;
+        expect(rhythmRuler._get_save_lock()).toBe(true);
+    });
+});


### PR DESCRIPTION
## Description

Extends the `RhythmRuler` test suite with focused coverage of the widget's timer lifecycle helpers. Raises statement coverage for `rhythmruler.js` from ~18% to ~20% and function coverage from ~19% to ~22% as part of the ongoing Music Blocks maintenance / test-completion effort.

## Related Issue

Not tied to a specific issue — general test-coverage improvement for the `rhythmruler` widget.

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `_setWidgetTimeout` / `_setWidgetInterval` — both the `ManagedTimer` delegation path and the native fallback that tracks ids in the active-timer sets.
-   `_clearWidgetTimeout` / `_clearWidgetInterval` — the null/undefined guard, the manager-clears-it path, the tracked-id cancellation, and the untracked-id `false` return.
-   `_clearWidgetTimers` — cancels every tracked timeout/interval, returns the combined count (including the manager's `clearAll` count), and nulls `_longPressBeep`.
-   `_get_save_lock` — returns the current save-lock state.

The fallback paths are exercised by setting `_timerManager = null`, since the default `ManagedTimer` instance otherwise short-circuits them; native timers are driven with Jest fake timers.

## Testing Performed

-   `npm run lint` — passes.
-   `npx prettier --check` on the modified file — passes.
-   `npm test` for the widget — 60 tests pass.
-   Coverage for `rhythmruler.js`: statements 18% -> 20%, functions 19% -> 22%, branches 17% -> 20%.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
