### PR TITLE
feat: add aria-live region for textMsg and errorMsg announcements (#6608)

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -4272,6 +4272,23 @@ class Activity {
          * @param {string|HTMLElement|DocumentFragment} msg - The message to display.
          * @param {number} [duration=60000] - Duration in milliseconds before message disappears.
          */
+        /**
+         * Ensures a visually hidden aria-live region exists for screen reader announcements.
+         * @returns {HTMLElement} The live region element.
+         */
+        const __ensureA11yLiveRegion = () => {
+            let region = document.getElementById("mbA11yLiveRegion");
+            if (region) return region;
+            region = document.createElement("div");
+            region.id = "mbA11yLiveRegion";
+            region.setAttribute("role", "status");
+            region.setAttribute("aria-live", "polite");
+            region.setAttribute("aria-atomic", "true");
+            region.style.cssText =
+                "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
+            document.body.appendChild(region);
+            return region;
+        };
         this.textMsg = (msg, duration = AlertController.MSG_TIMEOUT) => {
             if (this.msgText === null) {
                 // The container may not be ready yet, so do nothing.
@@ -4281,6 +4298,10 @@ class Activity {
             const showMsg = () => {
                 this.alertRenderer.showTextMsg(msg);
             };
+            // Announce to screen readers via aria-live region
+            if (msg && typeof msg === "string") {
+                __ensureA11yLiveRegion().textContent = msg;
+            }
 
             const hideMsg = () => {
                 this.alertRenderer.hideTextMsg();
@@ -4304,6 +4325,11 @@ class Activity {
             // The container may not be ready yet, so do nothing.
             if (this.errorMsgText === null) {
                 return;
+            }
+
+            // Announce errors to screen readers via aria-live region
+            if (msg && typeof msg === "string") {
+                __ensureA11yLiveRegion().textContent = msg;
             }
 
             const showMsg = () => {


### PR DESCRIPTION
## Description

Adds a visually hidden `aria-live` region to `js/activity.js` so that
screen reader users receive announcements for status and error messages
that currently only appear visually on screen.

Two functions are hooked:

- `textMsg()` — used for keyboard shortcut confirmations, scroll
  notifications, plugin messages, and general status updates
- `errorMsg()` — used for block errors and program warnings

A shared helper `__ensureA11yLiveRegion()` lazily creates a single
`role="status"` / `aria-live="polite"` region on first use and reuses
it for all subsequent announcements. This follows the same pattern used
in PR #5592 for pie menu announcements, keeping the implementation
consistent across the codebase.

## Related Issue

Part of #6608

## Type of Change

- [x] Accessibility Enhancement

## Category

- [x] Feature

## Testing Performed

1. Opened the app locally, triggered `textMsg` via Alt+R (Play) —
   screen reader announced "Alt-R Play".
2. Triggered an error condition — `errorMsg` content was announced.
3. Confirmed the live region is injected into the DOM only once
   (lazy creation working correctly).
4. `npx prettier --check js/activity.js` — no formatting issues.
5. `npm run lint -- js/activity.js` — no new errors introduced.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts