### PR TITLE
test(pitchdrummatrix): cover block, node, and save-lock methods

### DIFF
--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -211,6 +211,79 @@ describe("PitchDrumMatrix Widget", () => {
         });
     });
 
+    describe("block and node methods", () => {
+        test("clearBlocks resets the row and column block arrays", () => {
+            pdm._rowBlocks = [10, 20];
+            pdm._colBlocks = [30];
+
+            pdm.clearBlocks();
+
+            expect(pdm._rowBlocks).toEqual([]);
+            expect(pdm._colBlocks).toEqual([]);
+        });
+
+        test("addRowBlock appends a pitch block", () => {
+            pdm.addRowBlock(10);
+            pdm.addRowBlock(20);
+
+            expect(pdm._rowBlocks).toEqual([10, 20]);
+        });
+
+        test("addColBlock appends a drum block", () => {
+            pdm.addColBlock(30);
+            pdm.addColBlock(40);
+
+            expect(pdm._colBlocks).toEqual([30, 40]);
+        });
+
+        test("addNode adds new intersections", () => {
+            pdm.addNode(0, 1);
+            pdm.addNode(1, 0);
+
+            expect(pdm._blockMap).toEqual([
+                [0, 1],
+                [1, 0]
+            ]);
+        });
+
+        test("addNode ignores a duplicate intersection", () => {
+            pdm.addNode(0, 1);
+            pdm.addNode(0, 1);
+
+            expect(pdm._blockMap).toEqual([[0, 1]]);
+        });
+
+        test("removeNode marks a matching intersection as removed", () => {
+            pdm.addNode(0, 1);
+            pdm.addNode(1, 0);
+
+            pdm.removeNode(0, 1);
+
+            expect(pdm._blockMap).toEqual([
+                [-1, -1],
+                [1, 0]
+            ]);
+        });
+
+        test("removeNode leaves the map unchanged when nothing matches", () => {
+            pdm.addNode(0, 1);
+
+            pdm.removeNode(5, 5);
+
+            expect(pdm._blockMap).toEqual([[0, 1]]);
+        });
+    });
+
+    describe("_get_save_lock", () => {
+        test("returns the current save lock state", () => {
+            pdm._save_lock = false;
+            expect(pdm._get_save_lock()).toBe(false);
+
+            pdm._save_lock = true;
+            expect(pdm._get_save_lock()).toBe(true);
+        });
+    });
+
     // --- Playing State Tests ---
     describe("playing state", () => {
         test("should toggle playing state", () => {


### PR DESCRIPTION
## Description

Extends the `PitchDrumMatrix` test suite with coverage for its data-management methods, raising statement coverage for `pitchdrummatrix.js` from ~37% to ~41% and function coverage from ~23% to ~42%, as part of the ongoing Music Blocks maintenance / test-completion effort.

## Related Issue

Not tied to a specific issue — general test-coverage improvement for the `pitchdrummatrix` widget.

## PR Category

-   [ ] Bug Fix
-   [ ] Feature
-   [ ] Performance
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation
-   [ ] Chore / Refactor
-   [ ] CI/CD

## Changes Made

-   `clearBlocks`, `addRowBlock`, `addColBlock` — the row/column block arrays.
-   `addNode` — adding new intersections and ignoring duplicates.
-   `removeNode` — the matching case (marks the node `[-1, -1]`) and the no-match case.
-   `_get_save_lock` — returns the current save-lock state.

The existing "data management" tests poke the arrays directly; these call the actual methods, which were previously uncovered.

## Testing Performed

-   `npm run lint` and `npx prettier --check` pass.
-   `npm test` for the widget — 38 tests pass.
-   Coverage for `pitchdrummatrix.js`: statements 37% -> 41%, functions 23% -> 42%, branches 21% -> 30%.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.
