### PR TITLE
chore(lint): remove deprecated eslint-env comment from ManagedTimer.test.js

### DIFF
--- a/js/utils/__tests__/ManagedTimer.test.js
+++ b/js/utils/__tests__/ManagedTimer.test.js
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* eslint-env jest */
 const ManagedTimer = require("../ManagedTimer.js");
 
 describe("ManagedTimer", () => {


### PR DESCRIPTION
### PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [x] Chore

---

### What does this PR do?
This PR removes the deprecated `/* eslint-env jest */` comment at the top of the test file `js/utils/__tests__/ManagedTimer.test.js`.

### Why is this change necessary?
With the transition to ESLint Flat Configurations (defined in `eslint.config.mjs`), inline `eslint-env` comments are deprecated and will be reported as hard errors in ESLint v10.0.0. 

Since the project-wide configuration in `eslint.config.mjs` already specifies `...globals.jest` in the global environment scope (line 31), the inline comment is redundant. Removing it keeps the codebase clean and ready for ESLint upgrades.

### How was this tested?
- Checked code styling using Prettier:
  ```bash
  npx prettier --check js/utils/__tests__/ManagedTimer.test.js
