### PR TITLE
fix: correct ManagedTimer require destructuring in logo.js

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -316,8 +316,8 @@ class Logo {
         } else {
             // Node.js / Jest environment — require the module
             try {
-                const { ManagedTimer: MT } = require("./utils/ManagedTimer");
-                this._timerManager = new MT();
+                const ManagedTimerCtor = require("./utils/ManagedTimer");
+                this._timerManager = new ManagedTimerCtor();
             } catch (e) {
                 // Fallback: create a minimal shim so the engine still works
                 this._timerManager = {


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
In Node.js and Jest environments, the Logo constructor always fell through to a degraded, broken fallback timer manager instead of using the real ManagedTimer class. This was not a rare edge case, it happened on every single run of that code path, because the require call threw internally due to an export and import shape mismatch, and the broken fallback shim's clearAll method never actually cancelled any timers.

## Root Cause
The file js/utils/ManagedTimer.js exports the class directly using `module.exports = ManagedTimer`. But logo.js was destructuring it as if it were a named export, writing `const { ManagedTimer: MT } = require("./utils/ManagedTimer")`, then `new MT()`. Since require returns the class itself and not an object containing a ManagedTimer property, MT ended up undefined, and calling new on it threw a TypeError saying MT is not a constructor. This was caught by the surrounding try catch block, which silently routed every Node and Jest instantiation into the broken fallback shim. That shim's clearAll method simply returned zero and never called the real clearTimeout or clearInterval on anything, reintroducing the exact zombie timer bug that ManagedTimer was built to prevent, but only in code paths going through this require branch.

In the real browser and RequireJS boot path, loader.js lists utils/ManagedTimer as an explicit dependency of activity/logo in its shim configuration, so window.ManagedTimer is guaranteed to be defined before logo.js runs there. That primary branch was never affected. This bug was isolated entirely to the require based Node and Jest branch.

## Fix

In logo.js, the destructuring was corrected to match the module's actual export shape. Instead of destructuring a property called ManagedTimer off the result of require, the class itself is now assigned directly to a local constant and instantiated from there.

```js
// before
const { ManagedTimer: MT } = require("./utils/ManagedTimer");
this._timerManager = new MT();

// after
const ManagedTimerCtor = require("./utils/ManagedTimer");
this._timerManager = new ManagedTimerCtor();
```
## Testing
1. Reproduced the bug in isolation by destructuring require of the module the old way and confirming the resulting value was undefined, and that calling new on it threw the exact TypeError described above.
2. Applied the fix and confirmed require of the module now correctly returns the class, and that instantiating it produces a working ManagedTimer instance with a functioning clearAll method.
3. Ran the full test suite locally. All 180 test suites passed, covering 6185 tests, with zero failures.
4. Specifically verified js/__tests__/logo.test.js and js/__tests__/logo-dependencies.test.js, which require logo directly, now receive a real ManagedTimer instance rather than the fallback shim.
