### PR TITLE
fix: preserve numeric action names when importing Turtle Blocks projects

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -5913,6 +5913,10 @@ class Blocks {
                 const blkData = blockObjs[actionNames[b]];
                 if (typeof blkData[1][1] === "string") {
                     name = blkData[1][1];
+                } else if (typeof blkData[1][1] === "number") {
+                    /** Turtle Blocks files may label actions with numbers. */
+                    name = blkData[1][1].toString();
+                    blkData[1][1] = { value: name };
                 } else {
                     name = blkData[1][1]["value"];
                 }


### PR DESCRIPTION
## Problem

When importing a `.tb` (Turtle Blocks) project, actions labeled with **numbers** lose their names. Old Turtle Art files commonly name actions `0`, `1`, `2`, `3`:

```
[10, "hat", 33, 869, [null, 11, 70]],
[36, ["number", 3], ...]     ← hat label
```

On import, every such action is renamed `undefined`, `undefined1`, `undefined2`, … (visible in the console: `action undefined is being renamed undefined1`), so the `stack` calls that reference them no longer resolve.

This is follow-up 1 of the remaining gaps listed in #7727 (related to #7696).

## Root cause

In `loadNewBlocks`'s action-name pass, the label extraction only handles `string` and `{ value }` shapes:

```js
if (typeof blkData[1][1] === "string") {
    name = blkData[1][1];
} else {
    name = blkData[1][1]["value"];   // (3)["value"] → undefined
}
```

For a numeric label, `(3)["value"]` is `undefined`, all such actions collide on the name `undefined`, and the uniqueness loop renames them `undefinedN`.

## Fix

Handle the numeric case: use the number's string form as the action name and normalize the label in place to the `{ value }` shape so it loads as a text value downstream (same shape the existing rename write-back produces).

## Verification

Dragged [`turtleart-activity/samples/basic-intro-1-en.tb`](https://github.com/sugarlabs/turtleart-activity/blob/master/samples/basic-intro-1-en.tb) (5 hats: one string label, four numeric) onto the canvas:

| | Action names after import |
|---|---|
| Before | `next`, `undefined`, `undefined1`, `undefined2`, `undefined3` |
| After | `next`, `3`, `1`, `0`, `2` |

No console errors; `_loadCounter` drains to 0 in both cases.

## Category

- [x] Bug Fix
