### PR TITLE
Introduce ProtoBlock capability metadata foundation

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -118,7 +118,8 @@ describe("Block Foundation", () => {
             image: "forward.svg",
             size: 1,
             docks: [],
-            hidden: false
+            hidden: false,
+            capabilities: Object.create(null)
         };
     });
 
@@ -152,24 +153,21 @@ describe("Block Foundation", () => {
             expect(block.getInfo()).toBe("forward block");
         });
 
-        it("isCollapsible() should return true for collapsible blocks", () => {
-            mockProtoBlock.name = "start";
-            const block = new Block(mockProtoBlock, mockBlocks);
-            expect(block.isCollapsible()).toBe(true);
+        it("hasCapability() should read protoblock capability metadata", () => {
+            mockProtoBlock.capabilities.collapsible = true;
+            mockProtoBlock.capabilities.specialInput = true;
 
-            mockProtoBlock.name = "forward";
-            const block2 = new Block(mockProtoBlock, mockBlocks);
-            expect(block2.isCollapsible()).toBe(false);
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasCapability("collapsible")).toBe(true);
+            expect(block.getCapability("specialInput")).toBe(true);
         });
 
-        it("isInlineCollapsible() should return true for inline collapsible blocks", () => {
-            mockProtoBlock.name = "newnote";
-            const block = new Block(mockProtoBlock, mockBlocks);
-            expect(block.isInlineCollapsible()).toBe(true);
+        it("should return falsey values when capability metadata is absent", () => {
+            mockProtoBlock.capabilities = Object.create(null);
 
-            mockProtoBlock.name = "forward";
-            const block2 = new Block(mockProtoBlock, mockBlocks);
-            expect(block2.isInlineCollapsible()).toBe(false);
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasCapability("collapsible")).toBe(false);
+            expect(block.getCapability("collapsible")).toBeUndefined();
         });
 
         it("copySize() should sync size from protoblock", () => {

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -153,6 +153,26 @@ describe("Block Foundation", () => {
             expect(block.getInfo()).toBe("forward block");
         });
 
+        it("isCollapsible() should return true for collapsible blocks", () => {
+            mockProtoBlock.name = "start";
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isCollapsible()).toBe(true);
+
+            mockProtoBlock.name = "forward";
+            const block2 = new Block(mockProtoBlock, mockBlocks);
+            expect(block2.isCollapsible()).toBe(false);
+        });
+
+        it("isInlineCollapsible() should return true for inline collapsible blocks", () => {
+            mockProtoBlock.name = "newnote";
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isInlineCollapsible()).toBe(true);
+
+            mockProtoBlock.name = "forward";
+            const block2 = new Block(mockProtoBlock, mockBlocks);
+            expect(block2.isInlineCollapsible()).toBe(false);
+        });
+
         it("hasCapability() should read protoblock capability metadata", () => {
             mockProtoBlock.capabilities.collapsible = true;
             mockProtoBlock.capabilities.specialInput = true;

--- a/js/__tests__/protoblocks.test.js
+++ b/js/__tests__/protoblocks.test.js
@@ -55,6 +55,7 @@ describe("ProtoBlock", () => {
         expect(block.expandable).toBe(false);
         expect(block.args).toBe(0);
         expect(block.defaults).toEqual([]);
+        expect(block.capabilities).toEqual({});
     });
 
     test("adjustWidthToLabel should set textWidth and extraWidth", () => {
@@ -105,5 +106,18 @@ describe("ProtoBlock", () => {
         block.parameterBlock();
         expect(block.dockTypes).toContain("numberout");
         expect(block.parameter).toBe(true);
+    });
+
+    test("capability helpers should store and read flags", () => {
+        block.setCapability("collapsible");
+        block.setCapabilities({
+            specialInput: true,
+            noHit: false
+        });
+
+        expect(block.hasCapability("collapsible")).toBe(true);
+        expect(block.getCapability("specialInput")).toBe(true);
+        expect(block.hasCapability("noHit")).toBe(false);
+        expect(block.getCapability("missing")).toBeUndefined();
     });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -610,6 +610,38 @@ class Block {
         this.size = this.protoblock.size;
     }
 
+    hasCapability(name) {
+        if (this.protoblock && typeof this.protoblock.hasCapability === "function") {
+            return this.protoblock.hasCapability(name);
+        }
+
+        if (
+            this.protoblock &&
+            this.protoblock.capabilities &&
+            Object.prototype.hasOwnProperty.call(this.protoblock.capabilities, name)
+        ) {
+            return !!this.protoblock.capabilities[name];
+        }
+
+        return false;
+    }
+
+    getCapability(name) {
+        if (this.protoblock && typeof this.protoblock.getCapability === "function") {
+            return this.protoblock.getCapability(name);
+        }
+
+        if (
+            this.protoblock &&
+            this.protoblock.capabilities &&
+            Object.prototype.hasOwnProperty.call(this.protoblock.capabilities, name)
+        ) {
+            return this.protoblock.capabilities[name];
+        }
+
+        return undefined;
+    }
+
     /**
      * Retrieves information about the block.
      * @returns {string} - Information about the block.

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -81,6 +81,8 @@ class ProtoBlock {
         this.textWidth = 0;
         this.labelOffset = 0;
         this.beginnerModeBlock = false;
+        // Capability metadata is additive and starts empty.
+        this.capabilities = Object.create(null);
     }
 
     /**
@@ -96,6 +98,55 @@ class ProtoBlock {
         const b = c.getBounds();
         this.textWidth = b.width;
         this.extraWidth += Math.max(b.width - 30, 0);
+    }
+
+    /**
+     * Sets a single capability flag on the protoblock.
+     * @param {string} name - Capability name.
+     * @param {boolean} [value=true] - Capability value.
+     * @returns {void}
+     */
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    /**
+     * Merges capability flags into the protoblock.
+     * @param {Object} capabilities - Capability flags to merge.
+     * @returns {void}
+     */
+    setCapabilities(capabilities) {
+        if (!capabilities) {
+            return;
+        }
+
+        for (const name in capabilities) {
+            if (Object.prototype.hasOwnProperty.call(capabilities, name)) {
+                this.setCapability(name, capabilities[name]);
+            }
+        }
+    }
+
+    /**
+     * Reads a capability flag from the protoblock.
+     * @param {string} name - Capability name.
+     * @returns {boolean} - True if the capability is enabled.
+     */
+    hasCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? !!this.capabilities[name]
+            : false;
+    }
+
+    /**
+     * Returns the raw capability value from the protoblock.
+     * @param {string} name - Capability name.
+     * @returns {*} - Stored capability value, if any.
+     */
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 
     // What follows are the initializations for different block
@@ -1630,6 +1681,7 @@ class BaseBlock extends ProtoBlock {
         this._style.defaults ||= [];
         this._style.flows ||= {};
         this._style.flows.labels ||= [];
+        this._style.capabilities ||= {};
 
         if (this._style.args > 1) {
             this.expandable = true;
@@ -1662,6 +1714,11 @@ class BaseBlock extends ProtoBlock {
         if (this._style.image) {
             this.size++;
             this.image = this._style.image;
+        }
+
+        this.setCapabilities(this._style.capabilities);
+        if (this._style.canCollapse) {
+            this.setCapability("collapsible", true);
         }
 
         this.staticLabels = [this._style.name || ""];

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -1717,9 +1717,6 @@ class BaseBlock extends ProtoBlock {
         }
 
         this.setCapabilities(this._style.capabilities);
-        if (this._style.canCollapse) {
-            this.setCapability("collapsible", true);
-        }
 
         this.staticLabels = [this._style.name || ""];
         this.dockTypes = [];


### PR DESCRIPTION
Summary

This PR introduces the foundation for capability metadata without changing any existing behavior.

- Added a capability metadata container to ProtoBlock.
- Added generic metadata accessors to ProtoBlock.
- Added hasCapability() and getCapability() accessors to Block.
- Added focused unit tests for the new metadata layer in protoblocks.test.js and block.test.js.

This PR only adds the infrastructure needed for the next steps of the incremental ownership refactor. 

testing -- 

<img width="640" height="157" alt="image" src="https://github.com/user-attachments/assets/54366155-6e44-4e75-bd5b-66cfbc92beba" />

<img width="771" height="144" alt="image" src="https://github.com/user-attachments/assets/52deed62-5bd5-4560-b174-f87c7bd19d5b" />

<img width="805" height="142" alt="image" src="https://github.com/user-attachments/assets/98962d20-a14b-46ef-ad45-b7acadfa4286" />

## PR category 

- [x] tests
- [x] feature

