### PR TITLE
refactor: migrate note container classification to metadata

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -213,6 +213,29 @@ describe("Block Foundation", () => {
             expect(block.isNoHitBlock()).toBe(false);
         });
 
+        it("isNoteContainer() should return true from capability metadata", () => {
+            mockProtoBlock.capabilities.noteContainer = true;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(true);
+        });
+
+        it("isNoteContainer() should respect explicit false metadata", () => {
+            mockProtoBlock.name = "newnote";
+            mockProtoBlock.capabilities.noteContainer = false;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(false);
+        });
+
+        it("isNoteContainer() should return false for ordinary blocks", () => {
+            mockProtoBlock.name = "forward";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(false);
+        });
+
         it("copySize() should sync size from protoblock", () => {
             mockProtoBlock.size = 5;
             const block = new Block(mockProtoBlock, mockBlocks);

--- a/js/block.js
+++ b/js/block.js
@@ -2131,6 +2131,19 @@ class Block {
     }
 
     /**
+     * Checks if the block is a note container.
+     * @returns {boolean} - True if the block is a note container, false otherwise.
+     */
+    isNoteContainer() {
+        const noteContainerCapability = this.getCapability("noteContainer");
+        if (noteContainerCapability !== undefined) {
+            return !!noteContainerCapability;
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if the block is an argument block.
      * @returns {boolean} - True if the block is an argument block, false otherwise.
      */

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -90,7 +90,6 @@ function getInlineCollapsiblesSet() {
 const CAMERAVALUE = "##__CAMERA__##";
 const VIDEOVALUE = "##__VIDEO__##";
 
-const NOTEBLOCKS = ["newnote", "osctime"];
 const PITCHBLOCKS = ["pitch", "steppitch", "hertz", "pitchnumber", "nthmodalpitch", "playdrum"];
 
 const ALLOWED_CONNECTIONS = new Set([
@@ -1605,7 +1604,7 @@ class Blocks {
                         oldBlock
                     ]);
                 }
-            } else if (NOTEBLOCKS.includes(this.blockList[parentblk].name)) {
+            } else if (this.blockList[parentblk].isNoteContainer()) {
                 cblk = this.blockList[parentblk].connections[2];
                 if (cblk === null) {
                     const newVspaceBlock = this.makeBlock("vspace", "__NOARG__");
@@ -1644,7 +1643,7 @@ class Blocks {
             let counter = 0;
 
             while (true) {
-                if (NOTEBLOCKS.includes(this.blockList[c].name)) {
+                if (this.blockList[c].isNoteContainer()) {
                     break;
                 }
 
@@ -1777,7 +1776,7 @@ class Blocks {
             } else {
                 while (thisBlockobj.connections[0] !== null) {
                     const i = thisBlockobj.connections[0];
-                    if (NOTEBLOCKS.includes(this.blockList[i].name)) {
+                    if (this.blockList[i].isNoteContainer()) {
                         break;
                     } else if (this.blockList[i].name === "rest2") {
                         const silenceBlock = i;
@@ -4966,7 +4965,7 @@ class Blocks {
                         /** Connection 1 of a note block is not inside the clamp. */
                         return null;
                     } else {
-                        if (NOTEBLOCKS.includes(this.blockList[cblk].name)) {
+                        if (this.blockList[cblk].isNoteContainer()) {
                             return cblk;
                         } else {
                             return null;
@@ -4979,7 +4978,7 @@ class Blocks {
         };
 
         this._isConnectedToNoteValue = blk => {
-            if (NOTEBLOCKS.includes(this.blockList[blk].name)) {
+            if (this.blockList[blk].isNoteContainer()) {
                 return true;
             } else if (this.blockList[blk].connections[0] === null) {
                 return false;

--- a/js/blocks/RhythmBlocks.js
+++ b/js/blocks/RhythmBlocks.js
@@ -67,7 +67,7 @@ function setupRhythmBlocks(activity) {
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -118,7 +118,7 @@ function setupRhythmBlocks(activity) {
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -140,6 +140,7 @@ function setupRhythmBlocks(activity) {
          */
         constructor() {
             super("osctime");
+            this.setCapability("noteContainer");
             this.setPalette("rhythm", activity);
             this.setHelpString([
                 _(
@@ -1115,6 +1116,7 @@ function setupRhythmBlocks(activity) {
          */
         constructor() {
             super("newnote");
+            this.setCapability("noteContainer");
             this.setPalette("rhythm", activity);
             this.beginnerBlock(true);
             this.setHelpString([

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -21,10 +21,15 @@
  */
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
+const Blocks = jest.requireActual("../../blocks");
 
 global._ = s => s;
 global.NOINPUTERRORMSG = "NO_INPUT";
 global.DEFAULTDRUM = "kick";
+global.DEFAULTBLOCKSCALE = 1.0;
+global.COLLAPSIBLES = ["repeat", "forever", "if"];
+global.INLINECOLLAPSIBLES = ["newnote", "interval", "osctime"];
+global.last = arr => (arr && arr.length > 0 ? arr[arr.length - 1] : null);
 global.mixedNumber = jest.fn(val => val);
 global.i18nSolfege = jest.fn(val => val);
 global.Singer = {
@@ -124,6 +129,57 @@ global.BaseBlock = BaseBlock;
 global.FlowBlock = FlowBlock;
 global.FlowClampBlock = FlowClampBlock;
 global.ValueBlock = ValueBlock;
+
+const createBlocksHarness = () => {
+    const blocks = new Blocks({
+        storage: {},
+        trashcan: {},
+        turtles: {},
+        boundary: {},
+        macroDict: {},
+        palettes: {
+            dict: {}
+        },
+        logo: {
+            synth: {
+                loadSynth: jest.fn()
+            }
+        },
+        blocksContainer: { x: 0, y: 0 },
+        canvas: { width: 800, height: 600 },
+        refreshCanvas: jest.fn(),
+        errorMsg: jest.fn(),
+        setSelectionMode: jest.fn(),
+        stopLoadAnimation: jest.fn(),
+        setHomeContainers: jest.fn(),
+        __tick: jest.fn()
+    });
+    blocks.activity = {
+        errorMsg: jest.fn(),
+        palettes: {
+            dict: {}
+        }
+    };
+    blocks.blockList = [];
+    blocks._blockInStack = jest.fn().mockReturnValue(false);
+    blocks.makeBlock = jest.fn((name, value) => {
+        const index = blocks.blockList.length;
+        blocks.blockList.push({
+            name,
+            value,
+            connections: [null, null, null],
+            hide: jest.fn(),
+            trash: false,
+            isNoteContainer: jest.fn().mockReturnValue(false),
+            isExpandableBlock: jest.fn().mockReturnValue(false),
+            isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+            isLeftClampBlock: jest.fn().mockReturnValue(false)
+        });
+        return index;
+    });
+
+    return blocks;
+};
 
 describe("RhythmBlocks", () => {
     let activity;
@@ -873,6 +929,127 @@ describe("RhythmBlocks", () => {
 
         test("osctime declares noteContainer capability", () => {
             expect(getBlock("osctime").getCapability("noteContainer")).toBe(true);
+        });
+    });
+
+    describe("Blocks note-container migration", () => {
+        test("addDefaultBlock() adds vspace and rest2 inside a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                name: "newnote",
+                connections: [null, null, null],
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            blocks.addDefaultBlock(0, 1, false);
+
+            expect(blocks.blockList[0].connections[2]).toBe(1);
+            expect(blocks.blockList[1].name).toBe("vspace");
+            expect(blocks.blockList[1].connections[0]).toBe(0);
+            expect(blocks.blockList[1].connections[1]).toBe(2);
+            expect(blocks.blockList[2].name).toBe("rest2");
+            expect(blocks.blockList[2].connections[0]).toBe(1);
+            expect(blocks.blockList[2].connections[1]).toBeNull();
+        });
+
+        test("deletePreviousDefault() keeps pitch cleanup inside a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks._blockInStack.mockReturnValue(true);
+            blocks.blockList[0] = {
+                name: "rest2",
+                connections: [1, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                name: "newnote",
+                connections: [null, null, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks.deletePreviousDefault(0)).toBe(1);
+        });
+
+        test("deletePreviousDefault() stops when the next ancestor is a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks._blockInStack.mockReturnValue(false);
+            blocks.blockList[0] = {
+                name: "vspace",
+                connections: [1],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                name: "newnote",
+                connections: [null, null, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks.deletePreviousDefault(0)).toBe(1);
+        });
+
+        test("_insideNoteBlock() returns the note container ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [null, 2, 3],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBe(1);
+        });
+
+        test("_insideNoteBlock() returns null for a non-container expandable ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [null, 2, 3],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBeNull();
+        });
+
+        test("_insideNoteBlock() recurses through a non-expandable ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [2],
+                isExpandableBlock: jest.fn().mockReturnValue(false),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[2] = {
+                connections: [null, 3, 4],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBe(2);
         });
     });
 });

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -50,10 +50,21 @@ global.Queue = class Queue {
 class BaseBlock {
     constructor(name) {
         this.name = name;
+        this.capabilities = Object.create(null);
         this.dockTypes = [null];
         this.size = 1;
         this.lang = "en";
         this.hidden = false;
+    }
+
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 
     setPalette(palette) {
@@ -852,6 +863,16 @@ describe("RhythmBlocks", () => {
             listener({});
             expect(turtle.singer.swing.length).toBe(1);
             expect(turtle.singer.swingTarget.length).toBe(1);
+        });
+    });
+
+    describe("noteContainer capability", () => {
+        test("newnote declares noteContainer capability", () => {
+            expect(getBlock("newnote").getCapability("noteContainer")).toBe(true);
+        });
+
+        test("osctime declares noteContainer capability", () => {
+            expect(getBlock("osctime").getCapability("noteContainer")).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Description

This PR migrates the NOTEBLOCKS list to capability metadata.

## Changes
- Added the noteContainer capability to newnote and osctime.
- Added isNoteContainer() helper to Block.
- Updated the existing NOTEBLOCKS checks to use the new helper.
- Removed the old NOTEBLOCKS list.
- Added focused tests for the new capability and helper behavior.
- Kept the existing behavior and tests unchanged.


testing ... 

<img width="365" height="73" alt="Screenshot 2026-07-12 162212" src="https://github.com/user-attachments/assets/c8c341cb-c914-4ac5-a7f1-b13c240ac287" />

<img width="321" height="71" alt="Screenshot 2026-07-12 162252" src="https://github.com/user-attachments/assets/8fa10af9-d8d6-4a85-a180-03827e86e22e" />

<img width="277" height="80" alt="Screenshot 2026-07-12 162344" src="https://github.com/user-attachments/assets/4d528f41-0e9f-45bf-b677-42a4a43fe5d5" />

## PR Category 

- [x] feature 
- [x] tests