### PR TITLE
fix(intervals): replace hardcoded 12/21 with temperamentLength in Get…

### DIFF
--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -166,6 +166,9 @@ function setupIntervalsActions(activity) {
                 }
             }
 
+            // +9 is the original 12-EDO offset: intervals beyond
+            // temperamentLength + 9 get an explicit "plus N octave(s)"
+            // suffix. Same offset scales proportionally for all EDOs.
             if (totalIntervals > temperamentLength + 9) {
                 if (octave >= 1) {
                     lastWord = `, ${_("plus")} ${os} ${plural}`;

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -154,7 +154,7 @@ function setupIntervalsActions(activity) {
             const plural = Math.abs(octave) > 1 ? _("octaves") : _("octave");
 
             let os = numberToStringMap[Math.abs(octave) - 1] || Math.abs(octave);
-            if (totalIntervals % 12 === 0 && letterGap === 0) {
+            if (totalIntervals % temperamentLength === 0 && letterGap === 0) {
                 if (octave < 0) {
                     if (octave === -1) os = "";
                     const a = `${os} ${_("perfect")} ${plural} ${_("below")}`;
@@ -166,7 +166,7 @@ function setupIntervalsActions(activity) {
                 }
             }
 
-            if (totalIntervals > 21) {
+            if (totalIntervals > temperamentLength + 9) {
                 if (octave >= 1) {
                     lastWord = `, ${_("plus")} ${os} ${plural}`;
                 }

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -291,6 +291,75 @@ describe("setupIntervalsActions", () => {
         expect(typeof Singer.IntervalsActions.GetCurrentInterval(0)).toBe("string");
     });
 
+    describe("GetCurrentInterval with custom temperaments", () => {
+        beforeEach(() => {
+            logo.synth.inTemperament = "custom_edo19";
+            global.TEMPERAMENT.custom_edo19 = { pitchNumber: 19 };
+
+            // Extend SEMITONETOINTERVALMAP so indices up to 24 are accessible
+            global.SEMITONETOINTERVALMAP = Array(25)
+                .fill(null)
+                .map(() => Array(7).fill("test_interval"));
+        });
+
+        test("19-EDO overflow guard triggers at > 28 (not > 21)", () => {
+            // C→B (diff=11), octave=1 → totalIntervals = 11 + 19 = 30
+            // 30 > 28 → trigger overflow, reduce by 19 → 11
+            const notes = { firstNote: "C", secondNote: "B", octave: 1 };
+            GetNotesForInterval.mockReturnValueOnce(notes);
+            GetNotesForInterval.mockReturnValueOnce(notes);
+
+            const result = Singer.IntervalsActions.GetCurrentInterval(0);
+            // lastWord = ", plus one octave" → "test_interval, plus one octave"
+            expect(result).toContain("plus");
+            expect(result).toContain("octave");
+        });
+
+        test("19-EDO overflow with multiple octaves uses correct plural", () => {
+            // C→C (forwardDiff=0 → base=1), octave=2 → totalIntervals = 1 + 19 + 19 = 39
+            // 39 > 28 → trigger overflow, reduce: 39-19=20, 20-19=1
+            const notes = { firstNote: "C", secondNote: "C", octave: 2 };
+            GetNotesForInterval.mockReturnValueOnce(notes);
+            GetNotesForInterval.mockReturnValueOnce(notes);
+
+            const result = Singer.IntervalsActions.GetCurrentInterval(0);
+            // lastWord = ", plus two octaves"
+            expect(result).toContain("two");
+            expect(result).toContain("octaves");
+        });
+
+        test("19-EDO small interval skips overflow guard", () => {
+            // C→D# (diff=3), octave=0 → totalIntervals = 3
+            // 3 > 28 → false, no overflow
+            const notes = { firstNote: "C", secondNote: "D#", octave: 0 };
+            GetNotesForInterval.mockReturnValueOnce(notes);
+            GetNotesForInterval.mockReturnValueOnce(notes);
+
+            const result = Singer.IntervalsActions.GetCurrentInterval(0);
+            expect(result).toBe("test_interval"); // no lastWord
+        });
+
+        test("12-EDO regression: same behavior as before temperament fix", () => {
+            // Reset to default 12-EDO temperament
+            logo.synth.inTemperament = null;
+            delete global.TEMPERAMENT.custom_edo19;
+
+            // Use default mock SEMITONETOINTERVALMAP (13×7 "perfect")
+            global.SEMITONETOINTERVALMAP = Array(13)
+                .fill(null)
+                .map(() => Array(7).fill("perfect"));
+
+            // C→G (diff=7), octave=0 → totalIntervals = 7
+            const notes = { firstNote: "C", secondNote: "G", octave: 0 };
+            GetNotesForInterval.mockReturnValueOnce(notes);
+            GetNotesForInterval.mockReturnValueOnce(notes);
+
+            const result = Singer.IntervalsActions.GetCurrentInterval(0);
+            // SEMITONETOINTERVALMAP[7][4] = "perfect", no lastWord
+            expect(result).toBe("perfect");
+        });
+    });
+
     test("setKey updates keySignature", () => {
         Singer.IntervalsActions.setKey("C", "major", 0);
         expect(turtle.singer.keySignature).toContain("C");

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -86,6 +86,8 @@ const {
     getVoiceSynthName,
     isCustomTemperament,
     getTemperamentName,
+    getTemperamentCents,
+    getTemperamentRatio,
     noteToObj,
     frequencyToPitch,
     getArticulation,
@@ -913,6 +915,105 @@ describe("frequencyToPitch", () => {
         const result = frequencyToPitch(440, "unknown");
         expect(result[0]).toBe("A");
         expect(result[1]).toBe(4);
+    });
+});
+
+describe("cents calculations", () => {
+    global.TWELVEHUNDRETHROOT2 = Number("1.0005777895065549");
+    global.A0 = 27.5;
+
+    beforeEach(() => {
+        global.TEMPERAMENT = {
+            equal: { pitchNumber: 12 },
+            equal19: { pitchNumber: 19 },
+            equal31: { pitchNumber: 31 }
+        };
+    });
+
+    describe("getTemperamentCents", () => {
+        it("converts numeric ratio to cents", () => {
+            // 3/2 ratio = 701.96 cents
+            const cents = getTemperamentCents(3 / 2);
+            expect(cents).toBeCloseTo(701.955, 1);
+        });
+
+        it("returns cents from object format", () => {
+            const cents = getTemperamentCents({ ratio: 3 / 2, cents: 700 });
+            expect(cents).toBe(700);
+        });
+
+        it("returns 0 for invalid input", () => {
+            expect(getTemperamentCents(null)).toBe(0);
+            expect(getTemperamentCents(undefined)).toBe(0);
+            expect(getTemperamentCents("invalid")).toBe(0);
+        });
+    });
+
+    describe("getTemperamentRatio", () => {
+        it("returns numeric ratio as-is", () => {
+            expect(getTemperamentRatio(1.5)).toBe(1.5);
+        });
+
+        it("extracts ratio from object format", () => {
+            expect(getTemperamentRatio({ ratio: 3 / 2, cents: 700 })).toBe(3 / 2);
+        });
+
+        it("returns 1 for invalid input", () => {
+            expect(getTemperamentRatio(null)).toBe(1);
+            expect(getTemperamentRatio(undefined)).toBe(1);
+        });
+    });
+
+    describe("frequencyToPitch cents with non-12 EDO", () => {
+        it("computes cents deviation in 19-EDO", () => {
+            // ~0.05 steps above A4 in 19-EDO → stays on "A" with ~3 cents deviation
+            const freq = 440 * Math.pow(2, 0.05 / 19);
+            const result = frequencyToPitch(freq, "equal19");
+            expect(result[0]).toBe("A");
+            expect(result[1]).toBe(4);
+            expect(result[2]).toBeGreaterThan(2);
+            expect(result[2]).toBeLessThan(5);
+        });
+
+        it("computes cents deviation in 31-EDO", () => {
+            // ~0.3 steps above A4 in 31-EDO → stays on "A" with ~12 cents deviation
+            const freq = 440 * Math.pow(2, 0.3 / 31);
+            const result = frequencyToPitch(freq, "equal31");
+            expect(result[0]).toBe("A");
+            expect(result[1]).toBe(4);
+            expect(result[2]).toBeGreaterThan(10);
+            expect(result[2]).toBeLessThan(15);
+        });
+    });
+
+    describe("pitchToFrequency cents with non-12 EDO", () => {
+        it("handles non-zero cents with 19-EDO", () => {
+            // A4 in 19-EDO = pitchNumber 76 (4 * 19)
+            const result = pitchToFrequency("A", 4, 50, "C", "equal19");
+            const expected = A0 * Math.pow(2, 1 / (19 * 100)) ** (76 * 100 + 50);
+            expect(result).toBeCloseTo(expected, 4);
+        });
+
+        it("handles non-zero cents with 31-EDO", () => {
+            // A4 in 31-EDO = pitchNumber 124 (4 * 31)
+            const result = pitchToFrequency("A", 4, 50, "C", "equal31");
+            const expected = A0 * Math.pow(2, 1 / (31 * 100)) ** (124 * 100 + 50);
+            expect(result).toBeCloseTo(expected, 4);
+        });
+
+        it("handles negative cents", () => {
+            const result = pitchToFrequency("A", 4, -30, "C");
+            const expected = A0 * Math.pow(2, 1 / 1200) ** (48 * 100 - 30);
+            expect(result).toBeCloseTo(expected, 4);
+        });
+    });
+
+    describe("frequencyToPitch sub-cent rounding", () => {
+        it("rounds sub-0.5-cent deviation to 0", () => {
+            const freq = 440 * Math.pow(2, 0.003 / 12); // tiny deviation (~0.003 steps = ~0.25 cents)
+            const result = frequencyToPitch(freq);
+            expect(result[2]).toBe(0);
+        });
     });
 });
 


### PR DESCRIPTION
I finally got around to killing the hardcoded 12 and 21 in GetCurrentInterval - it now uses temperamentLength everywhere, so 19‑EDO and 31‑EDO work without incorrect wrapping or false "too large" errors.

Core problems:

19‑EDO wrapped at 12 instead of 19 - wrong note.
31‑EDO valid intervals > 21 flagged invalid - half the scale unusable.
Interval names wrong for any non‑12 tuning.

Changes:

Line 157: % 12  -  % temperamentLength (wrapping respects current EDO).
Line 169: > 21  -  > temperamentLength + 9 (overflow guard no longer false‑positives on valid 31‑EDO).

Files touched:

js/turtleactions/IntervalsActions.js - the two lines above.
js/turtleactions/__tests__/IntervalsActions.test.js – new tests for 19‑EDO overflow, multiple octaves, and 12‑EDO regression.
js/utils/__tests__/musicutils.test.js - added cents tests per Walter's feedback.

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation

Part of : #7171 