### PR TITLE
feat: announce widget open/close to screen readers via aria-live region (#6608)

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -2,6 +2,7 @@ global.localStorage = {
     beginnerMode: "false"
 };
 global._ = x => x;
+global.announceToScreenReader = jest.fn();
 global.TextEncoder = require("util").TextEncoder;
 global.TextDecoder = require("util").TextDecoder;
 global.last = arr => arr[arr.length - 1];

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -25,6 +25,7 @@ const PhraseMaker = require("../phrasemaker.js");
 // --- Global Mocks ---
 
 global._ = msg => msg;
+global.announceToScreenReader = jest.fn();
 global.last = arr => arr[arr.length - 1];
 global.LCD = (a, b) => (a * b) / gcd(a, b);
 function gcd(a, b) {

--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -21,6 +21,7 @@
  */
 
 global._ = msg => msg;
+global.announceToScreenReader = jest.fn();
 
 const mockOscillator = {
     toDestination: jest.fn().mockReturnThis(),

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -24,6 +24,7 @@ const PitchStaircase = require("../pitchstaircase.js");
 
 // --- Global Mocks ---
 global._ = msg => msg;
+global.announceToScreenReader = jest.fn();
 global.platformColor = {
     labelColor: "#90c100",
     selectorBackground: "#f0f0f0",

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -19,7 +19,7 @@
    MATRIXSOLFEHEIGHT, i18nSolfege, MATRIXSOLFEWIDTH, toFraction,
    wheelnav, slicePath, getNote, PREVIEWVOLUME, DEFAULTVOICE,
    PITCHES3, SOLFEGENAMES, SOLFEGECONVERSIONTABLE, NOTESSHARP,
-   NOTESFLAT, PITCHES, PITCHES2, convertFromSolfege, normalizeNoteAccidentals, */
+   NOTESFLAT, PITCHES, PITCHES2, convertFromSolfege, normalizeNoteAccidentals, announceToScreenReader */
 /*
    Global Locations
     - lib/wheelnav
@@ -663,6 +663,7 @@ function MusicKeyboard(activity) {
          * @type {Window}
          */
         const widgetWindow = window.widgetWindows.windowFor(this, "music keyboard");
+        announceToScreenReader(_("Music Keyboard opened"));
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
@@ -742,6 +743,7 @@ function MusicKeyboard(activity) {
             if (this._durationWheel) this._durationWheel.removeWheel();
             if (this._accidentalsWheel) this._accidentalsWheel.removeWheel();
             if (this._octavesWheel) this._octavesWheel.removeWheel();
+            announceToScreenReader(_("Music Keyboard closed"));
             widgetWindow.destroy();
         };
 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -19,7 +19,7 @@
    noteIsSolfege, isCustomTemperament, i18nSolfege, getNote, DEFAULTDRUM, last,
    DRUMS, SHARP, FLAT, PREVIEWVOLUME, DEFAULTVOLUME, noteToFrequency,
    LCD, calcNoteValueToDisplay, NOTESYMBOLS,
-   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals, parseNoteString
+   EIGHTHNOTEWIDTH, docBySelector, getTemperament, normalizeNoteAccidentals, parseNoteString, announceToScreenReader
 */
 
 /*
@@ -407,6 +407,7 @@ class PhraseMaker {
         const iconSize = PhraseMaker.ICONSIZE * this._cellScale;
 
         const widgetWindow = window.widgetWindows.windowFor(this, "phrase maker");
+        announceToScreenReader(_("Phrase Maker opened"));
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
@@ -430,6 +431,7 @@ class PhraseMaker {
             this._stopOrCloseClicked = true;
             this.activity.hideMsgs();
             this.docById("wheelDivptm").style.display = "none";
+            announceToScreenReader(_("Phrase Maker closed"));
             widgetWindow.destroy();
         };
 

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -13,7 +13,7 @@
 // from given frequency to nextoctave frequency(two times the given frequency)
 // in continuous manner.
 
-/* global _, Tone */
+/* global _, Tone, announceToScreenReader */
 
 /*
    Global locations
@@ -54,6 +54,7 @@ class PitchSlider {
 
         this._cellScale = 1.0;
         this.widgetWindow = window.widgetWindows.windowFor(this, "pitch slider", "slider", true);
+        announceToScreenReader(_("Pitch Slider opened"));
 
         this.isActive = true;
 
@@ -64,6 +65,7 @@ class PitchSlider {
             for (const osc of oscillators) osc.triggerRelease();
             this.isActive = false;
             activity.logo.pitchSlider = null;
+            announceToScreenReader(_("Pitch Slider closed"));
             this.widgetWindow.destroy();
         };
 

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
-   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last
+   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last, announceToScreenReader
  */
 
 /*
@@ -714,6 +714,7 @@ class PitchStaircase {
             "pitch staircase",
             true
         );
+        announceToScreenReader(_("Pitch Staircase opened"));
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
@@ -723,6 +724,7 @@ class PitchStaircase {
             // Restore the project's master volume so audio still works
             // after exiting mid-playback (was incorrectly left at PREVIEWVOLUME).
             this.activity.logo.synth.setMasterVolume(last(Singer.masterVolume));
+            announceToScreenReader(_("Pitch Staircase closed"));
             widgetWindow.destroy();
         };
 

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -20,7 +20,7 @@
    TONEBPM, Singer, _, delayExecution, deepClone, docById, ManagedTimer,
    calcNoteValueToDisplay, platformColor, beginnerMode, last,
    EIGHTHNOTEWIDTH, nearestBeat, rationalToFraction, DRUMNAMES,
-   VOICENAMES, EFFECTSNAMES
+   VOICENAMES, EFFECTSNAMES, announceToScreenReader
 */
 /*
     Globals location
@@ -560,6 +560,7 @@ class RhythmRuler {
          * @type {WidgetWindow}
          */
         const widgetWindow = window.widgetWindows.windowFor(this, "rhythm maker");
+        announceToScreenReader(_("Rhythm Maker opened"));
         /**
          * The widget window associated with the rhythm maker.
          * @type {WidgetWindow}
@@ -617,6 +618,7 @@ class RhythmRuler {
             this.activity.hideMsgs();
             this._circularCanvas = null;
             this._circularView = false;
+            announceToScreenReader(_("Rhythm Maker closed"));
 
             this.widgetWindow.destroy();
         };

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -17,7 +17,7 @@
    DEFAULTOSCILLATORTYPE, platformColor, rationalToFraction, last,
    Singer, instrumentsEffects:writeable, instrumentsFilters:writeable,
    docById, DEFAULTFILTERTYPE, docByName, OSCTYPES, FILTERTYPES,
-   oneHundredToFraction, delayExecution, ManagedTimer
+   oneHundredToFraction, delayExecution, ManagedTimer, announceToScreenReader
  */
 
 /*
@@ -755,6 +755,7 @@ class TimbreWidget {
         this._playing = false;
 
         const widgetWindow = window.widgetWindows.windowFor(this, "timbre", "timbre", true);
+        announceToScreenReader(_("Timbre Widget opened"));
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
@@ -773,6 +774,7 @@ class TimbreWidget {
             // Clean up all event listeners
             this._cleanupEventListeners();
             this.activity.hideMsgs();
+            announceToScreenReader(_("Timbre Widget closed"));
             widgetWindow.destroy();
         };
 


### PR DESCRIPTION
## Description

Adds screen reader announcements for open and close events across all
five Music Blocks widgets. When a widget opens or closes, an `aria-live`
region announces the action to assistive technologies.

Widgets covered:
- Phrase Maker — "Phrase Maker opened" / "Phrase Maker closed"
- Rhythm Maker — "Rhythm Maker opened" / "Rhythm Maker closed"
- Pitch Staircase — "Pitch Staircase opened" / "Pitch Staircase closed"
- Music Keyboard — "Music Keyboard opened" / "Music Keyboard closed"
- Timbre Widget — "Timbre Widget opened" / "Timbre Widget closed"

All announcements use the shared `announceToScreenReader()` helper
introduced in PR #7764, with no visual change for sighted users.

## Related Issue

Part of #6608

## Category

- [x] Feature

## Type of Change

- [x] Accessibility Enhancement

## Testing Performed

### How to test locally

1. Run `npm run serve` and open `http://localhost:3000`
2. Enable VoiceOver (`Cmd+F5` on Mac) or NVDA on Windows
3. Open any of the 5 widgets from the toolbar or palette
4. VoiceOver should announce e.g. "Phrase Maker opened"
5. Close the widget — VoiceOver should announce "Phrase Maker closed"
6. Repeat for all 5 widgets

### Test cases

1. Phrase Maker open/close — announcement fires correctly
2. Rhythm Maker open/close — announcement fires correctly
3. Pitch Staircase open/close — announcement fires correctly
4. Music Keyboard open/close — announcement fires correctly
5. Timbre Widget open/close — announcement fires correctly
6. `npx prettier --check` on all 6 files — clean

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added screen-reader announcements when Music Keyboard, Phrase Maker, Pitch Slider, Pitch Staircase, Rhythm Maker, and Timbre tools open or close.

* **Tests**
  * Updated widget tests to support and verify screen-reader announcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->