### PR TITLE
fix: use justLoadStart instead of removed _loadStart in newProject

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -31,7 +31,7 @@ const mockActivity = {
     prepSearchWidget: jest.fn(),
     sendAllToTrash: jest.fn(),
     refreshCanvas: jest.fn(),
-    _loadStart: jest.fn(),
+    justLoadStart: jest.fn(),
     doLoadAnimation: jest.fn(),
     textMsg: jest.fn(),
     errorMsg: jest.fn(),
@@ -147,14 +147,14 @@ describe("PlanetInterface", () => {
         expect(planetInterface.showMusicBlocks).toHaveBeenCalled();
     });
 
-    test("newProject calls closePlanet, initialiseNewProject, _loadStart, and saveLocally", () => {
+    test("newProject calls closePlanet, initialiseNewProject, justLoadStart, and saveLocally", () => {
         jest.spyOn(planetInterface, "closePlanet").mockImplementation(() => {});
         jest.spyOn(planetInterface, "initialiseNewProject").mockImplementation(() => {});
         jest.spyOn(planetInterface, "saveLocally").mockImplementation(() => {});
         planetInterface.newProject();
         expect(planetInterface.closePlanet).toHaveBeenCalled();
         expect(planetInterface.initialiseNewProject).toHaveBeenCalled();
-        expect(mockActivity._loadStart).toHaveBeenCalled();
+        expect(mockActivity.justLoadStart).toHaveBeenCalled();
         expect(planetInterface.saveLocally).toHaveBeenCalled();
     });
     test("onConverterLoad sets window.Converter", () => {

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -195,7 +195,7 @@ class PlanetInterface {
         this.newProject = () => {
             this.closePlanet();
             this.initialiseNewProject();
-            this.activity._loadStart();
+            this.activity.justLoadStart();
             this.saveLocally();
         };
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
When creating a new project from the Planet interface, clicking the "+" (New Project) button throws a runtime `TypeError` in the browser console, and the newly created project is never saved locally.

## Root Cause
In `js/planetInterface.js`, `newProject()` calls `this.activity._loadStart()`. This method no longer exists on the public `Activity` API , it was made a **private** closure function inside `activity.js` during the refactor in [#2943](https://github.com/sugarlabs/musicblocks/pull/2943), and a new **public** method `justLoadStart()` was added in its place to serve the same purpose. `planetInterface.js` was never updated to match, so `this.activity._loadStart` is `undefined`, causing:TypeError: this.activity._loadStart is not a function
at PlanetInterface.newProject (planetInterface.js:198:27)
Because the throw happens before `this.saveLocally()` runs, newly created projects were also silently never saved locally. This went undetected in tests because the test's `mockActivity` object included a fake `_loadStart: jest.fn()` that doesn't exist on the real `Activity` class.

## Fix
In `js/planetInterface.js`, inside `newProject()`, replace the call to the nonexistent `this.activity._loadStart()` with `this.activity.justLoadStart()`. the real public method that loads the default blocks for a fresh project.
Also updated `js/__tests__/planetInterface.test.js` so `mockActivity` matches the real `Activity` public API, and the `newProject` test now asserts against `justLoadStart` instead of the nonexistent `_loadStart`.

## Testing
1. Reproduced the bug locally on `127.0.0.1:3000` — confirmed `TypeError: this.activity._loadStart is not a function` on clicking "+"
2. Applied fix. clicked Planet → "+" → new project loads with default starter blocks, no console errors
3. Updated `js/__tests__/planetInterface.test.js` to reflect the real `Activity` API
4. All tests in `planetInterface.test.js` pass (34/34)

Fixes #6185