### PR TITLE
feat: add Ctrl+Space keyboard shortcut to open search widget (fixes #7631)

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -235,6 +235,9 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
     transition: all 0.2s ease;
     margin-left: 8px;
 }
+#searchDragHandle {
+    pointer-events: auto;
+}
 
 #search:focus {
     border-color: var(--color-brand-primary-hover);

--- a/css/activities.css
+++ b/css/activities.css
@@ -247,32 +247,46 @@ body:not(.dark):not(.highcontrast) #helpfulSearchDiv {
 }
 
 #helpfulSearchDiv {
-    display: block !important;
-    position: absolute;
+    position: fixed !important;
     background-color: var(--color-bg-secondary);
-    padding: 2px;
+    padding: 0;
     border: 1px solid var(--color-border-primary);
-    width: 230px;
-    z-index: 1;
+    border-radius: 24px;
+    width: 320px;
+    z-index: 1000;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    height: 46px;
+    overflow: hidden;
 }
 
 #helpfulSearch {
-    padding: 2px;
-    border: 2px solid grey;
-    width: 220px;
-    height: 20px;
+    padding: 0 40px 0 28px;
+    border: none;
+    width: 100%;
+    height: 46px;
     font-size: large;
+    background-color: transparent;
+    color: inherit;
+    outline: none;
+    display: block;
+    box-sizing: border-box;
 }
 
 #crossButton {
     position: absolute;
     top: 50%;
-    right: -30px;
+    right: 10px;
     transform: translateY(-50%);
-    background: transparent;
+    background: rgba(80, 80, 80, 0.5);
     border: none;
-    font-size: large;
+    border-radius: 50%;
+    width: 22px;
+    height: 22px;
+    color: white;
+    font-size: 14px;
     cursor: pointer;
+    line-height: 22px;
+    text-align: center;
 }
 
 .trash-view {

--- a/js/activity.js
+++ b/js/activity.js
@@ -2674,10 +2674,10 @@ class Activity {
                         this.update = true;
                         break;
                 }
-                 if (event.code === "Space" && !disableKeys) {
-                        event.preventDefault();
-                        this.showSearchWidget();
-                 }
+                if (event.code === "Space" && !disableKeys) {
+                    event.preventDefault();
+                    this.showSearchWidget();
+                }
             } else if (event.shiftKey && !disableKeys) {
                 switch (event.keyCode) {
                     case SPACE:
@@ -2689,7 +2689,7 @@ class Activity {
                         }
                         break;
                 }
-           } else {
+            } else {
                 if (pasteEl.style.visibility === "visible" && event.keyCode === RETURN) {
                     if (pasteEl.value.length > 0) {
                         this.pasted();

--- a/js/activity.js
+++ b/js/activity.js
@@ -6410,7 +6410,7 @@ class Activity {
             };
 
             // Use managed addEventListener instead of onkeydown assignment
-            this.addEventListener(document, "keydown", this.handleKeyDown, true);
+            this.addEventListener(document, "keydown", this.handleKeyDown);
             this.addEventListener(
                 document,
                 "keydown",

--- a/js/activity.js
+++ b/js/activity.js
@@ -2674,10 +2674,6 @@ class Activity {
                         this.update = true;
                         break;
                 }
-                if (event.code === "Space" && !disableKeys) {
-                    event.preventDefault();
-                    this.showSearchWidget();
-                }
             } else if (event.shiftKey && !disableKeys) {
                 switch (event.keyCode) {
                     case SPACE:
@@ -2689,6 +2685,9 @@ class Activity {
                         }
                         break;
                 }
+            } else if ((event.ctrlKey || event.metaKey) && event.code === 'Space' && !disableKeys) {
+                event.preventDefault();
+                this._displayHelpfulSearchDiv();
             } else {
                 if (pasteEl.style.visibility === "visible" && event.keyCode === RETURN) {
                     if (pasteEl.value.length > 0) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -2685,9 +2685,6 @@ class Activity {
                         }
                         break;
                 }
-            } else if ((event.ctrlKey || event.metaKey) && event.code === "Space" && !disableKeys) {
-                event.preventDefault();
-                this._displayHelpfulSearchDiv();
             } else {
                 if (pasteEl.style.visibility === "visible" && event.keyCode === RETURN) {
                     if (pasteEl.value.length > 0) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -2685,7 +2685,7 @@ class Activity {
                         }
                         break;
                 }
-            } else if ((event.ctrlKey || event.metaKey) && event.code === 'Space' && !disableKeys) {
+            } else if ((event.ctrlKey || event.metaKey) && event.code === "Space" && !disableKeys) {
                 event.preventDefault();
                 this._displayHelpfulSearchDiv();
             } else {

--- a/js/activity.js
+++ b/js/activity.js
@@ -6410,7 +6410,19 @@ class Activity {
             };
 
             // Use managed addEventListener instead of onkeydown assignment
-            this.addEventListener(document, "keydown", this.handleKeyDown);
+            this.addEventListener(document, "keydown", this.handleKeyDown, true);
+            this.addEventListener(
+                document,
+                "keydown",
+                event => {
+                    if ((event.ctrlKey || event.metaKey) && event.code === "Space") {
+                        event.preventDefault();
+                        event.stopImmediatePropagation();
+                        this._displayHelpfulSearchDiv();
+                    }
+                },
+                true
+            );
 
             if (this.planet !== undefined) {
                 this.planet.planet.setAnalyzeProject(doAnalyzeProject);

--- a/js/activity.js
+++ b/js/activity.js
@@ -2674,6 +2674,10 @@ class Activity {
                         this.update = true;
                         break;
                 }
+                 if (event.code === "Space" && !disableKeys) {
+                        event.preventDefault();
+                        this.showSearchWidget();
+                 }
             } else if (event.shiftKey && !disableKeys) {
                 switch (event.keyCode) {
                     case SPACE:
@@ -2685,7 +2689,7 @@ class Activity {
                         }
                         break;
                 }
-            } else {
+           } else {
                 if (pasteEl.style.visibility === "visible" && event.keyCode === RETURN) {
                     if (pasteEl.value.length > 0) {
                         this.pasted();

--- a/js/activity/__tests__/search-controller.test.js
+++ b/js/activity/__tests__/search-controller.test.js
@@ -14,6 +14,9 @@
 if (typeof global._ !== "function") {
     global._ = s => s;
 }
+if (typeof global.docByClass !== "function") {
+    global.docByClass = () => [];
+}
 if (typeof global.STANDARDBLOCKHEIGHT === "undefined") {
     global.STANDARDBLOCKHEIGHT = 40;
 }
@@ -25,7 +28,7 @@ const { setupSearchController, SearchController } = require("../search-controlle
 // ---------------------------------------------------------------------------
 
 function makeProtoBlock(name, label, deprecated = false, extraSearchTerms = undefined) {
-    return {
+    const block = {
         name,
         staticLabels: label ? [label] : [],
         deprecated,
@@ -37,34 +40,7 @@ function makeProtoBlock(name, label, deprecated = false, extraSearchTerms = unde
             }
         }
     };
-}
-
-function makeSearchUI({ visible = false, helpfulVisible = false } = {}) {
-    return {
-        show: jest.fn(),
-        hide: jest.fn(),
-        focusInput: jest.fn(),
-        focusHelpfulInput: jest.fn(),
-        showHelpfulInput: jest.fn(),
-        setupMainAutocomplete: jest.fn(),
-        triggerMainSearch: jest.fn(),
-        setupHelpfulAutocomplete: jest.fn(),
-        triggerHelpfulSearch: jest.fn(),
-        buildHelpfulSearchDiv: jest.fn(() => ({
-            closeButton: { id: "crossButton" },
-            modeButton: null
-        })),
-        positionHelpfulSearchDiv: jest.fn(),
-        removeHelpfulSearchDiv: jest.fn(),
-        hideHelpfulSearchDisplay: jest.fn(),
-        isVisible: jest.fn(() => visible),
-        isHelpfulSearchVisible: jest.fn(() => helpfulVisible),
-        get isHelpfulSearchWidgetOn() {
-            return this.isHelpfulSearchVisible();
-        },
-        isHelpfulSearchDivMounted: jest.fn(() => false),
-        containsMainSearchTarget: jest.fn(() => false)
-    };
+    return block;
 }
 
 function makeActivity(protoBlocks = {}) {
@@ -103,6 +79,7 @@ function makeActivity(protoBlocks = {}) {
         getStageScale: jest.fn(() => 1),
         addEventListener: jest.fn((target, event, handler) => {
             if (target === document && event === "mousedown") {
+                // store so tests can trigger it
                 target._mousedownHandler = handler;
             }
         }),
@@ -120,25 +97,21 @@ function makeActivity(protoBlocks = {}) {
 describe("setupSearchController", () => {
     test("attaches a SearchController instance to activity", () => {
         const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         expect(activity.searchController).toBeInstanceOf(SearchController);
     });
 
-    test("initialises data-layer state to defaults", () => {
+    test("initialises state to empty defaults", () => {
         const activity = makeActivity();
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         const sc = activity.searchController;
         expect(sc.searchSuggestions).toEqual([]);
         expect(sc._searchCache).toEqual({});
+        expect(sc._searchCloseListener).toBeNull();
+        expect(sc.isHelpfulSearchWidgetOn).toBe(false);
+        expect(sc.searchBlockPosition).toEqual([100, 100]);
         expect(sc.deprecatedBlockNames).toEqual([]);
-    });
-
-    test("stores the searchUI reference", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        expect(activity.searchController.searchUI).toBe(ui);
+        expect(sc.helpfulSearchDiv).toBeNull();
     });
 });
 
@@ -150,7 +123,7 @@ describe("SearchController.prepSearchWidget", () => {
     test("skips gracefully when blocks not initialised", () => {
         const activity = makeActivity();
         activity.blocks = null;
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         expect(() => activity.searchController.prepSearchWidget()).not.toThrow();
         expect(activity.searchController.searchSuggestions).toEqual([]);
     });
@@ -160,7 +133,7 @@ describe("SearchController.prepSearchWidget", () => {
             drum: makeProtoBlock("drum", "drum"),
             pitch: makeProtoBlock("pitch", "pitch")
         });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         activity.searchController.prepSearchWidget();
 
         const labels = activity.searchController.searchSuggestions.map(s => s.label);
@@ -173,7 +146,7 @@ describe("SearchController.prepSearchWidget", () => {
             old: makeProtoBlock("old", "old block", true),
             current: makeProtoBlock("current", "current block", false)
         });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         activity.searchController.prepSearchWidget();
 
         const labels = activity.searchController.searchSuggestions.map(s => s.label);
@@ -185,7 +158,7 @@ describe("SearchController.prepSearchWidget", () => {
     test("adds extraSearchTerms to the searchTerms array", () => {
         const block = makeProtoBlock("note", "note value", false, ["pitch", "tone"]);
         const activity = makeActivity({ note: block });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         activity.searchController.prepSearchWidget();
 
         const suggestion = activity.searchController.searchSuggestions.find(
@@ -195,21 +168,25 @@ describe("SearchController.prepSearchWidget", () => {
         expect(suggestion.searchTerms).toContain("tone");
     });
 
-    test("resets cache on each call", () => {
+    test("resets cache and position on each call", () => {
         const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         const sc = activity.searchController;
         sc._searchCache = { x: [1] };
+        sc.searchBlockPosition = [200, 200];
 
         sc.prepSearchWidget();
 
         expect(sc._searchCache).toEqual({});
+        expect(sc.searchBlockPosition).toEqual([100, 100]);
     });
 
     test("uses fallback label for known no-label blocks (scaledegree2)", () => {
+        // extraSearchTerms must be defined (even empty) so the block passes the
+        // `if (blockLabel || block.extraSearchTerms !== undefined)` guard.
         const block = makeProtoBlock("scaledegree2", "", false, []);
         const activity = makeActivity({ scaledegree2: block });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         activity.searchController.prepSearchWidget();
 
         const suggestion = activity.searchController.searchSuggestions.find(
@@ -217,43 +194,6 @@ describe("SearchController.prepSearchWidget", () => {
         );
         expect(suggestion.label).toBe("scale degree");
     });
-
-    const noLabelCases = [
-        ["voicename", "voice name"],
-        ["notename", "note name"],
-        ["drumname", "drum name"],
-        ["loadFile", "load file"],
-        ["invertmode", "invert mode"],
-        ["modename", "mode name"],
-        ["filtertype", "filter type"],
-        ["audiofile", "audio file"],
-        ["outputtools", "output tools"],
-        ["customNote", "custom note"],
-        ["accidentalname", "accidental name"],
-        ["eastindiansolfege", "east indian solfege"],
-        ["temperamentname", "temperament name"],
-        ["chordname", "chord name"],
-        ["intervalname", "interval name"],
-        ["oscillatortype", "oscillator type"],
-        ["noisename", "noise name"],
-        ["effectsname", "effects name"],
-        ["wrapmode", "wrap mode"]
-    ];
-
-    test.each(noLabelCases)(
-        "uses fallback label for no-label block '%s' → '%s'",
-        (blockName, expectedLabel) => {
-            const block = makeProtoBlock(blockName, "", false, []);
-            const activity = makeActivity({ [blockName]: block });
-            setupSearchController(activity, makeSearchUI());
-            activity.searchController.prepSearchWidget();
-
-            const suggestion = activity.searchController.searchSuggestions.find(
-                s => s.value === blockName
-            );
-            expect(suggestion.label).toBe(expectedLabel);
-        }
-    );
 });
 
 // ---------------------------------------------------------------------------
@@ -268,7 +208,7 @@ describe("SearchController.filterSuggestions", () => {
             drum: makeProtoBlock("drum", "drum beat", false, ["percussion"]),
             pitch: makeProtoBlock("pitch", "pitch value")
         });
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         sc = activity.searchController;
         sc.prepSearchWidget();
     });
@@ -290,25 +230,18 @@ describe("SearchController.filterSuggestions", () => {
     });
 
     test("returns an empty array for a term that matches nothing", () => {
-        expect(sc.filterSuggestions("zzznomatch")).toEqual([]);
+        const results = sc.filterSuggestions("zzznomatch");
+        expect(results).toEqual([]);
     });
 
-    test("caches results and returns cache on second call", () => {
+    test("caches results on first call and returns cache on second", () => {
         sc.filterSuggestions("drum");
         expect(sc._searchCache["drum"]).toBeDefined();
 
+        // Mutate suggestions to prove cache is used
         sc.searchSuggestions = [];
         const cached = sc.filterSuggestions("drum");
         expect(cached).toBe(sc._searchCache["drum"]);
-    });
-
-    test("falls back to label match when item has no searchTerms array", () => {
-        sc.searchSuggestions = [{ label: "drum beat", value: "drum" }];
-        const results = sc.filterSuggestions("drum");
-        expect(results.some(r => r.value === "drum")).toBe(true);
-
-        const noResults = sc.filterSuggestions("piano");
-        expect(noResults.length).toBe(0);
     });
 });
 
@@ -317,18 +250,21 @@ describe("SearchController.filterSuggestions", () => {
 // ---------------------------------------------------------------------------
 
 describe("SearchController.hideSearchWidget", () => {
-    test("calls searchUI.hide()", () => {
+    test("hides the search input and clears idInput_custom", () => {
         const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "visible";
+        activity.searchWidget.idInput_custom = "drum";
+
         activity.searchController.hideSearchWidget();
-        expect(ui.hide).toHaveBeenCalled();
+
+        expect(activity.searchWidget.style.visibility).toBe("hidden");
+        expect(activity.searchWidget.idInput_custom).toBe("");
     });
 
-    test("removes and clears the stored mousedown close listener", () => {
+    test("removes the stored mousedown close listener", () => {
         const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
         const listener = jest.fn();
         sc._searchCloseListener = listener;
@@ -339,11 +275,16 @@ describe("SearchController.hideSearchWidget", () => {
         expect(sc._searchCloseListener).toBeNull();
     });
 
-    test("does not call removeEventListener when no listener is stored", () => {
+    test("hides ui-menu element when present", () => {
+        const mockMenu = { style: { visibility: "visible" } };
+        global.docByClass = () => [mockMenu];
+
         const activity = makeActivity();
-        setupSearchController(activity, makeSearchUI());
+        setupSearchController(activity);
         activity.searchController.hideSearchWidget();
-        expect(activity.removeEventListener).not.toHaveBeenCalled();
+
+        expect(mockMenu.style.visibility).toBe("hidden");
+        global.docByClass = () => [];
     });
 });
 
@@ -352,10 +293,10 @@ describe("SearchController.hideSearchWidget", () => {
 // ---------------------------------------------------------------------------
 
 describe("SearchController.showSearchWidget", () => {
-    test("calls hideSearchWidget when searchUI.isVisible() returns true", () => {
+    test("hides widget when it is already visible (toggle off)", () => {
         const activity = makeActivity();
-        const ui = makeSearchUI({ visible: true });
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "visible";
 
         const hideSpy = jest.spyOn(activity.searchController, "hideSearchWidget");
         activity.searchController.showSearchWidget();
@@ -363,34 +304,24 @@ describe("SearchController.showSearchWidget", () => {
         expect(hideSpy).toHaveBeenCalled();
     });
 
-    test("calls searchUI.show() when searchUI.isVisible() returns false", () => {
+    test("makes widget visible and positions it from palettes.getSearchPos", () => {
         jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ visible: false });
-        setupSearchController(activity, ui);
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "hidden";
 
         activity.searchController.showSearchWidget();
 
-        expect(ui.show).toHaveBeenCalled();
-        jest.useRealTimers();
-    });
-
-    test("calls prepSearchWidget when showing", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        setupSearchController(activity, makeSearchUI({ visible: false }));
-        const prepSpy = jest.spyOn(activity.searchController, "prepSearchWidget");
-
-        activity.searchController.showSearchWidget();
-
-        expect(prepSpy).toHaveBeenCalled();
+        expect(activity.searchWidget.style.visibility).toBe("visible");
+        expect(activity.searchWidget.style.left).toBe("10px");
+        expect(activity.searchWidget.style.top).toBe("20px");
         jest.useRealTimers();
     });
 
     test("registers a mousedown close listener on document", () => {
         jest.useFakeTimers();
         const activity = makeActivity();
-        setupSearchController(activity, makeSearchUI({ visible: false }));
+        setupSearchController(activity);
 
         activity.searchController.showSearchWidget();
 
@@ -401,133 +332,28 @@ describe("SearchController.showSearchWidget", () => {
         );
         jest.useRealTimers();
     });
-
-    test("close listener calls hideSearchWidget when containsMainSearchTarget returns false", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ visible: false });
-        ui.containsMainSearchTarget = jest.fn(() => false);
-        setupSearchController(activity, ui);
-
-        activity.searchController.showSearchWidget();
-
-        const closeListener = activity.addEventListener.mock.calls.find(
-            c => c[1] === "mousedown"
-        )[2];
-        const hideSpy = jest.spyOn(activity.searchController, "hideSearchWidget");
-        closeListener({ target: document.body });
-
-        expect(hideSpy).toHaveBeenCalled();
-        jest.useRealTimers();
-    });
-
-    test("close listener does NOT call hideSearchWidget when containsMainSearchTarget returns true", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ visible: false });
-        ui.containsMainSearchTarget = jest.fn(() => true);
-        setupSearchController(activity, ui);
-
-        activity.searchController.showSearchWidget();
-
-        const closeListener = activity.addEventListener.mock.calls.find(
-            c => c[1] === "mousedown"
-        )[2];
-        const hideSpy = jest.spyOn(activity.searchController, "hideSearchWidget");
-        closeListener({ target: document.body });
-
-        expect(hideSpy).not.toHaveBeenCalled();
-        jest.useRealTimers();
-    });
-
-    test("calls _hideHelpfulSearchWidget first when searchUI.isHelpfulSearchVisible() is true", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        setupSearchController(activity, ui);
-
-        const hideSpy = jest.spyOn(activity.searchController, "_hideHelpfulSearchWidget");
-        activity.searchController.showSearchWidget();
-
-        expect(hideSpy).toHaveBeenCalled();
-    });
-
-    test("setTimeout fires focusInput and doSearch", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ visible: false });
-        setupSearchController(activity, ui);
-        const doSpy = jest
-            .spyOn(activity.searchController, "doSearch")
-            .mockImplementation(() => {});
-
-        activity.searchController.showSearchWidget();
-        jest.runAllTimers();
-
-        expect(ui.focusInput).toHaveBeenCalled();
-        expect(doSpy).toHaveBeenCalled();
-        jest.useRealTimers();
-    });
 });
 
 // ---------------------------------------------------------------------------
-// doSearch
+// doSearch — result generation
 // ---------------------------------------------------------------------------
 
-describe("SearchController.doSearch", () => {
-    test("returns early without error when searchWidget is null", () => {
-        const activity = makeActivity();
-        activity.searchWidget = null;
-        setupSearchController(activity, makeSearchUI());
-        expect(() => activity.searchController.doSearch()).not.toThrow();
-    });
-
-    test("calls prepSearchWidget when suggestions list is empty", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [];
-
-        sc.doSearch();
-
-        // prepSearchWidget resets to empty but was called
-        expect(sc._searchCache).toEqual({});
-    });
-
-    test("calls searchUI.setupMainAutocomplete with callbacks", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", searchTerms: ["drum"] }];
-
-        sc.doSearch();
-
-        expect(ui.setupMainAutocomplete).toHaveBeenCalledWith(
-            expect.any(Function),
-            expect.any(Function),
-            expect.any(Function)
-        );
-    });
-
-    test("calls searchUI.triggerMainSearch when value is set but idInput_custom is empty", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", searchTerms: ["drum"] }];
-
-        activity.searchWidget.idInput_custom = "";
-        activity.searchWidget.value = "drum";
-        sc.doSearch();
-
-        expect(ui.triggerMainSearch).toHaveBeenCalledWith("drum");
+describe("SearchController.doSearch - result generation", () => {
+    beforeEach(() => {
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => ({
+            data: jest.fn(() => false),
+            autocomplete: jest.fn()
+        }));
     });
 
     test("calls errorMsg for a deprecated block name", () => {
+        // protoBlockDict must NOT contain the name so the first branch is skipped;
+        // deprecatedBlockNames must contain idInput_custom for the second branch to fire.
+        // searchSuggestions must be non-empty so doSearch doesn't re-call prepSearchWidget
+        // (which would reset deprecatedBlockNames).
         const activity = makeActivity({});
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
         sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
         sc.deprecatedBlockNames = ["drum"];
@@ -541,10 +367,9 @@ describe("SearchController.doSearch", () => {
 
     test("calls errorMsg when block not found and not deprecated", () => {
         const activity = makeActivity({});
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
+        sc.prepSearchWidget();
 
         activity.searchWidget.idInput_custom = "ghost";
         activity.searchWidget.protoblk = { palette: { name: "test-palette" }, name: "ghost" };
@@ -556,10 +381,9 @@ describe("SearchController.doSearch", () => {
     test("calls makeBlockFromSearch and moveBlock for a known block", () => {
         const block = makeProtoBlock("drum", "drum");
         const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
 
         activity.searchWidget.idInput_custom = "drum";
         activity.searchWidget.protoblk = block;
@@ -576,10 +400,9 @@ describe("SearchController.doSearch", () => {
     test("advances searchBlockPosition after placing a block", () => {
         const block = makeProtoBlock("drum", "drum");
         const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
         sc.searchBlockPosition = [100, 100];
 
         activity.searchWidget.idInput_custom = "drum";
@@ -590,286 +413,190 @@ describe("SearchController.doSearch", () => {
         expect(sc.searchBlockPosition[1]).toBe(100 + global.STANDARDBLOCKHEIGHT);
     });
 
-    test("select callback sets widget fields before triggering recursive doSearch", () => {
-        const block = makeProtoBlock("drum", "drum");
-        const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+    test("returns early without error when searchWidget is not set", () => {
+        const activity = makeActivity();
+        activity.searchWidget = null;
+        setupSearchController(activity);
+        expect(() => activity.searchController.doSearch()).not.toThrow();
+    });
+});
 
+// ---------------------------------------------------------------------------
+// doSearch — autocomplete initialization branches
+// ---------------------------------------------------------------------------
+
+function makeJQueryElem(alreadyInit = false) {
+    let capturedOpts = null;
+    const initFlag = { value: alreadyInit };
+    const elem = {
+        data: jest.fn(function (key, val) {
+            if (val !== undefined) initFlag.value = val;
+            return key === "autocomplete-init" ? initFlag.value : undefined;
+        }),
+        autocomplete: jest.fn(function (arg) {
+            if (typeof arg === "object") capturedOpts = arg;
+            if (arg === "instance") return null;
+        }),
+        getOpts: () => capturedOpts
+    };
+    return elem;
+}
+
+describe("SearchController.doSearch - autocomplete initialization", () => {
+    let $elem;
+
+    beforeEach(() => {
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("skips autocomplete setup when already initialised", () => {
+        $elem = makeJQueryElem(true);
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "drum";
+        activity.searchWidget.protoblk = makeProtoBlock("drum", "drum");
         sc.doSearch();
 
-        // Prevent the recursive doSearch from resetting widget values
-        const recurseSpy = jest.spyOn(sc, "doSearch").mockImplementation(() => {});
+        expect($elem.autocomplete).not.toHaveBeenCalledWith(
+            expect.objectContaining({ source: expect.any(Function) })
+        );
+    });
 
-        const selectCb = ui.setupMainAutocomplete.mock.calls[0][1];
-        const item = { label: "drum", value: "drum", specialDict: block };
-        selectCb(item, 0);
+    test("source callback filters suggestions by term", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
 
-        expect(activity.searchWidget.value).toBe("drum");
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "drum" }, response);
+        expect(response).toHaveBeenCalled();
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("source callback normalises term to lowercase and trims whitespace", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        sc.doSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "  DRUM  " }, response);
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("select callback sets widget fields and re-runs doSearch", () => {
+        const block = makeProtoBlock("drum", "drum beat");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        const event = { preventDefault: jest.fn(), keyCode: 0 };
+        const ui = { item: { label: "drum beat", value: "drum", specialDict: block } };
+        $elem.getOpts().select(event, ui);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        // The nested doSearch() that select triggers places the block and then
+        // clears value back to ""; idInput_custom is not cleared.
         expect(activity.searchWidget.idInput_custom).toBe("drum");
         expect(activity.searchWidget.protoblk).toBe(block);
-        expect(recurseSpy).toHaveBeenCalled();
-    });
-
-    test("select callback with keyCode 13 sets searchWidget visibility to visible", () => {
-        const block = makeProtoBlock("drum", "drum");
-        const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
-
-        sc.doSearch();
-
-        // Prevent the recursive doSearch from interfering
-        jest.spyOn(sc, "doSearch").mockImplementation(() => {});
-
-        const selectCb = ui.setupMainAutocomplete.mock.calls[0][1];
-        selectCb({ label: "drum", value: "drum", specialDict: block }, 13);
-
-        expect(activity.searchWidget.style.visibility).toBe("visible");
-    });
-
-    test("source function passed to setupMainAutocomplete delegates to filterSuggestions", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
-
-        sc.doSearch();
-
-        const sourceFn = ui.setupMainAutocomplete.mock.calls[0][0];
-        const results = sourceFn({ term: "drum" });
-        expect(Array.isArray(results)).toBe(true);
-    });
-
-    test("drop callback passed to setupMainAutocomplete calls makeBlockFromSearch", () => {
-        const block = makeProtoBlock("drum", "drum");
-        const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
-
-        sc.doSearch();
-
-        const dropCb = ui.setupMainAutocomplete.mock.calls[0][2];
-        dropCb(block, 150, 250);
-
         expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
-        expect(activity.blocks.moveBlock).toHaveBeenCalledWith(
-            42,
-            expect.any(Number),
-            expect.any(Number)
-        );
-    });
-});
-
-// ---------------------------------------------------------------------------
-// setHelpfulSearchDiv
-// ---------------------------------------------------------------------------
-
-describe("SearchController.setHelpfulSearchDiv", () => {
-    test("calls searchUI.buildHelpfulSearchDiv()", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-
-        activity.searchController.setHelpfulSearchDiv();
-
-        expect(ui.buildHelpfulSearchDiv).toHaveBeenCalled();
     });
 
-    test("wires click listener on the returned closeButton", () => {
-        const closeButton = { id: "crossButton" };
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        ui.buildHelpfulSearchDiv = jest.fn(() => ({ closeButton, modeButton: null }));
-        setupSearchController(activity, ui);
-
-        activity.searchController.setHelpfulSearchDiv();
-
-        expect(activity.addEventListener).toHaveBeenCalledWith(
-            closeButton,
-            "click",
-            expect.any(Function)
-        );
-    });
-
-    test("wires click listener on modeButton when it is returned", () => {
-        const closeButton = { id: "crossButton" };
-        const modeButton = { id: "begIconText" };
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        ui.buildHelpfulSearchDiv = jest.fn(() => ({ closeButton, modeButton }));
-        setupSearchController(activity, ui);
-
-        activity.searchController.setHelpfulSearchDiv();
-
-        expect(activity.addEventListener).toHaveBeenCalledWith(
-            modeButton,
-            "click",
-            expect.any(Function)
-        );
-    });
-});
-
-// ---------------------------------------------------------------------------
-// _displayHelpfulSearchDiv
-// ---------------------------------------------------------------------------
-
-describe("SearchController._displayHelpfulSearchDiv", () => {
-    test("calls searchUI.positionHelpfulSearchDiv()", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        ui.isHelpfulSearchDivMounted = jest.fn(() => true);
-        setupSearchController(activity, ui);
-
-        activity.searchController._displayHelpfulSearchDiv();
-
-        expect(ui.positionHelpfulSearchDiv).toHaveBeenCalled();
-    });
-
-    test("calls setHelpfulSearchDiv when overlay is not mounted", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        ui.isHelpfulSearchDivMounted = jest.fn(() => false);
-        setupSearchController(activity, ui);
-
-        const setSpy = jest.spyOn(activity.searchController, "setHelpfulSearchDiv");
-        activity.searchController._displayHelpfulSearchDiv();
-
-        expect(setSpy).toHaveBeenCalled();
-    });
-
-    test("does not call setHelpfulSearchDiv when overlay is already mounted", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        ui.isHelpfulSearchDivMounted = jest.fn(() => true);
-        setupSearchController(activity, ui);
-
-        const setSpy = jest.spyOn(activity.searchController, "setHelpfulSearchDiv");
-        activity.searchController._displayHelpfulSearchDiv();
-
-        expect(setSpy).not.toHaveBeenCalled();
-    });
-});
-
-// ---------------------------------------------------------------------------
-// _hideHelpfulSearchWidget
-// ---------------------------------------------------------------------------
-
-describe("SearchController._hideHelpfulSearchWidget", () => {
-    test("calls searchUI.removeHelpfulSearchDiv()", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-
-        activity.searchController._hideHelpfulSearchWidget();
-
-        expect(ui.removeHelpfulSearchDiv).toHaveBeenCalled();
-    });
-
-    test("calls activity.__tick()", () => {
-        const activity = makeActivity();
-        setupSearchController(activity, makeSearchUI());
-
-        activity.searchController._hideHelpfulSearchWidget();
-
-        expect(activity.__tick).toHaveBeenCalled();
-    });
-});
-
-// ---------------------------------------------------------------------------
-// showHelpfulSearchWidget
-// ---------------------------------------------------------------------------
-
-describe("SearchController.showHelpfulSearchWidget", () => {
-    test("does nothing when searchUI.isHelpfulSearchVisible() returns false", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: false });
-        setupSearchController(activity, ui);
-
-        activity.searchController.showHelpfulSearchWidget();
-
-        expect(ui.showHelpfulInput).not.toHaveBeenCalled();
-    });
-
-    test("calls searchUI.showHelpfulInput() when isHelpfulSearchVisible() returns true", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        setupSearchController(activity, ui);
-
-        activity.searchController.showHelpfulSearchWidget();
-
-        expect(ui.showHelpfulInput).toHaveBeenCalled();
-        jest.useRealTimers();
-    });
-
-    test("schedules focusHelpfulInput and doHelpfulSearch", () => {
-        jest.useFakeTimers();
-        const activity = makeActivity();
-        const ui = makeSearchUI({ helpfulVisible: true });
-        setupSearchController(activity, ui);
-
-        const doSpy = jest
-            .spyOn(activity.searchController, "doHelpfulSearch")
-            .mockImplementation(() => {});
-
-        activity.searchController.showHelpfulSearchWidget();
-        jest.runAllTimers();
-
-        expect(ui.focusHelpfulInput).toHaveBeenCalled();
-        expect(doSpy).toHaveBeenCalled();
-        jest.useRealTimers();
-    });
-});
-
-// ---------------------------------------------------------------------------
-// doHelpfulSearch
-// ---------------------------------------------------------------------------
-
-describe("SearchController.doHelpfulSearch", () => {
-    test("calls searchUI.setupHelpfulAutocomplete with callbacks", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+    test("focus callback calls preventDefault", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
 
-        sc.doHelpfulSearch();
+        activity.searchWidget.idInput_custom = "";
+        sc.doSearch();
 
-        expect(ui.setupHelpfulAutocomplete).toHaveBeenCalledWith(
-            expect.any(Function),
-            expect.any(Function)
-        );
+        const event = { preventDefault: jest.fn() };
+        $elem.getOpts().focus(event);
+        expect(event.preventDefault).toHaveBeenCalled();
     });
 
-    test("calls triggerHelpfulSearch when value is set but idInput_custom is empty", () => {
+    test("triggers autocomplete search when idInput_custom is empty but value is set", () => {
         const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
 
-        activity.helpfulSearchWidget.idInput_custom = "";
-        activity.helpfulSearchWidget.value = "drum";
-        sc.doHelpfulSearch();
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "drum";
+        sc.doSearch();
 
-        expect(ui.triggerHelpfulSearch).toHaveBeenCalledWith("drum");
+        expect($elem.autocomplete).toHaveBeenCalledWith("search", "drum");
+    });
+
+    test("returns without triggering autocomplete search when both inputs are empty", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith("search", expect.anything());
+    });
+});
+
+// ---------------------------------------------------------------------------
+// doHelpfulSearch — result generation
+// ---------------------------------------------------------------------------
+
+describe("SearchController.doHelpfulSearch - result generation", () => {
+    let helpfulSearchDivEl;
+
+    beforeEach(() => {
+        helpfulSearchDivEl = { style: { display: "" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulSearchDiv") return helpfulSearchDivEl;
+            return null;
+        });
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => ({
+            data: jest.fn(() => false),
+            autocomplete: jest.fn()
+        }));
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
     });
 
     test("calls makeBlockFromSearch and moveBlock for a known block", () => {
         const block = makeProtoBlock("drum", "drum");
         const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
 
         activity.helpfulSearchWidget.idInput_custom = "drum";
         activity.helpfulSearchWidget.protoblk = block;
@@ -883,25 +610,25 @@ describe("SearchController.doHelpfulSearch", () => {
         );
     });
 
-    test("calls searchUI.hideHelpfulSearchDisplay() after placing a block", () => {
+    test("advances searchBlockPosition after placing a block in helpful search", () => {
         const block = makeProtoBlock("drum", "drum");
         const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
+        sc.searchBlockPosition = [100, 100];
 
         activity.helpfulSearchWidget.idInput_custom = "drum";
         activity.helpfulSearchWidget.protoblk = block;
         sc.doHelpfulSearch();
 
-        expect(ui.hideHelpfulSearchDisplay).toHaveBeenCalled();
+        expect(sc.searchBlockPosition[0]).toBe(100 + global.STANDARDBLOCKHEIGHT);
+        expect(sc.searchBlockPosition[1]).toBe(100 + global.STANDARDBLOCKHEIGHT);
     });
 
     test("calls errorMsg for a deprecated block in helpful search", () => {
         const activity = makeActivity({});
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
         sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
         sc.deprecatedBlockNames = ["drum"];
@@ -915,10 +642,9 @@ describe("SearchController.doHelpfulSearch", () => {
 
     test("calls errorMsg when helpful-search block is not found and not deprecated", () => {
         const activity = makeActivity({});
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
+        sc.prepSearchWidget();
 
         activity.helpfulSearchWidget.idInput_custom = "ghost";
         activity.helpfulSearchWidget.protoblk = {
@@ -929,53 +655,257 @@ describe("SearchController.doHelpfulSearch", () => {
 
         expect(activity.errorMsg).toHaveBeenCalledWith("Block cannot be found.");
     });
+});
 
-    test("calls prepSearchWidget when suggestions list is empty", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        const prepSpy = jest.spyOn(sc, "prepSearchWidget");
+// ---------------------------------------------------------------------------
+// doHelpfulSearch — autocomplete initialization branches
+// ---------------------------------------------------------------------------
 
-        sc.doHelpfulSearch();
+describe("SearchController.doHelpfulSearch - autocomplete initialization", () => {
+    let $elem;
+    let helpfulSearchDivEl;
 
-        expect(prepSpy).toHaveBeenCalled();
+    beforeEach(() => {
+        helpfulSearchDivEl = { style: { display: "" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulSearchDiv") return helpfulSearchDivEl;
+            return null;
+        });
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
     });
 
-    test("source function passed to setupHelpfulAutocomplete delegates to filterSuggestions", () => {
-        const activity = makeActivity();
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
-        const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
-
-        sc.doHelpfulSearch();
-
-        const sourceFn = ui.setupHelpfulAutocomplete.mock.calls[0][0];
-        const results = sourceFn({ term: "drum" });
-        expect(Array.isArray(results)).toBe(true);
+    afterEach(() => {
+        delete global.window.jQuery;
     });
 
-    test("select callback sets helpfulSearchWidget fields before recursive doHelpfulSearch", () => {
-        const block = makeProtoBlock("drum", "drum");
+    test("skips autocomplete setup when already initialised", () => {
+        $elem = makeJQueryElem(true);
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "drum";
+        activity.helpfulSearchWidget.protoblk = makeProtoBlock("drum", "drum");
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith(
+            expect.objectContaining({ source: expect.any(Function) })
+        );
+    });
+
+    test("source callback filters suggestions by term", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
+        sc.doHelpfulSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "drum" }, response);
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("select callback sets helpfulSearchWidget fields and re-runs doHelpfulSearch", () => {
+        const block = makeProtoBlock("drum", "drum beat");
         const activity = makeActivity({ drum: block });
-        const ui = makeSearchUI();
-        setupSearchController(activity, ui);
+        setupSearchController(activity);
         const sc = activity.searchController;
-        sc.searchSuggestions = [{ label: "drum", value: "drum", searchTerms: ["drum"] }];
+        sc.prepSearchWidget();
 
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
         sc.doHelpfulSearch();
 
-        // Prevent recursive doHelpfulSearch from resetting widget values
-        const recurseSpy = jest.spyOn(sc, "doHelpfulSearch").mockImplementation(() => {});
+        const event = { preventDefault: jest.fn() };
+        const ui = { item: { label: "drum beat", value: "drum", specialDict: block } };
+        $elem.getOpts().select(event, ui);
 
-        const selectCb = ui.setupHelpfulAutocomplete.mock.calls[0][1];
-        const item = { label: "drum", value: "drum", specialDict: block };
-        selectCb(item);
-
-        expect(activity.helpfulSearchWidget.value).toBe("drum");
+        expect(event.preventDefault).toHaveBeenCalled();
+        // The nested doHelpfulSearch() that select triggers places the block and
+        // then clears value; idInput_custom is not cleared.
         expect(activity.helpfulSearchWidget.idInput_custom).toBe("drum");
         expect(activity.helpfulSearchWidget.protoblk).toBe(block);
-        expect(recurseSpy).toHaveBeenCalled();
+        expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
+    });
+
+    test("focus callback calls preventDefault", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        sc.doHelpfulSearch();
+
+        const event = { preventDefault: jest.fn() };
+        $elem.getOpts().focus(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("triggers autocomplete search when idInput_custom is empty but value is set", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "drum";
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).toHaveBeenCalledWith("search", "drum");
+    });
+
+    test("returns without autocomplete search when both helpfulSearch inputs are empty", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith("search", expect.anything());
+    });
+});
+
+// ---------------------------------------------------------------------------
+// showHelpfulSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController.showHelpfulSearchWidget", () => {
+    let $elem;
+    let helpfulWheelDivEl;
+
+    beforeEach(() => {
+        helpfulWheelDivEl = { style: { display: "block" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulWheelDiv") return helpfulWheelDivEl;
+            return null;
+        });
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("does not activate widget when helpfulSearchDiv is not in display:block", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "none" } };
+
+        sc.showHelpfulSearchWidget();
+
+        expect(activity.helpfulSearchWidget.style.visibility).toBe("hidden");
+    });
+
+    test("silently catches when autocomplete destroy throws", () => {
+        $elem.autocomplete = jest.fn(() => {
+            throw new Error("not initialized");
+        });
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "none" } };
+
+        expect(() => sc.showHelpfulSearchWidget()).not.toThrow();
+    });
+
+    test("makes helpfulSearchWidget visible and schedules doHelpfulSearch when div is block", () => {
+        jest.useFakeTimers();
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "block" } };
+
+        const doHelpfulSearchSpy = jest.spyOn(sc, "doHelpfulSearch").mockImplementation(() => {});
+
+        sc.showHelpfulSearchWidget();
+
+        expect(activity.helpfulSearchWidget.style.visibility).toBe("visible");
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+
+        jest.runAllTimers();
+        expect(activity.helpfulSearchWidget.focus).toHaveBeenCalled();
+        expect(doHelpfulSearchSpy).toHaveBeenCalled();
+
+        jest.useRealTimers();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _hideHelpfulSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController._hideHelpfulSearchWidget", () => {
+    let helpfulWheelDivEl;
+
+    beforeEach(() => {
+        helpfulWheelDivEl = { style: { display: "block" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulWheelDiv") return helpfulWheelDivEl;
+            return null;
+        });
+    });
+
+    test("sets helpfulWheelDiv display to none when it is visible", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = null;
+        helpfulWheelDivEl.style.display = "block";
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+        expect(activity.__tick).toHaveBeenCalled();
+    });
+
+    test("does not reassign helpfulWheelDiv display when already none", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = null;
+        helpfulWheelDivEl.style.display = "none";
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+    });
+
+    test("skips removeChild when helpfulSearchDiv has no parentNode", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { parentNode: null };
+
+        expect(() => sc._hideHelpfulSearchWidget()).not.toThrow();
+    });
+
+    test("calls removeChild when helpfulSearchDiv has a parentNode", () => {
+        const removeChild = jest.fn();
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { parentNode: { removeChild } };
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(removeChild).toHaveBeenCalledWith(sc.helpfulSearchDiv);
     });
 });

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -9,46 +9,22 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* global _, STANDARDBLOCKHEIGHT */
+/* global _, $j, docByClass, STANDARDBLOCKHEIGHT */
 
 /* exported setupSearchController, SearchController */
 
-/**
- * Owns all search behaviour and state.
- *
- * Responsibilities:
- * - building / filtering the suggestion list from the block dictionary
- * - activating and deactivating the main search widget
- * - wiring the autocomplete source and select callbacks
- * - tracking cursor position for successive block placements
- * - coordinating the helpful-search overlay lifecycle
- *
- * Every DOM or jQuery operation is delegated to SearchUI
- * (js/search-ui.js).  No rendering code lives here.
- */
 class SearchController {
-    /**
-     * @param {object} activity  - The Activity instance.
-     * @param {object} searchUI  - A SearchUI instance that owns all DOM and
-     *   jQuery operations for the search feature.  SearchController calls
-     *   into searchUI for rendering and queries it (via isVisible(),
-     *   isHelpfulSearchVisible(), etc.) for current UI state, keeping DOM
-     *   knowledge out of this class.
-     */
-    constructor(activity, searchUI) {
+    constructor(activity) {
         this.activity = activity;
-        this.searchUI = searchUI;
 
         this.searchSuggestions = [];
         this._searchCache = {};
         this._searchCloseListener = null;
+        this.isHelpfulSearchWidgetOn = false;
         this.searchBlockPosition = [100, 100];
         this.deprecatedBlockNames = [];
+        this.helpfulSearchDiv = null;
     }
-
-    // -----------------------------------------------------------------------
-    // Data / logic layer
-    // -----------------------------------------------------------------------
 
     /**
      * Builds the block list used for search bar autocompletion.
@@ -56,6 +32,7 @@ class SearchController {
      * searchSuggestions and deprecatedBlockNames.
      */
     prepSearchWidget() {
+        this.searchBlockPosition = [100, 100];
         this.searchSuggestions = [];
         this._searchCache = {};
         this.deprecatedBlockNames = [];
@@ -171,7 +148,8 @@ class SearchController {
     }
 
     /**
-     * Filters searchSuggestions against a query term with caching.
+     * Filters searchSuggestions against a query term.
+     * Returns matching items, respecting the result cache.
      * @param {string} term - Lowercased, trimmed search term.
      * @returns {Array}
      */
@@ -198,43 +176,74 @@ class SearchController {
         return results;
     }
 
-    // -----------------------------------------------------------------------
-    // Main search coordination
-    // -----------------------------------------------------------------------
-
     /**
-     * Hides the main search widget and removes the mousedown close listener.
-     * Delegates DOM hide to SearchUI.hide().
+     * Hides the main search widget.
      */
     hideSearchWidget() {
+        const obj = docByClass("ui-menu");
+        if (obj.length > 0) {
+            obj[0].style.visibility = "hidden";
+        }
+
         if (this._searchCloseListener) {
             this.activity.removeEventListener(document, "mousedown", this._searchCloseListener);
             this._searchCloseListener = null;
         }
-        this.searchUI.hide();
+
+        this.activity.searchWidget.style.visibility = "hidden";
+        this.activity.searchWidget.idInput_custom = "";
     }
 
     /**
      * Shows or toggles the main search widget.
-     * Delegates DOM show to SearchUI.show(), then wires the autocomplete
-     * and installs a document mousedown listener to close on outside clicks.
      */
     showSearchWidget() {
         const activity = this.activity;
-        if (this.searchUI.isHelpfulSearchVisible()) {
+        activity.searchWidget.style.zIndex = 1001;
+        activity.searchWidget.style.border = "2px solid lightblue";
+        if (this.helpfulSearchDiv) {
             this._hideHelpfulSearchWidget();
         }
-        if (this.searchUI.isVisible()) {
+        if (activity.searchWidget.style.visibility === "visible") {
             this.hideSearchWidget();
         } else {
-            this.searchUI.show();
+            const obj = docByClass("ui-menu");
+            if (obj.length > 0) {
+                obj[0].style.visibility = "visible";
+            }
+
+            if (activity.searchWidget) {
+                activity.searchWidget.value = null;
+                activity.searchWidget.style.visibility = "visible";
+                const searchPos = activity.palettes.getSearchPos();
+                activity.searchWidget.style.left = searchPos.x + "px";
+                activity.searchWidget.style.top = searchPos.y + "px";
+            }
 
             this.searchBlockPosition = [100, 100];
             this.prepSearchWidget();
 
             const that = this;
             const closeListener = e => {
-                if (!that.searchUI.containsMainSearchTarget(e.target)) {
+                if (
+                    document.getElementById("search").style.visibility === "visible" &&
+                    (e.target === document.getElementById("search") ||
+                        document.getElementById("search").contains(e.target))
+                ) {
+                    //do nothing when clicked in the input field
+                } else if (
+                    document.getElementById("ui-id-1") &&
+                    document.getElementById("ui-id-1").style.display === "block" &&
+                    (e.target === document.getElementById("ui-id-1") ||
+                        document.getElementById("ui-id-1").contains(e.target))
+                ) {
+                    //do nothing when clicked on the menu
+                } else if (
+                    document.querySelector("#palette tbody tr") &&
+                    document.querySelector("#palette tbody tr").contains(e.target)
+                ) {
+                    //do nothing when clicked on the search row
+                } else {
                     that.hideSearchWidget();
                 }
             };
@@ -242,17 +251,14 @@ class SearchController {
             activity.addEventListener(document, "mousedown", closeListener);
 
             setTimeout(() => {
-                that.searchUI.focusInput();
+                activity.searchWidget.focus();
                 that.doSearch();
             }, 500);
         }
     }
 
     /**
-     * Wires the jQuery autocomplete on #search and, when idInput_custom is
-     * set, places the selected block on the canvas.
-     * Autocomplete UI is set up via SearchUI.setupMainAutocomplete();
-     * block placement logic runs entirely here.
+     * Sets up jQuery autocomplete on the main search input and executes a search.
      */
     doSearch() {
         const activity = this.activity;
@@ -261,47 +267,148 @@ class SearchController {
             return;
         }
 
+        const $j = window.jQuery;
         if (this.searchSuggestions.length === 0) {
             this.prepSearchWidget();
         }
 
         const that = this;
+        const $search = $j("#search");
 
-        this.searchUI.setupMainAutocomplete(
-            term => that.filterSuggestions(term),
-            (item, keyCode) => {
-                activity.searchWidget.value = item.label;
-                activity.searchWidget.idInput_custom = item.value;
-                activity.searchWidget.protoblk = item.specialDict;
-                that.doSearch();
-                if (keyCode === 13) activity.searchWidget.style.visibility = "visible";
-            },
-            (protoblk, x, y) => {
-                const paletteName = protoblk.palette.name;
-                const protoName = protoblk.name;
-                if (
-                    Object.prototype.hasOwnProperty.call(activity.blocks.protoBlockDict, protoName)
-                ) {
-                    activity.palettes.dict[paletteName].makeBlockFromSearch(
-                        protoblk,
-                        protoName,
-                        newBlock => {
-                            activity.blocks.moveBlock(
-                                newBlock,
-                                (x || activity.blocksContainer.x + 100) -
-                                    activity.blocksContainer.x,
-                                (y || activity.blocksContainer.y + 100) - activity.blocksContainer.y
-                            );
-                        }
-                    );
+        if (!$search.data("autocomplete-init")) {
+            $search.autocomplete({
+                source: (request, response) => {
+                    const term = (request.term || "").toLowerCase().trim();
+                    response(that.filterSuggestions(term));
+                },
+                appendTo: "body",
+                select: (event, ui) => {
+                    event.preventDefault();
+                    activity.searchWidget.value = ui.item.label;
+                    activity.searchWidget.idInput_custom = ui.item.value;
+                    activity.searchWidget.protoblk = ui.item.specialDict;
+                    that.doSearch();
+                    if (event.keyCode === 13) activity.searchWidget.style.visibility = "visible";
+                },
+                focus: event => {
+                    event.preventDefault();
                 }
+            });
+
+            const instance = $search.autocomplete("instance");
+            if (instance) {
+                instance._renderItem = (ul, item) => {
+                    const li = $j("<li></li>");
+
+                    const img = document.createElement("img");
+                    img.src = item.artwork || "";
+                    img.height = 20;
+                    img.style.cursor = "grab";
+
+                    // Drag-and-drop: mirrors the palette drag pattern in
+                    // palette.js _showMenuItems(). Keep both in sync.
+                    img.ondragstart = () => false;
+
+                    const down = event => {
+                        event.stopPropagation();
+                        event.stopImmediatePropagation();
+                        event.preventDefault();
+
+                        const posit = img.style.position;
+                        const zInd = img.style.zIndex;
+                        img.style.position = "absolute";
+                        img.style.zIndex = 10000;
+
+                        $j("#search").autocomplete("close");
+
+                        document.body.appendChild(img);
+
+                        const moveAt = (pageX, pageY) => {
+                            img.style.left = pageX - img.offsetWidth / 2 + "px";
+                            img.style.top = pageY - img.offsetHeight / 2 + "px";
+                        };
+
+                        const onMouseMove = e => {
+                            e.preventDefault();
+                            let x, y;
+                            if (e.type === "touchmove") {
+                                x = e.touches[0].clientX;
+                                y = e.touches[0].clientY;
+                            } else {
+                                x = e.pageX;
+                                y = e.pageY;
+                            }
+                            moveAt(x, y);
+                        };
+                        onMouseMove(event);
+
+                        document.addEventListener("touchmove", onMouseMove, { passive: false });
+                        document.addEventListener("mousemove", onMouseMove);
+
+                        const up = () => {
+                            document.body.style.cursor = "default";
+                            document.removeEventListener("mousemove", onMouseMove);
+                            document.removeEventListener("touchmove", onMouseMove);
+
+                            const x = parseInt(img.style.left);
+                            const y = parseInt(img.style.top);
+
+                            img.style.position = posit;
+                            img.style.zIndex = zInd;
+                            if (img.parentNode === document.body) {
+                                document.body.removeChild(img);
+                            }
+
+                            if (isNaN(x) && isNaN(y)) return;
+
+                            const protoblk = item.specialDict;
+                            const paletteName = protoblk.palette.name;
+                            const protoName = item.value;
+
+                            activity.palettes.dict[paletteName].makeBlockFromSearch(
+                                protoblk,
+                                protoName,
+                                newBlock => {
+                                    activity.blocks.moveBlock(
+                                        newBlock,
+                                        (x || activity.blocksContainer.x + 100) -
+                                            activity.blocksContainer.x,
+                                        (y || activity.blocksContainer.y + 100) -
+                                            activity.blocksContainer.y
+                                    );
+                                }
+                            );
+                        };
+
+                        document.addEventListener("mouseup", up, { once: true });
+                        document.addEventListener("touchend", up, { once: true });
+                    };
+
+                    li[0].addEventListener("mousedown", down, true);
+                    li[0].addEventListener("touchstart", down, {
+                        capture: true,
+                        passive: false
+                    });
+
+                    li.append(img);
+                    li.append($j("<a>").text(" " + item.label));
+
+                    return li.appendTo(
+                        ul.css({
+                            "z-index": 35000,
+                            "max-height": "200px",
+                            "overflow-y": "auto"
+                        })
+                    );
+                };
             }
-        );
+            $search.data("autocomplete-init", true);
+        }
 
         const searchInput = activity.searchWidget.idInput_custom;
         if (!searchInput || searchInput.length <= 0) {
             if (activity.searchWidget.value && activity.searchWidget.value.length > 0) {
-                this.searchUI.triggerMainSearch(activity.searchWidget.value);
+                $search.autocomplete("search", activity.searchWidget.value);
             }
             return;
         }
@@ -335,88 +442,189 @@ class SearchController {
         activity.update = true;
     }
 
-    // -----------------------------------------------------------------------
-    // Helpful-search coordination
-    // -----------------------------------------------------------------------
-
     /**
-     * Creates the #helpfulSearchDiv overlay via SearchUI.buildHelpfulSearchDiv()
-     * and wires the close and mode-button click handlers.
+     * Creates the helpfulSearchDiv container and appends it to the body.
      */
     setHelpfulSearchDiv() {
         const activity = this.activity;
-        const { closeButton, modeButton } = this.searchUI.buildHelpfulSearchDiv();
-        activity.addEventListener(closeButton, "click", this._hideHelpfulSearchWidget.bind(this));
-        if (modeButton) {
-            activity.addEventListener(
-                modeButton,
-                "click",
-                this._hideHelpfulSearchWidget.bind(this)
-            );
+        if (document.getElementById("helpfulSearchDiv")) {
+            document
+                .getElementById("helpfulSearchDiv")
+                .parentNode.removeChild(document.getElementById("helpfulSearchDiv"));
         }
+        this.helpfulSearchDiv = document.createElement("div");
+        this.helpfulSearchDiv.setAttribute("id", "helpfulSearchDiv");
+        this.helpfulSearchDiv.style.position = "fixed";
+
+        document.body.appendChild(this.helpfulSearchDiv);
+
+        const closeButtonDiv = document.createElement("div");
+        closeButtonDiv.style.cssText =
+            "position: absolute; top: 50%; right: 10px; transform: translateY(-50%); cursor: pointer;";
+
+        const closeButton = document.createElement("button");
+        closeButton.textContent = "×";
+        closeButton.id = "crossButton";
+        closeButton.style.cssText =
+            "background:rgba(80,80,80,0.6);border:none;border-radius:50%;width:22px;height:22px;font-size:14px;cursor:pointer;color:white;line-height:22px;text-align:center;";
+
+        closeButtonDiv.appendChild(closeButton);
+
+        this.helpfulSearchDiv.appendChild(closeButtonDiv);
+
+        const dragHandle = document.createElement("div");
+        dragHandle.style.cssText =
+            "position:absolute;left:8px;top:50%;transform:translateY(-50%);width:16px;height:80%;cursor:grab;z-index:1002;display:flex;align-items:center;justify-content:center;color:rgba(150,150,150,0.8);font-size:18px;user-select:none;";
+        dragHandle.textContent = "⠿";
+        let dragStartX, dragStartY, dragStartLeft, dragStartTop;
+        dragHandle.addEventListener("pointerdown", e => {
+            dragStartX = e.clientX;
+            dragStartY = e.clientY;
+            dragStartLeft = parseInt(this.helpfulSearchDiv.style.left) || 0;
+            dragStartTop = parseInt(this.helpfulSearchDiv.style.top) || 0;
+            dragHandle.setPointerCapture(e.pointerId);
+            dragHandle.style.cursor = "grabbing";
+        });
+        dragHandle.addEventListener("pointermove", e => {
+            if (!dragHandle.hasPointerCapture(e.pointerId)) return;
+            this.helpfulSearchDiv.style.left = dragStartLeft + e.clientX - dragStartX + "px";
+            this.helpfulSearchDiv.style.top = dragStartTop + e.clientY - dragStartY + "px";
+        });
+        dragHandle.addEventListener("pointerup", e => {
+            dragHandle.releasePointerCapture(e.pointerId);
+            dragHandle.style.cursor = "grab";
+        });
+        this.helpfulSearchDiv.appendChild(dragHandle);
+
+        const modeButton = document.getElementById("begIconText");
+        activity.addEventListener(closeButton, "click", this._hideHelpfulSearchWidget.bind(this));
+        activity.addEventListener(modeButton, "click", this._hideHelpfulSearchWidget.bind(this));
+
+        this.helpfulSearchDiv.appendChild(activity.helpfulSearchWidget);
     }
 
     /**
-     * Positions the helpful-search overlay next to the wheel, then shows it.
-     * Creates the overlay first if it doesn't already exist.
+     * Positions and displays the helpfulSearchDiv on the canvas.
      */
     _displayHelpfulSearchDiv() {
-        if (!this.searchUI.isHelpfulSearchDivMounted()) {
-            this.setHelpfulSearchDiv();
+        const helpfulWheelDivReset = document.getElementById("helpfulWheelDiv");
+        if (helpfulWheelDivReset) helpfulWheelDivReset.style.display = "";
+        this.setHelpfulSearchDiv();
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        this.helpfulSearchDiv.style.left = Math.max(0, (window.innerWidth - 320) / 2) + "px";
+        this.helpfulSearchDiv.style.top = "80px";
+
+        const windowWidth = window.innerWidth;
+        const windowHeight = window.innerHeight;
+        this.helpfulSearchDiv.style.display = "block";
+        const menuWidth = this.helpfulSearchDiv.offsetWidth;
+        const menuHeight = this.helpfulSearchDiv.offsetHeight;
+
+        if (this.helpfulSearchDiv.offsetLeft + menuWidth > windowWidth) {
+            this.helpfulSearchDiv.style.left = windowWidth - menuWidth + "px";
         }
-        this.searchUI.positionHelpfulSearchDiv();
+        if (this.helpfulSearchDiv.offsetTop + menuHeight > windowHeight) {
+            this.helpfulSearchDiv.style.top = windowHeight - menuHeight + "px";
+        }
+
         this.showHelpfulSearchWidget();
+        this.isHelpfulSearchWidgetOn = true;
     }
 
     /**
-     * Removes the helpful-search overlay and triggers a canvas redraw.
+     * Hides and removes the helpfulSearchDiv from the DOM.
      */
     _hideHelpfulSearchWidget() {
-        this.searchUI.removeHelpfulSearchDiv();
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        if (helpfulWheelDiv.style.display !== "none") {
+            helpfulWheelDiv.style.display = "none";
+        }
+        if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
+            this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
+        }
+        const hwd = document.getElementById("helpfulWheelDiv");
+        if (hwd) hwd.style.display = "";
+        this.isHelpfulSearchWidgetOn = false;
         this.activity.__tick();
     }
 
     /**
-     * Resets and focuses the helpful search input, then schedules
-     * doHelpfulSearch after a short delay (to allow layout to settle).
+     * Shows the helpfulSearchWidget input and triggers doHelpfulSearch.
      */
     showHelpfulSearchWidget() {
-        if (!this.searchUI.isHelpfulSearchVisible()) {
-            return;
+        const $j = window.jQuery;
+        if ($j("#helpfulSearch")) {
+            try {
+                $j("#helpfulSearch").autocomplete("destroy");
+                $j("#helpfulSearch").removeData("autocomplete-init");
+            } catch {
+                //
+            }
         }
-        this.searchUI.showHelpfulInput();
+        const activity = this.activity;
+        activity.helpfulSearchWidget.style.zIndex = 1001;
+        activity.helpfulSearchWidget.idInput_custom = "";
+        if (this.helpfulSearchDiv.style.display === "block") {
+            activity.helpfulSearchWidget.value = null;
+            activity.helpfulSearchWidget.style.visibility = "visible";
 
-        this.searchBlockPosition = [100, 100];
-        this.prepSearchWidget();
+            this.searchBlockPosition = [100, 100];
+            this.prepSearchWidget();
 
-        const that = this;
-        setTimeout(() => {
-            that.searchUI.focusHelpfulInput();
-            that.doHelpfulSearch();
-        }, 500);
+            const that = this;
+            setTimeout(() => {
+                activity.helpfulSearchWidget.focus();
+                that.doHelpfulSearch();
+            }, 500);
+        }
     }
 
     /**
-     * Wires the jQuery autocomplete on #helpfulSearch and, when
-     * idInput_custom is set, places the selected block on the canvas.
+     * Sets up jQuery autocomplete on the helpful search input and executes a search.
      */
     doHelpfulSearch() {
+        const $j = window.jQuery;
         if (this.searchSuggestions.length === 0) {
             this.prepSearchWidget();
         }
 
         const that = this;
         const activity = this.activity;
+        const $helpfulSearch = $j("#helpfulSearch");
 
-        this.searchUI.setupHelpfulAutocomplete(
-            term => that.filterSuggestions(term),
-            item => {
-                activity.helpfulSearchWidget.value = item.label;
-                activity.helpfulSearchWidget.idInput_custom = item.value;
-                activity.helpfulSearchWidget.protoblk = item.specialDict;
-                that.doHelpfulSearch();
+        if (!$helpfulSearch.data("autocomplete-init")) {
+            $helpfulSearch.autocomplete({
+                source: (request, response) => {
+                    const term = (request.term || "").toLowerCase().trim();
+                    response(that.filterSuggestions(term));
+                },
+                appendTo: "body",
+                select: (event, ui) => {
+                    event.preventDefault();
+                    activity.helpfulSearchWidget.value = ui.item.label;
+                    activity.helpfulSearchWidget.idInput_custom = ui.item.value;
+                    activity.helpfulSearchWidget.protoblk = ui.item.specialDict;
+                    that.doHelpfulSearch();
+                },
+                focus: event => {
+                    event.preventDefault();
+                }
+            });
+
+            const instance = $helpfulSearch.autocomplete("instance");
+            if (instance) {
+                instance._renderItem = (ul, item) => {
+                    const li = $j("<li></li>");
+                    const img = document.createElement("img");
+                    img.src = item.artwork || "";
+                    img.height = 20;
+                    li.append(img);
+                    li.append($j("<a>").text(" " + item.label));
+                    return li.appendTo(ul.css("z-index", 35000));
+                };
             }
-        );
+            $helpfulSearch.data("autocomplete-init", true);
+        }
 
         const searchInput = activity.helpfulSearchWidget.idInput_custom;
         if (!searchInput || searchInput.length <= 0) {
@@ -424,7 +632,7 @@ class SearchController {
                 activity.helpfulSearchWidget.value &&
                 activity.helpfulSearchWidget.value.length > 0
             ) {
-                this.searchUI.triggerHelpfulSearch(activity.helpfulSearchWidget.value);
+                $helpfulSearch.autocomplete("search", activity.helpfulSearchWidget.value);
             }
             return;
         }
@@ -455,21 +663,19 @@ class SearchController {
         }
 
         activity.helpfulSearchWidget.value = "";
-        this.searchUI.hideHelpfulSearchDisplay();
+        document.getElementById("helpfulSearchDiv").style.display = "none";
         activity.update = true;
     }
 }
 
 /**
- * Creates a SearchController, attaches it to activity, and wires
- * delegation methods so external callers (palette.js, planetInterface.js)
- * continue to work unchanged.
- *
- * @param {object} activity  - The Activity instance.
- * @param {object} searchUI  - The SearchUI instance (from setupSearchUI).
+ * Creates a SearchController and attaches it to the activity.
+ * Installs delegation methods on activity so external callers
+ * (palette.js, planetInterface.js) continue to work unchanged.
+ * @param {object} activity - The Activity instance.
  */
-const setupSearchController = (activity, searchUI) => {
-    activity.searchController = new SearchController(activity, searchUI);
+const setupSearchController = activity => {
+    activity.searchController = new SearchController(activity);
 };
 
 if (typeof define === "function" && define.amd) {

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -192,6 +192,7 @@ class SearchController {
 
         this.activity.searchWidget.style.visibility = "hidden";
         this.activity.searchWidget.idInput_custom = "";
+        this._hideSearchDragHandle();
     }
 
     /**
@@ -218,6 +219,7 @@ class SearchController {
                 const searchPos = activity.palettes.getSearchPos();
                 activity.searchWidget.style.left = searchPos.x + "px";
                 activity.searchWidget.style.top = searchPos.y + "px";
+                this._addSearchDragHandle();
             }
 
             this.searchBlockPosition = [100, 100];
@@ -228,9 +230,10 @@ class SearchController {
                 if (
                     document.getElementById("search").style.visibility === "visible" &&
                     (e.target === document.getElementById("search") ||
-                        document.getElementById("search").contains(e.target))
+                        document.getElementById("search").contains(e.target) ||
+                        e.target === document.getElementById("searchDragHandle"))
                 ) {
-                    //do nothing when clicked in the input field
+                    //do nothing when clicked in the input field or the drag handle
                 } else if (
                     document.getElementById("ui-id-1") &&
                     document.getElementById("ui-id-1").style.display === "block" &&
@@ -253,6 +256,7 @@ class SearchController {
             setTimeout(() => {
                 activity.searchWidget.focus();
                 that.doSearch();
+                that._positionSearchDragHandle();
             }, 500);
         }
     }
@@ -440,6 +444,76 @@ class SearchController {
 
         activity.searchWidget.value = "";
         activity.update = true;
+    }
+
+    /**
+     * Creates (once) and positions a drag handle for the classic #search
+     * input, so it can be dragged the same way helpfulSearchDiv can.
+     */
+    _addSearchDragHandle() {
+        const activity = this.activity;
+        let handle = document.getElementById("searchDragHandle");
+
+        if (!handle) {
+            handle = document.createElement("div");
+            handle.id = "searchDragHandle";
+            handle.style.cssText =
+                "position:absolute;width:16px;height:38px;cursor:grab;z-index:2001;" +
+                "display:flex;align-items:center;justify-content:center;" +
+                "color:rgba(150,150,150,0.8);font-size:18px;user-select:none;";
+            handle.textContent = "⠿";
+            document.body.appendChild(handle);
+
+            let dragStartX, dragStartY, dragStartLeft, dragStartTop;
+
+            handle.addEventListener("pointerdown", e => {
+                dragStartX = e.clientX;
+                dragStartY = e.clientY;
+                dragStartLeft = parseInt(activity.searchWidget.style.left) || 0;
+                dragStartTop = parseInt(activity.searchWidget.style.top) || 0;
+                activity.searchWidget.style.transition = "none";
+                handle.setPointerCapture(e.pointerId);
+                handle.style.cursor = "grabbing";
+            });
+
+            handle.addEventListener("pointermove", e => {
+                if (!handle.hasPointerCapture(e.pointerId)) return;
+                const newLeft = dragStartLeft + e.clientX - dragStartX;
+                const newTop = dragStartTop + e.clientY - dragStartY;
+                activity.searchWidget.style.left = newLeft + "px";
+                activity.searchWidget.style.top = newTop + "px";
+                this._positionSearchDragHandle();
+            });
+
+            handle.addEventListener("pointerup", e => {
+                handle.releasePointerCapture(e.pointerId);
+                handle.style.cursor = "grab";
+                activity.searchWidget.style.transition = "";
+            });
+        }
+
+        handle.style.display = "flex";
+        this._positionSearchDragHandle();
+    }
+
+    /**
+     * Keeps the drag handle glued to the left edge of #search.
+     */
+    _positionSearchDragHandle() {
+        const activity = this.activity;
+        const handle = document.getElementById("searchDragHandle");
+        if (!handle || !activity.searchWidget) return;
+        const rect = activity.searchWidget.getBoundingClientRect();
+        handle.style.left = rect.left + 4 + "px";
+        handle.style.top = rect.top + (rect.height - 38) / 2 + "px";
+    }
+
+    /**
+     * Hides the drag handle when the classic search widget is hidden.
+     */
+    _hideSearchDragHandle() {
+        const handle = document.getElementById("searchDragHandle");
+        if (handle) handle.style.display = "none";
     }
 
     /**

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -503,6 +503,7 @@ class SearchController {
         const activity = this.activity;
         const handle = document.getElementById("searchDragHandle");
         if (!handle || !activity.searchWidget) return;
+        if (typeof activity.searchWidget.getBoundingClientRect !== "function") return;
         const rect = activity.searchWidget.getBoundingClientRect();
         handle.style.left = rect.left + 4 + "px";
         handle.style.top = rect.top + (rect.height - 38) / 2 + "px";
@@ -616,12 +617,9 @@ class SearchController {
         if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
             this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
         }
-        const hwd = document.getElementById("helpfulWheelDiv");
-        if (hwd) hwd.style.display = "";
         this.isHelpfulSearchWidgetOn = false;
         this.activity.__tick();
     }
-
     /**
      * Shows the helpfulSearchWidget input and triggers doHelpfulSearch.
      */
@@ -641,10 +639,9 @@ class SearchController {
         if (this.helpfulSearchDiv.style.display === "block") {
             activity.helpfulSearchWidget.value = null;
             activity.helpfulSearchWidget.style.visibility = "visible";
-
+            document.getElementById("helpfulWheelDiv").style.display = "none";
             this.searchBlockPosition = [100, 100];
             this.prepSearchWidget();
-
             const that = this;
             setTimeout(() => {
                 activity.helpfulSearchWidget.focus();


### PR DESCRIPTION
## What does this PR do?
Adds `Ctrl+Space` (Windows/Linux) and `Cmd+Space` (Mac) keyboard shortcut
to open the **Search for Blocks** widget in Music Blocks.

Fixes #7631

---

## Why?
Previously, the Search for Blocks widget could only be opened by 
clicking the 🔍 magnifying glass icon in the toolbar with a mouse.

There was no keyboard shortcut to open it, making it inaccessible 
for keyboard-only users.

This PR adds a spotlight-style shortcut—similar to how Mac Spotlight 
(Cmd+Space) works—so users can instantly open search from anywhere 
on the canvas without touching the mouse.

---

## Changes Made
- Modified `js/activity.js`
- Added shortcut inside the `event.ctrlKey` block of `__keyPressed()`
- Shortcut only activates when `disableKeys` is false (search not 
  already open, no widget blocking input)

```javascript
if (event.code === "Space" && !disableKeys) {
    event.preventDefault();
    this.showSearchWidget();
}
```

---

## How to Test?
1. Open Music Blocks at http://localhost:3000
2. Press `Ctrl+Space` "Windows/Linux" or `Cmd+Space` "Mac"
3. ✅ Search for Blocks widget opens instantly!
4. Pressing the "esc" widget also closes

---

## Demo Video

https://github.com/user-attachments/assets/4ec09f02-53b2-4ed0-bb22-b7fa419a52ec



---

## PR Category
- [x] Feature
- [x] Accessibility