### PR TITLE
feat: announce block name when sent to trash via aria-live region (#6608)

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -7627,6 +7627,25 @@ class Blocks {
                 this.activity.refreshCanvas();
             }
 
+            // Announce block sent to trash to screen readers (aria-live only, no visual message)
+            const blockLabel =
+                (myBlock.protoblock.staticLabels && myBlock.protoblock.staticLabels[0]) ||
+                myBlock.name;
+            const liveRegion =
+                document.getElementById("mbA11yLiveRegion") ||
+                (() => {
+                    const r = document.createElement("div");
+                    r.id = "mbA11yLiveRegion";
+                    r.setAttribute("role", "status");
+                    r.setAttribute("aria-live", "polite");
+                    r.setAttribute("aria-atomic", "true");
+                    r.style.cssText =
+                        "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
+                    document.body.appendChild(r);
+                    return r;
+                })();
+            liveRegion.textContent = blockLabel + " " + _("block sent to trash");
+
             /** Adjust the stack from which we just deleted blocks. */
             if (parentBlock !== null) {
                 const topBlk = this.findTopBlock(parentBlock);


### PR DESCRIPTION
## Description

Adds a screen reader announcement when a block is dragged to the trash
and deleted. When `sendStackToTrash` is called in `js/blocks.js`, an
`aria-live` region announces "[block name] block sent to trash" to
assistive technologies.

The announcement is silent visually — it goes directly to the
`mbA11yLiveRegion` (the same shared region set up in PR #7674), with
no `textMsg` call. The block's human-readable label is used where
available, falling back to the internal block name.

## Related Issue

Part of #6608

## Category

- [x] Feature

## Type of Change

- [x] Accessibility Enhancement

## Testing Performed

1. Opened the app locally at `localhost:3000`, enabled VoiceOver on macOS.
2. Dragged a block to the trash — "[block name] block sent to trash" was
   announced by screen reader.
3. Confirmed no visual message appears — aria-live region only.
4. Confirmed `mbA11yLiveRegion` is reused if already present in the DOM
   (lazy creation working correctly).
5. `npx prettier --check js/blocks.js` — clean.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts