### PR TITLE
chore: update formatting and CSS tooling dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@tonejs/midi": "^2.0.28",
                 "abcjs": "6.3.0",
-                "autoprefixer": "^10.5.0",
+                "autoprefixer": "10.5.2",
                 "compression": "^1.8.1",
                 "cssnano": "^7.1.9",
                 "express": "5.2.1",
@@ -27,8 +27,8 @@
                 "jquery": "3.7.1",
                 "jquery-ui-dist": "1.12.1",
                 "materialize-css": "0.100.2",
-                "postcss": "^8.5.14",
-                "sass": "^1.98.0",
+                "postcss": "8.5.18",
+                "sass": "1.101.0",
                 "tone": "^15.1.22"
             },
             "devDependencies": {
@@ -54,7 +54,7 @@
                 "jest-environment-jsdom": "^30.4.1",
                 "lint-staged": "^15.5.2",
                 "nodemon": "^3.1.9",
-                "prettier": "^3.8.3"
+                "prettier": "3.9.5"
             },
             "engines": {
                 "node": "^20.0.0"
@@ -3469,9 +3469,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3491,9 +3488,6 @@
             "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3515,9 +3509,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3537,9 +3528,6 @@
             "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3561,9 +3549,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3583,9 +3568,6 @@
             "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4476,7 +4458,9 @@
             "license": "0BSD"
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.0",
+            "version": "10.5.2",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+            "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4493,8 +4477,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.2",
-                "caniuse-lite": "^1.0.30001787",
+                "browserslist": "^4.28.4",
+                "caniuse-lite": "^1.0.30001799",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -4726,7 +4710,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.32",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -4900,7 +4886,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4917,10 +4905,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -5114,7 +5102,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
+            "version": "1.0.30001805",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6490,7 +6480,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.361",
+            "version": "1.5.389",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -11201,7 +11193,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.46",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -11779,7 +11773,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
+            "version": "8.5.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+            "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -12224,7 +12220,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+            "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -12866,7 +12864,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.100.0",
+            "version": "1.101.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+            "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
         "dist": "electron-builder"
     },
     "devDependencies": {
-        "@commitlint/cli": "^19.0.0",
-        "@commitlint/config-conventional": "^19.0.0",
         "@babel/core": "^7.28.5",
         "@babel/eslint-parser": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
+        "@commitlint/cli": "^19.0.0",
+        "@commitlint/config-conventional": "^19.0.0",
         "cross-env": "^7.0.3",
         "cypress": "^15.15.0",
         "electron": "40.8.5",
@@ -52,12 +52,12 @@
         "jest-environment-jsdom": "^30.4.1",
         "lint-staged": "^15.5.2",
         "nodemon": "^3.1.9",
-        "prettier": "^3.8.3"
+        "prettier": "3.9.5"
     },
     "dependencies": {
         "@tonejs/midi": "^2.0.28",
         "abcjs": "6.3.0",
-        "autoprefixer": "^10.5.0",
+        "autoprefixer": "10.5.2",
         "compression": "^1.8.1",
         "cssnano": "^7.1.9",
         "express": "5.2.1",
@@ -73,8 +73,8 @@
         "jquery": "3.7.1",
         "jquery-ui-dist": "1.12.1",
         "materialize-css": "0.100.2",
-        "postcss": "^8.5.14",
-        "sass": "^1.98.0",
+        "postcss": "8.5.18",
+        "sass": "1.101.0",
         "tone": "^15.1.22"
     },
     "build": {


### PR DESCRIPTION
Updates formatting and CSS tooling dependencies to their latest compatible versions.

Dependency updates:
- Prettier: 3.8.3 → 3.9.5
- Autoprefixer: 10.5.0 → 10.5.2
- PostCSS: 8.5.14 → 8.5.18
- Sass: 1.98.0 → 1.101.0

## PR Category

- [x] Chore