### PR TITLE
fix: Resolve TypeError in Temperament Widget when using just intonation or Pythagorean temperaments

### DIFF
--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1894,8 +1894,9 @@ function TemperamentWidget() {
                 const temperamentRatios = [];
                 for (let j = 0; j < t.interval.length; j++) {
                     intervals[j] = t.interval[j];
-                    temperamentRatios[j] = t[intervals[j]];
-                    temperamentRatios[j] = temperamentRatios[j].toFixed(2);
+                    const raw = t[intervals[j]];
+                    const numericRatio = raw !== null && typeof raw === "object" ? raw.ratio : raw;
+                    temperamentRatios[j] = Number(numericRatio).toFixed(2);
                 }
                 const ratiosEqual =
                     ratios.length === temperamentRatios.length &&


### PR DESCRIPTION
## Summary

Fixes #7683 — Preview, Clear, and Done buttons in the Temperament Widget throw a `TypeError` and stop working when `just intonation` or `Pythagorean` is selected as the active temperament.

## Root Cause

The `TEMPERAMENT` object in `musicutils.js` stores interval values in two different formats depending on the temperament:
- EDO/meantone temperaments: plain `number` (e.g. `Math.pow(2, 4/12)`)
- Just intonation / Pythagorean: `{ratio, cents}` object (e.g. `{ ratio: 5/4, cents: 386.31 }`)

`checkTemperament()` called `.toFixed(2)` directly on the raw value without checking its type, causing a `TypeError: .toFixed is not a function` when the value was an object.

## Fix

In `js/widgets/temperament.js`, extract `.ratio` when the interval value is a non-null object before calling `.toFixed(2)`:

```js
const raw = t[intervals[j]];
const numericRatio = raw !== null && typeof raw === "object" ? raw.ratio : raw;
temperamentRatios[j] = Number(numericRatio).toFixed(2);

## PR category
- [x] Bug fix


