### PR TITLE
fix(i18n): localize grid option labels

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4053,18 +4053,17 @@ const piemenuGrid = activity => {
             "imgsrc: images/grid/Tenor.svg",
             "imgsrc: images/grid/Bass.svg"
         ];
-
         gridLabels = [
-            "Blank",
-            "Cartesian",
-            "Cartesian/Polar",
-            "Polar",
-            "Treble",
-            "Grand",
-            "Mezzo Soprano",
-            "Alto",
-            "Tenor",
-            "Bass"
+            _("Blank"),
+            _("Cartesian"),
+            _("Cartesian/Polar"),
+            _("Polar"),
+            _("Treble"),
+            _("Grand"),
+            _("Mezzo Soprano"),
+            _("Alto"),
+            _("Tenor"),
+            _("Bass")
         ];
     }
 


### PR DESCRIPTION
## Summary

This change marks the grid option labels as translatable by wrapping the string literals with `_()`.

## Context

Most tooltips in the project are already passed through the i18n system before being displayed. The grid option labels, however, were defined as plain string literals, so they were not picked up by gettext extraction.

I verified this using `xgettext`

- Wrapping `setTooltip(gridLabels[i])` with `_()` did **not** extract the labels.
- But wrapping the string literals in the `gridLabels` array allowed labels such as `Blank`, `Treble`, and `Grand` to be extracted correctly.

## PR Category

- [x] Bug Fix

This change makes the grid labels available for localization while preserving the existing behavior.