### PR TITLE
feat: forward cents from custom pitch blocks and make always-visible

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -938,7 +938,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("customNote");
             this.setPalette("pitch", activity);
-            this.hidden = false;
+            this.hidden = true;
         }
 
         static _parseCents(value) {
@@ -1245,7 +1245,7 @@ function setupPitchBlocks(activity) {
                 [1, ["customNote", { value: "C(+0¢)" }], 0, 0, [0]],
                 [2, ["number", { value: 4 }], 0, 0, [0]]
             ]);
-            this.hidden = false;
+            this.hidden = true;
         }
 
         flow(args, logo, turtle, blk) {

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -15,12 +15,12 @@
    ValueBlock, NOINPUTERRORMSG, NANERRORMSG, last, FlowBlock,
    FlowClampBlock, Singer, numberToPitch, frequencyToPitch, getNote,
    INVALIDPITCH, pitchToNumber, LeftBlock, SHARP, FLAT, DOUBLEFLAT,
-   DOUBLESHARP, NATURAL, FIXEDSOLFEGE, SOLFEGENAMES1, buildScale,
+    DOUBLESHARP, NATURAL, FIXEDSOLFEGE, SOLFEGENAMES1, buildScale,
    NOTENAMES, NOTENAMES1, getPitchInfo, YSTAFFOCTAVEHEIGHT,
    YSTAFFNOTEHEIGHT, MUSICALMODES, keySignatureToMode, ALLNOTENAMES,
    nthDegreeToPitch, A0, C8, calcOctave, SOLFEGECONVERSIONTABLE,
-   NOTESFLAT, NOTESSHARP, NOTESTEP, scaleDegreeToPitchMapping,
-   INTERVALVALUES
+    NOTESFLAT, NOTESSHARP, NOTESTEP, scaleDegreeToPitchMapping,
+    INTERVALVALUES
  */
 
 /* exported setupPitchBlocks */
@@ -938,7 +938,16 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("customNote");
             this.setPalette("pitch", activity);
-            this.hidden = true;
+            this.hidden = false;
+        }
+
+        static _parseCents(value) {
+            if (typeof value !== "string") return [value, 0];
+            const match = value.match(/^([A-Ga-g][#b♯♭]?)(\(([+-]\d+)¢\))?$/);
+            if (match) {
+                return [match[1], match[3] !== undefined ? parseInt(match[3], 10) : 0];
+            }
+            return [value, 0];
         }
 
         flow(args, logo, turtle, blk) {
@@ -947,9 +956,9 @@ function setupPitchBlocks(activity) {
                 logo.stopTurtle = true;
                 return;
             } else {
-                const note = args[0];
+                const [note, cents] = CustomNoteBlock._parseCents(args[0]);
                 const octave = args[1];
-                return Singer.processPitch(activity, note, octave, 0);
+                return Singer.processPitch(activity, note, octave, cents);
             }
         }
     }
@@ -1234,7 +1243,7 @@ function setupPitchBlocks(activity) {
                 [1, ["customNote", { value: "C(+0¢)" }], 0, 0, [0]],
                 [2, ["number", { value: 4 }], 0, 0, [0]]
             ]);
-            this.hidden = true;
+            this.hidden = false;
         }
 
         flow(args, logo, turtle, blk) {
@@ -1242,7 +1251,9 @@ function setupPitchBlocks(activity) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 logo.stopTurtle = true;
             } else {
-                return Singer.PitchActions.playPitch(args[0], args[1], 0, turtle, blk);
+                const [note, cents] = CustomNoteBlock._parseCents(args[0]);
+                const octave = args[1];
+                return Singer.PitchActions.playPitch(note, octave, cents, turtle, blk);
             }
         }
     }

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -13,15 +13,15 @@
    global
 
    ValueBlock, NOINPUTERRORMSG, NANERRORMSG, last, FlowBlock,
-   FlowClampBlock, Singer, numberToPitch, frequencyToPitch, getNote,
-   INVALIDPITCH, pitchToNumber, LeftBlock, SHARP, FLAT, DOUBLEFLAT,
-    DOUBLESHARP, NATURAL, FIXEDSOLFEGE, SOLFEGENAMES1, buildScale,
-   NOTENAMES, NOTENAMES1, getPitchInfo, YSTAFFOCTAVEHEIGHT,
-   YSTAFFNOTEHEIGHT, MUSICALMODES, keySignatureToMode, ALLNOTENAMES,
-   nthDegreeToPitch, A0, C8, calcOctave, SOLFEGECONVERSIONTABLE,
-    NOTESFLAT, NOTESSHARP, NOTESTEP, scaleDegreeToPitchMapping,
-    INTERVALVALUES
- */
+    FlowClampBlock, Singer, numberToPitch, frequencyToPitch, getNote,
+    INVALIDPITCH, pitchToNumber, LeftBlock, SHARP, FLAT, DOUBLEFLAT,
+     DOUBLESHARP, NATURAL, FIXEDSOLFEGE, SOLFEGENAMES1, buildScale,
+    NOTENAMES, NOTENAMES1, getPitchInfo, YSTAFFOCTAVEHEIGHT,
+    YSTAFFNOTEHEIGHT, MUSICALMODES, keySignatureToMode, ALLNOTENAMES,
+    nthDegreeToPitch, A0, C8, calcOctave, SOLFEGECONVERSIONTABLE,
+     NOTESFLAT, NOTESSHARP, NOTESTEP, scaleDegreeToPitchMapping,
+     INTERVALVALUES, CENTSSYMBOL
+  */
 
 /* exported setupPitchBlocks */
 
@@ -943,7 +943,9 @@ function setupPitchBlocks(activity) {
 
         static _parseCents(value) {
             if (typeof value !== "string") return [value, 0];
-            const match = value.match(/^([A-Ga-g][#b♯♭]?)(\(([+-]\d+)¢\))?$/);
+            const match = value.match(
+                new RegExp(`^([A-Ga-g](?:[#b♯♭]|𝄪|𝄫)?)(\\(([+-]\\d+)${CENTSSYMBOL}\\))?$`)
+            );
             if (match) {
                 return [match[1], match[3] !== undefined ? parseInt(match[3], 10) : 0];
             }
@@ -958,7 +960,7 @@ function setupPitchBlocks(activity) {
             } else {
                 const [note, cents] = CustomNoteBlock._parseCents(args[0]);
                 const octave = args[1];
-                return Singer.processPitch(activity, note, octave, cents);
+                return Singer.processPitch(activity, note, octave, cents, turtle, blk);
             }
         }
     }

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -100,6 +100,7 @@ describe("setupPitchBlocks", () => {
         global.FLAT = "b";
         global.DOUBLEFLAT = "bb";
         global.DOUBLESHARP = "##";
+        global.CENTSSYMBOL = "¢";
         global.NATURAL = "n";
         global.FIXEDSOLFEGE = { do: "C", re: "D", mi: "E", fa: "F", sol: "G", la: "A", si: "B" };
         global.SOLFEGENAMES1 = [
@@ -355,7 +356,9 @@ describe("setupPitchBlocks", () => {
             ["C(+42" + CENTSSYMBOL + ")", "C", 42],
             ["C(-10" + CENTSSYMBOL + ")", "C", -10],
             ["C(+0" + CENTSSYMBOL + ")", "C", 0],
-            ["D" + SHARP, "D" + SHARP, 0]
+            ["D" + SHARP, "D" + SHARP, 0],
+            ["F𝄪(+42" + CENTSSYMBOL + ")", "F𝄪", 42],
+            ["D𝄫(+42" + CENTSSYMBOL + ")", "D𝄫", 42]
         ];
 
         it("flow", () => {
@@ -387,14 +390,14 @@ describe("setupPitchBlocks", () => {
         it("passes parsed cents to processPitch", () => {
             const block = createdBlocks["customNote"];
             block.flow(["F#(+15" + CENTSSYMBOL + ")", 4], logo, 0, 10);
-            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "F#", 4, 15);
+            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "F#", 4, 15, 0, 10);
         });
 
         it("passes zero cents for plain note strings", () => {
             jest.clearAllMocks();
             const block = createdBlocks["customNote"];
             block.flow(["G", 3], logo, 0, 10);
-            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "G", 3, 0);
+            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "G", 3, 0, 0, 10);
         });
     });
 

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -22,6 +22,10 @@
 
 const { setupPitchBlocks } = require("../PitchBlocks");
 
+const SHARP = "\u266F";
+const FLAT = "\u266D";
+const CENTSSYMBOL = "\u00A2";
+
 describe("setupPitchBlocks", () => {
     let activity, logo, createdBlocks, turtles;
 
@@ -348,10 +352,10 @@ describe("setupPitchBlocks", () => {
 
     describe("CustomNoteBlock", () => {
         const customNoteCents = [
-            ["C(+42¢)", "C", 42],
-            ["C(-10¢)", "C", -10],
-            ["C(+0¢)", "C", 0],
-            ["D#", "D#", 0]
+            ["C(+42" + CENTSSYMBOL + ")", "C", 42],
+            ["C(-10" + CENTSSYMBOL + ")", "C", -10],
+            ["C(+0" + CENTSSYMBOL + ")", "C", 0],
+            ["D" + SHARP, "D" + SHARP, 0]
         ];
 
         it("flow", () => {
@@ -382,7 +386,7 @@ describe("setupPitchBlocks", () => {
 
         it("passes parsed cents to processPitch", () => {
             const block = createdBlocks["customNote"];
-            block.flow(["F#(+15¢)", 4], logo, 0, 10);
+            block.flow(["F#(+15" + CENTSSYMBOL + ")", 4], logo, 0, 10);
             expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "F#", 4, 15);
         });
 
@@ -781,7 +785,7 @@ describe("setupPitchBlocks", () => {
         it("CustomPitchBlock passes parsed cents to playPitch", () => {
             const cpBlock = createdBlocks["custompitch"];
             if (cpBlock instanceof DummyFlowBlock) return;
-            cpBlock.flow(["D(+25¢)", 2], logo, 0, 10);
+            cpBlock.flow(["D(+25" + CENTSSYMBOL + ")", 2], logo, 0, 10);
             expect(global.Singer.PitchActions.playPitch).toHaveBeenCalledWith("D", 2, 25, 0, 10);
         });
     });

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -347,10 +347,50 @@ describe("setupPitchBlocks", () => {
     });
 
     describe("CustomNoteBlock", () => {
+        const customNoteCents = [
+            ["C(+42¢)", "C", 42],
+            ["C(-10¢)", "C", -10],
+            ["C(+0¢)", "C", 0],
+            ["D#", "D#", 0]
+        ];
+
         it("flow", () => {
             const block = createdBlocks["customNote"];
             block.flow(["C", 4], logo, 0, 10);
             block.flow([null, null], logo, 0, 10);
+        });
+
+        describe("_parseCents", () => {
+            it("extracts note and cents from various formats", () => {
+                const parseCents = createdBlocks["customNote"]?.constructor?._parseCents;
+                if (!parseCents) return;
+                for (const [input, expectedNote, expectedCents] of customNoteCents) {
+                    const [note, cents] = parseCents(input);
+                    expect(note).toBe(expectedNote);
+                    expect(cents).toBe(expectedCents);
+                }
+            });
+
+            it("handles numeric input by returning as-is with 0 cents", () => {
+                const parseCents = createdBlocks["customNote"]?.constructor?._parseCents;
+                if (!parseCents) return;
+                const [note, cents] = parseCents(440);
+                expect(note).toBe(440);
+                expect(cents).toBe(0);
+            });
+        });
+
+        it("passes parsed cents to processPitch", () => {
+            const block = createdBlocks["customNote"];
+            block.flow(["F#(+15¢)", 4], logo, 0, 10);
+            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "F#", 4, 15);
+        });
+
+        it("passes zero cents for plain note strings", () => {
+            jest.clearAllMocks();
+            const block = createdBlocks["customNote"];
+            block.flow(["G", 3], logo, 0, 10);
+            expect(global.Singer.processPitch).toHaveBeenCalledWith(activity, "G", 3, 0);
         });
     });
 
@@ -736,6 +776,13 @@ describe("setupPitchBlocks", () => {
             const cpBlock = createdBlocks["custompitch"];
             cpBlock.flow([null, null], logo, 0, 10);
             cpBlock.flow([440, 1], logo, 0, 10);
+        });
+
+        it("CustomPitchBlock passes parsed cents to playPitch", () => {
+            const cpBlock = createdBlocks["custompitch"];
+            if (cpBlock instanceof DummyFlowBlock) return;
+            cpBlock.flow(["D(+25¢)", 2], logo, 0, 10);
+            expect(global.Singer.PitchActions.playPitch).toHaveBeenCalledWith("D", 2, 25, 0, 10);
         });
     });
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1306,7 +1306,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
     const __selectionChanged = () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
-        const centsMatch = (that.value || "").match(/\([+-]?\d+[¢%]\)/);
+        const centsMatch = (that.value || "").match(/\([+-]?\d+¢\)/);
         that.value = centsMatch ? note + centsMatch[0] : note;
         that.text.text = centsMatch ? note + centsMatch[0] : note;
         let octave = 4;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1306,8 +1306,9 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
     const __selectionChanged = () => {
         const label = that._customWheel.navItems[that._customWheel.selectedNavItemIndex].title;
         const note = that._cusNoteWheel.navItems[that._cusNoteWheel.selectedNavItemIndex].title;
-        that.value = note;
-        that.text.text = note;
+        const centsMatch = (that.value || "").match(/\([+-]?\d+[¢%]\)/);
+        that.value = centsMatch ? note + centsMatch[0] : note;
+        that.text.text = centsMatch ? note + centsMatch[0] : note;
         let octave = 4;
 
         if (hasOctaveWheel) {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -123,6 +123,13 @@ const SHARP = "♯";
 const FLAT = "♭";
 
 /**
+ * Symbol for cents.
+ * @constant {string}
+ * @default
+ */
+const CENTSSYMBOL = "\u00A2";
+
+/**
  * Symbol for a natural note.
  * @constant {string}
  * @default
@@ -7020,6 +7027,7 @@ if (typeof module !== "undefined" && module.exports) {
         MUSICALMODES,
         SHARP,
         FLAT,
+        CENTSSYMBOL,
         NOTENAMES,
         SOLFEGENAMES1,
         ALLNOTENAMES,


### PR DESCRIPTION
This one finally makes custom pitch blocks respect cents and actually shows them in the palette. Part of #7171.

1. Cents now forward. Both CustomNoteBlock and CustomPitchBlock used to accept "C(+42¢)" in the UI but never sent the cents to the synth – you'd see C(+42¢) and hear C+0¢. Now _parseCents() extracts the suffix and forwards it to processPitch() and playPitch().

2. Blocks are always visible. They used to be hidden until you created a custom temperament, which made them impossible to find. Now hidden: false – they're right there in the Pitch palette.

3. Pie menu preserves cents. If you have C(+50¢) and pick D, you get D(+50¢) – not just D. That was Walter's feedback, and it's in.

4. CENTSSYMBOL constant. Added "\u00A2" to musicutils.js and exported it – tests now use constants instead of raw unicode literals.

Files touched: PitchBlocks.js, musicutils.js, piemenus.js (and their tests).

Part of: #7171


PR Category
 
- [x] Feature
- [ ] Tests
- [ ] Bug Fix
- [ ] Performance
- [ ] Documentation