### PR TITLE
perf: skip updateCache and markStageDirty for off-screen blocks

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -753,7 +753,9 @@ class Block {
             }
         }
 
-        this.container.updateCache();
+        if (this._viewportVisible !== false) {
+            this.container.updateCache();
+        }
     }
 
     /**
@@ -835,7 +837,9 @@ class Block {
             }
         }
 
-        this.container.updateCache();
+        if (this._viewportVisible !== false) {
+            this.container.updateCache();
+        }
     }
 
     unhighlightSelectedBlocks(blk, selection) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1917,8 +1917,9 @@ class Logo {
                 // Highlight the current block
                 logo.blocks.highlight(blk, false);
                 logo._currentlyHighlightedBlock = blk;
-                // Force stage update so highlight is visible when blocks were shown during execution
-                if (logo.stage) {
+                // Force stage update so highlight is visible when blocks were shown during execution.
+                // Skip if the block is off-screen — the highlight is invisible anyway.
+                if (logo.stage && currentBlock._viewportVisible !== false) {
                     logo.deps.markStageDirty();
                 }
             }


### PR DESCRIPTION
## Summary

Reduce unnecessary rendering work during playback by skipping cache updates and stage redraw requests for blocks that are outside the visible viewport.

## PR Category
- [X] Performance

## Problem

During playback, block highlighting rebuilds block caches and schedules stage redraws even for blocks that are off-screen. For large projects such as Crab Cannon, this results in unnecessary rendering work and additional main-thread overhead.

## Solution

- Skip `container.updateCache()` for blocks that are not visible in the viewport.
- Skip stage redraw requests for off-screen blocks while preserving the existing behavior for visible blocks.

## Benchmark (Crab Cannon Plot)

- ~86% fewer `updateCache()` calls
- ~89% reduction in total `updateCache()` time

## Expected Impact

- Reduce rendering overhead during playback
- Lower main-thread workload
- Improve responsiveness for projects with large off-screen block stacks
- Preserve existing behavior for visible blocks