### PR TITLE
test(widgetwindows): cover global handlers, drag, and window-control paths

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -24,6 +24,7 @@
 global._ = str => str;
 global.docById = jest.fn(id => document.getElementById(id));
 global.requestAnimationFrame = jest.fn(cb => cb());
+global.ManagedTimer = require("../../utils/ManagedTimer.js");
 
 // Set up the DOM before loading the module
 const floatingWindows = document.createElement("div");
@@ -749,6 +750,16 @@ describe("widgetWindows", () => {
             expect(win._rolled).toBe(false);
             expect(win._body.style.display).toBe("flex");
         });
+
+        test("unroll removes the plus class left by the roll button toggle", () => {
+            const win = createTestWindow();
+            win._rollButton.onclick({ preventDefault: jest.fn(), stopPropagation: jest.fn() });
+            expect(win._rollButton.classList.contains("plus")).toBe(true);
+
+            win.unroll();
+
+            expect(win._rollButton.classList.contains("plus")).toBe(false);
+        });
     });
 
     describe("widgetWindows global functions", () => {
@@ -791,6 +802,523 @@ describe("widgetWindows", () => {
             const win = windowFor(widget, "FallbackTitle");
 
             expect(window.widgetWindows.openWindows["FallbackTitle"]).toBe(win);
+        });
+    });
+
+    describe("_handleGlobalKeyDown", () => {
+        afterEach(() => {
+            window.widgetWindows.focused = null;
+        });
+
+        test("does nothing when no window is focused", () => {
+            window.widgetWindows.focused = null;
+            const e = { key: "Escape", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            expect(() => window.widgetWindows._handleGlobalKeyDown(e)).not.toThrow();
+        });
+
+        test("ignores repeated key events", () => {
+            const win = createTestWindow();
+            win.onclose = jest.fn();
+            window.widgetWindows.focused = win;
+            const e = { key: "Escape", repeat: true, preventDefault: jest.fn() };
+
+            window.widgetWindows._handleGlobalKeyDown(e);
+
+            expect(win.onclose).not.toHaveBeenCalled();
+        });
+
+        test("ignores Escape when focus is inside an input", () => {
+            const win = createTestWindow();
+            win.onclose = jest.fn();
+            window.widgetWindows.focused = win;
+            const input = document.createElement("input");
+            document.body.appendChild(input);
+            input.focus();
+            const e = { key: "Escape", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            window.widgetWindows._handleGlobalKeyDown(e);
+
+            expect(win.onclose).not.toHaveBeenCalled();
+            document.body.removeChild(input);
+        });
+
+        test("Escape closes the focused window", () => {
+            const win = createTestWindow();
+            win.onclose = jest.fn();
+            window.widgetWindows.focused = win;
+            const e = { key: "Escape", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            window.widgetWindows._handleGlobalKeyDown(e);
+
+            expect(win.onclose).toHaveBeenCalled();
+            expect(e.preventDefault).toHaveBeenCalled();
+        });
+
+        test("Ctrl+Shift+M maximizes a non-maximized fullscreen window", () => {
+            const win = createTestWindow("Win", true);
+            window.widgetWindows.focused = win;
+            const e = {
+                key: "M",
+                code: "KeyM",
+                ctrlKey: true,
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            window.widgetWindows._handleGlobalKeyDown(e);
+
+            expect(win._maximized).toBe(true);
+        });
+
+        test("Ctrl+Shift+M restores an already-maximized fullscreen window", () => {
+            const win = createTestWindow("Win", true);
+            win._maximize();
+            window.widgetWindows.focused = win;
+            const e = {
+                key: "M",
+                code: "KeyM",
+                ctrlKey: true,
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            window.widgetWindows._handleGlobalKeyDown(e);
+
+            expect(win._maximized).toBe(false);
+        });
+
+        test("Ctrl+Shift+M does nothing for a non-fullscreen window", () => {
+            const win = createTestWindow("Win", false);
+            window.widgetWindows.focused = win;
+            const e = {
+                key: "M",
+                code: "KeyM",
+                ctrlKey: true,
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            expect(() => window.widgetWindows._handleGlobalKeyDown(e)).not.toThrow();
+            expect(e.preventDefault).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("global mouse handlers", () => {
+        test("_handleGlobalMouseMove delegates to the dragging window", () => {
+            const handler = jest.fn();
+            window.widgetWindows.draggingWindow = { _docMouseMoveHandler: handler };
+            const e = { clientX: 1, clientY: 2 };
+
+            window.widgetWindows._handleGlobalMouseMove(e);
+
+            expect(handler).toHaveBeenCalledWith(e);
+        });
+
+        test("_handleGlobalMouseMove does nothing without a dragging window", () => {
+            window.widgetWindows.draggingWindow = null;
+
+            expect(() => window.widgetWindows._handleGlobalMouseMove({})).not.toThrow();
+        });
+
+        test("_handleGlobalMouseUp delegates and clears the dragging window", () => {
+            const handler = jest.fn();
+            window.widgetWindows.draggingWindow = { _dragTopHandler: handler };
+            const e = {};
+
+            window.widgetWindows._handleGlobalMouseUp(e);
+
+            expect(handler).toHaveBeenCalledWith(e);
+            expect(window.widgetWindows.draggingWindow).toBeNull();
+        });
+
+        test("_handleGlobalMouseDown focuses the window under the click target", () => {
+            const win = createTestWindow();
+            window.widgetWindows.openWindows[win._key] = win;
+            const e = { target: win._frame };
+
+            window.widgetWindows._handleGlobalMouseDown(e);
+
+            expect(win._frame.style.opacity).toBe("1");
+            expect(win._frame.style.zIndex).toBe("10000");
+            expect(window.widgetWindows.focused).toBe(win);
+        });
+
+        test("_handleGlobalMouseDown dims windows not under the click target", () => {
+            const win1 = createTestWindow("W1", false);
+            const win2 = createTestWindow("W2", false);
+            window.widgetWindows.openWindows[win1._key] = win1;
+            window.widgetWindows.openWindows[win2._key] = win2;
+            const outside = document.createElement("div");
+            const e = { target: outside };
+
+            window.widgetWindows._handleGlobalMouseDown(e);
+
+            expect(win1._frame.style.opacity).toBe("0.7");
+            expect(win2._frame.style.opacity).toBe("0.7");
+            expect(window.widgetWindows.focused).toBeNull();
+        });
+
+        test("_handleGlobalMouseDown treats toolbar interactions as in-window", () => {
+            const win = createTestWindow();
+            window.widgetWindows.openWindows[win._key] = win;
+            const toolbarEl = document.createElement("div");
+            toolbarEl.id = "toolbars";
+            const toolbarChild = document.createElement("span");
+            toolbarEl.appendChild(toolbarChild);
+            document.body.appendChild(toolbarEl);
+            const e = { target: toolbarChild };
+
+            window.widgetWindows._handleGlobalMouseDown(e);
+
+            expect(win._frame.style.opacity).toBe("1");
+            document.body.removeChild(toolbarEl);
+        });
+    });
+
+    describe("drag and window-control handlers", () => {
+        test("_drag ondblclick maximizes a fullscreen window", () => {
+            const win = createTestWindow("Win", true);
+            const e = { preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
+
+            win._drag.ondblclick(e);
+
+            expect(win._maximized).toBe(true);
+            expect(e.preventDefault).toHaveBeenCalled();
+        });
+
+        test("close button calls onclose", () => {
+            const win = createTestWindow();
+            win.onclose = jest.fn();
+            const closeButton = win._drag.querySelector(".close");
+            const e = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            closeButton.onclick(e);
+
+            expect(win.onclose).toHaveBeenCalled();
+        });
+
+        test("roll button rolls up and toggles the plus class", () => {
+            const win = createTestWindow();
+            const e = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            win._rollButton.onclick(e);
+
+            expect(win._rolled).toBe(true);
+            expect(win._rollButton.classList.contains("plus")).toBe(true);
+        });
+
+        test("roll button unrolls when already rolled", () => {
+            const win = createTestWindow();
+            win._rollup();
+            const e = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+            win._rollButton.onclick(e);
+
+            expect(win._rolled).toBe(false);
+        });
+
+        test("maxmin button maximizes when not maximized", () => {
+            const win = createTestWindow("Win", true);
+            const maxminButton = win._maxminIcon.parentElement;
+            const e = { preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
+
+            maxminButton.onclick(e);
+
+            expect(win._maximized).toBe(true);
+        });
+
+        test("maxmin button restores and sends to center when maximized", () => {
+            const win = createTestWindow("Win", true);
+            win._maximize();
+            const maxminButton = win._maxminIcon.parentElement;
+            const e = { preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
+
+            maxminButton.onclick(e);
+
+            expect(win._maximized).toBe(false);
+        });
+
+        test("_nonclose onmousedown starts dragging and records offsets", () => {
+            const win = createTestWindow();
+            const e = { clientX: 50, clientY: 60, preventDefault: jest.fn() };
+
+            win._nonclose.onmousedown(e);
+
+            expect(window.widgetWindows.draggingWindow).toBe(win);
+            expect(e.preventDefault).toHaveBeenCalled();
+        });
+
+        test("_nonclose onmousedown restores and repositions when maximized", () => {
+            const win = createTestWindow();
+            win._maximize();
+            const e = { clientX: 50, clientY: 60, preventDefault: jest.fn() };
+
+            win._nonclose.onmousedown(e);
+
+            expect(win._maximized).toBe(false);
+        });
+    });
+
+    describe("_docMouseMoveHandler", () => {
+        test("shows the overlay when the frame is docked at the top", () => {
+            const win = createTestWindow("Win", true);
+            win.setPosition(0, 10);
+            const e = { clientX: 100, clientY: 100 };
+
+            win._docMouseMoveHandler(e);
+
+            expect(win._overlayframe.style.top).toBe("64px");
+        });
+
+        test("hides the overlay when the frame is not docked at the top", () => {
+            const win = createTestWindow("Win", true);
+            win.setPosition(0, 200);
+            const e = { clientX: 100, clientY: 100 };
+
+            win._docMouseMoveHandler(e);
+
+            expect(win._frame.style.zIndex).toBe("10000");
+        });
+
+        test("updates position based on the cursor offset", () => {
+            const win = createTestWindow();
+            win._dx = 5;
+            win._dy = 5;
+            const e = { clientX: 105, clientY: 205 };
+
+            win._docMouseMoveHandler(e);
+
+            expect(win._frame.style.left).toBe("100px");
+            expect(win._frame.style.top).toBe("200px");
+        });
+    });
+
+    describe("_dragTopHandler", () => {
+        test("maximizes a fullscreen window docked at the top", () => {
+            const win = createTestWindow("Win", true);
+            win.setPosition(0, 10);
+            const e = { preventDefault: jest.fn() };
+
+            win._dragTopHandler(e);
+
+            expect(win._maximized).toBe(true);
+            expect(e.preventDefault).toHaveBeenCalled();
+        });
+
+        test("does nothing when already maximized", () => {
+            const win = createTestWindow("Win", true);
+            win.setPosition(0, 10);
+            win._maximized = true;
+            const e = { preventDefault: jest.fn() };
+
+            win._dragTopHandler(e);
+
+            expect(e.preventDefault).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("_setupLanguage", () => {
+        test("moves the toolbar to the top for Japanese", () => {
+            window.localStorage.languagePreference = "ja";
+
+            const win = createTestWindow();
+
+            expect(win._body.style.flexDirection).toBe("column");
+            expect(win._toolbar.style.display).toBe("flex");
+            window.localStorage.languagePreference = "en";
+        });
+
+        test("leaves default layout for non-Japanese locales", () => {
+            window.localStorage.languagePreference = "en";
+
+            const win = createTestWindow();
+
+            expect(win._body.style.flexDirection).toBe("");
+        });
+
+        test("falls back to navigator.language when no preference is stored", () => {
+            window.localStorage.languagePreference = undefined;
+
+            expect(() => createTestWindow()).not.toThrow();
+        });
+    });
+
+    describe("constructor position cache", () => {
+        test("restores a cached position for a reused key", () => {
+            const widget = { blockNo: 980 };
+            const win1 = windowFor(widget, "Cached");
+            win1.setPosition(77, 88);
+            win1.destroy();
+            window.widgetWindows.openWindows[980] = undefined;
+            const setPositionSpy = jest.spyOn(win1.constructor.prototype, "setPosition");
+
+            windowFor(widget, "Cached");
+
+            expect(setPositionSpy.mock.calls[0]).toEqual([77, 88]);
+            setPositionSpy.mockRestore();
+        });
+    });
+
+    describe("addRangeSlider", () => {
+        test("creates a range input with the given bounds", () => {
+            const win = createTestWindow();
+            const slider = win.addRangeSlider(5, undefined, 0, 10, "myClass");
+
+            expect(slider.type).toBe("range");
+            expect(slider.min).toBe("0");
+            expect(slider.max).toBe("10");
+            expect(slider.value).toBe("5");
+            expect(slider.className).toBe("myClass");
+        });
+    });
+
+    describe("addSelectorButton", () => {
+        test("creates a select populated with the given options", () => {
+            const win = createTestWindow();
+            const selector = win.addSelectorButton([1, 2, 3], 2);
+
+            expect(selector.tagName).toBe("SELECT");
+            expect(selector.options).toHaveLength(3);
+            expect(selector.options[1].text).toBe("turtle 2");
+        });
+    });
+
+    describe("modifyButton", () => {
+        test("replaces the button's icon", () => {
+            const win = createTestWindow();
+            win.addButton("old.svg", 24, "Old");
+
+            win.modifyButton(0, "new.svg", 32, "New");
+            const img = win._buttons[0].querySelector("img");
+
+            expect(img.getAttribute("src")).toBe("header-icons/new.svg");
+            expect(img.getAttribute("height")).toBe("32");
+        });
+    });
+
+    describe("sendToCenter with a visible canvas", () => {
+        test("centers the frame relative to the canvas", () => {
+            const win = createTestWindow();
+            jest.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
+                width: 800,
+                height: 600
+            });
+            jest.spyOn(win._frame, "getBoundingClientRect").mockReturnValue({
+                width: 400,
+                height: 300
+            });
+
+            win.sendToCenter();
+
+            expect(win._frame.style.left).toBe("200px");
+            jest.restoreAllMocks();
+        });
+    });
+
+    describe("getDragElement", () => {
+        test("returns the drag handle", () => {
+            const win = createTestWindow();
+
+            expect(win.getDragElement()).toBe(win._drag);
+        });
+    });
+
+    describe("onmaximize", () => {
+        test("returns this by default", () => {
+            const win = createTestWindow();
+
+            expect(win.onmaximize()).toBe(win);
+        });
+    });
+
+    describe("destroy timer cleanup", () => {
+        test("clears all managed timers", () => {
+            const win = createTestWindow();
+            const clearAllSpy = jest.spyOn(win.timerManager, "clearAll");
+
+            win.destroy();
+
+            expect(clearAllSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("deprecated widgetWindows.clear", () => {
+        test("closes the window for the given name", () => {
+            const widget = { blockNo: 950 };
+            const win = windowFor(widget, "Clearable");
+            win.onclose = jest.fn();
+
+            clearWindow(950);
+
+            expect(win.onclose).toHaveBeenCalled();
+        });
+
+        test("does nothing when the window does not exist", () => {
+            expect(() => clearWindow("nonexistent")).not.toThrow();
+        });
+    });
+
+    describe("hideAllWindows", () => {
+        test("hides every open window and clears focus", () => {
+            const win1 = createTestWindow("H1");
+            const win2 = createTestWindow("H2");
+
+            hideAllWindows();
+
+            expect(win1._frame.style.display).toBe("none");
+            expect(win2._frame.style.display).toBe("none");
+            expect(window.widgetWindows.focused).toBeNull();
+        });
+    });
+
+    describe("hideWindow", () => {
+        test("hides the named window and clears focus if it was focused", () => {
+            const widget = { blockNo: 960 };
+            const win = windowFor(widget, "Hideable");
+            window.widgetWindows.focused = win;
+
+            window.widgetWindows.hideWindow(960);
+
+            expect(win._frame.style.display).toBe("none");
+            expect(window.widgetWindows.focused).toBeNull();
+        });
+
+        test("does nothing when the window does not exist", () => {
+            expect(() => window.widgetWindows.hideWindow("nonexistent")).not.toThrow();
+        });
+    });
+
+    describe("closeWindow", () => {
+        test("calls close on the named window", () => {
+            const widget = { blockNo: 970 };
+            const win = windowFor(widget, "Closeable");
+            const closeSpy = jest.spyOn(win, "close");
+
+            window.widgetWindows.closeWindow(970);
+
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        test("does nothing when the window does not exist", () => {
+            expect(() => window.widgetWindows.closeWindow("nonexistent")).not.toThrow();
+        });
+    });
+
+    describe("showWindows", () => {
+        test("shows every open window", () => {
+            const win1 = createTestWindow("S1");
+            const win2 = createTestWindow("S2");
+            win1._frame.style.display = "none";
+            win2._frame.style.display = "none";
+
+            showWindows();
+
+            expect(win1._frame.style.display).toBe("block");
+            expect(win2._frame.style.display).toBe("block");
         });
     });
 });


### PR DESCRIPTION
## Description

Extends the `widgetWindows.js` test suite. This module (the shared window-chrome singleton and `WidgetWindow` class used by every widget) had good structural coverage but was missing the interactive/event-driven paths. This PR raises statement coverage from ~54% to ~100% and function coverage from ~55% to 100% as part of the ongoing Music Blocks maintenance / test-completion effort.

## Related Issue

Not tied to a specific issue — general test-coverage improvement for `widgetWindows.js`.

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `_handleGlobalKeyDown` — Escape close, Ctrl/Cmd+Shift+M maximize/restore, and the input-focus and repeat-event guards.
-   The global mouse delegation handlers (`_handleGlobalMouseMove`, `_handleGlobalMouseUp`, `_handleGlobalMouseDown`), including the toolbar-interaction and dim-other-windows branches.
-   The per-window drag/control wiring set up in `_createUIelements`: double-click maximize, close/roll/maxmin button clicks, and drag-start with the maximized-window repositioning math.
-   `_docMouseMoveHandler`'s overlay show/hide branches and `_dragTopHandler`.
-   `_setupLanguage`'s Japanese-layout branch and the `navigator.language` fallback.
-   `addRangeSlider`, `addSelectorButton`, `modifyButton`.
-   `sendToCenter`'s non-zero-canvas centering path.
-   `getDragElement`, `onmaximize`, and `destroy`'s `timerManager.clearAll()` cleanup.
-   The constructor's cached-position restore for a reused window key.
-   The deprecated `widgetWindows.clear` global helper, and `hideAllWindows`, `hideWindow`, `closeWindow`, `showWindows`.

## Testing Performed

-   `npm run lint` — passes.
-   `npx prettier --check` on the modified file — passes.
-   `npm test` for the widget — 125 tests pass.
-   Coverage for `widgetWindows.js`: statements 54% -> 100%, branches 32% -> 86%, functions 55% -> 100%, lines 55% -> 100%.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
