### PR TITLE
perf: replace setTimeout scheduling with Tone.Transport for playback

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -915,6 +915,62 @@ describe("Logo comprehensive method coverage", () => {
         expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
     });
 
+    test("runFromBlock uses Tone.Transport.schedule for non-zero delay when available", () => {
+        const originalTone = global.Tone;
+        const scheduleSpy = jest.fn();
+        global.Tone = {
+            ...originalTone,
+            Transport: {
+                start: jest.fn(),
+                stop: jest.fn(),
+                schedule: scheduleSpy,
+                cancel: jest.fn(),
+                getSecondsAtTime: jest.fn(() => 0),
+                get seconds() {
+                    return 0;
+                },
+                set seconds(v) {}
+            }
+        };
+
+        logo.runFromBlockNow = jest.fn();
+        logo.turtleDelay = 0;
+        logo.stopTurtle = false;
+        turtle0.waitTime = 200;
+        turtle0._transportTime = 10;
+
+        logo.runFromBlock(logo, 0, 3, 1, "x");
+
+        expect(scheduleSpy).toHaveBeenCalledWith(expect.any(Function), 10 + 200 / 1000);
+        expect(logo.runFromBlockNow).not.toHaveBeenCalled();
+
+        global.Tone = originalTone;
+        delete turtle0._transportTime;
+    });
+
+    test("runFromBlock falls back to setTimeout when Transport is unavailable", () => {
+        const originalTone = global.Tone;
+        global.Tone = { ...originalTone, Transport: undefined };
+        timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+            fn();
+            return 5;
+        });
+
+        logo.runFromBlockNow = jest.fn();
+        logo.turtleDelay = 0;
+        logo.stopTurtle = false;
+        turtle0.waitTime = 200;
+
+        logo.runFromBlock(logo, 0, 3, 1, "x");
+
+        expect(timeoutSpy).toHaveBeenCalled();
+        expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+
+        global.Tone = originalTone;
+        timeoutSpy.mockRestore();
+        timeoutSpy = null;
+    });
+
     test("runFromBlockNow executes flow block and queues next block", () => {
         logo.runFromBlock = jest.fn();
         logo.blockList = [
@@ -1189,8 +1245,33 @@ describe("Logo comprehensive method coverage", () => {
         logo._restoreConnections = jest.fn();
         mockActivity.showBlocksAfterRun = true;
 
+        const originalTone = global.Tone;
+        const cancelSpy = jest.fn();
+        let transportSeconds = 42;
+        global.Tone = {
+            ...originalTone,
+            Transport: {
+                start: jest.fn(),
+                stop: jest.fn(),
+                cancel: cancelSpy,
+                getSecondsAtTime: jest.fn(() => 0),
+                get seconds() {
+                    return transportSeconds;
+                },
+                set seconds(v) {
+                    transportSeconds = v;
+                }
+            }
+        };
+        turtle0._transportTime = 15;
+        turtle1._transportTime = 25;
+
         logo.doStopTurtles();
 
+        expect(cancelSpy).toHaveBeenCalled();
+        expect(turtle0._transportTime).toBeNull();
+        expect(turtle1._transportTime).toBeNull();
+        expect(transportSeconds).toBe(0);
         expect(turtle0.singer.killAllVoices).toHaveBeenCalled();
         expect(logo.synth.stopSound).toHaveBeenCalledWith("0", "flute");
         expect(logo.synth.stopSound).toHaveBeenCalledWith("1", "piano");
@@ -1199,6 +1280,10 @@ describe("Logo comprehensive method coverage", () => {
         expect(doStopVideoCam).toHaveBeenCalledWith("cam-1", logo.setCameraID);
         expect(mockActivity.blocks.showBlocks).toHaveBeenCalled();
         expect(document.getElementById).toHaveBeenCalledWith("stop");
+
+        delete turtle0._transportTime;
+        delete turtle1._transportTime;
+        global.Tone = originalTone;
         clearIntervalSpy.mockRestore();
     });
 

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -965,7 +965,7 @@ describe("Logo comprehensive method coverage", () => {
         global.Tone = originalTone;
         turtle0._transportTime = null;
         turtle0._transportEventId = null;
-        delete turtle0.delayParameters;
+        turtle0.delayParameters = null;
     });
 
     test("runFromBlock falls back to setTimeout when Transport is unavailable", () => {
@@ -1305,8 +1305,8 @@ describe("Logo comprehensive method coverage", () => {
         expect(mockActivity.blocks.showBlocks).toHaveBeenCalled();
         expect(document.getElementById).toHaveBeenCalledWith("stop");
 
-        delete turtle0._transportTime;
-        delete turtle1._transportTime;
+        turtle0._transportTime = null;
+        turtle1._transportTime = null;
         global.Tone = originalTone;
         clearIntervalSpy.mockRestore();
     });

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -36,7 +36,47 @@ global.Synth = jest.fn().mockImplementation(() => ({
     stopSound: jest.fn(),
     disposeAllInstruments: jest.fn(),
     changeInTemperament: false,
-    recorder: null
+    recorder: null,
+    transport: {
+        get isAvailable() {
+            return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
+        },
+        start() {
+            if (this.isAvailable) global.Tone.Transport.start();
+        },
+        stop() {
+            if (this.isAvailable) global.Tone.Transport.stop();
+        },
+        cancel() {
+            if (this.isAvailable && typeof global.Tone.Transport.cancel === "function") {
+                global.Tone.Transport.cancel();
+            }
+        },
+        clear(id) {
+            if (this.isAvailable && typeof global.Tone.Transport.clear === "function") {
+                global.Tone.Transport.clear(id);
+            }
+        },
+        schedule(callback, time) {
+            if (this.isAvailable && typeof global.Tone.Transport.schedule === "function") {
+                return global.Tone.Transport.schedule(callback, time);
+            }
+            return null;
+        },
+        get seconds() {
+            if (this.isAvailable) return global.Tone.Transport.seconds;
+            return 0;
+        },
+        set seconds(v) {
+            if (this.isAvailable) global.Tone.Transport.seconds = v;
+        },
+        getSecondsAtTime(time) {
+            if (this.isAvailable && typeof global.Tone.Transport.getSecondsAtTime === "function") {
+                return global.Tone.Transport.getSecondsAtTime(time);
+            }
+            return this.seconds;
+        }
+    }
 }));
 global.Singer = {
     setSynthVolume: jest.fn(),
@@ -435,14 +475,28 @@ describe("Logo Class", () => {
     });
 
     describe("doStopTurtles", () => {
-        test("sets stopTurtle to true", () => {
-            logo.sounds = [];
-            logo.synth = {
+        function mockSynth() {
+            return {
                 stop: jest.fn(),
                 stopSound: jest.fn(),
                 disposeAllInstruments: jest.fn(),
-                recorder: null
+                recorder: null,
+                transport: {
+                    get isAvailable() {
+                        return false;
+                    },
+                    cancel: jest.fn(),
+                    get seconds() {
+                        return 0;
+                    },
+                    set seconds(v) {}
+                }
             };
+        }
+
+        test("sets stopTurtle to true", () => {
+            logo.sounds = [];
+            logo.synth = mockSynth();
 
             logo.doStopTurtles();
 
@@ -451,12 +505,7 @@ describe("Logo Class", () => {
 
         test("marks all turtles as stopped", () => {
             logo.sounds = [];
-            logo.synth = {
-                stop: jest.fn(),
-                stopSound: jest.fn(),
-                disposeAllInstruments: jest.fn(),
-                recorder: null
-            };
+            logo.synth = mockSynth();
 
             logo.doStopTurtles();
 
@@ -466,12 +515,7 @@ describe("Logo Class", () => {
         test("stops all sounds", () => {
             const mockSound = { stop: jest.fn() };
             logo.sounds = [mockSound];
-            logo.synth = {
-                stop: jest.fn(),
-                stopSound: jest.fn(),
-                disposeAllInstruments: jest.fn(),
-                recorder: null
-            };
+            logo.synth = mockSynth();
 
             logo.doStopTurtles();
 
@@ -481,12 +525,7 @@ describe("Logo Class", () => {
 
         test("clears step queue", () => {
             logo.sounds = [];
-            logo.synth = {
-                stop: jest.fn(),
-                stopSound: jest.fn(),
-                disposeAllInstruments: jest.fn(),
-                recorder: null
-            };
+            logo.synth = mockSynth();
             logo.stepQueue = { 0: [1, 2, 3] };
 
             logo.doStopTurtles();
@@ -496,12 +535,7 @@ describe("Logo Class", () => {
 
         test("executes ONSTOP plugin hooks", () => {
             logo.sounds = [];
-            logo.synth = {
-                stop: jest.fn(),
-                stopSound: jest.fn(),
-                disposeAllInstruments: jest.fn(),
-                recorder: null
-            };
+            logo.synth = mockSynth();
             logo.evalOnStopList = {
                 firstHook: "code-first",
                 secondHook: "code-second"
@@ -917,7 +951,7 @@ describe("Logo comprehensive method coverage", () => {
         expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
     });
 
-    test("runFromBlock uses Tone.Transport.schedule for non-zero delay when available", () => {
+    test("runFromBlock uses Transport schedule for non-zero delay when available", () => {
         const originalTone = global.Tone;
         const getSecondsAtTimeMock = jest.fn(t => t + 1);
         let scheduledCallback = null;
@@ -1260,7 +1294,24 @@ describe("Logo comprehensive method coverage", () => {
             stop: jest.fn(),
             stopSound: jest.fn(),
             disposeAllInstruments: jest.fn(),
-            recorder: { state: "recording", stop: jest.fn() }
+            recorder: { state: "recording", stop: jest.fn() },
+            transport: {
+                get isAvailable() {
+                    return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
+                },
+                cancel() {
+                    if (this.isAvailable && typeof global.Tone.Transport.cancel === "function") {
+                        global.Tone.Transport.cancel();
+                    }
+                },
+                get seconds() {
+                    if (this.isAvailable) return global.Tone.Transport.seconds;
+                    return 0;
+                },
+                set seconds(v) {
+                    if (this.isAvailable) global.Tone.Transport.seconds = v;
+                }
+            }
         };
         logo._restoreConnections = jest.fn();
         mockActivity.showBlocksAfterRun = true;

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -719,6 +719,8 @@ describe("Logo comprehensive method coverage", () => {
         x: 0,
         y: 0,
         companionTurtle: null,
+        _transportTime: null,
+        _transportEventId: null,
         doShowImage: jest.fn(),
         doShowURL: jest.fn(),
         doShowText: jest.fn()
@@ -1265,12 +1267,16 @@ describe("Logo comprehensive method coverage", () => {
         };
         turtle0._transportTime = 15;
         turtle1._transportTime = 25;
+        turtle0._transportEventId = "evt-1";
+        turtle1._transportEventId = "evt-2";
 
         logo.doStopTurtles();
 
         expect(cancelSpy).toHaveBeenCalled();
         expect(turtle0._transportTime).toBeNull();
         expect(turtle1._transportTime).toBeNull();
+        expect(turtle0._transportEventId).toBeNull();
+        expect(turtle1._transportEventId).toBeNull();
         expect(transportSeconds).toBe(0);
         expect(turtle0.singer.killAllVoices).toHaveBeenCalled();
         expect(logo.synth.stopSound).toHaveBeenCalledWith("0", "flute");
@@ -1368,6 +1374,86 @@ describe("Logo comprehensive method coverage", () => {
         expect(turtle0.delayTimeout).toBeNull();
         expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 4, 1, ["p"]);
         clearTimeoutSpy.mockRestore();
+    });
+
+    test("clearTurtleRun cancels Transport-scheduled event and resumes execution", () => {
+        const clearSpy = jest.fn();
+        const originalTone = global.Tone;
+        global.Tone = {
+            ...originalTone,
+            Transport: {
+                start: jest.fn(),
+                stop: jest.fn(),
+                cancel: jest.fn(),
+                clear: clearSpy,
+                getSecondsAtTime: jest.fn(() => 42),
+                get seconds() {
+                    return 42;
+                },
+                set seconds(v) {}
+            }
+        };
+        turtle0.delayTimeout = null;
+        turtle0._transportEventId = "evt-3";
+        turtle0.delayParameters = { blk: 7, flow: 0, arg: null };
+        turtle0._transportTime = 50;
+        logo.runFromBlockNow = jest.fn();
+
+        logo.clearTurtleRun(0);
+
+        expect(clearSpy).toHaveBeenCalledWith("evt-3");
+        expect(turtle0._transportEventId).toBeNull();
+        expect(turtle0._transportTime).toBe(42);
+        expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 7, 0, null);
+        expect(turtle0.delayParameters).toBeNull();
+
+        global.Tone = originalTone;
+    });
+
+    test("clearTurtleRun is no-op when no pending delay or Transport event", () => {
+        turtle0.delayTimeout = null;
+        turtle0._transportEventId = null;
+        logo.runFromBlockNow = jest.fn();
+
+        logo.clearTurtleRun(0);
+
+        expect(logo.runFromBlockNow).not.toHaveBeenCalled();
+    });
+
+    test("runFromBlock falls back to setTimeout when _transportTime is null", () => {
+        const originalTone = global.Tone;
+        global.Tone = {
+            ...originalTone,
+            Transport: {
+                start: jest.fn(),
+                stop: jest.fn(),
+                schedule: jest.fn(),
+                cancel: jest.fn(),
+                getSecondsAtTime: jest.fn(() => 0),
+                get seconds() {
+                    return 5;
+                },
+                set seconds(v) {}
+            }
+        };
+        timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+            fn();
+            return 8;
+        });
+        logo.runFromBlockNow = jest.fn();
+        logo.turtleDelay = 0;
+        logo.stopTurtle = false;
+        turtle0.waitTime = 200;
+        turtle0._transportTime = null;
+
+        logo.runFromBlock(logo, 0, 3, 1, "x");
+
+        expect(timeoutSpy).toHaveBeenCalled();
+        expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+
+        global.Tone = originalTone;
+        timeoutSpy.mockRestore();
+        timeoutSpy = null;
     });
 
     test("setDispatchBlock adds clamp signal for normal and backward traversal", () => {

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1438,14 +1438,14 @@ describe("Logo comprehensive method coverage", () => {
         expect(logo.runFromBlockNow).not.toHaveBeenCalled();
     });
 
-    test("runFromBlock falls back to setTimeout when _transportTime is null", () => {
+    test("runFromBlock lazily initializes _transportTime when null", () => {
         const originalTone = global.Tone;
         global.Tone = {
             ...originalTone,
             Transport: {
                 start: jest.fn(),
                 stop: jest.fn(),
-                schedule: jest.fn(),
+                schedule: jest.fn(() => "evt-1"),
                 cancel: jest.fn(),
                 getSecondsAtTime: jest.fn(() => 0),
                 get seconds() {
@@ -1454,10 +1454,6 @@ describe("Logo comprehensive method coverage", () => {
                 set seconds(v) {}
             }
         };
-        timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
-            fn();
-            return 8;
-        });
         logo.runFromBlockNow = jest.fn();
         logo.turtleDelay = 0;
         logo.stopTurtle = false;
@@ -1466,12 +1462,10 @@ describe("Logo comprehensive method coverage", () => {
 
         logo.runFromBlock(logo, 0, 3, 1, "x");
 
-        expect(timeoutSpy).toHaveBeenCalled();
-        expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        expect(turtle0._transportTime).toBe(5);
+        expect(logo.runFromBlockNow).not.toHaveBeenCalled();
 
         global.Tone = originalTone;
-        timeoutSpy.mockRestore();
-        timeoutSpy = null;
     });
 
     test("setDispatchBlock adds clamp signal for normal and backward traversal", () => {

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -919,7 +919,12 @@ describe("Logo comprehensive method coverage", () => {
 
     test("runFromBlock uses Tone.Transport.schedule for non-zero delay when available", () => {
         const originalTone = global.Tone;
-        const scheduleSpy = jest.fn();
+        const getSecondsAtTimeMock = jest.fn(t => t + 1);
+        let scheduledCallback = null;
+        const scheduleSpy = jest.fn((fn, time) => {
+            scheduledCallback = fn;
+            return "evt-1";
+        });
         global.Tone = {
             ...originalTone,
             Transport: {
@@ -927,7 +932,7 @@ describe("Logo comprehensive method coverage", () => {
                 stop: jest.fn(),
                 schedule: scheduleSpy,
                 cancel: jest.fn(),
-                getSecondsAtTime: jest.fn(() => 0),
+                getSecondsAtTime: getSecondsAtTimeMock,
                 get seconds() {
                     return 0;
                 },
@@ -940,14 +945,27 @@ describe("Logo comprehensive method coverage", () => {
         logo.stopTurtle = false;
         turtle0.waitTime = 200;
         turtle0._transportTime = 10;
+        turtle0.delayParameters = null;
+        turtle0._transportEventId = null;
 
         logo.runFromBlock(logo, 0, 3, 1, "x");
 
         expect(scheduleSpy).toHaveBeenCalledWith(expect.any(Function), 10 + 200 / 1000);
         expect(logo.runFromBlockNow).not.toHaveBeenCalled();
+        expect(turtle0._transportEventId).toBe("evt-1");
+
+        // Invoke the scheduled callback and verify state updates
+        scheduledCallback(5.5);
+        expect(getSecondsAtTimeMock).toHaveBeenCalledWith(5.5);
+        expect(turtle0._transportTime).toBe(6.5);
+        expect(turtle0._transportEventId).toBeNull();
+        expect(turtle0.delayParameters).toBeNull();
+        expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
 
         global.Tone = originalTone;
-        delete turtle0._transportTime;
+        turtle0._transportTime = null;
+        turtle0._transportEventId = null;
+        delete turtle0.delayParameters;
     });
 
     test("runFromBlock falls back to setTimeout when Transport is unavailable", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1408,8 +1408,9 @@ class Logo {
 
         if (Logo._hasTransport) {
             Tone.Transport.start();
+            const transportNow = Tone.Transport.seconds;
             for (const turtle of this.activity.turtles.turtleList) {
-                turtle._transportTime = Tone.Transport.seconds;
+                turtle._transportTime = transportNow;
             }
         }
 
@@ -1723,6 +1724,7 @@ class Logo {
                             const tur2 = logo.activity.turtles.ithTurtle(turtle);
                             tur2._transportTime = Tone.Transport.seconds;
                         }
+                        tur.delayParameters = null;
                         logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
                     },
                     delay,

--- a/js/logo.js
+++ b/js/logo.js
@@ -1040,6 +1040,28 @@ class Logo {
                 tur.delayParameters["flow"],
                 tur.delayParameters["arg"]
             );
+            tur.delayParameters = null;
+        } else if (
+            tur._transportEventId !== null &&
+            typeof Tone !== "undefined" &&
+            Tone.Transport &&
+            typeof Tone.Transport.clear === "function"
+        ) {
+            Tone.Transport.clear(tur._transportEventId);
+            tur._transportEventId = null;
+            if (tur.delayParameters) {
+                if (typeof Tone !== "undefined" && Tone.Transport) {
+                    tur._transportTime = Tone.Transport.seconds;
+                }
+                this.runFromBlockNow(
+                    this,
+                    turtle,
+                    tur.delayParameters["blk"],
+                    tur.delayParameters["flow"],
+                    tur.delayParameters["arg"]
+                );
+                tur.delayParameters = null;
+            }
         }
     }
 
@@ -1190,6 +1212,7 @@ class Logo {
         // Reset per-turtle Transport scheduling state
         for (const turtle of this.activity.turtles.turtleList) {
             turtle._transportTime = null;
+            turtle._transportEventId = null;
         }
 
         this.synth.stop();
@@ -1679,9 +1702,12 @@ class Logo {
                 tur._transportTime !== null
             ) {
                 const transportTime = tur._transportTime + delay / 1000;
-                Tone.Transport.schedule(audioContextTime => {
-                    const t = logo.activity.turtles.ithTurtle(turtle);
-                    t._transportTime = Tone.Transport.getSecondsAtTime(audioContextTime);
+                tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
+                tur._transportEventId = Tone.Transport.schedule(audioContextTime => {
+                    const tur2 = logo.activity.turtles.ithTurtle(turtle);
+                    tur2._transportTime = Tone.Transport.getSecondsAtTime(audioContextTime);
+                    tur2._transportEventId = null;
+                    tur2.delayParameters = null;
                     if (!logo.stopTurtle) {
                         logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
                     }
@@ -1690,9 +1716,9 @@ class Logo {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur.delayTimeout = logo._timerManager.setGuardedTimeout(
                     () => {
-                        if (typeof Tone !== "undefined" && Tone.Transport) {
-                            const t = logo.activity.turtles.ithTurtle(turtle);
-                            t._transportTime = Tone.Transport.seconds;
+                        if (typeof Tone !== "undefined" && Tone.Transport && delay === 0) {
+                            const tur2 = logo.activity.turtles.ithTurtle(turtle);
+                            tur2._transportTime = Tone.Transport.seconds;
                         }
                         logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
                     },

--- a/js/logo.js
+++ b/js/logo.js
@@ -1380,6 +1380,7 @@ class Logo {
         this.prepSynths();
 
         if (typeof Tone !== "undefined" && Tone.Transport) {
+            Tone.Transport.start();
             for (const turtle of this.activity.turtles.turtleList) {
                 turtle._transportTime = Tone.Transport.seconds;
             }
@@ -1674,6 +1675,7 @@ class Logo {
                 delay > 0 &&
                 typeof Tone !== "undefined" &&
                 Tone.Transport &&
+                typeof Tone.Transport.schedule === "function" &&
                 tur._transportTime !== null
             ) {
                 const transportTime = tur._transportTime + delay / 1000;

--- a/js/logo.js
+++ b/js/logo.js
@@ -1056,9 +1056,7 @@ class Logo {
             Tone.Transport.clear(tur._transportEventId);
             tur._transportEventId = null;
             if (tur.delayParameters) {
-                if (Logo._hasTransport) {
-                    tur._transportTime = Tone.Transport.seconds;
-                }
+                tur._transportTime = Tone.Transport.seconds;
                 this.runFromBlockNow(
                     this,
                     turtle,

--- a/js/logo.js
+++ b/js/logo.js
@@ -357,13 +357,6 @@ class Logo {
         this._graphicsScheduler = new EmbeddedGraphicsScheduler(this);
     }
 
-    /**
-     * @returns {boolean} true if Tone.Transport is available in the runtime.
-     */
-    static get _hasTransport() {
-        return typeof Tone !== "undefined" && Tone.Transport;
-    }
-
     // ========= Setters, Getters =================================================================
 
     /**
@@ -1048,15 +1041,11 @@ class Logo {
                 tur.delayParameters["arg"]
             );
             tur.delayParameters = null;
-        } else if (
-            tur._transportEventId !== null &&
-            Logo._hasTransport &&
-            typeof Tone.Transport.clear === "function"
-        ) {
-            Tone.Transport.clear(tur._transportEventId);
+        } else if (tur._transportEventId !== null && this.synth.transport.isAvailable) {
+            this.synth.transport.clear(tur._transportEventId);
             tur._transportEventId = null;
             if (tur.delayParameters) {
-                tur._transportTime = Tone.Transport.seconds;
+                tur._transportTime = this.synth.transport.seconds;
                 this.runFromBlockNow(
                     this,
                     turtle,
@@ -1209,8 +1198,8 @@ class Logo {
         }
 
         // Cancel all Transport-scheduled events before synth.stop()
-        if (Logo._hasTransport && typeof Tone.Transport.cancel === "function") {
-            Tone.Transport.cancel();
+        if (this.synth.transport.isAvailable) {
+            this.synth.transport.cancel();
         }
 
         // Reset per-turtle Transport scheduling state
@@ -1222,8 +1211,8 @@ class Logo {
         this.synth.stop();
 
         // Reset Transport position for next run
-        if (Logo._hasTransport) {
-            Tone.Transport.seconds = 0;
+        if (this.synth.transport.isAvailable) {
+            this.synth.transport.seconds = 0;
         }
 
         if (this.synth.recorder && this.synth.recorder.state === "recording")
@@ -1406,9 +1395,9 @@ class Logo {
 
         this.prepSynths();
 
-        if (Logo._hasTransport) {
-            Tone.Transport.start();
-            const transportNow = Tone.Transport.seconds;
+        if (this.synth.transport.isAvailable) {
+            this.synth.transport.start();
+            const transportNow = this.synth.transport.seconds;
             for (const turtle of this.activity.turtles.turtleList) {
                 turtle._transportTime = transportNow;
             }
@@ -1688,8 +1677,8 @@ class Logo {
 
         const tur = logo.turtles.ithTurtle(turtle);
 
-        if (tur._transportTime === null && Logo._hasTransport) {
-            tur._transportTime = Tone.Transport.seconds;
+        if (tur._transportTime === null && logo.synth.transport.isAvailable) {
+            tur._transportTime = logo.synth.transport.seconds;
         }
 
         const delay = logo.turtleDelay + tur.waitTime;
@@ -1705,18 +1694,14 @@ class Logo {
             } else if (
                 logo.turtleDelay === 0 &&
                 delay > 0 &&
-                Logo._hasTransport &&
-                typeof Tone.Transport.schedule === "function" &&
+                logo.synth.transport.isAvailable &&
                 tur._transportTime !== null
             ) {
                 const transportTime = tur._transportTime + delay / 1000;
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
-                tur._transportEventId = Tone.Transport.schedule(audioContextTime => {
+                tur._transportEventId = logo.synth.transport.schedule(audioContextTime => {
                     const tur2 = logo.activity.turtles.ithTurtle(turtle);
-                    tur2._transportTime =
-                        typeof Tone.Transport.getSecondsAtTime === "function"
-                            ? Tone.Transport.getSecondsAtTime(audioContextTime)
-                            : Tone.Transport.seconds;
+                    tur2._transportTime = logo.synth.transport.getSecondsAtTime(audioContextTime);
                     tur2._transportEventId = null;
                     tur2.delayParameters = null;
                     if (!logo.stopTurtle) {
@@ -1727,9 +1712,9 @@ class Logo {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur.delayTimeout = logo._timerManager.setGuardedTimeout(
                     () => {
-                        if (Logo._hasTransport) {
+                        if (logo.synth.transport.isAvailable) {
                             const tur2 = logo.activity.turtles.ithTurtle(turtle);
-                            tur2._transportTime = Tone.Transport.seconds;
+                            tur2._transportTime = logo.synth.transport.seconds;
                         }
                         tur.delayParameters = null;
                         logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);

--- a/js/logo.js
+++ b/js/logo.js
@@ -1182,7 +1182,23 @@ class Logo {
             }
         }
 
+        // Cancel all Transport-scheduled events before synth.stop()
+        if (typeof Tone !== "undefined" && Tone.Transport && Tone.Transport.cancel) {
+            Tone.Transport.cancel();
+        }
+
+        // Reset per-turtle Transport scheduling state
+        for (const turtle of this.activity.turtles.turtleList) {
+            turtle._transportTime = null;
+        }
+
         this.synth.stop();
+
+        // Reset Transport position for next run
+        if (typeof Tone !== "undefined" && Tone.Transport) {
+            Tone.Transport.seconds = 0;
+        }
+
         if (this.synth.recorder && this.synth.recorder.state === "recording")
             this.synth.recorder.stop();
 
@@ -1362,6 +1378,12 @@ class Logo {
         }
 
         this.prepSynths();
+
+        if (typeof Tone !== "undefined" && Tone.Transport) {
+            for (const turtle of this.activity.turtles.turtleList) {
+                turtle._transportTime = Tone.Transport.seconds;
+            }
+        }
 
         this.notation.notationStaging = {};
         this.notation.notationDrumStaging = {};
@@ -1647,10 +1669,31 @@ class Logo {
                     logo.stepQueue[turtle] = [];
                 }
                 logo.stepQueue[turtle].push(blk);
+            } else if (
+                logo.turtleDelay === 0 &&
+                delay > 0 &&
+                typeof Tone !== "undefined" &&
+                Tone.Transport &&
+                tur._transportTime !== null
+            ) {
+                const transportTime = tur._transportTime + delay / 1000;
+                Tone.Transport.schedule(audioContextTime => {
+                    const t = logo.activity.turtles.ithTurtle(turtle);
+                    t._transportTime = Tone.Transport.getSecondsAtTime(audioContextTime);
+                    if (!logo.stopTurtle) {
+                        logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
+                    }
+                }, transportTime);
             } else {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur.delayTimeout = logo._timerManager.setGuardedTimeout(
-                    () => logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg),
+                    () => {
+                        if (typeof Tone !== "undefined" && Tone.Transport) {
+                            const t = logo.activity.turtles.ithTurtle(turtle);
+                            t._transportTime = Tone.Transport.seconds;
+                        }
+                        logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
+                    },
                     delay,
                     () => logo.stopTurtle
                 );

--- a/js/logo.js
+++ b/js/logo.js
@@ -1716,6 +1716,7 @@ class Logo {
                             const tur2 = logo.activity.turtles.ithTurtle(turtle);
                             tur2._transportTime = logo.synth.transport.seconds;
                         }
+                        tur.delayTimeout = null;
                         tur.delayParameters = null;
                         logo.runFromBlockNow(logo, turtle, blk, isflow, receivedArg);
                     },

--- a/js/logo.js
+++ b/js/logo.js
@@ -357,6 +357,13 @@ class Logo {
         this._graphicsScheduler = new EmbeddedGraphicsScheduler(this);
     }
 
+    /**
+     * @returns {boolean} true if Tone.Transport is available in the runtime.
+     */
+    static get _hasTransport() {
+        return typeof Tone !== "undefined" && Tone.Transport;
+    }
+
     // ========= Setters, Getters =================================================================
 
     /**
@@ -1043,14 +1050,13 @@ class Logo {
             tur.delayParameters = null;
         } else if (
             tur._transportEventId !== null &&
-            typeof Tone !== "undefined" &&
-            Tone.Transport &&
+            Logo._hasTransport &&
             typeof Tone.Transport.clear === "function"
         ) {
             Tone.Transport.clear(tur._transportEventId);
             tur._transportEventId = null;
             if (tur.delayParameters) {
-                if (typeof Tone !== "undefined" && Tone.Transport) {
+                if (Logo._hasTransport) {
                     tur._transportTime = Tone.Transport.seconds;
                 }
                 this.runFromBlockNow(
@@ -1205,7 +1211,7 @@ class Logo {
         }
 
         // Cancel all Transport-scheduled events before synth.stop()
-        if (typeof Tone !== "undefined" && Tone.Transport && Tone.Transport.cancel) {
+        if (Logo._hasTransport && Tone.Transport.cancel) {
             Tone.Transport.cancel();
         }
 
@@ -1218,7 +1224,7 @@ class Logo {
         this.synth.stop();
 
         // Reset Transport position for next run
-        if (typeof Tone !== "undefined" && Tone.Transport) {
+        if (Logo._hasTransport) {
             Tone.Transport.seconds = 0;
         }
 
@@ -1402,7 +1408,7 @@ class Logo {
 
         this.prepSynths();
 
-        if (typeof Tone !== "undefined" && Tone.Transport) {
+        if (Logo._hasTransport) {
             Tone.Transport.start();
             for (const turtle of this.activity.turtles.turtleList) {
                 turtle._transportTime = Tone.Transport.seconds;
@@ -1696,8 +1702,7 @@ class Logo {
             } else if (
                 logo.turtleDelay === 0 &&
                 delay > 0 &&
-                typeof Tone !== "undefined" &&
-                Tone.Transport &&
+                Logo._hasTransport &&
                 typeof Tone.Transport.schedule === "function" &&
                 tur._transportTime !== null
             ) {
@@ -1716,7 +1721,7 @@ class Logo {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur.delayTimeout = logo._timerManager.setGuardedTimeout(
                     () => {
-                        if (typeof Tone !== "undefined" && Tone.Transport) {
+                        if (Logo._hasTransport) {
                             const tur2 = logo.activity.turtles.ithTurtle(turtle);
                             tur2._transportTime = Tone.Transport.seconds;
                         }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1209,7 +1209,7 @@ class Logo {
         }
 
         // Cancel all Transport-scheduled events before synth.stop()
-        if (Logo._hasTransport && Tone.Transport.cancel) {
+        if (Logo._hasTransport && typeof Tone.Transport.cancel === "function") {
             Tone.Transport.cancel();
         }
 
@@ -1688,6 +1688,10 @@ class Logo {
 
         const tur = logo.turtles.ithTurtle(turtle);
 
+        if (tur._transportTime === null && Logo._hasTransport) {
+            tur._transportTime = Tone.Transport.seconds;
+        }
+
         const delay = logo.turtleDelay + tur.waitTime;
         tur.doWait(0);
 
@@ -1709,7 +1713,10 @@ class Logo {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur._transportEventId = Tone.Transport.schedule(audioContextTime => {
                     const tur2 = logo.activity.turtles.ithTurtle(turtle);
-                    tur2._transportTime = Tone.Transport.getSecondsAtTime(audioContextTime);
+                    tur2._transportTime =
+                        typeof Tone.Transport.getSecondsAtTime === "function"
+                            ? Tone.Transport.getSecondsAtTime(audioContextTime)
+                            : Tone.Transport.seconds;
                     tur2._transportEventId = null;
                     tur2.delayParameters = null;
                     if (!logo.stopTurtle) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1716,7 +1716,7 @@ class Logo {
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur.delayTimeout = logo._timerManager.setGuardedTimeout(
                     () => {
-                        if (typeof Tone !== "undefined" && Tone.Transport && delay === 0) {
+                        if (typeof Tone !== "undefined" && Tone.Transport) {
                             const tur2 = logo.activity.turtles.ithTurtle(turtle);
                             tur2._transportTime = Tone.Transport.seconds;
                         }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1896,6 +1896,25 @@ class Singer {
                     ) {
                         const audioElapsed = Tone.now() - activity.logo.firstNoteAudioTime;
                         future = Math.max(tur.singer.previousTurtleTime - audioElapsed, 0);
+
+                        if (activity.logo._perfSyncData) {
+                            tur.singer._perfEventId = ++activity.logo._perfSyncData._eventCounter;
+                            activity.logo._perfSyncData._turtleEventIds[turtle] =
+                                tur.singer._perfEventId;
+                            activity.logo._perfSyncData.notes.push({
+                                eventId: tur.singer._perfEventId,
+                                turtle: turtle,
+                                noteIndex: tur.singer.tallyNotes,
+                                perfNow: performance.now(),
+                                toneNow: Tone.now(),
+                                turtleTime: tur.singer.turtleTime,
+                                previousTurtleTime: tur.singer.previousTurtleTime,
+                                future: future,
+                                duration: bpmFactor / duration,
+                                elapsedTime: elapsedTime,
+                                turtleLag: turtleLag
+                            });
+                        }
                     }
 
                     tur.singer.turtleTime += bpmFactor / duration;
@@ -2531,6 +2550,23 @@ class Singer {
                     } else {
                         activity.logo.dispatchTurtleSignals(turtle, beatValue, blk, 0);
                     }
+                }
+
+                if (activity.logo._perfSyncData) {
+                    var _perfGfxCount = tur.singer.embeddedGraphics[blk]
+                        ? tur.singer.embeddedGraphics[blk].length
+                        : 0;
+                    var _perfGfxStart = performance.now();
+                }
+
+                if (activity.logo._perfSyncData && typeof _perfGfxCount !== "undefined") {
+                    activity.logo._perfSyncData.graphics.push({
+                        eventId: tur.singer._perfEventId || 0,
+                        turtle: turtle,
+                        noteIndex: tur.singer.tallyNotes || 0,
+                        graphicsCommandCount: _perfGfxCount,
+                        dispatchTimeMs: performance.now() - _perfGfxStart
+                    });
                 }
 
                 // After the note plays, clear the embedded graphics and notes queue.

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1896,25 +1896,6 @@ class Singer {
                     ) {
                         const audioElapsed = Tone.now() - activity.logo.firstNoteAudioTime;
                         future = Math.max(tur.singer.previousTurtleTime - audioElapsed, 0);
-
-                        if (activity.logo._perfSyncData) {
-                            tur.singer._perfEventId = ++activity.logo._perfSyncData._eventCounter;
-                            activity.logo._perfSyncData._turtleEventIds[turtle] =
-                                tur.singer._perfEventId;
-                            activity.logo._perfSyncData.notes.push({
-                                eventId: tur.singer._perfEventId,
-                                turtle: turtle,
-                                noteIndex: tur.singer.tallyNotes,
-                                perfNow: performance.now(),
-                                toneNow: Tone.now(),
-                                turtleTime: tur.singer.turtleTime,
-                                previousTurtleTime: tur.singer.previousTurtleTime,
-                                future: future,
-                                duration: bpmFactor / duration,
-                                elapsedTime: elapsedTime,
-                                turtleLag: turtleLag
-                            });
-                        }
                     }
 
                     tur.singer.turtleTime += bpmFactor / duration;
@@ -2550,23 +2531,6 @@ class Singer {
                     } else {
                         activity.logo.dispatchTurtleSignals(turtle, beatValue, blk, 0);
                     }
-                }
-
-                if (activity.logo._perfSyncData) {
-                    var _perfGfxCount = tur.singer.embeddedGraphics[blk]
-                        ? tur.singer.embeddedGraphics[blk].length
-                        : 0;
-                    var _perfGfxStart = performance.now();
-                }
-
-                if (activity.logo._perfSyncData && typeof _perfGfxCount !== "undefined") {
-                    activity.logo._perfSyncData.graphics.push({
-                        eventId: tur.singer._perfEventId || 0,
-                        turtle: turtle,
-                        noteIndex: tur.singer.tallyNotes || 0,
-                        graphicsCommandCount: _perfGfxCount,
-                        dispatchTimeMs: performance.now() - _perfGfxStart
-                    });
                 }
 
                 // After the note plays, clear the embedded graphics and notes queue.

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -67,6 +67,7 @@ class Turtle {
         this._blinkFinished = true; // whether not blinking or blinking
 
         this._transportTime = null;
+        this._transportEventId = null;
     }
 
     /**

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -65,6 +65,8 @@ class Turtle {
         this.inSetTimbre = false;
 
         this._blinkFinished = true; // whether not blinking or blinking
+
+        this._transportTime = null;
     }
 
     /**

--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -152,6 +152,7 @@ class Transport {
     static stop() {}
     static schedule() {}
     static cancel() {}
+    static clear() {}
     static getSecondsAtTime() {
         return 0;
     }

--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -150,6 +150,15 @@ class context {
 class Transport {
     static start() {}
     static stop() {}
+    static schedule() {}
+    static cancel() {}
+    static getSecondsAtTime() {
+        return 0;
+    }
+    static get seconds() {
+        return 0;
+    }
+    static set seconds(value) {}
 }
 
 class ToneAudioBuffer {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1723,8 +1723,7 @@ function Synth() {
         paramsEffects,
         paramsFilters,
         setNote,
-        future,
-        eventId
+        future
     ) => {
         const isStandardNote = note => {
             if (typeof note !== "string") return true;
@@ -1792,26 +1791,6 @@ function Synth() {
                 try {
                     await Tone.ToneAudioBuffer.loaded();
                     if (this._instrumentEpoch !== epoch) return;
-                    if (
-                        typeof eventId !== "undefined" &&
-                        typeof window !== "undefined" &&
-                        window.ActivityContext
-                    ) {
-                        try {
-                            var _perfLogo = window.ActivityContext.getActivity().logo;
-                            if (_perfLogo && _perfLogo._perfSyncData) {
-                                var _perfToneNow = Tone.now();
-                                _perfLogo._perfSyncData.triggers.push({
-                                    eventId: eventId,
-                                    perfNow: performance.now(),
-                                    toneNow: _perfToneNow,
-                                    scheduledTime: _perfToneNow + future,
-                                    future: future,
-                                    path: "simple"
-                                });
-                            }
-                        } catch (e) {}
-                    }
                     synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                 } catch (e) {
                     console.debug("Error triggering note:", e);
@@ -1863,26 +1842,6 @@ function Synth() {
                     try {
                         await Tone.ToneAudioBuffer.loaded();
                         if (this._instrumentEpoch !== epoch) return;
-                        if (
-                            typeof eventId !== "undefined" &&
-                            typeof window !== "undefined" &&
-                            window.ActivityContext
-                        ) {
-                            try {
-                                var _perfLogo2 = window.ActivityContext.getActivity().logo;
-                                if (_perfLogo2 && _perfLogo2._perfSyncData) {
-                                    var _perfToneNow2 = Tone.now();
-                                    _perfLogo2._perfSyncData.triggers.push({
-                                        eventId: eventId,
-                                        perfNow: performance.now(),
-                                        toneNow: _perfToneNow2,
-                                        scheduledTime: _perfToneNow2 + future,
-                                        future: future,
-                                        path: "fast"
-                                    });
-                                }
-                            } catch (e) {}
-                        }
                         synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                     } catch (e) {
                         console.debug("Error triggering note (no-graph-rewire fast path):", e);
@@ -2035,26 +1994,6 @@ function Synth() {
                         try {
                             await Tone.ToneAudioBuffer.loaded();
                             if (this._instrumentEpoch === epoch) {
-                                if (
-                                    typeof eventId !== "undefined" &&
-                                    typeof window !== "undefined" &&
-                                    window.ActivityContext
-                                ) {
-                                    try {
-                                        var _perfLogo3 = window.ActivityContext.getActivity().logo;
-                                        if (_perfLogo3 && _perfLogo3._perfSyncData) {
-                                            var _perfToneNow3 = Tone.now();
-                                            _perfLogo3._perfSyncData.triggers.push({
-                                                eventId: eventId,
-                                                perfNow: performance.now(),
-                                                toneNow: _perfToneNow3,
-                                                scheduledTime: _perfToneNow3 + future,
-                                                future: future,
-                                                path: "effects"
-                                            });
-                                        }
-                                    } catch (e) {}
-                                }
                                 synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                             }
                         } catch (e) {
@@ -2288,14 +2227,6 @@ function Synth() {
                 return; // Exit gracefully - synth is no longer available
             }
 
-            var _perfTriggerEventId;
-            try {
-                var _perfTriggerLogo = window.ActivityContext.getActivity().logo;
-                if (_perfTriggerLogo && _perfTriggerLogo._perfSyncData) {
-                    _perfTriggerEventId = _perfTriggerLogo._perfSyncData._turtleEventIds[turtle];
-                }
-            } catch (e) {}
-
             switch (flag) {
                 case 1: // drum
                     if (
@@ -2325,8 +2256,7 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future,
-                        _perfTriggerEventId
+                        future
                     );
                     break;
                 case 3: // builtin synth
@@ -2342,28 +2272,11 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future,
-                        _perfTriggerEventId
+                        future
                     );
                     break;
                 case 4:
                     this._trackVoice(turtle, tempSynth);
-                    if (typeof _perfTriggerEventId !== "undefined") {
-                        try {
-                            var _perfTriggerLogo2 = window.ActivityContext.getActivity().logo;
-                            if (_perfTriggerLogo2 && _perfTriggerLogo2._perfSyncData) {
-                                var _perfToneNow4 = Tone.now();
-                                _perfTriggerLogo2._perfSyncData.triggers.push({
-                                    eventId: _perfTriggerEventId,
-                                    perfNow: performance.now(),
-                                    toneNow: _perfToneNow4,
-                                    scheduledTime: _perfToneNow4 + future,
-                                    future: future,
-                                    path: "noise"
-                                });
-                            }
-                        } catch (e) {}
-                    }
                     tempSynth.triggerAttackRelease("c2", beatValue, Tone.now() + future);
                     break;
                 case 0: // default synth
@@ -2376,8 +2289,7 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future,
-                        _perfTriggerEventId
+                        future
                     );
                     break;
             }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1723,7 +1723,8 @@ function Synth() {
         paramsEffects,
         paramsFilters,
         setNote,
-        future
+        future,
+        eventId
     ) => {
         const isStandardNote = note => {
             if (typeof note !== "string") return true;
@@ -1791,6 +1792,26 @@ function Synth() {
                 try {
                     await Tone.ToneAudioBuffer.loaded();
                     if (this._instrumentEpoch !== epoch) return;
+                    if (
+                        typeof eventId !== "undefined" &&
+                        typeof window !== "undefined" &&
+                        window.ActivityContext
+                    ) {
+                        try {
+                            var _perfLogo = window.ActivityContext.getActivity().logo;
+                            if (_perfLogo && _perfLogo._perfSyncData) {
+                                var _perfToneNow = Tone.now();
+                                _perfLogo._perfSyncData.triggers.push({
+                                    eventId: eventId,
+                                    perfNow: performance.now(),
+                                    toneNow: _perfToneNow,
+                                    scheduledTime: _perfToneNow + future,
+                                    future: future,
+                                    path: "simple"
+                                });
+                            }
+                        } catch (e) {}
+                    }
                     synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                 } catch (e) {
                     console.debug("Error triggering note:", e);
@@ -1842,6 +1863,26 @@ function Synth() {
                     try {
                         await Tone.ToneAudioBuffer.loaded();
                         if (this._instrumentEpoch !== epoch) return;
+                        if (
+                            typeof eventId !== "undefined" &&
+                            typeof window !== "undefined" &&
+                            window.ActivityContext
+                        ) {
+                            try {
+                                var _perfLogo2 = window.ActivityContext.getActivity().logo;
+                                if (_perfLogo2 && _perfLogo2._perfSyncData) {
+                                    var _perfToneNow2 = Tone.now();
+                                    _perfLogo2._perfSyncData.triggers.push({
+                                        eventId: eventId,
+                                        perfNow: performance.now(),
+                                        toneNow: _perfToneNow2,
+                                        scheduledTime: _perfToneNow2 + future,
+                                        future: future,
+                                        path: "fast"
+                                    });
+                                }
+                            } catch (e) {}
+                        }
                         synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                     } catch (e) {
                         console.debug("Error triggering note (no-graph-rewire fast path):", e);
@@ -1994,6 +2035,26 @@ function Synth() {
                         try {
                             await Tone.ToneAudioBuffer.loaded();
                             if (this._instrumentEpoch === epoch) {
+                                if (
+                                    typeof eventId !== "undefined" &&
+                                    typeof window !== "undefined" &&
+                                    window.ActivityContext
+                                ) {
+                                    try {
+                                        var _perfLogo3 = window.ActivityContext.getActivity().logo;
+                                        if (_perfLogo3 && _perfLogo3._perfSyncData) {
+                                            var _perfToneNow3 = Tone.now();
+                                            _perfLogo3._perfSyncData.triggers.push({
+                                                eventId: eventId,
+                                                perfNow: performance.now(),
+                                                toneNow: _perfToneNow3,
+                                                scheduledTime: _perfToneNow3 + future,
+                                                future: future,
+                                                path: "effects"
+                                            });
+                                        }
+                                    } catch (e) {}
+                                }
                                 synth.triggerAttackRelease(notes, beatValue, Tone.now() + future);
                             }
                         } catch (e) {
@@ -2227,6 +2288,14 @@ function Synth() {
                 return; // Exit gracefully - synth is no longer available
             }
 
+            var _perfTriggerEventId;
+            try {
+                var _perfTriggerLogo = window.ActivityContext.getActivity().logo;
+                if (_perfTriggerLogo && _perfTriggerLogo._perfSyncData) {
+                    _perfTriggerEventId = _perfTriggerLogo._perfSyncData._turtleEventIds[turtle];
+                }
+            } catch (e) {}
+
             switch (flag) {
                 case 1: // drum
                     if (
@@ -2256,7 +2325,8 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future
+                        future,
+                        _perfTriggerEventId
                     );
                     break;
                 case 3: // builtin synth
@@ -2272,11 +2342,28 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future
+                        future,
+                        _perfTriggerEventId
                     );
                     break;
                 case 4:
                     this._trackVoice(turtle, tempSynth);
+                    if (typeof _perfTriggerEventId !== "undefined") {
+                        try {
+                            var _perfTriggerLogo2 = window.ActivityContext.getActivity().logo;
+                            if (_perfTriggerLogo2 && _perfTriggerLogo2._perfSyncData) {
+                                var _perfToneNow4 = Tone.now();
+                                _perfTriggerLogo2._perfSyncData.triggers.push({
+                                    eventId: _perfTriggerEventId,
+                                    perfNow: performance.now(),
+                                    toneNow: _perfToneNow4,
+                                    scheduledTime: _perfToneNow4 + future,
+                                    future: future,
+                                    path: "noise"
+                                });
+                            }
+                        } catch (e) {}
+                    }
                     tempSynth.triggerAttackRelease("c2", beatValue, Tone.now() + future);
                     break;
                 case 0: // default synth
@@ -2289,7 +2376,8 @@ function Synth() {
                         paramsEffects,
                         paramsFilters,
                         setNote,
-                        future
+                        future,
+                        _perfTriggerEventId
                     );
                     break;
             }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -464,6 +464,52 @@ const instrumentsEffects = { 0: {} };
 const instrumentsFilters = { 0: {} };
 
 /**
+ * Transport wrapper — isolates Tone.Transport behind a stable interface.
+ * All timing/scheduling operations should go through this object so that
+ * Tone.js remains a swappable implementation detail of synthutils.js.
+ */
+const transport = {
+    get isAvailable() {
+        return typeof Tone !== "undefined" && Tone.Transport;
+    },
+    start() {
+        if (this.isAvailable) Tone.Transport.start();
+    },
+    stop() {
+        if (this.isAvailable) Tone.Transport.stop();
+    },
+    cancel() {
+        if (this.isAvailable && typeof Tone.Transport.cancel === "function") {
+            Tone.Transport.cancel();
+        }
+    },
+    clear(id) {
+        if (this.isAvailable && typeof Tone.Transport.clear === "function") {
+            Tone.Transport.clear(id);
+        }
+    },
+    schedule(callback, time) {
+        if (this.isAvailable && typeof Tone.Transport.schedule === "function") {
+            return Tone.Transport.schedule(callback, time);
+        }
+        return null;
+    },
+    get seconds() {
+        if (this.isAvailable) return Tone.Transport.seconds;
+        return 0;
+    },
+    set seconds(v) {
+        if (this.isAvailable) Tone.Transport.seconds = v;
+    },
+    getSecondsAtTime(time) {
+        if (this.isAvailable && typeof Tone.Transport.getSecondsAtTime === "function") {
+            return Tone.Transport.getSecondsAtTime(time);
+        }
+        return this.seconds;
+    }
+};
+
+/**
  * Synth constructor function.
  * @constructor
  */
@@ -502,6 +548,7 @@ function Synth() {
     // Using Tone.js
     // this.tone = new Tone();
     this.tone = null;
+    this.transport = transport;
 
     Tone.Buffer.onload = () => {
         console.debug("sample loaded");
@@ -2344,11 +2391,11 @@ function Synth() {
     };
 
     this.start = () => {
-        Tone.Transport.start();
+        this.transport.start();
     };
 
     this.stop = () => {
-        Tone.Transport.stop();
+        this.transport.stop();
     };
 
     this.rampTo = (turtle, instrumentName, oldVol, volume, rampTime) => {


### PR DESCRIPTION
## PR Type

- [x] Performance

## Summary

Replace the `setTimeout`-based scheduling used for non-zero-delay playback events in `runFromBlock()` with `Tone.Transport.schedule()`. By scheduling note playback against Tone.js' audio clock instead of the JavaScript timer queue, this improves scheduling precision, reduces callback latency and cumulative synchronization drift, and preserves the existing interpreter and playback behavior.

## Motivation

Music Blocks currently schedules delayed playback using JavaScript's `setTimeout()`. Since `setTimeout()` executes on the browser's event loop, callback timing is affected by main-thread activity, garbage collection, rendering, and timer clamping. During long or multi-voice playback this can introduce callback latency and accumulate synchronization drift.

Tone.js already provides a high-precision audio scheduler through `Tone.Transport`, which schedules callbacks relative to the audio clock rather than the JavaScript timer queue. Migrating note scheduling to `Tone.Transport.schedule()` allows playback timing to remain significantly more stable while keeping the interpreter logic unchanged.

## Changes

### Scheduling

- Replace `setTimeout()` with `Tone.Transport.schedule()` for non-zero-delay playback events.
- Schedule callbacks relative to Tone.js' Transport timeline instead of browser timers.
- Preserve the existing scheduling semantics and execution order.

### Compatibility

The original `setTimeout()` implementation is intentionally retained for:

- Zero-delay execution.
- Step mode.
- Cases where Transport scheduling is unavailable.
- Existing asynchronous interpreter yielding.

### State Management

- Add per-turtle Transport scheduling state (`_transportTime`).
- Initialize Transport scheduling state before playback begins.
- Reset scheduling state when playback finishes or is stopped.
- Cancel all pending Transport events during `doStopTurtles()` to ensure clean stop/restart behavior.

### Behavior Preservation

The following behavior is intentionally unchanged:

- Interpreter execution flow.
- Graphics scheduling.
- Turtle execution semantics.
- Playback ordering.
- Async-yield execution.
- Existing fallback behavior.

## Benchmark Results

The benchmark uses identical callback-interval instrumentation before and after the scheduler migration, providing an apples-to-apples comparison.

### Benchmark

**Project:** Frère Jacques

- 268 notes
- 4 simultaneous voices

### Results

| Metric | `setTimeout` | `Tone.Transport` | Improvement |
|--------|-------------:|-----------------:|------------:|
| Mean callback latency | ~44.95 ms | ~11.73 ms | ~4× lower |
| Worst-case callback latency | ~1861.5 ms |~ 327.3 ms | ~5× lower |
| Cumulative scheduling drift | ~29.8 s | ~7.8 s | ~4× lower |

All values are conservatively rounded from the benchmark JSON output.

## Validation

- [x] Playback fingerprint unchanged.
- [x] Stop/restart lifecycle verified.
- [x] Existing interpreter execution preserved.
- [x] End-to-end stop cancellation verified.
- [x] Graceful fallback to `setTimeout` verified.
- [x] 5900 tests passed (175 test suites).
- [x] ESLint clean.
- [x] Prettier formatting verified.

## Notes

- This PR changes only the scheduling mechanism used for delayed playback callbacks.
- Graphics dispatch continues to use `setTimeout`.
- Async-yield execution continues to use `setTimeout`.
- Interpreter semantics and playback behavior remain unchanged.
- When Transport scheduling is unavailable, execution automatically falls back to the original `setTimeout` implementation.
- The benchmark improvements measure scheduler precision (callback timing) and do not represent changes to musical output, interpreter correctness, or playback semantics.