### PR TITLE
fix: stop button audio in pitch staircase

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -746,6 +746,7 @@ describe("PitchStaircase Widget", () => {
             mockSynth = {
                 trigger: jest.fn(),
                 stop: jest.fn(),
+                stopSound: jest.fn(),
                 setMasterVolume: jest.fn()
             };
 
@@ -783,81 +784,57 @@ describe("PitchStaircase Widget", () => {
         });
 
         test("row click mid-play should stop row and synth", () => {
-            // First click plays
             psc.Stairs = [["A", "", 220.0]];
-            psc._stepTables = [{ rows: [{ cells: [null, mockStepCell] }] }];
+            psc.init({
+                logo: { synth: mockSynth },
+                textMsg: jest.fn(),
+                palettes: { dict: {} }
+            });
 
-            // Re-bind onclick handler mock logic in init or manually as in _makeStairs
-            const playCellClick = () => {
-                const i = Number(mockPlayCell.getAttribute("id"));
-                const stepCell = psc._stepTables[i].rows[0].cells[1];
-                if (psc._playingRowIndex === i) {
-                    clearTimeout(psc._rowStopTimeout);
-                    stepCell.classList.remove("active");
-                    stepCell.style.backgroundColor = "";
-                    psc._setButtonIcon(mockPlayCell, "play-button.svg", _("Play"));
-                    psc.activity.logo.synth.stop();
-                    psc._playingRowIndex = null;
-                } else {
-                    psc._playOne(stepCell, mockPlayCell);
-                }
-            };
+            const playCell = psc._stepTables[0].rows[0].cells[0];
+            playCell.setAttribute("id", "0");
+            playCell.replaceChildren = jest.fn();
 
             // Play the row
-            playCellClick();
+            playCell.onclick();
             expect(mockSynth.trigger).toHaveBeenCalled();
             expect(psc._playingRowIndex).toBe(0);
 
             // Click again to stop
-            mockPlayCell.replaceChildren.mockClear();
-            playCellClick();
+            playCell.replaceChildren.mockClear();
+            mockSynth.stopSound.mockClear();
+            playCell.onclick();
 
-            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE, 220);
+            expect(mockSynth.stop).not.toHaveBeenCalled();
             expect(psc._playingRowIndex).toBeNull();
-            let img = mockPlayCell.replaceChildren.mock.calls[0][1];
+            let img = playCell.replaceChildren.mock.calls[0][0];
             expect(img.getAttribute("src")).toBe("header-icons/play-button.svg");
         });
 
         test("_playAll and header button click mid-play should play and stop", () => {
             psc.Stairs = [["A", "", 220.0]];
-            psc._stepTables = [{ rows: [{ cells: [null, mockStepCell] }] }];
-
-            const mockHeaderButton = {
-                replaceChildren: jest.fn(),
-                classList: {
-                    contains: jest.fn().mockReturnValue(false)
-                }
-            };
-            psc._playAllButton = mockHeaderButton;
-
-            const playAllClick = () => {
-                if (psc._isPlayingAll) {
-                    clearTimeout(psc._playAllTimeout);
-                    for (let i = 0; i < psc.Stairs.length; i++) {
-                        const stepCell = psc._stepTables[i].rows[0].cells[1];
-                        stepCell.classList.remove("active");
-                    }
-                    psc._setButtonIcon(psc._playAllButton, "play-chord.svg", _("Play chord"));
-                    psc.activity.logo.synth.stop();
-                    psc._isPlayingAll = false;
-                } else {
-                    psc._playAll();
-                }
-            };
+            psc.init({
+                logo: { synth: mockSynth },
+                textMsg: jest.fn(),
+                palettes: { dict: {} }
+            });
 
             // Start playing chord
-            playAllClick();
+            psc._playAllButton.onclick();
             expect(mockSynth.trigger).toHaveBeenCalled();
             expect(psc._isPlayingAll).toBe(true);
-            let img1 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            let img1 = psc._playAllButton.replaceChildren.mock.calls[0][0];
             expect(img1.getAttribute("src")).toBe("header-icons/stop-button.svg");
 
             // Stop playing chord
-            mockHeaderButton.replaceChildren.mockClear();
-            playAllClick();
-            expect(mockSynth.stop).toHaveBeenCalled();
+            psc._playAllButton.replaceChildren.mockClear();
+            mockSynth.stopSound.mockClear();
+            psc._playAllButton.onclick();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE);
+            expect(mockSynth.stop).not.toHaveBeenCalled();
             expect(psc._isPlayingAll).toBe(false);
-            let img2 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            let img2 = psc._playAllButton.replaceChildren.mock.calls[0][0];
             expect(img2.getAttribute("src")).toBe("header-icons/play-chord.svg");
         });
 
@@ -866,48 +843,28 @@ describe("PitchStaircase Widget", () => {
                 ["A", "", 220.0],
                 ["B", "", 240.0]
             ];
-            const mockRowA = { cells: [null, mockStepCell] };
-            const mockRowB = { cells: [null, mockStepCell] };
-            psc._stepTables = [{ rows: [mockRowA] }, { rows: [mockRowB] }];
-
-            const mockHeaderButton = {
-                replaceChildren: jest.fn(),
-                classList: {
-                    contains: jest.fn().mockReturnValue(false)
-                }
-            };
-            psc._playScaleButton = mockHeaderButton;
-
-            const playScaleClick = () => {
-                if (psc._isPlayingScale) {
-                    psc._scaleStopped = true;
-                    clearTimeout(psc._scaleTimeout);
-                    for (let i = 0; i < psc.Stairs.length; i++) {
-                        const stepCell = psc._stepTables[i].rows[0].cells[1];
-                        stepCell.classList.remove("active");
-                    }
-                    psc._setButtonIcon(psc._playScaleButton, "play-scale.svg", _("Play scale"));
-                    psc.activity.logo.synth.stop();
-                    psc._isPlayingScale = false;
-                } else {
-                    psc.playUpAndDown();
-                }
-            };
+            psc.init({
+                logo: { synth: mockSynth },
+                textMsg: jest.fn(),
+                palettes: { dict: {} }
+            });
 
             // Start playing scale
-            playScaleClick();
+            psc._playScaleButton.onclick();
             expect(mockSynth.trigger).toHaveBeenCalled();
             expect(psc._isPlayingScale).toBe(true);
-            let img1 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            let img1 = psc._playScaleButton.replaceChildren.mock.calls[0][0];
             expect(img1.getAttribute("src")).toBe("header-icons/stop-button.svg");
 
             // Stop playing scale
-            mockHeaderButton.replaceChildren.mockClear();
-            playScaleClick();
-            expect(mockSynth.stop).toHaveBeenCalled();
+            psc._playScaleButton.replaceChildren.mockClear();
+            mockSynth.stopSound.mockClear();
+            psc._playScaleButton.onclick();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE);
+            expect(mockSynth.stop).not.toHaveBeenCalled();
             expect(psc._isPlayingScale).toBe(false);
             expect(psc._scaleStopped).toBe(true);
-            let img2 = mockHeaderButton.replaceChildren.mock.calls[0][0];
+            let img2 = psc._playScaleButton.replaceChildren.mock.calls[0][0];
             expect(img2.getAttribute("src")).toBe("header-icons/play-scale.svg");
         });
 
@@ -933,9 +890,9 @@ describe("PitchStaircase Widget", () => {
             expect(psc._playAllButton.replaceChildren).toHaveBeenCalled();
 
             // Stop playing all
-            mockSynth.stop.mockClear();
+            mockSynth.stopSound.mockClear();
             psc._playAllButton.onclick();
-            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE);
             expect(psc._isPlayingAll).toBe(false);
 
             // 2. Play Scale Button
@@ -945,9 +902,9 @@ describe("PitchStaircase Widget", () => {
             expect(psc._isPlayingScale).toBe(true);
 
             // Stop playing scale
-            mockSynth.stop.mockClear();
+            mockSynth.stopSound.mockClear();
             psc._playScaleButton.onclick();
-            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE);
             expect(psc._isPlayingScale).toBe(false);
             expect(psc._scaleStopped).toBe(true);
         });
@@ -982,9 +939,9 @@ describe("PitchStaircase Widget", () => {
             expect(psc._playingRowIndex).toBe(0);
 
             // Stop playing row
-            mockSynth.stop.mockClear();
+            mockSynth.stopSound.mockClear();
             playCell.onclick();
-            expect(mockSynth.stop).toHaveBeenCalled();
+            expect(mockSynth.stopSound).toHaveBeenCalledWith(0, global.DEFAULTVOICE, 220);
             expect(psc._playingRowIndex).toBeNull();
         });
 

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -58,6 +58,8 @@ class PitchStaircase {
         this._isPlayingScale = false;
         this._scaleStopped = false;
         this._scaleTimeout = null;
+        this._playAllNotes = [];
+        this._playScaleNotes = [];
     }
 
     /**
@@ -374,6 +376,8 @@ class PitchStaircase {
      */
     _playAll() {
         const pitchnotes = [];
+        this._playAllNotes = [];
+
         this._isPlayingAll = true;
         if (this._playAllButton) {
             this._setButtonIcon(
@@ -386,10 +390,13 @@ class PitchStaircase {
         for (let i = 0; i < this.Stairs.length; i++) {
             const note = this.Stairs[i][0] + this.Stairs[i][1];
             pitchnotes.push(normalizeNoteAccidentals(note));
+            this._playAllNotes.push(normalizeNoteAccidentals(note));
             const stepCell = this._stepTables[i].rows[0].cells[1];
             stepCell.classList.add("active");
             this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
         }
+
+        this._playAllNotes = [...pitchnotes];
 
         this._playAllTimeout = setTimeout(() => {
             for (let i = 0; i < this.Stairs.length; i++) {
@@ -410,17 +417,27 @@ class PitchStaircase {
     playUpAndDown() {
         this._scaleStopped = false;
         this._isPlayingScale = true;
+        this._playScaleNotes = [];
+
         if (this._playScaleButton) {
             this._setButtonIcon(this._playScaleButton, "stop-button.svg", _("Stop"));
         }
+
         const pitchnotes = [];
         const note =
             this.Stairs[this.Stairs.length - 1][0] + this.Stairs[this.Stairs.length - 1][1];
-        pitchnotes.push(normalizeNoteAccidentals(note));
+
+        const normalizedNote = normalizeNoteAccidentals(note);
+
+        pitchnotes.push(normalizedNote);
+        this._playScaleNotes.push(normalizedNote);
+
         const last = this.Stairs.length - 1;
         const stepCell = this._stepTables[last].rows[0].cells[1];
         stepCell.classList.add("active");
+
         this.activity.logo.synth.trigger(0, pitchnotes, 1, DEFAULTVOICE, null, null);
+
         this._playNext(this.Stairs.length - 2, -1);
     }
 
@@ -473,7 +490,10 @@ class PitchStaircase {
 
         const pitchnotes = [];
         const note = this.Stairs[index][0] + this.Stairs[index][1];
-        pitchnotes.push(normalizeNoteAccidentals(note));
+        const normalizedNote = normalizeNoteAccidentals(note);
+
+        this._playScaleNotes.push(normalizedNote);
+        pitchnotes.push(normalizedNote);
         const previousRowNumber = index - next;
         // _stepTables is a dense array; a negative index yields undefined,
         // not null, so use != null (loose) to catch both.
@@ -743,7 +763,10 @@ class PitchStaircase {
                     stepCell.classList.remove("active");
                 }
                 this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
-                this.activity.logo.synth.stop();
+                for (const notes of this._playAllNotes) {
+                    this.activity.logo.synth.stopSound(0, DEFAULTVOICE, notes);
+                }
+
                 this._isPlayingAll = false;
             } else {
                 this._playAll();
@@ -759,12 +782,19 @@ class PitchStaircase {
             if (this._isPlayingScale) {
                 this._scaleStopped = true;
                 clearTimeout(this._scaleTimeout);
+
                 for (let i = 0; i < this.Stairs.length; i++) {
                     const stepCell = this._stepTables[i].rows[0].cells[1];
                     stepCell.classList.remove("active");
                 }
+
                 this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
-                this.activity.logo.synth.stop();
+
+                for (const note of this._playScaleNotes) {
+                    this.activity.logo.synth.stopSound(0, DEFAULTVOICE, note);
+                }
+
+                this._playScaleNotes = [];
                 this._isPlayingScale = false;
             } else {
                 this.playUpAndDown();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -208,7 +208,8 @@ class PitchStaircase {
                     stepCell.classList.remove("active");
                     stepCell.style.backgroundColor = "";
                     this._setButtonIcon(playCell, "play-button.svg", _("Play"));
-                    this.activity.logo.synth.stop();
+                    const frequency = Number(stepCell.getAttribute("id"));
+                    this.activity.logo.synth.stopSound(0, DEFAULTVOICE, frequency);
                     this._playingRowIndex = null;
                 } else {
                     this._playOne(stepCell, playCell);

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -211,7 +211,8 @@ class PitchStaircase {
                     stepCell.classList.remove("active");
                     stepCell.style.backgroundColor = "";
                     this._setButtonIcon(playCell, "play-button.svg", _("Play"));
-                    this.activity.logo.synth.stop();
+                    const frequency = Number(stepCell.getAttribute("id"));
+                    this.activity.logo.synth.stopSound(0, DEFAULTVOICE, frequency);
                     this._playingRowIndex = null;
                 } else {
                     this._playOne(stepCell, playCell);

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -746,7 +746,7 @@ class PitchStaircase {
                     stepCell.classList.remove("active");
                 }
                 this._setButtonIcon(this._playAllButton, "play-chord.svg", _("Play chord"));
-                this.activity.logo.synth.stop();
+                this.activity.logo.synth.stopSound(0, DEFAULTVOICE);
                 this._isPlayingAll = false;
             } else {
                 this._playAll();
@@ -767,7 +767,7 @@ class PitchStaircase {
                     stepCell.classList.remove("active");
                 }
                 this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
-                this.activity.logo.synth.stop();
+                this.activity.logo.synth.stopSound(0, DEFAULTVOICE);
                 this._isPlayingScale = false;
             } else {
                 this.playUpAndDown();


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Pitch Staircase widget where clicking the *Stop* button updates the UI but does not stop the currently playing audio.

### Changes
•⁠  ⁠Stop the currently playing note using ⁠ stopSound() ⁠.
•⁠  ⁠Keep the Play/Stop button state synchronized with the audio playback.
•⁠  ⁠Preserve the existing playback behavior while ensuring the audio stops immediately when requested.

Fixes #7810 

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD