### PR TITLE
fix: pie submenu renders behind widget and clips off-canvas

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -83,6 +83,7 @@ describe("MusicKeyboard add-row submenu", () => {
     let originalSlicePath;
     let originalWheelnav;
     let originalTranslate;
+    let originalI18nSolfege;
 
     beforeEach(() => {
         document.body.innerHTML = '<div id="wheelDivptm"></div><div id="addnotes"></div>';
@@ -93,17 +94,21 @@ describe("MusicKeyboard add-row submenu", () => {
         originalSlicePath = global.slicePath;
         originalWheelnav = global.wheelnav;
         originalTranslate = global._;
+        originalI18nSolfege = global.i18nSolfege;
 
         global.docById = id => document.getElementById(id);
         global.platformColor = {
             paletteColors: { pitch: ["#000", "#fff"] },
-            exitWheelcolors: ["#000", "#fff"]
+            exitWheelcolors: ["#000", "#fff"],
+            pitchWheelcolors: ["#000", "#fff"],
+            blockLabelsWheelcolors: ["#000", "#fff"]
         };
         global.slicePath = () => ({
             DonutSlice: jest.fn(),
             DonutSliceCustomization: () => ({})
         });
         global._ = value => value;
+        global.i18nSolfege = val => val;
         global.wheelnav = function () {
             this.raphael = {};
             this.navItems = [];
@@ -115,7 +120,8 @@ describe("MusicKeyboard add-row submenu", () => {
                     sliceSelectedAttr: {},
                     sliceHoverAttr: {},
                     titleSelectedAttr: {},
-                    titleHoverAttr: {}
+                    titleHoverAttr: {},
+                    navItem: { hide: jest.fn(), show: jest.fn() }
                 }));
             };
             this.removeWheel = jest.fn();
@@ -128,6 +134,7 @@ describe("MusicKeyboard add-row submenu", () => {
         global.slicePath = originalSlicePath;
         global.wheelnav = originalWheelnav;
         global._ = originalTranslate;
+        global.i18nSolfege = originalI18nSolfege;
         document.body.innerHTML = "";
     });
 
@@ -155,5 +162,45 @@ describe("MusicKeyboard add-row submenu", () => {
             [1, ["solfege", { value: "do♯" }], 0, 0, [0]],
             [2, ["number", { value: 392 }], 0, 0, [0]]
         ]);
+    });
+
+    test("creates pie submenu and sets z-index and top position correctly", () => {
+        document.body.innerHTML =
+            '<div id="wheelDivptm"></div><div id="_exitWheel"></div><div id="_tabsWheel"></div><div id="_durationWheel"></div><div id="cell-0"></div>';
+        document.getElementById("cell-0").getBoundingClientRect = () => ({ x: 100, y: 400 });
+
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1
+        });
+
+        expect(() => {
+            keyboard._createpiesubmenu("cell-0", "0");
+        }).not.toThrow();
+
+        expect(docById("wheelDivptm").style.zIndex).toBe("10001");
+        expect(docById("wheelDivptm").style.top).toBe("350px"); // min(600 - 250, 400) = 350
+    });
+
+    test("creates column pie submenu and sets z-index and top position correctly", () => {
+        document.body.innerHTML =
+            '<div id="wheelDivptm"></div><div id="_exitWheel"></div><div id="labelcol0"></div>';
+        document.getElementById("labelcol0").getBoundingClientRect = () => ({ x: 100, y: 400 });
+
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            blocks: {
+                blockList: [{ connections: [null, 1, null] }, { value: 392 }]
+            }
+        });
+        keyboard.layout = [{ noteName: "hertz", noteOctave: 392, blockNumber: 0 }];
+
+        expect(() => {
+            keyboard._createColumnPieSubmenu(0, "synthsblocks");
+        }).not.toThrow();
+
+        expect(docById("wheelDivptm").style.zIndex).toBe("10001");
+        expect(docById("wheelDivptm").style.top).toBe("300px"); // min(600 - 300, 400) = 300
     });
 });

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1792,6 +1792,7 @@ function MusicKeyboard(activity) {
      */
     this._createpiesubmenu = function (cellId, start) {
         docById("wheelDivptm").style.display = "";
+        docById("wheelDivptm").style.zIndex = "10001";
 
         this._menuWheel = new wheelnav("wheelDivptm", null, 600, 600);
         this._exitWheel = new wheelnav("_exitWheel", this._menuWheel.raphael);
@@ -2071,7 +2072,7 @@ function MusicKeyboard(activity) {
      */
     this._createAddRowPieSubmenu = function () {
         docById("wheelDivptm").style.display = "";
-        // docById("wheelDivptm").style.zIndex = "300";
+        docById("wheelDivptm").style.zIndex = "10001";
         const pitchLabels = [
             "do",
             "do♯",
@@ -2152,7 +2153,7 @@ function MusicKeyboard(activity) {
             ) + "px";
         docById("wheelDivptm").style.top =
             Math.min(
-                this.activity.canvas.height - 250,
+                this.activity.canvas.height - 300,
                 Math.max(0, y * this.activity.getStageScale())
             ) + "px";
 
@@ -2451,7 +2452,7 @@ function MusicKeyboard(activity) {
         }
 
         docById("wheelDivptm").style.display = "";
-        docById("wheelDivptm").style.zIndex = "300";
+        docById("wheelDivptm").style.zIndex = "10001";
 
         const accidentals = ["𝄪", "♯", "♮", "♭", "𝄫"];
         let noteLabels = ["ti", "la", "sol", "fa", "mi", "re", "do"];
@@ -2580,7 +2581,7 @@ function MusicKeyboard(activity) {
             ) + "px";
         docById("wheelDivptm").style.top =
             Math.min(
-                this.activity.canvas.height - 250,
+                this.activity.canvas.height - 300,
                 Math.max(0, y * this.activity.getStageScale())
             ) + "px";
 


### PR DESCRIPTION
## Description

The pie/wheel submenus opened from the Music Keyboard widget (cell-click
menu, "Add Note" menu, and column-header menu) were rendering behind the
widget window instead of on top of it, making the menus unusable in
many cases. Additionally, two of the three menus were positioned such
that part of the wheel (the bottom-most slices, e.g. octave/duration
options "1" and "2") rendered off the visible canvas area.

## PR Category

- [x] Bug Fix 

## Changes Made

- Set `zIndex` to `10001` on `#wheelDivptm` in all three pie-menu
  builder functions (`_createpiesubmenu`, `_createAddRowPieSubmenu`,
  `_createColumnPieSubmenu`) in `js/widgets/musickeyboard.js`, so the
  menu reliably renders above the widget window's frame, which is set
  to `zIndex: 10000` on focus (`takeFocus()` in
  `js/widgets/widgetWindows.js`). Previously one function set no
  `zIndex` at all, one had it commented out, and one used `300`, none
  of which beat the widget's `10000`.
- Fixed a height/top mismatch in `_createAddRowPieSubmenu` and
  _createColumnPieSubmenu: both size `#wheelDivptm` at `300px` tall
  but capped the vertical (`top`) position using a stale value of
  `250`, leaving up to 50px of the wheel positioned below the visible
  canvas. Changed the cap to `300` to match the actual height in both
  functions.

## Testing Performed

- Confirmed the column-header menu and "Add Note" menu no longer clip
  their bottom-most slices off the visible canvas.
- Ran `npm run lint` — 0 errors, no new warnings.
- Ran `npx prettier --check js/widgets/musickeyboard.js` — passes.
- Ran `npm test` — all 5900 tests passed.

