### PR TITLE
feat: implement native language search in language dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -927,6 +927,9 @@
                     </ul>
 
                     <ul id="languagedropdown" class="dropdown-content">
+                        <li class="search-field" style="background-color: transparent; position: sticky; top: 0; z-index: 2;">
+                            <input type="text" id="langSearch" placeholder="Search language..." style="width: calc(100% - 20px); margin: 0 10px; border-bottom: 1px solid var(--color-border-primary, #ccc); font-size: 14px; box-sizing: border-box; color: var(--color-text-primary, inherit); background-color: transparent;">
+                        </li>
                         <li><a id="enUS" role="button" tabindex="0"></a></li>
                         <li><a id="enUK" role="button" tabindex="0"></a></li>
                         <li><a id="es" role="button" tabindex="0"></a></li>

--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -1245,6 +1245,57 @@ describe("Toolbar Class", () => {
         expect(mockLangElement.classList.remove).toHaveBeenCalledWith("selected-language");
     });
 
+    test("renderLanguageSelectIcon correctly filters languages when typing in search input", () => {
+        const mockLangElement = {
+            onclick: null,
+            classList: { add: jest.fn(), remove: jest.fn() },
+            style: { display: "" }
+        };
+        const languageSelectIcon = { onclick: null, ...mockLangElement };
+        const langSearch = { addEventListener: jest.fn(), ...mockLangElement };
+
+        const hiParentElement = { style: { display: "" } };
+        const enParentElement = { style: { display: "" } };
+        const hiElement = { innerHTML: "Hindi", parentElement: hiParentElement };
+        const enElement = { innerHTML: "English (United States)", parentElement: enParentElement };
+
+        global.docById.mockImplementation(id => {
+            if (id === "languageSelectIcon") return languageSelectIcon;
+            if (id === "langSearch") return langSearch;
+            if (id === "hi") return hiElement;
+            if (id === "enUS") return enElement;
+            return { innerHTML: "Test", parentElement: { style: { display: "" } } };
+        });
+
+        const languageBox = {};
+        ["enUS", "hi"].forEach(l => {
+            languageBox[`${l}_onclick`] = jest.fn();
+        });
+
+        toolbar.renderLanguageSelectIcon(languageBox);
+
+        // Test click event
+        const clickCallback = langSearch.addEventListener.mock.calls.find(c => c[0] === "click")[1];
+        const stopPropagationMock = jest.fn();
+        clickCallback({ stopPropagation: stopPropagationMock });
+        expect(stopPropagationMock).toHaveBeenCalled();
+
+        // Test input event
+        const searchCallback = langSearch.addEventListener.mock.calls.find(
+            c => c[0] === "input"
+        )[1];
+
+        // Simulate typing "hin"
+        searchCallback({ target: { value: "hin" } });
+        expect(hiParentElement.style.display).toBe("");
+        expect(enParentElement.style.display).toBe("none");
+
+        // Simulate typing "eng"
+        searchCallback({ target: { value: "eng" } });
+        expect(hiParentElement.style.display).toBe("none");
+        expect(enParentElement.style.display).toBe("");
+    });
+
     test("renderModeSelectIcon toggles beginnerMode on click", () => {
         const activity = {
             beginnerMode: false,

--- a/js/activity.js
+++ b/js/activity.js
@@ -2389,6 +2389,7 @@ class Activity {
             }
 
             if (window.widgetWindows.isOpen("JavaScript Editor") === true) return;
+            if (document.activeElement && document.activeElement.id === "langSearch") return;
             if (!this.keyboardEnableFlag) {
                 return;
             }

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -1637,6 +1637,56 @@ class ToolbarUI {
             "he"
         ];
 
+        const langSearch = docById("langSearch");
+        if (langSearch) {
+            const englishNames = {
+                enUS: _("English (United States)"),
+                enUK: _("English (United Kingdom)"),
+                es: _("Spanish"),
+                pt: _("Portuguese"),
+                fr: _("French"),
+                it: _("Italian"),
+                de: _("German"),
+                ja: _("Japanese"),
+                kana: _("Japanese (Kana)"),
+                ko: _("Korean"),
+                zhCN: _("Chinese"),
+                th: _("Thai"),
+                ayc: _("Aymara"),
+                quz: _("Quechua"),
+                gug: _("Guarani"),
+                hi: _("Hindi"),
+                ta: _("Tamil"),
+                te: _("Telugu"),
+                ibo: _("Igbo"),
+                tr: _("Turkish"),
+                ar: _("Arabic"),
+                bn: _("Bengali"),
+                ur: _("Urdu"),
+                he: _("Hebrew")
+            };
+
+            langSearch.addEventListener("click", e => {
+                e.stopPropagation();
+            });
+
+            langSearch.addEventListener("input", e => {
+                const query = e.target.value.toLowerCase();
+                languages.forEach(lang => {
+                    const langElem = docById(lang);
+                    if (langElem && langElem.parentElement) {
+                        const nativeName = langElem.innerHTML.toLowerCase();
+                        const englishName = (englishNames[lang] || "").toLowerCase();
+                        if (nativeName.includes(query) || englishName.includes(query)) {
+                            langElem.parentElement.style.display = "";
+                        } else {
+                            langElem.parentElement.style.display = "none";
+                        }
+                    }
+                });
+            });
+        }
+
         /**
          * Updates the selected-language class to highlight the currently selected language.
          * @param {string} selectedLang - The language code to highlight.

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -1666,25 +1666,27 @@ class ToolbarUI {
                 he: _("Hebrew")
             };
 
-            langSearch.addEventListener("click", e => {
-                e.stopPropagation();
-            });
-
-            langSearch.addEventListener("input", e => {
-                const query = e.target.value.toLowerCase();
-                languages.forEach(lang => {
-                    const langElem = docById(lang);
-                    if (langElem && langElem.parentElement) {
-                        const nativeName = langElem.innerHTML.toLowerCase();
-                        const englishName = (englishNames[lang] || "").toLowerCase();
-                        if (nativeName.includes(query) || englishName.includes(query)) {
-                            langElem.parentElement.style.display = "";
-                        } else {
-                            langElem.parentElement.style.display = "none";
-                        }
-                    }
+            if (langSearch.addEventListener) {
+                langSearch.addEventListener("click", e => {
+                    e.stopPropagation();
                 });
-            });
+
+                langSearch.addEventListener("input", e => {
+                    const query = e.target.value.toLowerCase();
+                    languages.forEach(lang => {
+                        const langElem = docById(lang);
+                        if (langElem && langElem.parentElement) {
+                            const nativeName = langElem.innerHTML.toLowerCase();
+                            const englishName = (englishNames[lang] || "").toLowerCase();
+                            if (nativeName.includes(query) || englishName.includes(query)) {
+                                langElem.parentElement.style.display = "";
+                            } else {
+                                langElem.parentElement.style.display = "none";
+                            }
+                        }
+                    });
+                });
+            }
         }
 
         /**


### PR DESCRIPTION
### Description
Added a search input field directly inside the language dropdown to improve usability for non-English speakers. Users can now search for a language using its translated name (e.g., "Hindi") or its native name (e.g., "हिंदी"). 

### Changes Made
* **UI Updates (`index.html`):** Inserted a native-feeling search input inside the `#languagedropdown` list, styled with existing CSS variables (`--color-bg-primary`, `--color-border-primary`) to seamlessly adapt to Light, Dark, and High Contrast themes.
* **Search Logic (`js/toolbar-ui.js`):** Added dynamic filtering that iterates over supported languages and matches the user's query against both native text and localized English names.


- [x] Feature



https://github.com/user-attachments/assets/c3d149aa-4e78-4954-af15-001ee0c93153

