### PR TITLE
fix: report divide-by-zero on mod block instead of Not a Number

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -56,6 +56,10 @@ function setupNumberBlocks(activity) {
      */
     const handleMathError = (logo, error, blk, onError = NANERRORMSG) => {
         logo.stopTurtle = true;
+        if (error && error.message === "DivByZeroError") {
+            activity.errorMsg(ZERODIVIDEERRORMSG, blk);
+            return;
+        }
         activity.errorMsg(onError, blk);
     };
 

--- a/js/blocks/__tests__/NumberBlocks.test.js
+++ b/js/blocks/__tests__/NumberBlocks.test.js
@@ -283,6 +283,19 @@ describe("setupNumberBlocks", () => {
             expect(result).toEqual(0);
             global.MathUtility.doMod = (a, b) => Number(a) % Number(b);
         });
+
+        it("should call errorMsg with ZERODIVIDEERRORMSG when MathUtility.doMod throws DivByZeroError", () => {
+            activity.blocks.blockList[110] = { connections: [null, "c1", "c2"] };
+            logo.parseArg = jest.fn(() => 5);
+            global.MathUtility.doMod = () => {
+                throw new Error("DivByZeroError");
+            };
+            const modBlock = createdBlocks["mod"];
+            const result = modBlock.arg(logo, 0, 110, null);
+            expect(activity.errorMsg).toHaveBeenCalledWith(global.ZERODIVIDEERRORMSG, 110);
+            expect(result).toEqual(0);
+            global.MathUtility.doMod = (a, b) => Number(a) % Number(b);
+        });
     });
 
     describe("PowerBlock - extra branches", () => {

--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -130,7 +130,7 @@ describe("MathUtility", () => {
         });
 
         test("throws error for invalid inputs", () => {
-            expect(() => MathUtility.doMod("a", 3)).toThrow("Invalid number input");
+            expect(() => MathUtility.doMod("a", 3)).toThrow("NanError");
         });
 
         // Edge case tests
@@ -159,7 +159,7 @@ describe("MathUtility", () => {
         });
 
         test("throws error when second arg is string", () => {
-            expect(() => MathUtility.doMod(10, "a")).toThrow("Invalid number input");
+            expect(() => MathUtility.doMod(10, "a")).toThrow("NanError");
         });
     });
 
@@ -556,7 +556,7 @@ describe("MathUtility", () => {
 
     describe("edge cases - Infinity, NaN, and boundary values", () => {
         test("doMod throws an error when divisor is zero", () => {
-            expect(() => MathUtility.doMod(5, 0)).toThrow();
+            expect(() => MathUtility.doMod(5, 0)).toThrow("DivByZeroError");
         });
 
         test("doSqrt handles Infinity", () => {

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -130,11 +130,11 @@ class MathUtility {
     static doMod(a, b) {
         if (typeof a === "number" && typeof b === "number") {
             if (Number(b) === 0) {
-                throw new Error("Division by zero");
+                throw new Error("DivByZeroError");
             }
             return Number(a) % Number(b);
         } else {
-            throw new Error("Invalid number input");
+            throw new Error("NanError");
         }
     }
 


### PR DESCRIPTION
## Description

The `mod` block on the Number palette showed the wrong toast when the divisor was zero: `Not a Number` instead of `Cannot divide by zero.` (the message the `divide` block correctly shows for `5 / 0`).

Root cause was a token mismatch. `MathUtility.doMod` threw `Error("Division by zero")`, but the block-level error dispatcher only recognizes the token `"DivByZeroError"` (what `MathUtility.doDivide` throws). The unrecognized message fell through to the default `NANERRORMSG` toast, so the divide-by-zero case was silently misreported.

## Related Issue

This PR fixes #7056

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/utils/mathutils.js`: `doMod` now throws the same error tokens as `doDivide` — `"DivByZeroError"` (was `"Division by zero"`) for a zero divisor and `"NanError"` (was `"Invalid number input"`) for non-numeric input. This matches the tokens already documented in `doMod`'s JSDoc and lets any caller dispatch on a single, shared token.
-   `js/blocks/NumberBlocks.js`: `handleMathError` now maps `DivByZeroError` to `ZERODIVIDEERRORMSG` before falling back to the default. Fixing the shared handler (rather than duplicating the divide block's inline check) means every math block routed through it gets correct divide-by-zero messaging, not just `mod`.
-   `js/utils/__tests__/mathutils.test.js`: tightened the existing `doMod` zero-divisor test to assert the specific `DivByZeroError` message, and updated the two non-numeric-input assertions to the unified `NanError` token.

## Testing Performed

-   Confirmed the tightened test fails against the old error string and passes with the fix
-   `npx jest js/utils/__tests__/mathutils.test.js` — all pass
-   `npx jest` (full suite) — 6075/6075 pass, zero regressions
-   `npx eslint` and `npx prettier --check` on all three changed files — clean

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run \`pnpm run lint\` and \`pnpm exec prettier --check .\` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Single-topic fix. The `divide` block's behavior is unchanged and served as the reference for the correct `mod` behavior.