### PR TITLE
fix: skip trailing Turtle Blocks metadata entries when loading .tb projects

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -5740,6 +5740,24 @@ class Blocks {
                 );
             }
 
+            /**
+             * Turtle Blocks (.tb) files end with turtle-state and
+             * _saved_font_scale entries. These are metadata, not blocks:
+             * their connections field (index 4) is a scalar, so treating
+             * them as blocks crashes _processOneBlock and stalls
+             * _loadCounter, leaving the project half-loaded.
+             */
+            while (
+                blockObjs.length > 0 &&
+                !Array.isArray(blockObjs[blockObjs.length - 1][4])
+            ) {
+                console.debug(
+                    "Removing non-block metadata entry from project: " +
+                        JSON.stringify(blockObjs[blockObjs.length - 1][1])
+                );
+                blockObjs.pop();
+            }
+
             /** Check for blocks connected to themselves, */
             /** and for action blocks not connected to text blocks. */
             for (let b = 0; b < blockObjs.length; b++) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -5747,10 +5747,7 @@ class Blocks {
              * them as blocks crashes _processOneBlock and stalls
              * _loadCounter, leaving the project half-loaded.
              */
-            while (
-                blockObjs.length > 0 &&
-                !Array.isArray(blockObjs[blockObjs.length - 1][4])
-            ) {
+            while (blockObjs.length > 0 && !Array.isArray(blockObjs[blockObjs.length - 1][4])) {
                 console.debug(
                     "Removing non-block metadata entry from project: " +
                         JSON.stringify(blockObjs[blockObjs.length - 1][1])


### PR DESCRIPTION
## Problem

Importing a `.tb` (Turtle Blocks) file by dragging it onto the canvas throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading '4')
    at Blocks._processOneBlock (blocks.js)
    at processChunk (blocks.js)
```

The chunked-load rAF chain dies, `_loadCounter` never reaches 0, `finishedLoading` never fires, and the project is left half-loaded — matching the screenshot in #7696 (only a bare start block visible).

## Root cause

Turtle Blocks saves append **metadata rows** after the block rows — turtle state and font scale:

```
[-1, ["turtle", "Yertle"], -1144.79..., 980.36..., 100.00..., 78, 99, 25]
[-1, "_saved_font_scale", 0, 0, 2]
```

These are not blocks: index 4 is a **scalar**, not a connections array. In `_processOneBlock`'s unknown-block branch:

```js
const c = blkData[4][0];            // (100.00)[0] → undefined (not null!)
if (c !== null) {
    const cc = blockObjs[c][4]...   // blockObjs[undefined] → TypeError
```

Reproducible with [`samples/graphics-dalton.tb`](https://github.com/sugarlabs/turtleart-activity/blob/master/samples/graphics-dalton.tb) from `sugarlabs/turtleart-activity` (or any file saved by recent Turtle Blocks, which always appends these rows).

## Fix

Drop trailing rows whose connections field is not an array, in the `loadNewBlocks` preamble — same pattern as the existing deprecated-playbackQueue cleanup a few lines above. Only trailing rows are removed, so block indices (used by the connection graph) are untouched.

## Verification (manual, per the drag-and-drop flow in the report)

| File | Before | After |
|---|---|---|
| `graphics-dalton.tb` (has metadata rows) | TypeError, `_loadCounter` stuck at 2, project half-loaded | no errors, `_loadCounter` drains to 0, 38 blocks load |
| `turtleart-activity/samples/basic-intro-1-en.tb` | loads (no metadata rows) | unchanged, 167 blocks |
| `turtleblocksjs/samples/a.tb` | loads (no metadata rows) | unchanged, 698 blocks |

## Remaining gaps in .tb import (not addressed here — happy to follow up)

1. Actions with **numeric labels** (`["number", 3]`, common in old TA files) lose their names: the label extraction only handles `string` and `{value}` shapes, so such actions get renamed `undefined1`, `undefined2`, … and `stack` calls to them dangle.
2. TB-only block names (`setxy2`, `plus2`, `minus2`, `xcor`, `ycor`, `clean`, `stack`, …) fall through to "unknown" NOP blocks; several have direct MB equivalents that could be added to `BACKWARDCOMPATIBILITYDICT`.

Fixes #7696

## Category

- [x] Bug Fix
