### PR TITLE
fix: route portamento notes through setNote path, not fast-path triggerRelease

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1512,6 +1512,77 @@ describe("Utility Functions (logic-only)", () => {
         });
     });
 
+    describe("_performNotes glide/portamento setNote routing ", () => {
+        it("should call setNote (continuous glide) instead of triggerAttackRelease when doPortamento and setNote are true", async () => {
+            const mockSynth = {
+                oscillator: {},
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn(),
+                setNote: jest.fn(),
+                chain: jest.fn().mockReturnThis(),
+                disconnect: jest.fn(),
+                connect: jest.fn()
+            };
+            Synth.inTemperament = "equal";
+
+            const paramsEffects = {
+                doPortamento: true,
+                portamento: 0.05
+            };
+
+            await _performNotes.call(Synth, mockSynth, "D4", 0.5, paramsEffects, null, true, 0);
+
+            // This is the regression check: glide notes must continue the same
+            // voice via setNote, not retrigger a fresh attack+release.
+            expect(mockSynth.setNote).toHaveBeenCalledWith("D4");
+            expect(mockSynth.triggerAttackRelease).not.toHaveBeenCalled();
+        });
+
+        it("should still call triggerAttackRelease for a portamento note when setNote is false", async () => {
+            const mockSynth = {
+                oscillator: {},
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn(),
+                setNote: jest.fn(),
+                chain: jest.fn().mockReturnThis(),
+                disconnect: jest.fn(),
+                connect: jest.fn()
+            };
+            Synth.inTemperament = "equal";
+
+            const paramsEffects = {
+                doPortamento: true,
+                portamento: 0.05
+            };
+
+            await _performNotes.call(Synth, mockSynth, "C4", 0.5, paramsEffects, null, false, 0);
+
+            // Non-continuation notes (setNote=false) should still play normally.
+            expect(mockSynth.triggerAttackRelease).toHaveBeenCalled();
+            expect(mockSynth.setNote).not.toHaveBeenCalled();
+        });
+
+        it("should route plain (non-portamento) notes through the fast path unaffected", async () => {
+            const mockSynth = {
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn(),
+                setNote: jest.fn()
+            };
+            Synth.inTemperament = "equal";
+
+            const paramsEffects = {
+                doPartials: true,
+                partials: [1]
+            };
+
+            await _performNotes.call(Synth, mockSynth, "E4", 0.5, paramsEffects, null, true, 0);
+
+            // No portamento involved — fast path is fine here, no regression expected.
+            expect(mockSynth.triggerAttackRelease).toHaveBeenCalled();
+            expect(mockSynth.setNote).not.toHaveBeenCalled();
+        });
+    });
+
     describe("_performNotes effects routing and cleanup", () => {
         it("should reconnect synth to destination and disconnect old routing when effects complete", async () => {
             jest.useFakeTimers();

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1872,7 +1872,8 @@ function Synth() {
                             paramsEffects.doTremolo ||
                             paramsEffects.doPhaser ||
                             paramsEffects.doChorus ||
-                            paramsEffects.doNeighbor));
+                            paramsEffects.doNeighbor ||
+                            (paramsEffects.doPortamento && setNote)));
 
                 if (!_needsGraphRewire) {
                     // Apply in-place property mutations then take the fast path.


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem

Playing a `glide` block over multiple notes did not slide the pitch across the whole phrase. Instead, the first note played normally and the next notes played as separate, disconnected notes breaking issue.

fixes #7023.

## Root Cause

Inside `_performNotes()` in `js/utils/synthutils.js`, there is a "fast path" added for performance that skips the normal effects setup for simple notes.

- The check that decides which notes need the full setup (`_needsGraphRewire`, ~line 1864) only looks at vibrato, distortion, tremolo, phaser, chorus, and neighbor effects.
- It never checks for portamento (glide).
- Because of this, every glide note takes the fast path, which always calls `triggerAttackRelease` and completely ignores the `setNote` flag.
- The correct glide logic already existed in the slow path (~lines 2043–2062), where `setNote` is checked and `synth.setNote(notes)` is called to continue the same note and bend the pitch , but glide notes never reached that code.

## Fix

Added `doPortamento && setNote` to the `_needsGraphRewire` check, so glide notes go through the slow path where `setNote` is handled correctly.


## Testing

1. Open Music Blocks, drag a `glide` block onto the canvas.
2. Put two `note` blocks inside it with different pitches (e.g. `sol 4` then `la 4`).
3. Run the project.
4. Before the fix: two separate notes play, no slide.
5. After the fix: pitch slides smoothly from the first note into the second, no gap.
6. Added 3 Jest tests in `js/utils/__tests__/synthutils.test.js` (`_performNotes glide/portamento setNote routing`):
   - checks `setNote` is called (not `triggerAttackRelease`) when glide + setNote are both true
   - checks `triggerAttackRelease` still runs when setNote is false (no regression)
   - checks normal, non-glide notes still work the same as before
7. Ran the full `synthutils.test.js` suite locally ,  all 118 tests pass, nothing broke.