### PR TITLE
fix: block unvetted plugin setup code from executing in main realm

### DIFF
--- a/js/utils/__tests__/utils-plugin-security.test.js
+++ b/js/utils/__tests__/utils-plugin-security.test.js
@@ -1,0 +1,96 @@
+/**
+ * MusicBlocks v3.6.2
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Regression coverage for #7046: unvetted plugin setup code (BLOCKPLUGINS,
+// GLOBALS, ONLOAD) must NOT be executed in the main realm, even after the
+// user clears the confirmation dialog. Vetted (built-in/local) plugins keep
+// their existing execution path. Runs in the default jsdom environment.
+
+global._ = msg => msg;
+global.base64Encode = jest.fn(str => str);
+
+const { processPluginData } = require("../utils.js");
+
+describe("processPluginData plugin setup security (#7046)", () => {
+    let createObjectURL;
+    let appendChildSpy;
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+
+        window.__mb_plugin_registry = {};
+
+        createObjectURL = jest.fn(() => "blob:mock");
+        global.URL.createObjectURL = createObjectURL;
+        global.URL.revokeObjectURL = jest.fn();
+
+        // A real jsdom-appended blob <script> never fires onload, so the await in
+        // processPluginData would hang. Trigger onload synchronously on append.
+        appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
+            if (typeof script.onload === "function") script.onload();
+            return script;
+        });
+
+        jest.spyOn(document.head, "removeChild").mockImplementation(() => {});
+
+        // User clicks "allow" on the unvetted-plugin confirmation dialog.
+        jest.spyOn(window, "confirm").mockImplementation(() => true);
+
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.spyOn(console, "debug").mockImplementation(() => {});
+    });
+
+    const makeActivity = () => ({
+        blocks: { protoBlockDict: {} },
+        palettes: { show: jest.fn(), updatePalettes: jest.fn() }
+    });
+
+    test("blocks unvetted plugin GLOBALS setup from executing in the main realm", async () => {
+        const plugin = JSON.stringify({ GLOBALS: "window.__pwned = true;" });
+
+        await processPluginData(makeActivity(), plugin, "upload");
+
+        // No Blob script injected -> untrusted setup code never runs.
+        expect(createObjectURL).not.toHaveBeenCalled();
+        expect(appendChildSpy).not.toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalledWith(
+            "Blocked unvetted plugin setup execution:",
+            "GLOBALS",
+            "upload"
+        );
+    });
+
+    test("blocks unvetted plugin BLOCKPLUGINS setup from executing", async () => {
+        const plugin = JSON.stringify({ BLOCKPLUGINS: { evil: "window.__pwned = true;" } });
+
+        await processPluginData(makeActivity(), plugin, "upload");
+
+        expect(createObjectURL).not.toHaveBeenCalled();
+        expect(appendChildSpy).not.toHaveBeenCalled();
+    });
+
+    test("allows vetted (local) plugin GLOBALS setup to execute", async () => {
+        const plugin = JSON.stringify({ GLOBALS: "window.__ok = true;" });
+
+        await processPluginData(makeActivity(), plugin, "plugins/example.json");
+
+        // Vetted source -> setup Blob script injected as before.
+        expect(createObjectURL).toHaveBeenCalled();
+        expect(appendChildSpy).toHaveBeenCalled();
+    });
+});

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -639,6 +639,18 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     const safeEval = (code, label = "plugin") => {
         if (typeof code !== "string" || !userConfirmed) return;
 
+        // Only vetted (built-in/local/previously-approved) plugins may run setup
+        // code (BLOCKPLUGINS, GLOBALS, ONLOAD) in the main realm. Unvetted plugin
+        // setup code is refused here, mirroring the isVettedPlugin() gate already
+        // applied to FLOW/ARG/PARAMETER/ONSTART/ONSTOP handlers and the fail-closed
+        // string handling in Logo.safePluginExecute(). Without this, an unvetted
+        // plugin that cleared the confirmation dialog could execute arbitrary
+        // JavaScript with full activity/window access.
+        if (!isVettedPlugin(pluginSource)) {
+            console.warn("Blocked unvetted plugin setup execution:", label, pluginSource);
+            return;
+        }
+
         // Basic sanity limit
         if (code.length > 500000) {
             console.warn("Plugin code too large:", label);
@@ -1512,6 +1524,7 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         ...UtilsLogic,
         extractProjectDataFromHTML,
+        processPluginData,
         _,
         format,
         delayExecution,


### PR DESCRIPTION
## Description

`processPluginData` (`js/utils/utils.js`) applies the `isVettedPlugin()` trust gate to 5 of 8 plugin handler types (FLOW/ARG/PARAMETER/ONSTART/ONSTOP), but **not** to the three *setup* types — `BLOCKPLUGINS`, `GLOBALS`, `ONLOAD`. Those route through the local `safeEval()` closure, which checks only `userConfirmed`, then executes the code via a Blob `<script>` in the main realm with full `activity`/`window` access.

Result: an unvetted plugin that clears the `confirm()` dialog runs arbitrary JavaScript with full privileges through those three keys — bypassing the exact-match whitelist in `Logo.safePluginExecute()` that already protects the other handler types. This is the core privilege-escalation concern in #7046, and it presents as an inconsistency: one trust predicate applied everywhere except these three handlers.

## Related Issue

Partially addresses #7046

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature
-   [ ] Performance
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation
-   [ ] CI/CD

## Changes Made

-   `js/utils/utils.js`: added the `isVettedPlugin(pluginSource)` check to the `safeEval` closure. Unvetted `BLOCKPLUGINS`/`GLOBALS`/`ONLOAD` setup code is now refused (logged) instead of executed in the main realm. Vetted sources (built-in \`plugins/\`, \`./plugins/\`, \`localStorage:plugins\`) keep their existing execution path. Reuses the existing predicate — no new helper.
-   Exported \`processPluginData\` through the guarded CommonJS export path so the loader can be tested in Jest without changing browser behavior.
-   \`js/utils/__tests__/utils-plugin-security.test.js\` (new): asserts unvetted \`GLOBALS\`/\`BLOCKPLUGINS\` setup produces no Blob/script injection (with a warning), and that vetted setup still executes.

## Testing Performed

-   Confirmed the new tests fail when the gate is removed (they catch the hole), pass with it.
-   \`npx jest\` — 179 suites / 6078 tests pass, zero regressions.
-   \`npx eslint\` and \`npx prettier --check\` on both changed files — clean.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run \`pnpm run lint\` and \`pnpm exec prettier --check .\` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Scoped intentionally narrow: this closes the immediate main-realm code-execution path for unvetted plugins as a single-file change, rather than the full iframe-sandbox/CSP overhaul in #7046's acceptance criteria (which remains valuable as follow-up work). It supersedes #7081's approach on current master by reusing the existing \`isVettedPlugin\` predicate uniformly instead of adding a parallel helper.

**Tradeoff:** unvetted plugins become partially inert (palette/blocks register; setup JS blocked) until a sandbox lands. Fail-closed is the safe default for an educational tool and matches the existing whitelist behavior in \`Logo.safePluginExecute()\`.