### PR TITLE
feat: add reusable announceToScreenReader helper and refactor block.js (#6608)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3352,20 +3352,7 @@ class Block {
                         const blockLabel =
                             (that.protoblock.staticLabels && that.protoblock.staticLabels[0]) ||
                             that.name;
-                        const liveRegion =
-                            document.getElementById("mbA11yLiveRegion") ||
-                            (() => {
-                                const r = document.createElement("div");
-                                r.id = "mbA11yLiveRegion";
-                                r.setAttribute("role", "status");
-                                r.setAttribute("aria-live", "polite");
-                                r.setAttribute("aria-atomic", "true");
-                                r.style.cssText =
-                                    "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
-                                document.body.appendChild(r);
-                                return r;
-                            })();
-                        liveRegion.textContent = _("picked up") + " " + blockLabel;
+                        announceToScreenReader(_("picked up") + " " + blockLabel);
                     }
                 }
             } else {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -38,7 +38,7 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 /* exported
-   canvasPixelRatio, changeImage, closeBlkWidgets, closeWidgets,
+   announceToScreenReader,canvasPixelRatio, changeImage, closeBlkWidgets, closeWidgets,
    delayExecution, displayMsg, doBrowserCheck, docByClass, docByName,
    docBySelector, docByTagName, doPublish, doStopVideoCam, doSVG,
    doUseCamera, format, getTextWidth, hideDOMLabel, httpGet, httpPost, HttpRequest,
@@ -1456,6 +1456,25 @@ let closeBlkWidgets = name => {
  * @param {*[]} viewArgs - Constructor arguments for the view.
  * @returns {void}
  */
+/**
+ * Announces a message to screen readers via a shared aria-live region.
+ * Creates the region lazily on first use and reuses it for all subsequent calls.
+ * @param {string} msg - The message to announce.
+ */
+const announceToScreenReader = msg => {
+    let region = document.getElementById("mbA11yLiveRegion");
+    if (!region) {
+        region = document.createElement("div");
+        region.id = "mbA11yLiveRegion";
+        region.setAttribute("role", "status");
+        region.setAttribute("aria-live", "polite");
+        region.setAttribute("aria-atomic", "true");
+        region.style.cssText =
+            "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
+        document.body.appendChild(region);
+    }
+    region.textContent = msg;
+};
 let importMembers = (obj, className, modelArgs, viewArgs) => {
     /**
      * Adds methods and variables of one class to another class's instance.
@@ -1544,6 +1563,7 @@ if (typeof module !== "undefined" && module.exports) {
         processPluginData,
         processMacroData,
         hideDOMLabel,
-        displayMsg
+        displayMsg,
+        announceToScreenReader
     };
 }


### PR DESCRIPTION
## Description

Extracts the `aria-live` region creation logic into a reusable `announceToScreenReader` helper function in `js/utils/utils.js`. Refactors the drag announcement in `js/block.js` to use this new helper instead of an inline IIFE.

This centralizes screen reader announcements, avoiding duplicate DOM creation logic and making it easier to trigger silent assistive announcements across the rest of the codebase.

## Related Issue

Part of #6608

## Category

- [x] Feature
- [x] Refactoring

## Type of Change

- [x] Accessibility Enhancement
- [x] Code Quality

## Testing Performed

1. Opened the app locally at `localhost:3000`, enabled VoiceOver on macOS.
2. Dragged a block — "picked up [block name]" was announced by screen reader.
3. Confirmed no visual message appears — aria-live region only.
4. Confirmed `mbA11yLiveRegion` is correctly lazy-loaded into the DOM on the first call and reused for subsequent announcements.
5. `npx prettier --check js/block.js js/utils/utils.js` — clean.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts