### PR TITLE
fix: resolve Temperament widget crashes and play loop regressions

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -458,6 +458,42 @@ describe("Utility Functions (logic-only)", () => {
             expect(temperamentChanged("equal", "Bb3")).toBe(undefined);
             expect(whichTemperament()).toBe("equal");
         });
+
+        it("should handle custom temperaments with numeric array properties", () => {
+            const customTempName = "myCustomNumericTemp";
+            global.TEMPERAMENT[customTempName] = {
+                pitchNumber: 2,
+                0: [1.0, "C", 4],
+                1: [1.5, "G", 4]
+            };
+            const originalInTemp = Synth.inTemperament;
+            Synth.inTemperament = customTempName;
+            expect(() => temperamentChanged(customTempName, "C4")).not.toThrow();
+            expect(whichTemperament()).toBe(customTempName);
+            expect(Synth.noteFrequencies["C"]).toEqual([4, expect.any(Number)]);
+            expect(Synth.noteFrequencies["G"]).toEqual([4, expect.any(Number)]);
+            delete global.TEMPERAMENT[customTempName];
+            Synth.inTemperament = originalInTemp;
+        });
+
+        it("should skip custom temperament numeric keys that map to plain numbers without throwing", () => {
+            const customTempName = "myCustomNumericTemp2";
+            global.TEMPERAMENT[customTempName] = {
+                "pitchNumber": 2,
+                "0": 1.0,
+                "1": 1.5,
+                "perfect 1": 1.0,
+                "perfect 5": 1.5
+            };
+            const originalInTemp = Synth.inTemperament;
+            Synth.inTemperament = customTempName;
+            expect(() => temperamentChanged(customTempName, "C4")).not.toThrow();
+            expect(whichTemperament()).toBe(customTempName);
+            expect(Synth.noteFrequencies["C"]).toEqual([4, expect.any(Number)]);
+            expect(Synth.noteFrequencies["G"]).toEqual([4, expect.any(Number)]);
+            delete global.TEMPERAMENT[customTempName];
+            Synth.inTemperament = originalInTemp;
+        });
     });
 
     describe("resume", () => {
@@ -1406,6 +1442,28 @@ describe("Utility Functions (logic-only)", () => {
             expect(mockSynth.triggerAttackRelease).toHaveBeenCalled();
             const noteArg = mockSynth.triggerAttackRelease.mock.calls[0][0];
             expect(noteArg).toBe(300);
+
+            Synth._getFrequency = originalGetFrequency;
+        });
+
+        it("should handle numeric notes frequency under custom temperament without throwing error", async () => {
+            const mockSynth = {
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn()
+            };
+            Synth.inTemperament = "myCustomTemp";
+            const originalGetFrequency = Synth._getFrequency;
+            Synth._getFrequency = jest.fn().mockReturnValue(440);
+
+            await expect(
+                _performNotes.call(Synth, mockSynth, 440, 0.25, null, null, false, 0)
+            ).resolves.not.toThrow();
+
+            expect(mockSynth.triggerAttackRelease).toHaveBeenCalledWith(
+                440,
+                0.25,
+                expect.any(Number)
+            );
 
             Synth._getFrequency = originalGetFrequency;
         });

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -494,6 +494,23 @@ describe("Utility Functions (logic-only)", () => {
             delete global.TEMPERAMENT[customTempName];
             Synth.inTemperament = originalInTemp;
         });
+
+        it("should handle standard temperaments with object ratios and invalid ratios", () => {
+            const customTempName = "myCustomNumericTemp3";
+            global.TEMPERAMENT[customTempName] = {
+                "pitchNumber": 3,
+                "perfect 1": { ratio: 1.0 },
+                "perfect 5": 1.5,
+                "major 3": "invalid"
+            };
+            const originalInTemp = Synth.inTemperament;
+            Synth.inTemperament = customTempName;
+            expect(() => temperamentChanged(customTempName, "C4")).not.toThrow();
+            expect(Synth.noteFrequencies["C"]).toEqual([4, expect.any(Number)]);
+            expect(Synth.noteFrequencies["G"]).toEqual([4, expect.any(Number)]);
+            delete global.TEMPERAMENT[customTempName];
+            Synth.inTemperament = originalInTemp;
+        });
     });
 
     describe("resume", () => {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -687,16 +687,28 @@ function Synth() {
                 interval !== "octaveRatio" &&
                 interval !== "generator"
             ) {
-                const noteInfo = getNoteFromInterval(startingPitch, interval);
+                let noteInfo;
                 let ratio;
-                if (typeof t[interval] === "number") {
+                if (!isNaN(interval)) {
+                    if (t[interval] && Array.isArray(t[interval]) && t[interval].length >= 3) {
+                        noteInfo = [t[interval][1], t[interval][2]];
+                        ratio = t[interval][0];
+                    } else {
+                        continue;
+                    }
+                } else if (typeof t[interval] === "number") {
+                    noteInfo = getNoteFromInterval(startingPitch, interval);
                     ratio = t[interval];
                 } else if (
                     t[interval] &&
                     typeof t[interval] === "object" &&
                     typeof t[interval].ratio === "number"
                 ) {
+                    noteInfo = getNoteFromInterval(startingPitch, interval);
                     ratio = t[interval].ratio;
+                } else if (t[interval] && Array.isArray(t[interval]) && t[interval].length >= 3) {
+                    noteInfo = [t[interval][1], t[interval][2]];
+                    ratio = t[interval][0];
                 } else {
                     continue;
                 }
@@ -1819,7 +1831,10 @@ function Synth() {
 
         if (isCustomTemperament(this.inTemperament)) {
             const notes1 = notes;
-            if (notes.search("[+]") !== -1 || notes.search("[-]") !== -1) {
+            if (
+                typeof notes === "string" &&
+                (notes.search("[+]") !== -1 || notes.search("[-]") !== -1)
+            ) {
                 notes = this.getCustomFrequency(notes, this.inTemperament);
             }
             if (notes === undefined || notes === "undefined") {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -690,9 +690,10 @@ function Synth() {
                 let noteInfo;
                 let ratio;
                 if (!isNaN(interval)) {
-                    if (t[interval] && Array.isArray(t[interval]) && t[interval].length >= 3) {
-                        noteInfo = [t[interval][1], t[interval][2]];
-                        ratio = t[interval][0];
+                    const val = t[interval];
+                    if (Array.isArray(val) && val.length >= 3) {
+                        noteInfo = [val[1], val[2]];
+                        ratio = val[0];
                     } else {
                         continue;
                     }
@@ -706,9 +707,6 @@ function Synth() {
                 ) {
                     noteInfo = getNoteFromInterval(startingPitch, interval);
                     ratio = t[interval].ratio;
-                } else if (t[interval] && Array.isArray(t[interval]) && t[interval].length >= 3) {
-                    noteInfo = [t[interval][1], t[interval][2]];
-                    ratio = t[interval][0];
                 } else {
                     continue;
                 }

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1,6 +1,38 @@
 const TemperamentWidget = require("../temperament");
 describe("TemperamentWidget basic tests", () => {
     let widget;
+    const createMockElement = id => ({
+        id: id,
+        innerHTML: "",
+        textContent: "",
+        appendChild: jest.fn(),
+        setAttribute: jest.fn(),
+        style: {},
+        width: 100,
+        height: 100,
+        dataset: { message: "1" },
+        append: jest.fn(),
+        remove: jest.fn(),
+        getElementsByTagName: jest.fn(() => [createMockElement("img")]),
+        addEventListener: jest.fn(),
+        getContext: jest.fn(() => ({
+            beginPath: jest.fn(),
+            arc: jest.fn(),
+            fill: jest.fn(),
+            stroke: jest.fn(),
+            lineWidth: 0,
+            fillStyle: "",
+            strokeStyle: ""
+        })),
+        getBoundingClientRect: jest.fn(() => ({ left: 0, top: 0 })),
+        insertCell: jest.fn(() => createMockElement("cell")),
+        createTHead: jest.fn(() => ({
+            insertRow: jest.fn(() => ({
+                id: "",
+                insertCell: jest.fn(() => createMockElement("cell"))
+            }))
+        }))
+    });
     global._ = jest.fn(text => text);
     global.PREVIEWVOLUME = 80;
 
@@ -46,7 +78,8 @@ describe("TemperamentWidget basic tests", () => {
             labelColor: "#ddd"
         };
 
-        global.Singer = { defaultBPMFactor: 1 };
+        global.last = arr => arr[arr.length - 1];
+        global.Singer = { defaultBPMFactor: 1, masterVolume: [80] };
         const util = require("util");
         global.TextEncoder = util.TextEncoder;
         global.TextDecoder = util.TextDecoder;
@@ -67,39 +100,6 @@ describe("TemperamentWidget basic tests", () => {
 
         global.FLAT = "♭";
         global.SHARP = "♯";
-
-        const createMockElement = id => ({
-            id: id,
-            innerHTML: "",
-            textContent: "",
-            appendChild: jest.fn(),
-            setAttribute: jest.fn(),
-            style: {},
-            width: 100,
-            height: 100,
-            dataset: { message: "1" },
-            append: jest.fn(),
-            remove: jest.fn(),
-            getElementsByTagName: jest.fn(() => [createMockElement("img")]),
-            addEventListener: jest.fn(),
-            getContext: jest.fn(() => ({
-                beginPath: jest.fn(),
-                arc: jest.fn(),
-                fill: jest.fn(),
-                stroke: jest.fn(),
-                lineWidth: 0,
-                fillStyle: "",
-                strokeStyle: ""
-            })),
-            getBoundingClientRect: jest.fn(() => ({ left: 0, top: 0 })),
-            insertCell: jest.fn(() => createMockElement("cell")),
-            createTHead: jest.fn(() => ({
-                insertRow: jest.fn(() => ({
-                    id: "",
-                    insertCell: jest.fn(() => createMockElement("cell"))
-                }))
-            }))
-        });
 
         const mockElements = {};
         global.docById = jest.fn(id => {
@@ -1064,6 +1064,116 @@ describe("TemperamentWidget basic tests", () => {
             const cents = 47;
             const freq = widget._centsToFreq(cents, 440);
             expect(widget._freqToCents(freq, 440)).toBeCloseTo(cents, 6);
+        });
+    });
+
+    describe("TemperamentWidget interactive events", () => {
+        let mockWidgetWindow;
+        let mockActivity;
+
+        beforeEach(() => {
+            mockWidgetWindow = {
+                clear: jest.fn(),
+                show: jest.fn(),
+                getWidgetBody: jest.fn(() => ({ append: jest.fn(), style: {} })),
+                addButton: jest.fn(() => ({
+                    onclick: null,
+                    getElementsByTagName: jest.fn(() => [createMockElement("img")])
+                })),
+                sendToCenter: jest.fn(),
+                destroy: jest.fn(),
+                onclose: null
+            };
+            global.window.widgetWindows = { windowFor: jest.fn(() => mockWidgetWindow) };
+            global.window.innerWidth = 1200;
+            global.buildScale = jest.fn(() => [["C"], []]);
+            global.getNoteFromInterval = jest.fn(() => ["C", 4]);
+            global.isCustomTemperament = jest.fn(() => false);
+
+            mockActivity = {
+                errorMsg: jest.fn(),
+                logo: {
+                    synth: {
+                        startingPitch: "C4",
+                        _getFrequency: jest.fn(() => 440),
+                        setMasterVolume: jest.fn(),
+                        stop: jest.fn(),
+                        trigger: jest.fn()
+                    },
+                    resetSynth: jest.fn()
+                }
+            };
+
+            widget.inTemperament = "equal";
+            widget.scale = ["C", "Major"];
+            widget.octaveChanged = true;
+            widget.init(mockActivity);
+            widget.octaveChanged = true;
+            widget._circleOfNotes();
+
+            widget.tempRatios1 = [1];
+            widget.ratios = [1.0];
+            widget.intervals = ["unison"];
+            widget.notes = [["C", 4]];
+            widget.scaleNotes = ["C"];
+            widget.frequencies = [440];
+            widget.wheel = { removeWheel: jest.fn() };
+            widget.notesCircle = { removeWheel: jest.fn() };
+            widget.wheel1 = { removeWheel: jest.fn() };
+        });
+
+        test("onclose cleans up timeouts and playing state", () => {
+            widget._playing = true;
+            widget._playTimeout = setTimeout(() => {}, 1000);
+
+            expect(mockWidgetWindow.onclose).toBeDefined();
+            mockWidgetWindow.onclose();
+
+            expect(widget._playing).toBe(false);
+            expect(widget._playTimeout).toBeNull();
+            expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
+            expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalled();
+        });
+
+        test("noteCell click stops playing if active", () => {
+            widget._playing = true;
+            widget._playTimeout = setTimeout(() => {}, 1000);
+            widget.playButton = createMockElement("play");
+
+            const noteCell = mockWidgetWindow.addButton.mock.results[2].value;
+            expect(noteCell.onclick).toBeDefined();
+
+            // Toggle noteCell twice to cover both circleIsVisible branches
+            noteCell.onclick();
+            expect(widget._playing).toBe(false);
+            expect(widget._lastPlaybackIndex).toBe(0);
+
+            noteCell.onclick();
+            expect(widget._lastPlaybackIndex).toBe(0);
+        });
+
+        test("clear button click resets play state and playback index", () => {
+            const clearBtn = global.docById("clearNotes");
+            expect(clearBtn.onclick).toBeDefined();
+
+            widget._playing = true;
+            widget.playButton = createMockElement("play");
+
+            clearBtn.onclick();
+            expect(widget._playing).toBe(false);
+            expect(widget._lastPlaybackIndex).toBe(0);
+        });
+
+        test("octave space button click resets play state and playback index", () => {
+            const octaveBtn = global.docById("standardOctave");
+            expect(octaveBtn.onclick).toBeDefined();
+
+            widget._playing = true;
+            widget.playButton = createMockElement("play");
+
+            octaveBtn.onclick();
+            expect(widget._playing).toBe(false);
+            expect(widget._lastPlaybackIndex).toBe(0);
         });
     });
 });

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -2,6 +2,7 @@ const TemperamentWidget = require("../temperament");
 describe("TemperamentWidget basic tests", () => {
     let widget;
     global._ = jest.fn(text => text);
+    global.PREVIEWVOLUME = 80;
 
     beforeEach(() => {
         document.body.innerHTML = `
@@ -235,9 +236,9 @@ describe("TemperamentWidget basic tests", () => {
             style: {}
         };
 
-        widget.pitchNumber = 0;
-        widget.frequencies = [440];
-        widget.tempRatios1 = [1];
+        widget.pitchNumber = 1;
+        widget.frequencies = [440, 880];
+        widget.tempRatios1 = [1, 2];
         widget.circleIsVisible = true;
 
         global.docById = jest.fn(() => ({

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1297,5 +1297,33 @@ describe("TemperamentWidget basic tests", () => {
 
             expect(widget.wheel1.refreshWheel).toHaveBeenCalled();
         });
+
+        test("playAll with truthy _lastPlaybackIndex does not execute playbackForward reset", () => {
+            widget.circleIsVisible = false;
+            widget.pitchNumber = 2;
+
+            global.docById = jest.fn(id => {
+                if (id === "wheelDiv4") return null;
+                return originalDocById(id);
+            });
+
+            const createMockSlice = () => ({
+                fillAttr: "",
+                sliceHoverAttr: {},
+                slicePathAttr: {},
+                sliceSelectedAttr: {}
+            });
+            widget.notesCircle = {
+                navItems: [createMockSlice(), createMockSlice(), createMockSlice()],
+                refreshWheel: jest.fn()
+            };
+
+            widget._lastPlaybackIndex = 1;
+            widget.playbackForward = false;
+
+            widget.playAll(); // starts playback
+
+            expect(widget.playbackForward).toBe(false);
+        });
     });
 });

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1176,4 +1176,108 @@ describe("TemperamentWidget basic tests", () => {
             expect(widget._lastPlaybackIndex).toBe(0);
         });
     });
+
+    describe("playAll play loop visual wheel coverage", () => {
+        let originalDocById;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            originalDocById = global.docById;
+            widget._logo = {
+                resetSynth: jest.fn(),
+                synth: {
+                    trigger: jest.fn(),
+                    stop: jest.fn(),
+                    setMasterVolume: jest.fn(),
+                    startingPitch: "C4"
+                }
+            };
+            widget.playButton = createMockElement("play");
+            widget.tempRatios1 = [1, 2, 3];
+            widget.frequencies = [440, 880, 1320];
+            widget.ratios = [1, 2, 3];
+            widget.notes = [
+                ["C", 4],
+                ["C", 5],
+                ["G", 5]
+            ];
+            widget.scaleNotes = ["C"];
+            widget.intervals = ["unison", "octave", "fifth"];
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+            global.docById = originalDocById;
+        });
+
+        test("colors notesCircle slices during forward and backward play loop ticks", () => {
+            widget.circleIsVisible = false;
+            widget.pitchNumber = 2;
+
+            // Override docById to return null for wheelDiv4
+            global.docById = jest.fn(id => {
+                if (id === "wheelDiv4") {
+                    return null;
+                }
+                return originalDocById(id);
+            });
+
+            // Mock navItems with dummy styling objects
+            const createMockSlice = () => ({
+                fillAttr: "",
+                sliceHoverAttr: {},
+                slicePathAttr: {},
+                sliceSelectedAttr: {}
+            });
+            widget.notesCircle = {
+                navItems: [createMockSlice(), createMockSlice(), createMockSlice()],
+                refreshWheel: jest.fn()
+            };
+
+            widget.playAll(); // starts playback, calls __playLoop(0)
+
+            // Advance timers to trigger subsequent loop ticks
+            jest.advanceTimersByTime(500); // triggers __playLoop(1)
+            jest.advanceTimersByTime(500); // triggers __playLoop(2), which sets playbackForward = false
+            jest.advanceTimersByTime(500); // triggers __playLoop(1) backward
+            jest.advanceTimersByTime(500); // triggers __playLoop(0) backward
+            jest.advanceTimersByTime(500); // triggers completion callback
+
+            expect(widget.notesCircle.refreshWheel).toHaveBeenCalled();
+        });
+
+        test("colors wheel1 slices during forward and backward play loop ticks with wheelDiv4 present", () => {
+            widget.circleIsVisible = false;
+            widget.pitchNumber = 2;
+
+            // Ensure docById("wheelDiv4") returns a mock element (not null)
+            global.docById = jest.fn(id => {
+                if (id === "wheelDiv4") {
+                    return createMockElement("wheelDiv4");
+                }
+                return originalDocById(id);
+            });
+
+            const createMockSlice = () => ({
+                fillAttr: "",
+                sliceHoverAttr: {},
+                slicePathAttr: {},
+                sliceSelectedAttr: {}
+            });
+            widget.wheel1 = {
+                navItems: [createMockSlice(), createMockSlice(), createMockSlice()],
+                refreshWheel: jest.fn()
+            };
+
+            widget.playAll(); // starts playback
+
+            jest.advanceTimersByTime(500);
+            jest.advanceTimersByTime(500);
+            jest.advanceTimersByTime(500);
+            jest.advanceTimersByTime(500);
+            jest.advanceTimersByTime(500);
+
+            expect(widget.wheel1.refreshWheel).toHaveBeenCalled();
+        });
+    });
 });

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1135,6 +1135,24 @@ describe("TemperamentWidget basic tests", () => {
             expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalled();
         });
 
+        test("playButton click triggers playAll", () => {
+            const playBtn = mockWidgetWindow.addButton.mock.results[0].value;
+            expect(playBtn.onclick).toBeDefined();
+
+            widget.playAll = jest.fn();
+            playBtn.onclick();
+            expect(widget.playAll).toHaveBeenCalled();
+        });
+
+        test("saveButton click triggers _save", () => {
+            const saveBtn = mockWidgetWindow.addButton.mock.results[1].value;
+            expect(saveBtn.onclick).toBeDefined();
+
+            widget._save = jest.fn();
+            saveBtn.onclick();
+            expect(widget._save).toHaveBeenCalled();
+        });
+
         test("noteCell click stops playing if active", () => {
             widget._playing = true;
             widget._playTimeout = setTimeout(() => {}, 1000);

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -22,8 +22,8 @@
    _, addTemperamentToDictionary, buildScale,
    deleteTemperamentFromList, docById, FLAT, getNoteFromInterval,
    getOctaveRatio, getTemperament, getTemperamentKeys, getTemperamentRatio,
-   isCustomTemperament, normalizeNoteAccidentals, parseNoteString, pitchToFrequency, platformColor,
-   rationalToFraction, setOctaveRatio, setOctaveRatio, SHARP, Singer,
+   isCustomTemperament, last, normalizeNoteAccidentals, parseNoteString, pitchToFrequency, platformColor,
+   PREVIEWVOLUME, rationalToFraction, setOctaveRatio, setOctaveRatio, SHARP, Singer,
    slicePath, updateTemperaments, wheelnav, frequencyToPitch
  */
 
@@ -67,6 +67,7 @@ function TemperamentWidget() {
      * @type {string|null}
      */
     this.inTemperament = null;
+    this._playTimeout = null;
 
     /**
      * Last triggered event.
@@ -374,6 +375,10 @@ function TemperamentWidget() {
          */
         if (divAppend1 !== undefined) {
             divAppend1.onclick = function () {
+                if (that._playing) {
+                    that.playAll();
+                }
+                that._lastPlaybackIndex = 0;
                 const ratio = that.ratios[0];
                 that.ratios = [];
                 that.ratios[0] = ratio;
@@ -394,6 +399,10 @@ function TemperamentWidget() {
          */
         if (divAppend2 !== undefined) {
             divAppend2.onclick = function () {
+                if (that._playing) {
+                    that.playAll();
+                }
+                that._lastPlaybackIndex = 0;
                 const powers = [];
                 const compareRatios = [];
                 const frequency = that.frequencies[0];
@@ -901,6 +910,10 @@ function TemperamentWidget() {
      * @returns {void}
      */
     this.edit = function () {
+        if (this._playing) {
+            this.playAll();
+        }
+        this._lastPlaybackIndex = 0;
         this.editMode = null;
         this._logo.synth.setMasterVolume(0);
         this._logo.synth.stop();
@@ -2279,12 +2292,14 @@ function TemperamentWidget() {
      * @returns {void}
      */
     this.playAll = function () {
+        const duration = 1 / 2;
         let p = 0;
         this._playing = !this._playing;
         this._logo.resetSynth(0);
 
         const cell = this.playButton;
         if (this._playing) {
+            this._logo.synth.setMasterVolume(PREVIEWVOLUME);
             cell.textContent = "\u00A0\u00A0";
             const stopImg = document.createElement("img");
             stopImg.src = "header-icons/stop-button.svg";
@@ -2297,6 +2312,10 @@ function TemperamentWidget() {
             cell.appendChild(stopImg);
             cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         } else {
+            if (this._playTimeout) {
+                clearTimeout(this._playTimeout);
+                this._playTimeout = null;
+            }
             this._logo.synth.setMasterVolume(0);
             this._logo.synth.stop();
             cell.textContent = "\u00A0\u00A0";
@@ -2312,7 +2331,6 @@ function TemperamentWidget() {
             cell.appendChild(document.createTextNode("\u00A0\u00A0"));
         }
 
-        const duration = 1 / 2;
         const startingPitch = this._logo.synth.startingPitch;
         const startPitchParsed = parseNoteString(startingPitch);
         const octave = startPitchParsed[1] - 1;
@@ -2330,8 +2348,8 @@ function TemperamentWidget() {
             pitchNumber = this.tempRatios1.length - 1;
         }
 
-        const currentTime = new Date().getTime();
         const __playLoop = function (i) {
+            that._lastPlaybackIndex = i;
             if (i === pitchNumber) {
                 that.playbackForward = false;
             }
@@ -2351,60 +2369,62 @@ function TemperamentWidget() {
             }
 
             if (that.circleIsVisible === false && docById("wheelDiv4") === null) {
-                if (i === pitchNumber && that._playing) {
-                    that.notesCircle.navItems[0].fillAttr =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[0].sliceHoverAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[0].slicePathAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                } else if (that._playing) {
-                    that.notesCircle.navItems[i].fillAttr =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[i].sliceHoverAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[i].slicePathAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.notesCircle.navItems[i].sliceSelectedAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                }
-
-                if (that.playbackForward === false && i < pitchNumber) {
-                    if (i === pitchNumber - 1) {
+                if (pitchNumber > 1) {
+                    if (i === pitchNumber && that._playing) {
                         that.notesCircle.navItems[0].fillAttr =
-                            platformColor.selectorBackground || "#c8C8C8";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.notesCircle.navItems[0].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.notesCircle.navItems[0].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                    } else {
-                        that.notesCircle.navItems[i + 1].fillAttr =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i + 1].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                    } else if (that._playing) {
+                        that.notesCircle.navItems[i].fillAttr =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.notesCircle.navItems[i].sliceHoverAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.notesCircle.navItems[i].slicePathAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.notesCircle.navItems[i].sliceSelectedAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
                     }
-                } else {
-                    if (i !== 0) {
-                        that.notesCircle.navItems[i - 1].fillAttr =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i - 1].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                    }
-                }
 
-                that.notesCircle.refreshWheel();
+                    if (that.playbackForward === false && i < pitchNumber) {
+                        if (i === pitchNumber - 1) {
+                            that.notesCircle.navItems[0].fillAttr =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                        } else {
+                            that.notesCircle.navItems[i + 1].fillAttr =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i + 1].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i + 1].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i + 1].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                        }
+                    } else {
+                        if (i !== 0) {
+                            that.notesCircle.navItems[i - 1].fillAttr =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i - 1].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i - 1].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[i - 1].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                        }
+                    }
+
+                    that.notesCircle.refreshWheel();
+                }
             } else if (that.circleIsVisible === true && docById("wheelDiv4") === null) {
                 docById("pitchNumber_" + i).style.background = platformColor.labelColor;
                 if (that.playbackForward === false && i < pitchNumber) {
@@ -2418,60 +2438,62 @@ function TemperamentWidget() {
                     }
                 }
             } else if (docById("wheelDiv4") !== null) {
-                if (i === pitchNumber) {
-                    that.wheel1.navItems[0].fillAttr =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[0].sliceHoverAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[0].slicePathAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[0].sliceSelectedAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                } else {
-                    that.wheel1.navItems[i].fillAttr =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[i].sliceHoverAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[i].slicePathAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                    that.wheel1.navItems[i].sliceSelectedAttr.fill =
-                        platformColor.selectorBackgroundHOFF || "#808080";
-                }
-
-                if (that.playbackForward === false && i < pitchNumber) {
-                    if (i === pitchNumber - 1) {
+                if (pitchNumber > 1) {
+                    if (i === pitchNumber) {
                         that.wheel1.navItems[0].fillAttr =
-                            platformColor.selectorBackground || "#e0e0e0";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.wheel1.navItems[0].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.wheel1.navItems[0].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                         that.wheel1.navItems[0].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
+                            platformColor.selectorBackgroundHOFF || "#808080";
                     } else {
-                        that.wheel1.navItems[i + 1].fillAttr =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i + 1].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i + 1].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i + 1].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
+                        that.wheel1.navItems[i].fillAttr =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.wheel1.navItems[i].sliceHoverAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.wheel1.navItems[i].slicePathAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
+                        that.wheel1.navItems[i].sliceSelectedAttr.fill =
+                            platformColor.selectorBackgroundHOFF || "#808080";
                     }
-                } else {
-                    if (i !== 0) {
-                        that.wheel1.navItems[i - 1].fillAttr =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i - 1].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i - 1].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
-                        that.wheel1.navItems[i - 1].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#e0e0e0";
-                    }
-                }
 
-                that.wheel1.refreshWheel();
+                    if (that.playbackForward === false && i < pitchNumber) {
+                        if (i === pitchNumber - 1) {
+                            that.wheel1.navItems[0].fillAttr =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[0].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[0].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[0].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                        } else {
+                            that.wheel1.navItems[i + 1].fillAttr =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i + 1].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i + 1].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i + 1].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                        }
+                    } else {
+                        if (i !== 0) {
+                            that.wheel1.navItems[i - 1].fillAttr =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i - 1].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i - 1].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                            that.wheel1.navItems[i - 1].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#e0e0e0";
+                        }
+                    }
+
+                    that.wheel1.refreshWheel();
+                }
             }
 
             if (that.playbackForward) {
@@ -2481,7 +2503,7 @@ function TemperamentWidget() {
             }
 
             if (i <= pitchNumber && i >= 0 && that._playing && p < 2) {
-                setTimeout(
+                that._playTimeout = setTimeout(
                     function () {
                         __playLoop(i);
                     },
@@ -2505,28 +2527,28 @@ function TemperamentWidget() {
                 that._playing = false;
                 that.playbackForward = true;
                 this.inbetween = false;
-                setTimeout(
+                that._playTimeout = setTimeout(
                     function () {
-                        that.notesCircle.navItems[0].fillAttr =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[0].sliceHoverAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[0].slicePathAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.navItems[0].sliceSelectedAttr.fill =
-                            platformColor.selectorBackground || "#c8C8C8";
-                        that.notesCircle.refreshWheel();
+                        if (pitchNumber > 1 && that.notesCircle && that.notesCircle.navItems) {
+                            that.notesCircle.navItems[0].fillAttr =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].sliceHoverAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].slicePathAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.navItems[0].sliceSelectedAttr.fill =
+                                platformColor.selectorBackground || "#c8C8C8";
+                            that.notesCircle.refreshWheel();
+                        }
                     },
                     Singer.defaultBPMFactor * 1000 * duration
                 );
             }
         };
-        if (
-            (this._playing &&
-                currentTime - this.lastClickTime > Singer.defaultBPMFactor * 1000 * duration) ||
-            this.inbetween
-        ) {
-            that.playbackForward = true;
+        if (this._playing || this.inbetween) {
+            if (!this._lastPlaybackIndex) {
+                that.playbackForward = true;
+            }
             this.inbetween = false;
             if (this.circleIsVisible) {
                 for (let i = 0; i <= this.pitchNumber; i++) {
@@ -2535,9 +2557,12 @@ function TemperamentWidget() {
                 }
             }
 
-            __playLoop(0);
+            console.log(
+                "Starting/Resuming playback from note index:",
+                this._lastPlaybackIndex || 0
+            );
+            __playLoop(this._lastPlaybackIndex || 0);
         }
-        this.lastClickTime = currentTime;
     };
 
     /**
@@ -2564,8 +2589,13 @@ function TemperamentWidget() {
         const that = this;
 
         widgetWindow.onclose = function () {
-            that._logo.synth.setMasterVolume(0);
+            if (that._playTimeout) {
+                clearTimeout(that._playTimeout);
+                that._playTimeout = null;
+            }
+            that._playing = false;
             that._logo.synth.stop();
+            that._logo.synth.setMasterVolume(last(Singer.masterVolume));
             if (docById("wheelDiv2") !== null) {
                 docById("wheelDiv2").style.display = "none";
                 that.notesCircle.removeWheel();
@@ -2604,6 +2634,7 @@ function TemperamentWidget() {
 
         this.playButton = widgetWindow.addButton("play-button.svg", ICONSIZE, _("Play all"));
         this.lastClickTime = 0;
+        this._lastPlaybackIndex = 0;
         this.playbackForward = true;
         this.inbetween = false;
         this.playButton.onclick = function () {
@@ -2733,6 +2764,10 @@ function TemperamentWidget() {
         this._circleOfNotes();
 
         noteCell.onclick = function () {
+            if (that._playing) {
+                that.playAll();
+            }
+            that._lastPlaybackIndex = 0;
             that.editMode = null;
             if (that.circleIsVisible) {
                 that._circleOfNotes();

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -2353,6 +2353,9 @@ function TemperamentWidget() {
             if (i === pitchNumber) {
                 that.playbackForward = false;
             }
+            // Note: If resuming from _lastPlaybackIndex > 0, the 'p < 2' loop check
+            // starts mid-sequence, meaning the first pass will play fewer notes.
+            // This is intended behavior to pick up exactly where playback was paused.
             if (i === 0) {
                 p++;
             }
@@ -2526,7 +2529,7 @@ function TemperamentWidget() {
                 cell.appendChild(document.createTextNode("\u00A0\u00A0"));
                 that._playing = false;
                 that.playbackForward = true;
-                this.inbetween = false;
+                that.inbetween = false;
                 that._playTimeout = setTimeout(
                     function () {
                         if (pitchNumber > 1 && that.notesCircle && that.notesCircle.navItems) {
@@ -2546,7 +2549,11 @@ function TemperamentWidget() {
             }
         };
         if (this._playing || this.inbetween) {
-            if (!this._lastPlaybackIndex) {
+            if (
+                this._lastPlaybackIndex === undefined ||
+                this._lastPlaybackIndex === null ||
+                this._lastPlaybackIndex === 0
+            ) {
                 that.playbackForward = true;
             }
             this.inbetween = false;
@@ -2557,10 +2564,6 @@ function TemperamentWidget() {
                 }
             }
 
-            console.log(
-                "Starting/Resuming playback from note index:",
-                this._lastPlaybackIndex || 0
-            );
             __playLoop(this._lastPlaybackIndex || 0);
         }
     };


### PR DESCRIPTION
### Description
The Temperament widget was experiencing several regressions, crashes, and UX issues during playback, temperament clearing, and closing:
1. **Custom Temperament Playback Crash**: Clearing the temperament (setting it to `"custom"`) and playing it threw `TypeError: Cannot read properties of undefined (reading '0')` in `findOtherIntervals` inside `musicutils.js`. This happened because `Synth.temperamentChanged` tried to resolve numeric ratio keys (like `"0"`, `"1"`, etc.) as standard musical interval names.
2. **Frequency Parsing Crash**: Passing numeric frequencies under custom temperaments threw `TypeError: notes.search is not a function` during playback because the notes were numbers rather than strings.
3. **Playback Loop & Mute Leak on Close**: Closing the widget while playing left the background `setTimeout` loop running and left the master volume muted at `0` (so future canvas playback played no sound).
4. **Raphael/wheelnav Crash on 1-Note Wheel**: Playing a cleared temperament (which has only 1 note, `"0"`) crashed Raphael internally with `Uncaught TypeError: Cannot set properties of null (setting 'next')` during wheel slice animations/refreshes.
5. **Play Button Freezing**: The 500ms click rate-limit threshold desynchronized the button icon to "Stop" without starting the loop if clicked too quickly, freezing the button.
6. **No Resume State**: Toggling play/stop did not preserve the pause index, forcing playback to restart from note `0` every time.

### Fix
1. **Numeric Key Skipping**: Updated `Synth.temperamentChanged` in `synthutils.js` to skip numeric keys pointing to plain ratio numbers, as they are already mapped under standard interval names.
2. **Notes Type Guard**: Guarded `notes.search` inside `_performNotes` to ensure it only runs on string inputs.
3. **Timeout Cancellation & Volume Restoration**: Tracked the active loop timeout in `_playTimeout` and cancelled it in `onclose` and when stopping. Restored the original master volume using `last(Singer.masterVolume)` in `onclose`.
4. **Playback Reset Checks**: Added active playback checks to the **Clear**, **Standard Octave**, **Add Pitches**, and **Circle/Table toggle** handlers to stop loops and reset button icons on layout modifications.
5. **Single-Item Wheel Guard**: Guarded `notesCircle` and `wheel1` style/refresh calls to only execute when `pitchNumber > 1`.
6. **Volume Initialization & Instant Toggle**: Set master volume to `PREVIEWVOLUME` (50) on play start and removed the click-rate limiter completely since loop cancellation makes it redundant.
7. **Pause and Resume Tracking**: Tracked the active index in `_lastPlaybackIndex` and initialized `__playLoop` at this index when resuming. Reset it to `0` on completions or pitch modifications.

### PR Category
- [x] Bug Fix
- [x] Feature / Refactoring / UX

### Changes Made
- Modified `js/utils/synthutils.js` (Guard notes search, skip numeric custom temperament keys)
- Modified `js/utils/__tests__/synthutils.test.js` (Added unit test coverage for numeric frequencies and key skipping)
- Modified `js/widgets/temperament.js` (Loop timeout cancellation, pause/resume, volume restoration, single-slice guards, click threshold removal)
- Modified `js/widgets/__tests__/temperament.test.js` (Mocked PREVIEWVOLUME, updated playAll test parameters)

### Testing Performed
- `npm run lint` — passes with 0 errors
- `npx prettier --check` — passes
- `npm test` — all 6188 tests passed successfully
