### PR TITLE
fix: clean up plugin setup script tags

### DIFF
--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -36,7 +36,10 @@ describe("processPluginData script cleanup", () => {
     let processPluginData;
     let originalCreateObjectURL;
     let originalRevokeObjectURL;
+    let originalBlob;
     let appendChildSpy;
+    let blobUrls;
+    let blobUrlIndex;
 
     beforeEach(() => {
         jest.useFakeTimers();
@@ -55,7 +58,24 @@ describe("processPluginData script cleanup", () => {
 
         originalCreateObjectURL = URL.createObjectURL;
         originalRevokeObjectURL = URL.revokeObjectURL;
-        URL.createObjectURL = jest.fn(() => "blob:plugin-setup");
+        originalBlob = global.Blob;
+        global.Blob = class {
+            constructor(parts) {
+                this.parts = parts;
+            }
+
+            text() {
+                return Promise.resolve(this.parts.join(""));
+            }
+        };
+        blobUrls = new Map();
+        blobUrlIndex = 0;
+        URL.createObjectURL = jest.fn(blob => {
+            const url = `blob:plugin-setup-${blobUrlIndex}`;
+            blobUrlIndex += 1;
+            blobUrls.set(url, blob);
+            return url;
+        });
         URL.revokeObjectURL = jest.fn();
 
         ({ processPluginData } = require("../utils.js"));
@@ -68,8 +88,10 @@ describe("processPluginData script cleanup", () => {
         }
         URL.createObjectURL = originalCreateObjectURL;
         URL.revokeObjectURL = originalRevokeObjectURL;
+        global.Blob = originalBlob;
         document.head.innerHTML = "";
         delete window.__mb_plugin_registry;
+        delete globalThis.pluginSetupLoaded;
         jest.useRealTimers();
     });
 
@@ -77,7 +99,13 @@ describe("processPluginData script cleanup", () => {
         const originalAppendChild = document.head.appendChild.bind(document.head);
         appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
             originalAppendChild(script);
-            script.onload();
+            blobUrls
+                .get(script.src)
+                .text()
+                .then(code => {
+                    Function(code)();
+                    script.onload();
+                });
             return script;
         });
 
@@ -91,8 +119,9 @@ describe("processPluginData script cleanup", () => {
             "plugins/test.json"
         );
 
+        expect(globalThis.pluginSetupLoaded).toBe(true);
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
-        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup");
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");
     });
 
     it("removes setup script elements after load errors", async () => {
@@ -114,6 +143,6 @@ describe("processPluginData script cleanup", () => {
         );
 
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
-        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup");
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");
     });
 });

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Music Blocks contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+const createActivity = () => ({
+    blocks: {
+        protoBlockDict: {}
+    },
+    logo: {
+        evalFlowDict: {},
+        evalArgDict: {},
+        evalSetterDict: {},
+        evalParameterDict: {},
+        evalOnStartList: {},
+        evalOnStopList: {}
+    },
+    palettes: {
+        buttons: {},
+        add: jest.fn(),
+        makePalettes: jest.fn(),
+        updatePalettes: jest.fn(),
+        show: jest.fn(),
+        pluginMacros: {}
+    },
+    pluginsImages: {}
+});
+
+describe("processPluginData script cleanup", () => {
+    let processPluginData;
+    let originalCreateObjectURL;
+    let originalRevokeObjectURL;
+    let appendChildSpy;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.resetModules();
+        document.head.innerHTML = "";
+
+        global._ = msg => msg;
+        global.PALETTEICONS = {};
+        global.PALETTEFILLCOLORS = {};
+        global.PALETTESTROKECOLORS = {};
+        global.PALETTEHIGHLIGHTCOLORS = {};
+        global.HIGHLIGHTSTROKECOLORS = {};
+        global.MULTIPALETTES = [[], [], []];
+        global.platformColor = { paletteColors: {} };
+        window.__mb_plugin_registry = {};
+
+        originalCreateObjectURL = URL.createObjectURL;
+        originalRevokeObjectURL = URL.revokeObjectURL;
+        URL.createObjectURL = jest.fn(() => "blob:plugin-setup");
+        URL.revokeObjectURL = jest.fn();
+
+        ({ processPluginData } = require("../utils.js"));
+    });
+
+    afterEach(() => {
+        if (appendChildSpy) {
+            appendChildSpy.mockRestore();
+            appendChildSpy = undefined;
+        }
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
+        document.head.innerHTML = "";
+        delete window.__mb_plugin_registry;
+        jest.useRealTimers();
+    });
+
+    it("removes setup script elements after they load", async () => {
+        const originalAppendChild = document.head.appendChild.bind(document.head);
+        appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
+            originalAppendChild(script);
+            script.onload();
+            return script;
+        });
+
+        await processPluginData(
+            createActivity(),
+            JSON.stringify({
+                BLOCKPLUGINS: {
+                    testBlock: "globalThis.pluginSetupLoaded = true;"
+                }
+            }),
+            "plugins/test.json"
+        );
+
+        expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup");
+    });
+
+    it("removes setup script elements after load errors", async () => {
+        const originalAppendChild = document.head.appendChild.bind(document.head);
+        appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
+            originalAppendChild(script);
+            script.onerror(new Error("load failed"));
+            return script;
+        });
+
+        await processPluginData(
+            createActivity(),
+            JSON.stringify({
+                BLOCKPLUGINS: {
+                    testBlock: "globalThis.pluginSetupLoaded = true;"
+                }
+            }),
+            "plugins/test.json"
+        );
+
+        expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup");
+    });
+});

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -43,7 +43,7 @@ if (typeof module !== "undefined" && module.exports) {
    docBySelector, docByTagName, doPublish, doStopVideoCam, doSVG,
    doUseCamera, format, getTextWidth, hideDOMLabel, httpGet, httpPost, HttpRequest,
    importMembers, isSVGEmpty, prepareMacroExports, preparePluginExports,
-   processMacroData, processRawPluginData, windowHeight, windowWidth,
+   processMacroData, processPluginData, processRawPluginData, windowHeight, windowWidth,
    fnBrowserDetect, waitForReadiness
 */
 
@@ -966,10 +966,16 @@ window.__mb_plugin_registry["${registryName}"] = function(activity, globalActivi
                     delete window.__mb_plugin_registry[registryName];
                 }
                 URL.revokeObjectURL(sUrl);
+                if (sScript.parentNode) {
+                    sScript.parentNode.removeChild(sScript);
+                }
                 resolve();
             };
             sScript.onerror = () => {
                 URL.revokeObjectURL(sUrl);
+                if (sScript.parentNode) {
+                    sScript.parentNode.removeChild(sScript);
+                }
                 resolve(); // Still resolve to let others run
             };
             document.head.appendChild(sScript);
@@ -1535,6 +1541,7 @@ if (typeof module !== "undefined" && module.exports) {
         doSVG,
         isSVGEmpty,
         prepareMacroExports,
+        processPluginData,
         processMacroData,
         hideDOMLabel,
         displayMsg


### PR DESCRIPTION
## Description

This PR fixes a remaining plugin loader cleanup path where temporary setup
`<script>` elements are appended to `document.head` but not removed after they
finish loading or fail to load.

The main Blob-based plugin registry script already cleans itself up on the
current branch. However, setup scripts created later for plugin initialization
logic, such as `BLOCKPLUGINS`, `GLOBALS`, and `ONLOAD`, still remained in the DOM
after execution.

The first-principle issue is that these setup scripts are temporary transport
mechanisms for executing Blob-backed plugin setup code. Once a setup script has
loaded or failed, the script element is no longer needed. Keeping it in
`document.head` causes repeated plugin loads to accumulate stale DOM nodes during
long-running sessions.

## Related Issue

This PR fixes #7388

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Updated `js/utils/utils.js` so temporary plugin setup script elements are removed from `document.head` after successful load.
-   Updated the same setup script error path so failed setup script loads are also removed from `document.head`.
-   Kept the existing `URL.revokeObjectURL(...)` behavior intact so Blob URLs are still released.
-   Exported `processPluginData` through the existing guarded CommonJS export path so the plugin loader behavior can be tested in Jest without changing browser loading behavior.
-   Added focused Jest coverage in `js/utils/__tests__/utils-plugin-loader.test.js` for:
    -   setup script cleanup after `onload`
    -   setup script cleanup after `onerror`
    -   Blob URL revocation in both paths

## Testing Performed

-   `npx jest js/utils/__tests__/utils-plugin-loader.test.js --runInBand --coverage=false`
    -   2 tests passed
-   `npm run lint`
    -   Passed with existing repository warnings
-   `npx prettier --check js/utils/utils.js js/utils/__tests__/utils-plugin-loader.test.js`
    -   Passed
-   `npm test`
    -   179 test suites passed
    -   6077 tests passed

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

This PR is intentionally limited to issue #7388. It does not change plugin
execution semantics; it only removes temporary setup script elements after their
load lifecycle has completed.

The browser-facing behavior remains the same: plugin setup code still runs from
Blob-backed script elements, Blob URLs are still revoked, and setup load errors
still resolve so later setup blocks can continue.
