### PR TITLE
test(retryWithBackoff): prevent fake timer leak using try/finally

### DIFF
--- a/js/__tests__/retryWithBackoff.test.js
+++ b/js/__tests__/retryWithBackoff.test.js
@@ -239,21 +239,23 @@ describe("retryWithBackoff", () => {
 
         it("should use default delay function if none provided", async () => {
             jest.useFakeTimers();
-            const check = jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true);
+            try {
+                const check = jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true);
 
-            const promise = retryWithBackoff({
-                check,
-                onSuccess: jest.fn(),
-                initialDelay: 50
-            });
+                const promise = retryWithBackoff({
+                    check,
+                    onSuccess: jest.fn(),
+                    initialDelay: 50
+                });
 
-            // Advance timers by 50ms to resolve the default delay (50 * 2^0 = 50ms)
-            jest.advanceTimersByTime(50);
+                // Advance timers by 50ms to resolve the default delay (50 * 2^0 = 50ms)
+                jest.advanceTimersByTime(50);
 
-            await promise;
-            expect(check).toHaveBeenCalledTimes(2);
-
-            jest.useRealTimers();
+                await promise;
+                expect(check).toHaveBeenCalledTimes(2);
+            } finally {
+                jest.useRealTimers();
+            }
         });
     });
 


### PR DESCRIPTION
This PR addresses a critical test hygiene issue in `js/__tests__/retryWithBackoff.test.js` where `jest.useFakeTimers()` could leak into subsequent tests if an assertion failed.

Previously, `jest.useRealTimers()` was placed at the very end of the test block. If an `expect()` failed midway through the test, an exception was thrown and the teardown was skipped. This caused cascading and confusing test failures in other unrelated tests that mistakenly inherited the faked timers.

### Changes Made:
- Wrapped the core logic of the `"should use default delay function if none provided"` test within a `try...finally` block.
- Moved `jest.useRealTimers()` into the `finally` block to guarantee proper timer cleanup regardless of whether the test passes or fails.


- [x] Tests