### PR TITLE
fix: ensure save filename is not empty string

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -232,10 +232,13 @@ class SaveInterface {
             }
             this.showToast(message);
         };
+
         if (defaultfilename === undefined || defaultfilename === null) {
             const planet = this.getPlanetInterface();
             defaultfilename =
-                planet && typeof planet.getCurrentProjectName === "function"
+                planet &&
+                typeof planet.getCurrentProjectName === "function" &&
+                planet.getCurrentProjectName().length > 0
                     ? planet.getCurrentProjectName()
                     : STR_MY_PROJECT;
 


### PR DESCRIPTION
The save filename was an empty string. This was due to a mistake in logic: zero-length strings were not checked. The solution is to add a test so as to replace a zero-length string with the the default string, "My Project".

Tested in Firefox.

Before:

<img width="567" height="257" alt="image" src="https://github.com/user-attachments/assets/f32eab3f-d59f-432b-b60d-1fc68df3fdcc" />


After:

<img width="567" height="257" alt="image" src="https://github.com/user-attachments/assets/632d8c1b-3bce-42e1-9990-948a3a97683d" />
