### PR TITLE
fix: centralize project name fallback to prevent blank filenames/titles

### DIFF
--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -1340,3 +1340,138 @@ describe("MXML Methods", () => {
         );
     });
 });
+
+describe("project name fallback regression (follow-up to PR #7800)", () => {
+    // These tests wire the real ProjectStorage implementation in as the
+    // `planet` backend (instead of a hand-rolled mock) so the fix is
+    // verified end-to-end: an invalid stored ProjectName must never
+    // surface as a blank filename or blank title in any SaveInterface
+    // export path.
+    const ProjectStorage = require("../../planet/js/ProjectStorage");
+
+    let storage;
+
+    const makeStorageWithName = name => {
+        const s = new ProjectStorage({});
+        s.data = {
+            CurrentProject: "proj1",
+            Projects: {
+                proj1: {
+                    ProjectName: name,
+                    ProjectData: null,
+                    ProjectImage: null,
+                    PublishedData: null,
+                    DateLastModified: 1000
+                }
+            }
+        };
+        return s;
+    };
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        delete window.MBDialog;
+        Object.defineProperty(window, "prompt", {
+            writable: true,
+            value: jest.fn((message, defaultValue) => defaultValue)
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it.each([
+        ["empty string", ""],
+        ["whitespace-only", "   \t  "],
+        ["null", null],
+        ["undefined", undefined]
+    ])("download() falls back to 'My Project' when stored name is %s", (_label, invalidName) => {
+        storage = makeStorageWithName(invalidName);
+        const instance = new SaveInterface({ planet: storage });
+        mockDownloadURL = jest.spyOn(instance, "downloadURL");
+
+        instance.download("png", "data", null);
+
+        expect(mockDownloadURL).toHaveBeenCalledWith("My Project.png", "data");
+    });
+
+    it("download() preserves a valid stored name unchanged", () => {
+        storage = makeStorageWithName("My Song");
+        const instance = new SaveInterface({ planet: storage });
+        mockDownloadURL = jest.spyOn(instance, "downloadURL");
+
+        instance.download("png", "data", null);
+
+        expect(mockDownloadURL).toHaveBeenCalledWith("My Song.png", "data");
+    });
+
+    it("prepareHTML() never embeds a blank project title", () => {
+        storage = makeStorageWithName("");
+        const instance = new SaveInterface({
+            planet: storage,
+            prepareExport: () => "DATA"
+        });
+        instance.htmlSaveTemplate = "<title>{{ project_name }}</title>";
+
+        expect(instance.prepareHTML()).toContain("<title>My Project</title>");
+    });
+
+    it("saveHTMLNoPrompt() never downloads to a blank/dot filename", () => {
+        jest.useFakeTimers();
+        storage = makeStorageWithName("   ");
+        let capturedName = null;
+        const activity = {
+            save: {
+                prepareHTML: () => "<html></html>",
+                downloadURL: name => {
+                    capturedName = name;
+                }
+            },
+            planet: storage
+        };
+
+        const instance = new SaveInterface({ planet: storage });
+        instance.saveHTMLNoPrompt(activity);
+        jest.runAllTimers();
+
+        expect(capturedName).toBe("My Project.html");
+        jest.useRealTimers();
+    });
+
+    it("saveLilypond() populates the modal fileName/title fields with 'My Project' instead of blank", () => {
+        document.body.innerHTML = `
+            <div id="lilypondModal" style="display: none;">
+                <span class="close"></span>
+                <input type="text" id="fileName" value="">
+                <input type="text" id="title" value="">
+                <input type="text" id="author" value="">
+                <input type="checkbox" id="MIDICheck">
+                <input type="checkbox" id="guitarCheck">
+                <button id="submitLilypond"></button>
+                <div id="fileNameText"></div>
+                <div id="titleText"></div>
+                <div id="authorText"></div>
+                <div id="MIDIText"></div>
+                <div id="guitarText"></div>
+            </div>
+        `;
+        global.docById = jest.fn(id => document.getElementById(id));
+        global.docByClass = jest.fn(cls => document.getElementsByClassName(cls));
+
+        storage = makeStorageWithName("");
+        const activity = {
+            planet: storage,
+            storage: { getItem: () => null, setItem: () => {} },
+            logo: { recordingBuffer: { hasData: false } },
+            save: { saveLYFile: jest.fn() }
+        };
+
+        const instance = new SaveInterface(activity);
+        instance.saveLilypond(activity);
+
+        expect(document.getElementById("fileName").value).toBe("My Project.ly");
+        expect(document.getElementById("title").value).toBe("My Project");
+    });
+});

--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -191,11 +191,16 @@ describe("PlanetInterface", () => {
     });
 
     // Regression test for #7350: when running from file:///index.html,
-    // planet.planet is null so getCurrentProjectName() must return ""
-    // to prevent _afterDelete from entering the Planet branch.
-    test("getCurrentProjectName returns empty string when inner Planet is null (#7350)", () => {
+    // planet.planet is null. _afterDelete no longer relies on the return
+    // value of getCurrentProjectName() to skip the Planet branch (it checks
+    // that.planet.planet !== null directly), so it is safe for this getter
+    // to fall back to the default project name like every other caller.
+    test("getCurrentProjectName returns the default project name when inner Planet is null (#7350)", () => {
+        const saved_ = global._;
+        global._ = jest.fn(str => str);
         planetInterface.planet = null;
-        expect(planetInterface.getCurrentProjectName()).toBe("");
+        expect(planetInterface.getCurrentProjectName()).toBe("My Project");
+        global._ = saved_;
     });
 
     test("loadProjectFromData: default merge=false", () => {
@@ -512,10 +517,13 @@ describe("PlanetInterface", () => {
     });
 
     it("project getters return safe defaults when Planet storage is unavailable", () => {
+        const saved_ = global._;
+        global._ = jest.fn(str => str);
         planetInterface.planet = null;
-        expect(planetInterface.getCurrentProjectName()).toBe("");
+        expect(planetInterface.getCurrentProjectName()).toBe("My Project");
         expect(planetInterface.getCurrentProjectDescription()).toBe("");
         expect(planetInterface.getCurrentProjectImage()).toBeNull();
         expect(planetInterface.getTimeLastSaved()).toBeNull();
+        global._ = saved_;
     });
 });

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -333,7 +333,7 @@ class PlanetInterface {
         this.getCurrentProjectName = () => {
             const projectStorage = this._getProjectStorage();
             if (!projectStorage || typeof projectStorage.getCurrentProjectName !== "function") {
-                return "";
+                return _("My Project");
             }
 
             return projectStorage.getCurrentProjectName();

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -84,7 +84,8 @@ class ProjectStorage {
 
     getCurrentProjectName() {
         const c = this.data.CurrentProject;
-        return this.data.Projects[c]?.ProjectName ?? this.defaultProjectName;
+        const name = this.data.Projects[c]?.ProjectName;
+        return typeof name === "string" && name.trim().length > 0 ? name : this.defaultProjectName;
     }
 
     getCurrentProjectDescription() {

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -456,6 +456,31 @@ describe("ProjectStorage", () => {
             expect(storage.getCurrentProjectName()).toBe("My Project");
         });
 
+        it("getCurrentProjectName should return default for an empty string name", () => {
+            storage.data.Projects["proj1"].ProjectName = "";
+            expect(storage.getCurrentProjectName()).toBe("My Project");
+        });
+
+        it("getCurrentProjectName should return default for a whitespace-only name", () => {
+            storage.data.Projects["proj1"].ProjectName = "   \t  ";
+            expect(storage.getCurrentProjectName()).toBe("My Project");
+        });
+
+        it("getCurrentProjectName should return default for a null name", () => {
+            storage.data.Projects["proj1"].ProjectName = null;
+            expect(storage.getCurrentProjectName()).toBe("My Project");
+        });
+
+        it("getCurrentProjectName should return default for an undefined name", () => {
+            storage.data.Projects["proj1"].ProjectName = undefined;
+            expect(storage.getCurrentProjectName()).toBe("My Project");
+        });
+
+        it("getCurrentProjectName should preserve a valid name with surrounding whitespace", () => {
+            storage.data.Projects["proj1"].ProjectName = "  Song A  ";
+            expect(storage.getCurrentProjectName()).toBe("  Song A  ");
+        });
+
         it("getCurrentProjectID should return current project ID", () => {
             expect(storage.getCurrentProjectID()).toBe("proj1");
         });


### PR DESCRIPTION
## Summary

This PR follows the same principle as #7796 by moving shared logic to a single source of truth instead of fixing individual call sites.

While #7796 centralized grid hover-help strings by reusing the existing translation strings from `ExtrasBlocks.js`, this PR centralizes project name fallback handling by making `ProjectStorage.getCurrentProjectName()` always return a valid project name.

## What Changed

- Updated `ProjectStorage.getCurrentProjectName()` to return the default project name when the stored name is:
  - `null`
  - `undefined`
  - an empty string (`""`)
  - a whitespace-only string
- Updated `PlanetInterface.getCurrentProjectName()` to return the same default when Planet storage is not yet initialized.
- Added regression tests covering empty, whitespace-only, `null`, `undefined`, and valid project names.
- Updated the existing `_afterDelete()` regression test to reflect the new behavior.

## Why

PR #7800 addressed one occurrence of this issue by adding fallback logic in `download()`. However, the same project name is used in multiple other places, allowing blank names to surface elsewhere.

By centralizing the fallback in `ProjectStorage.getCurrentProjectName()`, every caller receives a valid project name without duplicating validation logic, making future maintenance easier and preventing similar inconsistencies.

## Testing

- Added regression tests for all invalid project name cases.
- Verified save/export flows continue to work correctly.
- Confirmed all existing tests pass.