### PR TITLE
refactor: extract search logic to SearchController

### DIFF
--- a/js/__tests__/activity_toolbar_integration.test.js
+++ b/js/__tests__/activity_toolbar_integration.test.js
@@ -70,6 +70,7 @@ const loadActivityClass = () => {
         setupAlertController: jest.fn(),
         setupAlertRenderer: jest.fn(),
         setupPaletteLoader: jest.fn(),
+        setupSearchController: jest.fn(),
         hideDOMLabel: jest.fn(),
         setupActivityRecorder: jest.fn(),
         setupActivityAbcParser: jest.fn(),

--- a/js/activity.js
+++ b/js/activity.js
@@ -32,6 +32,7 @@ try {
    ErrorHandler, ActivityContext,
    Boundary, CARTESIAN, changeImage, closeWidgets, doRecordButton, setupActivityRecorder,
    setupGridController, setupGridRenderer, setupPluginController, setupToolbarController, setupAlertController, setupAlertRenderer, setupPaletteLoader, PluginDialog,
+   setupSearchController,
    setupActivityAbcParser, setupActivityIdleWatcher,
    COLLAPSEBLOCKSBUTTON, COLLAPSEBUTTON, createDefaultStack,
    createHelpContent, createjs, DATAOBJS, DEFAULTBLOCKSCALE,
@@ -129,6 +130,7 @@ let MYDEFINES = [
     "activity/alert-controller",
     "activity/alert-renderer",
     "palette/palette-loader",
+    "activity/search-controller",
     "widgets/plugin-dialog",
     "utils/musicutils",
     "utils/synthutils",
@@ -260,9 +262,6 @@ class Activity {
         this._listeners = [];
 
         this.cellSize = 55;
-        this.searchSuggestions = [];
-        this._searchCache = {}; // Cache for search results to improve performance
-        this._searchCloseListener = null;
         this.homeButtonContainer;
 
         this.msgText = null;
@@ -357,9 +356,6 @@ class Activity {
 
         // Flag to indicate the selection mode is on
         this.selectionModeOn = false;
-
-        // Flag to check if the helpful search widget is active or not (for "click" event handler purpose)
-        this.isHelpfulSearchWidgetOn = false;
 
         //Flag to check if any other input box is active or not
         this.isInputON = false;
@@ -472,6 +468,7 @@ class Activity {
         setupAlertController(this);
         setupAlertRenderer(this);
         setupPaletteLoader(this);
+        setupSearchController(this);
         this.pluginDialog = new PluginDialog({
             onLoadBuiltIn: name => this._loadBuiltInPlugin(name),
             onDelete: () => this._deletePlugin(),
@@ -620,84 +617,14 @@ class Activity {
         /*
          * creates helpfulSearchDiv for search
          */
-        this.setHelpfulSearchDiv = () => {
-            if (document.getElementById("helpfulSearchDiv")) {
-                document
-                    .getElementById("helpfulSearchDiv")
-                    .parentNode.removeChild(document.getElementById("helpfulSearchDiv"));
-            }
-            this.helpfulSearchDiv = document.createElement("div");
-            this.helpfulSearchDiv.setAttribute("id", "helpfulSearchDiv");
-
-            document.body.appendChild(this.helpfulSearchDiv);
-
-            // Create the div for the close button (cross button)
-            const closeButtonDiv = document.createElement("div");
-            closeButtonDiv.style.cssText =
-                "position: absolute;" + "top: 10px;" + "right: 10px;" + "cursor: pointer;";
-
-            // Create the cross button itself
-            const closeButton = document.createElement("button");
-            closeButton.textContent = "×";
-            closeButton.id = "crossButton";
-            document.body.appendChild(closeButton);
-
-            closeButtonDiv.appendChild(closeButton);
-
-            this.helpfulSearchDiv.appendChild(closeButtonDiv);
-
-            // Add event listener to remove the search div from the DOM
-            const modeButton = document.getElementById("begIconText");
-            this.addEventListener(closeButton, "click", this._hideHelpfulSearchWidget);
-            this.addEventListener(modeButton, "click", this._hideHelpfulSearchWidget);
-
-            this.helpfulSearchDiv.appendChild(this.helpfulSearchWidget);
-        };
+        this.setHelpfulSearchDiv = () => this.searchController.setHelpfulSearchDiv();
 
         /*
          * displays helpfulSearchDiv on canvas
          */
-        this._displayHelpfulSearchDiv = () => {
-            if (!document.getElementById("helpfulSearchDiv")) {
-                this.setHelpfulSearchDiv(); // Re-create and append the div if it's not found
-            }
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            this.helpfulSearchDiv.style.left =
-                helpfulWheelDiv.offsetLeft + 80 * this.getStageScale() + "px";
-            this.helpfulSearchDiv.style.top =
-                helpfulWheelDiv.offsetTop + 110 * this.getStageScale() + "px";
+        this._displayHelpfulSearchDiv = () => this.searchController._displayHelpfulSearchDiv();
 
-            const windowWidth = window.innerWidth;
-            const windowHeight = window.innerHeight;
-            this.helpfulSearchDiv.style.display = "block";
-            const menuWidth = this.helpfulSearchDiv.offsetWidth;
-            const menuHeight = this.helpfulSearchDiv.offsetHeight;
-
-            if (this.helpfulSearchDiv.offsetLeft + menuWidth > windowWidth) {
-                this.helpfulSearchDiv.style.left = windowWidth - menuWidth + "px";
-            }
-            if (this.helpfulSearchDiv.offsetTop + menuHeight > windowHeight) {
-                this.helpfulSearchDiv.style.top = windowHeight - menuHeight + "px";
-            }
-
-            this.showHelpfulSearchWidget();
-            this.isHelpfulSearchWidgetOn = true;
-        };
-
-        // hides helpfulSearchDiv on canvas
-
-        this._hideHelpfulSearchWidget = e => {
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
-            if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
-                this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
-            }
-            that.__tick();
-        };
+        this._hideHelpfulSearchWidget = e => this.searchController._hideHelpfulSearchWidget(e);
 
         /*
          * Sets up right click functionality opening the context menus
@@ -711,7 +638,7 @@ class Activity {
                     event.preventDefault();
                     event.stopPropagation();
                     if (this.beginnerMode) return;
-                    if (this.isHelpfulSearchWidgetOn) {
+                    if (this.searchController.isHelpfulSearchWidgetOn) {
                         this._hideHelpfulSearchWidget();
                     }
                     if (
@@ -2482,437 +2409,25 @@ class Activity {
             }
         };
 
-        /**
-
-
         /*
-             Prepare a list of blocks for the search bar autocompletion.
-            */
-        this.prepSearchWidget = () => {
-            //searchWidget.style.visibility = "hidden";
-            this.searchBlockPosition = [100, 100];
-
-            this.searchSuggestions = [];
-            this._searchCache = {}; // Reset cache to prevent memory leaks
-            this.deprecatedBlockNames = [];
-
-            // Guard: blocks may not be initialized yet during early loading
-            if (!this.blocks || !this.blocks.protoBlockDict) {
-                console.debug("prepSearchWidget: blocks not yet initialized, skipping");
-                return;
-            }
-
-            for (const i in this.blocks.protoBlockDict) {
-                const block = this.blocks.protoBlockDict[i];
-                const blockLabel = block.staticLabels.join(" ");
-                const artwork = block.palette.model.makeBlockInfo(0, block, block.name, block.name)[
-                    "artwork64"
-                ];
-                if (blockLabel || block.extraSearchTerms !== undefined) {
-                    if (block.deprecated) {
-                        this.deprecatedBlockNames.push(blockLabel);
-                    } else {
-                        // Determine the primary label to display for this block.
-                        let label = blockLabel;
-                        if (label.length === 0) {
-                            // Swap in a preferred, localized name when there is no label.
-                            label = _(block.name);
-                            switch (block.name) {
-                                case "scaledegree2":
-                                    label = _("scale degree");
-                                    break;
-                                case "voicename":
-                                    label = _("voice name");
-                                    break;
-                                case "invertmode":
-                                    label = _("invert mode");
-                                    break;
-                                case "outputtools":
-                                    label = _("output tools");
-                                    break;
-                                case "customNote":
-                                    label = _("custom note");
-                                    break;
-                                case "accidentalname":
-                                    label = _("accidental name");
-                                    break;
-                                case "eastindiansolfege":
-                                    label = _("east indian solfege");
-                                    break;
-                                case "notename":
-                                    label = _("note name");
-                                    break;
-                                case "temperamentname":
-                                    label = _("temperament name");
-                                    break;
-                                case "modename":
-                                    label = _("mode name");
-                                    break;
-                                case "chordname":
-                                    label = _("chord name");
-                                    break;
-                                case "intervalname":
-                                    label = _("interval name");
-                                    break;
-                                case "filtertype":
-                                    label = _("filter type");
-                                    break;
-                                case "oscillatortype":
-                                    label = _("oscillator type");
-                                    break;
-                                case "audiofile":
-                                    label = _("audio file");
-                                    break;
-                                case "noisename":
-                                    label = _("noise name");
-                                    break;
-                                case "drumname":
-                                    label = _("drum name");
-                                    break;
-                                case "effectsname":
-                                    label = _("effects name");
-                                    break;
-                                case "wrapmode":
-                                    label = _("wrap mode");
-                                    break;
-                                case "loadFile":
-                                    label = _("load file");
-                                    break;
-                            }
-                        }
-
-                        // Build a list of lowercased search terms (primary label + extra terms)
-                        // so we can match synonyms without duplicating the visual entry.
-                        const searchTerms = [];
-                        if (label && label.length > 0) {
-                            searchTerms.push(label.toLowerCase());
-                        }
-                        if (block.extraSearchTerms && Array.isArray(block.extraSearchTerms)) {
-                            for (let j = 0; j < block.extraSearchTerms.length; j++) {
-                                const term = block.extraSearchTerms[j];
-                                if (typeof term === "string" && term.length > 0) {
-                                    searchTerms.push(term.toLowerCase());
-                                }
-                            }
-                        }
-
-                        this.searchSuggestions.push({
-                            label: label,
-                            value: block.name,
-                            specialDict: block,
-                            artwork: artwork,
-                            searchTerms: searchTerms
-                        });
-                    }
-                }
-            }
-
-            this.searchSuggestions = this.searchSuggestions.reverse();
-        };
+         * Builds the block list for search bar autocompletion.
+         */
+        this.prepSearchWidget = () => this.searchController.prepSearchWidget();
 
         /*
          * Hides search widget
          */
-        this.hideSearchWidget = () => {
-            // Hide the jQuery search results widget.
-            const obj = docByClass("ui-menu");
-            if (obj.length > 0) {
-                obj[0].style.visibility = "hidden";
-            }
-
-            // Remove the document mousedown listener if it exists
-            if (this._searchCloseListener) {
-                this.removeEventListener(document, "mousedown", this._searchCloseListener);
-                this._searchCloseListener = null;
-            }
-
-            this.searchWidget.style.visibility = "hidden";
-            this.searchWidget.idInput_custom = "";
-        };
+        this.hideSearchWidget = () => this.searchController.hideSearchWidget();
 
         /*
          * Shows search widget
          */
-        this.showSearchWidget = () => {
-            // Bring widget to top.
-            this.searchWidget.style.zIndex = 1001;
-            this.searchWidget.style.border = "2px solid lightblue";
-            if (this.helpfulSearchDiv) {
-                this._hideHelpfulSearchWidget();
-            }
-            if (this.searchWidget.style.visibility === "visible") {
-                this.hideSearchWidget();
-            } else {
-                const obj = docByClass("ui-menu");
-                if (obj.length > 0) {
-                    obj[0].style.visibility = "visible";
-                }
-
-                if (this.searchWidget) {
-                    this.searchWidget.value = null;
-                    this.searchWidget.style.visibility = "visible";
-                    const searchPos = this.palettes.getSearchPos();
-                    this.searchWidget.style.left = searchPos.x + "px";
-                    this.searchWidget.style.top = searchPos.y + "px";
-                }
-
-                this.searchBlockPosition = [100, 100];
-                this.prepSearchWidget();
-
-                const that = this;
-                const closeListener = e => {
-                    if (
-                        document.getElementById("search").style.visibility === "visible" &&
-                        (e.target === document.getElementById("search") ||
-                            document.getElementById("search").contains(e.target))
-                    ) {
-                        //do nothing when clicked in the input field
-                    } else if (
-                        document.getElementById("ui-id-1") &&
-                        document.getElementById("ui-id-1").style.display === "block" &&
-                        (e.target === document.getElementById("ui-id-1") ||
-                            document.getElementById("ui-id-1").contains(e.target))
-                    ) {
-                        //do nothing when clicked on the menu
-                    } else if (
-                        document.querySelector("#palette tbody tr") &&
-                        document.querySelector("#palette tbody tr").contains(e.target)
-                    ) {
-                        //do nothing when clicked on the search row
-                    } else {
-                        // this will hide the search bar if someone clicks on menu items
-                        that.hideSearchWidget();
-                    }
-                };
-                this._searchCloseListener = closeListener;
-                this.addEventListener(document, "mousedown", closeListener);
-
-                // Give the browser time to update before selecting
-                // focus.
-                setTimeout(() => {
-                    that.searchWidget.focus();
-                    that.doSearch();
-                }, 500);
-            }
-        };
+        this.showSearchWidget = () => this.searchController.showSearchWidget();
 
         /*
          * Uses JQuery to add autocompleted search suggestions
          */
-        this.doSearch = () => {
-            // Guard: ensure searchWidget exists before proceeding
-            if (!this.searchWidget) {
-                console.debug("doSearch: searchWidget not yet initialized, skipping");
-                return;
-            }
-
-            const $j = window.jQuery;
-            if (this.searchSuggestions.length === 0) {
-                this.prepSearchWidget();
-            }
-
-            const that = this;
-            const $search = $j("#search");
-
-            if (!$search.data("autocomplete-init")) {
-                $search.autocomplete({
-                    // Custom source so we can match on extraSearchTerms but show each block only once.
-                    source: (request, response) => {
-                        const term = (request.term || "").toLowerCase().trim();
-
-                        // Check cache first for performance
-                        if (that._searchCache[term] !== undefined) {
-                            response(that._searchCache[term]);
-                            return;
-                        }
-
-                        const results = that.searchSuggestions.filter(item => {
-                            // If there is no active term, show all items.
-                            if (!term || term.length === 0) {
-                                return true;
-                            }
-
-                            // Prefer matching against searchTerms when present.
-                            if (item.searchTerms && Array.isArray(item.searchTerms)) {
-                                return item.searchTerms.some(t => t && t.indexOf(term) !== -1);
-                            }
-
-                            // Fallback to label matching for legacy entries.
-                            return (
-                                item.label &&
-                                typeof item.label === "string" &&
-                                item.label.toLowerCase().indexOf(term) !== -1
-                            );
-                        });
-
-                        // Cache the results for future use
-                        that._searchCache[term] = results;
-                        response(results);
-                    },
-                    appendTo: "body",
-                    select: (event, ui) => {
-                        event.preventDefault();
-                        that.searchWidget.value = ui.item.label;
-                        that.searchWidget.idInput_custom = ui.item.value;
-                        that.searchWidget.protoblk = ui.item.specialDict;
-                        that.doSearch();
-                        if (event.keyCode === 13) this.searchWidget.style.visibility = "visible";
-                    },
-                    focus: event => {
-                        event.preventDefault();
-                    }
-                });
-
-                const instance = $search.autocomplete("instance");
-                if (instance) {
-                    instance._renderItem = (ul, item) => {
-                        const li = $j("<li></li>");
-
-                        const img = document.createElement("img");
-                        img.src = item.artwork || "";
-                        img.height = 20;
-                        img.style.cursor = "grab";
-
-                        // Drag-and-drop: mirrors the palette drag pattern in
-                        // palette.js _showMenuItems(). Keep both in sync.
-                        img.ondragstart = () => false;
-
-                        const down = event => {
-                            // Stop jQuery UI autocomplete from handling this
-                            event.stopPropagation();
-                            event.stopImmediatePropagation();
-                            event.preventDefault();
-
-                            const posit = img.style.position;
-                            const zInd = img.style.zIndex;
-                            img.style.position = "absolute";
-                            img.style.zIndex = 10000;
-
-                            // Close the autocomplete dropdown
-                            $j("#search").autocomplete("close");
-
-                            document.body.appendChild(img);
-
-                            const moveAt = (pageX, pageY) => {
-                                img.style.left = pageX - img.offsetWidth / 2 + "px";
-                                img.style.top = pageY - img.offsetHeight / 2 + "px";
-                            };
-
-                            const onMouseMove = e => {
-                                e.preventDefault();
-                                let x, y;
-                                if (e.type === "touchmove") {
-                                    x = e.touches[0].clientX;
-                                    y = e.touches[0].clientY;
-                                } else {
-                                    x = e.pageX;
-                                    y = e.pageY;
-                                }
-                                moveAt(x, y);
-                            };
-                            onMouseMove(event);
-
-                            document.addEventListener("touchmove", onMouseMove, { passive: false });
-                            document.addEventListener("mousemove", onMouseMove);
-
-                            const up = () => {
-                                document.body.style.cursor = "default";
-                                document.removeEventListener("mousemove", onMouseMove);
-                                document.removeEventListener("touchmove", onMouseMove);
-
-                                const x = parseInt(img.style.left);
-                                const y = parseInt(img.style.top);
-
-                                img.style.position = posit;
-                                img.style.zIndex = zInd;
-                                if (img.parentNode === document.body) {
-                                    document.body.removeChild(img);
-                                }
-
-                                if (isNaN(x) && isNaN(y)) return;
-
-                                const protoblk = item.specialDict;
-                                const paletteName = protoblk.palette.name;
-                                const protoName = item.value;
-
-                                that.palettes.dict[paletteName].makeBlockFromSearch(
-                                    protoblk,
-                                    protoName,
-                                    newBlock => {
-                                        that.blocks.moveBlock(
-                                            newBlock,
-                                            (x || that.blocksContainer.x + 100) -
-                                                that.blocksContainer.x,
-                                            (y || that.blocksContainer.y + 100) -
-                                                that.blocksContainer.y
-                                        );
-                                    }
-                                );
-                            };
-
-                            document.addEventListener("mouseup", up, { once: true });
-                            document.addEventListener("touchend", up, { once: true });
-                        };
-
-                        // Capture phase fires BEFORE jQuery UI's event delegation
-                        li[0].addEventListener("mousedown", down, true);
-                        li[0].addEventListener("touchstart", down, {
-                            capture: true,
-                            passive: false
-                        });
-
-                        li.append(img);
-                        li.append($j("<a>").text(" " + item.label));
-
-                        return li.appendTo(
-                            ul.css({
-                                "z-index": 35000,
-                                "max-height": "200px",
-                                "overflow-y": "auto"
-                            })
-                        );
-                    };
-                }
-                $search.data("autocomplete-init", true);
-            }
-
-            const searchInput = this.searchWidget.idInput_custom;
-            if (!searchInput || searchInput.length <= 0) {
-                if (this.searchWidget.value && this.searchWidget.value.length > 0) {
-                    $search.autocomplete("search", this.searchWidget.value);
-                }
-                return;
-            }
-
-            const protoblk = this.searchWidget.protoblk;
-            const paletteName = protoblk.palette.name;
-            const protoName = protoblk.name;
-
-            if (Object.prototype.hasOwnProperty.call(this.blocks.protoBlockDict, protoName)) {
-                this.palettes.dict[paletteName].makeBlockFromSearch(
-                    protoblk,
-                    protoName,
-                    newBlock => {
-                        that.blocks.moveBlock(
-                            newBlock,
-                            100 + that.searchBlockPosition[0] - that.blocksContainer.x,
-                            that.searchBlockPosition[1] - that.blocksContainer.y
-                        );
-                    }
-                );
-
-                // Move the position of the next newly created block.
-                this.searchBlockPosition[0] += STANDARDBLOCKHEIGHT;
-                this.searchBlockPosition[1] += STANDARDBLOCKHEIGHT;
-            } else if (this.deprecatedBlockNames.indexOf(searchInput) > -1) {
-                this.errorMsg(_("This block is deprecated."));
-            } else {
-                this.errorMsg(_("Block cannot be found."));
-            }
-
-            this.searchWidget.value = "";
-            this.update = true;
-        };
+        this.doSearch = () => this.searchController.doSearch();
 
         //To create a sampler widget
         this.makeSamplerWidget = (sampleName, sampleData) => {
@@ -5328,145 +4843,9 @@ class Activity {
         /*
          * Shows search widget on helpfulSearchDiv
          */
-        this.showHelpfulSearchWidget = () => {
-            // Bring widget to top.
-            const $j = window.jQuery;
-            if ($j("#helpfulSearch")) {
-                try {
-                    $j("#helpfulSearch").autocomplete("destroy");
-                } catch {
-                    //
-                }
-            }
-            this.helpfulSearchWidget.style.zIndex = 1001;
-            this.helpfulSearchWidget.idInput_custom = "";
-            if (this.helpfulSearchDiv.style.display === "block") {
-                this.helpfulSearchWidget.value = null;
-                this.helpfulSearchWidget.style.visibility = "visible";
+        this.showHelpfulSearchWidget = () => this.searchController.showHelpfulSearchWidget();
 
-                this.searchBlockPosition = [100, 100];
-                this.prepSearchWidget();
-
-                const that = this;
-                setTimeout(() => {
-                    that.helpfulSearchWidget.focus();
-                    that.doHelpfulSearch();
-                }, 500);
-
-                document.getElementById("helpfulWheelDiv").style.display = "none";
-            }
-        };
-
-        /*
-         * Uses JQuery to add autocompleted search suggestions
-         */
-        this.doHelpfulSearch = () => {
-            const $j = window.jQuery;
-            if (this.searchSuggestions.length === 0) {
-                this.prepSearchWidget();
-            }
-
-            const that = this;
-            const $helpfulSearch = $j("#helpfulSearch");
-
-            if (!$helpfulSearch.data("autocomplete-init")) {
-                $helpfulSearch.autocomplete({
-                    source: (request, response) => {
-                        const term = (request.term || "").toLowerCase().trim();
-
-                        // Check cache first for performance
-                        if (that._searchCache[term] !== undefined) {
-                            response(that._searchCache[term]);
-                            return;
-                        }
-
-                        const results = that.searchSuggestions.filter(item => {
-                            if (!term || term.length === 0) {
-                                return true;
-                            }
-
-                            if (item.searchTerms && Array.isArray(item.searchTerms)) {
-                                return item.searchTerms.some(t => t && t.indexOf(term) !== -1);
-                            }
-
-                            return (
-                                item.label &&
-                                typeof item.label === "string" &&
-                                item.label.toLowerCase().indexOf(term) !== -1
-                            );
-                        });
-
-                        // Cache the results for future use
-                        that._searchCache[term] = results;
-                        response(results);
-                    },
-                    appendTo: "body",
-                    select: (event, ui) => {
-                        event.preventDefault();
-                        that.helpfulSearchWidget.value = ui.item.label;
-                        that.helpfulSearchWidget.idInput_custom = ui.item.value;
-                        that.helpfulSearchWidget.protoblk = ui.item.specialDict;
-                        that.doHelpfulSearch();
-                    },
-                    focus: event => {
-                        event.preventDefault();
-                    }
-                });
-
-                const instance = $helpfulSearch.autocomplete("instance");
-                if (instance) {
-                    instance._renderItem = (ul, item) => {
-                        const li = $j("<li></li>");
-                        const img = document.createElement("img");
-                        img.src = item.artwork || "";
-                        img.height = 20;
-                        li.append(img);
-                        li.append($j("<a>").text(" " + item.label));
-                        return li.appendTo(ul.css("z-index", 35000));
-                    };
-                }
-                $helpfulSearch.data("autocomplete-init", true);
-            }
-
-            const searchInput = this.helpfulSearchWidget.idInput_custom;
-            if (!searchInput || searchInput.length <= 0) {
-                if (this.helpfulSearchWidget.value && this.helpfulSearchWidget.value.length > 0) {
-                    $helpfulSearch.autocomplete("search", this.helpfulSearchWidget.value);
-                }
-                return;
-            }
-
-            const protoblk = this.helpfulSearchWidget.protoblk;
-            const paletteName = protoblk.palette.name;
-            const protoName = protoblk.name;
-
-            if (Object.prototype.hasOwnProperty.call(that.blocks.protoBlockDict, protoName)) {
-                this.palettes.dict[paletteName].makeBlockFromSearch(
-                    protoblk,
-                    protoName,
-                    newBlock => {
-                        that.blocks.moveBlock(
-                            newBlock,
-                            100 + that.searchBlockPosition[0] - that.blocksContainer.x,
-                            that.searchBlockPosition[1] - that.blocksContainer.y
-                        );
-                    }
-                );
-
-                // Move the position of the next newly created block.
-                this.searchBlockPosition[0] += STANDARDBLOCKHEIGHT;
-                this.searchBlockPosition[1] += STANDARDBLOCKHEIGHT;
-            } else if (this.deprecatedBlockNames.indexOf(searchInput) > -1) {
-                this.errorMsg(_("This block is deprecated."));
-            } else {
-                this.errorMsg(_("Block cannot be found."));
-            }
-
-            this.helpfulSearchWidget.value = "";
-            // Hide search div after search is complete.
-            document.getElementById("helpfulSearchDiv").style.display = "none";
-            this.update = true;
-        };
+        this.doHelpfulSearch = () => this.searchController.doHelpfulSearch();
 
         /**
          * Toggles display of javaScript editor widget.

--- a/js/activity/__tests__/search-controller.test.js
+++ b/js/activity/__tests__/search-controller.test.js
@@ -420,3 +420,492 @@ describe("SearchController.doSearch - result generation", () => {
         expect(() => activity.searchController.doSearch()).not.toThrow();
     });
 });
+
+// ---------------------------------------------------------------------------
+// doSearch — autocomplete initialization branches
+// ---------------------------------------------------------------------------
+
+function makeJQueryElem(alreadyInit = false) {
+    let capturedOpts = null;
+    const initFlag = { value: alreadyInit };
+    const elem = {
+        data: jest.fn(function (key, val) {
+            if (val !== undefined) initFlag.value = val;
+            return key === "autocomplete-init" ? initFlag.value : undefined;
+        }),
+        autocomplete: jest.fn(function (arg) {
+            if (typeof arg === "object") capturedOpts = arg;
+            if (arg === "instance") return null;
+        }),
+        getOpts: () => capturedOpts
+    };
+    return elem;
+}
+
+describe("SearchController.doSearch - autocomplete initialization", () => {
+    let $elem;
+
+    beforeEach(() => {
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("skips autocomplete setup when already initialised", () => {
+        $elem = makeJQueryElem(true);
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "drum";
+        activity.searchWidget.protoblk = makeProtoBlock("drum", "drum");
+        sc.doSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith(
+            expect.objectContaining({ source: expect.any(Function) })
+        );
+    });
+
+    test("source callback filters suggestions by term", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "drum" }, response);
+        expect(response).toHaveBeenCalled();
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("source callback normalises term to lowercase and trims whitespace", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        sc.doSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "  DRUM  " }, response);
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("select callback sets widget fields and re-runs doSearch", () => {
+        const block = makeProtoBlock("drum", "drum beat");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        const event = { preventDefault: jest.fn(), keyCode: 0 };
+        const ui = { item: { label: "drum beat", value: "drum", specialDict: block } };
+        $elem.getOpts().select(event, ui);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        // The nested doSearch() that select triggers places the block and then
+        // clears value back to ""; idInput_custom is not cleared.
+        expect(activity.searchWidget.idInput_custom).toBe("drum");
+        expect(activity.searchWidget.protoblk).toBe(block);
+        expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
+    });
+
+    test("focus callback calls preventDefault", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        sc.doSearch();
+
+        const event = { preventDefault: jest.fn() };
+        $elem.getOpts().focus(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("triggers autocomplete search when idInput_custom is empty but value is set", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "drum";
+        sc.doSearch();
+
+        expect($elem.autocomplete).toHaveBeenCalledWith("search", "drum");
+    });
+
+    test("returns without triggering autocomplete search when both inputs are empty", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "";
+        activity.searchWidget.value = "";
+        sc.doSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith("search", expect.anything());
+    });
+});
+
+// ---------------------------------------------------------------------------
+// doHelpfulSearch — result generation
+// ---------------------------------------------------------------------------
+
+describe("SearchController.doHelpfulSearch - result generation", () => {
+    let helpfulSearchDivEl;
+
+    beforeEach(() => {
+        helpfulSearchDivEl = { style: { display: "" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulSearchDiv") return helpfulSearchDivEl;
+            return null;
+        });
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => ({
+            data: jest.fn(() => false),
+            autocomplete: jest.fn()
+        }));
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("calls makeBlockFromSearch and moveBlock for a known block", () => {
+        const block = makeProtoBlock("drum", "drum");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "drum";
+        activity.helpfulSearchWidget.protoblk = block;
+        sc.doHelpfulSearch();
+
+        expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
+        expect(activity.blocks.moveBlock).toHaveBeenCalledWith(
+            42,
+            expect.any(Number),
+            expect.any(Number)
+        );
+    });
+
+    test("advances searchBlockPosition after placing a block in helpful search", () => {
+        const block = makeProtoBlock("drum", "drum");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+        sc.searchBlockPosition = [100, 100];
+
+        activity.helpfulSearchWidget.idInput_custom = "drum";
+        activity.helpfulSearchWidget.protoblk = block;
+        sc.doHelpfulSearch();
+
+        expect(sc.searchBlockPosition[0]).toBe(100 + global.STANDARDBLOCKHEIGHT);
+        expect(sc.searchBlockPosition[1]).toBe(100 + global.STANDARDBLOCKHEIGHT);
+    });
+
+    test("calls errorMsg for a deprecated block in helpful search", () => {
+        const activity = makeActivity({});
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
+        sc.deprecatedBlockNames = ["drum"];
+
+        activity.helpfulSearchWidget.idInput_custom = "drum";
+        activity.helpfulSearchWidget.protoblk = { palette: { name: "test-palette" }, name: "drum" };
+        sc.doHelpfulSearch();
+
+        expect(activity.errorMsg).toHaveBeenCalledWith("This block is deprecated.");
+    });
+
+    test("calls errorMsg when helpful-search block is not found and not deprecated", () => {
+        const activity = makeActivity({});
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "ghost";
+        activity.helpfulSearchWidget.protoblk = {
+            palette: { name: "test-palette" },
+            name: "ghost"
+        };
+        sc.doHelpfulSearch();
+
+        expect(activity.errorMsg).toHaveBeenCalledWith("Block cannot be found.");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// doHelpfulSearch — autocomplete initialization branches
+// ---------------------------------------------------------------------------
+
+describe("SearchController.doHelpfulSearch - autocomplete initialization", () => {
+    let $elem;
+    let helpfulSearchDivEl;
+
+    beforeEach(() => {
+        helpfulSearchDivEl = { style: { display: "" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulSearchDiv") return helpfulSearchDivEl;
+            return null;
+        });
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("skips autocomplete setup when already initialised", () => {
+        $elem = makeJQueryElem(true);
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "drum";
+        activity.helpfulSearchWidget.protoblk = makeProtoBlock("drum", "drum");
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith(
+            expect.objectContaining({ source: expect.any(Function) })
+        );
+    });
+
+    test("source callback filters suggestions by term", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum beat") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
+        sc.doHelpfulSearch();
+
+        const response = jest.fn();
+        $elem.getOpts().source({ term: "drum" }, response);
+        expect(response.mock.calls[0][0].some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("select callback sets helpfulSearchWidget fields and re-runs doHelpfulSearch", () => {
+        const block = makeProtoBlock("drum", "drum beat");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
+        sc.doHelpfulSearch();
+
+        const event = { preventDefault: jest.fn() };
+        const ui = { item: { label: "drum beat", value: "drum", specialDict: block } };
+        $elem.getOpts().select(event, ui);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        // The nested doHelpfulSearch() that select triggers places the block and
+        // then clears value; idInput_custom is not cleared.
+        expect(activity.helpfulSearchWidget.idInput_custom).toBe("drum");
+        expect(activity.helpfulSearchWidget.protoblk).toBe(block);
+        expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
+    });
+
+    test("focus callback calls preventDefault", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        sc.doHelpfulSearch();
+
+        const event = { preventDefault: jest.fn() };
+        $elem.getOpts().focus(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test("triggers autocomplete search when idInput_custom is empty but value is set", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "drum";
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).toHaveBeenCalledWith("search", "drum");
+    });
+
+    test("returns without autocomplete search when both helpfulSearch inputs are empty", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.helpfulSearchWidget.idInput_custom = "";
+        activity.helpfulSearchWidget.value = "";
+        sc.doHelpfulSearch();
+
+        expect($elem.autocomplete).not.toHaveBeenCalledWith("search", expect.anything());
+    });
+});
+
+// ---------------------------------------------------------------------------
+// showHelpfulSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController.showHelpfulSearchWidget", () => {
+    let $elem;
+    let helpfulWheelDivEl;
+
+    beforeEach(() => {
+        helpfulWheelDivEl = { style: { display: "block" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulWheelDiv") return helpfulWheelDivEl;
+            return null;
+        });
+        $elem = makeJQueryElem();
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => $elem);
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+    });
+
+    test("does not activate widget when helpfulSearchDiv is not in display:block", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "none" } };
+
+        sc.showHelpfulSearchWidget();
+
+        expect(activity.helpfulSearchWidget.style.visibility).toBe("hidden");
+    });
+
+    test("silently catches when autocomplete destroy throws", () => {
+        $elem.autocomplete = jest.fn(() => {
+            throw new Error("not initialized");
+        });
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "none" } };
+
+        expect(() => sc.showHelpfulSearchWidget()).not.toThrow();
+    });
+
+    test("makes helpfulSearchWidget visible and schedules doHelpfulSearch when div is block", () => {
+        jest.useFakeTimers();
+
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { style: { display: "block" } };
+
+        const doHelpfulSearchSpy = jest.spyOn(sc, "doHelpfulSearch").mockImplementation(() => {});
+
+        sc.showHelpfulSearchWidget();
+
+        expect(activity.helpfulSearchWidget.style.visibility).toBe("visible");
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+
+        jest.runAllTimers();
+        expect(activity.helpfulSearchWidget.focus).toHaveBeenCalled();
+        expect(doHelpfulSearchSpy).toHaveBeenCalled();
+
+        jest.useRealTimers();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// _hideHelpfulSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController._hideHelpfulSearchWidget", () => {
+    let helpfulWheelDivEl;
+
+    beforeEach(() => {
+        helpfulWheelDivEl = { style: { display: "block" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "helpfulWheelDiv") return helpfulWheelDivEl;
+            return null;
+        });
+    });
+
+    test("sets helpfulWheelDiv display to none when it is visible", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = null;
+        helpfulWheelDivEl.style.display = "block";
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+        expect(activity.__tick).toHaveBeenCalled();
+    });
+
+    test("does not reassign helpfulWheelDiv display when already none", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = null;
+        helpfulWheelDivEl.style.display = "none";
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(helpfulWheelDivEl.style.display).toBe("none");
+    });
+
+    test("skips removeChild when helpfulSearchDiv has no parentNode", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { parentNode: null };
+
+        expect(() => sc._hideHelpfulSearchWidget()).not.toThrow();
+    });
+
+    test("calls removeChild when helpfulSearchDiv has a parentNode", () => {
+        const removeChild = jest.fn();
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.helpfulSearchDiv = { parentNode: { removeChild } };
+
+        sc._hideHelpfulSearchWidget();
+
+        expect(removeChild).toHaveBeenCalledWith(sc.helpfulSearchDiv);
+    });
+});

--- a/js/activity/__tests__/search-controller.test.js
+++ b/js/activity/__tests__/search-controller.test.js
@@ -1,0 +1,422 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+"use strict";
+
+if (typeof global._ !== "function") {
+    global._ = s => s;
+}
+if (typeof global.docByClass !== "function") {
+    global.docByClass = () => [];
+}
+if (typeof global.STANDARDBLOCKHEIGHT === "undefined") {
+    global.STANDARDBLOCKHEIGHT = 40;
+}
+
+const { setupSearchController, SearchController } = require("../search-controller.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProtoBlock(name, label, deprecated = false, extraSearchTerms = undefined) {
+    const block = {
+        name,
+        staticLabels: label ? [label] : [],
+        deprecated,
+        extraSearchTerms,
+        palette: {
+            name: "test-palette",
+            model: {
+                makeBlockInfo: jest.fn(() => ({ artwork64: `img-${name}` }))
+            }
+        }
+    };
+    return block;
+}
+
+function makeActivity(protoBlocks = {}) {
+    const searchWidget = {
+        style: { visibility: "hidden", zIndex: "", border: "", left: "", top: "" },
+        value: null,
+        idInput_custom: "",
+        protoblk: null,
+        focus: jest.fn(),
+        placeholder: ""
+    };
+    const helpfulSearchWidget = {
+        style: { visibility: "hidden", zIndex: "" },
+        value: null,
+        idInput_custom: "",
+        protoblk: null,
+        focus: jest.fn(),
+        placeholder: ""
+    };
+    return {
+        searchWidget,
+        helpfulSearchWidget,
+        blocks: {
+            protoBlockDict: protoBlocks,
+            moveBlock: jest.fn()
+        },
+        palettes: {
+            getSearchPos: jest.fn(() => ({ x: 10, y: 20 })),
+            dict: {
+                "test-palette": {
+                    makeBlockFromSearch: jest.fn((proto, name, cb) => cb(42))
+                }
+            }
+        },
+        blocksContainer: { x: 0, y: 0 },
+        getStageScale: jest.fn(() => 1),
+        addEventListener: jest.fn((target, event, handler) => {
+            if (target === document && event === "mousedown") {
+                // store so tests can trigger it
+                target._mousedownHandler = handler;
+            }
+        }),
+        removeEventListener: jest.fn(),
+        errorMsg: jest.fn(),
+        __tick: jest.fn(),
+        update: false
+    };
+}
+
+// ---------------------------------------------------------------------------
+// setupSearchController
+// ---------------------------------------------------------------------------
+
+describe("setupSearchController", () => {
+    test("attaches a SearchController instance to activity", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        expect(activity.searchController).toBeInstanceOf(SearchController);
+    });
+
+    test("initialises state to empty defaults", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        expect(sc.searchSuggestions).toEqual([]);
+        expect(sc._searchCache).toEqual({});
+        expect(sc._searchCloseListener).toBeNull();
+        expect(sc.isHelpfulSearchWidgetOn).toBe(false);
+        expect(sc.searchBlockPosition).toEqual([100, 100]);
+        expect(sc.deprecatedBlockNames).toEqual([]);
+        expect(sc.helpfulSearchDiv).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// prepSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController.prepSearchWidget", () => {
+    test("skips gracefully when blocks not initialised", () => {
+        const activity = makeActivity();
+        activity.blocks = null;
+        setupSearchController(activity);
+        expect(() => activity.searchController.prepSearchWidget()).not.toThrow();
+        expect(activity.searchController.searchSuggestions).toEqual([]);
+    });
+
+    test("builds searchSuggestions from protoBlockDict", () => {
+        const activity = makeActivity({
+            drum: makeProtoBlock("drum", "drum"),
+            pitch: makeProtoBlock("pitch", "pitch")
+        });
+        setupSearchController(activity);
+        activity.searchController.prepSearchWidget();
+
+        const labels = activity.searchController.searchSuggestions.map(s => s.label);
+        expect(labels).toContain("drum");
+        expect(labels).toContain("pitch");
+    });
+
+    test("excludes deprecated blocks from suggestions", () => {
+        const activity = makeActivity({
+            old: makeProtoBlock("old", "old block", true),
+            current: makeProtoBlock("current", "current block", false)
+        });
+        setupSearchController(activity);
+        activity.searchController.prepSearchWidget();
+
+        const labels = activity.searchController.searchSuggestions.map(s => s.label);
+        expect(labels).not.toContain("old block");
+        expect(labels).toContain("current block");
+        expect(activity.searchController.deprecatedBlockNames).toContain("old block");
+    });
+
+    test("adds extraSearchTerms to the searchTerms array", () => {
+        const block = makeProtoBlock("note", "note value", false, ["pitch", "tone"]);
+        const activity = makeActivity({ note: block });
+        setupSearchController(activity);
+        activity.searchController.prepSearchWidget();
+
+        const suggestion = activity.searchController.searchSuggestions.find(
+            s => s.value === "note"
+        );
+        expect(suggestion.searchTerms).toContain("pitch");
+        expect(suggestion.searchTerms).toContain("tone");
+    });
+
+    test("resets cache and position on each call", () => {
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc._searchCache = { x: [1] };
+        sc.searchBlockPosition = [200, 200];
+
+        sc.prepSearchWidget();
+
+        expect(sc._searchCache).toEqual({});
+        expect(sc.searchBlockPosition).toEqual([100, 100]);
+    });
+
+    test("uses fallback label for known no-label blocks (scaledegree2)", () => {
+        // extraSearchTerms must be defined (even empty) so the block passes the
+        // `if (blockLabel || block.extraSearchTerms !== undefined)` guard.
+        const block = makeProtoBlock("scaledegree2", "", false, []);
+        const activity = makeActivity({ scaledegree2: block });
+        setupSearchController(activity);
+        activity.searchController.prepSearchWidget();
+
+        const suggestion = activity.searchController.searchSuggestions.find(
+            s => s.value === "scaledegree2"
+        );
+        expect(suggestion.label).toBe("scale degree");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// filterSuggestions
+// ---------------------------------------------------------------------------
+
+describe("SearchController.filterSuggestions", () => {
+    let sc;
+
+    beforeEach(() => {
+        const activity = makeActivity({
+            drum: makeProtoBlock("drum", "drum beat", false, ["percussion"]),
+            pitch: makeProtoBlock("pitch", "pitch value")
+        });
+        setupSearchController(activity);
+        sc = activity.searchController;
+        sc.prepSearchWidget();
+    });
+
+    test("returns all suggestions for an empty term", () => {
+        const results = sc.filterSuggestions("");
+        expect(results.length).toBe(sc.searchSuggestions.length);
+    });
+
+    test("matches on the primary label", () => {
+        const results = sc.filterSuggestions("drum");
+        expect(results.some(r => r.value === "drum")).toBe(true);
+        expect(results.every(r => r.value !== "pitch")).toBe(true);
+    });
+
+    test("matches on extraSearchTerms", () => {
+        const results = sc.filterSuggestions("percussion");
+        expect(results.some(r => r.value === "drum")).toBe(true);
+    });
+
+    test("returns an empty array for a term that matches nothing", () => {
+        const results = sc.filterSuggestions("zzznomatch");
+        expect(results).toEqual([]);
+    });
+
+    test("caches results on first call and returns cache on second", () => {
+        sc.filterSuggestions("drum");
+        expect(sc._searchCache["drum"]).toBeDefined();
+
+        // Mutate suggestions to prove cache is used
+        sc.searchSuggestions = [];
+        const cached = sc.filterSuggestions("drum");
+        expect(cached).toBe(sc._searchCache["drum"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// hideSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController.hideSearchWidget", () => {
+    test("hides the search input and clears idInput_custom", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "visible";
+        activity.searchWidget.idInput_custom = "drum";
+
+        activity.searchController.hideSearchWidget();
+
+        expect(activity.searchWidget.style.visibility).toBe("hidden");
+        expect(activity.searchWidget.idInput_custom).toBe("");
+    });
+
+    test("removes the stored mousedown close listener", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        const listener = jest.fn();
+        sc._searchCloseListener = listener;
+
+        sc.hideSearchWidget();
+
+        expect(activity.removeEventListener).toHaveBeenCalledWith(document, "mousedown", listener);
+        expect(sc._searchCloseListener).toBeNull();
+    });
+
+    test("hides ui-menu element when present", () => {
+        const mockMenu = { style: { visibility: "visible" } };
+        global.docByClass = () => [mockMenu];
+
+        const activity = makeActivity();
+        setupSearchController(activity);
+        activity.searchController.hideSearchWidget();
+
+        expect(mockMenu.style.visibility).toBe("hidden");
+        global.docByClass = () => [];
+    });
+});
+
+// ---------------------------------------------------------------------------
+// showSearchWidget
+// ---------------------------------------------------------------------------
+
+describe("SearchController.showSearchWidget", () => {
+    test("hides widget when it is already visible (toggle off)", () => {
+        const activity = makeActivity();
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "visible";
+
+        const hideSpy = jest.spyOn(activity.searchController, "hideSearchWidget");
+        activity.searchController.showSearchWidget();
+
+        expect(hideSpy).toHaveBeenCalled();
+    });
+
+    test("makes widget visible and positions it from palettes.getSearchPos", () => {
+        jest.useFakeTimers();
+        const activity = makeActivity({ drum: makeProtoBlock("drum", "drum") });
+        setupSearchController(activity);
+        activity.searchWidget.style.visibility = "hidden";
+
+        activity.searchController.showSearchWidget();
+
+        expect(activity.searchWidget.style.visibility).toBe("visible");
+        expect(activity.searchWidget.style.left).toBe("10px");
+        expect(activity.searchWidget.style.top).toBe("20px");
+        jest.useRealTimers();
+    });
+
+    test("registers a mousedown close listener on document", () => {
+        jest.useFakeTimers();
+        const activity = makeActivity();
+        setupSearchController(activity);
+
+        activity.searchController.showSearchWidget();
+
+        expect(activity.addEventListener).toHaveBeenCalledWith(
+            document,
+            "mousedown",
+            expect.any(Function)
+        );
+        jest.useRealTimers();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// doSearch — result generation
+// ---------------------------------------------------------------------------
+
+describe("SearchController.doSearch - result generation", () => {
+    beforeEach(() => {
+        global.window = global.window || {};
+        global.window.jQuery = jest.fn(() => ({
+            data: jest.fn(() => false),
+            autocomplete: jest.fn()
+        }));
+    });
+
+    test("calls errorMsg for a deprecated block name", () => {
+        // protoBlockDict must NOT contain the name so the first branch is skipped;
+        // deprecatedBlockNames must contain idInput_custom for the second branch to fire.
+        // searchSuggestions must be non-empty so doSearch doesn't re-call prepSearchWidget
+        // (which would reset deprecatedBlockNames).
+        const activity = makeActivity({});
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.searchSuggestions = [{ label: "dummy", value: "dummy", searchTerms: [] }];
+        sc.deprecatedBlockNames = ["drum"];
+
+        activity.searchWidget.idInput_custom = "drum";
+        activity.searchWidget.protoblk = { palette: { name: "test-palette" }, name: "drum" };
+        sc.doSearch();
+
+        expect(activity.errorMsg).toHaveBeenCalledWith("This block is deprecated.");
+    });
+
+    test("calls errorMsg when block not found and not deprecated", () => {
+        const activity = makeActivity({});
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "ghost";
+        activity.searchWidget.protoblk = { palette: { name: "test-palette" }, name: "ghost" };
+        sc.doSearch();
+
+        expect(activity.errorMsg).toHaveBeenCalledWith("Block cannot be found.");
+    });
+
+    test("calls makeBlockFromSearch and moveBlock for a known block", () => {
+        const block = makeProtoBlock("drum", "drum");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+
+        activity.searchWidget.idInput_custom = "drum";
+        activity.searchWidget.protoblk = block;
+        sc.doSearch();
+
+        expect(activity.palettes.dict["test-palette"].makeBlockFromSearch).toHaveBeenCalled();
+        expect(activity.blocks.moveBlock).toHaveBeenCalledWith(
+            42,
+            expect.any(Number),
+            expect.any(Number)
+        );
+    });
+
+    test("advances searchBlockPosition after placing a block", () => {
+        const block = makeProtoBlock("drum", "drum");
+        const activity = makeActivity({ drum: block });
+        setupSearchController(activity);
+        const sc = activity.searchController;
+        sc.prepSearchWidget();
+        sc.searchBlockPosition = [100, 100];
+
+        activity.searchWidget.idInput_custom = "drum";
+        activity.searchWidget.protoblk = block;
+        sc.doSearch();
+
+        expect(sc.searchBlockPosition[0]).toBe(100 + global.STANDARDBLOCKHEIGHT);
+        expect(sc.searchBlockPosition[1]).toBe(100 + global.STANDARDBLOCKHEIGHT);
+    });
+
+    test("returns early without error when searchWidget is not set", () => {
+        const activity = makeActivity();
+        activity.searchWidget = null;
+        setupSearchController(activity);
+        expect(() => activity.searchController.doSearch()).not.toThrow();
+    });
+});

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -1,0 +1,663 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/* global _, $j, docByClass, STANDARDBLOCKHEIGHT */
+
+/* exported setupSearchController, SearchController */
+
+class SearchController {
+    constructor(activity) {
+        this.activity = activity;
+
+        this.searchSuggestions = [];
+        this._searchCache = {};
+        this._searchCloseListener = null;
+        this.isHelpfulSearchWidgetOn = false;
+        this.searchBlockPosition = [100, 100];
+        this.deprecatedBlockNames = [];
+        this.helpfulSearchDiv = null;
+    }
+
+    /**
+     * Builds the block list used for search bar autocompletion.
+     * Reads from activity.blocks.protoBlockDict and populates
+     * searchSuggestions and deprecatedBlockNames.
+     */
+    prepSearchWidget() {
+        this.searchBlockPosition = [100, 100];
+        this.searchSuggestions = [];
+        this._searchCache = {};
+        this.deprecatedBlockNames = [];
+
+        const activity = this.activity;
+        if (!activity.blocks || !activity.blocks.protoBlockDict) {
+            console.debug("prepSearchWidget: blocks not yet initialized, skipping");
+            return;
+        }
+
+        for (const i in activity.blocks.protoBlockDict) {
+            const block = activity.blocks.protoBlockDict[i];
+            const blockLabel = block.staticLabels.join(" ");
+            const artwork = block.palette.model.makeBlockInfo(0, block, block.name, block.name)[
+                "artwork64"
+            ];
+            if (blockLabel || block.extraSearchTerms !== undefined) {
+                if (block.deprecated) {
+                    this.deprecatedBlockNames.push(blockLabel);
+                } else {
+                    let label = blockLabel;
+                    if (label.length === 0) {
+                        label = _(block.name);
+                        switch (block.name) {
+                            case "scaledegree2":
+                                label = _("scale degree");
+                                break;
+                            case "voicename":
+                                label = _("voice name");
+                                break;
+                            case "invertmode":
+                                label = _("invert mode");
+                                break;
+                            case "outputtools":
+                                label = _("output tools");
+                                break;
+                            case "customNote":
+                                label = _("custom note");
+                                break;
+                            case "accidentalname":
+                                label = _("accidental name");
+                                break;
+                            case "eastindiansolfege":
+                                label = _("east indian solfege");
+                                break;
+                            case "notename":
+                                label = _("note name");
+                                break;
+                            case "temperamentname":
+                                label = _("temperament name");
+                                break;
+                            case "modename":
+                                label = _("mode name");
+                                break;
+                            case "chordname":
+                                label = _("chord name");
+                                break;
+                            case "intervalname":
+                                label = _("interval name");
+                                break;
+                            case "filtertype":
+                                label = _("filter type");
+                                break;
+                            case "oscillatortype":
+                                label = _("oscillator type");
+                                break;
+                            case "audiofile":
+                                label = _("audio file");
+                                break;
+                            case "noisename":
+                                label = _("noise name");
+                                break;
+                            case "drumname":
+                                label = _("drum name");
+                                break;
+                            case "effectsname":
+                                label = _("effects name");
+                                break;
+                            case "wrapmode":
+                                label = _("wrap mode");
+                                break;
+                            case "loadFile":
+                                label = _("load file");
+                                break;
+                        }
+                    }
+
+                    const searchTerms = [];
+                    if (label && label.length > 0) {
+                        searchTerms.push(label.toLowerCase());
+                    }
+                    if (block.extraSearchTerms && Array.isArray(block.extraSearchTerms)) {
+                        for (let j = 0; j < block.extraSearchTerms.length; j++) {
+                            const term = block.extraSearchTerms[j];
+                            if (typeof term === "string" && term.length > 0) {
+                                searchTerms.push(term.toLowerCase());
+                            }
+                        }
+                    }
+
+                    this.searchSuggestions.push({
+                        label: label,
+                        value: block.name,
+                        specialDict: block,
+                        artwork: artwork,
+                        searchTerms: searchTerms
+                    });
+                }
+            }
+        }
+
+        this.searchSuggestions = this.searchSuggestions.reverse();
+    }
+
+    /**
+     * Filters searchSuggestions against a query term.
+     * Returns matching items, respecting the result cache.
+     * @param {string} term - Lowercased, trimmed search term.
+     * @returns {Array}
+     */
+    filterSuggestions(term) {
+        if (this._searchCache[term] !== undefined) {
+            return this._searchCache[term];
+        }
+
+        const results = this.searchSuggestions.filter(item => {
+            if (!term || term.length === 0) {
+                return true;
+            }
+            if (item.searchTerms && Array.isArray(item.searchTerms)) {
+                return item.searchTerms.some(t => t && t.indexOf(term) !== -1);
+            }
+            return (
+                item.label &&
+                typeof item.label === "string" &&
+                item.label.toLowerCase().indexOf(term) !== -1
+            );
+        });
+
+        this._searchCache[term] = results;
+        return results;
+    }
+
+    /**
+     * Hides the main search widget.
+     */
+    hideSearchWidget() {
+        const obj = docByClass("ui-menu");
+        if (obj.length > 0) {
+            obj[0].style.visibility = "hidden";
+        }
+
+        if (this._searchCloseListener) {
+            this.activity.removeEventListener(document, "mousedown", this._searchCloseListener);
+            this._searchCloseListener = null;
+        }
+
+        this.activity.searchWidget.style.visibility = "hidden";
+        this.activity.searchWidget.idInput_custom = "";
+    }
+
+    /**
+     * Shows or toggles the main search widget.
+     */
+    showSearchWidget() {
+        const activity = this.activity;
+        activity.searchWidget.style.zIndex = 1001;
+        activity.searchWidget.style.border = "2px solid lightblue";
+        if (this.helpfulSearchDiv) {
+            this._hideHelpfulSearchWidget();
+        }
+        if (activity.searchWidget.style.visibility === "visible") {
+            this.hideSearchWidget();
+        } else {
+            const obj = docByClass("ui-menu");
+            if (obj.length > 0) {
+                obj[0].style.visibility = "visible";
+            }
+
+            if (activity.searchWidget) {
+                activity.searchWidget.value = null;
+                activity.searchWidget.style.visibility = "visible";
+                const searchPos = activity.palettes.getSearchPos();
+                activity.searchWidget.style.left = searchPos.x + "px";
+                activity.searchWidget.style.top = searchPos.y + "px";
+            }
+
+            this.searchBlockPosition = [100, 100];
+            this.prepSearchWidget();
+
+            const that = this;
+            const closeListener = e => {
+                if (
+                    document.getElementById("search").style.visibility === "visible" &&
+                    (e.target === document.getElementById("search") ||
+                        document.getElementById("search").contains(e.target))
+                ) {
+                    //do nothing when clicked in the input field
+                } else if (
+                    document.getElementById("ui-id-1") &&
+                    document.getElementById("ui-id-1").style.display === "block" &&
+                    (e.target === document.getElementById("ui-id-1") ||
+                        document.getElementById("ui-id-1").contains(e.target))
+                ) {
+                    //do nothing when clicked on the menu
+                } else if (
+                    document.querySelector("#palette tbody tr") &&
+                    document.querySelector("#palette tbody tr").contains(e.target)
+                ) {
+                    //do nothing when clicked on the search row
+                } else {
+                    that.hideSearchWidget();
+                }
+            };
+            this._searchCloseListener = closeListener;
+            activity.addEventListener(document, "mousedown", closeListener);
+
+            setTimeout(() => {
+                activity.searchWidget.focus();
+                that.doSearch();
+            }, 500);
+        }
+    }
+
+    /**
+     * Sets up jQuery autocomplete on the main search input and executes a search.
+     */
+    doSearch() {
+        const activity = this.activity;
+        if (!activity.searchWidget) {
+            console.debug("doSearch: searchWidget not yet initialized, skipping");
+            return;
+        }
+
+        const $j = window.jQuery;
+        if (this.searchSuggestions.length === 0) {
+            this.prepSearchWidget();
+        }
+
+        const that = this;
+        const $search = $j("#search");
+
+        if (!$search.data("autocomplete-init")) {
+            $search.autocomplete({
+                source: (request, response) => {
+                    const term = (request.term || "").toLowerCase().trim();
+                    response(that.filterSuggestions(term));
+                },
+                appendTo: "body",
+                select: (event, ui) => {
+                    event.preventDefault();
+                    activity.searchWidget.value = ui.item.label;
+                    activity.searchWidget.idInput_custom = ui.item.value;
+                    activity.searchWidget.protoblk = ui.item.specialDict;
+                    that.doSearch();
+                    if (event.keyCode === 13) activity.searchWidget.style.visibility = "visible";
+                },
+                focus: event => {
+                    event.preventDefault();
+                }
+            });
+
+            const instance = $search.autocomplete("instance");
+            if (instance) {
+                instance._renderItem = (ul, item) => {
+                    const li = $j("<li></li>");
+
+                    const img = document.createElement("img");
+                    img.src = item.artwork || "";
+                    img.height = 20;
+                    img.style.cursor = "grab";
+
+                    // Drag-and-drop: mirrors the palette drag pattern in
+                    // palette.js _showMenuItems(). Keep both in sync.
+                    img.ondragstart = () => false;
+
+                    const down = event => {
+                        event.stopPropagation();
+                        event.stopImmediatePropagation();
+                        event.preventDefault();
+
+                        const posit = img.style.position;
+                        const zInd = img.style.zIndex;
+                        img.style.position = "absolute";
+                        img.style.zIndex = 10000;
+
+                        $j("#search").autocomplete("close");
+
+                        document.body.appendChild(img);
+
+                        const moveAt = (pageX, pageY) => {
+                            img.style.left = pageX - img.offsetWidth / 2 + "px";
+                            img.style.top = pageY - img.offsetHeight / 2 + "px";
+                        };
+
+                        const onMouseMove = e => {
+                            e.preventDefault();
+                            let x, y;
+                            if (e.type === "touchmove") {
+                                x = e.touches[0].clientX;
+                                y = e.touches[0].clientY;
+                            } else {
+                                x = e.pageX;
+                                y = e.pageY;
+                            }
+                            moveAt(x, y);
+                        };
+                        onMouseMove(event);
+
+                        document.addEventListener("touchmove", onMouseMove, { passive: false });
+                        document.addEventListener("mousemove", onMouseMove);
+
+                        const up = () => {
+                            document.body.style.cursor = "default";
+                            document.removeEventListener("mousemove", onMouseMove);
+                            document.removeEventListener("touchmove", onMouseMove);
+
+                            const x = parseInt(img.style.left);
+                            const y = parseInt(img.style.top);
+
+                            img.style.position = posit;
+                            img.style.zIndex = zInd;
+                            if (img.parentNode === document.body) {
+                                document.body.removeChild(img);
+                            }
+
+                            if (isNaN(x) && isNaN(y)) return;
+
+                            const protoblk = item.specialDict;
+                            const paletteName = protoblk.palette.name;
+                            const protoName = item.value;
+
+                            activity.palettes.dict[paletteName].makeBlockFromSearch(
+                                protoblk,
+                                protoName,
+                                newBlock => {
+                                    activity.blocks.moveBlock(
+                                        newBlock,
+                                        (x || activity.blocksContainer.x + 100) -
+                                            activity.blocksContainer.x,
+                                        (y || activity.blocksContainer.y + 100) -
+                                            activity.blocksContainer.y
+                                    );
+                                }
+                            );
+                        };
+
+                        document.addEventListener("mouseup", up, { once: true });
+                        document.addEventListener("touchend", up, { once: true });
+                    };
+
+                    li[0].addEventListener("mousedown", down, true);
+                    li[0].addEventListener("touchstart", down, {
+                        capture: true,
+                        passive: false
+                    });
+
+                    li.append(img);
+                    li.append($j("<a>").text(" " + item.label));
+
+                    return li.appendTo(
+                        ul.css({
+                            "z-index": 35000,
+                            "max-height": "200px",
+                            "overflow-y": "auto"
+                        })
+                    );
+                };
+            }
+            $search.data("autocomplete-init", true);
+        }
+
+        const searchInput = activity.searchWidget.idInput_custom;
+        if (!searchInput || searchInput.length <= 0) {
+            if (activity.searchWidget.value && activity.searchWidget.value.length > 0) {
+                $search.autocomplete("search", activity.searchWidget.value);
+            }
+            return;
+        }
+
+        const protoblk = activity.searchWidget.protoblk;
+        const paletteName = protoblk.palette.name;
+        const protoName = protoblk.name;
+
+        if (Object.prototype.hasOwnProperty.call(activity.blocks.protoBlockDict, protoName)) {
+            activity.palettes.dict[paletteName].makeBlockFromSearch(
+                protoblk,
+                protoName,
+                newBlock => {
+                    activity.blocks.moveBlock(
+                        newBlock,
+                        100 + that.searchBlockPosition[0] - activity.blocksContainer.x,
+                        that.searchBlockPosition[1] - activity.blocksContainer.y
+                    );
+                }
+            );
+
+            this.searchBlockPosition[0] += STANDARDBLOCKHEIGHT;
+            this.searchBlockPosition[1] += STANDARDBLOCKHEIGHT;
+        } else if (this.deprecatedBlockNames.indexOf(searchInput) > -1) {
+            activity.errorMsg(_("This block is deprecated."));
+        } else {
+            activity.errorMsg(_("Block cannot be found."));
+        }
+
+        activity.searchWidget.value = "";
+        activity.update = true;
+    }
+
+    /**
+     * Creates the helpfulSearchDiv container and appends it to the body.
+     */
+    setHelpfulSearchDiv() {
+        const activity = this.activity;
+        if (document.getElementById("helpfulSearchDiv")) {
+            document
+                .getElementById("helpfulSearchDiv")
+                .parentNode.removeChild(document.getElementById("helpfulSearchDiv"));
+        }
+        this.helpfulSearchDiv = document.createElement("div");
+        this.helpfulSearchDiv.setAttribute("id", "helpfulSearchDiv");
+
+        document.body.appendChild(this.helpfulSearchDiv);
+
+        const closeButtonDiv = document.createElement("div");
+        closeButtonDiv.style.cssText =
+            "position: absolute;" + "top: 10px;" + "right: 10px;" + "cursor: pointer;";
+
+        const closeButton = document.createElement("button");
+        closeButton.textContent = "×";
+        closeButton.id = "crossButton";
+        document.body.appendChild(closeButton);
+
+        closeButtonDiv.appendChild(closeButton);
+
+        this.helpfulSearchDiv.appendChild(closeButtonDiv);
+
+        const modeButton = document.getElementById("begIconText");
+        activity.addEventListener(closeButton, "click", this._hideHelpfulSearchWidget.bind(this));
+        activity.addEventListener(modeButton, "click", this._hideHelpfulSearchWidget.bind(this));
+
+        this.helpfulSearchDiv.appendChild(activity.helpfulSearchWidget);
+    }
+
+    /**
+     * Positions and displays the helpfulSearchDiv on the canvas.
+     */
+    _displayHelpfulSearchDiv() {
+        if (!document.getElementById("helpfulSearchDiv")) {
+            this.setHelpfulSearchDiv();
+        }
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        this.helpfulSearchDiv.style.left =
+            helpfulWheelDiv.offsetLeft + 80 * this.activity.getStageScale() + "px";
+        this.helpfulSearchDiv.style.top =
+            helpfulWheelDiv.offsetTop + 110 * this.activity.getStageScale() + "px";
+
+        const windowWidth = window.innerWidth;
+        const windowHeight = window.innerHeight;
+        this.helpfulSearchDiv.style.display = "block";
+        const menuWidth = this.helpfulSearchDiv.offsetWidth;
+        const menuHeight = this.helpfulSearchDiv.offsetHeight;
+
+        if (this.helpfulSearchDiv.offsetLeft + menuWidth > windowWidth) {
+            this.helpfulSearchDiv.style.left = windowWidth - menuWidth + "px";
+        }
+        if (this.helpfulSearchDiv.offsetTop + menuHeight > windowHeight) {
+            this.helpfulSearchDiv.style.top = windowHeight - menuHeight + "px";
+        }
+
+        this.showHelpfulSearchWidget();
+        this.isHelpfulSearchWidgetOn = true;
+    }
+
+    /**
+     * Hides and removes the helpfulSearchDiv from the DOM.
+     */
+    _hideHelpfulSearchWidget() {
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        if (helpfulWheelDiv.style.display !== "none") {
+            helpfulWheelDiv.style.display = "none";
+        }
+        if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
+            this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
+        }
+        this.activity.__tick();
+    }
+
+    /**
+     * Shows the helpfulSearchWidget input and triggers doHelpfulSearch.
+     */
+    showHelpfulSearchWidget() {
+        const $j = window.jQuery;
+        if ($j("#helpfulSearch")) {
+            try {
+                $j("#helpfulSearch").autocomplete("destroy");
+            } catch {
+                //
+            }
+        }
+        const activity = this.activity;
+        activity.helpfulSearchWidget.style.zIndex = 1001;
+        activity.helpfulSearchWidget.idInput_custom = "";
+        if (this.helpfulSearchDiv.style.display === "block") {
+            activity.helpfulSearchWidget.value = null;
+            activity.helpfulSearchWidget.style.visibility = "visible";
+
+            this.searchBlockPosition = [100, 100];
+            this.prepSearchWidget();
+
+            const that = this;
+            setTimeout(() => {
+                activity.helpfulSearchWidget.focus();
+                that.doHelpfulSearch();
+            }, 500);
+
+            document.getElementById("helpfulWheelDiv").style.display = "none";
+        }
+    }
+
+    /**
+     * Sets up jQuery autocomplete on the helpful search input and executes a search.
+     */
+    doHelpfulSearch() {
+        const $j = window.jQuery;
+        if (this.searchSuggestions.length === 0) {
+            this.prepSearchWidget();
+        }
+
+        const that = this;
+        const activity = this.activity;
+        const $helpfulSearch = $j("#helpfulSearch");
+
+        if (!$helpfulSearch.data("autocomplete-init")) {
+            $helpfulSearch.autocomplete({
+                source: (request, response) => {
+                    const term = (request.term || "").toLowerCase().trim();
+                    response(that.filterSuggestions(term));
+                },
+                appendTo: "body",
+                select: (event, ui) => {
+                    event.preventDefault();
+                    activity.helpfulSearchWidget.value = ui.item.label;
+                    activity.helpfulSearchWidget.idInput_custom = ui.item.value;
+                    activity.helpfulSearchWidget.protoblk = ui.item.specialDict;
+                    that.doHelpfulSearch();
+                },
+                focus: event => {
+                    event.preventDefault();
+                }
+            });
+
+            const instance = $helpfulSearch.autocomplete("instance");
+            if (instance) {
+                instance._renderItem = (ul, item) => {
+                    const li = $j("<li></li>");
+                    const img = document.createElement("img");
+                    img.src = item.artwork || "";
+                    img.height = 20;
+                    li.append(img);
+                    li.append($j("<a>").text(" " + item.label));
+                    return li.appendTo(ul.css("z-index", 35000));
+                };
+            }
+            $helpfulSearch.data("autocomplete-init", true);
+        }
+
+        const searchInput = activity.helpfulSearchWidget.idInput_custom;
+        if (!searchInput || searchInput.length <= 0) {
+            if (
+                activity.helpfulSearchWidget.value &&
+                activity.helpfulSearchWidget.value.length > 0
+            ) {
+                $helpfulSearch.autocomplete("search", activity.helpfulSearchWidget.value);
+            }
+            return;
+        }
+
+        const protoblk = activity.helpfulSearchWidget.protoblk;
+        const paletteName = protoblk.palette.name;
+        const protoName = protoblk.name;
+
+        if (Object.prototype.hasOwnProperty.call(activity.blocks.protoBlockDict, protoName)) {
+            activity.palettes.dict[paletteName].makeBlockFromSearch(
+                protoblk,
+                protoName,
+                newBlock => {
+                    activity.blocks.moveBlock(
+                        newBlock,
+                        100 + that.searchBlockPosition[0] - activity.blocksContainer.x,
+                        that.searchBlockPosition[1] - activity.blocksContainer.y
+                    );
+                }
+            );
+
+            this.searchBlockPosition[0] += STANDARDBLOCKHEIGHT;
+            this.searchBlockPosition[1] += STANDARDBLOCKHEIGHT;
+        } else if (this.deprecatedBlockNames.indexOf(searchInput) > -1) {
+            activity.errorMsg(_("This block is deprecated."));
+        } else {
+            activity.errorMsg(_("Block cannot be found."));
+        }
+
+        activity.helpfulSearchWidget.value = "";
+        document.getElementById("helpfulSearchDiv").style.display = "none";
+        activity.update = true;
+    }
+}
+
+/**
+ * Creates a SearchController and attaches it to the activity.
+ * Installs delegation methods on activity so external callers
+ * (palette.js, planetInterface.js) continue to work unchanged.
+ * @param {object} activity - The Activity instance.
+ */
+const setupSearchController = activity => {
+    activity.searchController = new SearchController(activity);
+};
+
+if (typeof define === "function" && define.amd) {
+    define(function () {
+        window.setupSearchController = setupSearchController;
+        window.SearchController = SearchController;
+        return { setupSearchController, SearchController };
+    });
+} else if (typeof module !== "undefined" && module.exports) {
+    module.exports = { setupSearchController, SearchController };
+}

--- a/js/loader.js
+++ b/js/loader.js
@@ -136,7 +136,8 @@ requirejs.config({
                 "activity/toolbar-ui",
                 "activity/alert-controller",
                 "activity/alert-renderer",
-                "palette/palette-loader"
+                "palette/palette-loader",
+                "activity/search-controller"
             ],
             exports: "Activity"
         },
@@ -181,6 +182,7 @@ requirejs.config({
         "activity/alert-controller": "js/activity/alert-controller",
         "activity/alert-renderer": "js/activity/alert-renderer",
         "palette/palette-loader": "js/palette/palette-loader",
+        "activity/search-controller": "js/activity/search-controller",
         "easeljs.min": "lib/easeljs.min",
         "tweenjs.min": "lib/tweenjs.min",
         "prefixfree.min": "lib/prefixfree.min",


### PR DESCRIPTION
## Summary

This PR refactors the search functionality by extracting all search-related logic from `activity.js` into a dedicated `SearchController`. The refactor improves code organization and separation of concerns without changing existing behavior.

## Changes

- Created `js/activity/search-controller.js`
- Moved search-related state into `SearchController`
  - `searchSuggestions`
  - `_searchCache`
  - `_searchCloseListener`
  - `isHelpfulSearchWidgetOn`
  - `searchBlockPosition`
  - `deprecatedBlockNames`
  - `helpfulSearchDiv`
- Moved search-related methods:
  - `prepSearchWidget`
  - `filterSuggestions`
  - `hideSearchWidget`
  - `showSearchWidget`
  - `doSearch`
  - `setHelpfulSearchDiv`
  - `_displayHelpfulSearchDiv`
  - `_hideHelpfulSearchWidget`
  - `showHelpfulSearchWidget`
  - `doHelpfulSearch`
- Initialized `SearchController` from `activity.js`
- Replaced the original implementations in `activity.js` with delegation methods
- Updated `doContextMenus` to reference `this.searchController.isHelpfulSearchWidgetOn`
- Added the new module to the AMD dependency list

## Behavior

- No functional changes.
- No UI changes.
- Existing callers continue to work through the delegation layer.

## Testing

- Verified that the search widget behaves as before.
- Verified that the helpful search widget behaves as before.
- Existing automated tests continue to pass.

- [x] Documentation