### PR TITLE
fix: resolve exit wheel cursor mismatch in Add-Note submenu

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -111,7 +111,11 @@ describe("MusicKeyboard add-row submenu", () => {
             this.createWheel = labels => {
                 this.navItems = labels.map(() => ({
                     navigateFunction: null,
-                    setTooltip: jest.fn()
+                    setTooltip: jest.fn(),
+                    sliceSelectedAttr: {},
+                    sliceHoverAttr: {},
+                    titleSelectedAttr: {},
+                    titleHoverAttr: {}
                 }));
             };
             this.removeWheel = jest.fn();

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2129,7 +2129,15 @@ function MusicKeyboard(activity) {
         this._exitWheel.sliceSelectedPathCustom = this._exitWheel.slicePathCustom;
         this._exitWheel.sliceInitPathCustom = this._exitWheel.slicePathCustom;
         this._exitWheel.clickModeRotate = false;
+        this._exitWheel.selectedNavItemIndex = null;
         this._exitWheel.createWheel(["×", " "]);
+        this._exitWheel.navItems[1].enabled = false;
+        if (this._exitWheel.navItems[0].sliceSelectedAttr) {
+            this._exitWheel.navItems[0].sliceSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].sliceHoverAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleHoverAttr.cursor = "pointer";
+        }
 
         const x = docById("addnotes").getBoundingClientRect().x;
         const y = docById("addnotes").getBoundingClientRect().y;


### PR DESCRIPTION
## Category

- [x] Bug Fix

## Problem

In the Music Keyboard widget, clicking the × (exit) button on the
Add-Note pie menu did not close it. The × slice appeared visually
present but felt unclickable — hovering over it showed a default arrow
cursor instead of a pointer, while the blank half of the same circle
showed a pointer cursor.

Root cause: `wheelnav` defaults `selectedNavItemIndex` to `0`, which
puts the × slice (Item 0) in a "selected" state on creation. Selected
items are styled with `cursor: "default"` by the library, making the
exit button appear and feel non-interactive.

## Fix

Aligned `_exitWheel` configuration inside `_createAddRowPieSubmenu`
with the established pattern used by other exit wheels in the codebase:

- Set `selectedNavItemIndex = null` before `createWheel()` to prevent
  the × slice from starting pre-selected
- Disabled Slice 1 (the blank/empty half) via `navItems[1].enabled = false`
- Explicitly set `cursor: "pointer"` on `sliceSelectedAttr`,
  `sliceHoverAttr`, `titleSelectedAttr`, and `titleHoverAttr` for
  Slice 0, wrapped in a null-check for test safety

## Testing

- `npm run lint` passes
- `npm test` passes (5,655 tests)
- Manually verified: clicking × closes the Add-Note menu; pitch/hertz
  selection auto-closes the menu; other pie menus.
