### PR TITLE
fix: hover help for grid piemenu

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4054,17 +4054,18 @@ const piemenuGrid = activity => {
             "imgsrc: images/grid/Bass.svg"
         ];
 
+        // Use the same strings as found in ExtraBlocks.js for i18n purposes.
         gridLabels = [
-            "Blank",
+            "none",
             "Cartesian",
             "Cartesian/Polar",
-            "Polar",
-            "Treble",
-            "Grand",
-            "Mezzo Soprano",
-            "Alto",
-            "Tenor",
-            "Bass"
+            "polar",
+            "treble",
+            "grand staff",
+            "mezzo-soprano",
+            "alto",
+            "tenor",
+            "bass"
         ];
     }
 
@@ -4097,7 +4098,7 @@ const piemenuGrid = activity => {
             activity.turtles.currentGrid = i;
             activity.turtles.doGrid(i);
         };
-        activity.turtles.gridWheel.navItems[i].setTooltip(gridLabels[i]);
+        activity.turtles.gridWheel.navItems[i].setTooltip(_(gridLabels[i]));
     }
 
     activity.turtles._exitWheel.colors = platformColor.exitWheelcolors;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4054,7 +4054,7 @@ const piemenuGrid = activity => {
             "imgsrc: images/grid/Bass.svg"
         ];
 
-        // Use the same strings as found in ExtraBlocks.js for i18n purposes.
+        // Use the same strings as found in ExtrasBlocks.js for i18n purposes.
         gridLabels = [
             "none",
             "Cartesian",

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4039,7 +4039,7 @@ const piemenuGrid = activity => {
             ""
         ];
 
-        gridLabels = ["Blank", "Cartesian", "Cartesian/Polar", "Polar", "Blank"];
+        gridLabels = ["none", "Cartesian", "Cartesian/Polar", "polar", "none"];
     } else {
         grids = [
             "imgsrc: images/grid/blank.svg",


### PR DESCRIPTION
There are two problems with hover help in the grid pie menu:

(1) the strings were not being translated; and
(2) the strings did not match the strings in ExtraBlocks.js so even if they were translated, they would not appear in the PO files.

This PR addresses both issues:
(1) the hover text is now wrapped in _() so it is sent through the translation system; and
(2) the list of labels now matches the strings in ExtraBlocks.js so that they are properly translated.

Before:

<img width="249" height="221" alt="image" src="https://github.com/user-attachments/assets/08af00d0-6689-4f30-a3b4-ec9eb2371756" />

After:

<img width="597" height="488" alt="image" src="https://github.com/user-attachments/assets/6b9646e4-7509-4174-a753-806184c8e0cb" />


Testing: Tested in both EN and JA to ensure hover text displays properly and grids are rendered properly.
