### PR TITLE
fix: handle stopped Transport clock and past-time scheduling

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -37,47 +37,62 @@ global.Synth = jest.fn().mockImplementation(() => ({
     disposeAllInstruments: jest.fn(),
     changeInTemperament: false,
     recorder: null,
-    transport: {
-        get isAvailable() {
-            return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
-        },
-        start() {
-            if (this.isAvailable) global.Tone.Transport.start();
-        },
-        stop() {
-            if (this.isAvailable) global.Tone.Transport.stop();
-        },
-        cancel() {
-            if (this.isAvailable && typeof global.Tone.Transport.cancel === "function") {
-                global.Tone.Transport.cancel();
-            }
-        },
-        clear(id) {
-            if (this.isAvailable && typeof global.Tone.Transport.clear === "function") {
-                global.Tone.Transport.clear(id);
-            }
-        },
-        schedule(callback, time) {
-            if (this.isAvailable && typeof global.Tone.Transport.schedule === "function") {
-                return global.Tone.Transport.schedule(callback, time);
-            }
-            return null;
-        },
-        get seconds() {
-            if (this.isAvailable) return global.Tone.Transport.seconds;
-            return 0;
-        },
-        set seconds(v) {
-            if (this.isAvailable) global.Tone.Transport.seconds = v;
-        },
-        getSecondsAtTime(time) {
-            if (this.isAvailable && typeof global.Tone.Transport.getSecondsAtTime === "function") {
-                return global.Tone.Transport.getSecondsAtTime(time);
-            }
-            return this.seconds;
-        }
-    }
+    transport: createTransportMock()
 }));
+
+/**
+ * Returns a transport mock that mirrors the wrapper in synthutils.js.
+ * Centralised here so both the Synth mock and test-local overrides stay in sync.
+ */
+const createTransportMock = () => ({
+    get isAvailable() {
+        return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
+    },
+    get isClockRunning() {
+        return (
+            this.isAvailable &&
+            typeof global.Tone.context !== "undefined" &&
+            global.Tone.context.state === "running" &&
+            global.Tone.Transport.state === "started"
+        );
+    },
+    start() {
+        if (this.isAvailable) global.Tone.Transport.start();
+    },
+    stop() {
+        if (this.isAvailable) global.Tone.Transport.stop();
+    },
+    cancel() {
+        if (this.isAvailable && typeof global.Tone.Transport.cancel === "function") {
+            global.Tone.Transport.cancel();
+        }
+    },
+    clear(id) {
+        if (this.isAvailable && typeof global.Tone.Transport.clear === "function") {
+            global.Tone.Transport.clear(id);
+        }
+    },
+    schedule(callback, time) {
+        if (this.isAvailable && typeof global.Tone.Transport.schedule === "function") {
+            return global.Tone.Transport.schedule(callback, time);
+        }
+        return null;
+    },
+    get seconds() {
+        if (this.isAvailable) return global.Tone.Transport.seconds;
+        return 0;
+    },
+    set seconds(v) {
+        if (this.isAvailable) global.Tone.Transport.seconds = v;
+    },
+    getSecondsAtTime(time) {
+        if (this.isAvailable && typeof global.Tone.Transport.getSecondsAtTime === "function") {
+            return global.Tone.Transport.getSecondsAtTime(time);
+        }
+        return this.seconds;
+    }
+});
+
 global.Singer = {
     setSynthVolume: jest.fn(),
     setMasterVolume: jest.fn(),
@@ -997,26 +1012,7 @@ describe("Logo doStopTurtles", () => {
                 stopSound: jest.fn(),
                 disposeAllInstruments: jest.fn(),
                 recorder: { state: "recording", stop: jest.fn() },
-                transport: {
-                    get isAvailable() {
-                        return typeof global.Tone !== "undefined" && !!global.Tone.Transport;
-                    },
-                    cancel() {
-                        if (
-                            this.isAvailable &&
-                            typeof global.Tone.Transport.cancel === "function"
-                        ) {
-                            global.Tone.Transport.cancel();
-                        }
-                    },
-                    get seconds() {
-                        if (this.isAvailable) return global.Tone.Transport.seconds;
-                        return 0;
-                    },
-                    set seconds(v) {
-                        if (this.isAvailable) global.Tone.Transport.seconds = v;
-                    }
-                }
+                transport: createTransportMock()
             };
         });
 
@@ -1275,7 +1271,7 @@ describe("Logo runFromBlock", () => {
     });
 
     describe("Transport scheduling", () => {
-        test("uses Transport.schedule when available", () => {
+        test("uses Transport.schedule when available and clock is running", () => {
             const getSecondsAtTimeMock = jest.fn(t => t + 1);
             let scheduledCallback = null;
             const scheduleSpy = jest.fn((fn, time) => {
@@ -1284,6 +1280,7 @@ describe("Logo runFromBlock", () => {
             });
             global.Tone = {
                 ...savedTone,
+                context: { state: "running" },
                 Transport: {
                     start: jest.fn(),
                     stop: jest.fn(),
@@ -1293,7 +1290,10 @@ describe("Logo runFromBlock", () => {
                     get seconds() {
                         return 0;
                     },
-                    set seconds(v) {}
+                    set seconds(v) {},
+                    get state() {
+                        return "started";
+                    }
                 }
             };
 
@@ -1329,6 +1329,114 @@ describe("Logo runFromBlock", () => {
 
             expect(timeoutSpy).toHaveBeenCalled();
             expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("falls back to setTimeout when AudioContext is suspended", () => {
+            global.Tone = {
+                ...savedTone,
+                context: { state: "suspended" },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    schedule: jest.fn(),
+                    cancel: jest.fn(),
+                    getSecondsAtTime: jest.fn(() => 0),
+                    get seconds() {
+                        return 5;
+                    },
+                    set seconds(v) {},
+                    get state() {
+                        return "started";
+                    }
+                }
+            };
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 5;
+            });
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 200;
+            turtle0._transportTime = 10;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            expect(global.Tone.Transport.schedule).not.toHaveBeenCalled();
+            expect(timeoutSpy).toHaveBeenCalled();
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("falls back to setTimeout when Transport clock is stopped", () => {
+            global.Tone = {
+                ...savedTone,
+                context: { state: "running" },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    schedule: jest.fn(),
+                    cancel: jest.fn(),
+                    getSecondsAtTime: jest.fn(() => 0),
+                    get seconds() {
+                        return 3;
+                    },
+                    set seconds(v) {},
+                    get state() {
+                        return "stopped";
+                    }
+                }
+            };
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 5;
+            });
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 200;
+            turtle0._transportTime = 10;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            expect(global.Tone.Transport.schedule).not.toHaveBeenCalled();
+            expect(timeoutSpy).toHaveBeenCalled();
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 3, 1, "x");
+        });
+
+        test("clamps transportTime to prevent scheduling in the past", () => {
+            const scheduleSpy = jest.fn((fn, time) => "evt-clamp");
+            global.Tone = {
+                ...savedTone,
+                context: { state: "running" },
+                Transport: {
+                    start: jest.fn(),
+                    stop: jest.fn(),
+                    schedule: scheduleSpy,
+                    cancel: jest.fn(),
+                    getSecondsAtTime: jest.fn(t => t),
+                    get seconds() {
+                        return 20;
+                    },
+                    set seconds(v) {},
+                    get state() {
+                        return "started";
+                    }
+                }
+            };
+
+            logo.runFromBlockNow = jest.fn();
+            logo.turtleDelay = 0;
+            logo.stopTurtle = false;
+            turtle0.waitTime = 100;
+            turtle0._transportTime = 10;
+
+            logo.runFromBlock(logo, 0, 3, 1, "x");
+
+            const computedTime = 10 + 100 / 1000;
+            expect(computedTime).toBeLessThan(20);
+            expect(scheduleSpy).toHaveBeenCalledWith(expect.any(Function), 20);
         });
     });
 });

--- a/js/logo.js
+++ b/js/logo.js
@@ -1695,9 +1695,13 @@ class Logo {
                 logo.turtleDelay === 0 &&
                 delay > 0 &&
                 logo.synth.transport.isAvailable &&
+                logo.synth.transport.isClockRunning &&
                 tur._transportTime !== null
             ) {
-                const transportTime = tur._transportTime + delay / 1000;
+                const transportTime = Math.max(
+                    tur._transportTime + delay / 1000,
+                    logo.synth.transport.seconds
+                );
                 tur.delayParameters = { blk: blk, flow: isflow, arg: receivedArg };
                 tur._transportEventId = logo.synth.transport.schedule(audioContextTime => {
                     const tur2 = logo.activity.turtles.ithTurtle(turtle);

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -61,7 +61,8 @@ describe("Utility Functions (logic-only)", () => {
         newTone,
         preloadProjectSamples,
         resolveInstrumentName,
-        Synth;
+        Synth,
+        transport;
 
     const turtle = "turtle1";
 
@@ -193,6 +194,7 @@ describe("Utility Functions (logic-only)", () => {
         newTone = Synth.newTone;
         preloadProjectSamples = Synth.preloadProjectSamples;
         resolveInstrumentName = Synth.resolveInstrumentName;
+        transport = Synth.transport;
     });
 
     describe("setupRecorder", () => {
@@ -896,6 +898,11 @@ describe("Utility Functions (logic-only)", () => {
     });
 
     describe("Tone Transport Controls", () => {
+        afterEach(() => {
+            Tone.context.state = "running";
+            Tone.Transport.state = "started";
+        });
+
         test("start should call Tone.Transport.start", () => {
             const startSpy = jest.spyOn(Tone.Transport, "start");
 
@@ -930,6 +937,28 @@ describe("Utility Functions (logic-only)", () => {
 
             startSpy.mockRestore();
             stopSpy.mockRestore();
+        });
+
+        test("isAvailable returns truthy when Tone.Transport exists", () => {
+            expect(transport.isAvailable).toBeTruthy();
+        });
+
+        test("isClockRunning returns true when context is running and transport is started", () => {
+            Tone.context.state = "running";
+            Tone.Transport.state = "started";
+            expect(transport.isClockRunning).toBe(true);
+        });
+
+        test("isClockRunning returns false when context is suspended", () => {
+            Tone.context.state = "suspended";
+            Tone.Transport.state = "started";
+            expect(transport.isClockRunning).toBe(false);
+        });
+
+        test("isClockRunning returns false when transport is stopped", () => {
+            Tone.context.state = "running";
+            Tone.Transport.state = "stopped";
+            expect(transport.isClockRunning).toBe(false);
         });
     });
 

--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -144,10 +144,12 @@ class PolySynth {
 }
 
 class context {
+    static state = "running";
     static resume() {}
 }
 
 class Transport {
+    static _state = "started";
     static start() {}
     static stop() {}
     static schedule() {}
@@ -156,10 +158,19 @@ class Transport {
     static getSecondsAtTime() {
         return 0;
     }
+    static _seconds = 0;
     static get seconds() {
-        return 0;
+        return Transport._seconds;
     }
-    static set seconds(value) {}
+    static set seconds(value) {
+        Transport._seconds = value;
+    }
+    static get state() {
+        return Transport._state;
+    }
+    static set state(v) {
+        Transport._state = v;
+    }
 }
 
 class ToneAudioBuffer {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -472,6 +472,14 @@ const transport = {
     get isAvailable() {
         return typeof Tone !== "undefined" && Tone.Transport;
     },
+    get isClockRunning() {
+        return (
+            this.isAvailable &&
+            typeof Tone.context !== "undefined" &&
+            Tone.context.state === "running" &&
+            Tone.Transport.state === "started"
+        );
+    },
     start() {
         if (this.isAvailable) Tone.Transport.start();
     },


### PR DESCRIPTION
## PR Category

- [X] Bug fix

# What does this PR do?

This PR improves the robustness of the `Tone.Transport` scheduling #7703 path by handling two edge cases that can prevent delayed playback from behaving correctly.

## Changes

### 1. Guard Transport scheduling when the clock is not running

The Transport scheduling path previously checked only `transport.isAvailable`, which indicates that `Tone.Transport` exists but not whether its clock is actively running.

If the `AudioContext` is suspended or `Tone.Transport` has been stopped, delayed events scheduled through `Tone.Transport` may never execute.

This change adds an `isClockRunning` getter to the transport wrapper that verifies:

- `Tone.context.state === "running"`
- `Tone.Transport.state === "started"`

When the Transport clock is not running, scheduling falls back to the existing `setTimeout` implementation.

### 2. Prevent scheduling in the past

`transportTime` is computed from the previously scheduled transport timestamp. Due to timing drift, the computed value can occasionally fall behind the current Transport position.

Scheduling an event in the past can result in immediate execution, causing multiple callbacks to run back-to-back.

This PR clamps the scheduled time to the current Transport position before scheduling:

```js
const transportTime = Math.max(
    tur._transportTime + delay / 1000,
    logo.synth.transport.seconds
);
```

## Files changed

- **`js/utils/synthutils.js`**
  - Add `isClockRunning` and `state` getters to the Transport wrapper.

- **`js/logo.js`**
  - Guard the Transport scheduling path using `isClockRunning`.
  - Clamp `transportTime` to avoid past-time scheduling.

- **`js/utils/__tests__/tonemock.js`**
  - Extend the Tone mock with `context.state` and `Transport.state`.

- **`js/__tests__/logo.test.js`**
  - Add regression tests covering:
    - Suspended `AudioContext`
    - Stopped `Tone.Transport`
    - Past-time scheduling
