### PR TITLE
style: fix prettier formatting for SugarAnimation.js

### DIFF
--- a/activity/SugarAnimation.js
+++ b/activity/SugarAnimation.js
@@ -1,5 +1,4 @@
 (function (lib, img, cjs) {
-
     var p; // shortcut to reference prototypes
 
     // library properties:
@@ -11,2322 +10,4900 @@
         manifest: []
     };
 
-
-
     // symbols:
 
-
-
-    (lib.rect4276 = function() {
+    (lib.rect4276 = function () {
         this.initialize();
 
         // Layer 1
         this.shape = new cjs.Shape();
-        this.shape.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape.setTransform(731.5,127.5);
+        this.shape.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape.setTransform(731.5, 127.5);
 
         this.shape_1 = new cjs.Shape();
         this.shape_1.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_1.setTransform(731.5,127.5);
+        this.shape_1.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_1,this.shape);
+        this.addChild(this.shape_1, this.shape);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0 = function() {
+    (lib.ClipGroup_0 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask = new cjs.Shape();
         mask._off = true;
         mask.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask.setTransform(692.1,132.2);
+        mask.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape = new cjs.Shape();
-        this.shape.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape.setTransform(693.6,123.7);
+        this.shape.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape.setTransform(693.6, 123.7);
 
         this.shape_1 = new cjs.Shape();
-        this.shape_1.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_1.setTransform(695.1,155.3);
+        this.shape_1.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_1.setTransform(695.1, 155.3);
 
         this.shape_2 = new cjs.Shape();
-        this.shape_2.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_2.setTransform(693.1,92.3);
+        this.shape_2.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_2.setTransform(693.1, 92.3);
 
         this.shape_3 = new cjs.Shape();
-        this.shape_3.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_3.setTransform(692.9,60.2);
+        this.shape_3.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_3.setTransform(692.9, 60.2);
 
         this.shape_4 = new cjs.Shape();
-        this.shape_4.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_4.setTransform(692.6,27.5);
+        this.shape_4.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_4.setTransform(692.6, 27.5);
 
-        this.shape.mask = this.shape_1.mask = this.shape_2.mask = this.shape_3.mask = this.shape_4.mask = mask;
+        this.shape.mask =
+            this.shape_1.mask =
+            this.shape_2.mask =
+            this.shape_3.mask =
+            this.shape_4.mask =
+                mask;
 
-        this.addChild(this.shape_4,this.shape_3,this.shape_2,this.shape_1,this.shape);
+        this.addChild(this.shape_4, this.shape_3, this.shape_2, this.shape_1, this.shape);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup = function() {
+    (lib.ClipGroup = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask = new cjs.Shape();
         mask._off = true;
         mask.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask.setTransform(950,718);
+        mask.setTransform(950, 718);
 
         // Layer 3
         this.shape = new cjs.Shape();
-        this.shape.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape.setTransform(952,924);
+        this.shape.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape.setTransform(952, 924);
 
         this.shape.mask = mask;
 
         this.addChild(this.shape);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_1 = function() {
+    (lib.rect4276_1 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_2 = new cjs.Shape();
-        this.shape_2.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_2.setTransform(731.5,127.5);
+        this.shape_2.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_2.setTransform(731.5, 127.5);
 
         this.shape_3 = new cjs.Shape();
         this.shape_3.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_3.setTransform(731.5,127.5);
+        this.shape_3.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_3,this.shape_2);
+        this.addChild(this.shape_3, this.shape_2);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_1 = function() {
+    (lib.ClipGroup_0_1 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_1 = new cjs.Shape();
         mask_1._off = true;
         mask_1.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_1.setTransform(692.1,132.2);
+        mask_1.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_5 = new cjs.Shape();
-        this.shape_5.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_5.setTransform(693.6,123.7);
+        this.shape_5.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_5.setTransform(693.6, 123.7);
 
         this.shape_6 = new cjs.Shape();
-        this.shape_6.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_6.setTransform(695.1,155.3);
+        this.shape_6.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_6.setTransform(695.1, 155.3);
 
         this.shape_7 = new cjs.Shape();
-        this.shape_7.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_7.setTransform(693.1,92.3);
+        this.shape_7.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_7.setTransform(693.1, 92.3);
 
         this.shape_8 = new cjs.Shape();
-        this.shape_8.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_8.setTransform(692.9,60.2);
+        this.shape_8.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_8.setTransform(692.9, 60.2);
 
         this.shape_9 = new cjs.Shape();
-        this.shape_9.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_9.setTransform(692.6,27.5);
+        this.shape_9.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_9.setTransform(692.6, 27.5);
 
-        this.shape_5.mask = this.shape_6.mask = this.shape_7.mask = this.shape_8.mask = this.shape_9.mask = mask_1;
+        this.shape_5.mask =
+            this.shape_6.mask =
+            this.shape_7.mask =
+            this.shape_8.mask =
+            this.shape_9.mask =
+                mask_1;
 
-        this.addChild(this.shape_9,this.shape_8,this.shape_7,this.shape_6,this.shape_5);
+        this.addChild(this.shape_9, this.shape_8, this.shape_7, this.shape_6, this.shape_5);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_1 = function() {
+    (lib.ClipGroup_1 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_1 = new cjs.Shape();
         mask_1._off = true;
         mask_1.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_1.setTransform(950,718);
+        mask_1.setTransform(950, 718);
 
         // Layer 3
         this.shape_1 = new cjs.Shape();
-        this.shape_1.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_1.setTransform(952,924);
+        this.shape_1.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_1.setTransform(952, 924);
 
         this.shape_1.mask = mask_1;
 
         this.addChild(this.shape_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_2 = function() {
+    (lib.rect4276_2 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_4 = new cjs.Shape();
-        this.shape_4.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_4.setTransform(731.5,127.5);
+        this.shape_4.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_4.setTransform(731.5, 127.5);
 
         this.shape_5 = new cjs.Shape();
         this.shape_5.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_5.setTransform(731.5,127.5);
+        this.shape_5.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_5,this.shape_4);
+        this.addChild(this.shape_5, this.shape_4);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_2 = function() {
+    (lib.ClipGroup_0_2 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_2 = new cjs.Shape();
         mask_2._off = true;
         mask_2.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_2.setTransform(692.1,132.2);
+        mask_2.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_10 = new cjs.Shape();
-        this.shape_10.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_10.setTransform(693.6,123.7);
+        this.shape_10.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_10.setTransform(693.6, 123.7);
 
         this.shape_11 = new cjs.Shape();
-        this.shape_11.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_11.setTransform(695.1,155.3);
+        this.shape_11.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_11.setTransform(695.1, 155.3);
 
         this.shape_12 = new cjs.Shape();
-        this.shape_12.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_12.setTransform(693.1,92.3);
+        this.shape_12.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_12.setTransform(693.1, 92.3);
 
         this.shape_13 = new cjs.Shape();
-        this.shape_13.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_13.setTransform(692.9,60.2);
+        this.shape_13.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_13.setTransform(692.9, 60.2);
 
         this.shape_14 = new cjs.Shape();
-        this.shape_14.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_14.setTransform(692.6,27.5);
+        this.shape_14.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_14.setTransform(692.6, 27.5);
 
-        this.shape_10.mask = this.shape_11.mask = this.shape_12.mask = this.shape_13.mask = this.shape_14.mask = mask_2;
+        this.shape_10.mask =
+            this.shape_11.mask =
+            this.shape_12.mask =
+            this.shape_13.mask =
+            this.shape_14.mask =
+                mask_2;
 
-        this.addChild(this.shape_14,this.shape_13,this.shape_12,this.shape_11,this.shape_10);
+        this.addChild(this.shape_14, this.shape_13, this.shape_12, this.shape_11, this.shape_10);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_2 = function() {
+    (lib.ClipGroup_2 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_2 = new cjs.Shape();
         mask_2._off = true;
         mask_2.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_2.setTransform(950,718);
+        mask_2.setTransform(950, 718);
 
         // Layer 3
         this.shape_2 = new cjs.Shape();
-        this.shape_2.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_2.setTransform(952,924);
+        this.shape_2.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_2.setTransform(952, 924);
 
         this.shape_2.mask = mask_2;
 
         this.addChild(this.shape_2);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_3 = function() {
+    (lib.rect4276_3 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_6 = new cjs.Shape();
-        this.shape_6.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_6.setTransform(731.5,127.5);
+        this.shape_6.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_6.setTransform(731.5, 127.5);
 
         this.shape_7 = new cjs.Shape();
         this.shape_7.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_7.setTransform(731.5,127.5);
+        this.shape_7.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_7,this.shape_6);
+        this.addChild(this.shape_7, this.shape_6);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_3 = function() {
+    (lib.ClipGroup_0_3 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_3 = new cjs.Shape();
         mask_3._off = true;
         mask_3.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_3.setTransform(692.1,132.2);
+        mask_3.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_15 = new cjs.Shape();
-        this.shape_15.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_15.setTransform(693.6,123.7);
+        this.shape_15.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_15.setTransform(693.6, 123.7);
 
         this.shape_16 = new cjs.Shape();
-        this.shape_16.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_16.setTransform(695.1,155.3);
+        this.shape_16.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_16.setTransform(695.1, 155.3);
 
         this.shape_17 = new cjs.Shape();
-        this.shape_17.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_17.setTransform(693.1,92.3);
+        this.shape_17.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_17.setTransform(693.1, 92.3);
 
         this.shape_18 = new cjs.Shape();
-        this.shape_18.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_18.setTransform(692.9,60.2);
+        this.shape_18.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_18.setTransform(692.9, 60.2);
 
         this.shape_19 = new cjs.Shape();
-        this.shape_19.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_19.setTransform(692.6,27.5);
+        this.shape_19.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_19.setTransform(692.6, 27.5);
 
-        this.shape_15.mask = this.shape_16.mask = this.shape_17.mask = this.shape_18.mask = this.shape_19.mask = mask_3;
+        this.shape_15.mask =
+            this.shape_16.mask =
+            this.shape_17.mask =
+            this.shape_18.mask =
+            this.shape_19.mask =
+                mask_3;
 
-        this.addChild(this.shape_19,this.shape_18,this.shape_17,this.shape_16,this.shape_15);
+        this.addChild(this.shape_19, this.shape_18, this.shape_17, this.shape_16, this.shape_15);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_3 = function() {
+    (lib.ClipGroup_3 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_3 = new cjs.Shape();
         mask_3._off = true;
         mask_3.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_3.setTransform(950,718);
+        mask_3.setTransform(950, 718);
 
         // Layer 3
         this.shape_3 = new cjs.Shape();
-        this.shape_3.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_3.setTransform(952,924);
+        this.shape_3.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_3.setTransform(952, 924);
 
         this.shape_3.mask = mask_3;
 
         this.addChild(this.shape_3);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_4 = function() {
+    (lib.rect4276_4 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_8 = new cjs.Shape();
-        this.shape_8.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_8.setTransform(731.5,127.5);
+        this.shape_8.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_8.setTransform(731.5, 127.5);
 
         this.shape_9 = new cjs.Shape();
         this.shape_9.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_9.setTransform(731.5,127.5);
+        this.shape_9.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_9,this.shape_8);
+        this.addChild(this.shape_9, this.shape_8);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_4 = function() {
+    (lib.ClipGroup_0_4 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_4 = new cjs.Shape();
         mask_4._off = true;
         mask_4.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_4.setTransform(692.1,132.2);
+        mask_4.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_20 = new cjs.Shape();
-        this.shape_20.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_20.setTransform(693.6,123.7);
+        this.shape_20.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_20.setTransform(693.6, 123.7);
 
         this.shape_21 = new cjs.Shape();
-        this.shape_21.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_21.setTransform(695.1,155.3);
+        this.shape_21.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_21.setTransform(695.1, 155.3);
 
         this.shape_22 = new cjs.Shape();
-        this.shape_22.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_22.setTransform(693.1,92.3);
+        this.shape_22.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_22.setTransform(693.1, 92.3);
 
         this.shape_23 = new cjs.Shape();
-        this.shape_23.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_23.setTransform(692.9,60.2);
+        this.shape_23.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_23.setTransform(692.9, 60.2);
 
         this.shape_24 = new cjs.Shape();
-        this.shape_24.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_24.setTransform(692.6,27.5);
+        this.shape_24.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_24.setTransform(692.6, 27.5);
 
-        this.shape_20.mask = this.shape_21.mask = this.shape_22.mask = this.shape_23.mask = this.shape_24.mask = mask_4;
+        this.shape_20.mask =
+            this.shape_21.mask =
+            this.shape_22.mask =
+            this.shape_23.mask =
+            this.shape_24.mask =
+                mask_4;
 
-        this.addChild(this.shape_24,this.shape_23,this.shape_22,this.shape_21,this.shape_20);
+        this.addChild(this.shape_24, this.shape_23, this.shape_22, this.shape_21, this.shape_20);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_4 = function() {
+    (lib.ClipGroup_4 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_4 = new cjs.Shape();
         mask_4._off = true;
         mask_4.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_4.setTransform(950,718);
+        mask_4.setTransform(950, 718);
 
         // Layer 3
         this.shape_4 = new cjs.Shape();
-        this.shape_4.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_4.setTransform(952,924);
+        this.shape_4.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_4.setTransform(952, 924);
 
         this.shape_4.mask = mask_4;
 
         this.addChild(this.shape_4);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_5 = function() {
+    (lib.rect4276_5 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_10 = new cjs.Shape();
-        this.shape_10.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_10.setTransform(731.5,127.5);
+        this.shape_10.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_10.setTransform(731.5, 127.5);
 
         this.shape_11 = new cjs.Shape();
         this.shape_11.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_11.setTransform(731.5,127.5);
+        this.shape_11.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_11,this.shape_10);
+        this.addChild(this.shape_11, this.shape_10);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_5 = function() {
+    (lib.ClipGroup_0_5 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_5 = new cjs.Shape();
         mask_5._off = true;
         mask_5.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_5.setTransform(692.1,132.2);
+        mask_5.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_25 = new cjs.Shape();
-        this.shape_25.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_25.setTransform(693.6,123.7);
+        this.shape_25.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_25.setTransform(693.6, 123.7);
 
         this.shape_26 = new cjs.Shape();
-        this.shape_26.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_26.setTransform(695.1,155.3);
+        this.shape_26.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_26.setTransform(695.1, 155.3);
 
         this.shape_27 = new cjs.Shape();
-        this.shape_27.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_27.setTransform(693.1,92.3);
+        this.shape_27.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_27.setTransform(693.1, 92.3);
 
         this.shape_28 = new cjs.Shape();
-        this.shape_28.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_28.setTransform(692.9,60.2);
+        this.shape_28.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_28.setTransform(692.9, 60.2);
 
         this.shape_29 = new cjs.Shape();
-        this.shape_29.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_29.setTransform(692.6,27.5);
+        this.shape_29.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_29.setTransform(692.6, 27.5);
 
-        this.shape_25.mask = this.shape_26.mask = this.shape_27.mask = this.shape_28.mask = this.shape_29.mask = mask_5;
+        this.shape_25.mask =
+            this.shape_26.mask =
+            this.shape_27.mask =
+            this.shape_28.mask =
+            this.shape_29.mask =
+                mask_5;
 
-        this.addChild(this.shape_29,this.shape_28,this.shape_27,this.shape_26,this.shape_25);
+        this.addChild(this.shape_29, this.shape_28, this.shape_27, this.shape_26, this.shape_25);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_5 = function() {
+    (lib.ClipGroup_5 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_5 = new cjs.Shape();
         mask_5._off = true;
         mask_5.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_5.setTransform(950,718);
+        mask_5.setTransform(950, 718);
 
         // Layer 3
         this.shape_5 = new cjs.Shape();
-        this.shape_5.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_5.setTransform(952,924);
+        this.shape_5.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_5.setTransform(952, 924);
 
         this.shape_5.mask = mask_5;
 
         this.addChild(this.shape_5);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_6 = function() {
+    (lib.rect4276_6 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_12 = new cjs.Shape();
-        this.shape_12.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_12.setTransform(731.5,127.5);
+        this.shape_12.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_12.setTransform(731.5, 127.5);
 
         this.shape_13 = new cjs.Shape();
         this.shape_13.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_13.setTransform(731.5,127.5);
+        this.shape_13.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_13,this.shape_12);
+        this.addChild(this.shape_13, this.shape_12);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_6 = function() {
+    (lib.ClipGroup_0_6 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_6 = new cjs.Shape();
         mask_6._off = true;
         mask_6.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_6.setTransform(692.1,132.2);
+        mask_6.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_30 = new cjs.Shape();
-        this.shape_30.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_30.setTransform(693.6,123.7);
+        this.shape_30.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_30.setTransform(693.6, 123.7);
 
         this.shape_31 = new cjs.Shape();
-        this.shape_31.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_31.setTransform(695.1,155.3);
+        this.shape_31.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_31.setTransform(695.1, 155.3);
 
         this.shape_32 = new cjs.Shape();
-        this.shape_32.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_32.setTransform(693.1,92.3);
+        this.shape_32.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_32.setTransform(693.1, 92.3);
 
         this.shape_33 = new cjs.Shape();
-        this.shape_33.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_33.setTransform(692.9,60.2);
+        this.shape_33.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_33.setTransform(692.9, 60.2);
 
         this.shape_34 = new cjs.Shape();
-        this.shape_34.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_34.setTransform(692.6,27.5);
+        this.shape_34.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_34.setTransform(692.6, 27.5);
 
-        this.shape_30.mask = this.shape_31.mask = this.shape_32.mask = this.shape_33.mask = this.shape_34.mask = mask_6;
+        this.shape_30.mask =
+            this.shape_31.mask =
+            this.shape_32.mask =
+            this.shape_33.mask =
+            this.shape_34.mask =
+                mask_6;
 
-        this.addChild(this.shape_34,this.shape_33,this.shape_32,this.shape_31,this.shape_30);
+        this.addChild(this.shape_34, this.shape_33, this.shape_32, this.shape_31, this.shape_30);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_6 = function() {
+    (lib.ClipGroup_6 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_6 = new cjs.Shape();
         mask_6._off = true;
         mask_6.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_6.setTransform(950,718);
+        mask_6.setTransform(950, 718);
 
         // Layer 3
         this.shape_6 = new cjs.Shape();
-        this.shape_6.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_6.setTransform(952,924);
+        this.shape_6.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_6.setTransform(952, 924);
 
         this.shape_6.mask = mask_6;
 
         this.addChild(this.shape_6);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_7 = function() {
+    (lib.rect4276_7 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_14 = new cjs.Shape();
-        this.shape_14.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_14.setTransform(731.5,127.5);
+        this.shape_14.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_14.setTransform(731.5, 127.5);
 
         this.shape_15 = new cjs.Shape();
         this.shape_15.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_15.setTransform(731.5,127.5);
+        this.shape_15.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_15,this.shape_14);
+        this.addChild(this.shape_15, this.shape_14);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_7 = function() {
+    (lib.ClipGroup_0_7 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_7 = new cjs.Shape();
         mask_7._off = true;
         mask_7.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_7.setTransform(692.1,132.2);
+        mask_7.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_35 = new cjs.Shape();
-        this.shape_35.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_35.setTransform(693.6,123.7);
+        this.shape_35.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_35.setTransform(693.6, 123.7);
 
         this.shape_36 = new cjs.Shape();
-        this.shape_36.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_36.setTransform(695.1,155.3);
+        this.shape_36.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_36.setTransform(695.1, 155.3);
 
         this.shape_37 = new cjs.Shape();
-        this.shape_37.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_37.setTransform(693.1,92.3);
+        this.shape_37.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_37.setTransform(693.1, 92.3);
 
         this.shape_38 = new cjs.Shape();
-        this.shape_38.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_38.setTransform(692.9,60.2);
+        this.shape_38.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_38.setTransform(692.9, 60.2);
 
         this.shape_39 = new cjs.Shape();
-        this.shape_39.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_39.setTransform(692.6,27.5);
+        this.shape_39.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_39.setTransform(692.6, 27.5);
 
-        this.shape_35.mask = this.shape_36.mask = this.shape_37.mask = this.shape_38.mask = this.shape_39.mask = mask_7;
+        this.shape_35.mask =
+            this.shape_36.mask =
+            this.shape_37.mask =
+            this.shape_38.mask =
+            this.shape_39.mask =
+                mask_7;
 
-        this.addChild(this.shape_39,this.shape_38,this.shape_37,this.shape_36,this.shape_35);
+        this.addChild(this.shape_39, this.shape_38, this.shape_37, this.shape_36, this.shape_35);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_7 = function() {
+    (lib.ClipGroup_7 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_7 = new cjs.Shape();
         mask_7._off = true;
         mask_7.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_7.setTransform(950,718);
+        mask_7.setTransform(950, 718);
 
         // Layer 3
         this.shape_7 = new cjs.Shape();
-        this.shape_7.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_7.setTransform(952,924);
+        this.shape_7.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_7.setTransform(952, 924);
 
         this.shape_7.mask = mask_7;
 
         this.addChild(this.shape_7);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_8 = function() {
+    (lib.rect4276_8 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_16 = new cjs.Shape();
-        this.shape_16.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_16.setTransform(731.5,127.5);
+        this.shape_16.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_16.setTransform(731.5, 127.5);
 
         this.shape_17 = new cjs.Shape();
         this.shape_17.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_17.setTransform(731.5,127.5);
+        this.shape_17.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_17,this.shape_16);
+        this.addChild(this.shape_17, this.shape_16);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_8 = function() {
+    (lib.ClipGroup_0_8 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_8 = new cjs.Shape();
         mask_8._off = true;
         mask_8.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_8.setTransform(692.1,132.2);
+        mask_8.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_40 = new cjs.Shape();
-        this.shape_40.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_40.setTransform(693.6,123.7);
+        this.shape_40.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_40.setTransform(693.6, 123.7);
 
         this.shape_41 = new cjs.Shape();
-        this.shape_41.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_41.setTransform(695.1,155.3);
+        this.shape_41.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_41.setTransform(695.1, 155.3);
 
         this.shape_42 = new cjs.Shape();
-        this.shape_42.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_42.setTransform(693.1,92.3);
+        this.shape_42.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_42.setTransform(693.1, 92.3);
 
         this.shape_43 = new cjs.Shape();
-        this.shape_43.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_43.setTransform(692.9,60.2);
+        this.shape_43.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_43.setTransform(692.9, 60.2);
 
         this.shape_44 = new cjs.Shape();
-        this.shape_44.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_44.setTransform(692.6,27.5);
+        this.shape_44.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_44.setTransform(692.6, 27.5);
 
-        this.shape_40.mask = this.shape_41.mask = this.shape_42.mask = this.shape_43.mask = this.shape_44.mask = mask_8;
+        this.shape_40.mask =
+            this.shape_41.mask =
+            this.shape_42.mask =
+            this.shape_43.mask =
+            this.shape_44.mask =
+                mask_8;
 
-        this.addChild(this.shape_44,this.shape_43,this.shape_42,this.shape_41,this.shape_40);
+        this.addChild(this.shape_44, this.shape_43, this.shape_42, this.shape_41, this.shape_40);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_8 = function() {
+    (lib.ClipGroup_8 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_8 = new cjs.Shape();
         mask_8._off = true;
         mask_8.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_8.setTransform(950,718);
+        mask_8.setTransform(950, 718);
 
         // Layer 3
         this.shape_8 = new cjs.Shape();
-        this.shape_8.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_8.setTransform(952,924);
+        this.shape_8.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_8.setTransform(952, 924);
 
         this.shape_8.mask = mask_8;
 
         this.addChild(this.shape_8);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_9 = function() {
+    (lib.rect4276_9 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_18 = new cjs.Shape();
-        this.shape_18.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_18.setTransform(731.5,127.5);
+        this.shape_18.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_18.setTransform(731.5, 127.5);
 
         this.shape_19 = new cjs.Shape();
         this.shape_19.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_19.setTransform(731.5,127.5);
+        this.shape_19.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_19,this.shape_18);
+        this.addChild(this.shape_19, this.shape_18);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_9 = function() {
+    (lib.ClipGroup_0_9 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_9 = new cjs.Shape();
         mask_9._off = true;
         mask_9.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_9.setTransform(692.1,132.2);
+        mask_9.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_45 = new cjs.Shape();
-        this.shape_45.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_45.setTransform(693.6,123.7);
+        this.shape_45.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_45.setTransform(693.6, 123.7);
 
         this.shape_46 = new cjs.Shape();
-        this.shape_46.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_46.setTransform(695.1,155.3);
+        this.shape_46.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_46.setTransform(695.1, 155.3);
 
         this.shape_47 = new cjs.Shape();
-        this.shape_47.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_47.setTransform(693.1,92.3);
+        this.shape_47.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_47.setTransform(693.1, 92.3);
 
         this.shape_48 = new cjs.Shape();
-        this.shape_48.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_48.setTransform(692.9,60.2);
+        this.shape_48.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_48.setTransform(692.9, 60.2);
 
         this.shape_49 = new cjs.Shape();
-        this.shape_49.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_49.setTransform(692.6,27.5);
+        this.shape_49.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_49.setTransform(692.6, 27.5);
 
-        this.shape_45.mask = this.shape_46.mask = this.shape_47.mask = this.shape_48.mask = this.shape_49.mask = mask_9;
+        this.shape_45.mask =
+            this.shape_46.mask =
+            this.shape_47.mask =
+            this.shape_48.mask =
+            this.shape_49.mask =
+                mask_9;
 
-        this.addChild(this.shape_49,this.shape_48,this.shape_47,this.shape_46,this.shape_45);
+        this.addChild(this.shape_49, this.shape_48, this.shape_47, this.shape_46, this.shape_45);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_9 = function() {
+    (lib.ClipGroup_9 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_9 = new cjs.Shape();
         mask_9._off = true;
         mask_9.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_9.setTransform(950,718);
+        mask_9.setTransform(950, 718);
 
         // Layer 3
         this.shape_9 = new cjs.Shape();
-        this.shape_9.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_9.setTransform(952,924);
+        this.shape_9.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_9.setTransform(952, 924);
 
         this.shape_9.mask = mask_9;
 
         this.addChild(this.shape_9);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.rect4276_10 = function() {
+    (lib.rect4276_10 = function () {
         this.initialize();
 
         // Layer 1
         this.shape_20 = new cjs.Shape();
-        this.shape_20.graphics.f().s("#505050").ss(14.4,1,1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
-        this.shape_20.setTransform(731.5,127.5);
+        this.shape_20.graphics.f().s("#505050").ss(14.4, 1, 1).p("EhxKgSyMDiVAAAMAAAAllMjiVAAAg");
+        this.shape_20.setTransform(731.5, 127.5);
 
         this.shape_21 = new cjs.Shape();
         this.shape_21.graphics.f("#899BB0").s().p("EhxKASzMAAAgllMDiVAAAMAAAAllg");
-        this.shape_21.setTransform(731.5,127.5);
+        this.shape_21.setTransform(731.5, 127.5);
 
-        this.addChild(this.shape_21,this.shape_20);
+        this.addChild(this.shape_21, this.shape_20);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(0.1,0.1,1463,255);
+    p.nominalBounds = new cjs.Rectangle(0.1, 0.1, 1463, 255);
 
-
-    (lib.ClipGroup_0_10 = function() {
+    (lib.ClipGroup_0_10 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_10 = new cjs.Shape();
         mask_10._off = true;
         mask_10.graphics.p("EhrvAUqMAAAgpTMDXfAAAMAAAApTg");
-        mask_10.setTransform(692.1,132.2);
+        mask_10.setTransform(692.1, 132.2);
 
         // Layer 3
         this.shape_50 = new cjs.Shape();
-        this.shape_50.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_50.setTransform(693.6,123.7);
+        this.shape_50.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_50.setTransform(693.6, 123.7);
 
         this.shape_51 = new cjs.Shape();
-        this.shape_51.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_51.setTransform(695.1,155.3);
+        this.shape_51.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_51.setTransform(695.1, 155.3);
 
         this.shape_52 = new cjs.Shape();
-        this.shape_52.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_52.setTransform(693.1,92.3);
+        this.shape_52.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_52.setTransform(693.1, 92.3);
 
         this.shape_53 = new cjs.Shape();
-        this.shape_53.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsNgANMDYbAAb");
-        this.shape_53.setTransform(692.9,60.2);
+        this.shape_53.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsNgANMDYbAAb");
+        this.shape_53.setTransform(692.9, 60.2);
 
         this.shape_54 = new cjs.Shape();
-        this.shape_54.graphics.f().s("#516B82").ss(5,0,0,4).p("EhsMgANMDYZAAb");
-        this.shape_54.setTransform(692.6,27.5);
+        this.shape_54.graphics.f().s("#516B82").ss(5, 0, 0, 4).p("EhsMgANMDYZAAb");
+        this.shape_54.setTransform(692.6, 27.5);
 
-        this.shape_50.mask = this.shape_51.mask = this.shape_52.mask = this.shape_53.mask = this.shape_54.mask = mask_10;
+        this.shape_50.mask =
+            this.shape_51.mask =
+            this.shape_52.mask =
+            this.shape_53.mask =
+            this.shape_54.mask =
+                mask_10;
 
-        this.addChild(this.shape_54,this.shape_53,this.shape_52,this.shape_51,this.shape_50);
+        this.addChild(this.shape_54, this.shape_53, this.shape_52, this.shape_51, this.shape_50);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(2.5,23.6,1379.3,135.7);
+    p.nominalBounds = new cjs.Rectangle(2.5, 23.6, 1379.3, 135.7);
 
-
-    (lib.ClipGroup_10 = function() {
+    (lib.ClipGroup_10 = function () {
         this.initialize();
 
         // Layer 2 (mask)
         var mask_10 = new cjs.Shape();
         mask_10._off = true;
         mask_10.graphics.p("EiUaBwMMAAAjgXMEo1AAAMAAADgXg");
-        mask_10.setTransform(950,718);
+        mask_10.setTransform(950, 718);
 
         // Layer 3
         this.shape_10 = new cjs.Shape();
-        this.shape_10.graphics.f("#A3B5C4").s().p("EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg");
-        this.shape_10.setTransform(952,924);
+        this.shape_10.graphics
+            .f("#A3B5C4")
+            .s()
+            .p(
+                "EgteBukQ0/pHwKwnQwMwno41iQpL2TgB4aQAB4ZJL2TQI41iQMwnQQKwnU/pHQVtpbXxAAQXxAAVuJbQU/JHQLQnQQLQnI4ViQJLWTAAYZQAAYapLWTQo4ViwLQnQwLQn0/JHQ1uJb3xAAQ3xAA1tpbg"
+            );
+        this.shape_10.setTransform(952, 924);
 
         this.shape_10.mask = mask_10;
 
         this.addChild(this.shape_10);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(204,156,1496,1280);
+    p.nominalBounds = new cjs.Rectangle(204, 156, 1496, 1280);
 
-
-    (lib.text320427 = function() {
+    (lib.text320427 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("octave", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text320497 = function() {
+    (lib.text320497 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("octave", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.1);
+        this.text.setTransform(-2, -4.1);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.1,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.1, 141.7, 56.2);
 
-
-    (lib.text320480 = function() {
+    (lib.text320480 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("octave", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text320467 = function() {
+    (lib.text320467 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("octave", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text3200365 = function() {
+    (lib.text3200365 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("note", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text320064 = function() {
+    (lib.text320064 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("note", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text320038 = function() {
+    (lib.text320038 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("note", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text32002 = function() {
+    (lib.text32002 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("note", "47px 'Arial'");
         this.text.lineHeight = 56;
-        this.text.setTransform(-2,-4.2);
+        this.text.setTransform(-2, -4.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text319635 = function() {
+    (lib.text319635 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("pitch", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319691 = function() {
+    (lib.text319691 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("pitch", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319672 = function() {
+    (lib.text319672 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("pitch", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319667 = function() {
+    (lib.text319667 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("pitch", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text302942 = function() {
+    (lib.text302942 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("action", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,190.9,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 190.9, 82.1);
 
-
-    (lib.text23946 = function() {
+    (lib.text23946 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("do", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,82,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 82, 82.1);
 
-
-    (lib.text23961 = function() {
+    (lib.text23961 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("4", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23993 = function() {
+    (lib.text23993 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("4", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23947 = function() {
+    (lib.text23947 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("5", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23903 = function() {
+    (lib.text23903 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("4", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text236 = function() {
+    (lib.text236 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("sol", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,93.7,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 93.7, 82.1);
 
-
-    (lib.text2323 = function() {
+    (lib.text2323 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("chunk2", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,229.8,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 229.8, 82.1);
 
-
-    (lib.text2311 = function() {
+    (lib.text2311 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("la", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,58.7,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 58.7, 82.1);
 
-
-    (lib.text2301 = function() {
+    (lib.text2301 = function () {
         this.initialize();
 
         // Layer 1
         this.text = new cjs.Text("ti", "70px 'Arial'");
         this.text.lineHeight = 84;
-        this.text.setTransform(-2,-5.2);
+        this.text.setTransform(-2, -5.2);
 
         this.addChild(this.text);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,39.2,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 39.2, 82.1);
 
-
-    (lib.text320427_1 = function() {
+    (lib.text320427_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("octave", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text320497_1 = function() {
+    (lib.text320497_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("octave", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.1);
+        this.text_1.setTransform(-2, -4.1);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.1,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.1, 141.7, 56.2);
 
-
-    (lib.text320480_1 = function() {
+    (lib.text320480_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("octave", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text320467_1 = function() {
+    (lib.text320467_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("octave", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,141.7,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 141.7, 56.2);
 
-
-    (lib.text3200365_1 = function() {
+    (lib.text3200365_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("note", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text320064_1 = function() {
+    (lib.text320064_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("note", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text320038_1 = function() {
+    (lib.text320038_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("note", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text32002_1 = function() {
+    (lib.text32002_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("note", "47px 'Arial'");
         this.text_1.lineHeight = 56;
-        this.text_1.setTransform(-2,-4.2);
+        this.text_1.setTransform(-2, -4.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-4.2,95,56.2);
+    p.nominalBounds = new cjs.Rectangle(-2, -4.2, 95, 56.2);
 
-
-    (lib.text319635_1 = function() {
+    (lib.text319635_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("pitch", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319691_1 = function() {
+    (lib.text319691_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("pitch", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319672_1 = function() {
+    (lib.text319672_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("pitch", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text319667_1 = function() {
+    (lib.text319667_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("pitch", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,152,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 152, 82.1);
 
-
-    (lib.text302942_1 = function() {
+    (lib.text302942_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("action", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,190.9,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 190.9, 82.1);
 
-
-    (lib.text23946_1 = function() {
+    (lib.text23946_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("fa", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,62.6,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 62.6, 82.1);
 
-
-    (lib.text23961_1 = function() {
+    (lib.text23961_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("4", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23993_1 = function() {
+    (lib.text23993_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("4", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23947_1 = function() {
+    (lib.text23947_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("4", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text23903_1 = function() {
+    (lib.text23903_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("4", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,43.1,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 43.1, 82.1);
 
-
-    (lib.text236_1 = function() {
+    (lib.text236_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("do", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,82,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 82, 82.1);
 
-
-    (lib.text2323_1 = function() {
+    (lib.text2323_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("chunk1", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,229.8,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 229.8, 82.1);
 
-
-    (lib.text2311_1 = function() {
+    (lib.text2311_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("re", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,66.4,82.1);
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 66.4, 82.1);
 
-
-    (lib.text2301_1 = function() {
+    (lib.text2301_1 = function () {
         this.initialize();
 
         // Layer 1
         this.text_1 = new cjs.Text("mi", "70px 'Arial'");
         this.text_1.lineHeight = 84;
-        this.text_1.setTransform(-2,-5.2);
+        this.text_1.setTransform(-2, -5.2);
 
         this.addChild(this.text_1);
     }).prototype = p = new cjs.Container();
-    p.nominalBounds = new cjs.Rectangle(-2,-5.2,78,82.1);
-
+    p.nominalBounds = new cjs.Rectangle(-2, -5.2, 78, 82.1);
 
     // stage content:
-    (lib.SugarAnimation = function(mode,startPosition,loop) {
-        if (loop === null) { loop = false; } this.initialize(mode,startPosition,loop,{});
+    (lib.SugarAnimation = function (mode, startPosition, loop) {
+        if (loop === null) {
+            loop = false;
+        }
+        this.initialize(mode, startPosition, loop, {});
 
         // Blocks R
         this.instance = new lib.text23947();
-        this.instance.setTransform(3463.7,1361.1,1,1,0,0,0,19.6,35.8);
+        this.instance.setTransform(3463.7, 1361.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape = new cjs.Shape();
-        this.shape.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV1MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape.setTransform(3433.6,1367.8);
+        this.shape.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV1MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape.setTransform(3433.6, 1367.8);
 
         this.shape_1 = new cjs.Shape();
-        this.shape_1.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADSIGkAAIAAp1MBBlAAAIAAV1g");
-        this.shape_1.setTransform(3433.6,1367.8);
+        this.shape_1.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADSIGkAAIAAp1MBBlAAAIAAV1g");
+        this.shape_1.setTransform(3433.6, 1367.8);
 
         this.instance_1 = new lib.text23946();
-        this.instance_1.setTransform(3476.1,1214.1,1,1,0,0,0,39,35.8);
+        this.instance_1.setTransform(3476.1, 1214.1, 1, 1, 0, 0, 0, 39, 35.8);
 
         this.shape_2 = new cjs.Shape();
-        this.shape_2.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_2.setTransform(3433.6,1220.8);
+        this.shape_2.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_2.setTransform(3433.6, 1220.8);
 
         this.shape_3 = new cjs.Shape();
-        this.shape_3.graphics.f("#76C61C").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_3.setTransform(3433.6,1220.8);
+        this.shape_3.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_3.setTransform(3433.6, 1220.8);
 
         this.instance_2 = new lib.text320497();
-        this.instance_2.setTransform(3109.6,1370.9,1,1,0,0,0,68.9,23.9);
+        this.instance_2.setTransform(3109.6, 1370.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_3 = new lib.text3200365();
-        this.instance_3.setTransform(3132.8,1216.9,1,1,0,0,0,45.5,23.9);
+        this.instance_3.setTransform(3132.8, 1216.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_4 = new lib.text319691();
-        this.instance_4.setTransform(3104.3,1294.6,1,1,0,0,0,74,35.8);
+        this.instance_4.setTransform(3104.3, 1294.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_4 = new cjs.Shape();
-        this.shape_4.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ8MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_4.setTransform(3048.6,1301.3);
+        this.shape_4.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ8MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_4.setTransform(3048.6, 1301.3);
 
         this.shape_5 = new cjs.Shape();
-        this.shape_5.graphics.f("#76C61C").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK8AAIAAiMMAlJAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_5.setTransform(3048.6,1301.3);
+        this.shape_5.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK8AAIAAiMMAlJAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_5.setTransform(3048.6, 1301.3);
 
         this.instance_5 = new lib.text23993();
-        this.instance_5.setTransform(3463.7,1066.3,1,1,0,0,0,19.6,35.8);
+        this.instance_5.setTransform(3463.7, 1066.3, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_6 = new cjs.Shape();
-        this.shape_6.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape_6.setTransform(3433.6,1073);
+        this.shape_6.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape_6.setTransform(3433.6, 1073);
 
         this.shape_7 = new cjs.Shape();
-        this.shape_7.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAovICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_7.setTransform(3433.6,1073);
+        this.shape_7.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAovICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_7.setTransform(3433.6, 1073);
 
         this.instance_6 = new lib.text2301();
-        this.instance_6.setTransform(3454.7,919.3,1,1,0,0,0,17.6,35.8);
+        this.instance_6.setTransform(3454.7, 919.3, 1, 1, 0, 0, 0, 17.6, 35.8);
 
         this.shape_8 = new cjs.Shape();
-        this.shape_8.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_8.setTransform(3433.6,926);
+        this.shape_8.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_8.setTransform(3433.6, 926);
 
         this.shape_9 = new cjs.Shape();
-        this.shape_9.graphics.f("#76C61C").s().p("A8aK8IAAp2ImkAAIAADRIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV3g");
-        this.shape_9.setTransform(3433.6,926);
+        this.shape_9.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK8IAAp2ImkAAIAADRIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV3g");
+        this.shape_9.setTransform(3433.6, 926);
 
         this.instance_7 = new lib.text320480();
-        this.instance_7.setTransform(3109.6,1076.1,1,1,0,0,0,68.9,23.9);
+        this.instance_7.setTransform(3109.6, 1076.1, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_8 = new lib.text320064();
-        this.instance_8.setTransform(3132.8,922.1,1,1,0,0,0,45.5,23.9);
+        this.instance_8.setTransform(3132.8, 922.1, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_9 = new lib.text319667();
-        this.instance_9.setTransform(3104.3,999.8,1,1,0,0,0,74,35.8);
+        this.instance_9.setTransform(3104.3, 999.8, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_10 = new cjs.Shape();
-        this.shape_10.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_10.setTransform(3048.6,1006.5);
+        this.shape_10.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_10.setTransform(3048.6, 1006.5);
 
         this.shape_11 = new cjs.Shape();
-        this.shape_11.graphics.f("#76C61C").s().p("A0wXhIAAiNIleAAQh0AAhShSQhShRAAh1MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACNIK8AAIAAiNMAlJAAAQB0AABSBSQBSBSAAB0IAAEZIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASkIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACNg");
-        this.shape_11.setTransform(3048.6,1006.5);
+        this.shape_11.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXhIAAiNIleAAQh0AAhShSQhShRAAh1MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACNIK8AAIAAiNMAlJAAAQB0AABSBSQBSBSAAB0IAAEZIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASkIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACNg"
+            );
+        this.shape_11.setTransform(3048.6, 1006.5);
 
         this.instance_10 = new lib.text23903();
-        this.instance_10.setTransform(3463.7,773.1,1,1,0,0,0,19.6,35.8);
+        this.instance_10.setTransform(3463.7, 773.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_12 = new cjs.Shape();
-        this.shape_12.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_12.setTransform(3433.6,779.8);
+        this.shape_12.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_12.setTransform(3433.6, 779.8);
 
         this.shape_13 = new cjs.Shape();
-        this.shape_13.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_13.setTransform(3433.6,779.8);
+        this.shape_13.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_13.setTransform(3433.6, 779.8);
 
         this.instance_11 = new lib.text2311();
-        this.instance_11.setTransform(3464.4,626.1,1,1,0,0,0,27.3,35.8);
+        this.instance_11.setTransform(3464.4, 626.1, 1, 1, 0, 0, 0, 27.3, 35.8);
 
         this.shape_14 = new cjs.Shape();
-        this.shape_14.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_14.setTransform(3433.6,632.8);
+        this.shape_14.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_14.setTransform(3433.6, 632.8);
 
         this.shape_15 = new cjs.Shape();
-        this.shape_15.graphics.f("#76C61C").s().p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_15.setTransform(3433.6,632.8);
+        this.shape_15.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_15.setTransform(3433.6, 632.8);
 
         this.instance_12 = new lib.text320467();
-        this.instance_12.setTransform(3109.6,782.9,1,1,0,0,0,68.9,23.9);
+        this.instance_12.setTransform(3109.6, 782.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_13 = new lib.text320038();
-        this.instance_13.setTransform(3132.8,628.9,1,1,0,0,0,45.5,23.9);
+        this.instance_13.setTransform(3132.8, 628.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_14 = new lib.text319672();
-        this.instance_14.setTransform(3104.3,706.6,1,1,0,0,0,74,35.8);
+        this.instance_14.setTransform(3104.3, 706.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_16 = new cjs.Shape();
-        this.shape_16.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkFQAAhzBShSQBShTB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBTQBSBSAABzIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_16.setTransform(3048.6,713.3);
+        this.shape_16.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkFQAAhzBShSQBShTB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBTQBSBSAABzIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_16.setTransform(3048.6, 713.3);
 
         this.shape_17 = new cjs.Shape();
-        this.shape_17.graphics.f("#76C61C").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_17.setTransform(3048.6,713.3);
+        this.shape_17.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_17.setTransform(3048.6, 713.3);
 
         this.instance_15 = new lib.text2323();
-        this.instance_15.setTransform(3491.3,188.3,1,1,0,0,0,112.9,35.9);
+        this.instance_15.setTransform(3491.3, 188.3, 1, 1, 0, 0, 0, 112.9, 35.9);
 
         this.shape_18 = new cjs.Shape();
-        this.shape_18.graphics.f().s("#5AA4AF").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape_18.setTransform(3468.6,196.9);
+        this.shape_18.graphics
+            .f()
+            .s("#5AA4AF")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape_18.setTransform(3468.6, 196.9);
 
         this.shape_19 = new cjs.Shape();
-        this.shape_19.graphics.f("#5DC1BC").s().p("A8bK7IAAp2ImkAAIAADTIiLAAIAAovICLAAIAADTIGkAAIAAp2MBBnAAAIAAV1g");
-        this.shape_19.setTransform(3468.6,196.9);
+        this.shape_19.graphics
+            .f("#5DC1BC")
+            .s()
+            .p("A8bK7IAAp2ImkAAIAADTIiLAAIAAovICLAAIAADTIGkAAIAAp2MBBnAAAIAAV1g");
+        this.shape_19.setTransform(3468.6, 196.9);
 
         this.instance_16 = new lib.text302942();
-        this.instance_16.setTransform(2907.5,199.7,1,1,0,0,0,93.5,35.9);
+        this.instance_16.setTransform(2907.5, 199.7, 1, 1, 0, 0, 0, 93.5, 35.9);
 
         this.shape_20 = new cjs.Shape();
-        this.shape_20.graphics.f().s("#C48D00").ss(7,1,0,4).p("EgmQBtXMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkIlemkIkYAAQhuAAhVhVQhVhVAAhug");
-        this.shape_20.setTransform(3034.6,854.1);
+        this.shape_20.graphics
+            .f()
+            .s("#C48D00")
+            .ss(7, 1, 0, 4)
+            .p(
+                "EgmQBtXMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkIlemkIkYAAQhuAAhVhVQhVhVAAhug"
+            );
+        this.shape_20.setTransform(3034.6, 854.1);
 
         this.shape_21 = new cjs.Shape();
-        this.shape_21.graphics.f("#FFC000").s().p("EgdgBxvIkYAAQhuAAhVhVQhVhVAAhuMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkg");
-        this.shape_21.setTransform(3034.6,854.1);
+        this.shape_21.graphics
+            .f("#FFC000")
+            .s()
+            .p(
+                "EgdgBxvIkYAAQhuAAhVhVQhVhVAAhuMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkg"
+            );
+        this.shape_21.setTransform(3034.6, 854.1);
 
         this.instance_17 = new lib.text23961();
-        this.instance_17.setTransform(3463.7,479.1,1,1,0,0,0,19.6,35.8);
+        this.instance_17.setTransform(3463.7, 479.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_22 = new cjs.Shape();
-        this.shape_22.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_22.setTransform(3433.6,485.8);
+        this.shape_22.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_22.setTransform(3433.6, 485.8);
 
         this.shape_23 = new cjs.Shape();
-        this.shape_23.graphics.f("#EE97A8").s().p("A8aK8IAAp2ImkAAIAADRIiNAAIAAotICNAAIAADRIGkAAIAAp2MBBlAAAIAAV3g");
-        this.shape_23.setTransform(3433.6,485.8);
+        this.shape_23.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK8IAAp2ImkAAIAADRIiNAAIAAotICNAAIAADRIGkAAIAAp2MBBlAAAIAAV3g");
+        this.shape_23.setTransform(3433.6, 485.8);
 
         this.instance_18 = new lib.text236();
-        this.instance_18.setTransform(3481.9,332.1,1,1,0,0,0,44.8,35.8);
+        this.instance_18.setTransform(3481.9, 332.1, 1, 1, 0, 0, 0, 44.8, 35.8);
 
         this.shape_24 = new cjs.Shape();
-        this.shape_24.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADRIGkAAg");
-        this.shape_24.setTransform(3433.6,338.8);
+        this.shape_24.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADRIGkAAg");
+        this.shape_24.setTransform(3433.6, 338.8);
 
         this.shape_25 = new cjs.Shape();
-        this.shape_25.graphics.f("#76C61C").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_25.setTransform(3433.6,338.8);
+        this.shape_25.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_25.setTransform(3433.6, 338.8);
 
         this.instance_19 = new lib.text320427();
-        this.instance_19.setTransform(3109.6,488.9,1,1,0,0,0,68.9,23.9);
+        this.instance_19.setTransform(3109.6, 488.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_20 = new lib.text32002();
-        this.instance_20.setTransform(3132.8,334.9,1,1,0,0,0,45.5,23.9);
+        this.instance_20.setTransform(3132.8, 334.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_21 = new lib.text319635();
-        this.instance_21.setTransform(3104.3,412.6,1,1,0,0,0,74,35.8);
+        this.instance_21.setTransform(3104.3, 412.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_26 = new cjs.Shape();
-        this.shape_26.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_26.setTransform(3048.6,419.3);
+        this.shape_26.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_26.setTransform(3048.6, 419.3);
 
         this.shape_27 = new cjs.Shape();
-        this.shape_27.graphics.f("#76C61C").s().p("A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkFQAAh0BShSQBShRB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBRQBSBSAAB0IAAEYIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjSIEYAAIAAEYQAABzhSBTQhSBSh0AAMgmQAAAIAACLg");
-        this.shape_27.setTransform(3048.6,419.3);
+        this.shape_27.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkFQAAh0BShSQBShRB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBRQBSBSAAB0IAAEYIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjSIEYAAIAAEYQAABzhSBTQhSBSh0AAMgmQAAAIAACLg"
+            );
+        this.shape_27.setTransform(3048.6, 419.3);
 
         this.shape_28 = new cjs.Shape();
-        this.shape_28.graphics.f("#FF99FF").s().p("A8aK8IAAp2ImkAAIAADRIiNAAIAAotICNAAIAADRIGkAAIAAp2MBBlAAAIAAV3g");
-        this.shape_28.setTransform(3433.6,485.8);
+        this.shape_28.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK8IAAp2ImkAAIAADRIiNAAIAAotICNAAIAADRIGkAAIAAp2MBBlAAAIAAV3g");
+        this.shape_28.setTransform(3433.6, 485.8);
 
         this.shape_29 = new cjs.Shape();
-        this.shape_29.graphics.f("#00FF33").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_29.setTransform(3433.6,338.8);
+        this.shape_29.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_29.setTransform(3433.6, 338.8);
 
         this.shape_30 = new cjs.Shape();
-        this.shape_30.graphics.f("#00FF33").s().p("A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkFQAAh0BShSQBShRB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBRQBSBSAAB0IAAEYIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjSIEYAAIAAEYQAABzhSBTQhSBSh0AAMgmQAAAIAACLg");
-        this.shape_30.setTransform(3048.6,419.3);
+        this.shape_30.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkFQAAh0BShSQBShRB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBRQBSBSAAB0IAAEYIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjSIEYAAIAAEYQAABzhSBTQhSBSh0AAMgmQAAAIAACLg"
+            );
+        this.shape_30.setTransform(3048.6, 419.3);
 
         this.shape_31 = new cjs.Shape();
-        this.shape_31.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_31.setTransform(3433.6,779.8);
+        this.shape_31.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_31.setTransform(3433.6, 779.8);
 
         this.shape_32 = new cjs.Shape();
-        this.shape_32.graphics.f("#00FF33").s().p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_32.setTransform(3433.6,632.8);
+        this.shape_32.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_32.setTransform(3433.6, 632.8);
 
         this.shape_33 = new cjs.Shape();
-        this.shape_33.graphics.f("#00FF33").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_33.setTransform(3048.6,713.3);
+        this.shape_33.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK8AAIAAiLMAlJAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_33.setTransform(3048.6, 713.3);
 
         this.shape_34 = new cjs.Shape();
-        this.shape_34.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImkAAIAADTIiNAAIAAovICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
-        this.shape_34.setTransform(3433.6,1073);
+        this.shape_34.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADTIiNAAIAAovICNAAIAADTIGkAAIAAp2MBBlAAAIAAV1g");
+        this.shape_34.setTransform(3433.6, 1073);
 
         this.shape_35 = new cjs.Shape();
-        this.shape_35.graphics.f("#00FF33").s().p("A8aK8IAAp2ImkAAIAADRIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV3g");
-        this.shape_35.setTransform(3433.6,926);
+        this.shape_35.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK8IAAp2ImkAAIAADRIiNAAIAAouICNAAIAADSIGkAAIAAp2MBBlAAAIAAV3g");
+        this.shape_35.setTransform(3433.6, 926);
 
         this.shape_36 = new cjs.Shape();
-        this.shape_36.graphics.f("#00FF33").s().p("A0wXhIAAiNIleAAQh0AAhShSQhShRAAh1MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACNIK8AAIAAiNMAlJAAAQB0AABSBSQBSBSAAB0IAAEZIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASkIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACNg");
-        this.shape_36.setTransform(3048.6,1006.5);
+        this.shape_36.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXhIAAiNIleAAQh0AAhShSQhShRAAh1MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACNIK8AAIAAiNMAlJAAAQB0AABSBSQBSBSAAB0IAAEZIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASkIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACNg"
+            );
+        this.shape_36.setTransform(3048.6, 1006.5);
 
         this.shape_37 = new cjs.Shape();
-        this.shape_37.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADSIGkAAIAAp1MBBlAAAIAAV1g");
-        this.shape_37.setTransform(3433.6,1367.8);
+        this.shape_37.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImkAAIAADSIiNAAIAAouICNAAIAADSIGkAAIAAp1MBBlAAAIAAV1g");
+        this.shape_37.setTransform(3433.6, 1367.8);
 
         this.shape_38 = new cjs.Shape();
-        this.shape_38.graphics.f("#00FF33").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK8AAIAAiMMAlJAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_38.setTransform(3048.6,1301.3);
+        this.shape_38.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK8AAIAAiMMAlJAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_38.setTransform(3048.6, 1301.3);
 
-        this.timeline.addTween(cjs.Tween.get({}).to({state:[{t:this.shape_27},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_25},{t:this.shape_24},{t:this.instance_18},{t:this.shape_23},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_17},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_15},{t:this.shape_14},{t:this.instance_11},{t:this.shape_13},{t:this.shape_12},{t:this.instance_10},{t:this.shape_11},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_9},{t:this.shape_8},{t:this.instance_6},{t:this.shape_7},{t:this.shape_6},{t:this.instance_5},{t:this.shape_5},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_3,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_1},{t:this.shape},{t:this.instance}]}).to({state:[{t:this.shape_30},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_29,p:{y:338.8}},{t:this.shape_24},{t:this.instance_18},{t:this.shape_28},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_17},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_15},{t:this.shape_14},{t:this.instance_11},{t:this.shape_13},{t:this.shape_12},{t:this.instance_10},{t:this.shape_11},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_9},{t:this.shape_8},{t:this.instance_6},{t:this.shape_7},{t:this.shape_6},{t:this.instance_5},{t:this.shape_5},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_3,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_1},{t:this.shape},{t:this.instance}]},5).to({state:[{t:this.shape_27},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_25},{t:this.shape_24},{t:this.instance_18},{t:this.shape_23},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_33},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_32},{t:this.shape_14},{t:this.instance_11},{t:this.shape_31},{t:this.shape_12},{t:this.instance_10},{t:this.shape_11},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_9},{t:this.shape_8},{t:this.instance_6},{t:this.shape_7},{t:this.shape_6},{t:this.instance_5},{t:this.shape_5},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_3,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_1},{t:this.shape},{t:this.instance}]},1).to({state:[{t:this.shape_27},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_25},{t:this.shape_24},{t:this.instance_18},{t:this.shape_23},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_17},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_15},{t:this.shape_14},{t:this.instance_11},{t:this.shape_13},{t:this.shape_12},{t:this.instance_10},{t:this.shape_36},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_35},{t:this.shape_8},{t:this.instance_6},{t:this.shape_34},{t:this.shape_6},{t:this.instance_5},{t:this.shape_5},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_3,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_1},{t:this.shape},{t:this.instance}]},1).to({state:[{t:this.shape_27},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_3,p:{y:338.8}},{t:this.shape_24},{t:this.instance_18},{t:this.shape_23},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_17},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_15},{t:this.shape_14},{t:this.instance_11},{t:this.shape_13},{t:this.shape_12},{t:this.instance_10},{t:this.shape_11},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_9},{t:this.shape_8},{t:this.instance_6},{t:this.shape_7},{t:this.shape_6},{t:this.instance_5},{t:this.shape_38},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_29,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_37},{t:this.shape},{t:this.instance}]},1).to({state:[{t:this.shape_27},{t:this.shape_26},{t:this.instance_21},{t:this.instance_20},{t:this.instance_19},{t:this.shape_25},{t:this.shape_24},{t:this.instance_18},{t:this.shape_23},{t:this.shape_22},{t:this.instance_17},{t:this.shape_21},{t:this.shape_20},{t:this.instance_16},{t:this.shape_19},{t:this.shape_18},{t:this.instance_15},{t:this.shape_17},{t:this.shape_16},{t:this.instance_14},{t:this.instance_13},{t:this.instance_12},{t:this.shape_15},{t:this.shape_14},{t:this.instance_11},{t:this.shape_13},{t:this.shape_12},{t:this.instance_10},{t:this.shape_11},{t:this.shape_10},{t:this.instance_9},{t:this.instance_8},{t:this.instance_7},{t:this.shape_9},{t:this.shape_8},{t:this.instance_6},{t:this.shape_7},{t:this.shape_6},{t:this.instance_5},{t:this.shape_5},{t:this.shape_4},{t:this.instance_4},{t:this.instance_3},{t:this.instance_2},{t:this.shape_3,p:{y:1220.8}},{t:this.shape_2},{t:this.instance_1},{t:this.shape_1},{t:this.shape},{t:this.instance}]},1).wait(6));
+        this.timeline.addTween(
+            cjs.Tween.get({})
+                .to({
+                    state: [
+                        { t: this.shape_27 },
+                        { t: this.shape_26 },
+                        { t: this.instance_21 },
+                        { t: this.instance_20 },
+                        { t: this.instance_19 },
+                        { t: this.shape_25 },
+                        { t: this.shape_24 },
+                        { t: this.instance_18 },
+                        { t: this.shape_23 },
+                        { t: this.shape_22 },
+                        { t: this.instance_17 },
+                        { t: this.shape_21 },
+                        { t: this.shape_20 },
+                        { t: this.instance_16 },
+                        { t: this.shape_19 },
+                        { t: this.shape_18 },
+                        { t: this.instance_15 },
+                        { t: this.shape_17 },
+                        { t: this.shape_16 },
+                        { t: this.instance_14 },
+                        { t: this.instance_13 },
+                        { t: this.instance_12 },
+                        { t: this.shape_15 },
+                        { t: this.shape_14 },
+                        { t: this.instance_11 },
+                        { t: this.shape_13 },
+                        { t: this.shape_12 },
+                        { t: this.instance_10 },
+                        { t: this.shape_11 },
+                        { t: this.shape_10 },
+                        { t: this.instance_9 },
+                        { t: this.instance_8 },
+                        { t: this.instance_7 },
+                        { t: this.shape_9 },
+                        { t: this.shape_8 },
+                        { t: this.instance_6 },
+                        { t: this.shape_7 },
+                        { t: this.shape_6 },
+                        { t: this.instance_5 },
+                        { t: this.shape_5 },
+                        { t: this.shape_4 },
+                        { t: this.instance_4 },
+                        { t: this.instance_3 },
+                        { t: this.instance_2 },
+                        { t: this.shape_3, p: { y: 1220.8 } },
+                        { t: this.shape_2 },
+                        { t: this.instance_1 },
+                        { t: this.shape_1 },
+                        { t: this.shape },
+                        { t: this.instance }
+                    ]
+                })
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_30 },
+                            { t: this.shape_26 },
+                            { t: this.instance_21 },
+                            { t: this.instance_20 },
+                            { t: this.instance_19 },
+                            { t: this.shape_29, p: { y: 338.8 } },
+                            { t: this.shape_24 },
+                            { t: this.instance_18 },
+                            { t: this.shape_28 },
+                            { t: this.shape_22 },
+                            { t: this.instance_17 },
+                            { t: this.shape_21 },
+                            { t: this.shape_20 },
+                            { t: this.instance_16 },
+                            { t: this.shape_19 },
+                            { t: this.shape_18 },
+                            { t: this.instance_15 },
+                            { t: this.shape_17 },
+                            { t: this.shape_16 },
+                            { t: this.instance_14 },
+                            { t: this.instance_13 },
+                            { t: this.instance_12 },
+                            { t: this.shape_15 },
+                            { t: this.shape_14 },
+                            { t: this.instance_11 },
+                            { t: this.shape_13 },
+                            { t: this.shape_12 },
+                            { t: this.instance_10 },
+                            { t: this.shape_11 },
+                            { t: this.shape_10 },
+                            { t: this.instance_9 },
+                            { t: this.instance_8 },
+                            { t: this.instance_7 },
+                            { t: this.shape_9 },
+                            { t: this.shape_8 },
+                            { t: this.instance_6 },
+                            { t: this.shape_7 },
+                            { t: this.shape_6 },
+                            { t: this.instance_5 },
+                            { t: this.shape_5 },
+                            { t: this.shape_4 },
+                            { t: this.instance_4 },
+                            { t: this.instance_3 },
+                            { t: this.instance_2 },
+                            { t: this.shape_3, p: { y: 1220.8 } },
+                            { t: this.shape_2 },
+                            { t: this.instance_1 },
+                            { t: this.shape_1 },
+                            { t: this.shape },
+                            { t: this.instance }
+                        ]
+                    },
+                    5
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_27 },
+                            { t: this.shape_26 },
+                            { t: this.instance_21 },
+                            { t: this.instance_20 },
+                            { t: this.instance_19 },
+                            { t: this.shape_25 },
+                            { t: this.shape_24 },
+                            { t: this.instance_18 },
+                            { t: this.shape_23 },
+                            { t: this.shape_22 },
+                            { t: this.instance_17 },
+                            { t: this.shape_21 },
+                            { t: this.shape_20 },
+                            { t: this.instance_16 },
+                            { t: this.shape_19 },
+                            { t: this.shape_18 },
+                            { t: this.instance_15 },
+                            { t: this.shape_33 },
+                            { t: this.shape_16 },
+                            { t: this.instance_14 },
+                            { t: this.instance_13 },
+                            { t: this.instance_12 },
+                            { t: this.shape_32 },
+                            { t: this.shape_14 },
+                            { t: this.instance_11 },
+                            { t: this.shape_31 },
+                            { t: this.shape_12 },
+                            { t: this.instance_10 },
+                            { t: this.shape_11 },
+                            { t: this.shape_10 },
+                            { t: this.instance_9 },
+                            { t: this.instance_8 },
+                            { t: this.instance_7 },
+                            { t: this.shape_9 },
+                            { t: this.shape_8 },
+                            { t: this.instance_6 },
+                            { t: this.shape_7 },
+                            { t: this.shape_6 },
+                            { t: this.instance_5 },
+                            { t: this.shape_5 },
+                            { t: this.shape_4 },
+                            { t: this.instance_4 },
+                            { t: this.instance_3 },
+                            { t: this.instance_2 },
+                            { t: this.shape_3, p: { y: 1220.8 } },
+                            { t: this.shape_2 },
+                            { t: this.instance_1 },
+                            { t: this.shape_1 },
+                            { t: this.shape },
+                            { t: this.instance }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_27 },
+                            { t: this.shape_26 },
+                            { t: this.instance_21 },
+                            { t: this.instance_20 },
+                            { t: this.instance_19 },
+                            { t: this.shape_25 },
+                            { t: this.shape_24 },
+                            { t: this.instance_18 },
+                            { t: this.shape_23 },
+                            { t: this.shape_22 },
+                            { t: this.instance_17 },
+                            { t: this.shape_21 },
+                            { t: this.shape_20 },
+                            { t: this.instance_16 },
+                            { t: this.shape_19 },
+                            { t: this.shape_18 },
+                            { t: this.instance_15 },
+                            { t: this.shape_17 },
+                            { t: this.shape_16 },
+                            { t: this.instance_14 },
+                            { t: this.instance_13 },
+                            { t: this.instance_12 },
+                            { t: this.shape_15 },
+                            { t: this.shape_14 },
+                            { t: this.instance_11 },
+                            { t: this.shape_13 },
+                            { t: this.shape_12 },
+                            { t: this.instance_10 },
+                            { t: this.shape_36 },
+                            { t: this.shape_10 },
+                            { t: this.instance_9 },
+                            { t: this.instance_8 },
+                            { t: this.instance_7 },
+                            { t: this.shape_35 },
+                            { t: this.shape_8 },
+                            { t: this.instance_6 },
+                            { t: this.shape_34 },
+                            { t: this.shape_6 },
+                            { t: this.instance_5 },
+                            { t: this.shape_5 },
+                            { t: this.shape_4 },
+                            { t: this.instance_4 },
+                            { t: this.instance_3 },
+                            { t: this.instance_2 },
+                            { t: this.shape_3, p: { y: 1220.8 } },
+                            { t: this.shape_2 },
+                            { t: this.instance_1 },
+                            { t: this.shape_1 },
+                            { t: this.shape },
+                            { t: this.instance }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_27 },
+                            { t: this.shape_26 },
+                            { t: this.instance_21 },
+                            { t: this.instance_20 },
+                            { t: this.instance_19 },
+                            { t: this.shape_3, p: { y: 338.8 } },
+                            { t: this.shape_24 },
+                            { t: this.instance_18 },
+                            { t: this.shape_23 },
+                            { t: this.shape_22 },
+                            { t: this.instance_17 },
+                            { t: this.shape_21 },
+                            { t: this.shape_20 },
+                            { t: this.instance_16 },
+                            { t: this.shape_19 },
+                            { t: this.shape_18 },
+                            { t: this.instance_15 },
+                            { t: this.shape_17 },
+                            { t: this.shape_16 },
+                            { t: this.instance_14 },
+                            { t: this.instance_13 },
+                            { t: this.instance_12 },
+                            { t: this.shape_15 },
+                            { t: this.shape_14 },
+                            { t: this.instance_11 },
+                            { t: this.shape_13 },
+                            { t: this.shape_12 },
+                            { t: this.instance_10 },
+                            { t: this.shape_11 },
+                            { t: this.shape_10 },
+                            { t: this.instance_9 },
+                            { t: this.instance_8 },
+                            { t: this.instance_7 },
+                            { t: this.shape_9 },
+                            { t: this.shape_8 },
+                            { t: this.instance_6 },
+                            { t: this.shape_7 },
+                            { t: this.shape_6 },
+                            { t: this.instance_5 },
+                            { t: this.shape_38 },
+                            { t: this.shape_4 },
+                            { t: this.instance_4 },
+                            { t: this.instance_3 },
+                            { t: this.instance_2 },
+                            { t: this.shape_29, p: { y: 1220.8 } },
+                            { t: this.shape_2 },
+                            { t: this.instance_1 },
+                            { t: this.shape_37 },
+                            { t: this.shape },
+                            { t: this.instance }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_27 },
+                            { t: this.shape_26 },
+                            { t: this.instance_21 },
+                            { t: this.instance_20 },
+                            { t: this.instance_19 },
+                            { t: this.shape_25 },
+                            { t: this.shape_24 },
+                            { t: this.instance_18 },
+                            { t: this.shape_23 },
+                            { t: this.shape_22 },
+                            { t: this.instance_17 },
+                            { t: this.shape_21 },
+                            { t: this.shape_20 },
+                            { t: this.instance_16 },
+                            { t: this.shape_19 },
+                            { t: this.shape_18 },
+                            { t: this.instance_15 },
+                            { t: this.shape_17 },
+                            { t: this.shape_16 },
+                            { t: this.instance_14 },
+                            { t: this.instance_13 },
+                            { t: this.instance_12 },
+                            { t: this.shape_15 },
+                            { t: this.shape_14 },
+                            { t: this.instance_11 },
+                            { t: this.shape_13 },
+                            { t: this.shape_12 },
+                            { t: this.instance_10 },
+                            { t: this.shape_11 },
+                            { t: this.shape_10 },
+                            { t: this.instance_9 },
+                            { t: this.instance_8 },
+                            { t: this.instance_7 },
+                            { t: this.shape_9 },
+                            { t: this.shape_8 },
+                            { t: this.instance_6 },
+                            { t: this.shape_7 },
+                            { t: this.shape_6 },
+                            { t: this.instance_5 },
+                            { t: this.shape_5 },
+                            { t: this.shape_4 },
+                            { t: this.instance_4 },
+                            { t: this.instance_3 },
+                            { t: this.instance_2 },
+                            { t: this.shape_3, p: { y: 1220.8 } },
+                            { t: this.shape_2 },
+                            { t: this.instance_1 },
+                            { t: this.shape_1 },
+                            { t: this.shape },
+                            { t: this.instance }
+                        ]
+                    },
+                    1
+                )
+                .wait(6)
+        );
 
         // Blocks L
         this.instance_22 = new lib.text23947_1();
-        this.instance_22.setTransform(718.4,1361.1,1,1,0,0,0,19.6,35.8);
+        this.instance_22.setTransform(718.4, 1361.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_39 = new cjs.Shape();
-        this.shape_39.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV1MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape_39.setTransform(688.3,1367.8);
+        this.shape_39.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV1MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape_39.setTransform(688.3, 1367.8);
 
         this.shape_40 = new cjs.Shape();
-        this.shape_40.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp1MBBlAAAIAAV1g");
-        this.shape_40.setTransform(688.3,1367.8);
+        this.shape_40.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp1MBBlAAAIAAV1g");
+        this.shape_40.setTransform(688.3, 1367.8);
 
         this.instance_23 = new lib.text23946_1();
-        this.instance_23.setTransform(721.1,1214.1,1,1,0,0,0,29.3,35.8);
+        this.instance_23.setTransform(721.1, 1214.1, 1, 1, 0, 0, 0, 29.3, 35.8);
 
         this.shape_41 = new cjs.Shape();
-        this.shape_41.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_41.setTransform(688.3,1220.8);
+        this.shape_41.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_41.setTransform(688.3, 1220.8);
 
         this.shape_42 = new cjs.Shape();
-        this.shape_42.graphics.f("#76C61C").s().p("A8aK8IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_42.setTransform(688.3,1220.8);
+        this.shape_42.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_42.setTransform(688.3, 1220.8);
 
         this.instance_24 = new lib.text320497_1();
-        this.instance_24.setTransform(364.3,1370.9,1,1,0,0,0,68.9,23.9);
+        this.instance_24.setTransform(364.3, 1370.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_25 = new lib.text3200365_1();
-        this.instance_25.setTransform(387.5,1216.9,1,1,0,0,0,45.5,23.9);
+        this.instance_25.setTransform(387.5, 1216.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_26 = new lib.text319691_1();
-        this.instance_26.setTransform(359,1294.6,1,1,0,0,0,74,35.8);
+        this.instance_26.setTransform(359, 1294.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_43 = new cjs.Shape();
-        this.shape_43.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ8MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_43.setTransform(303.3,1301.3);
+        this.shape_43.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ8MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_43.setTransform(303.3, 1301.3);
 
         this.shape_44 = new cjs.Shape();
-        this.shape_44.graphics.f("#76C61C").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_44.setTransform(303.3,1301.3);
+        this.shape_44.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_44.setTransform(303.3, 1301.3);
 
         this.instance_27 = new lib.text23993_1();
-        this.instance_27.setTransform(718.4,1066.3,1,1,0,0,0,19.6,35.8);
+        this.instance_27.setTransform(718.4, 1066.3, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_45 = new cjs.Shape();
-        this.shape_45.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape_45.setTransform(688.3,1073);
+        this.shape_45.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape_45.setTransform(688.3, 1073);
 
         this.shape_46 = new cjs.Shape();
-        this.shape_46.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImlAAIAADTIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_46.setTransform(688.3,1073);
+        this.shape_46.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADTIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_46.setTransform(688.3, 1073);
 
         this.instance_28 = new lib.text2301_1();
-        this.instance_28.setTransform(728.8,919.3,1,1,0,0,0,37,35.8);
+        this.instance_28.setTransform(728.8, 919.3, 1, 1, 0, 0, 0, 37, 35.8);
 
         this.shape_47 = new cjs.Shape();
-        this.shape_47.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_47.setTransform(688.3,926);
+        this.shape_47.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_47.setTransform(688.3, 926);
 
         this.shape_48 = new cjs.Shape();
-        this.shape_48.graphics.f("#76C61C").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_48.setTransform(688.3,926);
+        this.shape_48.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_48.setTransform(688.3, 926);
 
         this.instance_29 = new lib.text320480_1();
-        this.instance_29.setTransform(364.3,1076.1,1,1,0,0,0,68.9,23.9);
+        this.instance_29.setTransform(364.3, 1076.1, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_30 = new lib.text320064_1();
-        this.instance_30.setTransform(387.5,922.1,1,1,0,0,0,45.5,23.9);
+        this.instance_30.setTransform(387.5, 922.1, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_31 = new lib.text319667_1();
-        this.instance_31.setTransform(359,999.8,1,1,0,0,0,74,35.8);
+        this.instance_31.setTransform(359, 999.8, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_49 = new cjs.Shape();
-        this.shape_49.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_49.setTransform(303.3,1006.5);
+        this.shape_49.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_49.setTransform(303.3, 1006.5);
 
         this.shape_50 = new cjs.Shape();
-        this.shape_50.graphics.f("#76C61C").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_50.setTransform(303.3,1006.5);
+        this.shape_50.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_50.setTransform(303.3, 1006.5);
 
         this.instance_32 = new lib.text23903_1();
-        this.instance_32.setTransform(718.4,773.1,1,1,0,0,0,19.6,35.8);
+        this.instance_32.setTransform(718.4, 773.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_51 = new cjs.Shape();
-        this.shape_51.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_51.setTransform(688.3,779.8);
+        this.shape_51.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_51.setTransform(688.3, 779.8);
 
         this.shape_52 = new cjs.Shape();
-        this.shape_52.graphics.f("#EE97A8").s().p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_52.setTransform(688.3,779.8);
+        this.shape_52.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_52.setTransform(688.3, 779.8);
 
         this.instance_33 = new lib.text2311_1();
-        this.instance_33.setTransform(723,626.1,1,1,0,0,0,31.2,35.8);
+        this.instance_33.setTransform(723, 626.1, 1, 1, 0, 0, 0, 31.2, 35.8);
 
         this.shape_53 = new cjs.Shape();
-        this.shape_53.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_53.setTransform(688.3,632.8);
+        this.shape_53.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_53.setTransform(688.3, 632.8);
 
         this.shape_54 = new cjs.Shape();
-        this.shape_54.graphics.f("#76C61C").s().p("A8aK7IAAp2ImlAAIAADTIiLAAIAAovICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_54.setTransform(688.3,632.8);
+        this.shape_54.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADTIiLAAIAAovICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_54.setTransform(688.3, 632.8);
 
         this.instance_34 = new lib.text320467_1();
-        this.instance_34.setTransform(364.3,782.9,1,1,0,0,0,68.9,23.9);
+        this.instance_34.setTransform(364.3, 782.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_35 = new lib.text320038_1();
-        this.instance_35.setTransform(387.5,628.9,1,1,0,0,0,45.5,23.9);
+        this.instance_35.setTransform(387.5, 628.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_36 = new lib.text319672_1();
-        this.instance_36.setTransform(359,706.6,1,1,0,0,0,74,35.8);
+        this.instance_36.setTransform(359, 706.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_55 = new cjs.Shape();
-        this.shape_55.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkFQAAhzBShSQBShTB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBTQBSBSAABzIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_55.setTransform(303.3,713.3);
+        this.shape_55.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkFQAAhzBShSQBShTB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBTQBSBSAABzIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_55.setTransform(303.3, 713.3);
 
         this.shape_56 = new cjs.Shape();
-        this.shape_56.graphics.f("#76C61C").s().p("A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkEQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEXIkYAAIAAjRIkYAAIAAK7IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAAEZQAABzhSBTQhSBSh0AAMgmQAAAIAACLg");
-        this.shape_56.setTransform(303.3,713.3);
+        this.shape_56.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkEQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEXIkYAAIAAjRIkYAAIAAK7IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAAEZQAABzhSBTQhSBSh0AAMgmQAAAIAACLg"
+            );
+        this.shape_56.setTransform(303.3, 713.3);
 
         this.instance_37 = new lib.text2323_1();
-        this.instance_37.setTransform(746,188.3,1,1,0,0,0,112.9,35.9);
+        this.instance_37.setTransform(746, 188.3, 1, 1, 0, 0, 0, 112.9, 35.9);
 
         this.shape_57 = new cjs.Shape();
-        this.shape_57.graphics.f().s("#5AA4AF").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
-        this.shape_57.setTransform(723.3,196.9);
+        this.shape_57.graphics
+            .f()
+            .s("#5AA4AF")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADSIGkAAg");
+        this.shape_57.setTransform(723.3, 196.9);
 
         this.shape_58 = new cjs.Shape();
-        this.shape_58.graphics.f("#5DC1BC").s().p("A8bK7IAAp2ImjAAIAADTIiNAAIAAouICNAAIAADSIGjAAIAAp2MBBnAAAIAAV1g");
-        this.shape_58.setTransform(723.3,196.9);
+        this.shape_58.graphics
+            .f("#5DC1BC")
+            .s()
+            .p("A8bK7IAAp2ImjAAIAADTIiNAAIAAouICNAAIAADSIGjAAIAAp2MBBnAAAIAAV1g");
+        this.shape_58.setTransform(723.3, 196.9);
 
         this.instance_38 = new lib.text302942_1();
-        this.instance_38.setTransform(162.2,199.7,1,1,0,0,0,93.5,35.9);
+        this.instance_38.setTransform(162.2, 199.7, 1, 1, 0, 0, 0, 93.5, 35.9);
 
         this.shape_59 = new cjs.Shape();
-        this.shape_59.graphics.f().s("#C48D00").ss(7,1,0,4).p("EgmQBtXMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkIlemkIkYAAQhuAAhVhVQhVhVAAhug");
-        this.shape_59.setTransform(289.3,854.1);
+        this.shape_59.graphics
+            .f()
+            .s("#C48D00")
+            .ss(7, 1, 0, 4)
+            .p(
+                "EgmQBtXMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkIlemkIkYAAQhuAAhVhVQhVhVAAhug"
+            );
+        this.shape_59.setTransform(289.3, 854.1);
 
         this.shape_60 = new cjs.Shape();
-        this.shape_60.graphics.f("#FFC000").s().p("EgdgBxvIkYAAQhuAAhVhVQhVhVAAhuMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkg");
-        this.shape_60.setTransform(289.3,854.1);
+        this.shape_60.graphics
+            .f("#FFC000")
+            .s()
+            .p(
+                "EgdgBxvIkYAAQhuAAhVhVQhVhVAAhuMAAAjatQAAhuBVhVQBVhVBuAAIEYAAIFemkIFeGkMA0dAAAQBuAABVBVQBVBVAABuIAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAABuhVBVQhVBVhuAAMgrtAAAIAACMIowAAIAAiMIleAAQhFAAhBAbQhBAbgxAwQgwAxgbBBQgbBBAABFMAAACsxQAABFAbBBQAbBBAwAxQAqAqBJAZQAXAIBuAbIEYAAIAACMIK8AAIAAiMIIuAAIAARgQAABzhVBeQhbBhhmgaIuOAAIleGkg"
+            );
+        this.shape_60.setTransform(289.3, 854.1);
 
         this.instance_39 = new lib.text23961_1();
-        this.instance_39.setTransform(718.4,479.1,1,1,0,0,0,19.6,35.8);
+        this.instance_39.setTransform(718.4, 479.1, 1, 1, 0, 0, 0, 19.6, 35.8);
 
         this.shape_61 = new cjs.Shape();
-        this.shape_61.graphics.f().s("#A75862").ss(7,1,0,4).p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
-        this.shape_61.setTransform(688.3,485.8);
+        this.shape_61.graphics
+            .f()
+            .s("#A75862")
+            .ss(7, 1, 0, 4)
+            .p("A8bq7MBBnAAAIAAV3MhBnAAAIAAp2ImkAAIAADSIiMAAIAAovICMAAIAADSIGkAAg");
+        this.shape_61.setTransform(688.3, 485.8);
 
         this.shape_62 = new cjs.Shape();
-        this.shape_62.graphics.f("#EE97A8").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV2g");
-        this.shape_62.setTransform(688.3,485.8);
+        this.shape_62.graphics
+            .f("#EE97A8")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV2g");
+        this.shape_62.setTransform(688.3, 485.8);
 
         this.instance_40 = new lib.text236_1();
-        this.instance_40.setTransform(730.8,332.1,1,1,0,0,0,39,35.8);
+        this.instance_40.setTransform(730.8, 332.1, 1, 1, 0, 0, 0, 39, 35.8);
 
         this.shape_63 = new cjs.Shape();
-        this.shape_63.graphics.f().s("#538D38").ss(7,1,0,4).p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADRIGkAAg");
-        this.shape_63.setTransform(688.3,338.8);
+        this.shape_63.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p("A8bq6MBBnAAAIAAV2MhBnAAAIAAp2ImkAAIAADSIiMAAIAAouICMAAIAADRIGkAAg");
+        this.shape_63.setTransform(688.3, 338.8);
 
         this.shape_64 = new cjs.Shape();
-        this.shape_64.graphics.f("#76C61C").s().p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_64.setTransform(688.3,338.8);
+        this.shape_64.graphics
+            .f("#76C61C")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_64.setTransform(688.3, 338.8);
 
         this.instance_41 = new lib.text320427_1();
-        this.instance_41.setTransform(364.3,488.9,1,1,0,0,0,68.9,23.9);
+        this.instance_41.setTransform(364.3, 488.9, 1, 1, 0, 0, 0, 68.9, 23.9);
 
         this.instance_42 = new lib.text32002_1();
-        this.instance_42.setTransform(387.5,334.9,1,1,0,0,0,45.5,23.9);
+        this.instance_42.setTransform(387.5, 334.9, 1, 1, 0, 0, 0, 45.5, 23.9);
 
         this.instance_43 = new lib.text319635_1();
-        this.instance_43.setTransform(359,412.6,1,1,0,0,0,74,35.8);
+        this.instance_43.setTransform(359, 412.6, 1, 1, 0, 0, 0, 74, 35.8);
 
         this.shape_65 = new cjs.Shape();
-        this.shape_65.graphics.f().s("#538D38").ss(7,1,0,4).p("A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g");
-        this.shape_65.setTransform(303.3,419.3);
+        this.shape_65.graphics
+            .f()
+            .s("#538D38")
+            .ss(7, 1, 0, 4)
+            .p(
+                "A+mQ9MAAAgkEQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK7IEYAAIAAjSIEYAAIAASlIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMIovAAIAAiMIleAAQh0AAhShSQhShSAAh0g"
+            );
+        this.shape_65.setTransform(303.3, 419.3);
 
         this.shape_66 = new cjs.Shape();
-        this.shape_66.graphics.f("#76C61C").s().p("A0wXhIAAiNIleAAQh0AAhShRQhShTAAhzMAAAgkFQAAhzBShTQBShSB0AAIEYAAIAACNIK7AAIAAiNMAlKAAAQB0AABSBSQBSBTAABzIAAEYIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAASlIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAAEYQAABzhSBTQhSBRh0AAMgmQAAAIAACNg");
-        this.shape_66.setTransform(303.3,419.3);
+        this.shape_66.graphics
+            .f("#76C61C")
+            .s()
+            .p(
+                "A0wXhIAAiNIleAAQh0AAhShRQhShTAAhzMAAAgkFQAAhzBShTQBShSB0AAIEYAAIAACNIK7AAIAAiNMAlKAAAQB0AABSBSQBSBTAABzIAAEYIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAASlIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAAEYQAABzhSBTQhSBRh0AAMgmQAAAIAACNg"
+            );
+        this.shape_66.setTransform(303.3, 419.3);
 
         this.shape_67 = new cjs.Shape();
-        this.shape_67.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV2g");
-        this.shape_67.setTransform(688.3,486);
+        this.shape_67.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV2g");
+        this.shape_67.setTransform(688.3, 486);
 
         this.shape_68 = new cjs.Shape();
-        this.shape_68.graphics.f("#00FF33").s().p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_68.setTransform(688.3,339);
+        this.shape_68.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_68.setTransform(688.3, 339);
 
         this.shape_69 = new cjs.Shape();
-        this.shape_69.graphics.f("#00FF33").s().p("A0wXhIAAiNIleAAQh0AAhShRQhShTAAhzMAAAgkFQAAhzBShTQBShSB0AAIEYAAIAACNIK7AAIAAiNMAlKAAAQB0AABSBSQBSBTAABzIAAEYIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAASlIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAAEYQAABzhSBTQhSBRh0AAMgmQAAAIAACNg");
-        this.shape_69.setTransform(303.3,419.5);
+        this.shape_69.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXhIAAiNIleAAQh0AAhShRQhShTAAhzMAAAgkFQAAhzBShTQBShSB0AAIEYAAIAACNIK7AAIAAiNMAlKAAAQB0AABSBSQBSBTAABzIAAEYIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAASlIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAAEYQAABzhSBTQhSBRh0AAMgmQAAAIAACNg"
+            );
+        this.shape_69.setTransform(303.3, 419.5);
 
         this.shape_70 = new cjs.Shape();
-        this.shape_70.graphics.f("#FF99FF").s().p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_70.setTransform(688.3,780);
+        this.shape_70.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADRIiLAAIAAotICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_70.setTransform(688.3, 780);
 
         this.shape_71 = new cjs.Shape();
-        this.shape_71.graphics.f("#00FF33").s().p("A8aK7IAAp2ImlAAIAADTIiLAAIAAovICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_71.setTransform(688.3,633);
+        this.shape_71.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADTIiLAAIAAovICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_71.setTransform(688.3, 633);
 
         this.shape_72 = new cjs.Shape();
-        this.shape_72.graphics.f("#00FF33").s().p("A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkEQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEXIkYAAIAAjRIkYAAIAAK7IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAAEZQAABzhSBTQhSBSh0AAMgmQAAAIAACLg");
-        this.shape_72.setTransform(303.3,713.5);
+        this.shape_72.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiLIleAAQh0AAhShSQhShTAAhzMAAAgkEQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEXIkYAAIAAjRIkYAAIAAK7IEYAAIAAjSIEYAAIAASkIkYAAIAAjSIkYAAIAAK9IEYAAIAAjTIEYAAIAAEZQAABzhSBTQhSBSh0AAMgmQAAAIAACLg"
+            );
+        this.shape_72.setTransform(303.3, 713.5);
 
         this.shape_73 = new cjs.Shape();
-        this.shape_73.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImlAAIAADTIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_73.setTransform(688.3,1073.2);
+        this.shape_73.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADTIiLAAIAAouICLAAIAADSIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_73.setTransform(688.3, 1073.2);
 
         this.shape_74 = new cjs.Shape();
-        this.shape_74.graphics.f("#00FF33").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
-        this.shape_74.setTransform(688.3,926.2);
+        this.shape_74.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADTIGlAAIAAp2MBBlAAAIAAV1g");
+        this.shape_74.setTransform(688.3, 926.2);
 
         this.shape_75 = new cjs.Shape();
-        this.shape_75.graphics.f("#00FF33").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_75.setTransform(303.3,1006.7);
+        this.shape_75.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShRAAh1MAAAgkDQAAh1BShRQBShSB0AAIEYAAIAACLIK7AAIAAiLMAlKAAAQB0AABSBSQBSBRAAB1IAAEYIkYAAIAAjTIkYAAIAAK8IEYAAIAAjRIEYAAIAASjIkYAAIAAjRIkYAAIAAK8IEYAAIAAjTIEYAAIAAEYQAAB1hSBRQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_75.setTransform(303.3, 1006.7);
 
         this.shape_76 = new cjs.Shape();
-        this.shape_76.graphics.f("#FF99FF").s().p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp1MBBlAAAIAAV1g");
-        this.shape_76.setTransform(688.3,1367.9);
+        this.shape_76.graphics
+            .f("#FF99FF")
+            .s()
+            .p("A8aK7IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADSIGlAAIAAp1MBBlAAAIAAV1g");
+        this.shape_76.setTransform(688.3, 1367.9);
 
         this.shape_77 = new cjs.Shape();
-        this.shape_77.graphics.f("#00FF33").s().p("A8aK8IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
-        this.shape_77.setTransform(688.3,1221);
+        this.shape_77.graphics
+            .f("#00FF33")
+            .s()
+            .p("A8aK8IAAp2ImlAAIAADSIiLAAIAAouICLAAIAADRIGlAAIAAp2MBBlAAAIAAV3g");
+        this.shape_77.setTransform(688.3, 1221);
 
         this.shape_78 = new cjs.Shape();
-        this.shape_78.graphics.f("#00FF33").s().p("A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg");
-        this.shape_78.setTransform(303.3,1301.4);
+        this.shape_78.graphics
+            .f("#00FF33")
+            .s()
+            .p(
+                "A0wXgIAAiMIleAAQh0AAhShSQhShSAAh0MAAAgkDQAAh0BShSQBShSB0AAIEYAAIAACMIK7AAIAAiMMAlKAAAQB0AABSBSQBSBSAAB0IAAEYIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAASjIkYAAIAAjSIkYAAIAAK8IEYAAIAAjSIEYAAIAAEYQAAB0hSBSQhSBSh0AAMgmQAAAIAACMg"
+            );
+        this.shape_78.setTransform(303.3, 1301.4);
 
-        this.timeline.addTween(cjs.Tween.get({}).to({state:[{t:this.shape_66,p:{y:419.3}},{t:this.shape_65,p:{y:419.3}},{t:this.instance_43,p:{y:412.6}},{t:this.instance_42,p:{y:334.9}},{t:this.instance_41,p:{y:488.9}},{t:this.shape_64,p:{y:338.8}},{t:this.shape_63,p:{y:338.8}},{t:this.instance_40,p:{y:332.1}},{t:this.shape_62,p:{y:485.8}},{t:this.shape_61,p:{y:485.8}},{t:this.instance_39,p:{y:479.1}},{t:this.shape_60,p:{y:854.1}},{t:this.shape_59,p:{y:854.1}},{t:this.instance_38,p:{y:199.7}},{t:this.shape_58,p:{y:196.9}},{t:this.shape_57,p:{y:196.9}},{t:this.instance_37,p:{y:188.3}},{t:this.shape_56,p:{y:713.3}},{t:this.shape_55,p:{y:713.3}},{t:this.instance_36,p:{y:706.6}},{t:this.instance_35,p:{y:628.9}},{t:this.instance_34,p:{y:782.9}},{t:this.shape_54,p:{y:632.8}},{t:this.shape_53,p:{y:632.8}},{t:this.instance_33,p:{y:626.1}},{t:this.shape_52,p:{y:779.8}},{t:this.shape_51,p:{y:779.8}},{t:this.instance_32,p:{y:773.1}},{t:this.shape_50,p:{y:1006.5}},{t:this.shape_49,p:{y:1006.5}},{t:this.instance_31,p:{y:999.8}},{t:this.instance_30,p:{y:922.1}},{t:this.instance_29,p:{y:1076.1}},{t:this.shape_48,p:{y:926}},{t:this.shape_47,p:{y:926}},{t:this.instance_28,p:{y:919.3}},{t:this.shape_46,p:{y:1073}},{t:this.shape_45,p:{y:1073}},{t:this.instance_27,p:{y:1066.3}},{t:this.shape_44,p:{y:1301.3}},{t:this.shape_43,p:{y:1301.3}},{t:this.instance_26,p:{y:1294.6}},{t:this.instance_25,p:{y:1216.9}},{t:this.instance_24,p:{y:1370.9}},{t:this.shape_42,p:{y:1220.8}},{t:this.shape_41,p:{y:1220.8}},{t:this.instance_23,p:{y:1214.1}},{t:this.shape_40,p:{y:1367.8}},{t:this.shape_39,p:{y:1367.8}},{t:this.instance_22,p:{y:1361.1}}]}).to({state:[{t:this.shape_69},{t:this.shape_65,p:{y:419.5}},{t:this.instance_43,p:{y:412.7}},{t:this.instance_42,p:{y:335.1}},{t:this.instance_41,p:{y:489.1}},{t:this.shape_68},{t:this.shape_63,p:{y:339}},{t:this.instance_40,p:{y:332.2}},{t:this.shape_67},{t:this.shape_61,p:{y:486}},{t:this.instance_39,p:{y:479.2}},{t:this.shape_60,p:{y:854.3}},{t:this.shape_59,p:{y:854.3}},{t:this.instance_38,p:{y:199.8}},{t:this.shape_58,p:{y:197}},{t:this.shape_57,p:{y:197}},{t:this.instance_37,p:{y:188.4}},{t:this.shape_56,p:{y:713.5}},{t:this.shape_55,p:{y:713.5}},{t:this.instance_36,p:{y:706.7}},{t:this.instance_35,p:{y:629.1}},{t:this.instance_34,p:{y:783.1}},{t:this.shape_54,p:{y:633}},{t:this.shape_53,p:{y:633}},{t:this.instance_33,p:{y:626.2}},{t:this.shape_52,p:{y:780}},{t:this.shape_51,p:{y:780}},{t:this.instance_32,p:{y:773.2}},{t:this.shape_50,p:{y:1006.7}},{t:this.shape_49,p:{y:1006.7}},{t:this.instance_31,p:{y:999.9}},{t:this.instance_30,p:{y:922.3}},{t:this.instance_29,p:{y:1076.3}},{t:this.shape_48,p:{y:926.2}},{t:this.shape_47,p:{y:926.2}},{t:this.instance_28,p:{y:919.4}},{t:this.shape_46,p:{y:1073.2}},{t:this.shape_45,p:{y:1073.2}},{t:this.instance_27,p:{y:1066.4}},{t:this.shape_44,p:{y:1301.4}},{t:this.shape_43,p:{y:1301.4}},{t:this.instance_26,p:{y:1294.7}},{t:this.instance_25,p:{y:1217.1}},{t:this.instance_24,p:{y:1371}},{t:this.shape_42,p:{y:1221}},{t:this.shape_41,p:{y:1221}},{t:this.instance_23,p:{y:1214.2}},{t:this.shape_40,p:{y:1367.9}},{t:this.shape_39,p:{y:1367.9}},{t:this.instance_22,p:{y:1361.2}}]},1).to({state:[{t:this.shape_66,p:{y:419.5}},{t:this.shape_65,p:{y:419.5}},{t:this.instance_43,p:{y:412.7}},{t:this.instance_42,p:{y:335.1}},{t:this.instance_41,p:{y:489.1}},{t:this.shape_64,p:{y:339}},{t:this.shape_63,p:{y:339}},{t:this.instance_40,p:{y:332.2}},{t:this.shape_62,p:{y:486}},{t:this.shape_61,p:{y:486}},{t:this.instance_39,p:{y:479.2}},{t:this.shape_60,p:{y:854.3}},{t:this.shape_59,p:{y:854.3}},{t:this.instance_38,p:{y:199.8}},{t:this.shape_58,p:{y:197}},{t:this.shape_57,p:{y:197}},{t:this.instance_37,p:{y:188.4}},{t:this.shape_72},{t:this.shape_55,p:{y:713.5}},{t:this.instance_36,p:{y:706.7}},{t:this.instance_35,p:{y:629.1}},{t:this.instance_34,p:{y:783.1}},{t:this.shape_71},{t:this.shape_53,p:{y:633}},{t:this.instance_33,p:{y:626.2}},{t:this.shape_70},{t:this.shape_51,p:{y:780}},{t:this.instance_32,p:{y:773.2}},{t:this.shape_50,p:{y:1006.7}},{t:this.shape_49,p:{y:1006.7}},{t:this.instance_31,p:{y:999.9}},{t:this.instance_30,p:{y:922.3}},{t:this.instance_29,p:{y:1076.3}},{t:this.shape_48,p:{y:926.2}},{t:this.shape_47,p:{y:926.2}},{t:this.instance_28,p:{y:919.4}},{t:this.shape_46,p:{y:1073.2}},{t:this.shape_45,p:{y:1073.2}},{t:this.instance_27,p:{y:1066.4}},{t:this.shape_44,p:{y:1301.4}},{t:this.shape_43,p:{y:1301.4}},{t:this.instance_26,p:{y:1294.7}},{t:this.instance_25,p:{y:1217.1}},{t:this.instance_24,p:{y:1371}},{t:this.shape_42,p:{y:1221}},{t:this.shape_41,p:{y:1221}},{t:this.instance_23,p:{y:1214.2}},{t:this.shape_40,p:{y:1367.9}},{t:this.shape_39,p:{y:1367.9}},{t:this.instance_22,p:{y:1361.2}}]},1).to({state:[{t:this.shape_66,p:{y:419.5}},{t:this.shape_65,p:{y:419.5}},{t:this.instance_43,p:{y:412.7}},{t:this.instance_42,p:{y:335.1}},{t:this.instance_41,p:{y:489.1}},{t:this.shape_64,p:{y:339}},{t:this.shape_63,p:{y:339}},{t:this.instance_40,p:{y:332.2}},{t:this.shape_62,p:{y:486}},{t:this.shape_61,p:{y:486}},{t:this.instance_39,p:{y:479.2}},{t:this.shape_60,p:{y:854.3}},{t:this.shape_59,p:{y:854.3}},{t:this.instance_38,p:{y:199.8}},{t:this.shape_58,p:{y:197}},{t:this.shape_57,p:{y:197}},{t:this.instance_37,p:{y:188.4}},{t:this.shape_56,p:{y:713.5}},{t:this.shape_55,p:{y:713.5}},{t:this.instance_36,p:{y:706.7}},{t:this.instance_35,p:{y:629.1}},{t:this.instance_34,p:{y:783.1}},{t:this.shape_54,p:{y:633}},{t:this.shape_53,p:{y:633}},{t:this.instance_33,p:{y:626.2}},{t:this.shape_52,p:{y:780}},{t:this.shape_51,p:{y:780}},{t:this.instance_32,p:{y:773.2}},{t:this.shape_75},{t:this.shape_49,p:{y:1006.7}},{t:this.instance_31,p:{y:999.9}},{t:this.instance_30,p:{y:922.3}},{t:this.instance_29,p:{y:1076.3}},{t:this.shape_74},{t:this.shape_47,p:{y:926.2}},{t:this.instance_28,p:{y:919.4}},{t:this.shape_73},{t:this.shape_45,p:{y:1073.2}},{t:this.instance_27,p:{y:1066.4}},{t:this.shape_44,p:{y:1301.4}},{t:this.shape_43,p:{y:1301.4}},{t:this.instance_26,p:{y:1294.7}},{t:this.instance_25,p:{y:1217.1}},{t:this.instance_24,p:{y:1371}},{t:this.shape_42,p:{y:1221}},{t:this.shape_41,p:{y:1221}},{t:this.instance_23,p:{y:1214.2}},{t:this.shape_40,p:{y:1367.9}},{t:this.shape_39,p:{y:1367.9}},{t:this.instance_22,p:{y:1361.2}}]},1).to({state:[{t:this.shape_66,p:{y:419.5}},{t:this.shape_65,p:{y:419.5}},{t:this.instance_43,p:{y:412.7}},{t:this.instance_42,p:{y:335.1}},{t:this.instance_41,p:{y:489.1}},{t:this.shape_64,p:{y:339}},{t:this.shape_63,p:{y:339}},{t:this.instance_40,p:{y:332.2}},{t:this.shape_62,p:{y:486}},{t:this.shape_61,p:{y:486}},{t:this.instance_39,p:{y:479.2}},{t:this.shape_60,p:{y:854.3}},{t:this.shape_59,p:{y:854.3}},{t:this.instance_38,p:{y:199.8}},{t:this.shape_58,p:{y:197}},{t:this.shape_57,p:{y:197}},{t:this.instance_37,p:{y:188.4}},{t:this.shape_56,p:{y:713.5}},{t:this.shape_55,p:{y:713.5}},{t:this.instance_36,p:{y:706.7}},{t:this.instance_35,p:{y:629.1}},{t:this.instance_34,p:{y:783.1}},{t:this.shape_54,p:{y:633}},{t:this.shape_53,p:{y:633}},{t:this.instance_33,p:{y:626.2}},{t:this.shape_52,p:{y:780}},{t:this.shape_51,p:{y:780}},{t:this.instance_32,p:{y:773.2}},{t:this.shape_50,p:{y:1006.7}},{t:this.shape_49,p:{y:1006.7}},{t:this.instance_31,p:{y:999.9}},{t:this.instance_30,p:{y:922.3}},{t:this.instance_29,p:{y:1076.3}},{t:this.shape_48,p:{y:926.2}},{t:this.shape_47,p:{y:926.2}},{t:this.instance_28,p:{y:919.4}},{t:this.shape_46,p:{y:1073.2}},{t:this.shape_45,p:{y:1073.2}},{t:this.instance_27,p:{y:1066.4}},{t:this.shape_78},{t:this.shape_43,p:{y:1301.4}},{t:this.instance_26,p:{y:1294.7}},{t:this.instance_25,p:{y:1217.1}},{t:this.instance_24,p:{y:1371}},{t:this.shape_77},{t:this.shape_41,p:{y:1221}},{t:this.instance_23,p:{y:1214.2}},{t:this.shape_76},{t:this.shape_39,p:{y:1367.9}},{t:this.instance_22,p:{y:1361.2}}]},1).to({state:[{t:this.shape_66,p:{y:419.3}},{t:this.shape_65,p:{y:419.3}},{t:this.instance_43,p:{y:412.6}},{t:this.instance_42,p:{y:334.9}},{t:this.instance_41,p:{y:488.9}},{t:this.shape_64,p:{y:338.8}},{t:this.shape_63,p:{y:338.8}},{t:this.instance_40,p:{y:332.1}},{t:this.shape_62,p:{y:485.8}},{t:this.shape_61,p:{y:485.8}},{t:this.instance_39,p:{y:479.1}},{t:this.shape_60,p:{y:854.1}},{t:this.shape_59,p:{y:854.1}},{t:this.instance_38,p:{y:199.7}},{t:this.shape_58,p:{y:196.9}},{t:this.shape_57,p:{y:196.9}},{t:this.instance_37,p:{y:188.3}},{t:this.shape_56,p:{y:713.3}},{t:this.shape_55,p:{y:713.3}},{t:this.instance_36,p:{y:706.6}},{t:this.instance_35,p:{y:628.9}},{t:this.instance_34,p:{y:782.9}},{t:this.shape_54,p:{y:632.8}},{t:this.shape_53,p:{y:632.8}},{t:this.instance_33,p:{y:626.1}},{t:this.shape_52,p:{y:779.8}},{t:this.shape_51,p:{y:779.8}},{t:this.instance_32,p:{y:773.1}},{t:this.shape_50,p:{y:1006.5}},{t:this.shape_49,p:{y:1006.5}},{t:this.instance_31,p:{y:999.8}},{t:this.instance_30,p:{y:922.1}},{t:this.instance_29,p:{y:1076.1}},{t:this.shape_48,p:{y:926}},{t:this.shape_47,p:{y:926}},{t:this.instance_28,p:{y:919.3}},{t:this.shape_46,p:{y:1073}},{t:this.shape_45,p:{y:1073}},{t:this.instance_27,p:{y:1066.3}},{t:this.shape_44,p:{y:1301.3}},{t:this.shape_43,p:{y:1301.3}},{t:this.instance_26,p:{y:1294.6}},{t:this.instance_25,p:{y:1216.9}},{t:this.instance_24,p:{y:1370.9}},{t:this.shape_42,p:{y:1220.8}},{t:this.shape_41,p:{y:1220.8}},{t:this.instance_23,p:{y:1214.1}},{t:this.shape_40,p:{y:1367.8}},{t:this.shape_39,p:{y:1367.8}},{t:this.instance_22,p:{y:1361.1}}]},1).wait(10));
+        this.timeline.addTween(
+            cjs.Tween.get({})
+                .to({
+                    state: [
+                        { t: this.shape_66, p: { y: 419.3 } },
+                        { t: this.shape_65, p: { y: 419.3 } },
+                        { t: this.instance_43, p: { y: 412.6 } },
+                        { t: this.instance_42, p: { y: 334.9 } },
+                        { t: this.instance_41, p: { y: 488.9 } },
+                        { t: this.shape_64, p: { y: 338.8 } },
+                        { t: this.shape_63, p: { y: 338.8 } },
+                        { t: this.instance_40, p: { y: 332.1 } },
+                        { t: this.shape_62, p: { y: 485.8 } },
+                        { t: this.shape_61, p: { y: 485.8 } },
+                        { t: this.instance_39, p: { y: 479.1 } },
+                        { t: this.shape_60, p: { y: 854.1 } },
+                        { t: this.shape_59, p: { y: 854.1 } },
+                        { t: this.instance_38, p: { y: 199.7 } },
+                        { t: this.shape_58, p: { y: 196.9 } },
+                        { t: this.shape_57, p: { y: 196.9 } },
+                        { t: this.instance_37, p: { y: 188.3 } },
+                        { t: this.shape_56, p: { y: 713.3 } },
+                        { t: this.shape_55, p: { y: 713.3 } },
+                        { t: this.instance_36, p: { y: 706.6 } },
+                        { t: this.instance_35, p: { y: 628.9 } },
+                        { t: this.instance_34, p: { y: 782.9 } },
+                        { t: this.shape_54, p: { y: 632.8 } },
+                        { t: this.shape_53, p: { y: 632.8 } },
+                        { t: this.instance_33, p: { y: 626.1 } },
+                        { t: this.shape_52, p: { y: 779.8 } },
+                        { t: this.shape_51, p: { y: 779.8 } },
+                        { t: this.instance_32, p: { y: 773.1 } },
+                        { t: this.shape_50, p: { y: 1006.5 } },
+                        { t: this.shape_49, p: { y: 1006.5 } },
+                        { t: this.instance_31, p: { y: 999.8 } },
+                        { t: this.instance_30, p: { y: 922.1 } },
+                        { t: this.instance_29, p: { y: 1076.1 } },
+                        { t: this.shape_48, p: { y: 926 } },
+                        { t: this.shape_47, p: { y: 926 } },
+                        { t: this.instance_28, p: { y: 919.3 } },
+                        { t: this.shape_46, p: { y: 1073 } },
+                        { t: this.shape_45, p: { y: 1073 } },
+                        { t: this.instance_27, p: { y: 1066.3 } },
+                        { t: this.shape_44, p: { y: 1301.3 } },
+                        { t: this.shape_43, p: { y: 1301.3 } },
+                        { t: this.instance_26, p: { y: 1294.6 } },
+                        { t: this.instance_25, p: { y: 1216.9 } },
+                        { t: this.instance_24, p: { y: 1370.9 } },
+                        { t: this.shape_42, p: { y: 1220.8 } },
+                        { t: this.shape_41, p: { y: 1220.8 } },
+                        { t: this.instance_23, p: { y: 1214.1 } },
+                        { t: this.shape_40, p: { y: 1367.8 } },
+                        { t: this.shape_39, p: { y: 1367.8 } },
+                        { t: this.instance_22, p: { y: 1361.1 } }
+                    ]
+                })
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_69 },
+                            { t: this.shape_65, p: { y: 419.5 } },
+                            { t: this.instance_43, p: { y: 412.7 } },
+                            { t: this.instance_42, p: { y: 335.1 } },
+                            { t: this.instance_41, p: { y: 489.1 } },
+                            { t: this.shape_68 },
+                            { t: this.shape_63, p: { y: 339 } },
+                            { t: this.instance_40, p: { y: 332.2 } },
+                            { t: this.shape_67 },
+                            { t: this.shape_61, p: { y: 486 } },
+                            { t: this.instance_39, p: { y: 479.2 } },
+                            { t: this.shape_60, p: { y: 854.3 } },
+                            { t: this.shape_59, p: { y: 854.3 } },
+                            { t: this.instance_38, p: { y: 199.8 } },
+                            { t: this.shape_58, p: { y: 197 } },
+                            { t: this.shape_57, p: { y: 197 } },
+                            { t: this.instance_37, p: { y: 188.4 } },
+                            { t: this.shape_56, p: { y: 713.5 } },
+                            { t: this.shape_55, p: { y: 713.5 } },
+                            { t: this.instance_36, p: { y: 706.7 } },
+                            { t: this.instance_35, p: { y: 629.1 } },
+                            { t: this.instance_34, p: { y: 783.1 } },
+                            { t: this.shape_54, p: { y: 633 } },
+                            { t: this.shape_53, p: { y: 633 } },
+                            { t: this.instance_33, p: { y: 626.2 } },
+                            { t: this.shape_52, p: { y: 780 } },
+                            { t: this.shape_51, p: { y: 780 } },
+                            { t: this.instance_32, p: { y: 773.2 } },
+                            { t: this.shape_50, p: { y: 1006.7 } },
+                            { t: this.shape_49, p: { y: 1006.7 } },
+                            { t: this.instance_31, p: { y: 999.9 } },
+                            { t: this.instance_30, p: { y: 922.3 } },
+                            { t: this.instance_29, p: { y: 1076.3 } },
+                            { t: this.shape_48, p: { y: 926.2 } },
+                            { t: this.shape_47, p: { y: 926.2 } },
+                            { t: this.instance_28, p: { y: 919.4 } },
+                            { t: this.shape_46, p: { y: 1073.2 } },
+                            { t: this.shape_45, p: { y: 1073.2 } },
+                            { t: this.instance_27, p: { y: 1066.4 } },
+                            { t: this.shape_44, p: { y: 1301.4 } },
+                            { t: this.shape_43, p: { y: 1301.4 } },
+                            { t: this.instance_26, p: { y: 1294.7 } },
+                            { t: this.instance_25, p: { y: 1217.1 } },
+                            { t: this.instance_24, p: { y: 1371 } },
+                            { t: this.shape_42, p: { y: 1221 } },
+                            { t: this.shape_41, p: { y: 1221 } },
+                            { t: this.instance_23, p: { y: 1214.2 } },
+                            { t: this.shape_40, p: { y: 1367.9 } },
+                            { t: this.shape_39, p: { y: 1367.9 } },
+                            { t: this.instance_22, p: { y: 1361.2 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_66, p: { y: 419.5 } },
+                            { t: this.shape_65, p: { y: 419.5 } },
+                            { t: this.instance_43, p: { y: 412.7 } },
+                            { t: this.instance_42, p: { y: 335.1 } },
+                            { t: this.instance_41, p: { y: 489.1 } },
+                            { t: this.shape_64, p: { y: 339 } },
+                            { t: this.shape_63, p: { y: 339 } },
+                            { t: this.instance_40, p: { y: 332.2 } },
+                            { t: this.shape_62, p: { y: 486 } },
+                            { t: this.shape_61, p: { y: 486 } },
+                            { t: this.instance_39, p: { y: 479.2 } },
+                            { t: this.shape_60, p: { y: 854.3 } },
+                            { t: this.shape_59, p: { y: 854.3 } },
+                            { t: this.instance_38, p: { y: 199.8 } },
+                            { t: this.shape_58, p: { y: 197 } },
+                            { t: this.shape_57, p: { y: 197 } },
+                            { t: this.instance_37, p: { y: 188.4 } },
+                            { t: this.shape_72 },
+                            { t: this.shape_55, p: { y: 713.5 } },
+                            { t: this.instance_36, p: { y: 706.7 } },
+                            { t: this.instance_35, p: { y: 629.1 } },
+                            { t: this.instance_34, p: { y: 783.1 } },
+                            { t: this.shape_71 },
+                            { t: this.shape_53, p: { y: 633 } },
+                            { t: this.instance_33, p: { y: 626.2 } },
+                            { t: this.shape_70 },
+                            { t: this.shape_51, p: { y: 780 } },
+                            { t: this.instance_32, p: { y: 773.2 } },
+                            { t: this.shape_50, p: { y: 1006.7 } },
+                            { t: this.shape_49, p: { y: 1006.7 } },
+                            { t: this.instance_31, p: { y: 999.9 } },
+                            { t: this.instance_30, p: { y: 922.3 } },
+                            { t: this.instance_29, p: { y: 1076.3 } },
+                            { t: this.shape_48, p: { y: 926.2 } },
+                            { t: this.shape_47, p: { y: 926.2 } },
+                            { t: this.instance_28, p: { y: 919.4 } },
+                            { t: this.shape_46, p: { y: 1073.2 } },
+                            { t: this.shape_45, p: { y: 1073.2 } },
+                            { t: this.instance_27, p: { y: 1066.4 } },
+                            { t: this.shape_44, p: { y: 1301.4 } },
+                            { t: this.shape_43, p: { y: 1301.4 } },
+                            { t: this.instance_26, p: { y: 1294.7 } },
+                            { t: this.instance_25, p: { y: 1217.1 } },
+                            { t: this.instance_24, p: { y: 1371 } },
+                            { t: this.shape_42, p: { y: 1221 } },
+                            { t: this.shape_41, p: { y: 1221 } },
+                            { t: this.instance_23, p: { y: 1214.2 } },
+                            { t: this.shape_40, p: { y: 1367.9 } },
+                            { t: this.shape_39, p: { y: 1367.9 } },
+                            { t: this.instance_22, p: { y: 1361.2 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_66, p: { y: 419.5 } },
+                            { t: this.shape_65, p: { y: 419.5 } },
+                            { t: this.instance_43, p: { y: 412.7 } },
+                            { t: this.instance_42, p: { y: 335.1 } },
+                            { t: this.instance_41, p: { y: 489.1 } },
+                            { t: this.shape_64, p: { y: 339 } },
+                            { t: this.shape_63, p: { y: 339 } },
+                            { t: this.instance_40, p: { y: 332.2 } },
+                            { t: this.shape_62, p: { y: 486 } },
+                            { t: this.shape_61, p: { y: 486 } },
+                            { t: this.instance_39, p: { y: 479.2 } },
+                            { t: this.shape_60, p: { y: 854.3 } },
+                            { t: this.shape_59, p: { y: 854.3 } },
+                            { t: this.instance_38, p: { y: 199.8 } },
+                            { t: this.shape_58, p: { y: 197 } },
+                            { t: this.shape_57, p: { y: 197 } },
+                            { t: this.instance_37, p: { y: 188.4 } },
+                            { t: this.shape_56, p: { y: 713.5 } },
+                            { t: this.shape_55, p: { y: 713.5 } },
+                            { t: this.instance_36, p: { y: 706.7 } },
+                            { t: this.instance_35, p: { y: 629.1 } },
+                            { t: this.instance_34, p: { y: 783.1 } },
+                            { t: this.shape_54, p: { y: 633 } },
+                            { t: this.shape_53, p: { y: 633 } },
+                            { t: this.instance_33, p: { y: 626.2 } },
+                            { t: this.shape_52, p: { y: 780 } },
+                            { t: this.shape_51, p: { y: 780 } },
+                            { t: this.instance_32, p: { y: 773.2 } },
+                            { t: this.shape_75 },
+                            { t: this.shape_49, p: { y: 1006.7 } },
+                            { t: this.instance_31, p: { y: 999.9 } },
+                            { t: this.instance_30, p: { y: 922.3 } },
+                            { t: this.instance_29, p: { y: 1076.3 } },
+                            { t: this.shape_74 },
+                            { t: this.shape_47, p: { y: 926.2 } },
+                            { t: this.instance_28, p: { y: 919.4 } },
+                            { t: this.shape_73 },
+                            { t: this.shape_45, p: { y: 1073.2 } },
+                            { t: this.instance_27, p: { y: 1066.4 } },
+                            { t: this.shape_44, p: { y: 1301.4 } },
+                            { t: this.shape_43, p: { y: 1301.4 } },
+                            { t: this.instance_26, p: { y: 1294.7 } },
+                            { t: this.instance_25, p: { y: 1217.1 } },
+                            { t: this.instance_24, p: { y: 1371 } },
+                            { t: this.shape_42, p: { y: 1221 } },
+                            { t: this.shape_41, p: { y: 1221 } },
+                            { t: this.instance_23, p: { y: 1214.2 } },
+                            { t: this.shape_40, p: { y: 1367.9 } },
+                            { t: this.shape_39, p: { y: 1367.9 } },
+                            { t: this.instance_22, p: { y: 1361.2 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_66, p: { y: 419.5 } },
+                            { t: this.shape_65, p: { y: 419.5 } },
+                            { t: this.instance_43, p: { y: 412.7 } },
+                            { t: this.instance_42, p: { y: 335.1 } },
+                            { t: this.instance_41, p: { y: 489.1 } },
+                            { t: this.shape_64, p: { y: 339 } },
+                            { t: this.shape_63, p: { y: 339 } },
+                            { t: this.instance_40, p: { y: 332.2 } },
+                            { t: this.shape_62, p: { y: 486 } },
+                            { t: this.shape_61, p: { y: 486 } },
+                            { t: this.instance_39, p: { y: 479.2 } },
+                            { t: this.shape_60, p: { y: 854.3 } },
+                            { t: this.shape_59, p: { y: 854.3 } },
+                            { t: this.instance_38, p: { y: 199.8 } },
+                            { t: this.shape_58, p: { y: 197 } },
+                            { t: this.shape_57, p: { y: 197 } },
+                            { t: this.instance_37, p: { y: 188.4 } },
+                            { t: this.shape_56, p: { y: 713.5 } },
+                            { t: this.shape_55, p: { y: 713.5 } },
+                            { t: this.instance_36, p: { y: 706.7 } },
+                            { t: this.instance_35, p: { y: 629.1 } },
+                            { t: this.instance_34, p: { y: 783.1 } },
+                            { t: this.shape_54, p: { y: 633 } },
+                            { t: this.shape_53, p: { y: 633 } },
+                            { t: this.instance_33, p: { y: 626.2 } },
+                            { t: this.shape_52, p: { y: 780 } },
+                            { t: this.shape_51, p: { y: 780 } },
+                            { t: this.instance_32, p: { y: 773.2 } },
+                            { t: this.shape_50, p: { y: 1006.7 } },
+                            { t: this.shape_49, p: { y: 1006.7 } },
+                            { t: this.instance_31, p: { y: 999.9 } },
+                            { t: this.instance_30, p: { y: 922.3 } },
+                            { t: this.instance_29, p: { y: 1076.3 } },
+                            { t: this.shape_48, p: { y: 926.2 } },
+                            { t: this.shape_47, p: { y: 926.2 } },
+                            { t: this.instance_28, p: { y: 919.4 } },
+                            { t: this.shape_46, p: { y: 1073.2 } },
+                            { t: this.shape_45, p: { y: 1073.2 } },
+                            { t: this.instance_27, p: { y: 1066.4 } },
+                            { t: this.shape_78 },
+                            { t: this.shape_43, p: { y: 1301.4 } },
+                            { t: this.instance_26, p: { y: 1294.7 } },
+                            { t: this.instance_25, p: { y: 1217.1 } },
+                            { t: this.instance_24, p: { y: 1371 } },
+                            { t: this.shape_77 },
+                            { t: this.shape_41, p: { y: 1221 } },
+                            { t: this.instance_23, p: { y: 1214.2 } },
+                            { t: this.shape_76 },
+                            { t: this.shape_39, p: { y: 1367.9 } },
+                            { t: this.instance_22, p: { y: 1361.2 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.shape_66, p: { y: 419.3 } },
+                            { t: this.shape_65, p: { y: 419.3 } },
+                            { t: this.instance_43, p: { y: 412.6 } },
+                            { t: this.instance_42, p: { y: 334.9 } },
+                            { t: this.instance_41, p: { y: 488.9 } },
+                            { t: this.shape_64, p: { y: 338.8 } },
+                            { t: this.shape_63, p: { y: 338.8 } },
+                            { t: this.instance_40, p: { y: 332.1 } },
+                            { t: this.shape_62, p: { y: 485.8 } },
+                            { t: this.shape_61, p: { y: 485.8 } },
+                            { t: this.instance_39, p: { y: 479.1 } },
+                            { t: this.shape_60, p: { y: 854.1 } },
+                            { t: this.shape_59, p: { y: 854.1 } },
+                            { t: this.instance_38, p: { y: 199.7 } },
+                            { t: this.shape_58, p: { y: 196.9 } },
+                            { t: this.shape_57, p: { y: 196.9 } },
+                            { t: this.instance_37, p: { y: 188.3 } },
+                            { t: this.shape_56, p: { y: 713.3 } },
+                            { t: this.shape_55, p: { y: 713.3 } },
+                            { t: this.instance_36, p: { y: 706.6 } },
+                            { t: this.instance_35, p: { y: 628.9 } },
+                            { t: this.instance_34, p: { y: 782.9 } },
+                            { t: this.shape_54, p: { y: 632.8 } },
+                            { t: this.shape_53, p: { y: 632.8 } },
+                            { t: this.instance_33, p: { y: 626.1 } },
+                            { t: this.shape_52, p: { y: 779.8 } },
+                            { t: this.shape_51, p: { y: 779.8 } },
+                            { t: this.instance_32, p: { y: 773.1 } },
+                            { t: this.shape_50, p: { y: 1006.5 } },
+                            { t: this.shape_49, p: { y: 1006.5 } },
+                            { t: this.instance_31, p: { y: 999.8 } },
+                            { t: this.instance_30, p: { y: 922.1 } },
+                            { t: this.instance_29, p: { y: 1076.1 } },
+                            { t: this.shape_48, p: { y: 926 } },
+                            { t: this.shape_47, p: { y: 926 } },
+                            { t: this.instance_28, p: { y: 919.3 } },
+                            { t: this.shape_46, p: { y: 1073 } },
+                            { t: this.shape_45, p: { y: 1073 } },
+                            { t: this.instance_27, p: { y: 1066.3 } },
+                            { t: this.shape_44, p: { y: 1301.3 } },
+                            { t: this.shape_43, p: { y: 1301.3 } },
+                            { t: this.instance_26, p: { y: 1294.6 } },
+                            { t: this.instance_25, p: { y: 1216.9 } },
+                            { t: this.instance_24, p: { y: 1370.9 } },
+                            { t: this.shape_42, p: { y: 1220.8 } },
+                            { t: this.shape_41, p: { y: 1220.8 } },
+                            { t: this.instance_23, p: { y: 1214.1 } },
+                            { t: this.shape_40, p: { y: 1367.8 } },
+                            { t: this.shape_39, p: { y: 1367.8 } },
+                            { t: this.instance_22, p: { y: 1361.1 } }
+                        ]
+                    },
+                    1
+                )
+                .wait(10)
+        );
 
         // Animation
         this.shape_79 = new cjs.Shape();
-        this.shape_79.graphics.f().s("#505050").ss(7,1,1).p("AmTghQhkhLgYgWQhjhZgWhKQhEjgKAgvQJ1guBMD4QAYBOgjBiQgRAwgWAiQgUAvghAvQhDBchCgDQDqB3AZBUQAhBxkQCCQitA3k4gKQh+gEhjgOQhigPgYgSQj8hQAjizQAPhLBBhRQA+hLBbg+g");
-        this.shape_79.setTransform(2477.3,905.3);
+        this.shape_79.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "AmTghQhkhLgYgWQhjhZgWhKQhEjgKAgvQJ1guBMD4QAYBOgjBiQgRAwgWAiQgUAvghAvQhDBchCgDQDqB3AZBUQAhBxkQCCQitA3k4gKQh+gEhjgOQhigPgYgSQj8hQAjizQAPhLBBhRQA+hLBbg+g"
+            );
+        this.shape_79.setTransform(2477.3, 905.3);
 
         this.shape_80 = new cjs.Shape();
-        this.shape_80.graphics.f("#F8F8F8").s().p("AhII6Qh+gEhjgOQhigPgYgSQj8hQAjizQAPhLBBhRQA+hLBbg+QhkhLgYgWQhjhZgWhKQhEjgKAgvQJ1guBMD4QAYBOgjBiQgRAwgWAiQgUAvghAvQhDBchCgDQDqB3AZBUQAhBxkQCCQiUAvj5AAIhYgCg");
-        this.shape_80.setTransform(2477.3,905.3);
+        this.shape_80.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AhII6Qh+gEhjgOQhigPgYgSQj8hQAjizQAPhLBBhRQA+hLBbg+QhkhLgYgWQhjhZgWhKQhEjgKAgvQJ1guBMD4QAYBOgjBiQgRAwgWAiQgUAvghAvQhDBchCgDQDqB3AZBUQAhBxkQCCQiUAvj5AAIhYgCg"
+            );
+        this.shape_80.setTransform(2477.3, 905.3);
 
         this.shape_81 = new cjs.Shape();
-        this.shape_81.graphics.f().s("#505050").ss(7,1,1).p("Aj1gTQg+gvgOgNQg9g2gNgtQgpiJGGgdQGAgcAuCYQAYBMg2BRQgMAdgVAdQgoA3gpgCQCPBJAPAzQAVBFimBPQhqAii+gGQiygGgigZQiagxAWhtQASheB8hUg");
-        this.shape_81.setTransform(2363.7,1010.9);
+        this.shape_81.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "Aj1gTQg+gvgOgNQg9g2gNgtQgpiJGGgdQGAgcAuCYQAYBMg2BRQgMAdgVAdQgoA3gpgCQCPBJAPAzQAVBFimBPQhqAii+gGQiygGgigZQiagxAWhtQASheB8hUg"
+            );
+        this.shape_81.setTransform(2363.7, 1010.9);
 
         this.shape_82 = new cjs.Shape();
-        this.shape_82.graphics.f("#F8F8F8").s().p("AgrFcQiygGgigZQiagxAWhtQASheB8hUQg+gvgOgNQg9g2gNgtQgpiJGGgdQGAgcAuCYQAYBMg2BRQgMAdgVAdQgoA3gpgCQCPBJAPAzQAVBFimBPQhbAdiXAAIg2gBg");
-        this.shape_82.setTransform(2363.7,1010.9);
+        this.shape_82.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AgrFcQiygGgigZQiagxAWhtQASheB8hUQg+gvgOgNQg9g2gNgtQgpiJGGgdQGAgcAuCYQAYBMg2BRQgMAdgVAdQgoA3gpgCQCPBJAPAzQAVBFimBPQhbAdiXAAIg2gBg"
+            );
+        this.shape_82.setTransform(2363.7, 1010.9);
 
         this.shape_83 = new cjs.Shape();
-        this.shape_83.graphics.f().s("#505050").ss(10,1,1).p("AodFuQBrANB+gUQCcgYCOhGQF3i6CxnB");
-        this.shape_83.setTransform(2101.8,490.9);
+        this.shape_83.graphics.f().s("#505050").ss(10, 1, 1).p("AodFuQBrANB+gUQCcgYCOhGQF3i6CxnB");
+        this.shape_83.setTransform(2101.8, 490.9);
 
         this.shape_84 = new cjs.Shape();
-        this.shape_84.graphics.f().s("#505050").ss(15,0,0,4).p("AFak4QAOhCAGhdQALi4gmh/Qg3ixiTgmQi2gvlACwQpGE/g4EVQgSBXAlBIQASAkAWASIAOAkQAWAqAmAkQB7B2D4AHIgMBTQgMBmAGBhQARE2CzCSQC0CSC8hcQBfguA7hMIAegkQAkguAZgtQBRiRg1hVIAjAdQAwAgA7ANQC9AsDsiaQDriajUkEQhDhPhnhSIhahBQg2gfhBgfQiDg/g2gEg");
-        this.shape_84.setTransform(2560.1,575.9);
+        this.shape_84.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 0, 0, 4)
+            .p(
+                "AFak4QAOhCAGhdQALi4gmh/Qg3ixiTgmQi2gvlACwQpGE/g4EVQgSBXAlBIQASAkAWASIAOAkQAWAqAmAkQB7B2D4AHIgMBTQgMBmAGBhQARE2CzCSQC0CSC8hcQBfguA7hMIAegkQAkguAZgtQBRiRg1hVIAjAdQAwAgA7ANQC9AsDsiaQDriajUkEQhDhPhnhSIhahBQg2gfhBgfQiDg/g2gEg"
+            );
+        this.shape_84.setTransform(2560.1, 575.9);
 
         this.shape_85 = new cjs.Shape();
-        this.shape_85.graphics.f("#F8F8F8").s().p("AlBOWQiziSgRk2QgGhhAMhmIAMhTQj4gHh7h2QgmgkgWgqIgOgkQgWgSgSgkQglhIAShXQA4kVJGk/QFAiwC2AvQCTAmA3CxQAmB/gLC4QgGBdgOBCQA2AECDA/QBBAfA2AfIBaBBQBnBSBDBPQDUEEjrCaQjsCai9gsQg7gNgwggIgjgdQA1BVhRCRQgZAtgkAuIgeAkQg7BMhfAuQhIAjhIAAQhyAAhuhZg");
-        this.shape_85.setTransform(2560.1,575.9);
+        this.shape_85.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AlBOWQiziSgRk2QgGhhAMhmIAMhTQj4gHh7h2QgmgkgWgqIgOgkQgWgSgSgkQglhIAShXQA4kVJGk/QFAiwC2AvQCTAmA3CxQAmB/gLC4QgGBdgOBCQA2AECDA/QBBAfA2AfIBaBBQBnBSBDBPQDUEEjrCaQjsCai9gsQg7gNgwggIgjgdQA1BVhRCRQgZAtgkAuIgeAkQg7BMhfAuQhIAjhIAAQhyAAhuhZg"
+            );
+        this.shape_85.setTransform(2560.1, 575.9);
 
         this.shape_86 = new cjs.Shape();
-        this.shape_86.graphics.f().s("#505050").ss(15,0,0,4).p("AjfiZQgNBJgdApQg6BRhPicQAEiQg2h/QgwhzhKg6QhKg5g4AhQg+AlgKCJQgzGZC0FkQCcEyD/CZQByBEBnANQBoANBGgxQCihwhWlqQhEjGAPh4QAFglAMgaIALgPIATgOQAXgOAXACQBJAGAnCeQAVBRAEBNQAAALAABdQAAAuALAWQANAcAqAWQBSAsAlACQAaABArgZQCVjwgbkOQgYjjiSjgQh9i/iwiKQijiAhtgLQi3AOhvBmQhuBmAsBxQAkBdAiCqQARBVAJBCg");
-        this.shape_86.setTransform(2630.8,746.8);
+        this.shape_86.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 0, 0, 4)
+            .p(
+                "AjfiZQgNBJgdApQg6BRhPicQAEiQg2h/QgwhzhKg6QhKg5g4AhQg+AlgKCJQgzGZC0FkQCcEyD/CZQByBEBnANQBoANBGgxQCihwhWlqQhEjGAPh4QAFglAMgaIALgPIATgOQAXgOAXACQBJAGAnCeQAVBRAEBNQAAALAABdQAAAuALAWQANAcAqAWQBSAsAlACQAaABArgZQCVjwgbkOQgYjjiSjgQh9i/iwiKQijiAhtgLQi3AOhvBmQhuBmAsBxQAkBdAiCqQARBVAJBCg"
+            );
+        this.shape_86.setTransform(2630.8, 746.8);
 
         this.shape_87 = new cjs.Shape();
-        this.shape_87.graphics.f("#C9DAD8").s().p("AgTOAQhngMhyhFQj/iYickzQi0lkAzmYQAKiJA+glQA4giBKA6QBKA5AwBzQA2CAgECQQBPCcA6hRQAdgqANhJQgJhCgRhVQgiipgkheQgshxBuhlQBvhnC3gNQBtALCjB/QCwCKB9DAQCSDgAYDjQAbENiVDwQgrAagagCQglgChSgrQgqgWgNgcQgLgWAAguIAAhpQgEhMgVhSQgnidhJgGQgXgCgXANIgTAOIgLAQQgMAZgFAmQgPB3BEDGQBWFqiiBwQg3AnhOAAQgUAAgVgDg");
-        this.shape_87.setTransform(2630.8,746.8);
+        this.shape_87.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AgTOAQhngMhyhFQj/iYickzQi0lkAzmYQAKiJA+glQA4giBKA6QBKA5AwBzQA2CAgECQQBPCcA6hRQAdgqANhJQgJhCgRhVQgiipgkheQgshxBuhlQBvhnC3gNQBtALCjB/QCwCKB9DAQCSDgAYDjQAbENiVDwQgrAagagCQglgChSgrQgqgWgNgcQgLgWAAguIAAhpQgEhMgVhSQgnidhJgGQgXgCgXANIgTAOIgLAQQgMAZgFAmQgPB3BEDGQBWFqiiBwQg3AnhOAAQgUAAgVgDg"
+            );
+        this.shape_87.setTransform(2630.8, 746.8);
 
         this.shape_88 = new cjs.Shape();
-        this.shape_88.graphics.f().s("#505050").ss(15,0,0,4).p("AFJkaQAMg7AChQQAEiigvhsQhCiYifgZQjFgflPCrQh1BwhdC6Qi7F1B4FxIAOAZQATAgAgAhQBmBpC7BLQAoAQFKCNQC1BPCMApQCTAsCRheQBIgvArg4QAwhOANhlQAYjJizhuQizhuiRguQgtgPglgHIgcgDQAegyAghCQBBiEAMhFg");
-        this.shape_88.setTransform(2124.1,220.1);
+        this.shape_88.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 0, 0, 4)
+            .p(
+                "AFJkaQAMg7AChQQAEiigvhsQhCiYifgZQjFgflPCrQh1BwhdC6Qi7F1B4FxIAOAZQATAgAgAhQBmBpC7BLQAoAQFKCNQC1BPCMApQCTAsCRheQBIgvArg4QAwhOANhlQAYjJizhuQizhuiRguQgtgPglgHIgcgDQAegyAghCQBBiEAMhFg"
+            );
+        this.shape_88.setTransform(2124.1, 220.1);
 
         this.shape_89 = new cjs.Shape();
-        this.shape_89.graphics.f("#C9DAD8").s().p("AE3NbQiMgpi1hPQlKiNgogQQi7hLhmhpQggghgTggIgOgZQh4lxC7l1QBdi6B1hvQFPisDFAfQCfAZBCCYQAvBsgECiQgCBQgMA7QgMBFhBCFQggBBgeAyIAcADQAlAHAtAPQCRAuCzBuQCzBugYDJQgNBlgwBOQgrA4hIAvQhjBAhkAAQgvAAgugOg");
-        this.shape_89.setTransform(2124.1,220.1);
+        this.shape_89.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AE3NbQiMgpi1hPQlKiNgogQQi7hLhmhpQggghgTggIgOgZQh4lxC7l1QBdi6B1hvQFPisDFAfQCfAZBCCYQAvBsgECiQgCBQgMA7QgMBFhBCFQggBBgeAyIAcADQAlAHAtAPQCRAuCzBuQCzBugYDJQgNBlgwBOQgrA4hIAvQhjBAhkAAQgvAAgugOg"
+            );
+        this.shape_89.setTransform(2124.1, 220.1);
 
         this.shape_90 = new cjs.Shape();
-        this.shape_90.graphics.f().s("#505050").ss(15,1,1).p("ANShgQA0FFi0BEQg4AVhJgHIg9gMQhFgIhIgfQiOhAgLh2QgKh1iIhUQgqgbgygUIgngOQgwgTgkASQhGAjA/CzIABAPQAGATAXAWQBMBGDeBGQDhBFA2CGQAbBDgSA1Qg9B/gZAmQgoBAguAVQgxAXhVgKQhKgJiXgpQl+jCjQjcQi6jFghjKQgei3BhimQBZibCyhsQCuhpDRggQDYghDDA5QDVA+CRCgQChCzA5EYg");
-        this.shape_90.setTransform(2432.7,431.2);
+        this.shape_90.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p(
+                "ANShgQA0FFi0BEQg4AVhJgHIg9gMQhFgIhIgfQiOhAgLh2QgKh1iIhUQgqgbgygUIgngOQgwgTgkASQhGAjA/CzIABAPQAGATAXAWQBMBGDeBGQDhBFA2CGQAbBDgSA1Qg9B/gZAmQgoBAguAVQgxAXhVgKQhKgJiXgpQl+jCjQjcQi6jFghjKQgei3BhimQBZibCyhsQCuhpDRggQDYghDDA5QDVA+CRCgQChCzA5EYg"
+            );
+        this.shape_90.setTransform(2432.7, 431.2);
 
         this.shape_91 = new cjs.Shape();
-        this.shape_91.graphics.f("#C9DAD8").s().p("AC0MrQhKgJiXgpQl+jCjQjcQi6jFghjKQgei3BhimQBZibCyhsQCuhpDRggQDYghDDA5QDVA+CRCgQChCzA5EYQA0FFi0BEQg4AVhJgHIg9gMQhFgIhIgfQiOhAgLh2QgKh1iIhUQgqgbgygUIgngOQgwgTgkASQhGAjA/CzIABAPQAGATAXAWQBMBGDeBGQDhBFA2CGQAbBDgSA1Qg9B/gZAmQgoBAguAVQgiAQg0AAQgWAAgagDg");
-        this.shape_91.setTransform(2432.7,431.2);
+        this.shape_91.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AC0MrQhKgJiXgpQl+jCjQjcQi6jFghjKQgei3BhimQBZibCyhsQCuhpDRggQDYghDDA5QDVA+CRCgQChCzA5EYQA0FFi0BEQg4AVhJgHIg9gMQhFgIhIgfQiOhAgLh2QgKh1iIhUQgqgbgygUIgngOQgwgTgkASQhGAjA/CzIABAPQAGATAXAWQBMBGDeBGQDhBFA2CGQAbBDgSA1Qg9B/gZAmQgoBAguAVQgiAQg0AAQgWAAgagDg"
+            );
+        this.shape_91.setTransform(2432.7, 431.2);
 
         this.shape_92 = new cjs.Shape();
-        this.shape_92.graphics.f().s("#505050").ss(15,1,1).p("AByj+QA5AaAGBdQAHBdgwBnQgvBqhKA5QhIA4g5gZQg4gagHhdQgGhcAwhoQAvhqBKg5QBIg4A4AZg");
-        this.shape_92.setTransform(2303.1,294.6);
+        this.shape_92.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p("AByj+QA5AaAGBdQAHBdgwBnQgvBqhKA5QhIA4g5gZQg4gagHhdQgGhcAwhoQAvhqBKg5QBIg4A4AZg");
+        this.shape_92.setTransform(2303.1, 294.6);
 
         this.shape_93 = new cjs.Shape();
-        this.shape_93.graphics.f("#F8F8F8").s().p("AhyD/Qg4gagHhdQgGhcAwhoQAvhqBKg5QBIg4A4AZQA5AaAGBdQAHBdgwBnQgvBqhKA5QgxAngrAAQgTAAgSgIg");
-        this.shape_93.setTransform(2303.1,294.6);
+        this.shape_93.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AhyD/Qg4gagHhdQgGhcAwhoQAvhqBKg5QBIg4A4AZQA5AaAGBdQAHBdgwBnQgvBqhKA5QgxAngrAAQgTAAgSgIg"
+            );
+        this.shape_93.setTransform(2303.1, 294.6);
 
         this.shape_94 = new cjs.Shape();
-        this.shape_94.graphics.f().s("#505050").ss(15,1,1).p("AFErPQCjBKB8B7QB3B4BDCWQBCCVACCbQADCihCCTQhCCSh7BqQh3BlicAyQicAyipgKQisgLikhJQijhKh7h7Qh4h4hCiWQhCiVgDibQgDiiBCiTQBCiSB7hqQB4hmCcgxQCcgyCoAKQCtALCjBJg");
-        this.shape_94.setTransform(2300.6,296.7);
+        this.shape_94.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p(
+                "AFErPQCjBKB8B7QB3B4BDCWQBCCVACCbQADCihCCTQhCCSh7BqQh3BlicAyQicAyipgKQisgLikhJQijhKh7h7Qh4h4hCiWQhCiVgDibQgDiiBCiTQBCiSB7hqQB4hmCcgxQCcgyCoAKQCtALCjBJg"
+            );
+        this.shape_94.setTransform(2300.6, 296.7);
 
         this.shape_95 = new cjs.Shape();
-        this.shape_95.graphics.f("#F8F8F8").s().p("AANMkQisgLikhJQijhKh8h7Qh3h4hCiWQhCiVgDibQgDiiBCiTQBCiSB7hqQB3hmCdgxQCcgyCoAKQCtALCjBJQCjBKB8B7QB3B4BDCWQBBCVADCbQADCihCCTQhCCSh7BqQh4BlibAyQiCApiLAAQgcAAgcgBg");
-        this.shape_95.setTransform(2300.6,296.7);
+        this.shape_95.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AANMkQisgLikhJQijhKh8h7Qh3h4hCiWQhCiVgDibQgDiiBCiTQBCiSB7hqQB3hmCdgxQCcgyCoAKQCtALCjBJQCjBKB8B7QB3B4BDCWQBBCVADCbQADCihCCTQhCCSh7BqQh4BlibAyQiCApiLAAQgcAAgcgBg"
+            );
+        this.shape_95.setTransform(2300.6, 296.7);
 
         this.shape_96 = new cjs.Shape();
-        this.shape_96.graphics.f().s("#505050").ss(10,1,1).p("AAHhIQA9AGApAaQApAZgDAdQgDAfgtARQgtARg8gGQg9gGgpgaQgpgaADgcQADgfAtgRQAugSA7AHg");
-        this.shape_96.setTransform(1938.1,200.2);
+        this.shape_96.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p("AAHhIQA9AGApAaQApAZgDAdQgDAfgtARQgtARg8gGQg9gGgpgaQgpgaADgcQADgfAtgRQAugSA7AHg");
+        this.shape_96.setTransform(1938.1, 200.2);
 
         this.shape_97 = new cjs.Shape();
-        this.shape_97.graphics.f("#F8F8F8").s().p("AgGBJQg9gGgpgaQgpgaADgcQADgfAtgRQAugSA7AHQA9AGApAaQApAZgDAdQgDAfgtARQgiANgqAAQgPAAgOgCg");
-        this.shape_97.setTransform(1938.1,200.2);
+        this.shape_97.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AgGBJQg9gGgpgaQgpgaADgcQADgfAtgRQAugSA7AHQA9AGApAaQApAZgDAdQgDAfgtARQgiANgqAAQgPAAgOgCg"
+            );
+        this.shape_97.setTransform(1938.1, 200.2);
 
         this.shape_98 = new cjs.Shape();
-        this.shape_98.graphics.f().s("#505050").ss(10,1,1).p("AAGhFQA7AGAnAZQAnAZgDAbQgDAdgrAQQgrARg5gGQg6gGgngZQgngYADgbQACgdAsgRQArgQA4AFg");
-        this.shape_98.setTransform(1942.4,149.9);
+        this.shape_98.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p("AAGhFQA7AGAnAZQAnAZgDAbQgDAdgrAQQgrARg5gGQg6gGgngZQgngYADgbQACgdAsgRQArgQA4AFg");
+        this.shape_98.setTransform(1942.4, 149.9);
 
         this.shape_99 = new cjs.Shape();
-        this.shape_99.graphics.f("#F8F8F8").s().p("AgGBGQg6gGgngZQgngZADgbQACgcAsgRQArgRA4AGQA7AGAnAYQAnAZgDAbQgDAegrAQQggAMgpAAIgbgBg");
-        this.shape_99.setTransform(1942.4,149.9);
+        this.shape_99.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AgGBGQg6gGgngZQgngZADgbQACgcAsgRQArgRA4AGQA7AGAnAYQAnAZgDAbQgDAegrAQQggAMgpAAIgbgBg"
+            );
+        this.shape_99.setTransform(1942.4, 149.9);
 
         this.shape_100 = new cjs.Shape();
-        this.shape_100.graphics.f().s("#505050").ss(15,0,0,4).p("AkhryQiCgxiHAPQkNAegXE+QgSD+gkFBQgRDbAzBvQA9CFBDAvQBAAtC0AoQD4A3ERAGQF4AJDjhkQDVheAajdQAIhFgMhKIgNg7Qg0gwhQgzQgZgPAPgGQALgFAxgRQB0g1ASi2QATjBjUidQhCgwhRgoIhEgdg");
-        this.shape_100.setTransform(1941.2,179.7);
+        this.shape_100.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 0, 0, 4)
+            .p(
+                "AkhryQiCgxiHAPQkNAegXE+QgSD+gkFBQgRDbAzBvQA9CFBDAvQBAAtC0AoQD4A3ERAGQF4AJDjhkQDVheAajdQAIhFgMhKIgNg7Qg0gwhQgzQgZgPAPgGQALgFAxgRQB0g1ASi2QATjBjUidQhCgwhRgoIhEgdg"
+            );
+        this.shape_100.setTransform(1941.2, 179.7);
 
         this.shape_101 = new cjs.Shape();
-        this.shape_101.graphics.f("#F8F8F8").s().p("AAbMXQkRgGj4g3Qi0gohAgtQhDgvg9iFQgzhvARjbQAklBASj+QAXk+ENgeQCHgPCCAxIMRBdIBEAdQBRAoBCAwQDUCdgTDBQgSC2h0A1Ig8AWQgPAGAZAPQBQAzA0AwIANA7QAMBKgIBFQgaDdjVBeQjQBclOAAIg9gBg");
-        this.shape_101.setTransform(1941.2,179.7);
+        this.shape_101.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AAbMXQkRgGj4g3Qi0gohAgtQhDgvg9iFQgzhvARjbQAklBASj+QAXk+ENgeQCHgPCCAxIMRBdIBEAdQBRAoBCAwQDUCdgTDBQgSC2h0A1Ig8AWQgPAGAZAPQBQAzA0AwIANA7QAMBKgIBFQgaDdjVBeQjQBclOAAIg9gBg"
+            );
+        this.shape_101.setTransform(1941.2, 179.7);
 
         this.shape_102 = new cjs.Shape();
-        this.shape_102.graphics.f().s("#505050").ss(15,1,1).p("AGaq5QEqCRgvC6QgXBdhUBBQguA0hDAoQiFBRhng7Qhng8iRA/QguAUgtAdIgjAaQgLAHgLAKQgXAYgEAZQgLBOC4AzIANAIQATAGAdgHQBlgVC6iRQC5iOCNAhQBGAQAhAtQBFB4ASAqQAdBFgJAyQgJA2g5A/QgxA5h5BlQl7DLkpAsQkMAoi5hZQiohRhRiuQhMiiANjPQANjKBdi9QBijGCeh/QCuiLDWgbQDsgeEGBxg");
-        this.shape_102.setTransform(1659.7,206.9);
+        this.shape_102.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p(
+                "AGaq5QEqCRgvC6QgXBdhUBBQguA0hDAoQiFBRhng7Qhng8iRA/QguAUgtAdIgjAaQgLAHgLAKQgXAYgEAZQgLBOC4AzIANAIQATAGAdgHQBlgVC6iRQC5iOCNAhQBGAQAhAtQBFB4ASAqQAdBFgJAyQgJA2g5A/QgxA5h5BlQl7DLkpAsQkMAoi5hZQiohRhRiuQhMiiANjPQANjKBdi9QBijGCeh/QCuiLDWgbQDsgeEGBxg"
+            );
+        this.shape_102.setTransform(1659.7, 206.9);
 
         this.shape_103 = new cjs.Shape();
-        this.shape_103.graphics.f("#C9DAD8").s().p("AoOLWQiohRhRiuQhMiiANjPQANjKBdi9QBijGCeh/QCuiLDWgbQDsgeEGBxQEqCRgvC6QgXBdhUBBQguA0hDAoQiFBRhng7Qhng8iRA/QguAUgtAdIgjAaQgLAHgLAKQgXAYgEAZQgLBOC4AzIANAIQATAGAdgHQBlgVC6iRQC5iOCNAhQBGAQAhAtQBFB4ASAqQAdBFgJAyQgJA2g5A/QgxA5h5BlQl7DLkpAsQhSAMhLAAQioAAiAg9g");
-        this.shape_103.setTransform(1659.7,206.9);
+        this.shape_103.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AoOLWQiohRhRiuQhMiiANjPQANjKBdi9QBijGCeh/QCuiLDWgbQDsgeEGBxQEqCRgvC6QgXBdhUBBQguA0hDAoQiFBRhng7Qhng8iRA/QguAUgtAdIgjAaQgLAHgLAKQgXAYgEAZQgLBOC4AzIANAIQATAGAdgHQBlgVC6iRQC5iOCNAhQBGAQAhAtQBFB4ASAqQAdBFgJAyQgJA2g5A/QgxA5h5BlQl7DLkpAsQhSAMhLAAQioAAiAg9g"
+            );
+        this.shape_103.setTransform(1659.7, 206.9);
 
         this.shape_104 = new cjs.Shape();
-        this.shape_104.graphics.f().s("#505050").ss(15,1,1).p("Ak1OkQDPBYEPiAQD8h3DUj8QDXj/BEkKQBLkliMjIQlQlTlAhkQiLgrh0AJQhvAJhNA1QhLAzgcBUQgdBWAaBnQA6DrEoDZQAYAhADAoQACAngTAfQgrBOhjgYQk5jOjnAeQhkAOhDA7QhBA3gWBZQgXBaAZBpQAZBuBJBtQCoD6FhCeg");
-        this.shape_104.setTransform(1250.6,491.6);
+        this.shape_104.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p(
+                "Ak1OkQDPBYEPiAQD8h3DUj8QDXj/BEkKQBLkliMjIQlQlTlAhkQiLgrh0AJQhvAJhNA1QhLAzgcBUQgdBWAaBnQA6DrEoDZQAYAhADAoQACAngTAfQgrBOhjgYQk5jOjnAeQhkAOhDA7QhBA3gWBZQgXBaAZBpQAZBuBJBtQCoD6FhCeg"
+            );
+        this.shape_104.setTransform(1250.6, 491.6);
 
         this.shape_105 = new cjs.Shape();
-        this.shape_105.graphics.f("#F8F8F8").s().p("Ak1OkQlhieioj6QhJhtgZhuQgZhpAXhaQAWhZBBg3QBDg7BkgOQDngeE5DOQBjAYArhOQATgfgCgnQgDgogYghQkojZg6jrQgahnAdhWQAchUBLgzQBNg1BvgJQB0gJCLArQFABkFQFTQCMDIhLElQhEEKjXD/QjUD8j8B3QiiBMiJAAQhfAAhUgkg");
-        this.shape_105.setTransform(1250.6,491.6);
+        this.shape_105.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "Ak1OkQlhieioj6QhJhtgZhuQgZhpAXhaQAWhZBBg3QBDg7BkgOQDngeE5DOQBjAYArhOQATgfgCgnQgDgogYghQkojZg6jrQgahnAdhWQAchUBLgzQBNg1BvgJQB0gJCLArQFABkFQFTQCMDIhLElQhEEKjXD/QjUD8j8B3QiiBMiJAAQhfAAhUgkg"
+            );
+        this.shape_105.setTransform(1250.6, 491.6);
 
         this.shape_106 = new cjs.Shape();
-        this.shape_106.graphics.f().s("#505050").ss(15,0,0,4).p("AhXDnIArgBQAuABAeALQBfAjiCB1QiNAhhtBUQhjBMglBXQglBWAvAuQA0AyCHgZQGYg4EqkJQEBjlBSkbQAliAgOhnQgPhphBg4QiViAlJCvQiuB1h3AQQgkAFgbgFIgUgHQgjgUgHgkQgMhICOhPQBJgoBKgYQAKgDBagYQAtgLASgQQAYgVALgtQAVhbgIgkQgFgagkgjQkOhTj8BgQjXBRizDHQiaCphYDOQhRC8ARBsQA8CwCABRQB+BQBihHQBRg7CchMQBNgmA+gag");
-        this.shape_106.setTransform(1387.9,351.7);
+        this.shape_106.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 0, 0, 4)
+            .p(
+                "AhXDnIArgBQAuABAeALQBfAjiCB1QiNAhhtBUQhjBMglBXQglBWAvAuQA0AyCHgZQGYg4EqkJQEBjlBSkbQAliAgOhnQgPhphBg4QiViAlJCvQiuB1h3AQQgkAFgbgFIgUgHQgjgUgHgkQgMhICOhPQBJgoBKgYQAKgDBagYQAtgLASgQQAYgVALgtQAVhbgIgkQgFgagkgjQkOhTj8BgQjXBRizDHQiaCphYDOQhRC8ARBsQA8CwCABRQB+BQBihHQBRg7CchMQBNgmA+gag"
+            );
+        this.shape_106.setTransform(1387.9, 351.7);
 
         this.shape_107 = new cjs.Shape();
-        this.shape_107.graphics.f("#C9DAD8").s().p("Al7MmQgvguAlhWQAlhXBjhMQBthUCNghQCCh1hfgjQgegLgugBIgrABQg+AahNAmQicBMhRA7QhiBHh+hQQiAhRg8iwQgRhsBRi8QBYjOCaipQCzjHDXhRQD8hgEOBTQAkAjAFAaQAIAkgVBbQgLAtgYAVQgSAQgtALIhkAbQhKAYhJAoQiOBPAMBIQAHAkAjAUIAUAHQAbAFAkgFQB3gQCuh1QFJivCVCAQBBA4APBpQAOBnglCAQhSEbkBDlQkqEJmYA4QguAJgkAAQhHAAgigig");
-        this.shape_107.setTransform(1387.9,351.7);
+        this.shape_107.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "Al7MmQgvguAlhWQAlhXBjhMQBthUCNghQCCh1hfgjQgegLgugBIgrABQg+AahNAmQicBMhRA7QhiBHh+hQQiAhRg8iwQgRhsBRi8QBYjOCaipQCzjHDXhRQD8hgEOBTQAkAjAFAaQAIAkgVBbQgLAtgYAVQgSAQgtALIhkAbQhKAYhJAoQiOBPAMBIQAHAkAjAUIAUAHQAbAFAkgFQB3gQCuh1QFJivCVCAQBBA4APBpQAOBnglCAQhSEbkBDlQkqEJmYA4QguAJgkAAQhHAAgigig"
+            );
+        this.shape_107.setTransform(1387.9, 351.7);
 
         this.shape_108 = new cjs.Shape();
-        this.shape_108.graphics.f().s("#505050").ss(15,1,1).p("AldqPQCZhVDRCEQDTCFCREQQCSEOgGD8QgFD8iZBVQiZBVjRiEQjTiFiSkQQiRkOAFj8QAGj8CZhVg");
-        this.shape_108.setTransform(1514.5,264);
+        this.shape_108.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p("AldqPQCZhVDRCEQDTCFCREQQCSEOgGD8QgFD8iZBVQiZBVjRiEQjTiFiSkQQiRkOAFj8QAGj8CZhVg");
+        this.shape_108.setTransform(1514.5, 264);
 
         this.shape_109 = new cjs.Shape();
-        this.shape_109.graphics.f("#F8F8F8").s().p("AgLJhQjUiFiRkQQiRkOAFj8QAGj8CYhVQCahUDRCDQDTCFCREQQCSEOgGD8QgFD9iaBUQg7AhhFAAQhrAAh+hQg");
-        this.shape_109.setTransform(1514.5,264);
+        this.shape_109.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AgLJhQjUiFiRkQQiRkOAFj8QAGj8CYhVQCahUDRCDQDTCFCREQQCSEOgGD8QgFD9iaBUQg7AhhFAAQhrAAh+hQg"
+            );
+        this.shape_109.setTransform(1514.5, 264);
 
         this.shape_110 = new cjs.Shape();
-        this.shape_110.graphics.f().s("#505050").ss(15,1,1).p("AFdHNQCDgBBbg4QC1hwjMkUIApgHQA0gJA0gOQClgwBohLQCRhrACiTQACi5jfjwQjQh5jvhrQnbjXiVBCQjwBphfCZQiJDcCQFIIBaDkIkbBVIhoA3Qh3BIhKBaQjuEfEnFWQEnFVH4BMQD6AmDBgfQAlgPAugeQBeg7A0hLQCojtkxkmg");
-        this.shape_110.setTransform(1136.2,686.8);
+        this.shape_110.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p(
+                "AFdHNQCDgBBbg4QC1hwjMkUIApgHQA0gJA0gOQClgwBohLQCRhrACiTQACi5jfjwQjQh5jvhrQnbjXiVBCQjwBphfCZQiJDcCQFIIBaDkIkbBVIhoA3Qh3BIhKBaQjuEfEnFWQEnFVH4BMQD6AmDBgfQAlgPAugeQBeg7A0hLQCojtkxkmg"
+            );
+        this.shape_110.setTransform(1136.2, 686.8);
 
         this.shape_111 = new cjs.Shape();
-        this.shape_111.graphics.f("#C9DAD8").s().p("AiRSlQn4hMknlVQknlWDukfQBKhaB3hIIBog3IEbhVIhajkQiQlICJjcQBfiZDwhpQCVhCHbDXQDvBrDQB5QDfDwgCC5QgCCTiRBrQhoBLilAwQg0AOg0AJIgpAHQDMEUi1BwQhbA4iDABIApAZQExEmioDtQg0BLheA7QguAeglAPQhWAOhhAAQh4AAiMgVg");
-        this.shape_111.setTransform(1136.2,686.8);
+        this.shape_111.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AiRSlQn4hMknlVQknlWDukfQBKhaB3hIIBog3IEbhVIhajkQiQlICJjcQBfiZDwhpQCVhCHbDXQDvBrDQB5QDfDwgCC5QgCCTiRBrQhoBLilAwQg0AOg0AJIgpAHQDMEUi1BwQhbA4iDABIApAZQExEmioDtQg0BLheA7QguAeglAPQhWAOhhAAQh4AAiMgVg"
+            );
+        this.shape_111.setTransform(1136.2, 686.8);
 
         this.shape_112 = new cjs.Shape();
-        this.shape_112.graphics.f().s("#505050").ss(15,1,1).p("Aq5APICMA8QCwA/CvAUQIuBBFbmG");
-        this.shape_112.setTransform(1814,959);
+        this.shape_112.graphics.f().s("#505050").ss(15, 1, 1).p("Aq5APICMA8QCwA/CvAUQIuBBFbmG");
+        this.shape_112.setTransform(1814, 959);
 
         this.shape_113 = new cjs.Shape();
-        this.shape_113.graphics.f().s("#505050").ss(15,1,1).p("AI/iCQgoAihEArQiHBUiMAwQm+CYlAkk");
-        this.shape_113.setTransform(2148.5,911.2);
+        this.shape_113.graphics.f().s("#505050").ss(15, 1, 1).p("AI/iCQgoAihEArQiHBUiMAwQm+CYlAkk");
+        this.shape_113.setTransform(2148.5, 911.2);
 
         this.shape_114 = new cjs.Shape();
-        this.shape_114.graphics.f().s("#505050").ss(10,1,1).p("Ab0UaQAYgQD9hgQEThqCwhgQJUlHhsmhQhQkviEkoQiol3jTj8QkAkzkoheQlbhtmDC8QqwFQtzhxQkVgkkHhMIjQhFQh4gtiqgSQlTgjj4CNQlUDCjgEKQkSFGhZGmQhQF8MKHpQDzCZErCRQCWBIBlAqID/AcQE7AcEsgDQPAgJHLk0IBkBjQB9BxB+BLQGSDxD7jog");
-        this.shape_114.setTransform(1667.2,1280.1);
+        this.shape_114.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p(
+                "Ab0UaQAYgQD9hgQEThqCwhgQJUlHhsmhQhQkviEkoQiol3jTj8QkAkzkoheQlbhtmDC8QqwFQtzhxQkVgkkHhMIjQhFQh4gtiqgSQlTgjj4CNQlUDCjgEKQkSFGhZGmQhQF8MKHpQDzCZErCRQCWBIBlAqID/AcQE7AcEsgDQPAgJHLk0IBkBjQB9BxB+BLQGSDxD7jog"
+            );
+        this.shape_114.setTransform(1667.2, 1280.1);
 
         this.shape_115 = new cjs.Shape();
-        this.shape_115.graphics.f("#C9DAD8").s().p("EAkqALYIjXmaQgMgegagqQg2hThKg6Qjti4lhCHQliCJpEgXQi1gHi2gWIiQgVQxRk0wBDTQlABCkSBuQhWAjhHAjIg1AcIgHhAIBxl8QFvqtJCjEQC0g9C0gFQBagDA2AKQLZEbMNgZQD1gIDdgmQBugSA+gSIJEjwIGFgcIGTCwIDwCxIEpGoIEGImICGGaIhHD4Ij+FFIiqAxQAogjjPmhg");
-        this.shape_115.setTransform(1669.4,1256.4);
+        this.shape_115.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "EAkqALYIjXmaQgMgegagqQg2hThKg6Qjti4lhCHQliCJpEgXQi1gHi2gWIiQgVQxRk0wBDTQlABCkSBuQhWAjhHAjIg1AcIgHhAIBxl8QFvqtJCjEQC0g9C0gFQBagDA2AKQLZEbMNgZQD1gIDdgmQBugSA+gSIJEjwIGFgcIGTCwIDwCxIEpGoIEGImICGGaIhHD4Ij+FFIiqAxQAogjjPmhg"
+            );
+        this.shape_115.setTransform(1669.4, 1256.4);
 
         this.shape_116 = new cjs.Shape();
-        this.shape_116.graphics.f("#F8F8F8").s().p("AS/V1ImplpImMCxIsACNIyWg/IsRmoIo9n+QigjaBIkXQA5jgDLj+QCRi1DKiyICuiNQATgXArgeQBWg7B4ghQGAhqJDDCQJDDDL7hjQF/gyELhYQG6koGvCdQCHAxB1BYQA7AtAgAiQD3BvEbJXQCOEsBcETIAcFGIjGEsIlbEQIqREGIjbBqg");
-        this.shape_116.setTransform(1669,1280.4);
+        this.shape_116.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AS/V1ImplpImMCxIsACNIyWg/IsRmoIo9n+QigjaBIkXQA5jgDLj+QCRi1DKiyICuiNQATgXArgeQBWg7B4ghQGAhqJDDCQJDDDL7hjQF/gyELhYQG6koGvCdQCHAxB1BYQA7AtAgAiQD3BvEbJXQCOEsBcETIAcFGIjGEsIlbEQIqREGIjbBqg"
+            );
+        this.shape_116.setTransform(1669, 1280.4);
 
         this.shape_117 = new cjs.Shape();
-        this.shape_117.graphics.f().s("#505050").ss(10,1,1).p("ALBDJQkMAAiNgIQk+gRjdg6QmFhmhIjY");
-        this.shape_117.setTransform(1516.7,583.8);
+        this.shape_117.graphics.f().s("#505050").ss(10, 1, 1).p("ALBDJQkMAAiNgIQk+gRjdg6QmFhmhIjY");
+        this.shape_117.setTransform(1516.7, 583.8);
 
         this.shape_118 = new cjs.Shape();
-        this.shape_118.graphics.f().s("#505050").ss(10,1,1).p("AghkMIBDIZ");
-        this.shape_118.setTransform(2045.2,1145.5);
+        this.shape_118.graphics.f().s("#505050").ss(10, 1, 1).p("AghkMIBDIZ");
+        this.shape_118.setTransform(2045.2, 1145.5);
 
         this.shape_119 = new cjs.Shape();
-        this.shape_119.graphics.f().s("#505050").ss(10,1,1).p("AnigvIAcAcQAkAgApAgQCBBnB9ApQCtA5COhKQCxhdBykk");
-        this.shape_119.setTransform(2037.6,1097.3);
+        this.shape_119.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p("AnigvIAcAcQAkAgApAgQCBBnB9ApQCtA5COhKQCxhdBykk");
+        this.shape_119.setTransform(2037.6, 1097.3);
 
         this.shape_120 = new cjs.Shape();
-        this.shape_120.graphics.f().s("#505050").ss(10,1,1).p("AiUaoQlcBOkThnQj9hfivjxQijjfhSlGQhNk0AGlkQAFlcBVlMQBXlWCbkGQCkkWDaiUQDrihEUAJQEqgICdAHQEFAMDPA2QIRCKFiHR");
-        this.shape_120.setTransform(1485.5,677.7);
+        this.shape_120.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p(
+                "AiUaoQlcBOkThnQj9hfivjxQijjfhSlGQhNk0AGlkQAFlcBVlMQBXlWCbkGQCkkWDaiUQDrihEUAJQEqgICdAHQEFAMDPA2QIRCKFiHR"
+            );
+        this.shape_120.setTransform(1485.5, 677.7);
 
         this.shape_121 = new cjs.Shape();
-        this.shape_121.graphics.f().s("#505050").ss(10,1,1).p("A9nGMIBPg6QBlhIB5hJQGDjmGuiTQJajNJbgGQLygHLKE0");
-        this.shape_121.setTransform(1819.6,514.4);
+        this.shape_121.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p("A9nGMIBPg6QBlhIB5hJQGDjmGuiTQJajNJbgGQLygHLKE0");
+        this.shape_121.setTransform(1819.6, 514.4);
 
         this.shape_122 = new cjs.Shape();
-        this.shape_122.graphics.f().s("#505050").ss(10,1,1).p("AB1MAQj/n9AXnTQAKi6A2ibQAwiIBEhR");
-        this.shape_122.setTransform(1458.5,930.7);
+        this.shape_122.graphics.f().s("#505050").ss(10, 1, 1).p("AB1MAQj/n9AXnTQAKi6A2ibQAwiIBEhR");
+        this.shape_122.setTransform(1458.5, 930.7);
 
         this.shape_123 = new cjs.Shape();
-        this.shape_123.graphics.f().s("#505050").ss(10,1,1).p("AqZHkQg3AGhAgFQiAgKgwg1QibiqK6odQAegZA6ggQB2hBCSgjQHThyJLDX");
-        this.shape_123.setTransform(1530.6,1020.8);
+        this.shape_123.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p("AqZHkQg3AGhAgFQiAgKgwg1QibiqK6odQAegZA6ggQB2hBCSgjQHThyJLDX");
+        this.shape_123.setTransform(1530.6, 1020.8);
 
         this.shape_124 = new cjs.Shape();
-        this.shape_124.graphics.f().s("#505050").ss(10,1,1).p("Eg/8AgMQBWQcGeEbQCBBZCTABQBJAAAwgRQF7JcIUCXQCmAwCigEQBQgCAwgLQHCETHgAwQGAAmGBhtQERhND4iQQBOgsBBguIAyglQJ8BoH5hyQGThcEujiQDYiiCPjVQBIhrAchKQB8C+B2hOQBfg+BYjlQA/ikA0jnIAojHQAjhFA3DCQAcBgAUBvQEUrVhGlxQgWhzg3hCQgQgUgTgOIgOgJQFMAKAthnQAkhSiUiWQhqhri8iCIimhtQgLncgIilQgOkbggjRQgijohIj9QhGj4iElrQEMBHC2iDQCThrBij3QA8iZBAkfQA7kHAeg7QBHjBgGj/QgGj/hSkCQhWkQiZjcQimjvjeiPQjHiAjngqQj6gtkWA6QjeBmj0CiQj7CoiXCWQiDCCgpBiQgiBRATBY");
-        this.shape_124.setTransform(1873.3,863);
+        this.shape_124.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 1, 1)
+            .p(
+                "Eg/8AgMQBWQcGeEbQCBBZCTABQBJAAAwgRQF7JcIUCXQCmAwCigEQBQgCAwgLQHCETHgAwQGAAmGBhtQERhND4iQQBOgsBBguIAyglQJ8BoH5hyQGThcEujiQDYiiCPjVQBIhrAchKQB8C+B2hOQBfg+BYjlQA/ikA0jnIAojHQAjhFA3DCQAcBgAUBvQEUrVhGlxQgWhzg3hCQgQgUgTgOIgOgJQFMAKAthnQAkhSiUiWQhqhri8iCIimhtQgLncgIilQgOkbggjRQgijohIj9QhGj4iElrQEMBHC2iDQCThrBij3QA8iZBAkfQA7kHAeg7QBHjBgGj/QgGj/hSkCQhWkQiZjcQimjvjeiPQjHiAjngqQj6gtkWA6QjeBmj0CiQj7CoiXCWQiDCCgpBiQgiBRATBY"
+            );
+        this.shape_124.setTransform(1873.3, 863);
 
         this.shape_125 = new cjs.Shape();
-        this.shape_125.graphics.f("#F8F8F8").s().p("Ak/A2Qihipi0iWIiThzQIkgJE9mBQBjh5BBiQIAsh3QGUDkBnGfQBSFLhxGxQhRE2iqFLQg1Bog4BdIgtBIQiNotoDokg");
-        this.shape_125.setTransform(2130.2,566.3);
+        this.shape_125.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "Ak/A2Qihipi0iWIiThzQIkgJE9mBQBjh5BBiQIAsh3QGUDkBnGfQBSFLhxGxQhRE2iqFLQg1Bog4BdIgtBIQiNotoDokg"
+            );
+        this.shape_125.setTransform(2130.2, 566.3);
 
         this.shape_126 = new cjs.Shape();
-        this.shape_126.graphics.f("#F8F8F8").s().p("AprL8QjgkHhOlKQhRlYBrlHQB1lmFFkNQAoggAFAUIAEAcQAFAVAKAOQAcAlBSAxQAZAOCQBOQCTBQDAAeQCIAVApgIIImAZQojJ4ksK3QiTFdgpDeQk3h2jlkKg");
-        this.shape_126.setTransform(1489.6,679);
+        this.shape_126.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AprL8QjgkHhOlKQhRlYBrlHQB1lmFFkNQAoggAFAUIAEAcQAFAVAKAOQAcAlBSAxQAZAOCQBOQCTBQDAAeQCIAVApgIIImAZQojJ4ksK3QiTFdgpDeQk3h2jlkKg"
+            );
+        this.shape_126.setTransform(1489.6, 679);
 
         this.shape_127 = new cjs.Shape();
-        this.shape_127.graphics.f("#F8F8F8").s().p("EgJvAivQntgxoIkpQg0AKhXAAQiuABiugxQotiblepMQgwAMhKgHQiVgPiDhhQmkk2hYvzQgoADg0gFQhngKg1gmQith4F9leQF+leGmhQQCEgZB4AFQA9ADAhAHIImB4IgEADQgEAEACAFQAIASBGAdQDeBdL0CoQL1CpHYmDQCSh6BliiQAzhRAVg5QA+haBuh2QDajsDuiIQFMi+FDAkQGTAuFsGOIAyAtQBCA2BPAtQD/CPEsgHIAzgYQBAgbBDgOQDUgtCcBkQD6CgDcCWIAwA3QAxBBAHA2QAXCtmXgHIARAHQAUAKAUARQA9A4AaBsQBTFZkzLfIiMlAIgkDKQgxDrg6CqQhTDthaBIQhxBah5iwQgoBEhWBjQirDEjkCYQmCEBmzBlQoSB6nBigIgpApQg3AyhCAxQjWCckBBWQkNBakiAAQhgAAhigKg");
-        this.shape_127.setTransform(1855.4,1101.2);
+        this.shape_127.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "EgJvAivQntgxoIkpQg0AKhXAAQiuABiugxQotiblepMQgwAMhKgHQiVgPiDhhQmkk2hYvzQgoADg0gFQhngKg1gmQith4F9leQF+leGmhQQCEgZB4AFQA9ADAhAHIImB4IgEADQgEAEACAFQAIASBGAdQDeBdL0CoQL1CpHYmDQCSh6BliiQAzhRAVg5QA+haBuh2QDajsDuiIQFMi+FDAkQGTAuFsGOIAyAtQBCA2BPAtQD/CPEsgHIAzgYQBAgbBDgOQDUgtCcBkQD6CgDcCWIAwA3QAxBBAHA2QAXCtmXgHIARAHQAUAKAUARQA9A4AaBsQBTFZkzLfIiMlAIgkDKQgxDrg6CqQhTDthaBIQhxBah5iwQgoBEhWBjQirDEjkCYQmCEBmzBlQoSB6nBigIgpApQg3AyhCAxQjWCckBBWQkNBakiAAQhgAAhigKg"
+            );
+        this.shape_127.setTransform(1855.4, 1101.2);
 
         this.shape_128 = new cjs.Shape();
-        this.shape_128.graphics.f().s("#899BB0").ss(10,1,1).p("Azxv8QBiB+CzD3QBnCODlE9QG8JgEhFJQGdHSEEBhQE6B1BtmZQB9oggrtxQgNkUgdkVIgajdQhLgciDggQkIhBkdgWQuPhIsSF6g");
-        this.shape_128.setTransform(1848.8,607.7);
+        this.shape_128.graphics
+            .f()
+            .s("#899BB0")
+            .ss(10, 1, 1)
+            .p(
+                "Azxv8QBiB+CzD3QBnCODlE9QG8JgEhFJQGdHSEEBhQE6B1BtmZQB9oggrtxQgNkUgdkVIgajdQhLgciDggQkIhBkdgWQuPhIsSF6g"
+            );
+        this.shape_128.setTransform(1848.8, 607.7);
 
         this.shape_129 = new cjs.Shape();
-        this.shape_129.graphics.f("#899BB0").s().p("ALuUgQkEhhmdnSQkhlJm8pgIlMnLQizj3hih+QMSl6OPBIQEdAWEIBBQCDAgBLAcIAaDdQAdEVANEUQArNxh9IgQhVE+jQAAQg8AAhGgag");
-        this.shape_129.setTransform(1848.8,607.7);
+        this.shape_129.graphics
+            .f("#899BB0")
+            .s()
+            .p(
+                "ALuUgQkEhhmdnSQkhlJm8pgIlMnLQizj3hih+QMSl6OPBIQEdAWEIBBQCDAgBLAcIAaDdQAdEVANEUQArNxh9IgQhVE+jQAAQg8AAhGgag"
+            );
+        this.shape_129.setTransform(1848.8, 607.7);
 
         this.shape_130 = new cjs.Shape();
-        this.shape_130.graphics.f("#C9DAD8").s().p("AFfYqQgmgVghgZIgagWMgZDgguQgEgeAEgvQAJhdAshSQBJiICviaQCciJDkiPQFOjREngSQGAgYF7EdQBTA/B6CrQCnDsAtA1IASAYQAWAhAVApQBECFAlCuQB4IpjlLvQjmLvl+AZIgZAAQhrAAhrg6g");
-        this.shape_130.setTransform(2145.6,566.5);
+        this.shape_130.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AFfYqQgmgVghgZIgagWMgZDgguQgEgeAEgvQAJhdAshSQBJiICviaQCciJDkiPQFOjREngSQGAgYF7EdQBTA/B6CrQCnDsAtA1IASAYQAWAhAVApQBECFAlCuQB4IpjlLvQjmLvl+AZIgZAAQhrAAhrg6g"
+            );
+        this.shape_130.setTransform(2145.6, 566.5);
 
         this.shape_131 = new cjs.Shape();
-        this.shape_131.graphics.f("#C9DAD8").s().p("EgOiA/BQhXg7h2geQhPgTiMgQQihgRg8gMQh6gXhZgvQjUhUjMjFQhrhnjjkTQglgJhEgJQhOgKgegGQh+gZhHg+Qj7jRh3mKQguiYgijLQgRhlghj9QhvAPhZgjQhxgtAIhqQAjhnDTjHQB6h0AagbQAngnAWgfIgFgBQiqglhvqHQgRk9AahYQAEgPAbg8QAWgzAPhCQAqhDAZg1QAwhmhAgNQgkgHhJAKIiIAWQiwAegqgpQhDhAhWhCIiMhnQibh2hLh8Qhwi6g1ilQg1iigUjVQgckvAAi7QABj1Aui9QA5kRAoiSQBJkHBkhlQBFhGA5hPQA3hPAcgiQBahwDYhfQB0gzC9gSQBPgID3gIQDzgJCMAdQBRARB6ArQAoALCFAcQA5AMCKA3IDPByQBcA6BQBZQAcAgBBgTQAygPBhg4IC5hqQB1hABbgfQB9grGBiZQFgiMC/g8QB4gxDHgVQBhgKDrgKQDkACCjALQDHANC/AeQBoAfCyAsQCvAxDeBkQB2AqBLArQA0AeA8AxQBOBAAhAXQBOA3BvA2QE4DYDzEVQDdD9CqE4QC1FMCLG1QBuFPBzFPQBADAAPBtQAJBEAPFAQAUGlApH5QDwCXBAAuQDNCUAxBoQARBsihBBQhyAuiBAIQAiAnAtBQQA4BiAMBBQAtCvg+D3QgkCNhiESQgjAdgYgOQgTgLgUgrQgWg0gNgYQgWgqgbgLQgxCJhLEpQhNEHhwCSQg3BIhYgdQhJgXg5hIQgfAdgvBVQgvBTgkAhQj1FEmVCyQlyCjm1APQh6AOjxgXQj0gYhvAMQneFHo5A/Qh8AOh3AAQnIAAmKjHgEAlLAoJQAHBJAPAwQADgngLhBIgUhqIAGBZgEAk1Ak0QgDhNASgzQBSgmBGg2QguAcg5ARQitAyiahVQAmAaA9AQIBoAbQApA0ATBZIAAAAgAdJfMQAfAaARAMQBRA9g4gvQg5gvgqggIgBAAQgFAAAgAbgEAqjAdhQgmBDgNAQQgOAegTAbQBPhaAshqQgGAAghA4gAhmpgQhAAZgvAxQiwDagIFDQgGEaB1EjQBhDcCaCAQC6CdDQg2QDHhzBCkLQAzjQghkRQhWgLiYAoQiyAuhBADQhLgVAxhAQAiguA/glQAdgbAzgiIBZg4QBphIAbhEQhVi5huhwQiOiRiogGIgZgBQg0AAg1AUg");
-        this.shape_131.setTransform(1807.9,897.8);
+        this.shape_131.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "EgOiA/BQhXg7h2geQhPgTiMgQQihgRg8gMQh6gXhZgvQjUhUjMjFQhrhnjjkTQglgJhEgJQhOgKgegGQh+gZhHg+Qj7jRh3mKQguiYgijLQgRhlghj9QhvAPhZgjQhxgtAIhqQAjhnDTjHQB6h0AagbQAngnAWgfIgFgBQiqglhvqHQgRk9AahYQAEgPAbg8QAWgzAPhCQAqhDAZg1QAwhmhAgNQgkgHhJAKIiIAWQiwAegqgpQhDhAhWhCIiMhnQibh2hLh8Qhwi6g1ilQg1iigUjVQgckvAAi7QABj1Aui9QA5kRAoiSQBJkHBkhlQBFhGA5hPQA3hPAcgiQBahwDYhfQB0gzC9gSQBPgID3gIQDzgJCMAdQBRARB6ArQAoALCFAcQA5AMCKA3IDPByQBcA6BQBZQAcAgBBgTQAygPBhg4IC5hqQB1hABbgfQB9grGBiZQFgiMC/g8QB4gxDHgVQBhgKDrgKQDkACCjALQDHANC/AeQBoAfCyAsQCvAxDeBkQB2AqBLArQA0AeA8AxQBOBAAhAXQBOA3BvA2QE4DYDzEVQDdD9CqE4QC1FMCLG1QBuFPBzFPQBADAAPBtQAJBEAPFAQAUGlApH5QDwCXBAAuQDNCUAxBoQARBsihBBQhyAuiBAIQAiAnAtBQQA4BiAMBBQAtCvg+D3QgkCNhiESQgjAdgYgOQgTgLgUgrQgWg0gNgYQgWgqgbgLQgxCJhLEpQhNEHhwCSQg3BIhYgdQhJgXg5hIQgfAdgvBVQgvBTgkAhQj1FEmVCyQlyCjm1APQh6AOjxgXQj0gYhvAMQneFHo5A/Qh8AOh3AAQnIAAmKjHgEAlLAoJQAHBJAPAwQADgngLhBIgUhqIAGBZgEAk1Ak0QgDhNASgzQBSgmBGg2QguAcg5ARQitAyiahVQAmAaA9AQIBoAbQApA0ATBZIAAAAgAdJfMQAfAaARAMQBRA9g4gvQg5gvgqggIgBAAQgFAAAgAbgEAqjAdhQgmBDgNAQQgOAegTAbQBPhaAshqQgGAAghA4gAhmpgQhAAZgvAxQiwDagIFDQgGEaB1EjQBhDcCaCAQC6CdDQg2QDHhzBCkLQAzjQghkRQhWgLiYAoQiyAuhBADQhLgVAxhAQAiguA/glQAdgbAzgiIBZg4QBphIAbhEQhVi5huhwQiOiRiogGIgZgBQg0AAg1AUg"
+            );
+        this.shape_131.setTransform(1807.9, 897.8);
 
         this.shape_132 = new cjs.Shape();
-        this.shape_132.graphics.f().s("#505050").ss(10,0,0,4).p("AvYkDQiHAWi8AzQl3BmkGCTQlvDQhYEPQhuFTFOGiQJfL3GKhQQB7gZBWhqQAcghAUglIAPgfIAoAmQA0AqA6AVQC8BBC7iyQC7ixEziiQCahQB1guICKgUQCwggC/g2QJlisIWlOQEni4BGkJQA5jShYj+QhAi1iBi5Qgog5gqgzIgigoQiojajjjsQnFnZkjhYQkjhYnmg/QiWgUiZgPIh7gLg");
-        this.shape_132.setTransform(2143.7,1257.7);
+        this.shape_132.graphics
+            .f()
+            .s("#505050")
+            .ss(10, 0, 0, 4)
+            .p(
+                "AvYkDQiHAWi8AzQl3BmkGCTQlvDQhYEPQhuFTFOGiQJfL3GKhQQB7gZBWhqQAcghAUglIAPgfIAoAmQA0AqA6AVQC8BBC7iyQC7ixEziiQCahQB1guICKgUQCwggC/g2QJlisIWlOQEni4BGkJQA5jShYj+QhAi1iBi5Qgog5gqgzIgigoQiojajjjsQnFnZkjhYQkjhYnmg/QiWgUiZgPIh7gLg"
+            );
+        this.shape_132.setTransform(2143.7, 1257.7);
 
         this.shape_133 = new cjs.Shape();
-        this.shape_133.graphics.f("#C9DAD8").s().p("AwKWPQi8gGjEgdIifgcIh4uzISOvjQBUhgCJh/QETj9EKicQF3jaE0AJQGCALEBFvQBDBnAdA7QAjBHAIA8QAOBphMDTQhHDDjLDVQieCkkmDnQliEMi2CPQlCD7jKDKQkDDBoKAAQgyAAgzgBg");
-        this.shape_133.setTransform(2122.4,1210.9);
+        this.shape_133.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "AwKWPQi8gGjEgdIifgcIh4uzISOvjQBUhgCJh/QETj9EKicQF3jaE0AJQGCALEBFvQBDBnAdA7QAjBHAIA8QAOBphMDTQhHDDjLDVQieCkkmDnQliEMi2CPQlCD7jKDKQkDDBoKAAQgyAAgzgBg"
+            );
+        this.shape_133.setTransform(2122.4, 1210.9);
 
         this.shape_134 = new cjs.Shape();
-        this.shape_134.graphics.f("#F8F8F8").s().p("A6aboIlMkGIk3l3IFowkIBcp0QJSlTB4hHQA9gjD5iXQEOijDbh9QDfh+DYhcQB7g0DyhhQCjhHCkAHQBVAEBTARQAfAAAXAWQAMAKAFALIDbCNIITIgIIEKuIAjGbIAIAFQAJAHAGALQASAhgUA5QhCC0mtFHQmsFHpUCGQi6Aqi0ASIiQAJImRDxIpLGTIiUgrIi/hOIiHCxIjiAyg");
-        this.shape_134.setTransform(2154.9,1269.1);
+        this.shape_134.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "A6aboIlMkGIk3l3IFowkIBcp0QJSlTB4hHQA9gjD5iXQEOijDbh9QDfh+DYhcQB7g0DyhhQCjhHCkAHQBVAEBTARQAfAAAXAWQAMAKAFALIDbCNIITIgIIEKuIAjGbIAIAFQAJAHAGALQASAhgUA5QhCC0mtFHQmsFHpUCGQi6Aqi0ASIiQAJImRDxIpLGTIiUgrIi/hOIiHCxIjiAyg"
+            );
+        this.shape_134.setTransform(2154.9, 1269.1);
 
         this.shape_135 = new cjs.Shape();
-        this.shape_135.graphics.f().s("#C9DAD8").ss(10,1,1).p("AAA6nQFJAAEtCGQEjCCDgDrQDgDsB7EyQB/E9AAFZQAAFah/E9Qh7EyjgDsQjgDrkjCCQktCGlJAAQlIAAktiGQkiiCjgjrQjhjsh6kyQiAk9AAlaQAAlZCAk9QB6kyDhjsQDgjrEiiCQEtiGFIAAg");
-        this.shape_135.setTransform(1808.3,937.5);
+        this.shape_135.graphics
+            .f()
+            .s("#C9DAD8")
+            .ss(10, 1, 1)
+            .p(
+                "AAA6nQFJAAEtCGQEjCCDgDrQDgDsB7EyQB/E9AAFZQAAFah/E9Qh7EyjgDsQjgDrkjCCQktCGlJAAQlIAAktiGQkiiCjgjrQjhjsh6kyQiAk9AAlaQAAlZCAk9QB6kyDhjsQDgjrEiiCQEtiGFIAAg"
+            );
+        this.shape_135.setTransform(1808.3, 937.5);
 
         this.shape_136 = new cjs.Shape();
-        this.shape_136.graphics.f("#C9DAD8").s().p("Ap1YiQkiiCjhjrQjgjsh6kyQiAk9AAlaQAAlZCAk9QB6kyDgjsQDhjrEiiCQEtiGFIAAQFJAAEtCGQEiCCDhDrQDgDsB6EyQCAE9AAFZQAAFaiAE9Qh6EyjgDsQjhDrkiCCQktCGlJAAQlIAAktiGg");
-        this.shape_136.setTransform(1808.3,937.5);
+        this.shape_136.graphics
+            .f("#C9DAD8")
+            .s()
+            .p(
+                "Ap1YiQkiiCjhjrQjgjsh6kyQiAk9AAlaQAAlZCAk9QB6kyDgjsQDhjrEiiCQEtiGFIAAQFJAAEtCGQEiCCDhDrQDgDsB6EyQCAE9AAFZQAAFaiAE9Qh6EyjgDsQjhDrkiCCQktCGlJAAQlIAAktiGg"
+            );
+        this.shape_136.setTransform(1808.3, 937.5);
 
         this.shape_137 = new cjs.Shape();
-        this.shape_137.graphics.f("#F8F8F8").s().p("AACQsQheABhIhJQhIhKAJhcQAGhEBDgkQBDgkA+AgQBIAeAGBXQAFBWhBApQgGAGgVAHQgTAHgBACQA/AHAigDQA5gGAgggQAxg4AChZQABg5gWhiIgLg5QgHgggfAKQhmAMhjggQhkgghNhEQhshageiOQgeiOA9h6QAnhjBahmQAqgwCCh7QghiagFhSQgJiGAohkQBBipBqgPQAWgBAVAKQBJApAfBbQAZBHgDBhQABCDhDCKQg2BwhmB6IAqC8QAqABAXACQAkAEAbALQBQAiA2A7QA8BCAIBPQALBqg1BkQg2BkhfA1IAjCkQAQBfgNBHQgMBWhOA3QhFAxhSAAIgQAAgAjBgBQhWBVAOCEQANB+BfBSQAyAyBSAPQA9ALBXgIQgaiUg2jhQgsANgaAvQgYAsADAxQgEAhAUAgQAOAXAfAcQAQAJAEAUQAFAVgYgCQhLgZg1gxQg9g5gEhHQgLhXA6hRQA1hJBUgmQAAgZgIgpQgNgugEgWIgCgGQhPBQhcBogADJHMQAmgbAWgqQAWgqABguQAOhFgyg7Qgwg5hIgJIgHgBQAcB1A0DrgAAms0QgzBIgKBiQgIBWAZBeQASgOAagbQA3g8AhhFQAjhLAChKQAAgjgCgSQgDgggWgJQg0AHguA4g");
-        this.shape_137.setTransform(1268.9,1503.7);
+        this.shape_137.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AACQsQheABhIhJQhIhKAJhcQAGhEBDgkQBDgkA+AgQBIAeAGBXQAFBWhBApQgGAGgVAHQgTAHgBACQA/AHAigDQA5gGAgggQAxg4AChZQABg5gWhiIgLg5QgHgggfAKQhmAMhjggQhkgghNhEQhshageiOQgeiOA9h6QAnhjBahmQAqgwCCh7QghiagFhSQgJiGAohkQBBipBqgPQAWgBAVAKQBJApAfBbQAZBHgDBhQABCDhDCKQg2BwhmB6IAqC8QAqABAXACQAkAEAbALQBQAiA2A7QA8BCAIBPQALBqg1BkQg2BkhfA1IAjCkQAQBfgNBHQgMBWhOA3QhFAxhSAAIgQAAgAjBgBQhWBVAOCEQANB+BfBSQAyAyBSAPQA9ALBXgIQgaiUg2jhQgsANgaAvQgYAsADAxQgEAhAUAgQAOAXAfAcQAQAJAEAUQAFAVgYgCQhLgZg1gxQg9g5gEhHQgLhXA6hRQA1hJBUgmQAAgZgIgpQgNgugEgWIgCgGQhPBQhcBogADJHMQAmgbAWgqQAWgqABguQAOhFgyg7Qgwg5hIgJIgHgBQAcB1A0DrgAAms0QgzBIgKBiQgIBWAZBeQASgOAagbQA3g8AhhFQAjhLAChKQAAgjgCgSQgDgggWgJQg0AHguA4g"
+            );
+        this.shape_137.setTransform(1268.9, 1503.7);
 
         this.shape_138 = new cjs.Shape();
-        this.shape_138.graphics.f().s("#516B82").ss(4,0,0,4).p("AAAKAIAAz/");
-        this.shape_138.setTransform(2555.3,1501.8);
+        this.shape_138.graphics.f().s("#516B82").ss(4, 0, 0, 4).p("AAAKAIAAz/");
+        this.shape_138.setTransform(2555.3, 1501.8);
 
         this.shape_139 = new cjs.Shape();
-        this.shape_139.graphics.f().s("#516B82").ss(11.6,0,0,4).p("AAAKXIAB0t");
-        this.shape_139.setTransform(2570.4,1500.5);
+        this.shape_139.graphics.f().s("#516B82").ss(11.6, 0, 0, 4).p("AAAKXIAB0t");
+        this.shape_139.setTransform(2570.4, 1500.5);
 
         this.shape_140 = new cjs.Shape();
-        this.shape_140.graphics.f().s("#516B82").ss(9.8,0,0,4).p("AABKYIgB0v");
-        this.shape_140.setTransform(1198.9,1497.8);
+        this.shape_140.graphics.f().s("#516B82").ss(9.8, 0, 0, 4).p("AABKYIgB0v");
+        this.shape_140.setTransform(1198.9, 1497.8);
 
         this.instance_44 = new lib.ClipGroup_0_10();
-        this.instance_44.setTransform(1888,1539.4,1,1,0,0,0,692.6,131.6);
+        this.instance_44.setTransform(1888, 1539.4, 1, 1, 0, 0, 0, 692.6, 131.6);
 
         this.instance_45 = new lib.rect4276_10();
-        this.instance_45.setTransform(1883.6,1504.1,1,1,0,0,0,731,127.8);
+        this.instance_45.setTransform(1883.6, 1504.1, 1, 1, 0, 0, 0, 731, 127.8);
         this.instance_45.alpha = 0.98;
 
         this.instance_46 = new lib.ClipGroup_10();
-        this.instance_46.setTransform(1871.9,897.6,1,1,0,0,0,949.6,845.6);
+        this.instance_46.setTransform(1871.9, 897.6, 1, 1, 0, 0, 0, 949.6, 845.6);
 
         this.shape_141 = new cjs.Shape();
-        this.shape_141.graphics.f().s("#505050").ss(7,1,1).p("AjSgQQhxhWgPgyQgjh1FOgZQFHgYAoCCQAUBBguBFQgLAZgRAZQgjAvgigCQB6A+ANAsQARA7iOBEQhaAdiigFQiYgFgdgWQiEgqASheQAQhQBqhHg");
-        this.shape_141.setTransform(2392.8,781.5);
+        this.shape_141.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "AjSgQQhxhWgPgyQgjh1FOgZQFHgYAoCCQAUBBguBFQgLAZgRAZQgjAvgigCQB6A+ANAsQARA7iOBEQhaAdiigFQiYgFgdgWQiEgqASheQAQhQBqhHg"
+            );
+        this.shape_141.setTransform(2392.8, 781.5);
 
         this.shape_142 = new cjs.Shape();
-        this.shape_142.graphics.f("#F8F8F8").s().p("AglEqQiYgFgdgWQiEgqASheQAQhQBqhHQhxhWgPgyQgjh1FOgZQFHgYAoCCQAUBBguBFQgLAZgRAZQgjAvgigCQB6A+ANAsQARA7iOBEQhNAYiCAAIgtAAg");
-        this.shape_142.setTransform(2392.8,781.5);
+        this.shape_142.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AglEqQiYgFgdgWQiEgqASheQAQhQBqhHQhxhWgPgyQgjh1FOgZQFHgYAoCCQAUBBguBFQgLAZgRAZQgjAvgigCQB6A+ANAsQARA7iOBEQhNAYiCAAIgtAAg"
+            );
+        this.shape_142.setTransform(2392.8, 781.5);
 
         this.shape_143 = new cjs.Shape();
-        this.shape_143.graphics.f().s("#505050").ss(7,1,1).p("AlNgbQhTg/gTgRQhShKgSg8Qg4i6IQgmQIIgmA/DNQATBAgcBQQgPApgSAbQgQAogcAmQg2BMg4gDQDBBjAVBFQAcBdjhBsQiPAtkBgIQjxgIgugiQjQhCAdiUQAZh/Cnhzg");
-        this.shape_143.setTransform(2479.6,874);
+        this.shape_143.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "AlNgbQhTg/gTgRQhShKgSg8Qg4i6IQgmQIIgmA/DNQATBAgcBQQgPApgSAbQgQAogcAmQg2BMg4gDQDBBjAVBFQAcBdjhBsQiPAtkBgIQjxgIgugiQjQhCAdiUQAZh/Cnhzg"
+            );
+        this.shape_143.setTransform(2479.6, 874);
 
         this.shape_144 = new cjs.Shape();
-        this.shape_144.graphics.f("#F8F8F8").s().p("Ag7HXQjxgIgugiQjQhCAdiUQAZh/CnhzQhTg/gTgRQhShKgSg8Qg4i6IQgmQIIgmA/DNQATBAgcBQQgPApgSAbQgQAogcAmQg2BMg4gDQDBBjAVBFQAcBdjhBsQh5AmjOAAIhJgBg");
-        this.shape_144.setTransform(2479.6,874);
+        this.shape_144.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "Ag7HXQjxgIgugiQjQhCAdiUQAZh/CnhzQhTg/gTgRQhShKgSg8Qg4i6IQgmQIIgmA/DNQATBAgcBQQgPApgSAbQgQAogcAmQg2BMg4gDQDBBjAVBFQAcBdjhBsQh5AmjOAAIhJgBg"
+            );
+        this.shape_144.setTransform(2479.6, 874);
 
         this.shape_145 = new cjs.Shape();
-        this.shape_145.graphics.f().s("#505050").ss(7,1,1).p("AlJgaQhSg+gUgSQhRhJgSg8Qg4i3IMgnQIDgmA+DMQATA/gcBQQgOAogSAcQgQAngcAmQg2BLg3gDQDABiAUBFQAcBcjfBqQiOAtj+gIQjvgIgtgiQjPhBAdiTQAZh9Cmhyg");
-        this.shape_145.setTransform(2378.7,986.1);
+        this.shape_145.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "AlJgaQhSg+gUgSQhRhJgSg8Qg4i3IMgnQIDgmA+DMQATA/gcBQQgOAogSAcQgQAngcAmQg2BLg3gDQDABiAUBFQAcBcjfBqQiOAtj+gIQjvgIgtgiQjPhBAdiTQAZh9Cmhyg"
+            );
+        this.shape_145.setTransform(2378.7, 986.1);
 
         this.shape_146 = new cjs.Shape();
-        this.shape_146.graphics.f("#F8F8F8").s().p("Ag6HTQjvgIgtgiQjPhBAdiTQAZh9CmhyQhSg+gUgSQhRhJgSg8Qg4i3IMgnQIDgmA+DMQATA/gcBQQgOAogSAcQgQAngcAmQg2BLg3gDQDABiAUBFQAcBcjfBqQh3AmjJAAIhMgBg");
-        this.shape_146.setTransform(2378.7,986.1);
+        this.shape_146.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "Ag6HTQjvgIgtgiQjPhBAdiTQAZh9CmhyQhSg+gUgSQhRhJgSg8Qg4i3IMgnQIDgmA+DMQATA/gcBQQgOAogSAcQgQAngcAmQg2BLg3gDQDABiAUBFQAcBcjfBqQh3AmjJAAIhMgBg"
+            );
+        this.shape_146.setTransform(2378.7, 986.1);
 
         this.shape_147 = new cjs.Shape();
-        this.shape_147.graphics.f().s("#F8F8F8").ss(10,0,0,4).p("AlzAAILnAA");
-        this.shape_147.setTransform(1420.8,1592.1);
+        this.shape_147.graphics.f().s("#F8F8F8").ss(10, 0, 0, 4).p("AlzAAILnAA");
+        this.shape_147.setTransform(1420.8, 1592.1);
 
         this.shape_148 = new cjs.Shape();
-        this.shape_148.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhDgqAAg7QAAg6BDgqQBDgqBcAAg");
-        this.shape_148.setTransform(1421.3,1591.2);
+        this.shape_148.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhDgqAAg7QAAg6BDgqQBDgqBcAAg");
+        this.shape_148.setTransform(1421.3, 1591.2);
 
         this.instance_47 = new lib.ClipGroup_0_9();
-        this.instance_47.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_47.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_48 = new lib.rect4276_9();
-        this.instance_48.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_48.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_48.alpha = 0.98;
 
         this.instance_49 = new lib.ClipGroup_9();
-        this.instance_49.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_49.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_149 = new cjs.Shape();
-        this.shape_149.graphics.f().s("#505050").ss(7,1,1).p("Ai2gOQhihLgNgrQgfhmEigVQEdgVAiBxQASA4goA9QgJAVgPAWQgeAogfgBQBqA2ALAmQAQAzh8A7QhPAZiMgEQiEgEgZgTQhyglAQhRQANhGBcg+g");
-        this.shape_149.setTransform(2468,871.8);
+        this.shape_149.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "Ai2gOQhihLgNgrQgfhmEigVQEdgVAiBxQASA4goA9QgJAVgPAWQgeAogfgBQBqA2ALAmQAQAzh8A7QhPAZiMgEQiEgEgZgTQhyglAQhRQANhGBcg+g"
+            );
+        this.shape_149.setTransform(2468, 871.8);
 
         this.shape_150 = new cjs.Shape();
-        this.shape_150.graphics.f("#F8F8F8").s().p("AggEDQiEgEgZgTQhyglAQhRQANhGBcg+QhihLgNgrQgfhmEigVQEdgVAiBxQASA4goA9QgJAVgPAWQgeAogfgBQBqA2ALAmQAQAzh8A7QhDAVhwAAIgoAAg");
-        this.shape_150.setTransform(2468,871.8);
+        this.shape_150.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "AggEDQiEgEgZgTQhyglAQhRQANhGBcg+QhihLgNgrQgfhmEigVQEdgVAiBxQASA4goA9QgJAVgPAWQgeAogfgBQBqA2ALAmQAQAzh8A7QhDAVhwAAIgoAAg"
+            );
+        this.shape_150.setTransform(2468, 871.8);
 
         this.shape_151 = new cjs.Shape();
-        this.shape_151.graphics.f().s("#505050").ss(7,1,1).p("AlhgcQhYhDgUgTQhXhOgThAQg8jEIwgpQIngpBDDaQAVBEgfBVQgPArgTAdQgSAqgdApQg6BRg6gDQDMBoAWBKQAeBijuByQiYAwkRgJQj/gIgwgkQjdhHAeicQAbiGCxh6g");
-        this.shape_151.setTransform(2367.6,979.3);
+        this.shape_151.graphics
+            .f()
+            .s("#505050")
+            .ss(7, 1, 1)
+            .p(
+                "AlhgcQhYhDgUgTQhXhOgThAQg8jEIwgpQIngpBDDaQAVBEgfBVQgPArgTAdQgSAqgdApQg6BRg6gDQDMBoAWBKQAeBijuByQiYAwkRgJQj/gIgwgkQjdhHAeicQAbiGCxh6g"
+            );
+        this.shape_151.setTransform(2367.6, 979.3);
 
         this.shape_152 = new cjs.Shape();
-        this.shape_152.graphics.f("#F8F8F8").s().p("Ag/HzQj/gIgwgkQjdhHAeicQAbiGCxh6QhYhDgUgTQhXhOgThAQg8jEIwgpQIngpBDDaQAVBEgfBVQgPArgTAdQgSAqgdApQg6BRg6gDQDMBoAWBKQAeBijuByQiAApjYAAIhRgCg");
-        this.shape_152.setTransform(2367.6,979.3);
+        this.shape_152.graphics
+            .f("#F8F8F8")
+            .s()
+            .p(
+                "Ag/HzQj/gIgwgkQjdhHAeicQAbiGCxh6QhYhDgUgTQhXhOgThAQg8jEIwgpQIngpBDDaQAVBEgfBVQgPArgTAdQgSAqgdApQg6BRg6gDQDMBoAWBKQAeBijuByQiAApjYAAIhRgCg"
+            );
+        this.shape_152.setTransform(2367.6, 979.3);
 
         this.shape_153 = new cjs.Shape();
-        this.shape_153.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_153.setTransform(1569.8,1580.9);
+        this.shape_153.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_153.setTransform(1569.8, 1580.9);
 
         this.instance_50 = new lib.ClipGroup_0_8();
-        this.instance_50.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_50.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_51 = new lib.rect4276_8();
-        this.instance_51.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_51.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_51.alpha = 0.98;
 
         this.instance_52 = new lib.ClipGroup_8();
-        this.instance_52.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_52.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_154 = new cjs.Shape();
-        this.shape_154.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_154.setTransform(1569.8,1580.9);
+        this.shape_154.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_154.setTransform(1569.8, 1580.9);
 
         this.instance_53 = new lib.ClipGroup_0_7();
-        this.instance_53.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_53.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_54 = new lib.rect4276_7();
-        this.instance_54.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_54.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_54.alpha = 0.98;
 
         this.instance_55 = new lib.ClipGroup_7();
-        this.instance_55.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_55.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_155 = new cjs.Shape();
-        this.shape_155.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_155.setTransform(1569.8,1580.9);
+        this.shape_155.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_155.setTransform(1569.8, 1580.9);
 
         this.instance_56 = new lib.ClipGroup_0_6();
-        this.instance_56.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_56.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_57 = new lib.rect4276_6();
-        this.instance_57.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_57.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_57.alpha = 0.98;
 
         this.instance_58 = new lib.ClipGroup_6();
-        this.instance_58.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_58.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_156 = new cjs.Shape();
-        this.shape_156.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_156.setTransform(1569.8,1580.9);
+        this.shape_156.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_156.setTransform(1569.8, 1580.9);
 
         this.instance_59 = new lib.ClipGroup_0_5();
-        this.instance_59.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_59.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_60 = new lib.rect4276_5();
-        this.instance_60.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_60.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_60.alpha = 0.98;
 
         this.instance_61 = new lib.ClipGroup_5();
-        this.instance_61.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_61.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_157 = new cjs.Shape();
-        this.shape_157.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_157.setTransform(1569.8,1580.9);
+        this.shape_157.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_157.setTransform(1569.8, 1580.9);
 
         this.instance_62 = new lib.ClipGroup_0_4();
-        this.instance_62.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_62.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_63 = new lib.rect4276_4();
-        this.instance_63.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_63.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_63.alpha = 0.98;
 
         this.instance_64 = new lib.ClipGroup_4();
-        this.instance_64.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_64.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_158 = new cjs.Shape();
-        this.shape_158.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_158.setTransform(1569.8,1580.9);
+        this.shape_158.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_158.setTransform(1569.8, 1580.9);
 
         this.instance_65 = new lib.ClipGroup_0_3();
-        this.instance_65.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_65.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_66 = new lib.rect4276_3();
-        this.instance_66.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_66.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_66.alpha = 0.98;
 
         this.instance_67 = new lib.ClipGroup_3();
-        this.instance_67.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_67.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_159 = new cjs.Shape();
-        this.shape_159.graphics.f().s("#F8F8F8").ss(10,1,1).p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
-        this.shape_159.setTransform(1569.8,1580.9);
+        this.shape_159.graphics
+            .f()
+            .s("#F8F8F8")
+            .ss(10, 1, 1)
+            .p("AAAiOQBeAABCAqQBDAqAAA6QAAA7hDAqQhCAqheAAQhcAAhDgqQhCgqAAg7QAAg6BCgqQBDgqBcAAg");
+        this.shape_159.setTransform(1569.8, 1580.9);
 
         this.instance_68 = new lib.ClipGroup_0_2();
-        this.instance_68.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_68.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_69 = new lib.rect4276_2();
-        this.instance_69.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_69.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_69.alpha = 0.98;
 
         this.instance_70 = new lib.ClipGroup_2();
-        this.instance_70.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_70.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_160 = new cjs.Shape();
-        this.shape_160.graphics.f().s("#505050").ss(15,1,1).p("AEKnnQAIAMh/BuQizCYhoBZQmlFkALBDQAQBnFEAxQEpAuHIgM");
-        this.shape_160.setTransform(2141.2,876.1);
+        this.shape_160.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p("AEKnnQAIAMh/BuQizCYhoBZQmlFkALBDQAQBnFEAxQEpAuHIgM");
+        this.shape_160.setTransform(2141.2, 876.1);
 
         this.shape_161 = new cjs.Shape();
-        this.shape_161.graphics.f().s("#505050").ss(15,1,1).p("ArInuIDhAQQENAWDeAjQLMBwgIDFQgEBpldCoQlWCnobCn");
-        this.shape_161.setTransform(1804.1,960.4);
+        this.shape_161.graphics
+            .f()
+            .s("#505050")
+            .ss(15, 1, 1)
+            .p("ArInuIDhAQQENAWDeAjQLMBwgIDFQgEBpldCoQlWCnobCn");
+        this.shape_161.setTransform(1804.1, 960.4);
 
         this.instance_71 = new lib.ClipGroup_0_1();
-        this.instance_71.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_71.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_72 = new lib.rect4276_1();
-        this.instance_72.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_72.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_72.alpha = 0.98;
 
         this.instance_73 = new lib.ClipGroup_1();
-        this.instance_73.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_73.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
         this.shape_162 = new cjs.Shape();
-        this.shape_162.graphics.f("#505050").s().p("Ai2KuQjBiqhck0QhckzA8kZQA8kaCyhmQCzhmDICFQDJCEBzEoImyExIHuhmQBDE6hVEEQhVEDi/A+QgzAQgzAAQiKAAiOh7g");
-        this.shape_162.setTransform(2138.6,871.2);
+        this.shape_162.graphics
+            .f("#505050")
+            .s()
+            .p(
+                "Ai2KuQjBiqhck0QhckzA8kZQA8kaCyhmQCzhmDICFQDJCEBzEoImyExIHuhmQBDE6hVEEQhVEDi/A+QgzAQgzAAQiKAAiOh7g"
+            );
+        this.shape_162.setTransform(2138.6, 871.2);
 
         this.shape_163 = new cjs.Shape();
-        this.shape_163.graphics.f("#505050").s().p("AAGNwQhqgfhmhZQjXi8hllWQhmlVBCk4QBCk4DHhxQBhg3BvAKQBpAKBqBFQDfCTCAFIInhFTIIkhyQBKFdheEfQheEgjUBFQg0ARg3AAQg1AAg4gQg");
-        this.shape_163.setTransform(1817.8,918.1);
+        this.shape_163.graphics
+            .f("#505050")
+            .s()
+            .p(
+                "AAGNwQhqgfhmhZQjXi8hllWQhmlVBCk4QBCk4DHhxQBhg3BvAKQBpAKBqBFQDfCTCAFIInhFTIIkhyQBKFdheEfQheEgjUBFQg0ARg3AAQg1AAg4gQg"
+            );
+        this.shape_163.setTransform(1817.8, 918.1);
 
         this.instance_74 = new lib.ClipGroup_0();
-        this.instance_74.setTransform(1888.3,1540,1,1,0,0,0,693.9,132.2);
+        this.instance_74.setTransform(1888.3, 1540, 1, 1, 0, 0, 0, 693.9, 132.2);
 
         this.instance_75 = new lib.rect4276();
-        this.instance_75.setTransform(1884,1503.9,1,1,0,0,0,731.5,127.5);
+        this.instance_75.setTransform(1884, 1503.9, 1, 1, 0, 0, 0, 731.5, 127.5);
         this.instance_75.alpha = 0.98;
 
         this.instance_76 = new lib.ClipGroup();
-        this.instance_76.setTransform(1871.9,897.9,1,1,0,0,0,950,846);
+        this.instance_76.setTransform(1871.9, 897.9, 1, 1, 0, 0, 0, 950, 846);
 
-        this.timeline.addTween(cjs.Tween.get({}).to({state:[{t:this.instance_46},{t:this.instance_45},{t:this.instance_44},{t:this.shape_140,p:{x:1198.9}},{t:this.shape_139,p:{x:2570.4,y:1500.5}},{t:this.shape_138,p:{x:2555.3}},{t:this.shape_137,p:{x:1268.9}},{t:this.shape_136,p:{x:1808.3,y:937.5}},{t:this.shape_135,p:{x:1808.3,y:937.5}},{t:this.shape_134,p:{x:2154.9,y:1269.1}},{t:this.shape_133,p:{x:2122.4}},{t:this.shape_132,p:{x:2143.7}},{t:this.shape_131,p:{x:1807.9}},{t:this.shape_130,p:{x:2145.6,y:566.5}},{t:this.shape_129,p:{x:1848.8}},{t:this.shape_128,p:{x:1848.8}},{t:this.shape_127,p:{x:1855.4}},{t:this.shape_126,p:{x:1489.6,y:679}},{t:this.shape_125,p:{x:2130.2}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1819.6}},{t:this.shape_120,p:{x:1485.5}},{t:this.shape_119,p:{x:2037.6}},{t:this.shape_118,p:{x:2045.2,y:1145.5}},{t:this.shape_117,p:{x:1516.7}},{t:this.shape_116,p:{x:1669,y:1280.4}},{t:this.shape_115,p:{x:1669.4,y:1256.4}},{t:this.shape_114,p:{x:1667.2,y:1280.1}},{t:this.shape_113,p:{x:2148.5}},{t:this.shape_112,p:{x:1814,y:959}},{t:this.shape_111,p:{x:1136.2,y:686.8}},{t:this.shape_110,p:{x:1136.2,y:686.8}},{t:this.shape_109,p:{x:1514.5,y:264}},{t:this.shape_108,p:{x:1514.5,y:264}},{t:this.shape_107,p:{x:1387.9}},{t:this.shape_106,p:{x:1387.9}},{t:this.shape_105,p:{x:1250.6}},{t:this.shape_104,p:{x:1250.6}},{t:this.shape_103,p:{x:1659.7}},{t:this.shape_102,p:{x:1659.7}},{t:this.shape_101,p:{x:1941.2,y:179.7}},{t:this.shape_100,p:{x:1941.2,y:179.7}},{t:this.shape_99,p:{x:1942.4}},{t:this.shape_98,p:{x:1942.4}},{t:this.shape_97,p:{x:1938.1,y:200.2}},{t:this.shape_96,p:{x:1938.1,y:200.2}},{t:this.shape_95,p:{x:2300.6,y:296.7}},{t:this.shape_94,p:{x:2300.6,y:296.7}},{t:this.shape_93,p:{x:2303.1}},{t:this.shape_92,p:{x:2303.1}},{t:this.shape_91,p:{x:2432.7,y:431.2}},{t:this.shape_90,p:{x:2432.7,y:431.2}},{t:this.shape_89,p:{x:2124.1}},{t:this.shape_88,p:{x:2124.1}},{t:this.shape_87,p:{x:2630.8,y:746.8}},{t:this.shape_86,p:{x:2630.8}},{t:this.shape_85,p:{x:2560.1,y:575.9}},{t:this.shape_84,p:{x:2560.1,y:575.9}},{t:this.shape_83},{t:this.shape_82,p:{x:2363.7}},{t:this.shape_81,p:{x:2363.7}},{t:this.shape_80,p:{x:2477.3,y:905.3}},{t:this.shape_79,p:{x:2477.3,y:905.3}}]}).to({state:[{t:this.instance_49},{t:this.instance_48},{t:this.instance_47},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_146},{t:this.shape_145},{t:this.shape_144},{t:this.shape_143},{t:this.shape_142},{t:this.shape_141}]},1).to({state:[{t:this.instance_52},{t:this.instance_51},{t:this.instance_50},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_153,p:{x:1569.8,y:1580.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_152},{t:this.shape_151},{t:this.shape_150},{t:this.shape_149}]},1).to({state:[{t:this.instance_55},{t:this.instance_54},{t:this.instance_53},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_154,p:{x:1569.8,y:1580.9}},{t:this.shape_153,p:{x:1727.8,y:1562.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_146},{t:this.shape_145},{t:this.shape_144},{t:this.shape_143},{t:this.shape_142},{t:this.shape_141}]},1).to({state:[{t:this.instance_58},{t:this.instance_57},{t:this.instance_56},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_155,p:{x:1569.8,y:1580.9}},{t:this.shape_154,p:{x:1727.8,y:1562.9}},{t:this.shape_153,p:{x:1884.3,y:1546.4}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_82,p:{x:2364.2}},{t:this.shape_81,p:{x:2364.2}},{t:this.shape_80,p:{x:2477.8,y:905.4}},{t:this.shape_79,p:{x:2477.8,y:905.4}}]},1).to({state:[{t:this.instance_61},{t:this.instance_60},{t:this.instance_59},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_156,p:{x:1569.8,y:1580.9}},{t:this.shape_155,p:{x:1727.8,y:1562.9}},{t:this.shape_154,p:{x:1884.3,y:1546.4}},{t:this.shape_153,p:{x:2036.8,y:1530.2}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_146},{t:this.shape_145},{t:this.shape_144},{t:this.shape_143},{t:this.shape_142},{t:this.shape_141}]},1).to({state:[{t:this.instance_64},{t:this.instance_63},{t:this.instance_62},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_157,p:{x:1569.8,y:1580.9}},{t:this.shape_156,p:{x:1727.8,y:1562.9}},{t:this.shape_155,p:{x:1884.3,y:1546.4}},{t:this.shape_154,p:{x:2036.8,y:1530.2}},{t:this.shape_153,p:{x:2193.6,y:1517.7}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_152},{t:this.shape_151},{t:this.shape_150},{t:this.shape_149}]},1).to({state:[{t:this.instance_67},{t:this.instance_66},{t:this.instance_65},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_158,p:{x:1569.8,y:1580.9}},{t:this.shape_157,p:{x:1727.8,y:1562.9}},{t:this.shape_156,p:{x:1884.3,y:1546.4}},{t:this.shape_155,p:{x:2036.8,y:1530.2}},{t:this.shape_154,p:{x:2193.6,y:1517.7}},{t:this.shape_153,p:{x:2348.3,y:1499.7}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_146},{t:this.shape_145},{t:this.shape_144},{t:this.shape_143},{t:this.shape_142},{t:this.shape_141}]},1).to({state:[{t:this.instance_70},{t:this.instance_69},{t:this.instance_68},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_113,p:{x:2149}},{t:this.shape_112,p:{x:1814.5,y:959.1}},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83},{t:this.shape_82,p:{x:2364.2}},{t:this.shape_81,p:{x:2364.2}},{t:this.shape_80,p:{x:2477.8,y:905.4}},{t:this.shape_79,p:{x:2477.8,y:905.4}}]},1).to({state:[{t:this.instance_73},{t:this.instance_72},{t:this.instance_71},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_161},{t:this.shape_160},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).to({state:[{t:this.instance_76},{t:this.instance_75},{t:this.instance_74},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_163},{t:this.shape_162},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).to({state:[{t:this.instance_73},{t:this.instance_72},{t:this.instance_71},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_161},{t:this.shape_160},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).to({state:[{t:this.instance_76},{t:this.instance_75},{t:this.instance_74},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_163},{t:this.shape_162},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).to({state:[{t:this.instance_73},{t:this.instance_72},{t:this.instance_71},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_161},{t:this.shape_160},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).to({state:[{t:this.instance_76},{t:this.instance_75},{t:this.instance_74},{t:this.shape_140,p:{x:1199.4}},{t:this.shape_139,p:{x:2570.9,y:1500.6}},{t:this.shape_138,p:{x:2555.8}},{t:this.shape_137,p:{x:1269.4}},{t:this.shape_148},{t:this.shape_147},{t:this.shape_159},{t:this.shape_158,p:{x:1727.8,y:1562.9}},{t:this.shape_157,p:{x:1884.3,y:1546.4}},{t:this.shape_156,p:{x:2036.8,y:1530.2}},{t:this.shape_155,p:{x:2193.6,y:1517.7}},{t:this.shape_154,p:{x:2348.3,y:1499.7}},{t:this.shape_153,p:{x:2491.1,y:1485.9}},{t:this.shape_136,p:{x:1808.8,y:937.6}},{t:this.shape_135,p:{x:1808.8,y:937.6}},{t:this.shape_134,p:{x:2155.4,y:1269.2}},{t:this.shape_133,p:{x:2122.9}},{t:this.shape_132,p:{x:2144.2}},{t:this.shape_131,p:{x:1808.4}},{t:this.shape_130,p:{x:2146.1,y:566.6}},{t:this.shape_129,p:{x:1849.3}},{t:this.shape_128,p:{x:1849.3}},{t:this.shape_127,p:{x:1855.9}},{t:this.shape_126,p:{x:1490.1,y:679.1}},{t:this.shape_125,p:{x:2130.7}},{t:this.shape_124},{t:this.shape_123},{t:this.shape_122},{t:this.shape_121,p:{x:1820.1}},{t:this.shape_120,p:{x:1486}},{t:this.shape_119,p:{x:2038.1}},{t:this.shape_118,p:{x:2045.7,y:1145.6}},{t:this.shape_117,p:{x:1517.2}},{t:this.shape_116,p:{x:1669.5,y:1280.5}},{t:this.shape_115,p:{x:1669.9,y:1256.5}},{t:this.shape_114,p:{x:1667.7,y:1280.2}},{t:this.shape_163},{t:this.shape_162},{t:this.shape_111,p:{x:1136.7,y:686.9}},{t:this.shape_110,p:{x:1136.7,y:686.9}},{t:this.shape_109,p:{x:1515,y:264.1}},{t:this.shape_108,p:{x:1515,y:264.1}},{t:this.shape_107,p:{x:1388.4}},{t:this.shape_106,p:{x:1388.4}},{t:this.shape_105,p:{x:1251.1}},{t:this.shape_104,p:{x:1251.1}},{t:this.shape_103,p:{x:1660.2}},{t:this.shape_102,p:{x:1660.2}},{t:this.shape_101,p:{x:1941.7,y:179.8}},{t:this.shape_100,p:{x:1941.7,y:179.8}},{t:this.shape_99,p:{x:1942.9}},{t:this.shape_98,p:{x:1942.9}},{t:this.shape_97,p:{x:1938.6,y:200.3}},{t:this.shape_96,p:{x:1938.6,y:200.3}},{t:this.shape_95,p:{x:2301.1,y:296.8}},{t:this.shape_94,p:{x:2301.1,y:296.8}},{t:this.shape_93,p:{x:2303.6}},{t:this.shape_92,p:{x:2303.6}},{t:this.shape_91,p:{x:2433.2,y:431.3}},{t:this.shape_90,p:{x:2433.2,y:431.3}},{t:this.shape_89,p:{x:2124.6}},{t:this.shape_88,p:{x:2124.6}},{t:this.shape_87,p:{x:2631.3,y:746.9}},{t:this.shape_86,p:{x:2631.3}},{t:this.shape_85,p:{x:2560.6,y:576}},{t:this.shape_84,p:{x:2560.6,y:576}},{t:this.shape_83}]},1).wait(1));
-
+        this.timeline.addTween(
+            cjs.Tween.get({})
+                .to({
+                    state: [
+                        { t: this.instance_46 },
+                        { t: this.instance_45 },
+                        { t: this.instance_44 },
+                        { t: this.shape_140, p: { x: 1198.9 } },
+                        { t: this.shape_139, p: { x: 2570.4, y: 1500.5 } },
+                        { t: this.shape_138, p: { x: 2555.3 } },
+                        { t: this.shape_137, p: { x: 1268.9 } },
+                        { t: this.shape_136, p: { x: 1808.3, y: 937.5 } },
+                        { t: this.shape_135, p: { x: 1808.3, y: 937.5 } },
+                        { t: this.shape_134, p: { x: 2154.9, y: 1269.1 } },
+                        { t: this.shape_133, p: { x: 2122.4 } },
+                        { t: this.shape_132, p: { x: 2143.7 } },
+                        { t: this.shape_131, p: { x: 1807.9 } },
+                        { t: this.shape_130, p: { x: 2145.6, y: 566.5 } },
+                        { t: this.shape_129, p: { x: 1848.8 } },
+                        { t: this.shape_128, p: { x: 1848.8 } },
+                        { t: this.shape_127, p: { x: 1855.4 } },
+                        { t: this.shape_126, p: { x: 1489.6, y: 679 } },
+                        { t: this.shape_125, p: { x: 2130.2 } },
+                        { t: this.shape_124 },
+                        { t: this.shape_123 },
+                        { t: this.shape_122 },
+                        { t: this.shape_121, p: { x: 1819.6 } },
+                        { t: this.shape_120, p: { x: 1485.5 } },
+                        { t: this.shape_119, p: { x: 2037.6 } },
+                        { t: this.shape_118, p: { x: 2045.2, y: 1145.5 } },
+                        { t: this.shape_117, p: { x: 1516.7 } },
+                        { t: this.shape_116, p: { x: 1669, y: 1280.4 } },
+                        { t: this.shape_115, p: { x: 1669.4, y: 1256.4 } },
+                        { t: this.shape_114, p: { x: 1667.2, y: 1280.1 } },
+                        { t: this.shape_113, p: { x: 2148.5 } },
+                        { t: this.shape_112, p: { x: 1814, y: 959 } },
+                        { t: this.shape_111, p: { x: 1136.2, y: 686.8 } },
+                        { t: this.shape_110, p: { x: 1136.2, y: 686.8 } },
+                        { t: this.shape_109, p: { x: 1514.5, y: 264 } },
+                        { t: this.shape_108, p: { x: 1514.5, y: 264 } },
+                        { t: this.shape_107, p: { x: 1387.9 } },
+                        { t: this.shape_106, p: { x: 1387.9 } },
+                        { t: this.shape_105, p: { x: 1250.6 } },
+                        { t: this.shape_104, p: { x: 1250.6 } },
+                        { t: this.shape_103, p: { x: 1659.7 } },
+                        { t: this.shape_102, p: { x: 1659.7 } },
+                        { t: this.shape_101, p: { x: 1941.2, y: 179.7 } },
+                        { t: this.shape_100, p: { x: 1941.2, y: 179.7 } },
+                        { t: this.shape_99, p: { x: 1942.4 } },
+                        { t: this.shape_98, p: { x: 1942.4 } },
+                        { t: this.shape_97, p: { x: 1938.1, y: 200.2 } },
+                        { t: this.shape_96, p: { x: 1938.1, y: 200.2 } },
+                        { t: this.shape_95, p: { x: 2300.6, y: 296.7 } },
+                        { t: this.shape_94, p: { x: 2300.6, y: 296.7 } },
+                        { t: this.shape_93, p: { x: 2303.1 } },
+                        { t: this.shape_92, p: { x: 2303.1 } },
+                        { t: this.shape_91, p: { x: 2432.7, y: 431.2 } },
+                        { t: this.shape_90, p: { x: 2432.7, y: 431.2 } },
+                        { t: this.shape_89, p: { x: 2124.1 } },
+                        { t: this.shape_88, p: { x: 2124.1 } },
+                        { t: this.shape_87, p: { x: 2630.8, y: 746.8 } },
+                        { t: this.shape_86, p: { x: 2630.8 } },
+                        { t: this.shape_85, p: { x: 2560.1, y: 575.9 } },
+                        { t: this.shape_84, p: { x: 2560.1, y: 575.9 } },
+                        { t: this.shape_83 },
+                        { t: this.shape_82, p: { x: 2363.7 } },
+                        { t: this.shape_81, p: { x: 2363.7 } },
+                        { t: this.shape_80, p: { x: 2477.3, y: 905.3 } },
+                        { t: this.shape_79, p: { x: 2477.3, y: 905.3 } }
+                    ]
+                })
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_49 },
+                            { t: this.instance_48 },
+                            { t: this.instance_47 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_146 },
+                            { t: this.shape_145 },
+                            { t: this.shape_144 },
+                            { t: this.shape_143 },
+                            { t: this.shape_142 },
+                            { t: this.shape_141 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_52 },
+                            { t: this.instance_51 },
+                            { t: this.instance_50 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_153, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_152 },
+                            { t: this.shape_151 },
+                            { t: this.shape_150 },
+                            { t: this.shape_149 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_55 },
+                            { t: this.instance_54 },
+                            { t: this.instance_53 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_154, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_153, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_146 },
+                            { t: this.shape_145 },
+                            { t: this.shape_144 },
+                            { t: this.shape_143 },
+                            { t: this.shape_142 },
+                            { t: this.shape_141 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_58 },
+                            { t: this.instance_57 },
+                            { t: this.instance_56 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_155, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_154, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_153, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_82, p: { x: 2364.2 } },
+                            { t: this.shape_81, p: { x: 2364.2 } },
+                            { t: this.shape_80, p: { x: 2477.8, y: 905.4 } },
+                            { t: this.shape_79, p: { x: 2477.8, y: 905.4 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_61 },
+                            { t: this.instance_60 },
+                            { t: this.instance_59 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_156, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_155, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_154, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_153, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_146 },
+                            { t: this.shape_145 },
+                            { t: this.shape_144 },
+                            { t: this.shape_143 },
+                            { t: this.shape_142 },
+                            { t: this.shape_141 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_64 },
+                            { t: this.instance_63 },
+                            { t: this.instance_62 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_157, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_156, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_155, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_154, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_153, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_152 },
+                            { t: this.shape_151 },
+                            { t: this.shape_150 },
+                            { t: this.shape_149 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_67 },
+                            { t: this.instance_66 },
+                            { t: this.instance_65 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_158, p: { x: 1569.8, y: 1580.9 } },
+                            { t: this.shape_157, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_156, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_155, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_154, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_153, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_146 },
+                            { t: this.shape_145 },
+                            { t: this.shape_144 },
+                            { t: this.shape_143 },
+                            { t: this.shape_142 },
+                            { t: this.shape_141 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_70 },
+                            { t: this.instance_69 },
+                            { t: this.instance_68 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_113, p: { x: 2149 } },
+                            { t: this.shape_112, p: { x: 1814.5, y: 959.1 } },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 },
+                            { t: this.shape_82, p: { x: 2364.2 } },
+                            { t: this.shape_81, p: { x: 2364.2 } },
+                            { t: this.shape_80, p: { x: 2477.8, y: 905.4 } },
+                            { t: this.shape_79, p: { x: 2477.8, y: 905.4 } }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_73 },
+                            { t: this.instance_72 },
+                            { t: this.instance_71 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_161 },
+                            { t: this.shape_160 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_76 },
+                            { t: this.instance_75 },
+                            { t: this.instance_74 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_163 },
+                            { t: this.shape_162 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_73 },
+                            { t: this.instance_72 },
+                            { t: this.instance_71 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_161 },
+                            { t: this.shape_160 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_76 },
+                            { t: this.instance_75 },
+                            { t: this.instance_74 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_163 },
+                            { t: this.shape_162 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_73 },
+                            { t: this.instance_72 },
+                            { t: this.instance_71 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_161 },
+                            { t: this.shape_160 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .to(
+                    {
+                        state: [
+                            { t: this.instance_76 },
+                            { t: this.instance_75 },
+                            { t: this.instance_74 },
+                            { t: this.shape_140, p: { x: 1199.4 } },
+                            { t: this.shape_139, p: { x: 2570.9, y: 1500.6 } },
+                            { t: this.shape_138, p: { x: 2555.8 } },
+                            { t: this.shape_137, p: { x: 1269.4 } },
+                            { t: this.shape_148 },
+                            { t: this.shape_147 },
+                            { t: this.shape_159 },
+                            { t: this.shape_158, p: { x: 1727.8, y: 1562.9 } },
+                            { t: this.shape_157, p: { x: 1884.3, y: 1546.4 } },
+                            { t: this.shape_156, p: { x: 2036.8, y: 1530.2 } },
+                            { t: this.shape_155, p: { x: 2193.6, y: 1517.7 } },
+                            { t: this.shape_154, p: { x: 2348.3, y: 1499.7 } },
+                            { t: this.shape_153, p: { x: 2491.1, y: 1485.9 } },
+                            { t: this.shape_136, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_135, p: { x: 1808.8, y: 937.6 } },
+                            { t: this.shape_134, p: { x: 2155.4, y: 1269.2 } },
+                            { t: this.shape_133, p: { x: 2122.9 } },
+                            { t: this.shape_132, p: { x: 2144.2 } },
+                            { t: this.shape_131, p: { x: 1808.4 } },
+                            { t: this.shape_130, p: { x: 2146.1, y: 566.6 } },
+                            { t: this.shape_129, p: { x: 1849.3 } },
+                            { t: this.shape_128, p: { x: 1849.3 } },
+                            { t: this.shape_127, p: { x: 1855.9 } },
+                            { t: this.shape_126, p: { x: 1490.1, y: 679.1 } },
+                            { t: this.shape_125, p: { x: 2130.7 } },
+                            { t: this.shape_124 },
+                            { t: this.shape_123 },
+                            { t: this.shape_122 },
+                            { t: this.shape_121, p: { x: 1820.1 } },
+                            { t: this.shape_120, p: { x: 1486 } },
+                            { t: this.shape_119, p: { x: 2038.1 } },
+                            { t: this.shape_118, p: { x: 2045.7, y: 1145.6 } },
+                            { t: this.shape_117, p: { x: 1517.2 } },
+                            { t: this.shape_116, p: { x: 1669.5, y: 1280.5 } },
+                            { t: this.shape_115, p: { x: 1669.9, y: 1256.5 } },
+                            { t: this.shape_114, p: { x: 1667.7, y: 1280.2 } },
+                            { t: this.shape_163 },
+                            { t: this.shape_162 },
+                            { t: this.shape_111, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_110, p: { x: 1136.7, y: 686.9 } },
+                            { t: this.shape_109, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_108, p: { x: 1515, y: 264.1 } },
+                            { t: this.shape_107, p: { x: 1388.4 } },
+                            { t: this.shape_106, p: { x: 1388.4 } },
+                            { t: this.shape_105, p: { x: 1251.1 } },
+                            { t: this.shape_104, p: { x: 1251.1 } },
+                            { t: this.shape_103, p: { x: 1660.2 } },
+                            { t: this.shape_102, p: { x: 1660.2 } },
+                            { t: this.shape_101, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_100, p: { x: 1941.7, y: 179.8 } },
+                            { t: this.shape_99, p: { x: 1942.9 } },
+                            { t: this.shape_98, p: { x: 1942.9 } },
+                            { t: this.shape_97, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_96, p: { x: 1938.6, y: 200.3 } },
+                            { t: this.shape_95, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_94, p: { x: 2301.1, y: 296.8 } },
+                            { t: this.shape_93, p: { x: 2303.6 } },
+                            { t: this.shape_92, p: { x: 2303.6 } },
+                            { t: this.shape_91, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_90, p: { x: 2433.2, y: 431.3 } },
+                            { t: this.shape_89, p: { x: 2124.6 } },
+                            { t: this.shape_88, p: { x: 2124.6 } },
+                            { t: this.shape_87, p: { x: 2631.3, y: 746.9 } },
+                            { t: this.shape_86, p: { x: 2631.3 } },
+                            { t: this.shape_85, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_84, p: { x: 2560.6, y: 576 } },
+                            { t: this.shape_83 }
+                        ]
+                    },
+                    1
+                )
+                .wait(1)
+        );
     }).prototype = p = new cjs.MovieClip();
-    p.nominalBounds = new cjs.Rectangle(1935.9,923.5,3669.2,1692);
-
-})(lib = lib||{}, images = images||{}, createjs = createjs||{});
+    p.nominalBounds = new cjs.Rectangle(1935.9, 923.5, 3669.2, 1692);
+})((lib = lib || {}), (images = images || {}), (createjs = createjs || {}));
 var lib, images, createjs;


### PR DESCRIPTION
### Summary
This PR resolves global Prettier CI check failures caused by unformatted code residing in `activity/SugarAnimation.js`.

- Executed `npx prettier --write` on `activity/SugarAnimation.js` to strictly align it with the repository's defined code style rules.


- [x] Chore