### PR TITLE
fix: avoid redundant delay and callback on last failed retry attempt

### DIFF
--- a/js/utils/__tests__/retryWithBackoff.test.js
+++ b/js/utils/__tests__/retryWithBackoff.test.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+describe("retryWithBackoff", () => {
+    let retryWithBackoff;
+
+    beforeEach(() => {
+        retryWithBackoff = require("../retryWithBackoff").retryWithBackoff;
+    });
+
+    it("resolves immediately when check succeeds", async () => {
+        const check = jest.fn().mockReturnValue(true);
+        const onSuccess = jest.fn().mockResolvedValue();
+        const result = await retryWithBackoff({ check, onSuccess });
+        expect(result).toBe(true);
+        expect(check).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws error and breaks immediately without final delay when retries are exhausted", async () => {
+        const check = jest.fn().mockReturnValue(false);
+        const onSuccess = jest.fn();
+        const onRetry = jest.fn();
+        const delayFn = jest.fn().mockResolvedValue();
+
+        await expect(
+            retryWithBackoff({
+                check,
+                onSuccess,
+                onRetry,
+                delayFn,
+                maxRetries: 3,
+                initialDelay: 10,
+                errorMessage: "failed completely"
+            })
+        ).rejects.toThrow("failed completely");
+
+        expect(check).toHaveBeenCalledTimes(4);
+        expect(onRetry).toHaveBeenCalledTimes(3);
+        expect(onRetry).toHaveBeenLastCalledWith(2);
+        expect(delayFn).toHaveBeenCalledTimes(3);
+        expect(delayFn).toHaveBeenLastCalledWith(40);
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+});

--- a/js/utils/retryWithBackoff.js
+++ b/js/utils/retryWithBackoff.js
@@ -102,6 +102,10 @@ const retryWithBackoff = async ({
             return result;
         }
 
+        if (count === maxRetries) {
+            break;
+        }
+
         if (typeof onRetry === "function") {
             onRetry(count);
         }


### PR DESCRIPTION
In retryWithBackoff, the final attempt (when count reaches maxRetries) would still execute the onRetry callback and wait for the exponential delay (which can be up to 14.5 hours with default arguments) even though no further attempts would be made. This fix breaks out of the loop early if count equals maxRetries to avoid unnecessary delay and callback invocation on failure.