### PR TITLE
fix: resolve musickeyboard clicks desync and connection crashes

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1048,8 +1048,8 @@ class Blocks {
              * These checks are to test for malformed data. All blocks
              * should have connections.
              */
-            if (myBlock === null) {
-                console.debug("Saw a null block: " + blk);
+            if (myBlock === null || myBlock === undefined) {
+                console.debug("Saw a null or undefined block: " + blk);
                 if (isOuterCall) this._endDeferCheckBounds();
                 return;
             }
@@ -1105,8 +1105,10 @@ class Blocks {
                 }
 
                 /** Another database integrity check. */
-                if (this.blockList[cblk] === null) {
-                    console.debug("This is not good: we encountered a null block: " + cblk);
+                if (this.blockList[cblk] === null || this.blockList[cblk] === undefined) {
+                    console.debug(
+                        "This is not good: we encountered a null or undefined block: " + cblk
+                    );
                     continue;
                 }
 

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -216,6 +216,11 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
     let originalPlatformColor;
     let originalTranslate;
     let originalWheelnav;
+    let originalNoteToFrequency;
+    let originalConvertFromSolfege;
+    let originalPitches;
+    let originalPitches2;
+    let originalSolfegeNames;
     let mockActivity;
 
     beforeEach(() => {
@@ -223,6 +228,11 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         originalPlatformColor = global.platformColor;
         originalTranslate = global._;
         originalWheelnav = global.wheelnav;
+        originalNoteToFrequency = global.noteToFrequency;
+        originalConvertFromSolfege = global.convertFromSolfege;
+        originalPitches = global.PITCHES;
+        originalPitches2 = global.PITCHES2;
+        originalSolfegeNames = global.SOLFEGENAMES;
         mockActivity = {
             turtles: {
                 ithTurtle: jest.fn().mockReturnValue({
@@ -300,6 +310,20 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
             DonutSlice: jest.fn(),
             DonutSliceCustomization: () => ({})
         });
+        global.noteToFrequency = jest.fn().mockReturnValue(261.63);
+        global.convertFromSolfege = jest.fn(n => {
+            if (n === "do") return "C";
+            if (n === "re") return "D";
+            if (n === "mi") return "E";
+            if (n === "fa") return "F";
+            if (n === "sol") return "G";
+            if (n === "la") return "A";
+            if (n === "ti") return "B";
+            return n;
+        });
+        global.PITCHES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        global.PITCHES2 = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"];
+        global.SOLFEGENAMES = ["do", "re", "mi", "fa", "sol", "la", "ti"];
         global.wheelnav = function () {
             this.raphael = {};
             this.navItems = [];
@@ -327,6 +351,11 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         global.platformColor = originalPlatformColor;
         global._ = originalTranslate;
         global.wheelnav = originalWheelnav;
+        global.noteToFrequency = originalNoteToFrequency;
+        global.convertFromSolfege = originalConvertFromSolfege;
+        global.PITCHES = originalPitches;
+        global.PITCHES2 = originalPitches2;
+        global.SOLFEGENAMES = originalSolfegeNames;
     });
 
     test("onclose stops sequence playback, releases active key, and stops all voices", () => {
@@ -494,5 +523,78 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         // Verify normalization and trigger
         expect(global.normalizeNoteAccidentals).toHaveBeenCalledWith("F♭4");
         expect(mockActivity.logo.synth.trigger).toHaveBeenCalled();
+    });
+
+    test("synchronizes layout and displayLayout correctly, preserving real block numbers", () => {
+        const keyboard = new MusicKeyboard(mockActivity);
+        keyboard.noteNames = ["do", "sol"];
+        keyboard.octaves = [5, 4];
+        keyboard._rowBlocks = [44, 47];
+        keyboard.instruments = ["guitar", "guitar"];
+
+        mockActivity.blocks = {
+            blockList: {
+                44: { name: "pitch", connections: [null, 45, 46, null] },
+                45: { value: "do" },
+                46: { value: 5 },
+                47: { name: "pitch", connections: [null, 48, 49, null] },
+                48: { value: "sol" },
+                49: { value: 4 }
+            },
+            adjustDocks: jest.fn(),
+            clampBlocksToCheck: [],
+            adjustExpandableClampBlock: jest.fn(),
+            sendStackToTrash: jest.fn()
+        };
+
+        keyboard.init();
+
+        // Check if layout was synchronized correctly
+        expect(keyboard.displayLayout.length).toBeGreaterThan(2);
+
+        // Find C5 (do 5) in displayLayout
+        const c5Item = keyboard.displayLayout.find(
+            item => item.noteName === "C" && item.noteOctave === 5
+        );
+        expect(c5Item).toBeDefined();
+        expect(c5Item.blockNumber).toBe(44); // Real blockNumber should be preserved
+
+        const layoutC5Item = keyboard.layout.find(
+            item => item.noteName === "do" && item.noteOctave === 5
+        );
+        expect(layoutC5Item).toBeDefined();
+        expect(layoutC5Item.blockNumber).toBe(44);
+    });
+
+    test("handles sorting tie-breakers based on blockNumber", () => {
+        const keyboard = new MusicKeyboard(mockActivity);
+        // Add two notes with identical frequency (e.g. C4)
+        keyboard.noteNames = ["do", "do"];
+        keyboard.octaves = [4, 4];
+        keyboard._rowBlocks = [99, 44]; // 44 is smaller, so it should sort first
+        keyboard.instruments = ["guitar", "guitar"];
+
+        mockActivity.blocks = {
+            blockList: {
+                44: { name: "pitch", connections: [null, 45, 46, null] },
+                45: { value: "do" },
+                46: { value: 4 },
+                99: { name: "pitch", connections: [null, 100, 101, null] },
+                100: { value: "do" },
+                101: { value: 4 }
+            },
+            adjustDocks: jest.fn(),
+            clampBlocksToCheck: [],
+            adjustExpandableClampBlock: jest.fn(),
+            sendStackToTrash: jest.fn()
+        };
+
+        keyboard.init();
+
+        const c4Item = keyboard.displayLayout.find(
+            item => item.noteName === "C" && item.noteOctave === 4
+        );
+        expect(c4Item).toBeDefined();
+        expect(c4Item.blockNumber).toBe(44); // 44 should be kept as the blockNumber because it was sorted first
     });
 });

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1610,7 +1610,7 @@ function MusicKeyboard(activity) {
             const innerDiv = docById("mkbInnerDiv");
             if (innerDiv) {
                 innerDiv.style.width = "95.5vw";
-                innerDiv.style.height = "75%";
+                innerDiv.style.height = "auto";
                 innerDiv.scrollLeft = innerDiv.scrollWidth;
             }
 
@@ -1625,7 +1625,7 @@ function MusicKeyboard(activity) {
 
             const innerDiv = docById("mkbInnerDiv");
             if (innerDiv) {
-                innerDiv.style.height = "100%";
+                innerDiv.style.height = "auto";
             }
         }
     };

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2995,8 +2995,8 @@ function MusicKeyboard(activity) {
                     this.displayLayout[p].blockNumber
                 ]);
 
-                if (p < this.layout.length) {
-                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                if (this.layout[p]) {
                     this.layout[p].objId = "blackRow" + myrow2Id.toString();
                 }
 
@@ -3112,8 +3112,8 @@ function MusicKeyboard(activity) {
                             : null
                     );
                 }
-                if (p < this.layout.length) {
-                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                if (this.layout[p]) {
                     this.layout[p].objId = "blackRow" + myrow2Id.toString();
                 }
 
@@ -3181,8 +3181,8 @@ function MusicKeyboard(activity) {
                         );
                     }
                 }
-                if (p < this.layout.length) {
-                    this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                this.displayLayout[p].objId = "blackRow" + myrow2Id.toString();
+                if (this.layout[p]) {
                     this.layout[p].objId = "blackRow" + myrow2Id.toString();
                 }
 
@@ -3231,8 +3231,8 @@ function MusicKeyboard(activity) {
                         );
                     }
                 }
-                if (p < this.layout.length) {
-                    this.displayLayout[p].objId = "whiteRow" + myrowId.toString();
+                this.displayLayout[p].objId = "whiteRow" + myrowId.toString();
+                if (this.layout[p]) {
                     this.layout[p].objId = "whiteRow" + myrowId.toString();
                 }
 

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1355,6 +1355,9 @@ function MusicKeyboard(activity) {
         }
 
         let sortedList = sortableList.sort(function (a, b) {
+            if (a.frequency === b.frequency) {
+                return a.blockNumber - b.blockNumber;
+            }
             return a.frequency - b.frequency;
         });
 
@@ -1392,13 +1395,30 @@ function MusicKeyboard(activity) {
         let newList = fillChromaticGaps(sortedNotesList);
         newList = newList.concat(sortedHertzList);
 
+        const originalNotesMap = {};
+        for (const note of sortedList) {
+            const alphaName = convertFromSolfege(note.noteName);
+            originalNotesMap[alphaName + note.noteOctave] = note;
+        }
+
         for (let i = 0; i < newList.length; i++) {
-            this.layout.push({
-                noteName: newList[i].noteName,
-                noteOctave: newList[i].noteOctave,
-                blockNumber: newList[i].blockNumber,
-                voice: newList[i].voice
-            });
+            const key = newList[i].noteName + newList[i].noteOctave;
+            if (originalNotesMap[key]) {
+                newList[i].blockNumber = originalNotesMap[key].blockNumber;
+                this.layout.push({
+                    noteName: originalNotesMap[key].noteName,
+                    noteOctave: originalNotesMap[key].noteOctave,
+                    blockNumber: originalNotesMap[key].blockNumber,
+                    voice: originalNotesMap[key].voice
+                });
+            } else {
+                this.layout.push({
+                    noteName: newList[i].noteName,
+                    noteOctave: newList[i].noteOctave,
+                    blockNumber: newList[i].blockNumber,
+                    voice: newList[i].voice
+                });
+            }
         }
 
         return newList;
@@ -2310,21 +2330,8 @@ function MusicKeyboard(activity) {
                     });
                     this._sortLayout(this.layout);
 
-                    this.displayLayout = this.layout.map(note => {
-                        if (SOLFEGENAMES.includes(note.noteName)) {
-                            return { ...note, noteName: FIXEDSOLFEGE[note.noteName] };
-                        }
-                        return note;
-                    });
+                    this._syncLayouts();
 
-                    const sortedHertzList = this.displayLayout.filter(
-                        note => note.noteName === "hertz"
-                    );
-                    const sortedNotesList = this.displayLayout.filter(
-                        note => note.noteName !== "hertz"
-                    );
-                    this.displayLayout = fillChromaticGaps(sortedNotesList);
-                    this.displayLayout = this.displayLayout.concat(sortedHertzList);
                     this._createKeyboard();
                     this._createTable();
                     const n = this.layout.length;
@@ -2365,8 +2372,10 @@ function MusicKeyboard(activity) {
             this.activity.blocks.blockList[block].connections.length - 1
         ] = belowBlock;
 
-        this.activity.blocks.adjustDocks(this.blockNo, true);
-        this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
+        if (this.blockNo !== undefined && this.blockNo !== null) {
+            this.activity.blocks.adjustDocks(this.blockNo, true);
+            this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
+        }
         this.activity.blocks.adjustExpandableClampBlock();
         this.activity.refreshCanvas();
     };
@@ -2397,6 +2406,9 @@ function MusicKeyboard(activity) {
                 );
             }
 
+            if (aValue === bValue) {
+                return a.blockNumber - b.blockNumber;
+            }
             return aValue - bValue;
         });
 
@@ -2426,11 +2438,56 @@ function MusicKeyboard(activity) {
             this._removePitchBlock(this.remove[1]);
         }
 
+        this._syncLayouts();
+
         if (this.keyboardShown) {
             this._createKeyboard();
         } else {
             this._createTable();
         }
+    };
+
+    /**
+     * Synchronizes this.layout and this.displayLayout, ensuring all notes
+     * are aligned, gap-filled, and that real note blocks preserve their
+     * original solfege names and blockNumbers.
+     */
+    this._syncLayouts = function () {
+        const originalLayout = this.layout.filter(note => note.blockNumber < FAKEBLOCKNUMBER);
+
+        this.displayLayout = this.layout.map(note => {
+            return { ...note, noteName: convertFromSolfege(note.noteName) };
+        });
+
+        const sortedHertzList = this.displayLayout.filter(note => note.noteName === "hertz");
+        const sortedNotesList = this.displayLayout.filter(note => note.noteName !== "hertz");
+        this.displayLayout = fillChromaticGaps(sortedNotesList);
+        this.displayLayout = this.displayLayout.concat(sortedHertzList);
+
+        const originalNotesMap = {};
+        for (const note of originalLayout) {
+            const alphaName = convertFromSolfege(note.noteName);
+            originalNotesMap[alphaName + note.noteOctave] = note;
+        }
+
+        this.displayLayout = this.displayLayout.map(note => {
+            const key = note.noteName + note.noteOctave;
+            if (originalNotesMap[key]) {
+                return {
+                    ...note,
+                    blockNumber: originalNotesMap[key].blockNumber
+                };
+            }
+            return { ...note };
+        });
+
+        this.layout = this.displayLayout.map(note => {
+            const key = note.noteName + note.noteOctave;
+            if (originalNotesMap[key]) {
+                return { ...originalNotesMap[key] };
+            }
+            return { ...note };
+        });
     };
 
     /**
@@ -2456,8 +2513,10 @@ function MusicKeyboard(activity) {
             this.activity.blocks.blockList[blockNo].connections.length - 1
         ] = null;
         this.activity.blocks.sendStackToTrash(this.activity.blocks.blockList[blockNo]);
-        this.activity.blocks.adjustDocks(this.blockNo, true);
-        this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
+        if (this.blockNo !== undefined && this.blockNo !== null) {
+            this.activity.blocks.adjustDocks(this.blockNo, true);
+            this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
+        }
         this.activity.refreshCanvas();
     };
 
@@ -2468,11 +2527,13 @@ function MusicKeyboard(activity) {
      */
     this._createColumnPieSubmenu = function (index, condition) {
         index = parseInt(index);
-        if (
-            this.activity.blocks.blockList[
-                this.layout[this.layout.length - index - 1].blockNumber
-            ] === undefined
-        ) {
+        const displayLayout = this.displayLayout || this.layout;
+        const layoutItem = displayLayout[displayLayout.length - index - 1];
+
+        if (!layoutItem) {
+            return;
+        }
+        if (this.activity.blocks.blockList[layoutItem.blockNumber] === undefined) {
             return;
         }
 
@@ -2618,12 +2679,24 @@ function MusicKeyboard(activity) {
                 Math.max(0, y * this.activity.getStageScale())
             ) + "px";
 
-        index = this.layout.length - index - 1;
-        const block = this.layout[index].blockNumber;
+        index = displayLayout.length - index - 1;
+        const block = displayLayout[index].blockNumber;
 
         let noteValue =
             this.activity.blocks.blockList[this.activity.blocks.blockList[block].connections[1]]
                 .value;
+
+        if (typeof noteValue === "string") {
+            if (noteValue.endsWith("##") || noteValue.endsWith("x")) {
+                noteValue = noteValue.replace(/(##|x)$/, "𝄪");
+            } else if (noteValue.endsWith("#")) {
+                noteValue = noteValue.replace(/#$/, "♯");
+            } else if (noteValue.endsWith("bb")) {
+                noteValue = noteValue.replace(/bb$/, "𝄫");
+            } else if (noteValue.endsWith("b")) {
+                noteValue = noteValue.replace(/b$/, "♭");
+            }
+        }
 
         if (condition === "pitchblocks") {
             const octaveValue =
@@ -2672,12 +2745,15 @@ function MusicKeyboard(activity) {
             );
             this.activity.blocks.blockList[argBlock].updateCache();
 
-            const cell = docById("labelcol" + (this.layout.length - index - 1));
-            this.layout[index].noteOctave = parseInt(blockValue);
+            const cell = docById("labelcol" + (displayLayout.length - index - 1));
+            displayLayout[index].noteOctave = parseInt(blockValue);
+            if (this.layout[index]) {
+                this.layout[index].noteOctave = parseInt(blockValue);
+            }
             cell.textContent =
-                this.layout[index].noteName + this.layout[index].noteOctave.toString();
-            this._notesPlayed.map(function (item) {
-                if (item.objId === this.layout[index].blockNumber) {
+                displayLayout[index].noteName + displayLayout[index].noteOctave.toString();
+            this._notesPlayed.map(item => {
+                if (item.objId === displayLayout[index].blockNumber) {
                     item.noteOctave = parseInt(blockValue);
                 }
                 return item;
@@ -2733,11 +2809,15 @@ function MusicKeyboard(activity) {
                 );
             }
 
-            const cell = docById("labelcol" + (this.layout.length - index - 1));
-            this.layout[index].noteName = label;
-            this.layout[index].noteOctave = octave;
+            const cell = docById("labelcol" + (displayLayout.length - index - 1));
+            displayLayout[index].noteName = label;
+            displayLayout[index].noteOctave = octave;
+            if (this.layout[index]) {
+                this.layout[index].noteName = label;
+                this.layout[index].noteOctave = octave;
+            }
             cell.textContent =
-                this.layout[index].noteName + this.layout[index].noteOctave.toString();
+                displayLayout[index].noteName + displayLayout[index].noteOctave.toString();
             const temp1 = label;
             let temp2;
             if (temp1 in FIXEDSOLFEGE1) {
@@ -2747,7 +2827,7 @@ function MusicKeyboard(activity) {
             }
 
             this._notesPlayed.map(item => {
-                if (item.objId === this.layout[index].blockNumber) {
+                if (item.objId === displayLayout[index].blockNumber) {
                     item.noteOctave = temp2;
                 }
                 return item;

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1665,7 +1665,7 @@ function MusicKeyboard(activity) {
 
         let n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 8);
 
-        outerDiv.style.overflowY = "hidden";
+        outerDiv.style.overflowY = "auto";
         if (this.displayLayout.length > n) {
             outerDiv.style.height = this._cellScale * MATRIXSOLFEHEIGHT * (n + 5) + "px";
         } else {


### PR DESCRIPTION
This PR fixes two major bugs related to the Blocks workspace and the Music Keyboard widget:

1. **Uncaught TypeError Crashes:** Hardened `Blocks.prototype.adjustDocks` inside `js/blocks.js` against missing or undefined blocks. This prevents recursive `connections` lookup crashes when dragging or deleting workspace note blocks.
2. **Music Keyboard Clicks Desync:** Fixed a desynchronization bug between `this.layout` and `this.displayLayout` in `js/widgets/musickeyboard.js`.
   - Populated the correct workspace `blockNumber` back into the rendering layouts during startup (`_keysLayout`) and runtime updates (`_syncLayouts`).
   - Resolved note headers using `this.displayLayout` to keep clicks aligned.
   - Added a `blockNumber` frequency tie-breaker in sorted lists to prevent real notes from getting filtered out as duplicates of synthetic filler rows.
   - Ensured real note blocks (like `do 5`, `la 4`) correctly map to their real block IDs and successfully trigger their pie configuration submenus.
   
## PR Category

-   [x] Bug Fix
---

### **Verification**
- **ESLint Check:** Passed cleanly with 0 syntax/style errors.
- **Jest Unit Tests:** Passed all 5920 unit tests successfully.
