### PR TITLE
fix: replace innerHTML with secure DOM creation in modewidget.js

### DIFF
--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -304,17 +304,32 @@ class ModeWidget {
         modePianoDiv.style.border = "0px";
         modePianoDiv.style.top = "0px";
         modePianoDiv.style.left = "0px";
-        let pianoHTML =
-            '<img src="images/piano_keys.png"  id="modeKeyboard" style="top:0px; left:0px; position:relative;">';
-        for (let i = 0; i < 12; i++) {
-            pianoHTML += '<img id="pkey_' + i + '" style="top:0px; left:0px; position:absolute;">';
-        }
-        modePianoDiv.innerHTML = pianoHTML;
+        const elements = [];
 
-        // Cache piano key elements to avoid repeated getElementById calls
+        const baseImg = document.createElement("img");
+        baseImg.src = "images/piano_keys.png";
+        baseImg.id = "modeKeyboard";
+        baseImg.style.top = "0px";
+        baseImg.style.left = "0px";
+        baseImg.style.position = "relative";
+        elements.push(baseImg);
+
         this._pianoKeys = [];
         for (let i = 0; i < 12; i++) {
-            this._pianoKeys[i] = document.getElementById("pkey_" + i);
+            const keyImg = document.createElement("img");
+            keyImg.id = "pkey_" + i;
+            keyImg.style.top = "0px";
+            keyImg.style.left = "0px";
+            keyImg.style.position = "absolute";
+            elements.push(keyImg);
+            this._pianoKeys[i] = keyImg;
+        }
+
+        if (typeof modePianoDiv.replaceChildren === "function") {
+            modePianoDiv.replaceChildren(...elements);
+        } else {
+            modePianoDiv.innerHTML = "";
+            elements.forEach(el => modePianoDiv.appendChild(el));
         }
 
         const highlightImgs = [


### PR DESCRIPTION
## Description
This PR addresses a potential security flaw in `js/widgets/modewidget.js` by removing raw HTML string concatenation fed into `.innerHTML`. The piano UI elements are now securely constructed using `document.createElement("img")`. 

Additionally, this approach is more performant as it caches the element references at creation time, eliminating the need for redundant `document.getElementById` lookups.

## PR Category
- [x] Bug Fix - Fixes a bug or incorrect behavior
- [ ] Feature - Adds new functionality
- [ ] Performance - Improves performance (load time, memory, rendering, etc.)
- [ ] Tests - Adds or updates test coverage
- [ ] Documentation - Updates to docs, comments, or README
- [ ] Chore / Refactor - Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD - Changes to CI/CD workflows and automation

## Changes Made
- Refactored `_showPiano()` in `modewidget.js`.
- Replaced `innerHTML` concatenation with direct DOM node creation (`document.createElement`).
- Leveraged `replaceChildren(...)` for modern insertion, while keeping a robust fallback for older environments and testing frameworks like JSDOM.

## Testing Performed
- Ran `npx jest modewidget.test.js --verbose` (16/16 tests passing, confirming no regressions).
- Verified formatting using `npx prettier`.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers
The change is localized to `modewidget.js` and securely handles the DOM manipulations while keeping full backward compatibility in the testing environment.
