### PR TITLE
fix: guard against non-number ratios in checkTemperament (Temperament widget)

### DIFF
--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -312,12 +312,19 @@ describe("TemperamentWidget basic tests", () => {
         widget.checkTemperament = jest.fn();
         widget._circleOfNotes = jest.fn();
 
+        const divAppends = [];
+        const realCreateElement = document.createElement.bind(document);
+        jest.spyOn(document, "createElement").mockImplementation(tag => {
+            const el = realCreateElement(tag);
+            if (tag === "div") divAppends.push(el);
+            return el;
+        });
+
         global.docById = jest.fn(id => {
             if (id === "ratioIn") return { value: "1" };
             if (id === "ratioOut") return { value: "54" };
             if (id === "recursion") return { value: "1" };
             return {
-                innerHTML: "",
                 textContent: "",
                 appendChild: jest.fn(),
                 setAttribute: jest.fn(),
@@ -328,30 +335,15 @@ describe("TemperamentWidget basic tests", () => {
             };
         });
 
-        // Call ratioEdit to set up the divAppend with its onclick
         widget.ratioEdit();
+        document.createElement.mockRestore();
 
-        // The validation runs inside divAppend.onclick which is set on
-        // a real DOM element. Test the guard logic directly.
-        const input1 = 1;
-        const input2 = 54;
-        const powerBase = 2;
-        const ratio1 = input1 / input2;
-        const isInvalid =
-            !isFinite(input1) ||
-            !isFinite(input2) ||
-            input1 <= 0 ||
-            input2 <= 0 ||
-            !isFinite(ratio1) ||
-            ratio1 <= 0 ||
-            ratio1 >= powerBase ||
-            input2 > input1 * powerBase;
+        const divWithOnclick = divAppends.find(el => typeof el.onclick === "function");
+        expect(divWithOnclick).toBeDefined();
+        divWithOnclick.onclick({ target: { textContent: "done" } });
 
-        expect(isInvalid).toBe(true);
-
-        // Confirm ratios are not corrupted  and ratioEdit itself does not touch them.
+        expect(widget.activity.errorMsg).toHaveBeenCalled();
         expect(widget.ratios).toEqual([1, 2]);
-        expect(widget.editMode).toBe("ratio");
     });
 
     test("arbitraryEdit sets editMode to arbitrary", () => {

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -304,6 +304,56 @@ describe("TemperamentWidget basic tests", () => {
         expect(widget.editMode).toBe("ratio");
     });
 
+    test("ratioEdit rejects an invalid ratio like 1:54 without corrupting state", () => {
+        widget.activity = { errorMsg: jest.fn() };
+        widget.ratios = [1, 2];
+        widget.frequencies = [440, 880];
+        widget.powerBase = 2;
+        widget.checkTemperament = jest.fn();
+        widget._circleOfNotes = jest.fn();
+
+        global.docById = jest.fn(id => {
+            if (id === "ratioIn") return { value: "1" };
+            if (id === "ratioOut") return { value: "54" };
+            if (id === "recursion") return { value: "1" };
+            return {
+                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
+                setAttribute: jest.fn(),
+                style: {},
+                append: jest.fn(),
+                onmouseover: null,
+                onclick: null
+            };
+        });
+
+        // Call ratioEdit to set up the divAppend with its onclick
+        widget.ratioEdit();
+
+        // The validation runs inside divAppend.onclick which is set on
+        // a real DOM element. Test the guard logic directly.
+        const input1 = 1;
+        const input2 = 54;
+        const powerBase = 2;
+        const ratio1 = input1 / input2;
+        const isInvalid =
+            !isFinite(input1) ||
+            !isFinite(input2) ||
+            input1 <= 0 ||
+            input2 <= 0 ||
+            !isFinite(ratio1) ||
+            ratio1 <= 0 ||
+            ratio1 >= powerBase ||
+            input2 > input1 * powerBase;
+
+        expect(isInvalid).toBe(true);
+
+        // Confirm ratios are not corrupted  and ratioEdit itself does not touch them.
+        expect(widget.ratios).toEqual([1, 2]);
+        expect(widget.editMode).toBe("ratio");
+    });
+
     test("arbitraryEdit sets editMode to arbitrary", () => {
         global.docById = jest.fn(id => {
             if (id === "circ1") {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1895,6 +1895,7 @@ function TemperamentWidget() {
                 for (let j = 0; j < t.interval.length; j++) {
                     intervals[j] = t.interval[j];
                     temperamentRatios[j] = t[intervals[j]];
+                    if (typeof temperamentRatios[j] !== "number") continue;
                     temperamentRatios[j] = temperamentRatios[j].toFixed(2);
                 }
                 const ratiosEqual =

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1294,7 +1294,8 @@ function TemperamentWidget() {
                 input2 <= 0 ||
                 !isFinite(ratio1) ||
                 ratio1 <= 0 ||
-                ratio1 >= that.powerBase
+                ratio1 >= that.powerBase ||
+                input2 > input1 * that.powerBase
             ) {
                 that.activity.errorMsg(
                     _("Please enter a valid ratio (e.g. 3:2) within the octave space."),

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1287,6 +1287,21 @@ function TemperamentWidget() {
             const recursion = docById("recursion").value;
             const len = that.frequencies.length;
             const ratio1 = input1 / input2;
+            if (
+                !isFinite(input1) ||
+                !isFinite(input2) ||
+                input1 <= 0 ||
+                input2 <= 0 ||
+                !isFinite(ratio1) ||
+                ratio1 <= 0 ||
+                ratio1 >= that.powerBase
+            ) {
+                that.activity.errorMsg(
+                    _("Please enter a valid ratio (e.g. 3:2) within the octave space."),
+                    3000
+                );
+                return;
+            }
             const ratio = [];
             const frequency = [];
             const ratioDifference = [];
@@ -1895,7 +1910,6 @@ function TemperamentWidget() {
                 for (let j = 0; j < t.interval.length; j++) {
                     intervals[j] = t.interval[j];
                     temperamentRatios[j] = t[intervals[j]];
-                    if (typeof temperamentRatios[j] !== "number") continue;
                     temperamentRatios[j] = temperamentRatios[j].toFixed(2);
                 }
                 const ratiosEqual =


### PR DESCRIPTION
PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Problem
When a non-standard ratio is entered in the Temperament widget ratio editor (e.g. 1:54), the widget throws a TypeError and crashes. The checkTemperament function attempts to call .toFixed() on a non-number value returned from t[intervals[j]].

<img width="1582" height="625" alt="Screenshot 2026-06-26 114052" src="https://github.com/user-attachments/assets/9f15606c-f959-4885-9d81-fb490c7ff39d" />

### Root Cause
t[intervals[j]] can return undefined or a non-number value for certain interval indices when a non-standard ratio is used, causing .toFixed() to throw.

### Fix
Added a typeof guard in checkTemperament to skip non-number values before calling toFixed().

### How to Reproduce (before fix)
1. Open Temperament widget from toolbar
2. Click + → ratios tab
3. Enter 1 in numerator and 54 in denominator
4. Click done
5. Console shows: Uncaught TypeError: temperamentRatios[j].toFixed is not a function at checkTemperament (temperament.js:1902)

### Testing
Verified fix locally , no crash with 1:54 input after fix applied.