### PR TITLE
fix: add missing arg method to CalcBlock

### DIFF
--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -252,6 +252,30 @@ function setupActionBlocks(activity) {
                 argTypes: ["anyin"]
             });
         }
+        arg(logo, turtle, blk, receivedArg) {
+            const cblk = activity.blocks.blockList[blk].connections[1];
+            if (cblk === null) {
+                activity.errorMsg(NOINPUTERRORMSG, blk);
+                return 0;
+            } else {
+                const name = logo.parseArg(logo, turtle, cblk, blk, receivedArg);
+                if (name in logo.actions) {
+                    activity.turtles.getTurtle(turtle).running = true;
+                    logo.runFromBlockNow(
+                        logo,
+                        turtle,
+                        logo.actions[name],
+                        true,
+                        [],
+                        activity.turtles.getTurtle(turtle).queue.length
+                    );
+                    return logo.returns[turtle].pop();
+                } else {
+                    activity.errorMsg(NOACTIONERRORMSG, blk, name);
+                    return 0;
+                }
+            }
+        }
     }
     /**
      * Represents a Named Calculate block that returns a value calculated by an action.

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -276,6 +276,46 @@ describe("ActionBlocks", () => {
         });
     });
 
+    describe("CalcBlock - arg (new arg method)", () => {
+        test("calls errorMsg when cblk is null", () => {
+            const block = getBlock("calc");
+            activity.blocks.blockList[110] = { connections: [null, null] };
+
+            const result = block.arg(logo, 0, 110, null);
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(NOINPUTERRORMSG, 110);
+            expect(result).toBe(0);
+        });
+
+        test("returns result when action exists", () => {
+            const block = getBlock("calc");
+            activity.blocks.blockList[110] = { connections: [null, "c1"] };
+            logo.parseArg = jest.fn(() => "myAction");
+            logo.actions["myAction"] = [];
+            logo.returns[0] = [100];
+            activity.turtles.getTurtle = jest.fn(() => ({
+                running: false,
+                queue: []
+            }));
+
+            const result = block.arg(logo, 0, 110, null);
+
+            expect(logo.runFromBlockNow).toHaveBeenCalled();
+            expect(result).toBe(100);
+        });
+
+        test("calls errorMsg when action not found", () => {
+            const block = getBlock("calc");
+            activity.blocks.blockList[110] = { connections: [null, "c1"] };
+            logo.parseArg = jest.fn(() => "missingAction");
+
+            const result = block.arg(logo, 0, 110, null);
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(NOACTIONERRORMSG, 110, "missingAction");
+            expect(result).toBe(0);
+        });
+    });
+
     describe("DoBlock", () => {
         test("returns action for execution", () => {
             const block = getBlock("do");


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
The `calculate` block did nothing when used . no value was returned, and the console showed an error: "I do not know how to calc".

## Root Cause
`CalcBlock` (in `js/blocks/ActionBlocks.js`) was missing its `arg()` method entirely. Every other similar block (`CalcArgBlock`, `NamedCalcBlock`, etc.) has an `arg()` method that runs the action and returns its value. `CalcBlock` never had one, so it couldn't calculate anything.

## Fix
Added an `arg()` method to `CalcBlock` that:
- Reads the connected action name
- Runs the action
- Returns its value
- Shows a proper error message if the action name or action is missing

## Testing
1. Open Music Blocks and create an `action` block (leave the default name or rename it, e.g. `action`).
2. Inside the `action` block, place a `return` block and set its value to `100`.
3. Drag a `Start` block onto the canvas.
4. From the Action palette, drag the plain `calculate` block (the one with an empty slot, not the auto-generated named one) and type in the action's name (e.g. `action`).
5. Plug `calculate` into a `print` block, and plug `print` under `Start`.
6. Click the Play button.

## Screenshots
Before
<img width="1680" height="702" alt="image" src="https://github.com/user-attachments/assets/69ef1aac-1e21-409b-ae33-959c86d3205b" />



After
<img width="1867" height="790" alt="image" src="https://github.com/user-attachments/assets/8b66c2d7-7a78-4576-8c4b-aca6dfab6495" />


Also added unit tests in `js/blocks/__tests__/ActionBlocks.test.js` covering:
- Missing input (`cblk === null`) → returns `0` and shows `NOINPUTERRORMSG`
- Valid action → runs the action and returns its value
- Missing/invalid action name → returns `0` and shows `NOACTIONERRORMSG`

All 65 existing and new tests in `ActionBlocks.test.js` pass locally.