### PR TITLE
fix(tests): resolve post-merge test regressions from #7646 and #7647

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -794,6 +794,7 @@ describe("MusicKeyboard core logic", () => {
             keyboard.keyboardShown = true;
             keyboard._createKeyboard = jest.fn();
             keyboard._removePitchBlock = jest.fn();
+            keyboard._syncLayouts = jest.fn();
             keyboard.layout = [
                 { noteName: "sol", noteOctave: 4, blockNumber: 3 },
                 { noteName: "hertz", noteOctave: 440, blockNumber: 5 },

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -340,10 +340,16 @@ describe("PitchStaircase Widget", () => {
             psc.activity = { logo: { synth: { trigger: jest.fn() } } };
             const stepCell = {
                 classList: { add: jest.fn(), remove: jest.fn() },
-                getAttribute: jest.fn(() => "220")
+                getAttribute: jest.fn(() => "220"),
+                style: {}
+            };
+            const playCell = {
+                getAttribute: jest.fn(() => "0"),
+                replaceChildren: jest.fn(),
+                classList: { contains: jest.fn(() => false) }
             };
 
-            psc._playOne(stepCell);
+            psc._playOne(stepCell, playCell);
 
             expect(stepCell.classList.add).toHaveBeenCalledWith("active");
             expect(psc.activity.logo.synth.trigger).toHaveBeenCalledWith(
@@ -567,7 +573,11 @@ describe("PitchStaircase Widget", () => {
                 clear: jest.fn(),
                 show: jest.fn(),
                 addButton: jest.fn((icon, size, label) => {
-                    const button = { onclick: null };
+                    const button = {
+                        onclick: null,
+                        replaceChildren: jest.fn(),
+                        classList: { contains: jest.fn(() => false) }
+                    };
                     buttons[label] = button;
                     return button;
                 }),


### PR DESCRIPTION
## Description

Quick follow-up to fix test failures that slipped into `master` after #7646 and #7647 were merged on top of #7719.

## What changed

* Updated the `_playOne` test in `pitchstaircase.test.js` to match the new `_playOne(stepCell, playCell)` signature.
* Added the missing `style` mock on `stepCell` so the background color update does not throw.
* Improved the mocked widget buttons by adding `replaceChildren` and `classList.contains`, since later tests rely on those methods during `init()`.
* Mocked `_syncLayouts()` in the `_sortLayout` test in `musickeyboard.test.js` so the test stays focused on sorting only, without chromatic gap filling changing the layout.

## Testing

* All 84 tests in both files pass
* `npm run lint` passes
* `npx prettier --check .` passes
