### PR TITLE
feat: add ARIA attributes to widget windows for accessibility

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -626,6 +626,47 @@ describe("widgetWindows", () => {
         });
     });
 
+    describe("ARIA dialog and state semantics", () => {
+        test("frame is a focusable dialog labelled by its title element", () => {
+            const win = createTestWindow("My Widget");
+
+            expect(win._frame.getAttribute("tabindex")).toBe("-1");
+            expect(win._frame.getAttribute("aria-labelledby")).toBe(win._key + "WidgetID");
+        });
+
+        test("title bar and widget toolbar expose distinct toolbar roles", () => {
+            const win = createTestWindow();
+
+            expect(win._drag.getAttribute("role")).toBe("toolbar");
+            expect(win._toolbar.getAttribute("role")).toBe("toolbar");
+            expect(win._drag.getAttribute("aria-label")).not.toBe(
+                win._toolbar.getAttribute("aria-label")
+            );
+        });
+
+        test("maximize/restore keep the button aria-label in sync", () => {
+            const win = createTestWindow();
+
+            win._maximize();
+            expect(win._maxminButton.getAttribute("aria-label")).toBe("Restore");
+
+            win._restore();
+            expect(win._maxminButton.getAttribute("aria-label")).toBe("Maximize window");
+        });
+
+        test("rollup/unroll toggle aria-expanded on the roll button", () => {
+            const win = createTestWindow();
+
+            expect(win._rollButton.getAttribute("aria-expanded")).toBe("true");
+
+            win._rollup();
+            expect(win._rollButton.getAttribute("aria-expanded")).toBe("false");
+
+            win.unroll();
+            expect(win._rollButton.getAttribute("aria-expanded")).toBe("true");
+        });
+    });
+
     describe("updateTitle", () => {
         test("updates the title element innerHTML", () => {
             const win = createTestWindow("Old Title");

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -201,8 +201,13 @@ class WidgetWindow {
     _createUIelements() {
         const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
+        this._frame.setAttribute("role", "dialog");
+        this._frame.setAttribute("aria-label", _(this._title));
+        this._frame.setAttribute("tabindex", "-1");
         this._overlayframe = this._create("div", "windowFrame", windows);
         this._drag = this._create("div", "wfTopBar", this._frame);
+        this._drag.setAttribute("role", "toolbar");
+        this._drag.setAttribute("aria-label", _("Window controls"));
         this._drag.style.display = "flex";
         this._drag.style.justifyContent = "space-between";
 
@@ -235,6 +240,7 @@ class WidgetWindow {
         titleEl.replaceChildren();
         titleEl.textContent = _(this._title);
         titleEl.id = `${this._key}WidgetID`;
+        this._frame.setAttribute("aria-labelledby", titleEl.id);
 
         this._nonclose.onmousedown = e => {
             window.widgetWindows.draggingWindow = this;
@@ -306,6 +312,8 @@ class WidgetWindow {
 
         this._body = this._create("div", "wfWinBody", this._frame);
         this._toolbar = this._create("div", "wfbToolbar", this._body);
+        this._toolbar.setAttribute("role", "toolbar");
+        this._toolbar.setAttribute("aria-label", _("Widget toolbar"));
 
         this._widget = this._create("div", "wfbWidget", this._body);
         this._widgetWheelHandler = event => {
@@ -509,6 +517,7 @@ class WidgetWindow {
     updateTitle(title) {
         const wftTitle = docById(this._key + "WidgetID");
         wftTitle.textContent = title;
+        this._frame.setAttribute("aria-label", title);
     }
 
     /**
@@ -539,6 +548,9 @@ class WidgetWindow {
      */
     addButton(icon, iconSize, label, parent) {
         const el = this._create("div", "wfbtItem", parent || this._toolbar);
+        el.setAttribute("role", "button");
+        el.setAttribute("aria-label", label);
+        el.setAttribute("tabindex", "0");
         const img = document.createElement("img");
         img.src = `header-icons/${icon}`;
         img.title = label;
@@ -580,6 +592,7 @@ class WidgetWindow {
      */
     _restore() {
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
+        this._maxminIcon.parentElement.setAttribute("aria-label", _("Maximize window"));
         this._maximized = false;
 
         if (this._savedPos) {
@@ -600,6 +613,7 @@ class WidgetWindow {
      */
     _maximize() {
         this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
+        this._maxminIcon.parentElement.setAttribute("aria-label", _("Restore window"));
         this._maximized = true;
         this.unroll();
         this.takeFocus();
@@ -738,6 +752,8 @@ class WidgetWindow {
     _rollup() {
         this._rolled = true;
         this._body.style.display = "none";
+        this._rollButton.setAttribute("aria-label", _("Expand window"));
+        this._rollButton.setAttribute("aria-expanded", "false");
         return this;
     }
 
@@ -748,8 +764,12 @@ class WidgetWindow {
     unroll() {
         this._rolled = false;
         this._body.style.display = "flex";
-        if (this._rollButton && this._rollButton.classList.contains("plus")) {
-            this._rollButton.classList.remove("plus");
+        if (this._rollButton) {
+            if (this._rollButton.classList.contains("plus")) {
+                this._rollButton.classList.remove("plus");
+            }
+            this._rollButton.setAttribute("aria-label", _("Roll up window"));
+            this._rollButton.setAttribute("aria-expanded", "true");
         }
         return this;
     }

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -278,8 +278,11 @@ class WidgetWindow {
         this._frame = this._create("div", "windowFrame", windows);
         this._frame.setAttribute("role", "dialog");
         this._frame.setAttribute("aria-label", _(this._title));
+        this._frame.setAttribute("tabindex", "-1");
         this._overlayframe = this._create("div", "windowFrame", windows);
         this._drag = this._create("div", "wfTopBar", this._frame);
+        this._drag.setAttribute("role", "toolbar");
+        this._drag.setAttribute("aria-label", _("Window controls"));
         this._drag.style.display = "flex";
         this._drag.style.justifyContent = "space-between";
 
@@ -317,6 +320,7 @@ class WidgetWindow {
         titleEl.replaceChildren();
         titleEl.textContent = _(this._title);
         titleEl.id = `${this._key}WidgetID`;
+        this._frame.setAttribute("aria-labelledby", titleEl.id);
 
         this._nonclose.onmousedown = e => {
             window.widgetWindows.draggingWindow = this;
@@ -335,6 +339,7 @@ class WidgetWindow {
         rollButton.title = _("Minimize");
         rollButton.setAttribute("role", "button");
         rollButton.setAttribute("aria-label", _("Roll up window"));
+        rollButton.setAttribute("aria-expanded", "true");
         rollButton.setAttribute("tabindex", "0");
         rollButton.onclick = e => {
             if (this._rolled) {
@@ -376,6 +381,8 @@ class WidgetWindow {
 
         this._body = this._create("div", "wfWinBody", this._frame);
         this._toolbar = this._create("div", "wfbToolbar", this._body);
+        this._toolbar.setAttribute("role", "toolbar");
+        this._toolbar.setAttribute("aria-label", _("Widget toolbar"));
 
         this._widget = this._create("div", "wfbWidget", this._body);
         this._widgetWheelHandler = event => {
@@ -666,6 +673,7 @@ class WidgetWindow {
         this._maxminIcon.setAttribute("src", "header-icons/icon-expand.svg");
         if (this._maxminButton) {
             this._maxminButton.title = _("Maximize window");
+            this._maxminButton.setAttribute("aria-label", _("Maximize window"));
         }
         this._maximized = false;
 
@@ -689,6 +697,7 @@ class WidgetWindow {
         this._maxminIcon.setAttribute("src", "header-icons/icon-contract.svg");
         if (this._maxminButton) {
             this._maxminButton.title = _("Restore");
+            this._maxminButton.setAttribute("aria-label", _("Restore"));
         }
         this._maximized = true;
         this.unroll();
@@ -833,6 +842,9 @@ class WidgetWindow {
     _rollup() {
         this._rolled = true;
         this._body.style.display = "none";
+        if (this._rollButton) {
+            this._rollButton.setAttribute("aria-expanded", "false");
+        }
         return this;
     }
 
@@ -843,8 +855,11 @@ class WidgetWindow {
     unroll() {
         this._rolled = false;
         this._body.style.display = "flex";
-        if (this._rollButton && this._rollButton.classList.contains("plus")) {
-            this._rollButton.classList.remove("plus");
+        if (this._rollButton) {
+            if (this._rollButton.classList.contains("plus")) {
+                this._rollButton.classList.remove("plus");
+            }
+            this._rollButton.setAttribute("aria-expanded", "true");
         }
         return this;
     }


### PR DESCRIPTION
## Description

This PR adds comprehensive ARIA (Accessible Rich Internet Applications) attributes to widget windows in `widgetWindows.js`. The widget windows are draggable, focusable dialogs used across Music Blocks, but previously lacked semantic ARIA roles and labels, making them inaccessible to screen readers and assistive technologies.

## PR Category

-   [ ] Bug Fix - Fixes a bug or incorrect behavior
-   [x] Feature - Adds new functionality
-   [ ] Performance - Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests - Adds or updates test coverage
-   [ ] Documentation - Updates to docs, comments, or README
-   [ ] Chore / Refactor - Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD - Changes to CI/CD workflows and automation

## Changes Made

-   Added `role="dialog"`, `aria-label`, and `tabindex="-1"` to the widget window frame (`_frame`) so screen readers announce it as a dialog.
-   Added `aria-labelledby` linking the frame to its title element for dynamic label resolution.
-   Added `role="toolbar"` and `aria-label` to both the title bar (`_drag`) and the widget toolbar (`_toolbar`).
-   Added `role="button"`, `aria-label`, and `tabindex="0"` to toolbar buttons created via `addButton()`.
-   `updateTitle()` now also updates the frame's `aria-label` to keep it in sync.
-   `_maximize()` and `_restore()` now update the maximize/restore button's `aria-label` to reflect current state.
-   `_rollup()` and `unroll()` now set `aria-expanded` and update the roll button's `aria-label` to reflect collapsed/expanded state.

## Testing Performed

-   Ran `npx prettier --check js/widgets/widgetWindows.js` - no formatting issues (unchanged).
-   Ran `npx eslint js/widgets/widgetWindows.js` - no lint errors.
-   Ran `npx jest js/widgets/__tests__/widgetWindows.test.js` - all tests passed.
-   Ran full widget test suite (`js/widgets/__tests__/`) - 28/29 suites passed, 1444/1445 tests passed. The single failure (`sampler.test.js › startPitchDetection handles getUserMedia failure`) is a pre-existing issue unrelated to this PR.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.


