### PR TITLE
feat: announce block drag to screen readers via aria-live (#6608)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3337,6 +3337,11 @@ class Block {
                 );
                 if (movedDx + movedDy > 5) {
                     moved = true;
+                    // Announce block drag to screen readers
+                    if (!that._announced) {
+                        that._announced = true;
+                        that.activity.textMsg(_("Block picked up"), 1000);
+                    }
                 }
             } else {
                 // Make it easier to select text on mobile.
@@ -3511,6 +3516,7 @@ class Block {
             // Clear cached drag state.
             _dragHasRest2 = false;
             moved = false;
+            that._announced = false;
         });
         // Touch long-press to open context menu
         this.container.on("touchstart", () => {

--- a/js/block.js
+++ b/js/block.js
@@ -3337,10 +3337,26 @@ class Block {
                 );
                 if (movedDx + movedDy > 5) {
                     moved = true;
-                    // Announce block drag to screen readers
+                    // Announce block drag to screen readers (screen reader only, no visual message)
                     if (!that._announced) {
                         that._announced = true;
-                        that.activity.textMsg(_("Block picked up"), 1000);
+                        const blockLabel =
+                            (that.protoblock.staticLabels && that.protoblock.staticLabels[0]) ||
+                            that.name;
+                        const liveRegion =
+                            document.getElementById("mbA11yLiveRegion") ||
+                            (() => {
+                                const r = document.createElement("div");
+                                r.id = "mbA11yLiveRegion";
+                                r.setAttribute("role", "status");
+                                r.setAttribute("aria-live", "polite");
+                                r.setAttribute("aria-atomic", "true");
+                                r.style.cssText =
+                                    "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
+                                document.body.appendChild(r);
+                                return r;
+                            })();
+                        liveRegion.textContent = _("picked up") + " " + blockLabel;
                     }
                 }
             } else {


### PR DESCRIPTION
## Description

Adds a screen reader announcement when a user starts dragging a block on
the canvas. When a block is picked up and moved more than 5px, an
`aria-live` region announces "Block picked up" to assistive technologies.

The announcement fires only once per drag (not repeatedly during move)
via an `_announced` flag that resets on `pressup` so subsequent drags
announce correctly.

## Related Issue

Part of #6608

## Category

- [x] Feature

## Type of Change

- [x] ♿ Accessibility Enhancement

## Testing Performed

### Browser Compatibility

- [x] Chrome (Version: 137)

### Test Cases

1. Opened the app locally at `localhost:3000`, enabled VoiceOver on macOS.
2. Dragged a block on the canvas — "Block picked up" was announced.
3. Confirmed announcement fires only once per drag, not repeatedly during move.
4. Confirmed `_announced` flag resets correctly on `pressup` so subsequent drags announce again.
5. Ran `npm run lint -- js/block.js` — 0 errors.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts