### PR TITLE
Fix play button not toggling to stop icon after playback

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -49,6 +49,7 @@ class PitchStaircase {
         this._stepTables = [];
         this._musicRatio1 = null;
         this._musicRatio2 = null;
+        this._currentPlayingIndex = -1;
     }
 
     /**
@@ -118,6 +119,10 @@ class PitchStaircase {
                 PitchStaircase.ICONSIZE,
                 _("Play")
             );
+
+            const playImg = playCell.querySelector("img");
+            playCell.icon = playImg;
+
             playCell.className = "headcol"; // This cell is fixed horizontally.
             playCell.setAttribute("id", i);
             playCell.style.cursor = "pointer";
@@ -301,14 +306,40 @@ class PitchStaircase {
      * @returns {void}
      */
     _playOne(stepCell) {
-        // The frequency is stored in the stepCell.
         stepCell.classList.add("active");
+    
+        const index = Number(stepCell.parentElement.querySelector("td").id);
+    
+        if (this._currentPlayingIndex !== -1) {
+            const prevCell = this._stepTables[this._currentPlayingIndex].rows[0].cells[0];
+            const prevImg = prevCell.querySelector("img");
+            if (prevImg) {
+                prevImg.src = "header-icons/play-button.svg";
+            }
+        }
+    
+        this._currentPlayingIndex = index;
+    
+        const playCell = stepCell.parentElement.querySelector("td");
+        const img = playCell.querySelector("img");
+    
+        if (img) {
+            img.src = "header-icons/stop-button.svg";
+        }
+    
         const frequency = Number(stepCell.getAttribute("id"));
+    
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
-
+    
         setTimeout(() => {
             stepCell.classList.remove("active");
-        }, 1000);
+    
+            if (img) {
+                img.src = "header-icons/play-button.svg";
+            }
+    
+            this._currentPlayingIndex = -1;
+        }, 1200);
     }
 
     /**


### PR DESCRIPTION
### **This PR fixes an issue in the Pitch Staircase widget where the play button icon does not update when playback starts.**
### **Issue**
The audio playback works correctly, but the UI does not reflect the current state. The play button remains in the ▶️ state even while audio is playing.
### **Expected behavior**
The play button should switch from ▶️ (play) to ⏹️ (stop) when playback begins
The icon should revert back to ▶️ once playback ends
### **Root cause**
The playback state was not being tracked in the UI, and the button icon (img.src) was never updated during or after audio playback.
### **Fix**
Introduced playback state tracking
Updated button icon dynamically during playback
Reset icon after playback completes
### **Testing**
Verified single-note playback updates icon correctly

https://github.com/user-attachments/assets/13928cc7-174c-4fdc-b916-755e6fc1b52b


Verified icon resets after playback ends
Confirmed no impact on existing pitch functionality