### PR TITLE
fix: replace unsafe innerHTML with textContent for clearing elements

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3863,7 +3863,7 @@ class Block {
             el.type = "text";
 
             // Ensure it is the child of labelElem
-            labelElem.innerHTML = "";
+            labelElem.textContent = "";
             labelElem.appendChild(el);
 
             this.label = el;
@@ -4437,7 +4437,7 @@ class Block {
                 el.step = "any";
 
                 // Ensure it is the child of labelElem
-                labelElem.innerHTML = "";
+                labelElem.textContent = "";
                 labelElem.appendChild(el);
 
                 this.label = el;

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -582,7 +582,7 @@ class ToolbarUI {
         // Prevents listener accumulation when renderNewProjectIcon is called multiple times
         this._cleanupModalListeners?.();
 
-        newDropdown.innerHTML = "";
+        newDropdown.textContent = "";
         const title = document.createElement("div");
         title.classList.add("new-project-title");
         title.textContent = _("New project");

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -883,7 +883,7 @@ class ModeWidget {
         }
 
         // console.debug('setModeName:' + 'not found');
-        table.rows[n].cells[0].innerHTML = "";
+        table.rows[n].cells[0].textContent = "";
         this.widgetWindow.updateTitle("");
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes additional instances of unsafe `innerHTML = ""` usage that were 
not covered by #7603, addressing the remaining cases from issue #7602.

## Files changed

- `js/toolbar-ui.js` (1 instance) — not included in original issue #7602
- `js/widgets/modewidget.js` (1 instance) — not included in original issue #7602  
- `js/block.js` (2 instances) — included in #7602 but not yet merged

## Why?

`innerHTML = ""` is unsafe because it invokes the HTML parser 
unnecessarily. `textContent = ""` is the correct, safe alternative 
for clearing text content from DOM elements.

## Related

Closes #7602 (partial — covers files missed by #7603)

## PR Category
- [x] Bug Fix