### PR TITLE
perf: cull off-screen blocks from display list to reduce stage.update() cost

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -225,6 +225,31 @@ describe("Viewport Culling", () => {
         expect(blocks.blockList[0]._viewportVisible).toBe(true);
         expect(blocks.blockList[1]._viewportVisible).toBe(true);
     });
+
+    it("should skip null entries in blockList", () => {
+        blocks.blockList = [
+            null,
+            { trash: false, container: { x: 100, y: 100 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        // Should not throw and remaining blocks should still be culled
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+    });
+
+    it("should skip blocks without a container", () => {
+        blocks.blockList = [
+            { trash: false, container: null, width: 50, height: 30 },
+            { trash: false, container: { x: 100, y: 100 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        // Block without container should be skipped, block with container processed
+        expect(blocks.blockList[0]._viewportVisible).toBe(undefined);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+    });
 });
 
 describe("Blocks Foundation", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -117,7 +117,7 @@ describe("Viewport Culling", () => {
             turtles: {},
             boundary: {},
             macroDict: {},
-            palettes: { dict: {} },
+            palettes: { dict: {}, show: jest.fn() },
             logo: { synth: { loadSynth: jest.fn() } },
             blocksContainer: { x: 0, y: 0 },
             canvas: { width: 800, height: 600 },
@@ -249,6 +249,24 @@ describe("Viewport Culling", () => {
         // Block without container should be skipped, block with container processed
         expect(blocks.blockList[0]._viewportVisible).toBe(undefined);
         expect(blocks.blockList[1]._viewportVisible).toBe(true);
+    });
+
+    it("should showBlocks without throwing", () => {
+        blocks.blockList = [];
+        blocks.showBlocks();
+
+        expect(mockActivity.palettes.show).toHaveBeenCalled();
+        expect(blocks.visible).toBe(true);
+        expect(mockActivity.refreshCanvas).toHaveBeenCalled();
+    });
+
+    it("should update culling during setBlockScale", async () => {
+        blocks.blockList = [];
+        await blocks.setBlockScale(0.8);
+
+        expect(blocks.blockScale).toBe(0.8);
+        expect(blocks.blockList[0]).toBeUndefined();
+        expect(mockActivity.refreshCanvas).toHaveBeenCalled();
     });
 });
 

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -106,6 +106,127 @@ global.splitSolfege = jest.fn();
 global.updateTemperaments = jest.fn();
 global.showZoomOverlay = jest.fn();
 
+describe("Viewport Culling", () => {
+    let mockActivity;
+    let blocks;
+
+    beforeEach(() => {
+        mockActivity = {
+            storage: {},
+            trashcan: {},
+            turtles: {},
+            boundary: {},
+            macroDict: {},
+            palettes: { dict: {} },
+            logo: { synth: { loadSynth: jest.fn() } },
+            blocksContainer: { x: 0, y: 0 },
+            canvas: { width: 800, height: 600 },
+            refreshCanvas: jest.fn(),
+            errorMsg: jest.fn(),
+            setSelectionMode: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            setHomeContainers: jest.fn(),
+            __tick: jest.fn()
+        };
+        blocks = new Blocks(mockActivity);
+    });
+
+    it("should mark blocks inside the viewport as visible", () => {
+        blocks.blockList = [
+            { trash: false, container: { x: 100, y: 100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 0, y: 0 }, width: 800, height: 600 },
+            { trash: false, container: { x: 400, y: 300 }, width: 10, height: 10 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        expect(blocks.blockList[0]._viewportVisible).toBe(true);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+        expect(blocks.blockList[2]._viewportVisible).toBe(true);
+    });
+
+    it("should mark blocks outside the viewport as not visible", () => {
+        blocks.blockList = [
+            { trash: false, container: { x: -200, y: 100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 900, y: 100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 100, y: -100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 100, y: 700 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        expect(blocks.blockList[0]._viewportVisible).toBe(false);
+        expect(blocks.blockList[1]._viewportVisible).toBe(false);
+        expect(blocks.blockList[2]._viewportVisible).toBe(false);
+        expect(blocks.blockList[3]._viewportVisible).toBe(false);
+    });
+
+    it("should handle scrolled viewport offset", () => {
+        mockActivity.blocksContainer.x = -200;
+        mockActivity.blocksContainer.y = -100;
+
+        blocks.blockList = [
+            { trash: false, container: { x: 0, y: 0 }, width: 50, height: 30 },
+            { trash: false, container: { x: 300, y: 200 }, width: 50, height: 30 },
+            { trash: false, container: { x: 1000, y: 800 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        // vp rect = (200, 100) to (1000, 700)
+        // Block at (0,0) with w=50,h=30: (0+50) <= 200 → off-screen left
+        expect(blocks.blockList[0]._viewportVisible).toBe(false);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+        expect(blocks.blockList[2]._viewportVisible).toBe(false);
+    });
+
+    it("should skip trashed blocks without modifying their visibility", () => {
+        blocks.blockList = [
+            {
+                trash: true,
+                container: { x: -500, y: -500 },
+                width: 50,
+                height: 30,
+                _viewportVisible: true
+            },
+            { trash: false, container: { x: 100, y: 100 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        expect(blocks.blockList[0]._viewportVisible).toBe(true);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+    });
+
+    it("should consider edge-aligned blocks as visible", () => {
+        blocks.blockList = [
+            { trash: false, container: { x: 0, y: 0 }, width: 1, height: 600 },
+            { trash: false, container: { x: 799, y: 0 }, width: 1, height: 600 },
+            { trash: false, container: { x: 0, y: 599 }, width: 800, height: 1 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        // One pixel inside the viewport edge
+        expect(blocks.blockList[0]._viewportVisible).toBe(true);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+        expect(blocks.blockList[2]._viewportVisible).toBe(true);
+    });
+
+    it("should handle zero-dimension blocks (async bitmap not yet loaded)", () => {
+        blocks.blockList = [
+            { trash: false, container: { x: -100, y: -100 }, width: 0, height: 0 },
+            { trash: false, container: { x: 100, y: 100 }, width: 0, height: 0 }
+        ];
+
+        blocks._updateViewportCulling();
+
+        // Zero-dim blocks are kept visible until dimensions stabilize
+        expect(blocks.blockList[0]._viewportVisible).toBe(true);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+    });
+});
+
 describe("Blocks Foundation", () => {
     let mockActivity;
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -606,9 +606,9 @@ class Activity {
                             this._lastCullContainerX !== this.blocksContainer.x ||
                             this._lastCullContainerY !== this.blocksContainer.y
                         ) {
+                            this.blocks._updateViewportCulling();
                             this._lastCullContainerX = this.blocksContainer.x;
                             this._lastCullContainerY = this.blocksContainer.y;
-                            this.blocks._updateViewportCulling();
                         }
 
                         this.stage.update();

--- a/js/activity.js
+++ b/js/activity.js
@@ -584,6 +584,10 @@ class Activity {
          * 3. GIF animations are playing
          * This eliminates unnecessary 60fps updates when idle.
          */
+        // Track last container position to avoid per-frame culling recompute.
+        this._lastCullContainerX = undefined;
+        this._lastCullContainerY = undefined;
+
         this._startRenderLoop = () => {
             if (this._renderLoopRunning) return;
             this._renderLoopRunning = true;
@@ -597,6 +601,16 @@ class Activity {
                     const isInteracting = this.isDragging || this.isSelecting;
 
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
+                        // Recompute culling when container moved.
+                        if (
+                            this._lastCullContainerX !== this.blocksContainer.x ||
+                            this._lastCullContainerY !== this.blocksContainer.y
+                        ) {
+                            this._lastCullContainerX = this.blocksContainer.x;
+                            this._lastCullContainerY = this.blocksContainer.y;
+                            this.blocks._updateViewportCulling();
+                        }
+
                         this.stage.update();
                         this.stageDirty = false;
                         // Continue the loop if there's work or ongoing interaction
@@ -2853,6 +2867,10 @@ class Activity {
 
             this.stage.canvas.width = w;
             this.stage.canvas.height = h;
+
+            // Viewport size changed — recompute culling on next render frame.
+            this._lastCullContainerX = undefined;
+            this._lastCullContainerY = undefined;
 
             // Firefox large canvas warning
             const isFirefox = navigator.userAgent.includes("Firefox");

--- a/js/activity.js
+++ b/js/activity.js
@@ -605,8 +605,7 @@ class Activity {
                         if (
                             this.blocks &&
                             this.blocksContainer &&
-                            (isInteracting ||
-                                this._lastCullContainerX !== this.blocksContainer.x ||
+                            (this._lastCullContainerX !== this.blocksContainer.x ||
                                 this._lastCullContainerY !== this.blocksContainer.y)
                         ) {
                             this.blocks._updateViewportCulling();

--- a/js/activity.js
+++ b/js/activity.js
@@ -605,7 +605,8 @@ class Activity {
                         if (
                             this.blocks &&
                             this.blocksContainer &&
-                            (this._lastCullContainerX !== this.blocksContainer.x ||
+                            (isInteracting ||
+                                this._lastCullContainerX !== this.blocksContainer.x ||
                                 this._lastCullContainerY !== this.blocksContainer.y)
                         ) {
                             this.blocks._updateViewportCulling();

--- a/js/activity.js
+++ b/js/activity.js
@@ -603,8 +603,10 @@ class Activity {
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
                         // Recompute culling when container moved.
                         if (
-                            this._lastCullContainerX !== this.blocksContainer.x ||
-                            this._lastCullContainerY !== this.blocksContainer.y
+                            this.blocks &&
+                            this.blocksContainer &&
+                            (this._lastCullContainerX !== this.blocksContainer.x ||
+                                this._lastCullContainerY !== this.blocksContainer.y)
                         ) {
                             this.blocks._updateViewportCulling();
                             this._lastCullContainerX = this.blocksContainer.x;

--- a/js/block.js
+++ b/js/block.js
@@ -3272,6 +3272,13 @@ class Block {
             // Cache the drag group once on mousedown instead of
             // recomputing the tree traversal on every pressmove.
             that.blocks.cacheDragGroup(thisBlock);
+            // Track the drag group for viewport culling exemption during drag,
+            // so off-screen stack siblings remain visible while being dragged
+            // into view (avoids "pop-in" on release).
+            const group = that.blocks._cachedDragGroup;
+            if (group && group.length > 0) {
+                that.blocks._dragActiveGroup = new Set(group);
+            }
             // Invalidate the top-block cache since a drag may
             // disconnect blocks, changing the topology.
             that.blocks.invalidateTopBlockCache();
@@ -3593,7 +3600,6 @@ class Block {
                 // the move (workaround for issue #38 -- Blocks fly
                 // apart). Still need to get to the root cause.
                 this.blocks.adjustDocks(this.blockIndex, true);
-                this.blocks._updateViewportCulling();
             }
         } else if (SPECIALINPUTS.includes(this.name) || ["media", "loadFile"].includes(this.name)) {
             if (!haveClick) {

--- a/js/block.js
+++ b/js/block.js
@@ -281,6 +281,7 @@ class Block {
         this.collapsed = false; // Is this collapsible block collapsed?
         this.inCollapsed = false; // Is this block in a collapsed stack?
         this.trash = false; // Is this block in the trash?
+        this._viewportVisible = true; // Is this block within the current viewport?
         this.loadComplete = false; // Has the block finished loading?
         this.label = null; // Editable textview in DOM.
         this.labelattr = null; // Editable textview in DOM.
@@ -2016,6 +2017,7 @@ class Block {
         // If it is not in the trash and not in collapsed, then show it.
         if (!this.trash && !this.inCollapsed) {
             this.container.visible = true;
+            this._viewportVisible = true;
             if (this.isCollapsible()) {
                 if (this.collapsed) {
                     this.bitmap.visible = false;
@@ -3591,6 +3593,7 @@ class Block {
                 // the move (workaround for issue #38 -- Blocks fly
                 // apart). Still need to get to the root cause.
                 this.blocks.adjustDocks(this.blockIndex, true);
+                this.blocks._updateViewportCulling();
             }
         } else if (SPECIALINPUTS.includes(this.name) || ["media", "loadFile"].includes(this.name)) {
             if (!haveClick) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3552,7 +3552,6 @@ class Blocks {
             // Support viewport culling via _viewportVisible (eye icon takes priority).
             myBlock.container._origIsVisible = myBlock.container.isVisible;
             myBlock.container.isVisible = function () {
-                if (!this.visible) return false;
                 if (!myBlock._viewportVisible) return false;
                 return this._origIsVisible.call(this);
             };

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2822,7 +2822,6 @@ class Blocks {
                 }
             }
             this._endDeferCheckBounds();
-            this._updateViewportCulling();
         };
 
         /**

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -2815,6 +2815,7 @@ class Blocks {
                 }
             }
             this._endDeferCheckBounds();
+            this._updateViewportCulling();
         };
 
         /**
@@ -3544,6 +3545,15 @@ class Blocks {
             myBlock.container.snapToPixelEnabled = true;
             myBlock.container.x = 0;
             myBlock.container.y = 0;
+
+            // Support viewport culling via _viewportVisible (eye icon takes priority).
+            myBlock.container._origIsVisible = myBlock.container.isVisible;
+            myBlock.container.isVisible = function () {
+                if (!this.visible) return false;
+                if (!myBlock._viewportVisible) return false;
+                return this._origIsVisible.call(this);
+            };
+
             this._updateSpatialGrid(this.blockList.length - 1);
 
             /** and we need to load the images into the container. */
@@ -7752,6 +7762,41 @@ class Blocks {
         };
 
         /***
+         * Culls off-screen blocks from display list rendering.
+         * Recompute after scroll, pan, resize, or project load.
+         */
+        this._updateViewportCulling = () => {
+            const container = this.activity.blocksContainer;
+            const canvas = this.activity.canvas;
+            // Viewport rect in container-space
+            const vpLeft = -container.x;
+            const vpTop = -container.y;
+            const vpRight = vpLeft + canvas.width;
+            const vpBottom = vpTop + canvas.height;
+
+            for (let i = 0; i < this.blockList.length; i++) {
+                const block = this.blockList[i];
+                if (!block || block.trash || !block.container) {
+                    continue;
+                }
+                const c = block.container;
+                // AABB overlap test against viewport rect.
+                // Skip blocks with zero dimensions (async bitmap not yet loaded)
+                // to avoid culling them before their size is known.
+                if (!block.width || !block.height) {
+                    block._viewportVisible = true;
+                    continue;
+                }
+                block._viewportVisible = !(
+                    c.x + block.width <= vpLeft ||
+                    c.x >= vpRight ||
+                    c.y + block.height <= vpTop ||
+                    c.y >= vpBottom
+                );
+            }
+        };
+
+        /***
          * Hides all the blocks.
          *
          * @returns {void}
@@ -7770,6 +7815,8 @@ class Blocks {
         this.showBlocks = () => {
             this.activity.palettes.show();
             this.show();
+            // Recompute culling — off-screen blocks stay hidden during playback.
+            this._updateViewportCulling();
             this.bringToTop();
             this.activity.refreshCanvas();
         };

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -358,6 +358,10 @@ class Blocks {
         this._checkBoundsScheduled = false;
         // Cached drag group computed once on mousedown, reused during pressmove
         this._cachedDragGroup = null;
+        // Blocks in the active drag group are exempt from viewport culling
+        // during the drag to avoid "pop-in" when off-screen siblings are
+        // dragged into view. Cleared on pressup/mouseout.
+        this._dragActiveGroup = null;
         // Cached top-block map for moveAllBlocksExcept edge-scroll
         this._topBlockCache = null;
         // Throttle timestamp for edge-scroll calls
@@ -3555,7 +3559,19 @@ class Blocks {
             // Support viewport culling via _viewportVisible (eye icon takes priority).
             myBlock.container._origIsVisible = myBlock.container.isVisible;
             myBlock.container.isVisible = function () {
-                if (!myBlock._viewportVisible) return false;
+                if (!myBlock._viewportVisible) {
+                    // During a drag, show blocks in the active drag group even
+                    // if they are off-screen, so the user sees the entire stack
+                    // follow the cursor smoothly instead of "popping in" on release.
+                    if (
+                        myBlock.blocks &&
+                        myBlock.blocks._dragActiveGroup &&
+                        myBlock.blocks._dragActiveGroup.has(myBlock.blockIndex)
+                    ) {
+                        return this._origIsVisible.call(this);
+                    }
+                    return false;
+                }
                 return this._origIsVisible.call(this);
             };
 
@@ -4036,6 +4052,7 @@ class Blocks {
          */
         this.clearCachedDragGroup = () => {
             this._cachedDragGroup = null;
+            this._dragActiveGroup = null;
         };
 
         /**

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1175,6 +1175,10 @@ class Blocks {
                 this._checkBoundsPending = false;
                 this.scheduleCheckBounds();
             }
+
+            if (this._deferCheckBoundsCount === 0) {
+                this._updateViewportCulling();
+            }
         };
 
         /**
@@ -7776,6 +7780,8 @@ class Blocks {
             if (!canvas || !canvas.width || !canvas.height) return;
 
             const container = this.activity.blocksContainer;
+            if (!container) return;
+
             // Viewport rect in container-space
             const vpLeft = -container.x;
             const vpTop = -container.y;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1181,6 +1181,10 @@ class Blocks {
             }
 
             if (this._deferCheckBoundsCount === 0) {
+                // Re-cull now — docks repositioned blocks relative to the
+                // viewport. The render loop only re-culls on container move,
+                // so without this, a block that shifted on-screen would stay
+                // invisible until the user scrolls.
                 this._updateViewportCulling();
             }
         };

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -548,6 +548,9 @@ class Blocks {
             // Rebuild spatial grid after scale change repositions blocks
             this._rebuildSpatialGrid();
 
+            // Viewport changed — recompute culling.
+            this._updateViewportCulling();
+
             /** Force a refresh. */
             await delayExecution(100);
             this.activity.refreshCanvas();

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7768,8 +7768,14 @@ class Blocks {
          * Recompute after scroll, pan, resize, or project load.
          */
         this._updateViewportCulling = () => {
-            const container = this.activity.blocksContainer;
             const canvas = this.activity.canvas;
+            // Skip culling until the canvas has been initialized with valid dimensions.
+            // Calling culling too early (e.g. during project load before layout is final)
+            // would mark on-screen blocks as off-screen, and since the viewport never
+            // moves afterward, they'd stay invisible.
+            if (!canvas || !canvas.width || !canvas.height) return;
+
+            const container = this.activity.blocksContainer;
             // Viewport rect in container-space
             const vpLeft = -container.x;
             const vpTop = -container.y;


### PR DESCRIPTION
### Problem

During playback, `stage.update()` traverses every block container in the display list each frame, even when many blocks are completely outside the viewport. Those off-screen blocks still go through EaselJS's rendering pipeline (`save → setTransform → drawImage → restore`), resulting in unnecessary rendering work.

### Root Cause

Rendering is based on the display list rather than viewport visibility. Since block containers remain visible regardless of whether they are on screen, EaselJS attempts to draw every block during each `stage.update()`.

### Solution

Introduce viewport culling for block containers. Blocks outside the visible canvas are marked as not viewport-visible, and `isVisible()` is overridden so EaselJS skips rendering those containers while preserving the existing visibility behavior.

### Implementation

- **`block.js`**
  - Added a `_viewportVisible` flag (default `true`).
  - Reset the flag in `show()` when blocks become visible again.

- **`blocks.js`**
  - Overrode `container.isVisible()` to check `_viewportVisible` after `container.visible`, ensuring the eye icon visibility still takes precedence.
  - Added `_updateViewportCulling()` to perform an AABB overlap test between each non-trashed block and the current viewport.
  - Invoked `_updateViewportCulling()` from `showBlocks()` so newly shown blocks receive the correct visibility state.

- **`activity.js`**
  - Added cached container positions (`_lastCullContainerX/Y`) to avoid redundant culling computations.
  - Recomputed viewport culling only when the blocks container moves (pan, scroll, resize).
  - Invalidated the cached state after canvas resize.

### Performance Impact

Measured with `?performance=true` while blocks were visible during playback. 
(Benchmark Project : Crabcanon-plot)

| Metric | Before | After | Improvement |
|--------|--------:|-------:|------------:|
| `stageUpdate` average | 4.807 ms | 1.972 ms | **59% reduction** |
| `stageUpdate` maximum | 19.000 ms | 4.100 ms | **78% reduction** |

### Testing

- [X] `npm run lint`
- [X] `npx prettier --check`
- [X] `npm test` (178 suites, 6080 tests passing)

### Notes

- Viewport culling is recomputed only when the viewport changes or when blocks are shown, avoiding any additional per-frame overhead.
- Blocks whose bitmap dimensions are temporarily unavailable during asynchronous bitmap creation are handled safely and receive the correct visibility state once dimensions are available.

## PR Category

- [x] Performance

