### PR TITLE
fix: replace innerHTML with textContent across core widgets for security

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1516,6 +1516,8 @@ describe("Palettes Class", () => {
                         insertRow: jest.fn(() => ({
                             style: {},
                             innerHTML: "",
+                            textContent: "",
+                            appendChild: jest.fn(),
                             children: [{ style: {}, appendChild: jest.fn() }]
                         }))
                     },

--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -182,7 +182,8 @@ describe("Toolbar Class", () => {
     test("renderLogoIcon sets up logo with correct interactions", () => {
         const elements = {
             "mb-logo": {
-                innerHTML: "",
+                textContent: "",
+                appendChild: jest.fn(),
                 onmouseenter: null,
                 onmouseleave: null,
                 onclick: null,
@@ -208,7 +209,7 @@ describe("Toolbar Class", () => {
 
         //Non-Japanese language
         toolbar.renderLogoIcon(mockOnClick);
-        expect(elements["mb-logo"].innerHTML).toBe("");
+        expect(elements["mb-logo"].textContent).toBe("");
         expect(typeof elements["mb-logo"].onmouseenter).toBe("function");
         expect(typeof elements["mb-logo"].onmouseleave).toBe("function");
         expect(typeof elements["mb-logo"].onclick).toBe("function");
@@ -225,8 +226,7 @@ describe("Toolbar Class", () => {
         // Japanese language
         toolbar.language = "ja";
         toolbar.renderLogoIcon(mockOnClick);
-        expect(elements["mb-logo"].innerHTML).toContain("logo-ja.svg");
-        expect(elements["mb-logo"].innerHTML).toContain("transform: scale(0.85)");
+        expect(elements["mb-logo"].appendChild).toHaveBeenCalled();
         elements["mb-logo"].onclick();
         expect(mockOnClick).toHaveBeenCalledTimes(2);
     });
@@ -385,10 +385,19 @@ describe("Toolbar Class", () => {
     });
 
     test("renderThemeSelectIcon sets onclick and updates theme selection", () => {
-        const themeSelectIcon = { onclick: null };
+        const themeSelectIcon = {
+            onclick: null,
+            textContent: "",
+            childNodes: [],
+            appendChild: jest.fn(),
+            cloneNode: jest.fn()
+        };
         const themes = ["light", "dark"];
         const themeBox = { setAttribute: jest.fn() };
-        global.docById.mockReturnValue(themeSelectIcon);
+        global.docById.mockImplementation(id => {
+            if (id === "themeSelectIcon") return themeSelectIcon;
+            return { childNodes: [], cloneNode: jest.fn() };
+        });
         global.localStorage.themePreference = "light";
         toolbar.renderThemeSelectIcon(themeBox, themes);
         expect(themeSelectIcon.onclick).toBeInstanceOf(Function);
@@ -576,7 +585,9 @@ describe("Toolbar Class", () => {
         const recordButton = {
             classList: { add: jest.fn() },
             style: { display: "" },
-            innerHTML: ""
+            innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn()
         };
         global.docById.mockReturnValue(recordButton);
         global.fnBrowserDetect = jest.fn(() => "firefox");
@@ -592,6 +603,8 @@ describe("Toolbar Class", () => {
             classList: { add: jest.fn(), remove: jest.fn() },
             style: { display: "" },
             innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
             onclick: null
         };
 
@@ -599,6 +612,8 @@ describe("Toolbar Class", () => {
             classList: { add: jest.fn(), remove: jest.fn() },
             style: { display: "" },
             innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
             addEventListener: jest.fn(),
             removeEventListener: jest.fn(),
             querySelector: jest.fn(() => ({ textContent: "arrow_drop_down" })),
@@ -728,7 +743,7 @@ describe("Toolbar Class", () => {
         clickHandler();
 
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, false);
-        expect(elements.menu.innerHTML).toBe("more_vert");
+        expect(elements.menu.textContent).toBe("more_vert");
         expect(elements.toggleAuxBtn.classList.add).toHaveBeenCalledWith("blue", "darken-1");
         expect(elements.search.classList.toggle).toHaveBeenCalledWith("open");
 
@@ -737,7 +752,7 @@ describe("Toolbar Class", () => {
 
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, true);
         expect(elements["aux-toolbar"].style.display).toBe("none");
-        expect(elements.menu.innerHTML).toBe("menu");
+        expect(elements.menu.textContent).toBe("menu");
         expect(elements.toggleAuxBtn.classList.remove).toHaveBeenCalledWith("blue", "darken-1");
         expect(elements.toggleAuxBtn.className).toBe("tooltipped aux-toggle");
         expect(elements.chooseKeyDiv.style.display).toBe("none");
@@ -1062,7 +1077,7 @@ describe("Toolbar Class", () => {
     test("closeAuxToolbar hides auxiliary toolbar if visible", () => {
         const elements = {
             "aux-toolbar": { style: { display: "block" } },
-            "menu": { innerHTML: "" },
+            "menu": { innerHTML: "", textContent: "", appendChild: jest.fn() },
             "toggleAuxBtn": {
                 className: "some-class blue darken-1",
                 classList: {
@@ -1077,7 +1092,7 @@ describe("Toolbar Class", () => {
         toolbar.activity = {};
         toolbar.closeAuxToolbar(mockOnClick);
         expect(elements["aux-toolbar"].style.display).toBe("none");
-        expect(elements.menu.innerHTML).toBe("menu");
+        expect(elements.menu.textContent).toBe("menu");
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity, false);
         expect(elements.toggleAuxBtn.classList.remove).toHaveBeenCalledWith("blue", "darken-1");
     });
@@ -1283,6 +1298,8 @@ describe("Toolbar Class", () => {
             classList: { add: jest.fn(), remove: jest.fn(), contains: jest.fn(() => false) },
             style: { display: "block" },
             innerHTML: "",
+            textContent: "",
+            appendChild: jest.fn(),
             addEventListener: jest.fn(),
             querySelector: jest.fn(() => ({ textContent: "" })),
             contains: jest.fn(() => false)

--- a/js/palette.js
+++ b/js/palette.js
@@ -601,13 +601,13 @@ class Palettes {
 
         if (this.collapsed) {
             palette.style.transform = "translateX(-100%)";
-            document.getElementById("paletteToggle").innerHTML = "▶";
+            document.getElementById("paletteToggle").textContent = "▶";
             document.getElementById("paletteToggle").setAttribute("aria-expanded", "false");
             palette.style.transition = "transform 0.3s ease";
             this.paletteWidth = 0;
         } else {
             palette.style.transform = "translateX(0)";
-            document.getElementById("paletteToggle").innerHTML = "◀";
+            document.getElementById("paletteToggle").textContent = "◀";
             document.getElementById("paletteToggle").setAttribute("aria-expanded", "true");
             this.paletteWidth = 55 * PALETTE_WIDTH_FACTOR;
         }
@@ -650,7 +650,7 @@ class Palettes {
             document.body.appendChild(element);
 
             const toggleBtn = document.createElement("div");
-            toggleBtn.innerHTML = "◀";
+            toggleBtn.textContent = "◀";
             toggleBtn.id = "paletteToggle";
             toggleBtn.setAttribute("role", "button");
             toggleBtn.setAttribute("aria-label", _("Toggle Palette"));
@@ -1518,8 +1518,10 @@ class Palette {
             let header = this.menuContainer.children[0];
             header = header.insertRow();
             header.style.backgroundColor = platformColor.paletteLabelBackground;
-            header.innerHTML =
-                '<td style ="width: 100%; height: 42px; box-sizing: border-box; display: flex; flex-direction: row; align-items: center; justify-content: space-between;"></td>';
+            const headerCell = document.createElement("td");
+            headerCell.style.cssText =
+                "width: 100%; height: 42px; box-sizing: border-box; display: flex; flex-direction: row; align-items: center; justify-content: space-between;";
+            header.appendChild(headerCell);
             header = header.children[0];
             header.style.padding = "8px";
 

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -390,7 +390,7 @@ class ToolbarUI {
             const elem = docById(obj[0]);
             if (strings[i].length === 3) {
                 if (elem !== undefined && elem !== null) {
-                    elem.innerHTML = obj[1];
+                    elem.textContent = obj[1];
                 }
             } else {
                 if (elem !== undefined && elem !== null) {
@@ -457,8 +457,12 @@ class ToolbarUI {
     renderLogoIcon(onclick) {
         const logoIcon = docById("mb-logo");
         if (this.language === "ja") {
-            logoIcon.innerHTML =
-                '<img style="width: 100%; transform: scale(0.85);" src="images/logo-ja.svg">';
+            logoIcon.textContent = "";
+            const logoImg = document.createElement("img");
+            logoImg.style.width = "100%";
+            logoImg.style.transform = "scale(0.85)";
+            logoImg.src = "images/logo-ja.svg";
+            logoIcon.appendChild(logoImg);
         }
 
         logoIcon.onmouseenter = () => {
@@ -763,7 +767,10 @@ class ToolbarUI {
 
         themes.forEach(theme => {
             if (safeStorageGet("themePreference") === theme) {
-                icon.innerHTML = docById(theme).innerHTML;
+                icon.textContent = "";
+                Array.from(docById(theme).childNodes).forEach(node =>
+                    icon.appendChild(node.cloneNode(true))
+                );
             }
         });
 
@@ -1042,7 +1049,11 @@ class ToolbarUI {
             Record.classList.remove("hide");
             Record.style.display = "block";
         }
-        Record.innerHTML = `<i class="material-icons main">${RECORDBUTTON}</i>`;
+        Record.textContent = "";
+        const recordIcon = document.createElement("i");
+        recordIcon.className = "material-icons main";
+        recordIcon.textContent = RECORDBUTTON;
+        Record.appendChild(recordIcon);
 
         // Remove any existing onclick handler
         Record.onclick = null;
@@ -1059,7 +1070,12 @@ class ToolbarUI {
                 RecordDropdownArrow.classList.remove("hide");
                 RecordDropdownArrow.style.display = "block";
             }
-            RecordDropdownArrow.innerHTML = `<i class="material-icons main" style="font-size: 28px;">arrow_drop_down</i>`;
+            RecordDropdownArrow.textContent = "";
+            const arrowIcon = document.createElement("i");
+            arrowIcon.className = "material-icons main";
+            arrowIcon.style.fontSize = "28px";
+            arrowIcon.textContent = "arrow_drop_down";
+            RecordDropdownArrow.appendChild(arrowIcon);
 
             // Create handler function for arrow click
             const arrowClickHandler = () => {
@@ -1191,12 +1207,12 @@ class ToolbarUI {
             if (auxToolbar.style.display === "" || auxToolbar.style.display === "none") {
                 onclick(this.activity, false);
                 auxToolbar.style.display = "block";
-                menuIcon.innerHTML = "more_vert";
+                menuIcon.textContent = "more_vert";
                 this._setAuxToolbarButtonState(true);
             } else {
                 onclick(this.activity, true);
                 auxToolbar.style.display = "none";
-                menuIcon.innerHTML = "menu";
+                menuIcon.textContent = "menu";
                 this._setAuxToolbarButtonState(false);
                 docById("chooseKeyDiv").style.display = "none";
                 docById("movable").style.display = "none";
@@ -2260,7 +2276,7 @@ class ToolbarUI {
             onclick(this.activity, false);
             const menuIcon = docById("menu");
             auxToolbar.style.display = "none";
-            menuIcon.innerHTML = "menu";
+            menuIcon.textContent = "menu";
             this._setAuxToolbarButtonState(false);
         }
     };

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1039,7 +1039,7 @@ Turtles.TurtlesView = class {
                 if (auxToolbar.style.display === "block") {
                     const menuIcon = docById("menu");
                     auxToolbar.style.display = "none";
-                    menuIcon.innerHTML = "menu";
+                    menuIcon.textContent = "menu";
                     docById("toggleAuxBtn").classList.remove("blue", "darken-1");
                 }
                 this._expandButton.style.visibility = "visible";
@@ -1062,7 +1062,7 @@ Turtles.TurtlesView = class {
             if (auxToolbar.style.display === "block") {
                 const menuIcon = docById("menu");
                 auxToolbar.style.display = "none";
-                menuIcon.innerHTML = "menu";
+                menuIcon.textContent = "menu";
                 docById("toggleAuxBtn").classList.remove("blue", "darken-1");
             }
 
@@ -1115,7 +1115,7 @@ Turtles.TurtlesView = class {
             if (auxToolbar.style.display === "block") {
                 const menuIcon = docById("menu");
                 auxToolbar.style.display = "none";
-                menuIcon.innerHTML = "menu";
+                menuIcon.textContent = "menu";
                 docById("toggleAuxBtn").classList.remove("blue", "darken-1");
             }
             this.hideMenu();

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -1070,7 +1070,7 @@ class JSEditor {
             btnDiv.style.lineHeight = "20px";
 
             if (lineContent === "") {
-                btnDiv.innerHTML = "&nbsp;";
+                btnDiv.textContent = "\u00a0";
             } else if (hasDebugger) {
                 btnDiv.style.cursor = "pointer";
                 btnDiv.style.opacity = "1";
@@ -1255,11 +1255,11 @@ class JSEditor {
         if (this.isOpen) {
             this.isOpen = false;
             editorconsole.style.display = "none";
-            if (arrowBtn) arrowBtn.innerHTML = "keyboard_arrow_up";
+            if (arrowBtn) arrowBtn.textContent = "keyboard_arrow_up";
         } else {
             this.isOpen = true;
             editorconsole.style.display = "block";
-            if (arrowBtn) arrowBtn.innerHTML = "keyboard_arrow_down";
+            if (arrowBtn) arrowBtn.textContent = "keyboard_arrow_down";
         }
     }
 


### PR DESCRIPTION
## Description

This PR replaces multiple usages of `innerHTML` with safer DOM manipulation methods (`textContent` and `createElement`) across four core files (`jseditor.js`, `turtles.js`, `palette.js`, and `toolbar-ui.js`). These changes mitigate potential Cross-Site Scripting (XSS) risks by avoiding unnecessary HTML parsing for plain text updates (such as Material Icons and Unicode characters).

## PR Category

-   [x] Bug Fix - Fixes a bug or incorrect behavior
-   [ ] Feature - Adds new functionality
-   [ ] Performance -  Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README
-   [ ] Chore / Refactor - Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD - Changes to CI/CD workflows and automation

## Changes Made

-   **`jseditor.js`**: Replaced `innerHTML` with `textContent` for `&nbsp;` and console toggle arrows.
-   **`turtles.js`**: Replaced `innerHTML` with `textContent` when updating the Material Icons "menu" text.
-   **`palette.js`**: Swapped `innerHTML` for `textContent` on toggle arrows  and refactored a complex `innerHTML` table header cell to use `document.createElement`.
-   **`toolbar-ui.js`**: Replaced `innerHTML` with `textContent` for plain text string assignments. Refactored icon tags (`<i>` and `<img>`) to use `document.createElement()`, and used `node.cloneNode()` instead of `innerHTML` to duplicate the theme select icon.

## Testing Performed

-   Verified UI rendering for JS editor console arrows.
-   Verified turtle widget menu icons render correctly using `textContent` for Material Icons.
-   Ran `npx jest js/widgets/__tests__/jseditor.test.js` successfully (54/54 passed).
-   Ran `npx jest js/__tests__/turtles.test.js` successfully (45/45 passed).
-   Verified linting and Prettier checks passed completely.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [x] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

These changes follow the same security improvements recently made in other widgets. Using `textContent` for Material Icon strings is fully supported by the CSS font-family implementation and avoids triggering the browser's HTML parser entirely.
