### PR TITLE
docs: add missing help strings to setxyturtle and turtlenote blocks

### DIFF
--- a/js/blocks/EnsembleBlocks.js
+++ b/js/blocks/EnsembleBlocks.js
@@ -400,7 +400,13 @@ function setupEnsembleBlocks(activity) {
             if (_THIS_IS_MUSIC_BLOCKS_) {
                 //.TRANS: set xy position for this mouse
                 super("setxyturtle", _("set mouse"));
-                this.setHelpString();
+                this.setHelpString([
+                    _(
+                        "The Set mouse block places the specified mouse at a specific x and y coordinate."
+                    ),
+                    "documentation",
+                    ""
+                ]);
 
                 this.formBlock({
                     args: 3,
@@ -411,7 +417,13 @@ function setupEnsembleBlocks(activity) {
             } else {
                 //.TRANS: set xy position for this turtle
                 super("setxyturtle", _("set turtle"));
-                this.setHelpString();
+                this.setHelpString([
+                    _(
+                        "The Set turtle block places the specified turtle at a specific x and y coordinate."
+                    ),
+                    "documentation",
+                    ""
+                ]);
 
                 this.formBlock({
                     args: 3,


### PR DESCRIPTION
Currently, the active block SetXYTurtleBlock (which renders as set mouse in Music Blocks and set turtle in Turtle Blocks) calls this.setHelpString() with no arguments, resulting in an empty hover/help description in the UI.

This PR adds the appropriate localized descriptions:

Set Mouse: "The Set mouse block places the specified mouse at a specific x and y coordinate."
Set Turtle: "The Set turtle block places the specified turtle at a specific x and y coordinate."
This ensures children and educators get a helpful explanation when inspecting this block in the workspace.

## PR Category

- [x] Documentation
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] CI / CD
- [ ] Chore