### PR TITLE
Fix color sensor background parsing for hex themes

### DIFF
--- a/js/blocks/SensorsBlocks.js
+++ b/js/blocks/SensorsBlocks.js
@@ -672,10 +672,30 @@ function setupSensorsBlocks(activity) {
          * @returns {number} - The background color index.
          */
         getBackgroundColor() {
-            const [r, g, b] = platformColor.background
-                .match(/\(([^)]+)\)/)[1]
-                .split(/,\s*/)
-                .map(Number);
+            let r;
+            let g;
+            let b;
+            const background = platformColor.background;
+
+            if (background.startsWith("#")) {
+                const hex =
+                    background.length === 4
+                        ? background
+                              .slice(1)
+                              .split("")
+                              .map(value => value + value)
+                              .join("")
+                        : background.slice(1);
+                r = parseInt(hex.slice(0, 2), 16);
+                g = parseInt(hex.slice(2, 4), 16);
+                b = parseInt(hex.slice(4, 6), 16);
+            } else {
+                [r, g, b] = background
+                    .match(/\(([^)]+)\)/)[1]
+                    .split(/,\s*/)
+                    .map(Number);
+            }
+
             return searchColors(r, g, b);
         }
 

--- a/js/blocks/__tests__/SensorsBlocks.test.js
+++ b/js/blocks/__tests__/SensorsBlocks.test.js
@@ -239,6 +239,7 @@ describe("setupSensorsBlocks", () => {
 
         beforeEach(() => {
             block = DummyFlowBlock.createdBlocks["getcolorpixel"];
+            global.platformColor.background = "rgb(200,200,200)";
             logo = {
                 inStatusMatrix: false,
                 statusFields: [],
@@ -337,6 +338,13 @@ describe("setupSensorsBlocks", () => {
                 expect(color).toBe("rgb(200,200,200)");
             });
 
+            it("should return hex background color for transparent pixel", () => {
+                global.platformColor.background = "#303030";
+                const pixelData = [100, 150, 200, 0];
+                const color = block.detectColor(pixelData);
+                expect(color).toBe("rgb(48,48,48)");
+            });
+
             it("should throw an error for invalid pixel data", () => {
                 const pixelData = [100, 150]; // Invalid length
                 expect(() => block.detectColor(pixelData)).toThrow("Invalid pixel data");
@@ -347,6 +355,18 @@ describe("setupSensorsBlocks", () => {
             it("should parse and return background color", () => {
                 const color = block.getBackgroundColor();
                 expect(color).toBe("rgb(200,200,200)");
+            });
+
+            it("should parse and return full hex background color", () => {
+                global.platformColor.background = "#F9F9F9";
+                const color = block.getBackgroundColor();
+                expect(color).toBe("rgb(249,249,249)");
+            });
+
+            it("should parse and return shorthand hex background color", () => {
+                global.platformColor.background = "#abc";
+                const color = block.getBackgroundColor();
+                expect(color).toBe("rgb(170,187,204)");
             });
         });
 


### PR DESCRIPTION
## Summary
- Parse color sensor background fallbacks from both hex theme values and existing rgb/rgba values.
- Preserve support for shorthand hex colors such as `#abc`.
- Add regression coverage for transparent pixels resolving to the configured theme background instead of the gray fallback.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Related Issue
Related to #7003

## Testing
- `npx jest js/blocks/__tests__/SensorsBlocks.test.js --runInBand --coverage=false`
- `npm run lint`
- `npx prettier --check js/blocks/SensorsBlocks.js js/blocks/__tests__/SensorsBlocks.test.js`
- `npm test`
