### PR TITLE
Fix Play/Stop toggle and audio stop behavior in PitchStaircase widget 

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -161,6 +161,16 @@ class PitchStaircase {
             });
 
             playCell.onclick = () => {
+                const img = playCell.querySelector("img");
+
+                if (img.src.includes("stop-button.svg")) {
+                    this.activity.logo.synth.setMasterVolume(0);
+
+                    img.src = "header-icons/play-button.svg";
+                    return;
+                }
+                // console.log(img.src);
+                this.activity.logo.synth.setMasterVolume(100);
                 const i = playCell.getAttribute("id");
                 const stepCell = this._stepTables[i].rows[0].cells[1];
                 this._playOne(stepCell);
@@ -302,7 +312,12 @@ class PitchStaircase {
      */
     _playOne(stepCell) {
         // The frequency is stored in the stepCell.
+        const playCell = stepCell.previousElementSibling;
+
+        const img = playCell.querySelector("img");
+
         stepCell.classList.add("active");
+        img.src = "header-icons/stop-button.svg";
         stepCell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
         const frequency = Number(stepCell.getAttribute("id"));
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
@@ -310,6 +325,8 @@ class PitchStaircase {
         setTimeout(() => {
             stepCell.classList.remove("active");
             stepCell.style.backgroundColor = platformColor.selectorBackground;
+
+            img.src = "header-icons/play-button.svg";
         }, 1000);
     }
 


### PR DESCRIPTION
## Fix Play/Stop toggle and audio stop behavior in PitchStaircase widget

###  Problem

Previously, the Play button only triggered audio playback using the synth engine, but there was no proper mechanism to stop or control the ongoing audio.

As a result:

- Clicking Play started sound correctly
- There was no actual Stop functionality for audio
- UI state (icon change) and audio state were not synchronized

---

###  What was implemented

This PR fixes both UI and audio behavior in the PitchStaircase widget:

- Added proper Play/Stop toggle behavior on the same button
- Implemented actual audio stop control using synth master volume control
- Ensured audio state is properly reset when stopping playback
- Fixed mismatch between UI icon state and real audio playback state

---

###  Behavior after fix

#### ▶️ Play:
- Audio starts via synth trigger
- Button changes to Stop icon
- Playback continues normally

#### ⏹ Stop:
- Audio is immediately stopped via synth volume control
- Button changes back to Play icon
- No residual sound continues

---

###  Testing

1. Open PitchStaircase widget  
2. Click Play → audio starts + icon changes  
3. Click Stop → audio stops immediately + icon resets  
4. Verify no sound continues after stop  
5. Replay works correctly after stopping  

---

###  Notes

This fix ensures proper synchronization between UI state and actual audio engine state, preventing desync issues during playback control.