### PR TITLE
feat: announce program run/stop state via aria-live region (#6608)

### DIFF
--- a/js/__tests__/activity_toolbar_integration.test.js
+++ b/js/__tests__/activity_toolbar_integration.test.js
@@ -223,6 +223,8 @@ describe("Activity Toolbar Integration", () => {
             style: { visibility: "hidden" }
         };
 
+        activity.textMsg = jest.fn();
+
         global.window.widgetWindows = {
             isOpen: jest.fn(() => false),
             openWindows: {}
@@ -300,6 +302,20 @@ describe("Activity Toolbar Integration", () => {
             activity.onStopTurtle();
 
             expect(activity.toolbar.resetStop).toHaveBeenCalled();
+        });
+
+        test("announces program stopped to screen readers", () => {
+            activity.onStopTurtle();
+
+            expect(activity.textMsg).toHaveBeenCalledWith("Program stopped.");
+        });
+    });
+
+    describe("onRunTurtle", () => {
+        test("announces program running to screen readers", () => {
+            activity.onRunTurtle();
+
+            expect(activity.textMsg).toHaveBeenCalledWith("Program running.");
         });
     });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -3780,7 +3780,8 @@ class Activity {
             if (recordBtn) {
                 recordBtn.classList.remove("grey-text", "inactiveLink");
             }
-
+            // Announce program stop to screen readers
+            this.textMsg && this.textMsg(_("Program stopped."));
             // TODO: plugin support
         };
 
@@ -3789,6 +3790,8 @@ class Activity {
          */
         this.onRunTurtle = () => {
             // TODO: plugin support
+            // Announce program start to screen readers
+            this.textMsg && this.textMsg(_("Program running."));
         };
 
         /*

--- a/js/activity.js
+++ b/js/activity.js
@@ -2094,7 +2094,8 @@ class Activity {
             if (recordBtn) {
                 recordBtn.classList.remove("grey-text", "inactiveLink");
             }
-
+            // Announce program stop to screen readers
+            this.textMsg && this.textMsg(_("Program stopped."));
             // TODO: plugin support
         };
 
@@ -2103,6 +2104,8 @@ class Activity {
          */
         this.onRunTurtle = () => {
             // TODO: plugin support
+            // Announce program start to screen readers
+            this.textMsg && this.textMsg(_("Program running."));
         };
 
         /*


### PR DESCRIPTION
## Description

Adds screen reader announcements for program run and stop events in
`js/activity.js` by hooking into the existing `onRunTurtle` and
`onStopTurtle` callbacks.

- `onRunTurtle` — announces "Program running." when the user starts
  execution via the Play button or keyboard shortcut
- `onStopTurtle` — announces "Program stopped." when execution ends
  or is manually stopped

Both announcements are delivered via the `aria-live` region introduced
in PR #7674 (`textMsg` already pipes through that region), so no
additional DOM changes are needed here.

## Related Issue

Part of #6608

## Category

- [x] Feature

## Type of Change

- [x] Accessibility Enhancement

## Testing Performed

1. Clicked Play — screen reader announced "Program running."
2. Clicked Stop — screen reader announced "Program stopped."
3. Triggered stop via Alt+S — announcement fired correctly.
4. `npx prettier --check js/activity.js` — clean.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts