### PR TITLE
fix: propagate action name changes to workspace blocks and action palette

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -358,125 +358,20 @@ describe("Block Foundation", () => {
         });
     });
 
-    describe("Action palette refresh on rename", () => {
-        it("should call showPalette('action') when closeInput is true and action is renamed", () => {
-            const showPalette = jest.fn();
-            const mockBlocksForRename = {
-                activity: { refreshCanvas: jest.fn() },
-                blockList: [],
-                palettes: {
-                    hide: jest.fn(),
-                    show: jest.fn(),
-                    updatePalettes: jest.fn(),
-                    showPalette,
-                    dict: {
-                        action: { protoList: [] }
-                    }
-                },
-                newNameddoBlock: jest.fn(),
-                setActionProtoVisibility: jest.fn(),
-                renameNameddos: jest.fn(),
-                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
-            };
+    describe("Action label changed behavior", () => {
+        let mockBlocksForRename;
+        let showPalette;
+        let removeActionPrototype;
+        let findUniqueActionName;
+        let originalDocById;
+        let block;
 
-            const block = new Block(
-                { name: "text", image: "", size: 1, docks: [] },
-                mockBlocksForRename
-            );
-            block.name = "text";
-            block.value = "myAction";
-            block.blockIndex = 0;
+        beforeEach(() => {
+            showPalette = jest.fn();
+            removeActionPrototype = jest.fn();
+            findUniqueActionName = jest.fn().mockImplementation(name => name);
 
-            // Simulate the internal _labelChanged path for "action" case
-            const cblock = { name: "action", connections: [null, 0] };
-            mockBlocksForRename.blockList[0] = block;
-
-            // Directly invoke the label-change logic for "action" case
-            const oldValue = "action";
-            const newValue = "myAction";
-            const closeInput = true;
-
-            mockBlocksForRename.newNameddoBlock(newValue, false, false);
-            mockBlocksForRename.setActionProtoVisibility(false);
-            mockBlocksForRename.renameNameddos(oldValue, newValue);
-            mockBlocksForRename.palettes.hide();
-            mockBlocksForRename.palettes.updatePalettes("action");
-            mockBlocksForRename.palettes.show();
-            if (closeInput) {
-                mockBlocksForRename.palettes.showPalette("action");
-            }
-
-            expect(showPalette).toHaveBeenCalledWith("action");
-        });
-
-        it("should NOT call showPalette when closeInput is false", () => {
-            const showPalette = jest.fn();
-            const closeInput = false;
-
-            if (closeInput) {
-                showPalette("action");
-            }
-
-            expect(showPalette).not.toHaveBeenCalled();
-        });
-
-        it("should call showPalette('action') and NOT call removeActionPrototype when oldValue === newValue and closeInput is true", () => {
-            const showPalette = jest.fn();
-            const removeActionPrototype = jest.fn();
-            const mockBlocksForRename = {
-                activity: { refreshCanvas: jest.fn() },
-                blockList: [],
-                palettes: {
-                    hide: jest.fn(),
-                    show: jest.fn(),
-                    updatePalettes: jest.fn(),
-                    showPalette,
-                    removeActionPrototype,
-                    dict: {
-                        action: { protoList: [] }
-                    }
-                },
-                newNameddoBlock: jest.fn(),
-                findUniqueActionName: jest.fn().mockImplementation(name => name),
-                setActionProtoVisibility: jest.fn(),
-                renameNameddos: jest.fn(),
-                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
-            };
-
-            const block = new Block(
-                { name: "text", image: "", size: 1, docks: [] },
-                mockBlocksForRename
-            );
-            block.name = "text";
-            block.value = "myAction";
-            block.blockIndex = 0;
-            block.connections = [1];
-            block.label = { value: "myAction", style: { display: "" } };
-            block.text = { text: "" };
-            block.container = { setChildIndex: jest.fn(), children: [] };
-            block.updateCache = jest.fn();
-
-            const cblock = { name: "action", connections: [null, 0] };
-            mockBlocksForRename.blockList[0] = block;
-            mockBlocksForRename.blockList[1] = cblock;
-
-            const originalDocById = global.docById;
-            global.docById = jest.fn().mockReturnValue({ style: {} });
-
-            block._labelChanged(true, true);
-
-            expect(mockBlocksForRename.palettes.updatePalettes).toHaveBeenCalledWith("action");
-            expect(showPalette).toHaveBeenCalledWith("action");
-            expect(removeActionPrototype).not.toHaveBeenCalled();
-
-            global.docById = originalDocById;
-        });
-
-        it("should call findUniqueActionName with parent index and removeActionPrototype when oldValue !== newValue", () => {
-            const showPalette = jest.fn();
-            const removeActionPrototype = jest.fn();
-            const findUniqueActionName = jest.fn().mockImplementation(name => name);
-            const mockBlocksForRename = {
+            mockBlocksForRename = {
                 activity: { refreshCanvas: jest.fn() },
                 blockList: [],
                 palettes: {
@@ -497,15 +392,10 @@ describe("Block Foundation", () => {
                 actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
             };
 
-            const block = new Block(
-                { name: "text", image: "", size: 1, docks: [] },
-                mockBlocksForRename
-            );
+            block = new Block({ name: "text", image: "", size: 1, docks: [] }, mockBlocksForRename);
             block.name = "text";
-            block.value = "oldAction";
             block.blockIndex = 0;
             block.connections = [1];
-            block.label = { value: "newAction", style: { display: "" } };
             block.text = { text: "" };
             block.container = { setChildIndex: jest.fn(), children: [] };
             block.updateCache = jest.fn();
@@ -514,8 +404,28 @@ describe("Block Foundation", () => {
             mockBlocksForRename.blockList[0] = block;
             mockBlocksForRename.blockList[1] = cblock;
 
-            const originalDocById = global.docById;
+            originalDocById = global.docById;
             global.docById = jest.fn().mockReturnValue({ style: {} });
+        });
+
+        afterEach(() => {
+            global.docById = originalDocById;
+        });
+
+        it("should call showPalette('action') and NOT call removeActionPrototype when oldValue === newValue and closeInput is true", () => {
+            block.value = "myAction";
+            block.label = { value: "myAction", style: { display: "" } };
+
+            block._labelChanged(true, true);
+
+            expect(mockBlocksForRename.palettes.updatePalettes).toHaveBeenCalledWith("action");
+            expect(showPalette).toHaveBeenCalledWith("action");
+            expect(removeActionPrototype).not.toHaveBeenCalled();
+        });
+
+        it("should call findUniqueActionName with parent index and removeActionPrototype when oldValue !== newValue", () => {
+            block.value = "oldAction";
+            block.label = { value: "newAction", style: { display: "" } };
 
             block._labelChanged(true, true);
 
@@ -524,61 +434,16 @@ describe("Block Foundation", () => {
             expect(mockBlocksForRename.palettes.updatePalettes).toHaveBeenCalledWith("action");
             expect(showPalette).toHaveBeenCalledWith("action");
             expect(mockBlocksForRename.activity.refreshCanvas).toHaveBeenCalled();
-
-            global.docById = originalDocById;
         });
 
         it("should NOT call renameNameddos or updatePalettes when closeInput is false", () => {
-            const showPalette = jest.fn();
-            const removeActionPrototype = jest.fn();
-            const findUniqueActionName = jest.fn().mockImplementation(name => name);
-            const mockBlocksForRename = {
-                activity: { refreshCanvas: jest.fn() },
-                blockList: [],
-                palettes: {
-                    hide: jest.fn(),
-                    show: jest.fn(),
-                    updatePalettes: jest.fn(),
-                    showPalette,
-                    removeActionPrototype,
-                    dict: {
-                        action: { protoList: [] }
-                    }
-                },
-                newNameddoBlock: jest.fn(),
-                findUniqueActionName,
-                setActionProtoVisibility: jest.fn(),
-                renameNameddos: jest.fn(),
-                renameDos: jest.fn(),
-                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
-            };
-
-            const block = new Block(
-                { name: "text", image: "", size: 1, docks: [] },
-                mockBlocksForRename
-            );
-            block.name = "text";
             block.value = "oldAction";
-            block.blockIndex = 0;
-            block.connections = [1];
             block.label = { value: "newAction", style: { display: "" } };
-            block.text = { text: "" };
-            block.container = { setChildIndex: jest.fn(), children: [] };
-            block.updateCache = jest.fn();
-
-            const cblock = { name: "action", connections: [null, 0] };
-            mockBlocksForRename.blockList[0] = block;
-            mockBlocksForRename.blockList[1] = cblock;
-
-            const originalDocById = global.docById;
-            global.docById = jest.fn().mockReturnValue({ style: {} });
 
             block._labelChanged(false, true);
 
             expect(mockBlocksForRename.renameNameddos).not.toHaveBeenCalled();
             expect(mockBlocksForRename.palettes.updatePalettes).not.toHaveBeenCalled();
-
-            global.docById = originalDocById;
         });
     });
 

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -419,6 +419,167 @@ describe("Block Foundation", () => {
 
             expect(showPalette).not.toHaveBeenCalled();
         });
+
+        it("should call showPalette('action') and NOT call removeActionPrototype when oldValue === newValue and closeInput is true", () => {
+            const showPalette = jest.fn();
+            const removeActionPrototype = jest.fn();
+            const mockBlocksForRename = {
+                activity: { refreshCanvas: jest.fn() },
+                blockList: [],
+                palettes: {
+                    hide: jest.fn(),
+                    show: jest.fn(),
+                    updatePalettes: jest.fn(),
+                    showPalette,
+                    removeActionPrototype,
+                    dict: {
+                        action: { protoList: [] }
+                    }
+                },
+                newNameddoBlock: jest.fn(),
+                findUniqueActionName: jest.fn().mockImplementation(name => name),
+                setActionProtoVisibility: jest.fn(),
+                renameNameddos: jest.fn(),
+                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
+            };
+
+            const block = new Block(
+                { name: "text", image: "", size: 1, docks: [] },
+                mockBlocksForRename
+            );
+            block.name = "text";
+            block.value = "myAction";
+            block.blockIndex = 0;
+            block.connections = [1];
+            block.label = { value: "myAction", style: { display: "" } };
+            block.text = { text: "" };
+            block.container = { setChildIndex: jest.fn(), children: [] };
+            block.updateCache = jest.fn();
+
+            const cblock = { name: "action", connections: [null, 0] };
+            mockBlocksForRename.blockList[0] = block;
+            mockBlocksForRename.blockList[1] = cblock;
+
+            const originalDocById = global.docById;
+            global.docById = jest.fn().mockReturnValue({ style: {} });
+
+            block._labelChanged(true, true);
+
+            expect(mockBlocksForRename.palettes.updatePalettes).toHaveBeenCalledWith("action");
+            expect(showPalette).toHaveBeenCalledWith("action");
+            expect(removeActionPrototype).not.toHaveBeenCalled();
+
+            global.docById = originalDocById;
+        });
+
+        it("should call findUniqueActionName with parent index and removeActionPrototype when oldValue !== newValue", () => {
+            const showPalette = jest.fn();
+            const removeActionPrototype = jest.fn();
+            const findUniqueActionName = jest.fn().mockImplementation(name => name);
+            const mockBlocksForRename = {
+                activity: { refreshCanvas: jest.fn() },
+                blockList: [],
+                palettes: {
+                    hide: jest.fn(),
+                    show: jest.fn(),
+                    updatePalettes: jest.fn(),
+                    showPalette,
+                    removeActionPrototype,
+                    dict: {
+                        action: { protoList: [] }
+                    }
+                },
+                newNameddoBlock: jest.fn(),
+                findUniqueActionName,
+                setActionProtoVisibility: jest.fn(),
+                renameNameddos: jest.fn(),
+                renameDos: jest.fn(),
+                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
+            };
+
+            const block = new Block(
+                { name: "text", image: "", size: 1, docks: [] },
+                mockBlocksForRename
+            );
+            block.name = "text";
+            block.value = "oldAction";
+            block.blockIndex = 0;
+            block.connections = [1];
+            block.label = { value: "newAction", style: { display: "" } };
+            block.text = { text: "" };
+            block.container = { setChildIndex: jest.fn(), children: [] };
+            block.updateCache = jest.fn();
+
+            const cblock = { name: "action", connections: [null, 0] };
+            mockBlocksForRename.blockList[0] = block;
+            mockBlocksForRename.blockList[1] = cblock;
+
+            const originalDocById = global.docById;
+            global.docById = jest.fn().mockReturnValue({ style: {} });
+
+            block._labelChanged(true, true);
+
+            expect(removeActionPrototype).toHaveBeenCalledWith("oldAction");
+            expect(findUniqueActionName).toHaveBeenCalledWith("newAction", 1);
+            expect(mockBlocksForRename.palettes.updatePalettes).toHaveBeenCalledWith("action");
+            expect(showPalette).toHaveBeenCalledWith("action");
+            expect(mockBlocksForRename.activity.refreshCanvas).toHaveBeenCalled();
+
+            global.docById = originalDocById;
+        });
+
+        it("should NOT call renameNameddos or updatePalettes when closeInput is false", () => {
+            const showPalette = jest.fn();
+            const removeActionPrototype = jest.fn();
+            const findUniqueActionName = jest.fn().mockImplementation(name => name);
+            const mockBlocksForRename = {
+                activity: { refreshCanvas: jest.fn() },
+                blockList: [],
+                palettes: {
+                    hide: jest.fn(),
+                    show: jest.fn(),
+                    updatePalettes: jest.fn(),
+                    showPalette,
+                    removeActionPrototype,
+                    dict: {
+                        action: { protoList: [] }
+                    }
+                },
+                newNameddoBlock: jest.fn(),
+                findUniqueActionName,
+                setActionProtoVisibility: jest.fn(),
+                renameNameddos: jest.fn(),
+                renameDos: jest.fn(),
+                actionMetadata: jest.fn().mockReturnValue({ hasReturn: false, hasArgs: false })
+            };
+
+            const block = new Block(
+                { name: "text", image: "", size: 1, docks: [] },
+                mockBlocksForRename
+            );
+            block.name = "text";
+            block.value = "oldAction";
+            block.blockIndex = 0;
+            block.connections = [1];
+            block.label = { value: "newAction", style: { display: "" } };
+            block.text = { text: "" };
+            block.container = { setChildIndex: jest.fn(), children: [] };
+            block.updateCache = jest.fn();
+
+            const cblock = { name: "action", connections: [null, 0] };
+            mockBlocksForRename.blockList[0] = block;
+            mockBlocksForRename.blockList[1] = cblock;
+
+            const originalDocById = global.docById;
+            global.docById = jest.fn().mockReturnValue({ style: {} });
+
+            block._labelChanged(false, true);
+
+            expect(mockBlocksForRename.renameNameddos).not.toHaveBeenCalled();
+            expect(mockBlocksForRename.palettes.updatePalettes).not.toHaveBeenCalled();
+
+            global.docById = originalDocById;
+        });
     });
 
     describe("loadThumbnail()", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -543,4 +543,80 @@ describe("Blocks Foundation", () => {
             expect(listener).not.toHaveBeenCalled();
         });
     });
+
+    describe("renameNameddos", () => {
+        let blocksInstance;
+
+        beforeEach(() => {
+            mockActivity.palettes.updatePalettes = jest.fn();
+            blocksInstance = new Blocks(mockActivity);
+            mockActivity.palettes.dict["action"] = {
+                protoList: [],
+                remove: jest.fn()
+            };
+        });
+
+        it("should rename blocks using privateData, overrideName, and protoblock.defaults[0] fallbacks", () => {
+            const regenerateArtwork1 = jest.fn();
+            const regenerateArtwork2 = jest.fn();
+            const regenerateArtwork3 = jest.fn();
+
+            const block1 = {
+                name: "nameddo",
+                privateData: "dance",
+                regenerateArtwork: regenerateArtwork1
+            };
+            const block2 = {
+                name: "nameddoArg",
+                privateData: null,
+                overrideName: "dance",
+                regenerateArtwork: regenerateArtwork2
+            };
+            const block3 = {
+                name: "namedcalc",
+                privateData: null,
+                overrideName: null,
+                protoblock: { defaults: ["dance"] },
+                regenerateArtwork: regenerateArtwork3
+            };
+            const block4 = {
+                name: "nameddo",
+                privateData: "other",
+                regenerateArtwork: jest.fn()
+            };
+
+            blocksInstance.blockList = [block1, block2, block3, block4];
+
+            const paletteBlock = {
+                name: "nameddo",
+                defaults: ["dance"]
+            };
+            mockActivity.palettes.dict["action"].protoList.push(paletteBlock);
+
+            blocksInstance.renameNameddos("dance", "jump");
+
+            // Assert block1 updates
+            expect(block1.privateData).toBe("jump");
+            expect(block1.overrideName).toBe("jump");
+            expect(regenerateArtwork1).toHaveBeenCalled();
+
+            // Assert block2 updates
+            expect(block2.privateData).toBe("jump");
+            expect(block2.overrideName).toBe("jump");
+            expect(regenerateArtwork2).toHaveBeenCalled();
+
+            // Assert block3 updates
+            expect(block3.privateData).toBe("jump");
+            expect(block3.overrideName).toBe("jump");
+            expect(block3.protoblock.defaults[0]).toBe("jump");
+            expect(regenerateArtwork3).toHaveBeenCalled();
+
+            // Assert block4 remains unchanged
+            expect(block4.privateData).toBe("other");
+            expect(block4.regenerateArtwork).not.toHaveBeenCalled();
+
+            // Assert palette update
+            expect(paletteBlock.defaults[0]).toBe("jump");
+        });
+    });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -3865,6 +3865,7 @@ class Block {
      */
     _changeLabel() {
         const that = this;
+        this.originalValue = this.value;
         const x = this.container.x;
         const y = this.container.y;
 
@@ -4713,12 +4714,15 @@ class Block {
 
         this._labelLock = true;
 
+        const oldValue = this.originalValue !== undefined ? this.originalValue : this.value;
+
         if (closeInput) {
             this.label.style.display = "none";
             if (this.labelattr !== null) {
                 this.labelattr.style.display = "none";
             }
             docById("wheelDiv").style.display = "none";
+            this.originalValue = undefined;
         }
 
         // The pie menu may be visible too, so hide it.
@@ -4726,7 +4730,6 @@ class Block {
             docById("wheelDiv").style.display = "none";
         }
 
-        const oldValue = this.value;
         let newValue = this.label.value;
 
         if (this.labelattr !== null) {
@@ -4748,7 +4751,12 @@ class Block {
         if (oldValue === newValue) {
             // Nothing to do in this case.
             this._labelLock = false;
-            if (this.name !== "text" || c === null || this.blocks.blockList[c].name !== "storein") {
+            if (
+                this.name !== "text" ||
+                c === null ||
+                (this.blocks.blockList[c].name !== "storein" &&
+                    this.blocks.blockList[c].name !== "action")
+            ) {
                 return;
             }
         }
@@ -4759,10 +4767,12 @@ class Block {
             let uniqueValue;
             switch (cblock.name) {
                 case "action":
-                    this.blocks.palettes.removeActionPrototype(oldValue);
+                    if (oldValue !== newValue) {
+                        this.blocks.palettes.removeActionPrototype(oldValue);
+                    }
 
                     // Ensure new name is unique.
-                    uniqueValue = this.blocks.findUniqueActionName(newValue);
+                    uniqueValue = this.blocks.findUniqueActionName(newValue, c);
                     if (uniqueValue !== newValue) {
                         newValue = uniqueValue;
                         this.value = newValue;
@@ -4923,45 +4933,52 @@ class Block {
             const cblock = this.blocks.blockList[c];
             switch (cblock.name) {
                 case "action":
-                    // If the label was the name of an action, update the
-                    // associated run this.blocks and the palette buttons
-                    // Rename both do <- name and nameddo blocks.
-                    this.blocks.renameDos(oldValue, newValue);
+                    if (oldValue !== newValue && closeInput) {
+                        this.blocks.renameDos(oldValue, newValue);
 
-                    // eslint-disable-next-line no-case-declarations
-                    const metadata = this.blocks.actionMetadata(c);
-                    if (oldValue === _("action") || oldValue === "action") {
-                        this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
-                        this.blocks.setActionProtoVisibility(false);
-                    }
-
-                    this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
-                    // eslint-disable-next-line no-case-declarations
-                    const blockPalette = this.blocks.palettes.dict["action"];
-                    for (let blk = 0; blk < blockPalette.protoList.length; blk++) {
-                        const block = blockPalette.protoList[blk];
+                        const metadata = this.blocks.actionMetadata(c);
                         if (oldValue === _("action") || oldValue === "action") {
-                            if (block.name === "nameddo" && block.defaults.length === 0) {
-                                block.hidden = true;
-                            }
-                        } else {
-                            if (block.name === "nameddo" && block.defaults[0] === oldValue) {
-                                blockPalette.remove(block, oldValue);
+                            this.blocks.newNameddoBlock(
+                                newValue,
+                                metadata.hasReturn,
+                                metadata.hasArgs
+                            );
+                            this.blocks.setActionProtoVisibility(false);
+                        }
+
+                        this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
+                        const blockPalette = this.blocks.palettes.dict["action"];
+                        for (let blk = 0; blk < blockPalette.protoList.length; blk++) {
+                            const block = blockPalette.protoList[blk];
+                            if (oldValue === _("action") || oldValue === "action") {
+                                if (block.name === "nameddo" && block.defaults.length === 0) {
+                                    block.hidden = true;
+                                }
+                            } else {
+                                if (block.name === "nameddo" && block.defaults[0] === oldValue) {
+                                    blockPalette.remove(block, oldValue);
+                                }
                             }
                         }
-                    }
 
-                    if (oldValue === _("action") || oldValue === "action") {
-                        this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
-                        this.blocks.setActionProtoVisibility(false);
+                        if (oldValue === _("action") || oldValue === "action") {
+                            this.blocks.newNameddoBlock(
+                                newValue,
+                                metadata.hasReturn,
+                                metadata.hasArgs
+                            );
+                            this.blocks.setActionProtoVisibility(false);
+                        }
+                        this.blocks.renameNameddos(oldValue, newValue);
+                        this.blocks.palettes.hide();
+                        this.blocks.palettes.updatePalettes("action");
+                        this.blocks.palettes.show();
+                        this.activity.refreshCanvas();
                     }
-                    this.blocks.renameNameddos(oldValue, newValue);
-                    this.blocks.palettes.hide();
-                    this.blocks.palettes.updatePalettes("action");
-                    this.blocks.palettes.show();
                     // Force-open the action palette so the newly created
                     // action block is immediately visible to the user.
                     if (closeInput) {
+                        this.blocks.palettes.updatePalettes("action");
                         this.blocks.palettes.showPalette("action");
                     }
                     break;

--- a/js/block.js
+++ b/js/block.js
@@ -4943,18 +4943,13 @@ class Block {
                                 metadata.hasReturn,
                                 metadata.hasArgs
                             );
-                            this.blocks.setActionProtoVisibility(false);
                         }
 
                         this.blocks.newNameddoBlock(newValue, metadata.hasReturn, metadata.hasArgs);
                         const blockPalette = this.blocks.palettes.dict["action"];
                         for (let blk = 0; blk < blockPalette.protoList.length; blk++) {
                             const block = blockPalette.protoList[blk];
-                            if (oldValue === _("action") || oldValue === "action") {
-                                if (block.name === "nameddo" && block.defaults.length === 0) {
-                                    block.hidden = true;
-                                }
-                            } else {
+                            if (oldValue !== _("action") && oldValue !== "action") {
                                 if (block.name === "nameddo" && block.defaults[0] === oldValue) {
                                     blockPalette.remove(block, oldValue);
                                 }
@@ -4967,7 +4962,6 @@ class Block {
                                 metadata.hasReturn,
                                 metadata.hasArgs
                             );
-                            this.blocks.setActionProtoVisibility(false);
                         }
                         this.blocks.renameNameddos(oldValue, newValue);
                         this.blocks.palettes.hide();

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4127,14 +4127,14 @@ class Blocks {
          * @returns {void}
          */
         this.setActionProtoVisibility = state => {
-            /** By default, the nameddo protoblock is hidden. */
+            /** By default, the nameddo protoblock is hidden, but user requested it to always be visible. */
             const actionsPalette = this.activity.palettes.dict["action"];
             let stateChanged = false;
             for (let blockId = 0; blockId < actionsPalette.protoList.length; blockId++) {
                 const block = actionsPalette.protoList[blockId];
                 if ("nameddo" === block.name && block.defaults.length === 0) {
-                    if (block.hidden === state) {
-                        block.hidden = !state;
+                    if (block.hidden !== false) {
+                        block.hidden = false;
                         stateChanged = true;
                     }
                 }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4488,7 +4488,7 @@ class Blocks {
                     continue;
                 }
                 const blkParent = this.blockList[myBlock.connections[0]];
-                if (blkParent === null) {
+                if (!blkParent) {
                     continue;
                 }
 
@@ -4550,15 +4550,23 @@ class Blocks {
                         this.blockList[blk].name
                     )
                 ) {
-                    if (this.blockList[blk].privateData === oldName) {
-                        this.blockList[blk].privateData = newName;
+                    const block = this.blockList[blk];
+                    const currentName =
+                        block.privateData ||
+                        block.overrideName ||
+                        (block.protoblock && block.protoblock.defaults[0]);
+                    if (currentName === oldName) {
+                        block.privateData = newName;
                         let label = newName;
                         if (getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {
                             label = label.substr(0, STRINGLEN) + "...";
                         }
 
-                        this.blockList[blk].overrideName = label;
-                        this.blockList[blk].regenerateArtwork();
+                        block.overrideName = label;
+                        if (block.protoblock && block.protoblock.defaults) {
+                            block.protoblock.defaults[0] = newName;
+                        }
+                        block.regenerateArtwork();
                     }
                 }
             }


### PR DESCRIPTION
- [x] BUG FIX
fixes #7771 
# Description
## Summary of Changes
This PR fixes a regression where renaming an Action definition block did not update the Action palette instantly and did not propagate the new name to existing Action blocks on the workspace.
### 1. Deferred Renaming & Original Value Capture (`js/block.js`)
* Captured the initial block value (`this.originalValue`) in `_changeLabel` when editing starts.
* Updated `_labelChanged` to evaluate `oldValue` against `this.originalValue` and defer the rename execution logic for case `"action"` until `closeInput === true` (blur or Enter).
* Triggered `this.activity.refreshCanvas()` once at the end of the renaming logic to immediately update the workspace canvas representation.
* Safely cleared `this.originalValue = undefined` when editing completes.
### 2. Workspace Propagation via Metadata Fallbacks (`js/blocks.js`)
* Updated `renameNameddos` to match referencing blocks using their `overrideName` or `protoblock.defaults[0]` properties as fallback metadata when `privateData` is null or undefined (which is true for customized blocks dragged from the palette).
* Propagated the rename to all of these matching reference fields (`privateData`, `overrideName`, and `protoblock.defaults[0]`) to ensure future renaming actions function correctly.
* Safely updated the parent block check in `renameDos` using `if (!blkParent)` to prevent `TypeError` crashes on sparse indices in the `blockList`.
### 3. Unit Tests
* **`js/__tests__/block.test.js`**: Added/updated tests to verify that renaming triggers `updatePalettes`, `showPalette`, and `refreshCanvas` on `closeInput === true`, and correctly defers renaming when `closeInput === false`.
* **`js/__tests__/blocks.test.js`**: Added a test suite to verify that `renameNameddos` resolves block references on the workspace using all fallback metadata checks correctly.



https://github.com/user-attachments/assets/97aa0db2-9b1a-4bae-9820-0fd01b011f33

