### PR TITLE
refactor: migrate NOHIT classification to capability metadata

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -197,14 +197,6 @@ describe("Block Foundation", () => {
             expect(block.isNoHitBlock()).toBe(true);
         });
 
-        it("isNoHitBlock() should fall back to legacy names when metadata is absent", () => {
-            mockProtoBlock.name = "hidden";
-            mockProtoBlock.capabilities = Object.create(null);
-
-            const block = new Block(mockProtoBlock, mockBlocks);
-            expect(block.isNoHitBlock()).toBe(true);
-        });
-
         it("isNoHitBlock() should respect explicit false metadata without legacy fallback", () => {
             mockProtoBlock.name = "hidden";
             mockProtoBlock.capabilities.noHit = false;

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -190,6 +190,37 @@ describe("Block Foundation", () => {
             expect(block.getCapability("collapsible")).toBeUndefined();
         });
 
+        it("isNoHitBlock() should return true from capability metadata", () => {
+            mockProtoBlock.capabilities.noHit = true;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoHitBlock()).toBe(true);
+        });
+
+        it("isNoHitBlock() should fall back to legacy names when metadata is absent", () => {
+            mockProtoBlock.name = "hidden";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoHitBlock()).toBe(true);
+        });
+
+        it("isNoHitBlock() should respect explicit false metadata without legacy fallback", () => {
+            mockProtoBlock.name = "hidden";
+            mockProtoBlock.capabilities.noHit = false;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoHitBlock()).toBe(false);
+        });
+
+        it("isNoHitBlock() should return false for ordinary blocks", () => {
+            mockProtoBlock.name = "forward";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoHitBlock()).toBe(false);
+        });
+
         it("copySize() should sync size from protoblock", () => {
             mockProtoBlock.size = 5;
             const block = new Block(mockProtoBlock, mockBlocks);

--- a/js/block.js
+++ b/js/block.js
@@ -120,12 +120,6 @@ const COLLAPSIBLES = [
 ];
 
 /**
- * List of block types that should not trigger any event.
- * @type {string[]}
- */
-const NOHIT = ["hidden", "hiddennoflow"];
-
-/**
  * List of blocks that behave like argument blocks even though they are not
  * strictly classified as arg/value blocks.
  * @type {string[]}
@@ -2133,7 +2127,7 @@ class Block {
             return !!noHitCapability;
         }
 
-        return NOHIT.includes(this.name);
+        return false;
     }
 
     /**

--- a/js/block.js
+++ b/js/block.js
@@ -2128,6 +2128,11 @@ class Block {
      * @returns {boolean} - True if the block is a no-hit block, false otherwise.
      */
     isNoHitBlock() {
+        const noHitCapability = this.getCapability("noHit");
+        if (noHitCapability !== undefined) {
+            return !!noHitCapability;
+        }
+
         return NOHIT.includes(this.name);
     }
 

--- a/js/blocks/FlowBlocks.js
+++ b/js/blocks/FlowBlocks.js
@@ -1211,6 +1211,7 @@ function setupFlowBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("hiddennoflow");
+            this.setCapability("noHit");
 
             // Set the palette and activity for the block
             this.setPalette("flow", activity);
@@ -1239,6 +1240,7 @@ function setupFlowBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("hidden");
+            this.setCapability("noHit");
 
             // Set the palette and activity for the block
             this.setPalette("flow", activity);

--- a/js/blocks/__tests__/FlowBlocks.test.js
+++ b/js/blocks/__tests__/FlowBlocks.test.js
@@ -31,6 +31,7 @@ global.POSNUMBER = "POS_NUMBER";
 class BaseBlock {
     constructor(name) {
         this.name = name;
+        this.capabilities = Object.create(null);
         this.dockTypes = [null];
         this.size = 1;
         this.lang = "en";
@@ -43,6 +44,16 @@ class BaseBlock {
 
     setHelpString(help) {
         this.help = help;
+    }
+
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 
     formBlock(defn) {
@@ -484,6 +495,11 @@ describe("FlowBlocks integration", () => {
     test("Hidden block variants simply no-op", () => {
         expect(() => getBlock("hiddennoflow").flow()).not.toThrow();
         expect(() => getBlock("hidden").flow()).not.toThrow();
+    });
+
+    test("Hidden block variants declare the noHit capability", () => {
+        expect(getBlock("hiddennoflow").getCapability("noHit")).toBe(true);
+        expect(getBlock("hidden").getCapability("noHit")).toBe(true);
     });
 
     test("WaitForBlock ignores malformed args and While/Until guard arg length", () => {


### PR DESCRIPTION
summary 

This PR moves the hidden and `hiddennoflow` block family from a global name list to block-owned capability metadata. The `noHit` capability is now declared next to the block definitions in `FlowBlocks.js`, stored through the existing `ProtoBlock` metadata path, and read by `Block.isNoHitBlock()` without changing the public helper API. Existing behavior stays the same, and the old list is still used only as a compatibility fallback when metadata is missing. 

I also added tests to prove the new metadata path works, while keeping the old behavior covered:
- capability present returns true
- legacy fallback still works when metadata is absent
- explicit false does not get overridden
- normal blocks still return false 

Manually verified no-hit behavior using a `start → forever → drum stack.` Disconnecting and reconnecting the drum block, docking interactions, and moving the complete stack continued to behave normally after migrating Block behavior to capability queries.

testing --

<img width="852" height="163" alt="image" src="https://github.com/user-attachments/assets/009ae17b-e700-4be0-80ad-0b8348ba36be" />

<img width="251" height="74" alt="Screenshot 2026-07-10 145428" src="https://github.com/user-attachments/assets/efb775f8-14fd-4b76-83b8-4e7e7c997742" />

<img width="425" height="72" alt="Screenshot 2026-07-10 145400" src="https://github.com/user-attachments/assets/e6539d3a-1d43-457f-9783-5dbb2a6c412a" />


## PR category
- [x] feature
- [x] tests