### PR TITLE
fix: guard PlanetInterface.onConverterLoad against null planet

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -163,6 +163,14 @@ describe("PlanetInterface", () => {
         expect(window.Converter).toBe("mockConverter");
     });
 
+    test("onConverterLoad does not throw and clears window.Converter when planet is null", () => {
+        planetInterface.planet = null;
+
+        expect(() => planetInterface.onConverterLoad()).not.toThrow();
+
+        expect(window.Converter).toBeUndefined();
+    });
+
     test("getCurrentProjectName returns name from ProjectStorage", () => {
         planetInterface.planet = {
             ProjectStorage: { getCurrentProjectName: jest.fn(() => "ProjectX") }

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -323,7 +323,7 @@ class PlanetInterface {
          * Sets the Converter object in the window context.
          */
         this.onConverterLoad = () => {
-            window.Converter = this.planet.Converter;
+            window.Converter = this.planet ? this.planet.Converter : undefined;
         };
 
         /**


### PR DESCRIPTION
## Description

`PlanetInterface.onConverterLoad()` (`js/planetInterface.js`) unconditionally dereferenced `this.planet.Converter`:

```js
this.onConverterLoad = () => {
    window.Converter = this.planet.Converter;
};
```

This callback is registered once via `this.planet.setOnConverterLoad(this.onConverterLoad.bind(this))` while `this.planet` is truthy, but it reads `this.planet` fresh (not closure-captured) whenever it's actually invoked later. If `this.planet` gets set back to `null` in between (e.g. a subsequent init failure elsewhere in the same file), this callback crashes with a `TypeError`.

The issue's originally-cited call site (in the constructor/init flow) was already fixed by an earlier PR with a ternary guard — but this sibling call site, with the identical failure pattern, was missed.

## Related Issue

This PR fixes #6927

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/planetInterface.js`: guarded `onConverterLoad` — `window.Converter = this.planet ? this.planet.Converter : undefined;` — matching the exact guard style already used at the other (already-fixed) call site in this same file for consistency.
-   `js/__tests__/planetInterface.test.js`: the existing `onConverterLoad sets window.Converter` test only covered the happy path. Added a sibling case: set `planetInterface.planet = null`, call `onConverterLoad()`, assert it doesn't throw and `window.Converter` becomes `undefined`.

## Testing Performed

-   Verified the new test actually catches the bug: temporarily reverted the fix and confirmed the test fails with an uncaught `TypeError`, then re-applied the fix and confirmed it passes
-   `npx jest js/__tests__/planetInterface.test.js` — 34/34 pass
-   `npx jest` (full suite) — all suites pass, zero regressions
-   `npx eslint js/planetInterface.js js/__tests__/planetInterface.test.js` — clean

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `pnpm run lint` and `pnpm exec prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Note for context: the issue's originally-cited lines (constructor/init flow) are already fixed on master — this PR only addresses the remaining unguarded sibling call site with the same bug pattern. Single-topic, one function changed.
