### PR TITLE
Fix trackpad/mouse-wheel scrolling in Music Keyboard widget

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -391,6 +391,23 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         global.SOLFEGENAMES = originalSolfegeNames;
     });
 
+    test("wheel events on keyboardDiv and keyTable stop propagation", () => {
+        const keyboard = new MusicKeyboard(mockActivity);
+        keyboard.init();
+
+        const wheelEvent = new Event("wheel", { bubbles: true });
+        wheelEvent.stopPropagation = jest.fn();
+
+        keyboard.keyboardDiv.dispatchEvent(wheelEvent);
+        expect(wheelEvent.stopPropagation).toHaveBeenCalled();
+
+        const domMouseScrollEvent = new Event("DOMMouseScroll", { bubbles: true });
+        domMouseScrollEvent.stopPropagation = jest.fn();
+
+        keyboard.keyTable.dispatchEvent(domMouseScrollEvent);
+        expect(domMouseScrollEvent.stopPropagation).toHaveBeenCalled();
+    });
+
     test("onclose stops sequence playback, releases active key, and stops all voices", () => {
         const keyboard = new MusicKeyboard(mockActivity);
         keyboard._keysLayout = jest.fn().mockReturnValue([]);

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -894,6 +894,14 @@ function MusicKeyboard(activity) {
          */
         this.keyTable = document.createElement("div");
 
+        const stopPropagationHandler = e => {
+            e.stopPropagation();
+        };
+        this.keyboardDiv.addEventListener("wheel", stopPropagationHandler);
+        this.keyboardDiv.addEventListener("DOMMouseScroll", stopPropagationHandler);
+        this.keyTable.addEventListener("wheel", stopPropagationHandler);
+        this.keyTable.addEventListener("DOMMouseScroll", stopPropagationHandler);
+
         /**
          * Appends keyboard and table divs to the widget window body.
          */
@@ -1666,6 +1674,7 @@ function MusicKeyboard(activity) {
         let n = Math.max(Math.floor((window.innerHeight * 0.5) / 100), 8);
 
         outerDiv.style.overflowY = "auto";
+        outerDiv.style.overflowX = "auto";
         if (this.displayLayout.length > n) {
             outerDiv.style.height = this._cellScale * MATRIXSOLFEHEIGHT * (n + 5) + "px";
         } else {


### PR DESCRIPTION
### Description
In the Music Keyboard widget, scrolling over the note grid or the piano keyboard with a trackpad gesture or mouse wheel did nothing. The only way to scroll was by clicking and dragging the scrollbar thumb directly.

**Root cause:** `widgetWindows.js` registers a global wheel event handler on the widget wrapper (`.wfbWidget`). Any `wheel`/`DOMMouseScroll` event bubbling up from inside the widget — including from the note grid and the piano keyboard — gets intercepted by this handler, which unconditionally calls `event.preventDefault()` and `event.stopPropagation()`. This cancels the browser's native scroll behavior for the event before it can take effect on the inner scrollable containers.

**Fix:**
* Enabled horizontal scrolling on the note grid by setting `overflowX: auto` on `outerDiv` in `_createTable()` (previously only vertical scroll was enabled).
* Stopped `wheel`/`DOMMouseScroll` events from propagating past the note grid (`keyTable`) and the piano keyboard (`keyboardDiv`) containers, so they no longer reach `.wfbWidget`'s handler and get their default scroll action cancelled.

This restores native trackpad/mouse-wheel scrolling for both the note grid (horizontal and vertical) and the piano keyboard, without changing how the rest of the widget window scrolls.

### PR Category
- [x] Bug fix

### Testing
* `npm test` — all suites passing
* `npm run lint` / `prettier` — clean
* **Manual:** verified trackpad/wheel scroll now works over the note grid and piano keyboard; scrollbar-drag behavior unaffected.
