### PR TITLE
feat(pubsub): introduce lightweight synchronous PubSub module

### DIFF
--- a/js/__tests__/pubsub.test.js
+++ b/js/__tests__/pubsub.test.js
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+"use strict";
+
+const { PubSub, pubsub } = require("../pubsub.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBus() {
+    return new PubSub();
+}
+
+// ---------------------------------------------------------------------------
+// on() and emit()
+// ---------------------------------------------------------------------------
+
+describe("PubSub – on() and emit()", () => {
+    test("listener registered with on() is called when the event is emitted", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("test", fn);
+        bus.emit("test");
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("emit() with no listeners does not throw", () => {
+        const bus = makeBus();
+        expect(() => bus.emit("nonexistent")).not.toThrow();
+    });
+
+    test("payload is forwarded to listener", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("msg", fn);
+        const payload = { value: 42 };
+        bus.emit("msg", payload);
+        expect(fn).toHaveBeenCalledWith(payload);
+    });
+
+    test("payload is undefined when not provided", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("msg", fn);
+        bus.emit("msg");
+        expect(fn).toHaveBeenCalledWith(undefined);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple listeners
+// ---------------------------------------------------------------------------
+
+describe("PubSub – multiple listeners", () => {
+    test("all registered listeners are called for the same event", () => {
+        const bus = makeBus();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const fn3 = jest.fn();
+        bus.on("ev", fn1);
+        bus.on("ev", fn2);
+        bus.on("ev", fn3);
+        bus.emit("ev");
+        expect(fn1).toHaveBeenCalledTimes(1);
+        expect(fn2).toHaveBeenCalledTimes(1);
+        expect(fn3).toHaveBeenCalledTimes(1);
+    });
+
+    test("listeners for different events are isolated", () => {
+        const bus = makeBus();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        bus.on("ev1", fn1);
+        bus.on("ev2", fn2);
+        bus.emit("ev1");
+        expect(fn1).toHaveBeenCalledTimes(1);
+        expect(fn2).not.toHaveBeenCalled();
+    });
+
+    test("same listener registered twice is called twice", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("ev", fn);
+        bus.on("ev", fn);
+        bus.emit("ev");
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Ordering
+// ---------------------------------------------------------------------------
+
+describe("PubSub – listener ordering", () => {
+    test("listeners are called in registration order", () => {
+        const bus = makeBus();
+        const order = [];
+        bus.on("ev", () => order.push(1));
+        bus.on("ev", () => order.push(2));
+        bus.on("ev", () => order.push(3));
+        bus.emit("ev");
+        expect(order).toEqual([1, 2, 3]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// off()
+// ---------------------------------------------------------------------------
+
+describe("PubSub – off()", () => {
+    test("removed listener is not called after off()", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("ev", fn);
+        bus.off("ev", fn);
+        bus.emit("ev");
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("off() with a listener that was never registered does not throw", () => {
+        const bus = makeBus();
+        expect(() => bus.off("ev", jest.fn())).not.toThrow();
+    });
+
+    test("off() for an event with no listeners does not throw", () => {
+        const bus = makeBus();
+        expect(() => bus.off("nonexistent", jest.fn())).not.toThrow();
+    });
+
+    test("off() only removes the specific listener instance, leaving others intact", () => {
+        const bus = makeBus();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        bus.on("ev", fn1);
+        bus.on("ev", fn2);
+        bus.off("ev", fn1);
+        bus.emit("ev");
+        expect(fn1).not.toHaveBeenCalled();
+        expect(fn2).toHaveBeenCalledTimes(1);
+    });
+
+    test("off() removes only the first occurrence when a listener appears multiple times", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("ev", fn);
+        bus.on("ev", fn);
+        bus.off("ev", fn);
+        bus.emit("ev");
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// once()
+// ---------------------------------------------------------------------------
+
+describe("PubSub – once()", () => {
+    test("once() listener fires only on the first emit", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.once("ev", fn);
+        bus.emit("ev");
+        bus.emit("ev");
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("once() forwards the payload correctly", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.once("ev", fn);
+        bus.emit("ev", { x: 1 });
+        expect(fn).toHaveBeenCalledWith({ x: 1 });
+    });
+
+    test("once() does not interfere with persistent on() listeners", () => {
+        const bus = makeBus();
+        const persistent = jest.fn();
+        const single = jest.fn();
+        bus.on("ev", persistent);
+        bus.once("ev", single);
+        bus.emit("ev");
+        bus.emit("ev");
+        expect(persistent).toHaveBeenCalledTimes(2);
+        expect(single).toHaveBeenCalledTimes(1);
+    });
+
+    test("once() listener can be removed via off() before it fires", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.once("ev", fn);
+        const wrappers = bus._listeners["ev"];
+        expect(wrappers).toHaveLength(1);
+        bus.off("ev", wrappers[0]);
+        bus.emit("ev");
+        expect(fn).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// clear()
+// ---------------------------------------------------------------------------
+
+describe("PubSub – clear()", () => {
+    test("clear(eventName) removes all listeners for that event", () => {
+        const bus = makeBus();
+        const fn = jest.fn();
+        bus.on("ev", fn);
+        bus.clear("ev");
+        bus.emit("ev");
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("clear() with no argument removes all listeners for all events", () => {
+        const bus = makeBus();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        bus.on("ev1", fn1);
+        bus.on("ev2", fn2);
+        bus.clear();
+        bus.emit("ev1");
+        bus.emit("ev2");
+        expect(fn1).not.toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+    });
+
+    test("clear(eventName) does not affect listeners on other events", () => {
+        const bus = makeBus();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        bus.on("ev1", fn1);
+        bus.on("ev2", fn2);
+        bus.clear("ev1");
+        bus.emit("ev1");
+        bus.emit("ev2");
+        expect(fn1).not.toHaveBeenCalled();
+        expect(fn2).toHaveBeenCalledTimes(1);
+    });
+
+    test("clear() for an unknown event does not throw", () => {
+        const bus = makeBus();
+        expect(() => bus.clear("nonexistent")).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Nested emit()
+// ---------------------------------------------------------------------------
+
+describe("PubSub – nested emit()", () => {
+    test("a listener can emit another event synchronously", () => {
+        const bus = makeBus();
+        const inner = jest.fn();
+        bus.on("outer", () => bus.emit("inner"));
+        bus.on("inner", inner);
+        bus.emit("outer");
+        expect(inner).toHaveBeenCalledTimes(1);
+    });
+
+    test("a listener added during emit is not called in the same dispatch cycle", () => {
+        const bus = makeBus();
+        const lateListener = jest.fn();
+        bus.on("ev", () => bus.on("ev", lateListener));
+        bus.emit("ev");
+        expect(lateListener).not.toHaveBeenCalled();
+        bus.emit("ev");
+        expect(lateListener).toHaveBeenCalledTimes(1);
+    });
+
+    test("a listener removed during emit is still called in the current cycle but not the next", () => {
+        // emit() snapshots the listener list before dispatch, so fn2 was already captured
+        // and fires once even though fn1 removes it mid-cycle.
+        const bus = makeBus();
+        const fn2 = jest.fn();
+        const fn1 = jest.fn(() => bus.off("ev", fn2));
+        bus.on("ev", fn1);
+        bus.on("ev", fn2);
+        bus.emit("ev");
+        expect(fn2).toHaveBeenCalledTimes(1);
+        bus.emit("ev");
+        expect(fn2).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Listener exceptions
+// ---------------------------------------------------------------------------
+
+describe("PubSub – listener exceptions", () => {
+    test("an exception thrown by a listener propagates to the emit() caller", () => {
+        const bus = makeBus();
+        bus.on("ev", () => {
+            throw new Error("boom");
+        });
+        expect(() => bus.emit("ev")).toThrow("boom");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Module exports
+// ---------------------------------------------------------------------------
+
+describe("PubSub – module exports", () => {
+    test("exports the PubSub class", () => {
+        expect(typeof PubSub).toBe("function");
+    });
+
+    test("exports a default singleton pubsub instance", () => {
+        expect(pubsub).toBeInstanceOf(PubSub);
+    });
+
+    test("new PubSub() instances are independent", () => {
+        const a = new PubSub();
+        const b = new PubSub();
+        const fn = jest.fn();
+        a.on("ev", fn);
+        b.emit("ev");
+        expect(fn).not.toHaveBeenCalled();
+    });
+});

--- a/js/__tests__/pubsub.test.js
+++ b/js/__tests__/pubsub.test.js
@@ -325,3 +325,37 @@ describe("PubSub – module exports", () => {
         expect(fn).not.toHaveBeenCalled();
     });
 });
+
+// ---------------------------------------------------------------------------
+// AMD export
+// ---------------------------------------------------------------------------
+
+describe("PubSub – AMD export", () => {
+    test("define() is called, factory assigns pubsub singleton to window, and returns both exports", () => {
+        jest.resetModules();
+
+        let capturedFactory;
+        const mockDefine = jest.fn(factory => {
+            capturedFactory = factory;
+        });
+        mockDefine.amd = true;
+
+        const savedDefine = global.define;
+        global.define = mockDefine;
+
+        try {
+            require("../pubsub.js");
+        } finally {
+            global.define = savedDefine;
+        }
+
+        expect(mockDefine).toHaveBeenCalledTimes(1);
+
+        const result = capturedFactory();
+        expect(window.pubsub).toBeDefined();
+        expect(typeof result.PubSub).toBe("function");
+        expect(result.pubsub).toBe(window.pubsub);
+
+        delete window.pubsub;
+    });
+});

--- a/js/__tests__/pubsub.test.js
+++ b/js/__tests__/pubsub.test.js
@@ -194,13 +194,11 @@ describe("PubSub – once()", () => {
         expect(single).toHaveBeenCalledTimes(1);
     });
 
-    test("once() listener can be removed via off() before it fires", () => {
+    test("once() listener can be cancelled via the returned wrapper before it fires", () => {
         const bus = makeBus();
         const fn = jest.fn();
-        bus.once("ev", fn);
-        const wrappers = bus._listeners["ev"];
-        expect(wrappers).toHaveLength(1);
-        bus.off("ev", wrappers[0]);
+        const cancel = bus.once("ev", fn);
+        bus.off("ev", cancel);
         bus.emit("ev");
         expect(fn).not.toHaveBeenCalled();
     });

--- a/js/loader.js
+++ b/js/loader.js
@@ -183,6 +183,7 @@ requirejs.config({
         "activity/alert-renderer": "js/activity/alert-renderer",
         "palette/palette-loader": "js/palette/palette-loader",
         "activity/search-controller": "js/activity/search-controller",
+        "activity/pubsub": "js/pubsub",
         "easeljs.min": "lib/easeljs.min",
         "tweenjs.min": "lib/tweenjs.min",
         "prefixfree.min": "lib/prefixfree.min",

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -28,6 +28,8 @@ class PubSub {
         if (!list) return;
         const idx = list.indexOf(listener);
         if (idx !== -1) {
+            // Only the first matching reference is removed; duplicates registered
+            // via multiple on() calls each require a separate off() call.
             list.splice(idx, 1);
         }
     }
@@ -48,6 +50,7 @@ class PubSub {
             listener(payload);
         };
         this.on(eventName, wrapper);
+        return wrapper;
     }
 
     clear(eventName) {
@@ -63,7 +66,9 @@ const pubsub = new PubSub();
 
 if (typeof define === "function" && define.amd) {
     define(function () {
-        window.PubSub = PubSub;
+        // pubsub (the singleton) is exposed as a browser global for future callers.
+        // PubSub (the class) is not assigned to window because external scripts
+        // consume the shared singleton rather than constructing their own instances.
         window.pubsub = pubsub;
         return { PubSub, pubsub };
     });

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/* exported PubSub, pubsub */
+
+class PubSub {
+    constructor() {
+        this._listeners = Object.create(null);
+    }
+
+    on(eventName, listener) {
+        if (!this._listeners[eventName]) {
+            this._listeners[eventName] = [];
+        }
+        this._listeners[eventName].push(listener);
+    }
+
+    off(eventName, listener) {
+        const list = this._listeners[eventName];
+        if (!list) return;
+        const idx = list.indexOf(listener);
+        if (idx !== -1) {
+            list.splice(idx, 1);
+        }
+    }
+
+    emit(eventName, payload) {
+        const list = this._listeners[eventName];
+        if (!list) return;
+        // Snapshot the list so mid-iteration mutations (add/remove) do not affect this cycle.
+        const snapshot = list.slice();
+        for (const fn of snapshot) {
+            fn(payload);
+        }
+    }
+
+    once(eventName, listener) {
+        const wrapper = payload => {
+            this.off(eventName, wrapper);
+            listener(payload);
+        };
+        this.on(eventName, wrapper);
+    }
+
+    clear(eventName) {
+        if (eventName !== undefined) {
+            delete this._listeners[eventName];
+        } else {
+            this._listeners = Object.create(null);
+        }
+    }
+}
+
+const pubsub = new PubSub();
+
+if (typeof define === "function" && define.amd) {
+    define(function () {
+        window.PubSub = PubSub;
+        window.pubsub = pubsub;
+        return { PubSub, pubsub };
+    });
+} else if (typeof module !== "undefined" && module.exports) {
+    module.exports = { PubSub, pubsub };
+}


### PR DESCRIPTION
## Overview

This PR introduces a lightweight synchronous PubSub module as shared infrastructure for future event-dispatch refactoring.

Currently, various parts of Music Blocks communicate through `document.dispatchEvent`, `CustomEvent`, and DOM event listeners. While this works at runtime, it significantly increases the amount of DOM mocking required in Jest tests because even purely internal application events must be routed through JSDOM.

This PR **does not migrate any existing callers.** It only introduces the reusable infrastructure so future refactoring can happen incrementally in small, reviewable PRs without changing runtime behavior.

No user-facing behavior is changed.

---

## Changes

### New File

**`js/pubsub.js`**

Introduces a lightweight synchronous publish/subscribe implementation.

Provides:

* `emit(eventName, payload)`
* `on(eventName, listener)`
* `off(eventName, listener)`
* `once(eventName, listener)`
* `clear(eventName?)`

Characteristics:

* synchronous dispatch
* deterministic listener ordering
* no DOM dependencies
* no `document`
* no `CustomEvent`
* minimal API
* easy to mock in Jest

---

### Loader Integration

Updated **`js/loader.js`**

Registers the new PubSub module following the existing module registration pattern so it can be imported throughout the codebase when future migrations begin.

No existing modules are modified to use it.

---

## Tests

### Added

**`js/__tests__/pubsub.test.js`**

Comprehensive Jest coverage for:

* listener registration with `on()`
* synchronous `emit()`
* payload forwarding
* multiple listeners
* deterministic listener ordering
* `off()`
* `once()`
* removing unknown listeners
* emitting with no listeners
* nested synchronous emits
* snapshot iteration behavior
* listener exception propagation
* singleton/module exports

---

## Architecture

### PubSub Responsibilities

* listener registration
* listener removal
* synchronous event dispatch
* one-time listeners
* optional listener cleanup

### Not Responsible For

* browser events
* DOM events
* UI rendering
* controllers
* activity logic
* widgets

---

## What Is Not Changing

* Existing `document.dispatchEvent` usage
* Existing `document.addEventListener` usage
* Runtime behavior
* User interface
* Application logic
* Event flow

This PR introduces infrastructure only.

---

## Verification

### Automated

* New PubSub Jest test suite passes.
* Existing Jest test suite passes.
* ESLint passes.
* Prettier run only on modified files.

### Manual

Verified that no existing runtime paths were modified and the application behavior remains unchanged.

---

## Future Work

This infrastructure enables future refactoring PRs that migrate internal application events away from DOM-based dispatching one subsystem at a time.

Potential migration targets include:

* Activity lifecycle events
* Turtle execution events
* Controller-to-controller communication
* Internal application notifications

Each migration can be performed independently while preserving identical runtime behavior.

---

## Result

This PR establishes a reusable PubSub layer for internal event communication without changing any existing code paths. It provides the foundation for gradually replacing DOM-based event dispatching with a lightweight, test-friendly event system in future refactoring PRs.
- [x] Tests
