### PR TITLE
fix: make exit slice click responsive in all pie submenus

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -164,7 +164,7 @@ describe("MusicKeyboard add-row submenu", () => {
         ]);
     });
 
-    test("creates pie submenu and sets z-index and top position correctly", () => {
+    test("creates pie submenu and sets z-index, top position, and exit wheel correctly", () => {
         document.body.innerHTML =
             '<div id="wheelDivptm"></div><div id="_exitWheel"></div><div id="_tabsWheel"></div><div id="_durationWheel"></div><div id="cell-0"></div>';
         document.getElementById("cell-0").getBoundingClientRect = () => ({ x: 100, y: 400 });
@@ -180,9 +180,12 @@ describe("MusicKeyboard add-row submenu", () => {
 
         expect(docById("wheelDivptm").style.zIndex).toBe("10001");
         expect(docById("wheelDivptm").style.top).toBe("350px"); // min(600 - 250, 400) = 350
+        expect(keyboard._exitWheel.selectedNavItemIndex).toBeNull();
+        expect(keyboard._exitWheel.navItems[1].enabled).toBe(false);
+        expect(keyboard._exitWheel.navItems[0].sliceSelectedAttr.cursor).toBe("pointer");
     });
 
-    test("creates column pie submenu and sets z-index and top position correctly", () => {
+    test("creates column pie submenu and sets z-index, top position, and exit wheel correctly", () => {
         document.body.innerHTML =
             '<div id="wheelDivptm"></div><div id="_exitWheel"></div><div id="labelcol0"></div>';
         document.getElementById("labelcol0").getBoundingClientRect = () => ({ x: 100, y: 400 });
@@ -202,6 +205,9 @@ describe("MusicKeyboard add-row submenu", () => {
 
         expect(docById("wheelDivptm").style.zIndex).toBe("10001");
         expect(docById("wheelDivptm").style.top).toBe("300px"); // min(600 - 300, 400) = 300
+        expect(keyboard._exitWheel.selectedNavItemIndex).toBeNull();
+        expect(keyboard._exitWheel.navItems[1].enabled).toBe(false);
+        expect(keyboard._exitWheel.navItems[0].sliceSelectedAttr.cursor).toBe("pointer");
     });
 });
 

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1838,6 +1838,7 @@ function MusicKeyboard(activity) {
         this._exitWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._exitWheel.sliceSelectedPathCustom = this._exitWheel.slicePathCustom;
         this._exitWheel.sliceInitPathCustom = this._exitWheel.slicePathCustom;
+        this._exitWheel.selectedNavItemIndex = null;
 
         const tabsLabels = [
             "",
@@ -1894,6 +1895,13 @@ function MusicKeyboard(activity) {
 
         this._menuWheel.createWheel(mainTabsLabels);
         this._exitWheel.createWheel(["x", ""]);
+        this._exitWheel.navItems[1].enabled = false;
+        if (this._exitWheel.navItems[0].sliceSelectedAttr) {
+            this._exitWheel.navItems[0].sliceSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].sliceHoverAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleHoverAttr.cursor = "pointer";
+        }
 
         docById("wheelDivptm").style.position = "absolute";
         docById("wheelDivptm").style.height = "250px";
@@ -2526,7 +2534,15 @@ function MusicKeyboard(activity) {
         this._exitWheel.sliceSelectedPathCustom = this._exitWheel.slicePathCustom;
         this._exitWheel.sliceInitPathCustom = this._exitWheel.slicePathCustom;
         this._exitWheel.clickModeRotate = false;
+        this._exitWheel.selectedNavItemIndex = null;
         this._exitWheel.createWheel(["x", " "]);
+        this._exitWheel.navItems[1].enabled = false;
+        if (this._exitWheel.navItems[0].sliceSelectedAttr) {
+            this._exitWheel.navItems[0].sliceSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].sliceHoverAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleSelectedAttr.cursor = "pointer";
+            this._exitWheel.navItems[0].titleHoverAttr.cursor = "pointer";
+        }
 
         const octaveLabels = [
             "8",


### PR DESCRIPTION
## Description

The exit ("x") slice on the pie/wheel submenus (`_createpiesubmenu` and `_createColumnPieSubmenu`) inside `js/widgets/musickeyboard.js` became unresponsive (not closing the menu on click) after the first use. This was due to missing properties on the exit wheel's configuration.

## PR Category

- [x] Bug Fix

## Changes Made

- Set `this._exitWheel.selectedNavItemIndex = null;` before creation in both `_createpiesubmenu` and `_createColumnPieSubmenu`.
- Disabled the second slice (`navItems[1].enabled = false`) and configured pointer cursors on the active exit slice after creation, mirroring the working pattern already present in `_createAddRowPieSubmenu`.

## Testing Performed

- Confirmed exit slices for cell-click, add-note, and column-header submenus all closes now.
- Ran `npm run lint` — passes.
- Ran `npx prettier --check js/widgets/musickeyboard.js` — passes.
- Ran `npm test` — all 5900 tests passed.
