### PR TITLE
chore(eslint): disable eqeqeq rule and unused disable directive warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,12 @@ export default [
     },
 
     {
+        linterOptions: {
+            reportUnusedDisableDirectives: "off"
+        }
+    },
+
+    {
         files: ["**/*.js", "**/*.mjs"],
         languageOptions: {
             ecmaVersion: "latest",
@@ -169,7 +175,7 @@ export default [
             "semi": ["error", "always"],
             "no-duplicate-case": "error",
             "no-irregular-whitespace": "warn",
-            "eqeqeq": "warn",
+            "eqeqeq": "off",
             "no-dupe-keys": "error"
         }
     },


### PR DESCRIPTION
## Summary

Disables the `eqeqeq` rule globally in ESLint to eliminate ~350 noise warnings across the codebase. Also disables the reporting of unused disable directives to prevent warnings from existing local `eslint-disable eqeqeq` comments.

Fixes #7306

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [x] CI/CD

## Changes

### ESLint Configuration
- Set `"eqeqeq"` rule to `"off"` in `eslint.config.mjs`.
- Configured `linterOptions: { reportUnusedDisableDirectives: "off" }` in `eslint.config.mjs`.

## Verification
- `npm run lint` — ✅ Passes with zero warnings/errors
