### PR TITLE
fix: prevent Oscilloscope canvas memory leak from live HTMLCollection iteration

### DIFF
--- a/js/widgets/__tests__/oscilloscope.test.js
+++ b/js/widgets/__tests__/oscilloscope.test.js
@@ -365,6 +365,29 @@ describe("Oscilloscope", () => {
         });
     });
 
+    describe("_scale", () => {
+        test("removes all existing oscilloscopeCanvas elements, not just half", () => {
+            const osc = createOscilloscope();
+            const widgetBody = osc.widgetWindow.getWidgetBody();
+            // document.getElementsByClassName (used inside _scale) only searches
+            // elements attached to the live document tree.
+            document.body.appendChild(widgetBody);
+
+            for (let i = 0; i < 4; i++) {
+                const canvas = document.createElement("canvas");
+                canvas.className = "oscilloscopeCanvas";
+                widgetBody.appendChild(canvas);
+            }
+            expect(document.getElementsByClassName("oscilloscopeCanvas").length).toBe(4);
+
+            osc._scale();
+
+            expect(document.getElementsByClassName("oscilloscopeCanvas").length).toBe(0);
+
+            document.body.removeChild(widgetBody);
+        });
+    });
+
     describe("close", () => {
         test("calls _stopAnimation", () => {
             const osc = createOscilloscope();

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -295,7 +295,7 @@ class Oscilloscope {
         let width, height;
 
         const canvases = document.getElementsByClassName("oscilloscopeCanvas");
-        Array.prototype.forEach.call(canvases, ele => {
+        Array.from(canvases).forEach(ele => {
             this.widgetWindow.getWidgetBody().removeChild(ele);
         });
 


### PR DESCRIPTION
## Description

`Oscilloscope._scale()` (`js/widgets/oscilloscope.js`) cleans up old canvas elements before creating resized ones, using:

```js
const canvases = document.getElementsByClassName("oscilloscopeCanvas");
Array.prototype.forEach.call(canvases, ele => {
    this.widgetWindow.getWidgetBody().removeChild(ele);
});
```

`getElementsByClassName` returns a *live* `HTMLCollection`. As each `removeChild` call shrinks it, later elements shift down into already-visited indices and get skipped — a classic live-collection iteration bug. Over repeated resize/maximize/minimize cycles, roughly half the old canvases never get removed, leaking "zombie" canvas elements in the DOM and hurting performance.

## Related Issue

This PR fixes #6916

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/widgets/oscilloscope.js`: snapshot the live collection to a static array before iterating, per the issue's own suggested fix — `Array.from(canvases).forEach(...)` instead of `Array.prototype.forEach.call(canvases, ...)`
-   `js/widgets/__tests__/oscilloscope.test.js`: added a `describe("_scale", ...)` block (method had no prior coverage) that appends 4 real canvas elements to the widget body (attached to the live document, since `document.getElementsByClassName` only searches attached elements), calls `_scale()`, and asserts all 4 are removed — a naive live-collection bug leaves exactly half behind

## Testing Performed

-   Verified the new test actually catches the bug: temporarily reverted the fix and confirmed the test fails with 2 of 4 canvases surviving (the exact skip-every-other symptom described in the issue), then re-applied the fix and confirmed it passes
-   `npx jest js/widgets/__tests__/oscilloscope.test.js` — 52/52 pass
-   `npx jest` (full suite) — all suites pass, zero regressions
-   `npx eslint js/widgets/oscilloscope.js js/widgets/__tests__/oscilloscope.test.js` — clean

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `pnpm run lint` and `pnpm exec prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Single-topic, surgical fix — only `_scale()`'s cleanup loop changed, nothing else in the widget touched.
