### PR TITLE
fix(pitchstaircase): restore project master volume on widget close (Fixes #7664)

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -35,6 +35,8 @@ global.frequencyToPitch = jest.fn(f => ["A", "", 4]);
 global.base64Encode = jest.fn(s => s);
 global.PREVIEWVOLUME = 0.5;
 global.normalizeNoteAccidentals = jest.fn(n => n);
+global.Singer = { masterVolume: [50] };
+global.last = arr => arr[arr.length - 1];
 
 window.innerWidth = 1200;
 window.btoa = jest.fn(s => s);
@@ -302,7 +304,7 @@ describe("PitchStaircase Widget", () => {
             );
         });
 
-        test("should stop synth, set closed to true, and restore master volume to PREVIEWVOLUME on close", () => {
+        test("should stop synth, set closed to true, and restore project master volume on close", () => {
             psc.init(mockActivity);
 
             const widgetWindow = window.widgetWindows.windowFor();
@@ -315,7 +317,7 @@ describe("PitchStaircase Widget", () => {
 
             expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
             expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalledWith(
-                global.PREVIEWVOLUME
+                global.Singer.masterVolume[global.Singer.masterVolume.length - 1]
             );
             expect(psc.closed).toBe(true);
             expect(widgetWindow.destroy).toHaveBeenCalled();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
-   normalizeNoteAccidentals, PREVIEWVOLUME
+   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last
  */
 
 /*
@@ -24,11 +24,13 @@
     - js/utils/musicutils.js
         SYNTHSVG, frequencyToPitch, DEFAULTVOICE
     - js/utils/utils.js
-        _
+        _, last
     - js/utils/platformstyle.js
         platformColor
     - js/logoconstants.js
         PREVIEWVOLUME
+    - js/turtle-singer.js
+        Singer
 */
 /* exported PitchStaircase */
 
@@ -633,7 +635,9 @@ class PitchStaircase {
         widgetWindow.onclose = () => {
             this.closed = true;
             this.activity.logo.synth.stop();
-            this.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
+            // Restore the project's master volume so audio still works
+            // after exiting mid-playback (was incorrectly left at PREVIEWVOLUME).
+            this.activity.logo.synth.setMasterVolume(last(Singer.masterVolume));
             widgetWindow.destroy();
         };
 


### PR DESCRIPTION
Fixes #7664

## What
Exiting the Pitch Staircase widget mid-playback leaves all audio dead — neither widget play nor toolbar Play produces sound until reload.

## Why
#7623 restored setMasterVolume(PREVIEWVOLUME) in onclose. PREVIEWVOLUME is the preview-only level the widget switches to on open; on close the master volume should be returned to whatever the project actually had, not left at the preview value. The mismatch leaves the runtime's volume state inconsistent and breaks subsequent playback.

## Changes
`js/widgets/pitchstaircase.js`
- Added Singer and last to global declarations
- Replaced setMasterVolume(PREVIEWVOLUME) in onclose with setMasterVolume(last(Singer.masterVolume)) — same pattern timbre.js already uses

`js/widgets/__tests__/pitchstaircase.test.js`
- Added Singer and last to global mocks
- Updated close-behavior test to assert the restored value

## Testing
- npm run lint → 0 errors
- npx prettier --check on changed files → clean
- npx jest js/widgets/__tests__/pitchstaircase.test.js → 29/29 pass
- npx jest js/widgets/__tests__/ → 1250/1250 pass, no widget regressions

## Category
- [x] Bug Fix