### PR TITLE
fix: improve keyboard shortcuts dialog visibility in high contrast mode

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -484,17 +484,17 @@ body.highcontrast {
 .highcontrast .keyboard-shortcuts-hero,
 .highcontrast .keyboard-shortcuts-section,
 .highcontrast .keyboard-shortcuts-key {
-    border: 1px solid #ffffff;
-    background: #000000;
+    border: 1px solid var(--color-border-primary);
+    background: var(--color-bg-primary);
     box-shadow: none;
-    color: var(--color-text-inverse);
+     color: var(--color-text-primary) !important;
 }
 
 .highcontrast .keyboard-shortcuts-section-title,
 .highcontrast .keyboard-shortcuts-action,
 .highcontrast .keyboard-shortcuts-hero-copy,
 .highcontrast .keyboard-shortcuts-hero-title {
-    color: var(--color-text-inverse);
+     color: var(--color-text-primary) !important;
 }
 
 .highcontrast .keyboard-shortcuts-row,
@@ -535,7 +535,7 @@ body.highcontrast {
 }
 
 .highcontrast #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
-    color: var(--color-text-inverse);
+    color: var(--color-text-primary) !important;
 }
 
 .highcontrast #floatingWindows > .windowFrame > .wfWinBody .wfbWidget {


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem


When switching to **High Contrast** mode in MusicBlocks, the **Keyboard Shortcuts** dialog contains several unreadable UI elements:

* The window title ("Keyboard shortcuts") is difficult to read.
* Section headings are not clearly visible.
* Shortcut descriptions are difficult to read.
* Shortcut key labels have poor contrast.

This reduces the accessibility and usability of the Keyboard Shortcuts dialog in High Contrast mode.

## Root Cause

Some High Contrast styles applied colors that did not provide sufficient contrast for the Keyboard Shortcuts dialog. As a result, the window title and dialog content became difficult to read.

## Fix

**css/themes.css**

* Updated the High Contrast styles for the Keyboard Shortcuts dialog.
* Fixed the window title color to use the appropriate design token.
* Updated the dialog headings, shortcut key labels, and shortcut descriptions to use High Contrast theme colors.
* Replaced hardcoded values where appropriate with existing design tokens to maintain theme consistency.

## Testing

1. Open MusicBlocks.
2. Switch the application theme to **High Contrast**.
3. Open **Help and shortcuts → Keyboard Shortcuts**.
4. Verify that:

   * The window title is clearly visible.
   * Section headings are readable.
   * Shortcut key labels are visible.
   * Shortcut descriptions are readable.

## Result

<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/018838fd-19d0-4d16-aabe-d2f455269836" />

The Keyboard Shortcuts dialog is fully readable in High Contrast mode while preserving the existing appearance in Light and Dark themes.
