### PR TITLE
fix: resolve Japanese Kana language switching and outputtools translation issues

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -439,7 +439,17 @@ class Activity {
             let lang = "en";
             if (this.storage.languagePreference !== undefined) {
                 lang = this.storage.languagePreference;
-                if (lang.startsWith("ja")) lang = "ja"; // normalize Japanese
+                if (lang === "kana" || lang === "ja-kana") {
+                    this.storage.languagePreference = "ja";
+                    this.storage.kanaPreference = "kana";
+                    lang = "ja";
+                } else if (lang === "ja-kanji") {
+                    this.storage.languagePreference = "ja";
+                    this.storage.kanaPreference = "kanji";
+                    lang = "ja";
+                } else if (lang.startsWith("ja")) {
+                    lang = "ja"; // normalize Japanese
+                }
                 i18next.changeLanguage(lang);
             } else {
                 lang = navigator.language;

--- a/js/block.js
+++ b/js/block.js
@@ -1544,7 +1544,7 @@ class Block {
             } else if (this.name === "noisename") {
                 label = getNoiseName(this.value);
             } else if (this.name === "outputtools") {
-                label = this.overrideName;
+                label = _(this.overrideName);
             } else if (this.name === "grid") {
                 label = _(this.value);
             } else {

--- a/js/loader.js
+++ b/js/loader.js
@@ -343,6 +343,16 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
         try {
             const savedLanguage = window.localStorage && window.localStorage.languagePreference;
             if (savedLanguage) {
+                if (savedLanguage === "kana" || savedLanguage === "ja-kana") {
+                    window.localStorage.setItem("languagePreference", "ja");
+                    window.localStorage.setItem("kanaPreference", "kana");
+                    return "ja";
+                }
+                if (savedLanguage === "ja-kanji") {
+                    window.localStorage.setItem("languagePreference", "ja");
+                    window.localStorage.setItem("kanaPreference", "kanji");
+                    return "ja";
+                }
                 return savedLanguage.startsWith("ja") ? "ja" : savedLanguage;
             }
         } catch (e) {

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -164,6 +164,7 @@ class StatusMatrix {
                     if (typeof label === "object" && label !== null && label.value) {
                         label = label.value;
                     }
+                    label = _(label);
                     break;
                 default: {
                     const block = this.activity.blocks.blockList[statusField[0]];


### PR DESCRIPTION
fixes #7680 
- [x] Bug Fix
### Description
This pull request fixes a bug where switching the UI language from English to Japanese Kana (the early-reader version) failed to translate the interface and remained in English.


### Solution (Minimal Scope Fix)
The fix modifies only **4 files** to resolve the issue entirely at the source:
1. **[js/loader.js](file:///Users/rakshityadav/Desktop/OPEN-SOURCE/sugarlabs/musicblocks/js/loader.js)** & **[js/activity.js](file:///Users/rakshityadav/Desktop/OPEN-SOURCE/sugarlabs/musicblocks/js/activity.js)**:
   - Normalize `"ja-kana"`, `"ja-kanji"`, and `"kana"` to `"ja"` on load. This allows `i18next` to retrieve the unified `locales/ja.json` successfully.
   - Synchronize `localStorage.languagePreference` directly to `"ja"` and set `localStorage.kanaPreference` to `"kana"` or `"kanji"`. This ensures all other files checking `=== "ja"` automatically work out-of-the-box.
2. **[js/block.js](file:///Users/rakshityadav/Desktop/OPEN-SOURCE/sugarlabs/musicblocks/js/block.js)**:
   - Wrapped `this.overrideName` in `_()` for `outputtools` blocks so block labels are translated dynamically.
3. **[js/widgets/status.js](file:///Users/rakshityadav/Desktop/OPEN-SOURCE/sugarlabs/musicblocks/js/widgets/status.js)**:
   - Wrapped the resolved `outputtools` label in `_()` to correct English strings shown in the status panel.
