### PR TITLE
fix: guard localStorage access in RhythmBlockPaletteBlocks

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -19,7 +19,13 @@
 
 /* exported setupRhythmBlockPaletteBlocks */
 
-const language = localStorage.languagePreference || navigator.language;
+let language;
+try {
+    language = localStorage.languagePreference;
+} catch (e) {
+    language = undefined;
+}
+language = language || navigator.language;
 let rhythmBlockPalette = language === "ja" ? "rhythm" : "widgets";
 if (_THIS_IS_TURTLE_BLOCKS_) {
     rhythmBlockPalette = "rhythm";


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
The rhythm palette code in `js/blocks/RhythmBlockPaletteBlocks.js` reads `localStorage.languagePreference` directly at the top of the file, outside any function. This runs the moment the file loads, before any of the app's normal error handling kicks in.

In browsers or environments where Web Storage is blocked (private browsing modes, sandboxed iframes, some enterprise browser policies), reading `localStorage` throws a `SecurityError`. Since this line runs at module load time, that error can stop the whole file from loading, which breaks rhythm block palette setup before the app even finishes starting.

## Root Cause
This line ran unguarded:
js
const language = localStorage.languagePreference || navigator.language;


There was no `try/catch` around the `localStorage` read, so any environment that blocks storage access would throw immediately, with nothing to catch it.

## Fix
Wrapped the `localStorage` read in a `try/catch` in `js/blocks/RhythmBlockPaletteBlocks.js`. If reading `localStorage` throws for any reason, the code now falls back to `navigator.language` instead of crashing:

js
// before
const language = localStorage.languagePreference || navigator.language;

// after
let language;
try {
    language = localStorage.languagePreference;
} catch (e) {
    language = undefined;
}
language = language || navigator.language;


Nothing else in the file changed. The `rhythmBlockPalette` line right after it still gets the same value as before in normal browsers.
## Testing
- Confirmed the old code throws when `localStorage` access is blocked (simulated by mocking `localStorage` to throw).
- Confirmed the new code falls back to `navigator.language` cleanly in that same scenario, with no error.
- Ran the existing test suite locally to confirm nothing else broke.

Fixes #7007