### PR TITLE
fix: guard localStorage access in ProjectStorage.port()

### DIFF
--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -283,7 +283,12 @@ class ProjectStorage {
     }
 
     async port() {
-        const oldProjectData = localStorage.getItem(this.LocalStorageKey);
+        let oldProjectData = null;
+        try {
+            oldProjectData = localStorage.getItem(this.LocalStorageKey);
+        } catch (e) {
+            console.debug("localStorage unavailable during port(); skipping legacy read.", e);
+        }
         const isPortedAlready = await this.get(this.VersionKey);
         if (isPortedAlready !== this.Version) {
             // port

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -267,6 +267,77 @@ describe("ProjectStorage", () => {
         });
     });
 
+    describe("port()", () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("should port legacy localStorage data when not already ported", async () => {
+            jest.spyOn(Storage.prototype, "getItem").mockReturnValueOnce(
+                JSON.stringify({ Projects: { legacy: { ProjectName: "Old Project" } } })
+            );
+
+            await storage.port();
+
+            const ported = await storage.get(storage.LocalStorageKey);
+            expect(ported).toEqual(
+                JSON.stringify({ Projects: { legacy: { ProjectName: "Old Project" } } })
+            );
+
+            const version = await storage.get(storage.VersionKey);
+            expect(version).toBe(storage.Version);
+        });
+
+        it("should not re-port if already at current version", async () => {
+            await storage.set(storage.VersionKey, storage.Version);
+            const setSpy = jest.spyOn(storage, "set");
+
+            await storage.port();
+
+            expect(setSpy).not.toHaveBeenCalledWith(storage.LocalStorageKey, expect.anything());
+        });
+
+        it("should not throw when localStorage.getItem throws (restricted environment)", async () => {
+            const consoleSpy = jest.spyOn(console, "debug").mockImplementation();
+            jest.spyOn(Storage.prototype, "getItem").mockImplementationOnce(() => {
+                throw new Error("SecurityError: localStorage is disabled");
+            });
+
+            await expect(storage.port()).resolves.not.toThrow();
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                "localStorage unavailable during port(); skipping legacy read.",
+                expect.any(Error)
+            );
+        });
+
+        it("should still set version key after a guarded localStorage failure", async () => {
+            jest.spyOn(Storage.prototype, "getItem").mockImplementationOnce(() => {
+                throw new Error("SecurityError: localStorage is disabled");
+            });
+
+            await storage.port();
+
+            const version = await storage.get(storage.VersionKey);
+            expect(version).toBe(storage.Version);
+        });
+
+        it("should not crash init() when localStorage is unavailable throughout startup", async () => {
+            global.localforage = mockLocalforage; // init() reassigns this.LocalStorage from the global
+            Storage.prototype.getItem = jest.fn(() => {
+                throw new Error("SecurityError: localStorage is disabled");
+            });
+            jest.spyOn(console, "debug").mockImplementation();
+
+            try {
+                await expect(storage.init()).resolves.not.toThrow();
+                expect(storage.data).not.toBeNull();
+            } finally {
+                global.localforage = null;
+            }
+        });
+    });
+
     describe("initialiseStorage()", () => {
         it("should initialize empty data structure on first run", async () => {
             storage.data = null;


### PR DESCRIPTION
## PR Category
- [x] Bug Fix

## Problem
Planet init can fail in restricted environments because `ProjectStorage.port()` reads `localStorage` directly, with no protection. If browser policy or privacy settings block storage access, `localStorage.getItem()` throws synchronously and the whole Planet startup flow gets aborted before any recovery logic can run.

Fixes #6926.

## Root Cause
Inside `port()` in `planet/js/ProjectStorage.js`:
```js
const oldProjectData = localStorage.getItem(this.LocalStorageKey);
```
This line assumes `localStorage` is always reachable. In enterprise-locked browsers, sandboxed/iframed contexts, or hardened privacy profiles, this access can throw instead of just returning `null`. Since `init()` awaits `port()` directly, that thrown error bubbles all the way up and kills Planet initialization ,  local projects become unreachable and the user never even gets to the fallback/restore logic that exists further down.

## Fix
Wrapped the `localStorage.getItem()` call in a try/catch. If it throws, we treat it the same as "no legacy data to port" (`oldProjectData` stays `null`) and let the rest of `port()` continue normally ,  the version key still gets set, and `init()` proceeds to `restore()`/`initialiseStorage()` as usual instead of crashing.