### PR TITLE
fix: wait for stop button visibility before clicking in E2E test

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -208,7 +208,7 @@ describe("MusicBlocks Application", () => {
                 expect(ctx.state).to.eq("running");
             });
 
-            cy.get("#stop").click();
+            cy.get("#stop").should("be.visible").click();
 
             cy.window().then(win => {
                 const ctx = win.Tone.context;


### PR DESCRIPTION
## Description

Fixes a flaky Cypress E2E test in `main.cy.js` where `cy.get("#stop").click()`
was called immediately after clicking play, without waiting for the stop
button to become visible.

The stop button has `display: none` by default and only appears after the
program starts running. Adding `.should("be.visible")` before `.click()`
tells Cypress to wait until the button is visible before interacting with it,
eliminating the timing-dependent failure.

## Related Issue

N/A — pre-existing test flakiness, not tied to a specific issue.

## Category

- [x] Bug Fix

## Type of Change

- [x] Bug Fix

## Testing Performed

1. Change is a one-line addition of `.should("be.visible")` before `.click()`.
2. No app logic touched — test file only.

## PR Checklist

- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts