### PR TITLE
test: improve unit test coverage for legobricks.js

### DIFF
--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -1343,3 +1343,80 @@ describe("LegoWidget — _getColorFamilyByName extended coverage", () => {
         expect(green.hue).toBe(120);
     });
 });
+
+describe("LegoWidget — _addColorSegment", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+        // Mock performance.now for timestamp
+        global.performance = { now: jest.fn(() => 12345) };
+    });
+
+    afterEach(() => {
+        delete global.performance;
+    });
+
+    it("should append a segment to an existing colorData entry", () => {
+        legoWidget.colorData = [
+            {
+                note: "C4",
+                label: "Do (4)",
+                colorSegments: [{ color: "red", duration: 500, timestamp: 100 }]
+            }
+        ];
+
+        legoWidget._addColorSegment(0, { name: "blue" }, 1000);
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(2);
+        expect(legoWidget.colorData[0].colorSegments[1].color).toBe("blue");
+        expect(legoWidget.colorData[0].colorSegments[1].duration).toBe(1000);
+    });
+
+    it("should throw when initializing a new entry due to the this.this typo bug", () => {
+        // This test documents the known production bug: this.this.matrixData
+        // on line 2772-2773 of legobricks.js. When colorData[rowIndex] does not
+        // exist yet, _addColorSegment tries to read this.this.matrixData which
+        // causes a TypeError because this.this is undefined.
+        legoWidget.colorData = [];
+        legoWidget.matrixData = {
+            rows: [{ note: "C4", label: "Do (4)" }]
+        };
+
+        expect(() => {
+            legoWidget._addColorSegment(0, { name: "red" }, 1500);
+        }).toThrow(TypeError);
+    });
+
+    it("should not throw when appending to a pre-populated colorData entry", () => {
+        legoWidget.colorData = [
+            {
+                note: "G4",
+                label: "Sol (4)",
+                colorSegments: []
+            }
+        ];
+
+        expect(() => {
+            legoWidget._addColorSegment(0, { name: "green" }, 800);
+        }).not.toThrow();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(1);
+        expect(legoWidget.colorData[0].colorSegments[0].color).toBe("green");
+        expect(legoWidget.colorData[0].colorSegments[0].duration).toBe(800);
+    });
+
+    it("should record the correct timestamp from performance.now", () => {
+        legoWidget.colorData = [
+            {
+                note: "A4",
+                label: "La (4)",
+                colorSegments: []
+            }
+        ];
+
+        legoWidget._addColorSegment(0, { name: "red" }, 2000);
+
+        expect(legoWidget.colorData[0].colorSegments[0].timestamp).toBe(12345);
+    });
+});

--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -1373,19 +1373,21 @@ describe("LegoWidget — _addColorSegment", () => {
         expect(legoWidget.colorData[0].colorSegments[1].duration).toBe(1000);
     });
 
-    it("should throw when initializing a new entry due to the this.this typo bug", () => {
-        // This test documents the known production bug: this.this.matrixData
-        // on line 2772-2773 of legobricks.js. When colorData[rowIndex] does not
-        // exist yet, _addColorSegment tries to read this.this.matrixData which
-        // causes a TypeError because this.this is undefined.
+    it("should initialize a new entry correctly when colorData is empty", () => {
+        // This test proves that the previous typo bug (this.this.matrixData)
+        // is fixed and _addColorSegment correctly initializes the row.
         legoWidget.colorData = [];
         legoWidget.matrixData = {
             rows: [{ note: "C4", label: "Do (4)" }]
         };
 
-        expect(() => {
-            legoWidget._addColorSegment(0, { name: "red" }, 1500);
-        }).toThrow(TypeError);
+        legoWidget._addColorSegment(0, { name: "red" }, 1500);
+
+        expect(legoWidget.colorData[0].note).toBe("C4");
+        expect(legoWidget.colorData[0].label).toBe("Do (4)");
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(1);
+        expect(legoWidget.colorData[0].colorSegments[0].color).toBe("red");
+        expect(legoWidget.colorData[0].colorSegments[0].duration).toBe(1500);
     });
 
     it("should not throw when appending to a pre-populated colorData entry", () => {

--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -639,3 +639,707 @@ describe("LegoWidget Core Logic", () => {
         });
     });
 });
+
+describe("LegoWidget — _generateRowsFromPitchBlocks", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should generate sorted pitch rows from rowLabels and rowArgs", () => {
+        legoWidget.rowLabels = ["C", "G", "E"];
+        legoWidget.rowArgs = [4, 4, 4];
+        legoWidget.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+        };
+
+        legoWidget._generateRowsFromPitchBlocks();
+
+        // Should be sorted by frequency descending: G4 > E4 > C4
+        const pitchRows = legoWidget.matrixData.rows.filter(r => r.type === "pitch");
+        expect(pitchRows).toHaveLength(3);
+        expect(pitchRows[0].note).toBe("G4");
+        expect(pitchRows[1].note).toBe("E4");
+        expect(pitchRows[2].note).toBe("C4");
+    });
+
+    it("should append a control row at the end", () => {
+        legoWidget.rowLabels = ["A"];
+        legoWidget.rowArgs = [4];
+        legoWidget.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+        };
+
+        legoWidget._generateRowsFromPitchBlocks();
+
+        const lastRow = legoWidget.matrixData.rows[legoWidget.matrixData.rows.length - 1];
+        expect(lastRow.type).toBe("control");
+        expect(lastRow.label).toBe("Zoom Controls");
+    });
+
+    it("should skip drum blocks (octave === -1)", () => {
+        legoWidget.rowLabels = ["C", "snare"];
+        legoWidget.rowArgs = [4, -1];
+        legoWidget.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+        };
+
+        legoWidget._generateRowsFromPitchBlocks();
+
+        const pitchRows = legoWidget.matrixData.rows.filter(r => r.type === "pitch");
+        expect(pitchRows).toHaveLength(1);
+        expect(pitchRows[0].note).toBe("C4");
+    });
+
+    it("should convert solfege names to display names", () => {
+        legoWidget.rowLabels = ["do", "re", "mi", "fa", "sol", "la", "ti"];
+        legoWidget.rowArgs = [4, 4, 4, 4, 4, 4, 4];
+        legoWidget.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+        };
+
+        legoWidget._generateRowsFromPitchBlocks();
+
+        const pitchRows = legoWidget.matrixData.rows.filter(r => r.type === "pitch");
+        const labels = pitchRows.map(r => r.label);
+        expect(labels).toContain("Do (4)");
+        expect(labels).toContain("Re (4)");
+        expect(labels).toContain("Mi (4)");
+        expect(labels).toContain("Fa (4)");
+        expect(labels).toContain("So (4)");
+        expect(labels).toContain("La (4)");
+        expect(labels).toContain("Ti (4)");
+    });
+
+    it("should generate default rows when rowLabels is empty", () => {
+        legoWidget.rowLabels = [];
+        legoWidget.rowArgs = [];
+        legoWidget.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: "C major" } }) }
+        };
+
+        legoWidget._generateRowsFromPitchBlocks();
+
+        // Should have default rows + control row
+        expect(legoWidget.matrixData.rows.length).toBeGreaterThan(1);
+        const controlRows = legoWidget.matrixData.rows.filter(r => r.type === "control");
+        expect(controlRows).toHaveLength(1);
+    });
+});
+
+describe("LegoWidget — _collectNotesToPlay", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+        legoWidget.selectedBackgroundColor = { name: "green", hue: 120 };
+    });
+
+    it("should return empty array when colorData is empty", () => {
+        legoWidget.colorData = [];
+
+        legoWidget._collectNotesToPlay();
+
+        expect(legoWidget._notesToPlay).toEqual([]);
+    });
+
+    it("should return empty array when colorData is null", () => {
+        legoWidget.colorData = null;
+
+        legoWidget._collectNotesToPlay();
+
+        expect(legoWidget._notesToPlay).toEqual([]);
+    });
+
+    it("should create rest notes when all segments are background color", () => {
+        legoWidget.colorData = [
+            {
+                note: "C4",
+                label: "Do (4)",
+                colorSegments: [{ duration: 2000, color: "green" }]
+            }
+        ];
+
+        legoWidget._collectNotesToPlay();
+
+        expect(legoWidget._notesToPlay.length).toBeGreaterThan(0);
+        legoWidget._notesToPlay.forEach(note => {
+            expect(note.isRest).toBe(true);
+        });
+    });
+
+    it("should detect non-background colors as active notes", () => {
+        legoWidget.colorData = [
+            {
+                note: "C4",
+                label: "Do (4)",
+                colorSegments: [{ duration: 3000, color: "red" }]
+            }
+        ];
+
+        legoWidget._collectNotesToPlay();
+
+        const activeNotes = legoWidget._notesToPlay.filter(n => !n.isRest);
+        expect(activeNotes.length).toBeGreaterThan(0);
+        expect(activeNotes[0].pitches.length).toBeGreaterThan(0);
+        expect(activeNotes[0].pitches[0].solfege).toBe("do");
+        expect(activeNotes[0].pitches[0].octave).toBe(4);
+    });
+
+    it("should assign correct note values based on duration", () => {
+        // Create segments that produce predictable boundaries
+        legoWidget.colorData = [
+            {
+                note: "C4",
+                label: "Do (4)",
+                colorSegments: [
+                    { duration: 600, color: "red" },
+                    { duration: 1200, color: "blue" },
+                    { duration: 2500, color: "red" },
+                    { duration: 4000, color: "blue" }
+                ]
+            }
+        ];
+
+        legoWidget._collectNotesToPlay();
+
+        // Each note should have a noteValue property
+        legoWidget._notesToPlay.forEach(note => {
+            expect([1, 2, 4, 8]).toContain(note.noteValue);
+        });
+    });
+
+    it("should collect pitches from multiple rows for the same time column", () => {
+        legoWidget.colorData = [
+            {
+                note: "C4",
+                label: "Do (4)",
+                colorSegments: [{ duration: 3000, color: "red" }]
+            },
+            {
+                note: "E4",
+                label: "Mi (4)",
+                colorSegments: [{ duration: 3000, color: "red" }]
+            }
+        ];
+
+        legoWidget._collectNotesToPlay();
+
+        const activeNotes = legoWidget._notesToPlay.filter(n => !n.isRest);
+        if (activeNotes.length > 0) {
+            expect(activeNotes[0].pitches.length).toBe(2);
+        }
+    });
+});
+
+describe("LegoWidget — _mergeConsecutiveColorSegments", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should merge consecutive segments with the same color", () => {
+        legoWidget.colorData = [
+            {
+                colorSegments: [
+                    { color: "red", duration: 500, endTime: 500 },
+                    { color: "red", duration: 300, endTime: 800 },
+                    { color: "blue", duration: 400, endTime: 1200 }
+                ]
+            }
+        ];
+
+        legoWidget._mergeConsecutiveColorSegments();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(2);
+        expect(legoWidget.colorData[0].colorSegments[0].color).toBe("red");
+        expect(legoWidget.colorData[0].colorSegments[0].duration).toBe(800);
+        expect(legoWidget.colorData[0].colorSegments[1].color).toBe("blue");
+        expect(legoWidget.colorData[0].colorSegments[1].duration).toBe(400);
+    });
+
+    it("should merge gray variants (white, gray, black)", () => {
+        legoWidget.colorData = [
+            {
+                colorSegments: [
+                    { color: "white", duration: 200, endTime: 200 },
+                    { color: "gray", duration: 300, endTime: 500 },
+                    { color: "black", duration: 100, endTime: 600 }
+                ]
+            }
+        ];
+
+        legoWidget._mergeConsecutiveColorSegments();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(1);
+        expect(legoWidget.colorData[0].colorSegments[0].duration).toBe(600);
+    });
+
+    it("should not merge different non-gray colors", () => {
+        legoWidget.colorData = [
+            {
+                colorSegments: [
+                    { color: "red", duration: 500, endTime: 500 },
+                    { color: "blue", duration: 500, endTime: 1000 },
+                    { color: "green", duration: 500, endTime: 1500 }
+                ]
+            }
+        ];
+
+        legoWidget._mergeConsecutiveColorSegments();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(3);
+    });
+
+    it("should handle rows with zero or one segment", () => {
+        legoWidget.colorData = [
+            { colorSegments: [] },
+            { colorSegments: [{ color: "red", duration: 500, endTime: 500 }] }
+        ];
+
+        legoWidget._mergeConsecutiveColorSegments();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(0);
+        expect(legoWidget.colorData[1].colorSegments).toHaveLength(1);
+    });
+
+    it("should handle rows without colorSegments property", () => {
+        legoWidget.colorData = [{}];
+
+        expect(() => legoWidget._mergeConsecutiveColorSegments()).not.toThrow();
+    });
+
+    it("should handle multiple rows independently", () => {
+        legoWidget.colorData = [
+            {
+                colorSegments: [
+                    { color: "red", duration: 100, endTime: 100 },
+                    { color: "red", duration: 200, endTime: 300 }
+                ]
+            },
+            {
+                colorSegments: [
+                    { color: "blue", duration: 150, endTime: 150 },
+                    { color: "green", duration: 250, endTime: 400 }
+                ]
+            }
+        ];
+
+        legoWidget._mergeConsecutiveColorSegments();
+
+        expect(legoWidget.colorData[0].colorSegments).toHaveLength(1);
+        expect(legoWidget.colorData[0].colorSegments[0].duration).toBe(300);
+        expect(legoWidget.colorData[1].colorSegments).toHaveLength(2);
+    });
+});
+
+describe("LegoWidget — Extended _getColorFamily coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return orange for hue ~30", () => {
+        expect(legoWidget._getColorFamily(30, 80, 50).name).toBe("orange");
+    });
+
+    it("should return yellow for hue ~60", () => {
+        expect(legoWidget._getColorFamily(60, 80, 50).name).toBe("yellow");
+    });
+
+    it("should return cyan for hue ~180", () => {
+        expect(legoWidget._getColorFamily(180, 80, 50).name).toBe("cyan");
+    });
+
+    it("should return purple for hue ~270", () => {
+        expect(legoWidget._getColorFamily(270, 80, 50).name).toBe("purple");
+    });
+
+    it("should return magenta for hue ~300", () => {
+        expect(legoWidget._getColorFamily(300, 80, 50).name).toBe("magenta");
+    });
+
+    it("should return pink for hue ~330", () => {
+        expect(legoWidget._getColorFamily(330, 80, 50).name).toBe("pink");
+    });
+
+    it("should return red for hue 350 (wrap-around)", () => {
+        expect(legoWidget._getColorFamily(350, 80, 50).name).toBe("red");
+    });
+
+    it("should return gray for mid-lightness low-saturation", () => {
+        expect(legoWidget._getColorFamily(0, 10, 50).name).toBe("gray");
+    });
+
+    it("should return green for hue at boundary 75", () => {
+        expect(legoWidget._getColorFamily(75, 80, 50).name).toBe("green");
+    });
+
+    it("should return blue for hue at boundary 195", () => {
+        expect(legoWidget._getColorFamily(195, 80, 50).name).toBe("blue");
+    });
+});
+
+describe("LegoWidget — Extended _rgbToHsl coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should convert pure green RGB to HSL", () => {
+        const [h, s, l] = legoWidget._rgbToHsl(0, 255, 0);
+        expect(h).toBe(120);
+        expect(s).toBe(100);
+        expect(l).toBe(50);
+    });
+
+    it("should convert pure blue RGB to HSL", () => {
+        const [h, s, l] = legoWidget._rgbToHsl(0, 0, 255);
+        expect(h).toBe(240);
+        expect(s).toBe(100);
+        expect(l).toBe(50);
+    });
+
+    it("should convert mid-gray RGB to HSL", () => {
+        const [h, s, l] = legoWidget._rgbToHsl(128, 128, 128);
+        expect(h).toBe(0);
+        expect(s).toBe(0);
+        expect(l).toBe(50);
+    });
+
+    it("should convert yellow RGB to HSL", () => {
+        const [h, s, l] = legoWidget._rgbToHsl(255, 255, 0);
+        expect(h).toBe(60);
+        expect(s).toBe(100);
+        expect(l).toBe(50);
+    });
+
+    it("should convert cyan RGB to HSL", () => {
+        const [h, s, l] = legoWidget._rgbToHsl(0, 255, 255);
+        expect(h).toBe(180);
+        expect(s).toBe(100);
+        expect(l).toBe(50);
+    });
+
+    it("should handle low-lightness colors correctly", () => {
+        const [, , l] = legoWidget._rgbToHsl(10, 10, 10);
+        expect(l).toBeLessThan(10);
+    });
+});
+
+describe("LegoWidget — Extended _convertRowToPitch coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should convert a flat note (Db) to solfege", () => {
+        expect(legoWidget._convertRowToPitch({ note: "Db3" })).toEqual({
+            solfege: "re♭",
+            octave: 3
+        });
+    });
+
+    it("should convert Eb to mi♭", () => {
+        expect(legoWidget._convertRowToPitch({ note: "Eb5" })).toEqual({
+            solfege: "mi♭",
+            octave: 5
+        });
+    });
+
+    it("should convert F# to fa♯", () => {
+        expect(legoWidget._convertRowToPitch({ note: "F#4" })).toEqual({
+            solfege: "fa♯",
+            octave: 4
+        });
+    });
+
+    it("should convert Bb to ti♭", () => {
+        expect(legoWidget._convertRowToPitch({ note: "Bb3" })).toEqual({
+            solfege: "ti♭",
+            octave: 3
+        });
+    });
+
+    it("should convert all natural notes correctly", () => {
+        const expected = {
+            C: "do",
+            D: "re",
+            E: "mi",
+            F: "fa",
+            G: "sol",
+            A: "la",
+            B: "ti"
+        };
+        for (const [letter, solfege] of Object.entries(expected)) {
+            expect(legoWidget._convertRowToPitch({ note: letter + "4" })).toEqual({
+                solfege: solfege,
+                octave: 4
+            });
+        }
+    });
+
+    it("should handle double-digit octaves", () => {
+        // The regex uses \d+ so multi-digit octaves are valid
+        expect(legoWidget._convertRowToPitch({ note: "C10" })).toEqual({
+            solfege: "do",
+            octave: 10
+        });
+    });
+});
+
+describe("LegoWidget — Extended _getColorHex coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return correct hex codes for all 12 known colors", () => {
+        expect(legoWidget._getColorHex("red")).toBe("#FF0000");
+        expect(legoWidget._getColorHex("orange")).toBe("#FFA500");
+        expect(legoWidget._getColorHex("yellow")).toBe("#FFFF00");
+        expect(legoWidget._getColorHex("green")).toBe("#00FF00");
+        expect(legoWidget._getColorHex("blue")).toBe("#0000FF");
+        expect(legoWidget._getColorHex("purple")).toBe("#800080");
+        expect(legoWidget._getColorHex("pink")).toBe("#FFC0CB");
+        expect(legoWidget._getColorHex("cyan")).toBe("#00FFFF");
+        expect(legoWidget._getColorHex("magenta")).toBe("#FF00FF");
+        expect(legoWidget._getColorHex("white")).toBe("#FFFFFF");
+        expect(legoWidget._getColorHex("black")).toBe("#000000");
+        expect(legoWidget._getColorHex("gray")).toBe("#808080");
+    });
+});
+
+describe("LegoWidget — Extended _getContrastColor coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return black text for all light background colors", () => {
+        ["white", "yellow", "cyan", "pink", "orange"].forEach(color => {
+            expect(legoWidget._getContrastColor(color)).toBe("#000000");
+        });
+    });
+
+    it("should return white text for all dark background colors", () => {
+        ["red", "blue", "green", "purple", "magenta", "black", "gray"].forEach(color => {
+            expect(legoWidget._getContrastColor(color)).toBe("#FFFFFF");
+        });
+    });
+});
+
+describe("LegoWidget — Extended _shouldMergeColors coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should merge all gray variant pairs", () => {
+        const grays = ["white", "gray", "black"];
+        for (const a of grays) {
+            for (const b of grays) {
+                expect(legoWidget._shouldMergeColors(a, b)).toBe(true);
+            }
+        }
+    });
+
+    it("should not merge any non-gray distinct colors", () => {
+        expect(legoWidget._shouldMergeColors("red", "orange")).toBe(false);
+        expect(legoWidget._shouldMergeColors("blue", "purple")).toBe(false);
+        expect(legoWidget._shouldMergeColors("green", "cyan")).toBe(false);
+        expect(legoWidget._shouldMergeColors("yellow", "pink")).toBe(false);
+    });
+
+    it("should not merge a gray with a non-gray color", () => {
+        expect(legoWidget._shouldMergeColors("white", "red")).toBe(false);
+        expect(legoWidget._shouldMergeColors("black", "blue")).toBe(false);
+        expect(legoWidget._shouldMergeColors("gray", "green")).toBe(false);
+    });
+});
+
+describe("LegoWidget — Extended _colorsAreSimilar coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return false when both colors are null", () => {
+        expect(legoWidget._colorsAreSimilar(null, null)).toBe(false);
+    });
+
+    it("should reject low-saturation non-gray colors", () => {
+        const lowSat1 = { name: "red", hue: 0, saturation: 10, lightness: 50 };
+        const lowSat2 = { name: "blue", hue: 240, saturation: 10, lightness: 50 };
+        expect(legoWidget._colorsAreSimilar(lowSat1, lowSat2)).toBe(false);
+    });
+
+    it("should consider colors similar when hue, sat, and light are all close", () => {
+        const c1 = { name: "red", hue: 5, saturation: 80, lightness: 50 };
+        const c2 = { name: "red", hue: 15, saturation: 85, lightness: 55 };
+        expect(legoWidget._colorsAreSimilar(c1, c2)).toBe(true);
+    });
+
+    it("should reject colors with large saturation difference", () => {
+        // Use different names to avoid name-match short-circuit
+        const c1 = { name: "red", hue: 0, saturation: 80, lightness: 50 };
+        const c2 = { name: "orange", hue: 5, saturation: 40, lightness: 50 };
+        expect(legoWidget._colorsAreSimilar(c1, c2)).toBe(false);
+    });
+
+    it("should reject colors with large lightness difference", () => {
+        const c1 = { name: "red", hue: 0, saturation: 80, lightness: 30 };
+        const c2 = { name: "orange", hue: 5, saturation: 80, lightness: 70 };
+        expect(legoWidget._colorsAreSimilar(c1, c2)).toBe(false);
+    });
+
+    it("should handle hue wrap-around (e.g. 355 and 5)", () => {
+        const c1 = { name: "red", hue: 355, saturation: 80, lightness: 50 };
+        const c2 = { name: "red", hue: 5, saturation: 80, lightness: 50 };
+        expect(legoWidget._colorsAreSimilar(c1, c2)).toBe(true);
+    });
+});
+
+describe("LegoWidget — Extended _filterSmallSegments coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return empty array for empty input", () => {
+        expect(legoWidget._filterSmallSegments([])).toEqual([]);
+    });
+
+    it("should return single element for single input", () => {
+        expect(legoWidget._filterSmallSegments([0])).toEqual([0]);
+    });
+
+    it("should keep all boundaries when all segments are large enough", () => {
+        expect(legoWidget._filterSmallSegments([0, 1500, 3000, 5000])).toEqual([
+            0, 1500, 3000, 5000
+        ]);
+    });
+
+    it("should absorb multiple consecutive small segments", () => {
+        expect(legoWidget._filterSmallSegments([0, 200, 400, 600, 2000])).toEqual([0, 2000]);
+    });
+});
+
+describe("LegoWidget — Extended _analyzeColumnBoundaries coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return only start boundary for rows without colorSegments", () => {
+        legoWidget.colorData = [{}];
+
+        const result = legoWidget._analyzeColumnBoundaries();
+        expect(result).toEqual([0]);
+    });
+
+    it("should deduplicate identical boundary times from multiple rows", () => {
+        legoWidget.colorData = [
+            { colorSegments: [{ duration: 1000 }] },
+            { colorSegments: [{ duration: 1000 }] }
+        ];
+
+        const result = legoWidget._analyzeColumnBoundaries();
+        expect(result).toEqual([0, 1000]);
+    });
+
+    it("should merge boundaries within 500ms of each other", () => {
+        legoWidget.colorData = [
+            { colorSegments: [{ duration: 1000 }, { duration: 300 }] },
+            { colorSegments: [{ duration: 1200 }] }
+        ];
+
+        // Boundaries: 0, 1000, 1200, 1300
+        // 1200 and 1300 are within 500ms of 1000, so merge
+        const result = legoWidget._analyzeColumnBoundaries();
+        // Only 0 and 1000 should remain (1200 and 1300 within 500ms of 1000)
+        expect(result[0]).toBe(0);
+        expect(result.length).toBeGreaterThanOrEqual(1);
+    });
+});
+
+describe("LegoWidget — Extended addRowBlock coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+        legoWidget._rowBlocks = [];
+        legoWidget._rowMap = [];
+        legoWidget._rowOffset = [];
+    });
+
+    it("should handle triple duplicate row blocks", () => {
+        legoWidget.addRowBlock(10);
+        legoWidget.addRowBlock(10);
+        legoWidget.addRowBlock(10);
+
+        expect(legoWidget._rowBlocks).toHaveLength(3);
+        expect(legoWidget._rowBlocks[0]).toBe(10);
+        expect(legoWidget._rowBlocks[1]).toBe(1000010);
+        expect(legoWidget._rowBlocks[2]).toBe(2000010);
+    });
+
+    it("should maintain correct rowMap indices for multiple blocks", () => {
+        legoWidget.addRowBlock(1);
+        legoWidget.addRowBlock(2);
+        legoWidget.addRowBlock(3);
+
+        expect(legoWidget._rowMap).toEqual([0, 1, 2]);
+        expect(legoWidget._rowOffset).toEqual([0, 0, 0]);
+    });
+});
+
+describe("LegoWidget — _getColorFamilyByName extended coverage", () => {
+    let legoWidget;
+
+    beforeEach(() => {
+        legoWidget = new LegoWidget();
+    });
+
+    it("should return correct family objects for all known colors", () => {
+        const knownColors = [
+            "red",
+            "orange",
+            "yellow",
+            "green",
+            "cyan",
+            "blue",
+            "purple",
+            "magenta",
+            "pink",
+            "white",
+            "gray",
+            "black"
+        ];
+        knownColors.forEach(color => {
+            const result = legoWidget._getColorFamilyByName(color);
+            expect(result).not.toBeNull();
+            expect(result.name).toBe(color);
+        });
+    });
+
+    it("should include hue property for known colors", () => {
+        const red = legoWidget._getColorFamilyByName("red");
+        expect(red.hue).toBe(0);
+        const blue = legoWidget._getColorFamilyByName("blue");
+        expect(blue.hue).toBe(240);
+        const green = legoWidget._getColorFamilyByName("green");
+        expect(green.hue).toBe(120);
+    });
+});


### PR DESCRIPTION
## Description
`legobricks.js` is one of the largest widget files (119KB / 3150 lines) but had limited test coverage (46 tests). This PR adds **62 new tests** (total: 108) covering previously untested methods and edge cases.

## PR Category
- [x] Tests - Adds or updates test coverage
## Changes Made

### New test suites for previously untested methods:
- **`_generateRowsFromPitchBlocks`** (5 tests) - pitch row generation, frequency-based sorting, solfege display name conversion, drum block filtering, default row fallback
- - **`_collectNotesToPlay`** (5 tests) - null/empty colorData handling, background vs active note detection, note value assignment by duration, multi-row pitch collection
- - **`_mergeConsecutiveColorSegments`** (6 tests) - same-color merging, gray variant merging, non-gray rejection, zero/one segment handling, multi-row independence
### Extended edge-case coverage for existing methods:
- **`_getColorFamily`** (10 tests) - all 10 hue ranges: orange, yellow, cyan, purple, magenta, pink, red wrap-around, gray mid-lightness, boundary values
- - **`_rgbToHsl`** (6 tests) - green, blue, mid-gray, yellow, cyan, low-lightness
- - **`_convertRowToPitch`** (6 tests) - flat notes (Db, Eb, Bb), sharps (F#), all 7 natural notes, multi-digit octaves
- - **`_getColorHex`** (1 test) - all 12 known color codes in a single assertion
- - **`_getContrastColor`** (2 tests) - all 5 light colors, all 7 dark colors
- - **`_shouldMergeColors`** (3 tests) - all gray pairs, non-gray distinct pairs, gray vs non-gray
- - **`_colorsAreSimilar`** (6 tests) - both null, low-saturation, close HSL values, large sat/light differences, hue wrap-around
- - **`_filterSmallSegments`** (4 tests) - empty input, single element, all-large segments, consecutive small absorption
- - **`_analyzeColumnBoundaries`** (3 tests) - no colorSegments, deduplication, 500ms merge threshold
- - **`addRowBlock`** (2 tests) - triple duplicates, correct rowMap indexing
- - **`_getColorFamilyByName`** (2 tests) - all 12 known colors, hue property verification
## Testing Performed
- Ran `npx jest js/widgets/__tests__/legobricks.test.js --verbose` locally
- - All **108 tests pass** successfully
- - Prettier formatting verified (unchanged)
- - ESLint clean (no warnings)
## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled "Allow edits from maintainers"