### PR TITLE
fix: About tour image clipping on mobile devices

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -1270,6 +1270,21 @@ table {
     margin: auto;
 }
 
+#helpBodyDiv .help-tour-image,
+#helpBodyDiv .help-tour-detailed-icon,
+#helpBodyDiv .help-tour-icon {
+    display: block;
+    margin: 0 auto 0.5rem;
+}
+
+#helpBodyDiv .help-tour-large-image {
+    max-width: 100%;
+    max-height: min(38vh, 220px);
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
 #helpBodyDiv p {
     margin: 0.5rem 0;
 }
@@ -1318,9 +1333,18 @@ table {
 }
 
 @media (max-width: 600px) {
+    #helpBodyDiv {
+        justify-content: flex-start;
+        padding-top: 1rem;
+    }
+
     #helpBodyDiv .icon-container {
         margin-top: 0;
         padding-top: 0;
+    }
+
+    #helpBodyDiv .help-tour-large-image {
+        max-height: min(32vh, 180px);
     }
 
     .icon-container #findIcon,

--- a/js/widgets/__tests__/help.test.js
+++ b/js/widgets/__tests__/help.test.js
@@ -514,6 +514,7 @@ describe("HelpWidget", () => {
             // For known pages, the img should NOT have width/height attributes
             expect(img.getAttribute("width")).toBeNull();
             expect(img.classList.contains("help-tour-image")).toBe(true);
+            expect(img.classList.contains("help-tour-large-image")).toBe(true);
             expect(img.classList.contains("help-tour-icon")).toBe(false);
         });
 

--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -444,7 +444,7 @@ class HelpWidget {
         img.alt = `${title} icon`;
 
         if (this._isLargeTourImage(title)) {
-            img.classList.add("help-tour-image");
+            img.classList.add("help-tour-image", "help-tour-large-image");
         } else if (this._isDetailedTourIcon(title)) {
             img.classList.add("help-tour-detailed-icon");
         } else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the About tour avatar image was partially clipped on smaller screens.

## What changed

- Added a dedicated responsive class for large help tour images.
- Applied responsive sizing constraints to prevent clipping on smaller viewports while preserving the desktop layout.
- Added a regression test to verify that large tour images receive the new responsive class.

## Testing

### Before

- Reproduced the issue on a mobile device.
- Reproduced the same issue by resizing the browser window to a smaller viewport on desktop.

### After

- Verified that the About tour avatar is fully visible on mobile devices.
- Verified that the About tour avatar is fully visible on smaller desktop viewports.
- Confirmed that the desktop layout remains unchanged.

## Screenshots

### Before

**Mobile device**

<img width="719" height="952" alt="WhatsApp Image 2026-07-04 at 12 33 10 PM" src="https://github.com/user-attachments/assets/422ff14a-eca2-4034-be3c-a9b3a25188d4" />

--

**Desktop (small viewport)**

<img width="1023" height="622" alt="image" src="https://github.com/user-attachments/assets/bc0c7333-2e19-4b20-9dd2-9f434e55d0bd" />
--

### After

**Desktop (small viewport)**

<img width="891" height="688" alt="Screenshot 2026-07-03 231622" src="https://github.com/user-attachments/assets/abc83855-28c1-4206-9ff5-56509120ce1e" />

--

## PR Category

- [x] Bug Fix
