### PR TITLE
refactor: remove obsolete legacy DOM code

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -6329,11 +6329,6 @@ class Activity {
             // create functionality of 2D drag to select blocks in bulk
             this._create2Ddrag();
 
-            /*
-               document.addEventListener("mousewheel", scrollEvent, false);
-               document.addEventListener("DOMMouseScroll", scrollEvent, false);
-               */
-
             // Named event handler for proper cleanup
             const activity = this;
             this.handleKeyDown = event => {

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -129,27 +129,6 @@ const {
 } = require("../utils.js");
 
 describe("Utility Functions (logic-only)", () => {
-    describe("load handler registration", () => {
-        it("registers the IE check without overwriting an existing window.onload", () => {
-            const existingOnload = jest.fn();
-            const originalOnload = window.onload;
-            const addEventListenerSpy = jest.spyOn(window, "addEventListener");
-
-            jest.resetModules();
-            window.onload = existingOnload;
-
-            jest.isolateModules(() => {
-                require("../utils.js");
-            });
-
-            expect(window.onload).toBe(existingOnload);
-            expect(addEventListenerSpy).toHaveBeenCalledWith("load", expect.any(Function));
-
-            addEventListenerSpy.mockRestore();
-            window.onload = originalOnload;
-        });
-    });
-
     describe("toTitleCase()", () => {
         it("converts first character to uppercase", () => {
             expect(toTitleCase("hello")).toBe("Hello");

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -439,52 +439,6 @@ function waitForReadiness(callback, options = {}) {
     requestAnimationFrame(check);
 }
 
-// Check for Internet Explorer
-
-window.addEventListener("load", () => {
-    const userAgent = window.navigator.userAgent;
-    // For IE 10 or older
-    const MSIE = userAgent.indexOf("MSIE ");
-    let DetectVersionOfIE;
-    if (MSIE > 0) {
-        DetectVersionOfIE = parseInt(
-            userAgent.substring(MSIE + 5, userAgent.indexOf(".", MSIE)),
-            10
-        );
-    }
-
-    // For IE 11
-    const IETrident = userAgent.indexOf("Trident/");
-    if (IETrident > 0) {
-        const IERv = userAgent.indexOf("rv:");
-        DetectVersionOfIE = parseInt(
-            userAgent.substring(IERv + 3, userAgent.indexOf(".", IERv)),
-            10
-        );
-    }
-
-    // For IE 12
-    const IEEDGE = userAgent.indexOf("Edge/");
-    if (IEEDGE > 0) {
-        DetectVersionOfIE = parseInt(
-            userAgent.substring(IEEDGE + 5, userAgent.indexOf(".", IEEDGE)),
-            10
-        );
-    }
-
-    if (typeof DetectVersionOfIE !== "undefined") {
-        document.body.innerHTML =
-            "<div style='margin: 200px;'>" +
-            "<h1 style='font-size: 100px; font-family: Arial; text-align: center; color: #F00;'>Music Blocks</h1>" +
-            "<h3 style='font-size: 40px; font-family: Arial; text-align: center;'>Music Blocks will not work in Internet Explorer, you can use:</h3>" +
-            "<div style='width: 550px; margin: 0 auto;'><a href='https://www.chromium.org/getting-involved/download-chromium' style='float: left; display: inherit; font-family: Arial; font-size: 30px; color: #0327F1; text-decoration: none;'>Chromium</a>" +
-            "<a href='https://www.google.com/chrome/' style='float: left; margin-left: 40px;display: inherit; font-family: Arial; font-size: 30px; color: #0327F1; text-decoration: none;'>Chrome</a>" +
-            "<a href='https://support.apple.com/downloads/safari' style='float: left; margin-left: 40px;display: inherit; font-family: Arial; font-size: 30px; color: #0327F1; text-decoration: none;'>Safari</a>" +
-            "<a href='https://www.mozilla.org/en-US/firefox/new/' style='float: left; margin-left: 40px;display: inherit; font-family: Arial; font-size: 30px; color: #0327F1; text-decoration: none;'>Firefox</a>" +
-            "</div></div>";
-    }
-});
-
 /**
  * Retrieves a collection of elements by class name.
  * @param {string} classname - The class name to search for.


### PR DESCRIPTION
## Overview

This PR removes two obsolete pieces of legacy DOM-related code identified during the DOM event audit.

Neither change affects runtime behavior. Both remove code that is no longer used or relevant in supported browsers.

## Changes

### Remove Internet Explorer compatibility code

Removes the legacy Internet Explorer detection block from `js/utils/utils.js`.

The code existed only to display a warning for unsupported Internet Explorer versions. Since Internet Explorer reached end-of-life in 2022 and Music Blocks no longer targets it, this compatibility code is no longer needed.

Verified that:

* `DetectVersionOfIE` has no remaining runtime dependencies.
* Removing the code does not affect supported browsers (Chrome, Firefox, Safari, Chromium Edge).

### Remove obsolete commented-out mousewheel code

Removes the commented-out `mousewheel` / `DOMMouseScroll` listener block from `js/activity.js`.

The code was entirely inside a comment block and was never executed. Wheel handling is already implemented through the active `wheel` event listener elsewhere in the same method, so the commented code no longer serves any runtime purpose.

## What Is Not Changing

* Browser event handling
* Wheel event behavior
* Application functionality
* User interface
* Runtime behavior

Only obsolete and unused legacy code is removed.

## Verification

### Automated

* Existing Jest test suite passes.
* ESLint passes.
* Prettier run only on modified files.

### Manual

Verified that:

* Application startup is unchanged.
* Mouse wheel behavior continues to function normally.
* No Internet Explorer compatibility logic remains.
* No runtime behavior changes were introduced.

## Result

This PR completes the cleanup items identified during the DOM event audit by removing obsolete Internet Explorer compatibility code and deleting dead commented-out mouse wheel code, reducing maintenance overhead without changing application behavior.

Removes legacy Internet Explorer detection code and obsolete commented-out mousewheel listeners. These paths are no longer used and have no effect on runtime behavior, reducing maintenance overhead without changing functionality.

- [x] documentation