### PR TITLE
docs: remove outdated keyboard shortcut for note block creation

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -3591,12 +3591,6 @@ class Activity {
                         {
                             keys: platformKeys("Esc", "Esc"),
                             action: _("Hide block search when it is open")
-                        },
-                        {
-                            keys: platformKeys("d,r,m,f,s,l,t", "d,r,m,f,s,l,t"),
-                            action: _(
-                                "You can type d to create a do block and r to create a re block etc."
-                            )
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

This PR removes an outdated keyboard shortcut entry from the **Keyboard Shortcuts** dialog.

The dialog currently documents that pressing **`d`, `r`, `m`, `f`, `s`, `l`, `t`** creates the corresponding note blocks (do, re, mi, fa, sol, la, ti). However, these shortcuts are not implemented anywhere in the current codebase, making the documentation misleading.

This change updates the help dialog so that it accurately reflects the application's current behavior. No keyboard handling logic is modified.

## Changes

- Remove the outdated `d, r, m, f, s, l, t` keyboard shortcut entry from the Keyboard Shortcuts dialog.
- Leave all remaining documented shortcuts unchanged.
- No functional or behavioral changes.

## Testing

- Open the **Keyboard Shortcuts** dialog.
- Verify the outdated `d, r, m, f, s, l, t` entry is no longer displayed.
- Verify all other keyboard shortcuts remain unchanged.
- Confirm keyboard behavior is unchanged.

## Notes

This is a documentation-only change. It does not introduce or remove any functionality; it simply updates the help dialog to match the current implementation.