### PR TITLE
fix: visual play/stop toggling and stop-on-click for PitchStaircase play buttons

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -44,7 +44,15 @@ window.widgetWindows = {
     windowFor: jest.fn().mockReturnValue({
         clear: jest.fn(),
         show: jest.fn(),
-        addButton: jest.fn().mockReturnValue({ onclick: null }),
+        addButton: jest.fn().mockImplementation(() => {
+            return {
+                onclick: null,
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockReturnValue(false)
+                }
+            };
+        }),
         addInputButton: jest.fn().mockReturnValue({
             value: "3",
             addEventListener: jest.fn()
@@ -393,6 +401,7 @@ describe("PitchStaircase Widget", () => {
 
         beforeEach(() => {
             jest.useFakeTimers();
+            jest.clearAllTimers();
 
             mockPlayCell = {
                 getAttribute: jest.fn().mockReturnValue("0"),
@@ -413,7 +422,8 @@ describe("PitchStaircase Widget", () => {
 
             mockSynth = {
                 trigger: jest.fn(),
-                stop: jest.fn()
+                stop: jest.fn(),
+                setMasterVolume: jest.fn()
             };
 
             psc.activity = {
@@ -572,6 +582,152 @@ describe("PitchStaircase Widget", () => {
             expect(psc._scaleStopped).toBe(true);
             let img2 = mockHeaderButton.replaceChildren.mock.calls[0][0];
             expect(img2.getAttribute("src")).toBe("header-icons/play-scale.svg");
+        });
+
+        test("init should register and allow toggling play/stop on playAll and playScale buttons", () => {
+            psc.Stairs = [["A", "", 220.0]];
+
+            psc.init({
+                logo: {
+                    synth: mockSynth
+                },
+                textMsg: jest.fn(),
+                palettes: {
+                    dict: {}
+                }
+            });
+
+            // 1. Play All Button
+            expect(psc._playAllButton.onclick).toBeDefined();
+            // Start playing all
+            psc._playAllButton.onclick();
+            expect(mockSynth.trigger).toHaveBeenCalled();
+            expect(psc._isPlayingAll).toBe(true);
+            expect(psc._playAllButton.replaceChildren).toHaveBeenCalled();
+
+            // Stop playing all
+            mockSynth.stop.mockClear();
+            psc._playAllButton.onclick();
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._isPlayingAll).toBe(false);
+
+            // 2. Play Scale Button
+            expect(psc._playScaleButton.onclick).toBeDefined();
+            // Start playing scale
+            psc._playScaleButton.onclick();
+            expect(psc._isPlayingScale).toBe(true);
+
+            // Stop playing scale
+            mockSynth.stop.mockClear();
+            psc._playScaleButton.onclick();
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._isPlayingScale).toBe(false);
+            expect(psc._scaleStopped).toBe(true);
+        });
+
+        test("init should register and allow toggling play/stop on row play button", () => {
+            psc.Stairs = [["A", "", 220.0]];
+
+            psc.init({
+                logo: {
+                    synth: mockSynth
+                },
+                textMsg: jest.fn(),
+                palettes: {
+                    dict: {}
+                }
+            });
+
+            const playCell = psc._stepTables[0].rows[0].cells[0];
+            const stepCell = psc._stepTables[0].rows[0].cells[1];
+            expect(playCell.onclick).toBeDefined();
+
+            // Mock getAttribute to prevent returning null in tests
+            playCell.setAttribute("id", "0");
+            stepCell.setAttribute("id", "220.0");
+
+            // Mock replaceChildren on cell
+            playCell.replaceChildren = jest.fn();
+
+            // Start playing row
+            playCell.onclick();
+            expect(mockSynth.trigger).toHaveBeenCalled();
+            expect(psc._playingRowIndex).toBe(0);
+
+            // Stop playing row
+            mockSynth.stop.mockClear();
+            playCell.onclick();
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._playingRowIndex).toBeNull();
+        });
+
+        test("_playAll should terminate naturally after 1000ms", () => {
+            psc.Stairs = [["A", "", 220.0]];
+            psc._stepTables = [{ rows: [{ cells: [null, mockStepCell] }] }];
+            psc._playAllButton = {
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockReturnValue(false)
+                }
+            };
+
+            psc._playAll();
+            expect(psc._isPlayingAll).toBe(true);
+
+            jest.advanceTimersByTime(1000);
+            expect(psc._isPlayingAll).toBe(false);
+        });
+
+        test("playUpAndDown should play full scale down then up and terminate naturally", () => {
+            psc.Stairs = [
+                ["A", "", 220.0],
+                ["B", "", 240.0]
+            ];
+            const mockRowA = { cells: [null, mockStepCell] };
+            const mockRowB = { cells: [null, mockStepCell] };
+            psc._stepTables = [{ rows: [mockRowA] }, { rows: [mockRowB] }];
+
+            psc._playScaleButton = {
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockReturnValue(false)
+                }
+            };
+
+            // Start playing scale
+            psc.playUpAndDown();
+            expect(mockSynth.trigger).toHaveBeenCalledTimes(1);
+            expect(psc._isPlayingScale).toBe(true);
+
+            // 1. First step timeout (t3) to play index 0 (going down)
+            jest.advanceTimersByTime(1000);
+            expect(mockSynth.trigger).toHaveBeenCalledTimes(2);
+
+            // 2. Next timeout (t3) will trigger index -1
+            jest.advanceTimersByTime(1000);
+
+            // t1 schedules highlights cleanup in 1000ms, t2 schedules _playNext(0, 1) in 200ms
+            jest.advanceTimersByTime(200); // Trigger t2: _playNext(0, 1) going up
+            expect(mockSynth.trigger).toHaveBeenCalledTimes(3);
+
+            // _playNext(0, 1) schedules t3 in 1000ms
+            jest.advanceTimersByTime(1000); // Trigger t3: plays index 1 going up
+            expect(mockSynth.trigger).toHaveBeenCalledTimes(4);
+
+            // _playNext(1, 1) schedules t3 in 1000ms (to index === 2 boundary)
+            jest.advanceTimersByTime(1000);
+
+            // Terminate in 1000ms
+            jest.advanceTimersByTime(1000); // Trigger termination timeout
+
+            expect(psc._isPlayingScale).toBe(false);
+            let img = psc._playScaleButton.replaceChildren.mock.calls[1][0];
+            expect(img.getAttribute("src")).toBe("header-icons/play-scale.svg");
+        });
+
+        test("_setButtonIcon should handle invalid or mock cells gracefully", () => {
+            psc._setButtonIcon(null, "play-button.svg", "Play");
+            psc._setButtonIcon({}, "play-button.svg", "Play");
         });
     });
 });

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -385,4 +385,193 @@ describe("PitchStaircase Widget", () => {
             jest.useRealTimers();
         });
     });
+
+    describe("play buttons visual feedback and toggling stop", () => {
+        let mockPlayCell;
+        let mockStepCell;
+        let mockSynth;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+
+            mockPlayCell = {
+                getAttribute: jest.fn().mockReturnValue("0"),
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockImplementation(cls => cls === "pitch-staircase-btn")
+                }
+            };
+
+            mockStepCell = {
+                classList: {
+                    add: jest.fn(),
+                    remove: jest.fn()
+                },
+                getAttribute: jest.fn().mockReturnValue("220.0"),
+                style: {}
+            };
+
+            mockSynth = {
+                trigger: jest.fn(),
+                stop: jest.fn()
+            };
+
+            psc.activity = {
+                logo: {
+                    synth: mockSynth
+                }
+            };
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test("_playOne should change row icon to stop and then back to play", () => {
+            psc._playOne(mockStepCell, mockPlayCell);
+
+            // Verify icon changed to stop-button.svg
+            expect(mockPlayCell.replaceChildren).toHaveBeenCalled();
+            let img1 = mockPlayCell.replaceChildren.mock.calls[0][1];
+            expect(img1.getAttribute("src")).toBe("header-icons/stop-button.svg");
+            expect(psc._playingRowIndex).toBe(0);
+
+            // Advance timers by 1000ms
+            jest.advanceTimersByTime(1000);
+
+            // Verify icon changed back to play-button.svg
+            let img2 = mockPlayCell.replaceChildren.mock.calls[1][1];
+            expect(img2.getAttribute("src")).toBe("header-icons/play-button.svg");
+            expect(psc._playingRowIndex).toBeNull();
+        });
+
+        test("row click mid-play should stop row and synth", () => {
+            // First click plays
+            psc.Stairs = [["A", "", 220.0]];
+            psc._stepTables = [{ rows: [{ cells: [null, mockStepCell] }] }];
+
+            // Re-bind onclick handler mock logic in init or manually as in _makeStairs
+            const playCellClick = () => {
+                const i = Number(mockPlayCell.getAttribute("id"));
+                const stepCell = psc._stepTables[i].rows[0].cells[1];
+                if (psc._playingRowIndex === i) {
+                    clearTimeout(psc._rowStopTimeout);
+                    stepCell.classList.remove("active");
+                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    psc._setButtonIcon(mockPlayCell, "play-button.svg", _("Play"));
+                    psc.activity.logo.synth.stop();
+                    psc._playingRowIndex = null;
+                } else {
+                    psc._playOne(stepCell, mockPlayCell);
+                }
+            };
+
+            // Play the row
+            playCellClick();
+            expect(mockSynth.trigger).toHaveBeenCalled();
+            expect(psc._playingRowIndex).toBe(0);
+
+            // Click again to stop
+            mockPlayCell.replaceChildren.mockClear();
+            playCellClick();
+
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._playingRowIndex).toBeNull();
+            let img = mockPlayCell.replaceChildren.mock.calls[0][1];
+            expect(img.getAttribute("src")).toBe("header-icons/play-button.svg");
+        });
+
+        test("_playAll and header button click mid-play should play and stop", () => {
+            psc.Stairs = [["A", "", 220.0]];
+            psc._stepTables = [{ rows: [{ cells: [null, mockStepCell] }] }];
+
+            const mockHeaderButton = {
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockReturnValue(false)
+                }
+            };
+            psc._playAllButton = mockHeaderButton;
+
+            const playAllClick = () => {
+                if (psc._isPlayingAll) {
+                    clearTimeout(psc._playAllTimeout);
+                    for (let i = 0; i < psc.Stairs.length; i++) {
+                        const stepCell = psc._stepTables[i].rows[0].cells[1];
+                        stepCell.classList.remove("active");
+                    }
+                    psc._setButtonIcon(psc._playAllButton, "play-chord.svg", _("Play chord"));
+                    psc.activity.logo.synth.stop();
+                    psc._isPlayingAll = false;
+                } else {
+                    psc._playAll();
+                }
+            };
+
+            // Start playing chord
+            playAllClick();
+            expect(mockSynth.trigger).toHaveBeenCalled();
+            expect(psc._isPlayingAll).toBe(true);
+            let img1 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            expect(img1.getAttribute("src")).toBe("header-icons/stop-button.svg");
+
+            // Stop playing chord
+            mockHeaderButton.replaceChildren.mockClear();
+            playAllClick();
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._isPlayingAll).toBe(false);
+            let img2 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            expect(img2.getAttribute("src")).toBe("header-icons/play-chord.svg");
+        });
+
+        test("playUpAndDown and header button click mid-play should play and stop scale", () => {
+            psc.Stairs = [
+                ["A", "", 220.0],
+                ["B", "", 240.0]
+            ];
+            const mockRowA = { cells: [null, mockStepCell] };
+            const mockRowB = { cells: [null, mockStepCell] };
+            psc._stepTables = [{ rows: [mockRowA] }, { rows: [mockRowB] }];
+
+            const mockHeaderButton = {
+                replaceChildren: jest.fn(),
+                classList: {
+                    contains: jest.fn().mockReturnValue(false)
+                }
+            };
+            psc._playScaleButton = mockHeaderButton;
+
+            const playScaleClick = () => {
+                if (psc._isPlayingScale) {
+                    psc._scaleStopped = true;
+                    clearTimeout(psc._scaleTimeout);
+                    for (let i = 0; i < psc.Stairs.length; i++) {
+                        const stepCell = psc._stepTables[i].rows[0].cells[1];
+                        stepCell.classList.remove("active");
+                    }
+                    psc._setButtonIcon(psc._playScaleButton, "play-scale.svg", _("Play scale"));
+                    psc.activity.logo.synth.stop();
+                    psc._isPlayingScale = false;
+                } else {
+                    psc.playUpAndDown();
+                }
+            };
+
+            // Start playing scale
+            playScaleClick();
+            expect(mockSynth.trigger).toHaveBeenCalled();
+            expect(psc._isPlayingScale).toBe(true);
+            let img1 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            expect(img1.getAttribute("src")).toBe("header-icons/stop-button.svg");
+
+            // Stop playing scale
+            mockHeaderButton.replaceChildren.mockClear();
+            playScaleClick();
+            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(psc._isPlayingScale).toBe(false);
+            expect(psc._scaleStopped).toBe(true);
+            let img2 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            expect(img2.getAttribute("src")).toBe("header-icons/play-scale.svg");
+        });
+    });
 });

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -467,7 +467,7 @@ describe("PitchStaircase Widget", () => {
                 if (psc._playingRowIndex === i) {
                     clearTimeout(psc._rowStopTimeout);
                     stepCell.classList.remove("active");
-                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    stepCell.style.backgroundColor = "";
                     psc._setButtonIcon(mockPlayCell, "play-button.svg", _("Play"));
                     psc.activity.logo.synth.stop();
                     psc._playingRowIndex = null;

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -51,6 +51,13 @@ class PitchStaircase {
         this._stepTables = [];
         this._musicRatio1 = null;
         this._musicRatio2 = null;
+        this._playingRowIndex = null;
+        this._rowStopTimeout = null;
+        this._isPlayingAll = false;
+        this._playAllTimeout = null;
+        this._isPlayingScale = false;
+        this._scaleStopped = false;
+        this._scaleTimeout = null;
     }
 
     /**
@@ -87,6 +94,37 @@ class PitchStaircase {
         cell.classList.add("pitch-staircase-btn");
 
         return cell;
+    }
+
+    /**
+     * @private
+     * @param {Cell} cell
+     * @param {string} icon
+     * @param {string} label
+     * @returns {void}
+     */
+    _setButtonIcon(cell, icon, label) {
+        if (!cell || typeof cell.replaceChildren !== "function") {
+            return;
+        }
+        const img = document.createElement("img");
+        img.src = "header-icons/" + icon;
+        img.title = label;
+        img.alt = label;
+        img.height = PitchStaircase.ICONSIZE;
+        img.width = PitchStaircase.ICONSIZE;
+        img.style.verticalAlign = "middle";
+        img.style.alignContent = "center";
+
+        if (cell.classList.contains("pitch-staircase-btn")) {
+            cell.replaceChildren(
+                document.createTextNode("\u00a0\u00a0"),
+                img,
+                document.createTextNode("\u00a0\u00a0")
+            );
+        } else {
+            cell.replaceChildren(img);
+        }
     }
 
     /**
@@ -163,9 +201,18 @@ class PitchStaircase {
             });
 
             playCell.onclick = () => {
-                const i = playCell.getAttribute("id");
+                const i = Number(playCell.getAttribute("id"));
                 const stepCell = this._stepTables[i].rows[0].cells[1];
-                this._playOne(stepCell);
+                if (this._playingRowIndex === i) {
+                    clearTimeout(this._rowStopTimeout);
+                    stepCell.classList.remove("active");
+                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    this._setButtonIcon(playCell, "play-button.svg", _("Play"));
+                    this.activity.logo.synth.stop();
+                    this._playingRowIndex = null;
+                } else {
+                    this._playOne(stepCell, playCell);
+                }
             };
         }
     }
@@ -302,16 +349,21 @@ class PitchStaircase {
      * @param {Cell} stepcell
      * @returns {void}
      */
-    _playOne(stepCell) {
+    _playOne(stepCell, playCell) {
         // The frequency is stored in the stepCell.
         stepCell.classList.add("active");
         stepCell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
+        const i = Number(playCell.getAttribute("id"));
+        this._playingRowIndex = i;
         const frequency = Number(stepCell.getAttribute("id"));
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
+        this._setButtonIcon(playCell, "stop-button.svg", _("Stop"));
 
-        setTimeout(() => {
+        this._rowStopTimeout = setTimeout(() => {
             stepCell.classList.remove("active");
             stepCell.style.backgroundColor = platformColor.selectorBackground;
+            this._setButtonIcon(playCell, "play-button.svg", _("Play"));
+            this._playingRowIndex = null;
         }, 1000);
     }
 
@@ -321,6 +373,14 @@ class PitchStaircase {
      */
     _playAll() {
         const pitchnotes = [];
+        this._isPlayingAll = true;
+        if (this._playAllButton) {
+            this._setButtonIcon(
+                this._isPlayingAll ? this._playAllButton : null,
+                "stop-button.svg",
+                _("Stop")
+            );
+        }
 
         for (let i = 0; i < this.Stairs.length; i++) {
             const note = this.Stairs[i][0] + this.Stairs[i][1];
@@ -330,11 +390,15 @@ class PitchStaircase {
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         }
 
-        setTimeout(() => {
+        this._playAllTimeout = setTimeout(() => {
             for (let i = 0; i < this.Stairs.length; i++) {
                 const stepCell = this._stepTables[i].rows[0].cells[1];
                 stepCell.classList.remove("active");
             }
+            if (this._playAllButton) {
+                this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
+            }
+            this._isPlayingAll = false;
         }, 1000);
     }
 
@@ -343,6 +407,11 @@ class PitchStaircase {
      * @returns {void}
      */
     playUpAndDown() {
+        this._scaleStopped = false;
+        this._isPlayingScale = true;
+        if (this._playScaleButton) {
+            this._setButtonIcon(this._playScaleButton, "stop-button.svg", _("Stop"));
+        }
         const pitchnotes = [];
         const note =
             this.Stairs[this.Stairs.length - 1][0] + this.Stairs[this.Stairs.length - 1][1];
@@ -361,29 +430,42 @@ class PitchStaircase {
      * @returns {void}
      */
     _playNext(index, next) {
-        if (this.closed) return;
+        if (this.closed || this._scaleStopped) return;
 
         if (index === this.Stairs.length) {
-            setTimeout(() => {
+            const timeoutId = setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
                     stepCell.classList.remove("active");
                 }
+                if (this._playScaleButton) {
+                    this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
+                }
+                this._isPlayingScale = false;
             }, 1000);
+            if (this._playScaleButton) {
+                this._scaleTimeout = timeoutId;
+            }
             return;
         }
 
         if (index === -1) {
-            setTimeout(() => {
+            const t1 = setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
                     stepCell.classList.remove("active");
                 }
             }, 1000);
+            if (this._playScaleButton) {
+                this._scaleTimeout = t1;
+            }
 
-            setTimeout(() => {
+            const t2 = setTimeout(() => {
                 this._playNext(0, 1);
             }, 200);
+            if (this._playScaleButton) {
+                this._scaleTimeout = t2;
+            }
 
             return;
         }
@@ -396,8 +478,8 @@ class PitchStaircase {
         // not null, so use != null (loose) to catch both.
         const pscTableCell = previousRowNumber >= 0 ? this._stepTables[previousRowNumber] : null;
 
-        setTimeout(() => {
-            if (this.closed) return;
+        const t3 = setTimeout(() => {
+            if (this.closed || this._scaleStopped) return;
             if (pscTableCell !== null && pscTableCell !== undefined) {
                 const stepCell = pscTableCell.rows[0].cells[1];
                 stepCell.classList.remove("active");
@@ -413,6 +495,9 @@ class PitchStaircase {
                 this._playNext(index + next, next);
             }
         }, 1000);
+        if (this._playScaleButton) {
+            this._scaleTimeout = t3;
+        }
     }
 
     /**
@@ -644,15 +729,46 @@ class PitchStaircase {
         this.closed = false;
         this.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
 
-        widgetWindow.addButton("play-chord.svg", PitchStaircase.ICONSIZE, _("Play chord")).onclick =
-            () => {
+        this._playAllButton = widgetWindow.addButton(
+            "play-chord.svg",
+            PitchStaircase.ICONSIZE,
+            _("Play chord")
+        );
+        this._playAllButton.onclick = () => {
+            if (this._isPlayingAll) {
+                clearTimeout(this._playAllTimeout);
+                for (let i = 0; i < this.Stairs.length; i++) {
+                    const stepCell = this._stepTables[i].rows[0].cells[1];
+                    stepCell.classList.remove("active");
+                }
+                this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
+                this.activity.logo.synth.stop();
+                this._isPlayingAll = false;
+            } else {
                 this._playAll();
-            };
+            }
+        };
 
-        widgetWindow.addButton("play-scale.svg", PitchStaircase.ICONSIZE, _("Play scale")).onclick =
-            () => {
+        this._playScaleButton = widgetWindow.addButton(
+            "play-scale.svg",
+            PitchStaircase.ICONSIZE,
+            _("Play scale")
+        );
+        this._playScaleButton.onclick = () => {
+            if (this._isPlayingScale) {
+                this._scaleStopped = true;
+                clearTimeout(this._scaleTimeout);
+                for (let i = 0; i < this.Stairs.length; i++) {
+                    const stepCell = this._stepTables[i].rows[0].cells[1];
+                    stepCell.classList.remove("active");
+                }
+                this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
+                this.activity.logo.synth.stop();
+                this._isPlayingScale = false;
+            } else {
                 this.playUpAndDown();
-            };
+            }
+        };
 
         this._save_lock = false;
         widgetWindow.addButton("export-chunk.svg", PitchStaircase.ICONSIZE, _("Save")).onclick =

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -206,7 +206,7 @@ class PitchStaircase {
                 if (this._playingRowIndex === i) {
                     clearTimeout(this._rowStopTimeout);
                     stepCell.classList.remove("active");
-                    stepCell.style.backgroundColor = platformColor.selectorBackground;
+                    stepCell.style.backgroundColor = "";
                     this._setButtonIcon(playCell, "play-button.svg", _("Play"));
                     this.activity.logo.synth.stop();
                     this._playingRowIndex = null;
@@ -361,7 +361,7 @@ class PitchStaircase {
 
         this._rowStopTimeout = setTimeout(() => {
             stepCell.classList.remove("active");
-            stepCell.style.backgroundColor = platformColor.selectorBackground;
+            stepCell.style.backgroundColor = "";
             this._setButtonIcon(playCell, "play-button.svg", _("Play"));
             this._playingRowIndex = null;
         }, 1000);


### PR DESCRIPTION
## Description

The play buttons in the Pitch Staircase widget (row play buttons, "Play chord", and "Play scale") gave no visual feedback while audio was playing, and clicking a button again mid-playback restarted playback instead of stopping it.

## PR Category

- [x] Bug Fix

## Changes Made

- Row, chord, and scale play buttons now swap to `stop-button.svg` while playing and revert to their play icon when playback ends.
- Clicking a button while it's already playing stops that playback (clears pending timeouts, removes active highlights, stops the synth) instead of restarting it.
- Added regression tests covering the play/stop icon toggling and stop-on-click behavior for all three buttons.

## Testing Performed

- Ran `npm test` and `npm run lint` — all pass.
- Manually tested in the browser: row play/stop, chord play/stop, and scale play/stop, including clicking to stop mid-sequence.