### PR TITLE
fix: guard Transport scheduling against stopped clock and stale time

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -41,6 +41,10 @@ global.Synth = jest.fn().mockImplementation(() => ({
         get isAvailable() {
             return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
         },
+        get state() {
+            if (this.isAvailable) return global.Tone.Transport.state;
+            return "stopped";
+        },
         start() {
             if (this.isAvailable) global.Tone.Transport.start();
         },
@@ -1287,6 +1291,7 @@ describe("Logo runFromBlock", () => {
                 Transport: {
                     start: jest.fn(),
                     stop: jest.fn(),
+                    state: "started",
                     schedule: scheduleSpy,
                     cancel: jest.fn(),
                     getSecondsAtTime: getSecondsAtTimeMock,

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -167,6 +167,9 @@ function makeSynth() {
             get isAvailable() {
                 return false;
             },
+            get state() {
+                return "stopped";
+            },
             get isClockRunning() {
                 return false;
             },
@@ -1014,6 +1017,10 @@ describe("Logo doStopTurtles", () => {
                     get isAvailable() {
                         return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
                     },
+                    get state() {
+                        if (this.isAvailable) return global.Tone.Transport.state;
+                        return "stopped";
+                    },
                     get isClockRunning() {
                         if (this.isAvailable && global.Tone.context) {
                             return global.Tone.context.state === "running";
@@ -1340,6 +1347,43 @@ describe("Logo runFromBlock", () => {
 
         test("falls back to setTimeout when Transport is unavailable", () => {
             global.Tone = { ...savedTone, Transport: undefined };
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 5;
+            });
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 200;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            expect(timeoutSpy).toHaveBeenCalled();
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("falls back to setTimeout when Transport is stopped", () => {
+            global.Tone = {
+                ...savedTone,
+                context: {
+                    get state() {
+                        return "running";
+                    }
+                },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    state: "stopped",
+                    schedule: jest.fn(),
+                    cancel: jest.fn(),
+                    getSecondsAtTime: jest.fn(),
+                    get seconds() {
+                        return 0;
+                    },
+                    set seconds(v) {}
+                }
+            };
             timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
                 fn();
                 return 5;

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -45,6 +45,9 @@ global.Synth = jest.fn().mockImplementation(() => ({
             if (this.isAvailable) return global.Tone.Transport.state;
             return "stopped";
         },
+        get isClockRunning() {
+            return this.isAvailable;
+        },
         start() {
             if (this.isAvailable) global.Tone.Transport.start();
         },
@@ -159,6 +162,9 @@ function makeSynth() {
         recorder: null,
         transport: {
             get isAvailable() {
+                return false;
+            },
+            get isClockRunning() {
                 return false;
             },
             cancel: jest.fn(),
@@ -1005,6 +1011,9 @@ describe("Logo doStopTurtles", () => {
                     get isAvailable() {
                         return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
                     },
+                    get isClockRunning() {
+                        return this.isAvailable;
+                    },
                     cancel() {
                         if (
                             this.isAvailable &&
@@ -1288,6 +1297,11 @@ describe("Logo runFromBlock", () => {
             });
             global.Tone = {
                 ...savedTone,
+                context: {
+                    get state() {
+                        return "running";
+                    }
+                },
                 Transport: {
                     start: jest.fn(),
                     stop: jest.fn(),

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -46,7 +46,10 @@ global.Synth = jest.fn().mockImplementation(() => ({
             return "stopped";
         },
         get isClockRunning() {
-            return this.isAvailable;
+            if (this.isAvailable && global.Tone.context) {
+                return global.Tone.context.state === "running";
+            }
+            return false;
         },
         start() {
             if (this.isAvailable) global.Tone.Transport.start();
@@ -1012,7 +1015,10 @@ describe("Logo doStopTurtles", () => {
                         return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
                     },
                     get isClockRunning() {
-                        return this.isAvailable;
+                        if (this.isAvailable && global.Tone.context) {
+                            return global.Tone.context.state === "running";
+                        }
+                        return false;
                     },
                     cancel() {
                         if (
@@ -1347,6 +1353,90 @@ describe("Logo runFromBlock", () => {
             logo.runFromBlock(logo, 0, 3, 1, "x");
 
             expect(timeoutSpy).toHaveBeenCalled();
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("falls back to setTimeout when AudioContext is suspended", () => {
+            global.Tone = {
+                ...savedTone,
+                context: {
+                    get state() {
+                        return "suspended";
+                    }
+                },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    state: "started",
+                    schedule: jest.fn(),
+                    cancel: jest.fn(),
+                    getSecondsAtTime: jest.fn(),
+                    get seconds() {
+                        return 0;
+                    },
+                    set seconds(v) {}
+                }
+            };
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 5;
+            });
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 200;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            expect(timeoutSpy).toHaveBeenCalled();
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("clamps transport time to prevent scheduling in the past", () => {
+            const getSecondsAtTimeMock = jest.fn(t => t + 1);
+            let scheduledCallback = null;
+            const scheduleSpy = jest.fn((fn, time) => {
+                scheduledCallback = fn;
+                return "evt-1";
+            });
+            let transportSeconds = 50;
+            global.Tone = {
+                ...savedTone,
+                context: {
+                    get state() {
+                        return "running";
+                    }
+                },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    state: "started",
+                    schedule: scheduleSpy,
+                    cancel: jest.fn(),
+                    getSecondsAtTime: getSecondsAtTimeMock,
+                    get seconds() {
+                        return transportSeconds;
+                    },
+                    set seconds(v) {
+                        transportSeconds = v;
+                    }
+                }
+            };
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 200;
+            turtle0._transportTime = 10;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            const computedTime = 10 + 200 / 1000;
+            expect(computedTime).toBeLessThan(transportSeconds);
+            expect(scheduleSpy).toHaveBeenCalledWith(expect.any(Function), transportSeconds);
+
+            scheduledCallback(55.5);
             expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
         });
     });

--- a/js/logo.js
+++ b/js/logo.js
@@ -1696,6 +1696,7 @@ class Logo {
                 delay > 0 &&
                 logo.synth.transport.isAvailable &&
                 logo.synth.transport.state === "started" &&
+                logo.synth.transport.isClockRunning &&
                 tur._transportTime !== null
             ) {
                 const transportTime = Math.max(

--- a/js/logo.js
+++ b/js/logo.js
@@ -1695,9 +1695,13 @@ class Logo {
                 logo.turtleDelay === 0 &&
                 delay > 0 &&
                 logo.synth.transport.isAvailable &&
+                logo.synth.transport.state === "started" &&
                 tur._transportTime !== null
             ) {
-                const transportTime = tur._transportTime + delay / 1000;
+                const transportTime = Math.max(
+                    tur._transportTime + delay / 1000,
+                    logo.synth.transport.seconds
+                );
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur._transportEventId = logo.synth.transport.schedule(audioContextTime => {
                     const tur2 = logo.activity.turtles.ithTurtle(turtle);

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -477,7 +477,7 @@ const transport = {
         return "stopped";
     },
     get isClockRunning() {
-        if (this.isAvailable && typeof Tone !== "undefined" && Tone.context) {
+        if (this.isAvailable && Tone.context) {
             return Tone.context.state === "running";
         }
         return false;

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -476,6 +476,12 @@ const transport = {
         if (this.isAvailable) return Tone.Transport.state;
         return "stopped";
     },
+    get isClockRunning() {
+        if (this.isAvailable && typeof Tone !== "undefined" && Tone.context) {
+            return Tone.context.state === "running";
+        }
+        return false;
+    },
     start() {
         if (this.isAvailable) Tone.Transport.start();
     },

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -472,6 +472,10 @@ const transport = {
     get isAvailable() {
         return typeof Tone !== "undefined" && Tone.Transport;
     },
+    get state() {
+        if (this.isAvailable) return Tone.Transport.state;
+        return "stopped";
+    },
     start() {
         if (this.isAvailable) Tone.Transport.start();
     },


### PR DESCRIPTION
## PR Category
- [X] Bug fix

## What does this PR do?

This PR fixes three edge cases found after the `Tone.Transport` scheduling changes introduced in #7703.

### Fixes

- **Guard against stopped `Tone.Transport`**
    - Some widget code paths stop `Tone.Transport`, causing scheduled callbacks to never execute.
    - This PR checks that the transport is running before using `Tone.Transport.schedule()`. If not, it falls back to the existing `setTimeout` scheduling path.

- **Guard against suspended AudioContext**
    - `Tone.Transport.state` returns `"started"` even when the AudioContext is suspended (the frozen context time still shows "started").
    - This PR adds an `isClockRunning` getter that checks `Tone.context.state === "running"` to distinguish a truly running Transport from a stuck one.

- **Prevent scheduling in the past**
    - In some cases, the computed transport timestamp could be slightly behind the current transport time.
    - This PR clamps the scheduled time to the current transport position before scheduling.
    
These are follow-up fixes to #7703 that improve robustness without changing the scheduling improvements introduced there.