### PR TITLE
#7400 | fix(synth): route effects cleanup through ManagedTimer

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -270,6 +270,7 @@ class Logo {
         // Load the default synthesizer
         this.synth = new this.deps.classes.Synth();
         this.synth.activity = this.activity; // Reference for voice tracking
+        this.synth._timerManager = this._timerManager; // Share timer manager
         this.synth.changeInTemperament = false;
         this._synthsInitialized = false;
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -270,7 +270,6 @@ class Logo {
         // Load the default synthesizer
         this.synth = new this.deps.classes.Synth();
         this.synth.activity = this.activity; // Reference for voice tracking
-        this.synth._timerManager = this._timerManager; // Share timer manager
         this.synth.changeInTemperament = false;
         this._synthsInitialized = false;
 
@@ -353,6 +352,9 @@ class Logo {
                     }
                 };
             }
+        }
+        if (this.synth) {
+            this.synth._timerManager = this._timerManager;
         }
 
         this._graphicsScheduler = new EmbeddedGraphicsScheduler(this);

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1672,6 +1672,69 @@ describe("Utility Functions (logic-only)", () => {
 
             jest.useRealTimers();
         });
+
+        it("should route effects cleanup through setGuardedTimeout when timerManager is available", async () => {
+            const mockTimerManager = {
+                setGuardedTimeout: jest.fn()
+            };
+            const originalTimerManager = Synth._timerManager;
+            Synth._timerManager = mockTimerManager;
+
+            const mockSynth = {
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn(),
+                disconnect: jest.fn(),
+                connect: jest.fn(),
+                chain: jest.fn().mockReturnThis()
+            };
+            Synth.inTemperament = "equal";
+
+            const paramsEffects = {
+                doVibrato: true,
+                vibratoFrequency: 5,
+                vibratoIntensity: 1
+            };
+
+            try {
+                await _performNotes.call(
+                    Synth,
+                    mockSynth,
+                    "C4",
+                    0.25,
+                    paramsEffects,
+                    null,
+                    false,
+                    0
+                );
+
+                expect(mockTimerManager.setGuardedTimeout).toHaveBeenCalledWith(
+                    expect.any(Function),
+                    750,
+                    expect.any(Function)
+                );
+
+                // Extract and test the stop guard function
+                const stopGuardFn = mockTimerManager.setGuardedTimeout.mock.calls[0][2];
+                expect(stopGuardFn()).toBe(false);
+
+                // Mock activity and test stop guard function
+                Synth.activity = {
+                    logo: {
+                        stopTurtle: true
+                    }
+                };
+                expect(stopGuardFn()).toBe(true);
+
+                // Extract and test the cleanup callback
+                const cleanupFn = mockTimerManager.setGuardedTimeout.mock.calls[0][0];
+                cleanupFn();
+                expect(mockSynth.disconnect).toHaveBeenCalled();
+                expect(mockSynth.toDestination).toHaveBeenCalled();
+            } finally {
+                Synth._timerManager = originalTimerManager;
+                Synth.activity = undefined;
+            }
+        });
     });
 });
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2111,7 +2111,11 @@ function Synth() {
                 };
 
                 if (timerManager && typeof timerManager.setGuardedTimeout === "function") {
-                    timerManager.setGuardedTimeout(cleanupFn, beatValue * 1000 + 500, () => false);
+                    timerManager.setGuardedTimeout(cleanupFn, beatValue * 1000 + 500, () =>
+                        Boolean(
+                            this.activity && this.activity.logo && this.activity.logo.stopTurtle
+                        )
+                    );
                 } else {
                     setTimeout(cleanupFn, beatValue * 1000 + 500);
                 }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2071,52 +2071,50 @@ function Synth() {
                     }
                 }
 
-                // Schedule cleanup after the note duration.
-                // A 500 ms safety buffer is added beyond the note duration to prevent
-                // premature disposal caused by audio-clock drift or scheduler jitter,
-                // which would otherwise produce crackling artefacts in long sessions.
-                setTimeout(
-                    () => {
-                        try {
-                            // Dispose of effects
-                            effectsToDispose.forEach(effect => {
-                                if (effect && typeof effect.dispose === "function") {
-                                    effect.dispose();
+                const timerManager =
+                    this._timerManager ||
+                    (this.activity && this.activity.logo && this.activity.logo._timerManager);
+                const cleanupFn = () => {
+                    try {
+                        // Dispose of effects
+                        effectsToDispose.forEach(effect => {
+                            if (effect && typeof effect.dispose === "function") {
+                                effect.dispose();
+                            }
+                        });
+
+                        // Dispose of filters
+                        if (temp_filters.length > 0) {
+                            temp_filters.forEach(filter => {
+                                if (filter && typeof filter.dispose === "function") {
+                                    filter.dispose();
                                 }
                             });
-
-                            // Dispose of filters
-                            if (temp_filters.length > 0) {
-                                temp_filters.forEach(filter => {
-                                    if (filter && typeof filter.dispose === "function") {
-                                        filter.dispose();
-                                    }
-                                });
-                            }
-
-                            // Re-establish the dry path only when no other effects chain
-                            // is still active on this synth; otherwise the direct
-                            // connection would bypass the in-flight chain.
-                            const remaining = (_effectsInFlight.get(synth) || 1) - 1;
-                            _effectsInFlight.set(synth, remaining);
-                            if (
-                                remaining === 0 &&
-                                synth &&
-                                typeof synth.toDestination === "function"
-                            ) {
-                                try {
-                                    synth.disconnect();
-                                } catch (_) {
-                                    // Already disconnected — safe to ignore.
-                                }
-                                synth.toDestination();
-                            }
-                        } catch (e) {
-                            console.debug("Error disposing effects:", e);
                         }
-                    },
-                    beatValue * 1000 + 500
-                );
+
+                        // Re-establish the dry path only when no other effects chain
+                        // is still active on this synth; otherwise the direct
+                        // connection would bypass the in-flight chain.
+                        const remaining = (_effectsInFlight.get(synth) || 1) - 1;
+                        _effectsInFlight.set(synth, remaining);
+                        if (remaining === 0 && synth && typeof synth.toDestination === "function") {
+                            try {
+                                synth.disconnect();
+                            } catch (_) {
+                                // Already disconnected — safe to ignore.
+                            }
+                            synth.toDestination();
+                        }
+                    } catch (e) {
+                        console.debug("Error disposing effects:", e);
+                    }
+                };
+
+                if (timerManager && typeof timerManager.setGuardedTimeout === "function") {
+                    timerManager.setGuardedTimeout(cleanupFn, beatValue * 1000 + 500, () => false);
+                } else {
+                    setTimeout(cleanupFn, beatValue * 1000 + 500);
+                }
             }
         } catch (e) {
             console.error("Error in _performNotes:", e);

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2110,6 +2110,10 @@ function Synth() {
                     }
                 };
 
+                // Schedule cleanup after the note duration.
+                // A 500 ms safety buffer is added beyond the note duration to prevent
+                // premature disposal caused by audio-clock drift or scheduler jitter,
+                // which would otherwise produce crackling artefacts in long sessions.
                 if (timerManager && typeof timerManager.setGuardedTimeout === "function") {
                     timerManager.setGuardedTimeout(cleanupFn, beatValue * 1000 + 500, () =>
                         Boolean(

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -353,7 +353,6 @@ function LegoWidget() {
     this._initAudio = function () {
         // Create a new synthesizer instance
         this.synth = new Synth();
-        this.synth._timerManager = this._timerManager;
         this.synth.loadSamples();
 
         // Create the default electronic synth for all pitch playback

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -353,6 +353,7 @@ function LegoWidget() {
     this._initAudio = function () {
         // Create a new synthesizer instance
         this.synth = new Synth();
+        this.synth._timerManager = this._timerManager;
         this.synth.loadSamples();
 
         // Create the default electronic synth for all pitch playback


### PR DESCRIPTION
## Summary

Replaces raw `setTimeout` inside `_performNotes` in `js/utils/synthutils.js` with `setGuardedTimeout` from `ManagedTimer`. This registers temporary audio effect node cleanups under the centralized timer management system, ensuring they are cancelled when playback is stopped and avoiding errors on disposed audio nodes.

Fixes #7400

## PR Category

- [x] Bug Fix

## Changes

### 1. Synthesizer Utilities
- Replaced raw `setTimeout` in `_performNotes` (`js/utils/synthutils.js`) with `timerManager.setGuardedTimeout` when available, falling back to raw `setTimeout` otherwise.

### 2. Logo & Widgets
- Explicitly passed `_timerManager` to the `Synth` instance in `js/logo.js` and `js/widgets/legobricks.js`.

## Verification
- `npm test` — Passed 6,744/6,744 tests across all 190 suites ✅
- `npm run lint` — Passed cleanly on modified files ✅
