### PR TITLE
fix: microphone stays active after closing Sampler widget mid-recording/tuning

### DIFF
--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -749,6 +749,39 @@ describe("Sampler Widget", () => {
             jest.useRealTimers();
         });
 
+        test("onclose stops an active recording and releases the mic", () => {
+            widget.init(mockActivity, 1);
+
+            widget.is_recording = true;
+
+            widgetWindow.onclose();
+
+            expect(mockActivity.logo.synth.stopRecording).toHaveBeenCalled();
+            expect(widget.is_recording).toBe(false);
+        });
+
+        test("onclose stops the tuner and releases the mic", async () => {
+            widget.init(mockActivity, 1);
+
+            await widget._tunerBtn.onclick();
+
+            widgetWindow.onclose();
+
+            expect(mockActivity.logo.synth.stopTuner).toHaveBeenCalled();
+
+            await widget._tunerBtn.onclick();
+            expect(mockActivity.logo.synth.startTuner).toHaveBeenCalledTimes(2);
+        });
+
+        test("onclose does not call stopRecording/stopTuner when neither is active", () => {
+            widget.init(mockActivity, 1);
+
+            widgetWindow.onclose();
+
+            expect(mockActivity.logo.synth.stopRecording).not.toHaveBeenCalled();
+            expect(mockActivity.logo.synth.stopTuner).not.toHaveBeenCalled();
+        });
+
         test("prompt UI handles submit, preview, and save", async () => {
             widget.init(mockActivity, 1);
             widget._promptBtn.onclick();

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -487,6 +487,16 @@ function SampleWidget() {
                 this.audioPreview = null;
             }
 
+            if (this.is_recording) {
+                this.activity.logo.synth.stopRecording();
+                this.is_recording = false;
+            }
+
+            if (tunerOn) {
+                this.activity.logo.synth.stopTuner();
+                tunerOn = false;
+            }
+
             // Stop pitch detection and release resources (microphone, AudioContext)
             this.stopPitchDetection();
 


### PR DESCRIPTION
### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Problem
When the Sampler widget is closed while a recording or the tuner is active, the microphone stream is never released. The browser's mic-in-use indicator stays on after the widget is gone, and the underlying MediaStream/AudioContext keeps running in the background until the tab is closed.

### Root Cause
In `js/widgets/sampler.js`, `widgetWindow.onclose` only calls `this.stopPitchDetection()`, which tears down the separate YIN-based pitch-detection mic path used internally by this widget. It never calls the cleanup APIs for the other two mic-consuming features the Sampler widget can leave running:
1. `this.is_recording` (started via `this.activity.logo.synth.startRecording()` from the mic/record button) has no matching `stopRecording()` call on close.
2. `tunerOn` (started via `this.activity.logo.synth.startTuner()` from the tuner button) has no matching `stopTuner()` call on close.
Both `synth.stopRecording()` and `synth.stopTuner()` already exist in `js/utils/synthutils.js` and correctly call `.close()` on their respective `Tone.UserMedia` mic instances , they're just never invoked from the widget's close handler.

### Fix
In `js/widgets/sampler.js`, inside `this.init()`, in the `widgetWindow.onclose` handler:
1. If `this.is_recording` is true, call `this.activity.logo.synth.stopRecording()` and set `this.is_recording = false`.
2. If `tunerOn` is true, call `this.activity.logo.synth.stopTuner()` and set `tunerOn = false`.

### Testing
1. Open the Sampler widget.
2. Click the mic/record button to start recording, then close the widget without stopping the recording.
3. Observe the browser's mic-in-use indicator turns off immediately on close (previously stayed on).
4. Repeat with the Tuner button active instead of recording ,  same expected result.
5. Confirm no other Sampler functionality (playback, save, upload) is affected.