### PR TITLE
perf: optimize turtleCount using Int32Array

### DIFF
--- a/js/__tests__/turtles.test.js
+++ b/js/__tests__/turtles.test.js
@@ -729,3 +729,64 @@ describe("TurtlesModel doGrid initialization order", () => {
         expect(() => setupGridController(activity)).not.toThrow();
     });
 });
+
+describe("turtleCount", () => {
+    let turtles;
+
+    beforeEach(() => {
+        turtles = {
+            getTurtleCount: jest.fn(),
+            getTurtle: jest.fn(),
+            turtleCount: Turtles.TurtlesModel.prototype.turtleCount
+        };
+    });
+
+    test("counts all turtles when there are no companions and none in trash", () => {
+        turtles.getTurtleCount.mockReturnValue(3);
+        turtles.getTurtle.mockImplementation(t => ({ companionTurtle: undefined, inTrash: false }));
+
+        expect(turtles.turtleCount()).toBe(3);
+    });
+
+    test("does not count turtles in trash", () => {
+        turtles.getTurtleCount.mockReturnValue(3);
+        turtles.getTurtle.mockImplementation(t => ({
+            companionTurtle: undefined,
+            inTrash: t === 1
+        }));
+
+        expect(turtles.turtleCount()).toBe(2);
+    });
+
+    test("does not count turtles that are claimed as companions", () => {
+        turtles.getTurtleCount.mockReturnValue(3);
+        // 0 points to 1
+        turtles.getTurtle.mockImplementation(t => {
+            if (t === 0) return { companionTurtle: 1, inTrash: false };
+            return { companionTurtle: undefined, inTrash: false };
+        });
+
+        // Turtle 0: points to 1. Not claimed. Counted.
+        // Turtle 1: claimed by 0. Not counted.
+        // Turtle 2: Not claimed. Counted.
+        expect(turtles.turtleCount()).toBe(2);
+    });
+
+    test("counts self-referencing turtles if no one else claims them first", () => {
+        turtles.getTurtleCount.mockReturnValue(1);
+        turtles.getTurtle.mockImplementation(t => ({ companionTurtle: t, inTrash: false }));
+
+        expect(turtles.turtleCount()).toBe(1);
+    });
+
+    test("does not count a self-referencing turtle if someone else claims it first", () => {
+        turtles.getTurtleCount.mockReturnValue(2);
+        // 0 points to 1. 1 points to 1.
+        turtles.getTurtle.mockImplementation(t => {
+            if (t === 0) return { companionTurtle: 1, inTrash: false };
+            if (t === 1) return { companionTurtle: 1, inTrash: false };
+        });
+
+        expect(turtles.turtleCount()).toBe(1);
+    });
+});

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -606,10 +606,20 @@ Turtles.TurtlesModel = class {
      * (excluding turtles in the trash and companion turtles)
      */
     turtleCount() {
-        let count = 0;
         const totalTurtles = this.getTurtleCount();
+        const firstClaimer = new Int32Array(totalTurtles).fill(-1);
+
         for (let t = 0; t < totalTurtles; t++) {
-            if (this.companionTurtle(t) === t && !this.getTurtle(t).inTrash) {
+            const c = this.getTurtle(t).companionTurtle;
+            if (c !== undefined && firstClaimer[c] === -1) {
+                firstClaimer[c] = t;
+            }
+        }
+
+        let count = 0;
+        for (let t = 0; t < totalTurtles; t++) {
+            const comp = firstClaimer[t] !== -1 ? firstClaimer[t] : t;
+            if (comp === t && !this.getTurtle(t).inTrash) {
                 count += 1;
             }
         }


### PR DESCRIPTION

### What changed?
Optimized `turtleCount()` from $O(N^2)$ to $O(N)$ by replacing the dynamic loop lookup with a single-pass precomputed table. 

* **Speed:** Used a typed `Int32Array` to bypass JavaScript's slow "holey array" lookups. It executes significantly faster.
* **Memory:** Uses exactly 4 bytes per turtle, eliminating object overhead and reducing garbage collection.


- [x] Performance