### PR TITLE
fix: toggle Pitch Staircase play/stop button icon on playback

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
-   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last
+   normalizeNoteAccidentals
  */
 
 /*
@@ -24,13 +24,9 @@
     - js/utils/musicutils.js
         SYNTHSVG, frequencyToPitch, DEFAULTVOICE
     - js/utils/utils.js
-        _, last
+        _
     - js/utils/platformstyle.js
         platformColor
-    - js/logoconstants.js
-        PREVIEWVOLUME
-    - js/turtle-singer.js
-        Singer
 */
 /* exported PitchStaircase */
 
@@ -51,13 +47,7 @@ class PitchStaircase {
         this._stepTables = [];
         this._musicRatio1 = null;
         this._musicRatio2 = null;
-        this._playingRowIndex = null;
-        this._rowStopTimeout = null;
-        this._isPlayingAll = false;
-        this._playAllTimeout = null;
-        this._isPlayingScale = false;
-        this._scaleStopped = false;
-        this._scaleTimeout = null;
+        this._playing = false;
     }
 
     /**
@@ -70,61 +60,32 @@ class PitchStaircase {
      */
     _addButton(row, icon, iconSize, label) {
         const cell = row.insertCell(-1);
-        cell.replaceChildren(
-            document.createTextNode("\u00a0\u00a0"),
-            (() => {
-                const img = document.createElement("img");
-                img.src = "header-icons/" + icon;
-                img.title = label;
-                img.alt = label;
-                img.height = iconSize;
-                img.width = iconSize;
-                img.style.verticalAlign = "middle";
-                img.style.alignContent = "center";
-                return img;
-            })(),
-            document.createTextNode("\u00a0\u00a0")
-        );
+        cell.innerHTML = `&nbsp;&nbsp;<img 
+                src="header-icons/play-button.svg" 
+                title="${label}" 
+                alt="${label}" 
+                height="${iconSize}" 
+                width="${iconSize}" 
+                vertical-align="middle" 
+                align-content="center"
+            >&nbsp;&nbsp;`;
         cell.style.width = PitchStaircase.BUTTONSIZE + "px";
         cell.style.minWidth = cell.style.width;
         cell.style.maxWidth = cell.style.width;
         cell.style.height = cell.style.width;
         cell.style.minHeight = cell.style.height;
         cell.style.maxHeight = cell.style.height;
-        cell.classList.add("pitch-staircase-btn");
+        cell.style.backgroundColor = platformColor.selectorBackground;
+
+        cell.onmouseover = () => {
+            cell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
+        };
+
+        cell.onmouseout = () => {
+            cell.style.backgroundColor = platformColor.selectorBackground;
+        };
 
         return cell;
-    }
-
-    /**
-     * @private
-     * @param {Cell} cell
-     * @param {string} icon
-     * @param {string} label
-     * @returns {void}
-     */
-    _setButtonIcon(cell, icon, label) {
-        if (!cell || typeof cell.replaceChildren !== "function") {
-            return;
-        }
-        const img = document.createElement("img");
-        img.src = "header-icons/" + icon;
-        img.title = label;
-        img.alt = label;
-        img.height = PitchStaircase.ICONSIZE;
-        img.width = PitchStaircase.ICONSIZE;
-        img.style.verticalAlign = "middle";
-        img.style.alignContent = "center";
-
-        if (cell.classList.contains("pitch-staircase-btn")) {
-            cell.replaceChildren(
-                document.createTextNode("\u00a0\u00a0"),
-                img,
-                document.createTextNode("\u00a0\u00a0")
-            );
-        } else {
-            cell.replaceChildren(img);
-        }
     }
 
     /**
@@ -137,7 +98,7 @@ class PitchStaircase {
          * the first column and a table of buttons in the second column.
          */
         const pscTable = this._pscTable;
-        pscTable.replaceChildren();
+        pscTable.innerHTML = "";
         pscTable.style.textAlign = "center";
 
         for (let i = 0; i < this.Stairs.length; i++) {
@@ -169,15 +130,13 @@ class PitchStaircase {
                     this._cellScale) /
                     3 +
                 "px";
-            stepCell.replaceChildren(
-                document.createTextNode(frequency.toFixed(2)),
-                document.createElement("br"),
-                document.createTextNode(this.Stairs[i][0] + this.Stairs[i][1])
-            );
+            stepCell.innerHTML = `${frequency.toFixed(2)}<br>${this.Stairs[i][0]}${
+                this.Stairs[i][1]
+            }`;
             stepCell.style.minWidth = stepCell.style.width;
             stepCell.style.maxWidth = stepCell.style.width;
             stepCell.style.height = PitchStaircase.BUTTONSIZE + "px";
-            stepCell.classList.add("pitch-staircase-step");
+            stepCell.style.backgroundColor = platformColor.selectorBackground;
 
             const cellWidth = Number(stepCell.style.width.replace(/px/, ""));
             const svgWidth = cellWidth.toString();
@@ -201,18 +160,9 @@ class PitchStaircase {
             });
 
             playCell.onclick = () => {
-                const i = Number(playCell.getAttribute("id"));
+                const i = playCell.getAttribute("id");
                 const stepCell = this._stepTables[i].rows[0].cells[1];
-                if (this._playingRowIndex === i) {
-                    clearTimeout(this._rowStopTimeout);
-                    stepCell.classList.remove("active");
-                    stepCell.style.backgroundColor = "";
-                    this._setButtonIcon(playCell, "play-button.svg", _("Play"));
-                    this.activity.logo.synth.stop();
-                    this._playingRowIndex = null;
-                } else {
-                    this._playOne(stepCell, playCell);
-                }
+                this._playOne(stepCell);
             };
         }
     }
@@ -244,19 +194,19 @@ class PitchStaircase {
     _dissectStair(event) {
         let inputNum1 = this._musicRatio1.value;
 
-        if (isNaN(inputNum1) || Number(inputNum1) <= 0) {
+        if (isNaN(inputNum1)) {
             inputNum1 = 3;
         } else {
-            inputNum1 = Math.floor(inputNum1);
+            inputNum1 = Math.abs(Math.floor(inputNum1));
         }
 
         this._musicRatio1.value = inputNum1;
         let inputNum2 = this._musicRatio2.value;
 
-        if (isNaN(inputNum2) || Number(inputNum2) <= 0) {
+        if (isNaN(inputNum2)) {
             inputNum2 = 2;
         } else {
-            inputNum2 = Math.floor(inputNum2);
+            inputNum2 = Math.abs(Math.floor(inputNum2));
         }
 
         this._musicRatio2.value = inputNum2;
@@ -284,13 +234,6 @@ class PitchStaircase {
         let isStepDeleted = true;
         let i;
 
-        // Snapshot the source stair's metadata before any splice so that
-        // inserting at index i < n does not shift n and corrupt the values.
-        const srcNumerator = this.Stairs[n][3];
-        const srcDenominator = this.Stairs[n][4];
-        const srcFrequency = this.Stairs[n][2];
-        const srcOctave = this.Stairs[n][6];
-
         for (i = 0; i < this.Stairs.length; i++) {
             // Check if the frequency is effectively the same (within epsilon)
             if (Math.abs(this.Stairs[i][2] - newFrequency) < 0.001) {
@@ -298,10 +241,10 @@ class PitchStaircase {
                     obj[0],
                     obj[1],
                     newFrequency,
-                    srcNumerator * parseFloat(inputNum2),
-                    srcDenominator * parseFloat(inputNum1),
-                    srcFrequency,
-                    srcOctave
+                    this.Stairs[n][3] * parseFloat(inputNum2),
+                    this.Stairs[n][4] * parseFloat(inputNum1),
+                    this.Stairs[n][2],
+                    this.Stairs[n][6]
                 ]);
                 foundStep = true;
                 repeatStep = true;
@@ -314,10 +257,10 @@ class PitchStaircase {
                     obj[0],
                     obj[1],
                     newFrequency,
-                    srcNumerator * parseFloat(inputNum2),
-                    srcDenominator * parseFloat(inputNum1),
-                    srcFrequency,
-                    srcOctave
+                    this.Stairs[n][3] * parseFloat(inputNum2),
+                    this.Stairs[n][4] * parseFloat(inputNum1),
+                    this.Stairs[n][2],
+                    this.Stairs[n][6]
                 ]);
                 foundStep = true;
                 break;
@@ -329,10 +272,10 @@ class PitchStaircase {
                 obj[0],
                 obj[1],
                 newFrequency,
-                srcNumerator * parseFloat(inputNum2),
-                srcDenominator * parseFloat(inputNum1),
-                srcFrequency,
-                srcOctave
+                this.Stairs[n][3] * parseFloat(inputNum2),
+                this.Stairs[n][4] * parseFloat(inputNum1),
+                this.Stairs[n][2],
+                this.Stairs[n][6]
             ]);
             this._history.push(this.Stairs.length - 1);
         } else {
@@ -349,21 +292,14 @@ class PitchStaircase {
      * @param {Cell} stepcell
      * @returns {void}
      */
-    _playOne(stepCell, playCell) {
+    _playOne(stepCell) {
         // The frequency is stored in the stepCell.
-        stepCell.classList.add("active");
-        stepCell.style.backgroundColor = platformColor.selectorBackgroundHOVER;
-        const i = Number(playCell.getAttribute("id"));
-        this._playingRowIndex = i;
+        stepCell.style.backgroundColor = platformColor.selectorBackground;
         const frequency = Number(stepCell.getAttribute("id"));
         this.activity.logo.synth.trigger(0, frequency, 1, DEFAULTVOICE, null, null);
-        this._setButtonIcon(playCell, "stop-button.svg", _("Stop"));
 
-        this._rowStopTimeout = setTimeout(() => {
-            stepCell.classList.remove("active");
-            stepCell.style.backgroundColor = "";
-            this._setButtonIcon(playCell, "play-button.svg", _("Play"));
-            this._playingRowIndex = null;
+        setTimeout(() => {
+            stepCell.style.backgroundColor = platformColor.selectorBackground;
         }, 1000);
     }
 
@@ -373,32 +309,32 @@ class PitchStaircase {
      */
     _playAll() {
         const pitchnotes = [];
-        this._isPlayingAll = true;
-        if (this._playAllButton) {
-            this._setButtonIcon(
-                this._isPlayingAll ? this._playAllButton : null,
-                "stop-button.svg",
-                _("Stop")
-            );
-        }
 
         for (let i = 0; i < this.Stairs.length; i++) {
             const note = this.Stairs[i][0] + this.Stairs[i][1];
             pitchnotes.push(normalizeNoteAccidentals(note));
             const stepCell = this._stepTables[i].rows[0].cells[1];
-            stepCell.classList.add("active");
+            stepCell.style.backgroundColor = platformColor.selectorBackground;
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         }
 
-        this._playAllTimeout = setTimeout(() => {
+        setTimeout(() => {
             for (let i = 0; i < this.Stairs.length; i++) {
                 const stepCell = this._stepTables[i].rows[0].cells[1];
-                stepCell.classList.remove("active");
+                stepCell.style.backgroundColor = platformColor.selectorBackground;
             }
-            if (this._playAllButton) {
-                this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
+
+            this._playing = false;
+            if (this._playChordButton) {
+                this._playChordButton.innerHTML = `&nbsp;&nbsp;<img
+                        src="header-icons/play-chord.svg"
+                        title="${_("Play chord")}"
+                        alt="${_("Play chord")}"
+                        height="${PitchStaircase.ICONSIZE}"
+                        width="${PitchStaircase.ICONSIZE}"
+                        vertical-align="middle"
+                    >&nbsp;&nbsp;`;
             }
-            this._isPlayingAll = false;
         }, 1000);
     }
 
@@ -407,18 +343,13 @@ class PitchStaircase {
      * @returns {void}
      */
     playUpAndDown() {
-        this._scaleStopped = false;
-        this._isPlayingScale = true;
-        if (this._playScaleButton) {
-            this._setButtonIcon(this._playScaleButton, "stop-button.svg", _("Stop"));
-        }
         const pitchnotes = [];
         const note =
             this.Stairs[this.Stairs.length - 1][0] + this.Stairs[this.Stairs.length - 1][1];
         pitchnotes.push(normalizeNoteAccidentals(note));
         const last = this.Stairs.length - 1;
         const stepCell = this._stepTables[last].rows[0].cells[1];
-        stepCell.classList.add("active");
+        stepCell.style.backgroundColor = platformColor.selectorBackground;
         this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         this._playNext(this.Stairs.length - 2, -1);
     }
@@ -430,42 +361,41 @@ class PitchStaircase {
      * @returns {void}
      */
     _playNext(index, next) {
-        if (this.closed || this._scaleStopped) return;
+        if (this.closed) return;
 
         if (index === this.Stairs.length) {
-            const timeoutId = setTimeout(() => {
+            setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.classList.remove("active");
+                    stepCell.style.backgroundColor = platformColor.selectorBackground;
                 }
+
+                this._playing = false;
                 if (this._playScaleButton) {
-                    this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
+                    this._playScaleButton.innerHTML = `&nbsp;&nbsp;<img
+                            src="header-icons/play-scale.svg"
+                            title="${_("Play scale")}"
+                            alt="${_("Play scale")}"
+                            height="${PitchStaircase.ICONSIZE}"
+                            width="${PitchStaircase.ICONSIZE}"
+                            vertical-align="middle"
+                        >&nbsp;&nbsp;`;
                 }
-                this._isPlayingScale = false;
             }, 1000);
-            if (this._playScaleButton) {
-                this._scaleTimeout = timeoutId;
-            }
             return;
         }
 
         if (index === -1) {
-            const t1 = setTimeout(() => {
+            setTimeout(() => {
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.classList.remove("active");
+                    stepCell.style.backgroundColor = platformColor.selectorBackground;
                 }
             }, 1000);
-            if (this._playScaleButton) {
-                this._scaleTimeout = t1;
-            }
 
-            const t2 = setTimeout(() => {
+            setTimeout(() => {
                 this._playNext(0, 1);
             }, 200);
-            if (this._playScaleButton) {
-                this._scaleTimeout = t2;
-            }
 
             return;
         }
@@ -474,30 +404,21 @@ class PitchStaircase {
         const note = this.Stairs[index][0] + this.Stairs[index][1];
         pitchnotes.push(normalizeNoteAccidentals(note));
         const previousRowNumber = index - next;
-        // _stepTables is a dense array; a negative index yields undefined,
-        // not null, so use != null (loose) to catch both.
-        const pscTableCell = previousRowNumber >= 0 ? this._stepTables[previousRowNumber] : null;
+        const pscTableCell = this._stepTables[previousRowNumber];
 
-        const t3 = setTimeout(() => {
-            if (this.closed || this._scaleStopped) return;
-            if (pscTableCell !== null && pscTableCell !== undefined) {
+        setTimeout(() => {
+            if (pscTableCell !== null) {
                 const stepCell = pscTableCell.rows[0].cells[1];
-                stepCell.classList.remove("active");
+                stepCell.style.backgroundColor = platformColor.selectorBackground;
             }
 
             const stepCell = this._stepTables[index].rows[0].cells[1];
-            stepCell.classList.add("active");
+            stepCell.style.backgroundColor = platformColor.selectorBackground;
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
-            // Use && so playback terminates when index reaches either boundary;
-            // the boundary cases (=== -1 and === Stairs.length) are already
-            // handled by the early-return guards at the top of this function.
-            if (index > -1 && index < this.Stairs.length) {
+            if (index < this.Stairs.length || index > -1) {
                 this._playNext(index + next, next);
             }
         }, 1000);
-        if (this._playScaleButton) {
-            this._scaleTimeout = t3;
-        }
     }
 
     /**
@@ -718,33 +639,40 @@ class PitchStaircase {
         widgetWindow.clear();
         widgetWindow.show();
         widgetWindow.onclose = () => {
+            this.activity.logo.synth.setMasterVolume(0);
             this.closed = true;
-            this.activity.logo.synth.stop();
-            // Restore the project's master volume so audio still works
-            // after exiting mid-playback (was incorrectly left at PREVIEWVOLUME).
-            this.activity.logo.synth.setMasterVolume(last(Singer.masterVolume));
             widgetWindow.destroy();
         };
 
         this.closed = false;
-        this.activity.logo.synth.setMasterVolume(PREVIEWVOLUME);
 
-        this._playAllButton = widgetWindow.addButton(
+        this._playChordButton = widgetWindow.addButton(
             "play-chord.svg",
             PitchStaircase.ICONSIZE,
             _("Play chord")
         );
-        this._playAllButton.onclick = () => {
-            if (this._isPlayingAll) {
-                clearTimeout(this._playAllTimeout);
-                for (let i = 0; i < this.Stairs.length; i++) {
-                    const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.classList.remove("active");
-                }
-                this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
+        this._playChordButton.onclick = () => {
+            if (this._playing) {
+                this._playing = false;
+                this._playChordButton.innerHTML = `&nbsp;&nbsp;<img
+                        src="header-icons/play-chord.svg"
+                        title="${_("Play chord")}"
+                        alt="${_("Play chord")}"
+                        height="${PitchStaircase.ICONSIZE}"
+                        width="${PitchStaircase.ICONSIZE}"
+                        vertical-align="middle"
+                    >&nbsp;&nbsp;`;
                 this.activity.logo.synth.stop();
-                this._isPlayingAll = false;
             } else {
+                this._playing = true;
+                this._playChordButton.innerHTML = `&nbsp;&nbsp;<img
+                        src="header-icons/stop-button.svg"
+                        title="${_("Stop")}"
+                        alt="${_("Stop")}"
+                        height="${PitchStaircase.ICONSIZE}"
+                        width="${PitchStaircase.ICONSIZE}"
+                        vertical-align="middle"
+                    >&nbsp;&nbsp;`;
                 this._playAll();
             }
         };
@@ -755,17 +683,27 @@ class PitchStaircase {
             _("Play scale")
         );
         this._playScaleButton.onclick = () => {
-            if (this._isPlayingScale) {
-                this._scaleStopped = true;
-                clearTimeout(this._scaleTimeout);
-                for (let i = 0; i < this.Stairs.length; i++) {
-                    const stepCell = this._stepTables[i].rows[0].cells[1];
-                    stepCell.classList.remove("active");
-                }
-                this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
+            if (this._playing) {
+                this._playing = false;
+                this._playScaleButton.innerHTML = `&nbsp;&nbsp;<img
+                        src="header-icons/play-scale.svg"
+                        title="${_("Play scale")}"
+                        alt="${_("Play scale")}"
+                        height="${PitchStaircase.ICONSIZE}"
+                        width="${PitchStaircase.ICONSIZE}"
+                        vertical-align="middle"
+                    >&nbsp;&nbsp;`;
                 this.activity.logo.synth.stop();
-                this._isPlayingScale = false;
             } else {
+                this._playing = true;
+                this._playScaleButton.innerHTML = `&nbsp;&nbsp;<img
+                        src="header-icons/stop-button.svg"
+                        title="${_("Stop")}"
+                        alt="${_("Stop")}"
+                        height="${PitchStaircase.ICONSIZE}"
+                        width="${PitchStaircase.ICONSIZE}"
+                        vertical-align="middle"
+                    >&nbsp;&nbsp;`;
                 this.playUpAndDown();
             }
         };


### PR DESCRIPTION
Fixes #7453

The Pitch Staircase widget's play buttons (Play chord and Play scale) now toggle their icon to stop-button.svg during playback and revert back when playback finishes or is stopped.

- Added `_playing` state tracking
- Both buttons toggle between their original icon and stop-button.svg
- Icons reset automatically when playback ends (via setTimeout callbacks)
- Clicking a button during playback stops the audio and resets the icon

Pattern followed from ModeWidget's play button implementation.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD