### PR TITLE
fix: resolve text contrast issues in search bar and autocomplete under dark/high-contrast themes

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -127,7 +127,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark #helpfulSearch,
 .dark .ui-autocomplete {
     background-color: var(--color-bg-primary) !important;
-    color: var(--color-text-inverse) !important;
+    color: var(--color-text-primary) !important;
     border-color: var(--color-border-primary) !important;
 }
 
@@ -135,7 +135,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-menu-item,
 .dark .ui-autocomplete .ui-menu-item a,
 .dark .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
-    color: var(--color-text-inverse) !important;
+    color: var(--color-text-primary) !important;
     background-color: transparent !important;
 }
 
@@ -146,7 +146,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 .dark .ui-autocomplete .ui-state-focus,
 .dark .ui-autocomplete .ui-state-active {
     background-color: var(--color-bg-tertiary) !important;
-    color: var(--color-text-inverse) !important;
+    color: var(--color-text-primary) !important;
 }
 
 .dark #helpfulSearchDiv {
@@ -154,7 +154,7 @@ body.highcontrast #themedropdown.dropdown-content li > a:hover {
 }
 
 .dark #crossButton {
-    color: var(--color-text-inverse);
+    color: var(--color-text-primary);
 }
 
 .dark #chooseKeyDiv {
@@ -512,11 +512,11 @@ body.highcontrast {
 }
 
 .highcontrast .blue {
-    background-color: var(--color-text-inverse)080 !important;
+    background-color: var(--color-text-inverse) 080 !important;
 }
 
 .highcontrast .blue.darken-1 {
-    background-color: var(--color-text-inverse)0ff !important;
+    background-color: var(--color-text-inverse) 0ff !important;
 }
 
 .highcontrast #floatingWindows > .windowFrame {
@@ -566,28 +566,34 @@ body.highcontrast {
 .highcontrast #search,
 .highcontrast #helpfulSearch,
 .highcontrast .ui-autocomplete {
-    background-color: var(--color-text-inverse) !important;
-    color: var(--color-text-inverse) !important;
+    background-color: var(--color-bg-primary) !important;
+    color: var(--color-text-primary) !important;
     border: 1px solid #ffffff;
 }
 
-.highcontrast .ui-autocomplete .ui-menu-item a {
-    color: var(--color-text-inverse) !important;
-    background-color: var(--color-text-inverse) !important;
+.highcontrast .ui-autocomplete .ui-menu-item,
+.highcontrast .ui-autocomplete .ui-menu-item a,
+.highcontrast .ui-autocomplete .ui-menu-item .ui-menu-item-wrapper {
+    color: var(--color-text-primary) !important;
+    background-color: transparent !important;
 }
 
-.highcontrast .ui-autocomplete .ui-menu-item a:hover {
+.highcontrast .ui-autocomplete .ui-menu-item:hover,
+.highcontrast .ui-autocomplete .ui-menu-item:hover a,
+.highcontrast .ui-autocomplete .ui-menu-item:hover .ui-menu-item-wrapper,
+.highcontrast .ui-autocomplete .ui-state-focus,
+.highcontrast .ui-autocomplete .ui-state-active {
     color: var(--color-text-primary) !important;
     background-color: var(--color-brand-secondary) !important;
 }
 
 .highcontrast #helpfulSearchDiv {
-    color: var(--color-text-inverse) !important;
+    color: var(--color-text-primary) !important;
     background-color: transparent !important;
 }
 
 .highcontrast #crossButton {
-    color: var(--color-text-inverse);
+    color: var(--color-text-primary);
 }
 
 .highcontrast #chooseKeyDiv {


### PR DESCRIPTION
- [x] Bug fix
### Problem
When the application is configured to use **Dark Mode** or **High Contrast Mode**, the text typed into the search bar, the suggestion autocomplete list items, and the input clear button (`#crossButton`) are styled using the `var(--color-text-inverse)` color token. 
- In **Dark Mode**, `var(--color-text-inverse)` evaluates to `#111827`, which matches the dark background, causing text to be completely invisible.
- In **High Contrast Mode**, it similarly evaluates to `#000000` on a `#000000` background, creating a severe accessibility and contrast issue.

### Solution
Updated [css/themes.css](file:///Users/rakshityadav/Desktop/OPEN-SOURCE/sugarlabs/musicblocks/css/themes.css) to replace `var(--color-text-inverse)` with `var(--color-text-primary)` in the following components for both `.dark` and `.highcontrast` rules:
- Search Bar (`#search` and `#helpfulSearch`)
- Autocomplete element (`.ui-autocomplete`)
- Suggestions list items (`.ui-menu-item`, `.ui-menu-item a`, and `.ui-menu-item-wrapper`)
- Suggestions list items on hover/focus state
- Clear Input Button (`#crossButton`)
- Helpful search container description wrapper (`#helpfulSearchDiv`)

This ensures that the text correctly changes to a light/high-contrast color when dark themes are active, resolving the visibility and contrast issues.

## Environment:
- Browser: Firefox
- OS: macOS


## BEFORE:


<img width="557" height="378" alt="Screenshot 2026-06-25 at 11 46 20 PM" src="https://github.com/user-attachments/assets/6193c2f0-58d7-4f52-bba4-119a0c2a8bb1" />



## AFTER:

<img width="768" height="558" alt="Screenshot 2026-06-25 at 11 45 47 PM" src="https://github.com/user-attachments/assets/20329307-f921-4ddc-a808-d4612a4c564d" />


