### PR TITLE
fix: guard against null popup window in PhraseMaker export

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1372,4 +1372,55 @@ describe("PhraseMaker Widget", () => {
 
         phraseMaker._blockReplace(0, 1);
     });
+
+    describe("_export", () => {
+        const originalOpen = global.window.open;
+
+        afterEach(() => {
+            global.window.open = originalOpen;
+        });
+
+        test("shows a warning and returns safely when the popup is blocked", () => {
+            global.window.open = jest.fn().mockReturnValue(null);
+            phraseMaker.activity = { errorMsg: jest.fn() };
+
+            expect(() => phraseMaker._export()).not.toThrow();
+
+            expect(phraseMaker.activity.errorMsg).toHaveBeenCalledTimes(1);
+            expect(phraseMaker.activity.errorMsg).toHaveBeenCalledWith(
+                expect.stringContaining("export window")
+            );
+        });
+
+        test("builds the export document without warning when the popup succeeds", () => {
+            const makeCell = () => ({ style: {}, appendChild: jest.fn(), setAttribute: jest.fn() });
+            const makeRow = () => ({ insertCell: jest.fn(makeCell) });
+            const exportTableMock = {
+                createTHead: jest.fn(() => ({ insertRow: jest.fn(makeRow) }))
+            };
+            const exportDocumentMock = {
+                createElement: jest.fn(() => ({
+                    style: {},
+                    appendChild: jest.fn(),
+                    setAttribute: jest.fn()
+                })),
+                getElementById: jest.fn(id =>
+                    id === "exportTable" ? exportTableMock : { download: "", href: "" }
+                ),
+                head: { appendChild: jest.fn() },
+                body: { appendChild: jest.fn() },
+                documentElement: { outerHTML: "<html></html>" },
+                close: jest.fn()
+            };
+            global.window.open = jest.fn().mockReturnValue({ document: exportDocumentMock });
+            phraseMaker.activity = { errorMsg: jest.fn() };
+            phraseMaker._noteValueRow = { cells: [] };
+            phraseMaker._generateDataURI = jest.fn(() => "data:text/html;base64,mock");
+
+            expect(() => phraseMaker._export()).not.toThrow();
+
+            expect(phraseMaker.activity.errorMsg).not.toHaveBeenCalled();
+            expect(exportDocumentMock.close).toHaveBeenCalled();
+        });
+    });
 });

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2758,11 +2758,14 @@ class PhraseMaker {
      */
     _export() {
         const exportWindow = window.open("");
-        const exportDocument = exportWindow.document;
-        if (exportDocument === undefined) {
+        if (!exportWindow) {
             console.debug("Could not create export window");
+            this.activity.errorMsg(
+                this._("Could not open export window. Please allow pop-ups for this site.")
+            );
             return;
         }
+        const exportDocument = exportWindow.document;
 
         const title = exportDocument.createElement("title");
         title.textContent = "Music Matrix";

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2761,7 +2761,9 @@ class PhraseMaker {
         if (!exportWindow) {
             console.debug("Could not create export window");
             this.activity.errorMsg(
-                this._("Could not open export window. Please allow pop-ups for this site.")
+                this._(
+                    "Could not open export window. This is often caused by a browser pop-up blocker — check your settings and try again."
+                )
             );
             return;
         }


### PR DESCRIPTION
## Description

`PhraseMaker._export()` (`js/widgets/phrasemaker.js`) opens a new browser window/tab and renders the current Music Matrix into it as a formatted, downloadable HTML table. It does this with:

```js
const exportWindow = window.open("");
const exportDocument = exportWindow.document;
```

`window.open()` returns `null` whenever the browser's popup blocker prevents the window from opening — this is standard, spec-defined behavior, not an edge case. When that happens, `exportWindow.document` throws immediately:

```
TypeError: Cannot read properties of null (reading 'document')
```

There was already an attempt at a guard for this:

```js
if (exportDocument === undefined) {
    console.debug("Could not create export window");
    return;
}
```

but it's dead code: it checks the wrong variable (`exportDocument`, which is a derived property of the thing that's actually `null`) against the wrong falsy value (`undefined` instead of `null`), and the check runs one statement *after* the line that already threw. In practice the guard could never fire before the crash happened.

**Why it matters:** any user with popup blocking enabled (the browser default in most cases, and standard in locked-down school/classroom Chromebook profiles that Music Blocks is commonly deployed on) hits an uncaught exception the moment they try to export their Music Matrix, with no explanation and no way to recover short of reloading.

## Related Issue

This PR fixes #7082

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

**`js/widgets/phrasemaker.js`** — `_export()`:
- Moved the null-check to immediately after `window.open("")`, before any property is read off the result
- Check the actual returned value (`if (!exportWindow)`) instead of a property already derived from it
- Removed the old `exportDocument === undefined` check — it's unreachable/redundant once `exportWindow` is confirmed truthy (a real `Window` object always has a `.document`)
- Added a user-facing warning via `this.activity.errorMsg(...)` when the popup is blocked, so the user gets told *why* the export didn't happen instead of it failing silently (previously it only logged to `console.debug`, invisible to anyone but a developer with devtools open)
- The warning string is routed through `this._(...)` for i18n, matching every other user-facing string already in this widget (`this._("Play")`, `this._("Export")`, etc. — see line 84 where `this._` is bound from the injected `deps._`)
- `this.activity.errorMsg` is the established notification pattern already used elsewhere in this same file (passed as a callback at lines 773/785) and across other widgets (`reflection.js`, `legobricks.js`) — no new utility introduced, just reusing what's already there

Before:
```js
_export() {
    const exportWindow = window.open("");
    const exportDocument = exportWindow.document;
    if (exportDocument === undefined) {
        console.debug("Could not create export window");
        return;
    }
    // ...
```

After:
```js
_export() {
    const exportWindow = window.open("");
    if (!exportWindow) {
        console.debug("Could not create export window");
        this.activity.errorMsg(
            this._("Could not open export window. Please allow pop-ups for this site.")
        );
        return;
    }
    const exportDocument = exportWindow.document;
    // ...
```

Nothing else in the 188-line method was touched — the table/row/cell generation and download-link logic downstream of the guard is unrelated to this bug and works correctly once the guard fires (or doesn't) at the right time.

**`js/widgets/__tests__/phrasemaker.test.js`** — new `describe("_export", ...)` block (this method had no prior test coverage):
- **Blocked popup**: stubs `window.open` to return `null`, asserts `_export()` does not throw and that `activity.errorMsg` is called exactly once with a message mentioning the export window
- **Successful popup**: stubs `window.open` to return a mock window/document, asserts `_export()` runs to completion (including building the table and closing the document) without ever calling `errorMsg`

## Reproduction (before the fix)

1. Open Music Blocks in a browser with popup blocking enabled (default in most browsers for programmatic `window.open` calls not tied to a direct user gesture, and standard on locked-down classroom Chromebook profiles)
2. Open the PhraseMaker (Music Matrix) widget
3. Trigger the Music Matrix export action
4. Observe: uncaught `TypeError` in the console, export silently fails, no feedback to the user

After the fix, step 4 instead shows a visible warning message telling the user to allow pop-ups, and the app continues to function normally.

## Testing Performed

- `npx jest js/widgets/__tests__/phrasemaker.test.js` — 71/71 pass (69 pre-existing + 2 new)
- `npx jest` (full repo suite) — 6077/6077 pass, zero regressions
- `npx eslint js/widgets/phrasemaker.js js/widgets/__tests__/phrasemaker.test.js` — clean, zero warnings/errors
- Manually traced the fixed code path against the issue's exact reproduction steps and confirmed the guard now fires before any dereference, matching the failure mode described in the issue

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `pnpm run lint` and `pnpm exec prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Kept this surgical and single-topic per the contribution guidelines — only the guard clause and the new warning call changed, no drive-by refactoring of the rest of `_export()` or adjacent methods. `window.open()` isn't used anywhere else in the codebase, so there was no existing null-check convention to match; the `errorMsg`/`this._()` pattern chosen here is the one already used consistently throughout this file and the wider widget codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved export handling when a browser pop-up blocker prevents the export window from opening.
  - Displays a clear error message instead of failing unexpectedly.
  - Preserves successful exports and closes the export document correctly after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->