### PR TITLE
fix: display actual error text instead of placeholder

### DIFF
--- a/js/activity/alert-renderer.js
+++ b/js/activity/alert-renderer.js
@@ -218,6 +218,14 @@ class AlertRenderer {
         }
 
         activity.errorMsgText.parent.visible = true;
+        activity.errorMsgText.text = msg;
+        if (typeof activity.errorMsgText.parent.updateCache === "function") {
+            activity.errorMsgText.parent.updateCache();
+        }
+        activity.stage.setChildIndex(
+            activity.errorMsgText.parent,
+            activity.stage.children.length - 1
+        );
         if (
             blk !== undefined &&
             blk !== null &&
@@ -259,6 +267,9 @@ class AlertRenderer {
             head.y = toY;
             head.rotation = angle;
         }
+
+        activity.errorText.classList.add("show");
+        activity.errorTextContent.textContent = msg;
 
         switch (msg) {
             case NOMICERRORMSG:
@@ -335,10 +346,6 @@ class AlertRenderer {
                     activity.errorArtwork["noinput"],
                     activity.stage.children.length - 1
                 );
-                break;
-            default:
-                activity.errorText.classList.add("show");
-                activity.errorTextContent.textContent = msg;
                 break;
         }
         activity.refreshCanvas();


### PR DESCRIPTION
## Problem

When an error occurred during block execution, the error indicator appeared but the actual error message was not displayed. The canvas error bubble continued showing the placeholder text, and the DOM error overlay remained hidden for known error types.

## Root Cause

- `activity.errorMsgText.text` was never updated with the actual error message.
- The cached EaselJS container was not refreshed after updating the text.
- The DOM error overlay was only shown for the default case, not for known error constants.

## Fix

- Update the canvas error bubble with the actual error message.
- Refresh the cached EaselJS container after updating the text.
- Always display the DOM error overlay, regardless of the error type.
- Bring the error bubble to the top of the stage so it remains visible.

## Testing

- [X] All 178 test suites passed.
- [X] All 6085 tests passed.

## Before

<p align="center">
  <img src="https://github.com/user-attachments/assets/9bb4031c-e5b3-492e-935c-b5b9a90f5625" width="320" alt="Before">
</p>

## After

<p align="center">
  <img src="https://github.com/user-attachments/assets/9c549c86-acdd-42c3-9ade-bdcd1d5a3e54" width="320" alt="After">
</p>

## PR Category

- [x] Bug Fix

