### PR TITLE
fix: clear pending playback timeouts on Pitch Staircase close

### DIFF
--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -719,6 +719,13 @@ class PitchStaircase {
         widgetWindow.show();
         widgetWindow.onclose = () => {
             this.closed = true;
+            clearTimeout(this._rowStopTimeout);
+            clearTimeout(this._playAllTimeout);
+            clearTimeout(this._scaleTimeout);
+            this._scaleStopped = true;
+            this._isPlayingAll = false;
+            this._isPlayingScale = false;
+            this._playingRowIndex = null;
             this.activity.logo.synth.stop();
             // Restore the project's master volume so audio still works
             // after exiting mid-playback (was incorrectly left at PREVIEWVOLUME).


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation


## Problem
On reopening the Pitch Staircase widget shortly after closing it during scale playback, sound played automatically with no click from the user.

## Root Cause
`PitchStaircase` is a singleton reused across every open/close cycle. Playback (`_playOne`, `_playAll`, `playUpAndDown`/`_playNext`) schedules sound via `setTimeout` chains that check `this.closed` before triggering each note. The `onclose` handler set `this.closed = true` but never cancelled these pending timeouts (`_rowStopTimeout`, `_playAllTimeout`, `_scaleTimeout`), leaving them dangling. If the widget was reopened before a dangling timeout fired, `init()` reset `this.closed = false` again on the same instance, so the stale timeout's guard passed and it fired `synth.trigger(...)`, playing sound with no user interaction.

## Fix
In the `onclose` handler, clear all pending playback timeouts and reset the related state flags before destroying the widget:
- `clearTimeout(this._rowStopTimeout)`
- `clearTimeout(this._playAllTimeout)`
- `clearTimeout(this._scaleTimeout)`
- `this._scaleStopped = true;`
- `this._isPlayingAll = false;`
- `this._isPlayingScale = false;`
- `this._playingRowIndex = null;`

This ensures no timer left over from a previous session can fire sound after the widget is reopened.

## Testing
1. Open Pitch Staircase widget.
2. Click play scale.
3. Close the widget immediately, while it's still playing.
4. Reopen the Pitch Staircase widget immediately.
5. Before fix: a note plays automatically with no click. After fix: nothing plays until Play/Play chord/Play scale is clicked again.
6. Verified normal playback (single row, chord, scale, stop mid-scale) still works as expected.