### PR TITLE
feat: add Ctrl+Shift+F keyboard shortcut to open search widget(fixes …

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3165,6 +3165,11 @@ class Activity {
                             this.stageDirty = true;
                         }
                 }
+            } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.code === "KeyF") {
+                if (!disableKeys) {
+                    event.preventDefault();
+                    this.showSearchWidget();
+                }
             } else if (event.ctrlKey) {
                 switch (event.keyCode) {
                     case V:


### PR DESCRIPTION
Fixes #7631

## What does this PR do?
Adds a keyboard shortcut Ctrl+Shift+F (Windows/Linux) and 
Cmd+Shift+F (Mac) to open the Search for Blocks widget.

## Why?
Previously the search bar could only be opened by clicking 
the toolbar icon with a mouse. This shortcut makes it 
faster to access, similar to Spotlight Search on macOS 
as requested in issue #7631.

## How to test?
1. Open Music Blocks
2. Press Ctrl+Shift+F (Windows/Linux) or Cmd+Shift+F (Mac)
3. Search bar should open instantly
## PR Category
- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD