### PR TITLE
refactor(timbre): fix type comparisons and extract redundant parses

### DIFF
--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -770,4 +770,150 @@ describe("TimbreWidget", () => {
             expect(timbre._addFilter).toHaveBeenCalled();
         });
     });
+
+    describe("Effects and Envelope Event Listeners (Coverage)", () => {
+        let mockDocument;
+        let mockDocById;
+        let mockDocByName;
+
+        const createBlock = (name, connections, value) => ({
+            name,
+            connections,
+            value,
+            text: { text: value === undefined ? "" : value.toString() },
+            updateCache: jest.fn(),
+            isClampBlock: jest.fn(() => false)
+        });
+
+        beforeEach(() => {
+            mockDocument = global.document;
+            mockDocById = global.docById;
+            mockDocByName = global.docByName;
+
+            global.document = jsdomDocument;
+            global.docById = id => jsdomDocument.getElementById(id);
+            global.docByName = name => jsdomDocument.getElementsByName(name);
+            jsdomDocument.body.textContent = "";
+
+            const blocks = {
+                blockList: [createBlock("settimbre", [null, null, null])],
+                clampBlocksToCheck: [],
+                findBottomBlock: jest.fn(() => null),
+                adjustDocks: jest.fn(),
+                adjustExpandableClampBlock: jest.fn(),
+                sendStackToTrash: jest.fn(),
+                loadNewBlocks: jest.fn(blockObjs => {
+                    const blockOffset = blocks.blockList.length;
+                    for (const blockObj of blockObjs) {
+                        const blockName = Array.isArray(blockObj[1]) ? blockObj[1][0] : blockObj[1];
+                        const value = Array.isArray(blockObj[1]) ? blockObj[1][1].value : undefined;
+                        const connections = blockObj[4].map(connection =>
+                            connection === null ? null : connection + blockOffset
+                        );
+                        blocks.blockList.push(createBlock(blockName, connections, value));
+                    }
+                })
+            };
+
+            timbre.activity = {
+                blocks,
+                logo: { synth: { createSynth: jest.fn() } },
+                refreshCanvas: jest.fn(),
+                saveLocally: jest.fn()
+            };
+            timbre.timbreTableDiv = jsdomDocument.createElement("div");
+            timbre.timbreTableDiv.id = "timbreTable";
+            jsdomDocument.body.appendChild(timbre.timbreTableDiv);
+
+            timbre.blockNo = 0;
+            timbre._update = jest.fn();
+            timbre._playNote = jest.fn();
+            timbre.clampConnection = jest.fn();
+            timbre.clampConnectionVspace = jest.fn();
+            timbre.instrumentName = "custom";
+            global.instrumentsEffects[0]["custom"] = {};
+
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jsdomDocument.body.textContent = "";
+            global.document = mockDocument;
+            global.docById = mockDocById;
+            global.docByName = mockDocByName;
+            jest.useRealTimers();
+        });
+
+        const triggerChange = (id, value) => {
+            const el = jsdomDocument.getElementById(id);
+            if (el) {
+                el.value = value;
+                el.dispatchEvent(new jsdomDocument.defaultView.Event("change", { bubbles: true }));
+            }
+        };
+
+        const selectEffect = async name => {
+            const r = jsdomDocument.querySelector('input[value="' + name + '"]');
+            if (r) {
+                r.checked = true;
+                const promise = r.onclick({ target: r });
+                jest.runAllTimers();
+                await promise;
+            }
+        };
+
+        test("should update Tremolo params", async () => {
+            timbre._effects();
+            await selectEffect("Tremolo");
+            triggerChange("myRangeFx0", "45");
+            expect(global.instrumentsEffects[0]["custom"]["tremoloFrequency"]).toBe(45);
+            triggerChange("myRangeFx1", "55");
+            expect(global.instrumentsEffects[0]["custom"]["tremoloDepth"]).toBe(0.55);
+        });
+
+        test("should update Vibrato params", async () => {
+            timbre._effects();
+            await selectEffect("Vibrato");
+            triggerChange("myRangeFx0", "30");
+            expect(global.instrumentsEffects[0]["custom"]["vibratoIntensity"]).toBe(0.25);
+        });
+
+        test("should update Chorus params", async () => {
+            timbre._effects();
+            await selectEffect("Chorus");
+            triggerChange("myRangeFx0", "20");
+            expect(global.instrumentsEffects[0]["custom"]["chorusRate"]).toBe(20);
+            triggerChange("myRangeFx1", "10");
+            expect(global.instrumentsEffects[0]["custom"]["delayTime"]).toBe(10);
+            triggerChange("myRangeFx2", "50");
+            expect(global.instrumentsEffects[0]["custom"]["chorusDepth"]).toBe(0.5);
+        });
+
+        test("should update Phaser params", async () => {
+            timbre._effects();
+            await selectEffect("Phaser");
+            triggerChange("myRangeFx0", "12");
+            expect(global.instrumentsEffects[0]["custom"]["rate"]).toBe(12);
+            triggerChange("myRangeFx1", "3");
+            expect(global.instrumentsEffects[0]["custom"]["octaves"]).toBe(3);
+            triggerChange("myRangeFx2", "400");
+            expect(global.instrumentsEffects[0]["custom"]["baseFrequency"]).toBe(400);
+        });
+
+        test("should update Distortion params", async () => {
+            timbre._effects();
+            await selectEffect("Distortion");
+            triggerChange("myRangeFx0", "75");
+            expect(global.instrumentsEffects[0]["custom"]["distortionAmount"]).toBe(0.75);
+        });
+
+        test("should update Envelope params", async () => {
+            timbre._envelope();
+            // envelope uses a different delay? actually _envelope has NO delay execution!
+            triggerChange("myRange0", "15");
+            expect(timbre.synthVals["envelope"]["attack"]).toBe(0.15);
+            triggerChange("myRange3", "25");
+            expect(timbre.synthVals["envelope"]["release"]).toBe(0.25);
+        });
+    });
 });

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -1609,8 +1609,9 @@ class TimbreWidget {
                             .addEventListener("change", event => {
                                 const elem = event.target;
                                 const m = Number(elem.id.slice(-1));
+                                const val = parseFloat(elem.value);
                                 this.duoSynthParams[m] = elem.value;
-                                docById("myRangeS" + m).value = parseFloat(elem.value);
+                                docById("myRangeS" + m).value = val;
                                 if (m === 0) {
                                     this._setDuoSynthParamVals(elem.value, this.duoSynthParams[1]);
                                 } else if (m === 1) {
@@ -1827,11 +1828,12 @@ class TimbreWidget {
         for (let i = 0; i < 4; i++) {
             document.getElementById("wrapperEnv" + i).addEventListener("change", event => {
                 const elem = event.target;
-                const m = elem.id.slice(-1);
-                docById("myRange" + m).value = parseFloat(elem.value);
+                const m = Number(elem.id.slice(-1));
+                const val = parseFloat(elem.value);
+                docById("myRange" + m).value = val;
                 docById("myspan" + m).textContent = elem.value;
-                this.synthVals["envelope"][this.adsrMap[m]] = parseFloat(elem.value) / 100;
-                this._update(blockValue, parseFloat(elem.value), m);
+                this.synthVals["envelope"][this.adsrMap[m]] = val / 100;
+                this._update(blockValue, val, m);
                 this.activity.logo.synth.createSynth(
                     0,
                     this.instrumentName,
@@ -2376,21 +2378,22 @@ class TimbreWidget {
                             .getElementById("wrapperFx" + i)
                             .addEventListener("change", event => {
                                 const elem = event.target;
-                                const m = elem.id.slice(-1);
-                                docById("myRangeFx" + m).value = parseFloat(elem.value);
+                                const m = Number(elem.id.slice(-1));
+                                const val = parseFloat(elem.value);
+                                docById("myRangeFx" + m).value = val;
                                 docById("myspanFx" + m).textContent = elem.value;
 
                                 if (m === 0) {
                                     instrumentsEffects[0][this.instrumentName]["tremoloFrequency"] =
-                                        parseFloat(elem.value);
+                                        val;
                                 }
 
                                 if (m === 1) {
                                     instrumentsEffects[0][this.instrumentName]["tremoloDepth"] =
-                                        parseFloat(elem.value) / 100;
+                                        val / 100;
                                 }
 
-                                this._update(blockValue, parseFloat(elem.value), Number(m));
+                                this._update(blockValue, val, m);
                                 this._playNote("G4", 1 / 8);
                             });
                     }
@@ -2453,10 +2456,10 @@ class TimbreWidget {
                     // Add the listeners for the sliders.
                     document.getElementById("wrapperFx0").addEventListener("change", event => {
                         const elem = event.target;
-                        docById("myRangeFx0").value = parseFloat(elem.value);
+                        const val = parseFloat(elem.value);
+                        docById("myRangeFx0").value = val;
                         docById("myspanFx0").textContent = elem.value;
-                        instrumentsEffects[0][this.instrumentName]["vibratoIntensity"] =
-                            parseFloat(elem.value) / 100;
+                        instrumentsEffects[0][this.instrumentName]["vibratoIntensity"] = val / 100;
 
                         this._update(this.vibratoEffect.length - 1, elem.value, 0);
                         this._playNote("G4", 1 / 8);
@@ -2464,7 +2467,8 @@ class TimbreWidget {
 
                     document.getElementById("wrapperFx1").addEventListener("change", event => {
                         const elem = event.target;
-                        docById("myRangeFx1").value = parseFloat(elem.value);
+                        const val = parseFloat(elem.value);
+                        docById("myRangeFx1").value = val;
                         const obj = oneHundredToFraction(elem.value);
                         docById("myspanFx1").textContent = obj[0] + "/" + obj[1];
                         const temp = parseFloat(obj[0]) / parseFloat(obj[1]);
@@ -2536,26 +2540,25 @@ class TimbreWidget {
                             .getElementById("wrapperFx" + i)
                             .addEventListener("change", event => {
                                 const elem = event.target;
-                                const m = elem.id.slice(-1);
-                                docById("myRangeFx" + m).value = parseFloat(elem.value);
+                                const m = Number(elem.id.slice(-1));
+                                const val = parseFloat(elem.value);
+                                docById("myRangeFx" + m).value = val;
                                 docById("myspanFx" + m).textContent = elem.value;
 
                                 if (m === 0) {
-                                    instrumentsEffects[0][this.instrumentName]["chorusRate"] =
-                                        parseFloat(elem.value);
+                                    instrumentsEffects[0][this.instrumentName]["chorusRate"] = val;
                                 }
 
                                 if (m === 1) {
-                                    instrumentsEffects[0][this.instrumentName]["delayTime"] =
-                                        parseFloat(elem.value);
+                                    instrumentsEffects[0][this.instrumentName]["delayTime"] = val;
                                 }
 
                                 if (m === 2) {
                                     instrumentsEffects[0][this.instrumentName]["chorusDepth"] =
-                                        parseFloat(elem.value) / 100;
+                                        val / 100;
                                 }
 
-                                this._update(blockValue, elem.value, Number(m));
+                                this._update(blockValue, elem.value, m);
                                 this._playNote("G4", 1 / 8);
                             });
                     }
@@ -2625,27 +2628,25 @@ class TimbreWidget {
                             .getElementById("wrapperFx" + i)
                             .addEventListener("change", event => {
                                 const elem = event.target;
-                                const m = elem.id.slice(-1);
-                                docById("myRangeFx" + m).value = parseFloat(elem.value);
+                                const m = Number(elem.id.slice(-1));
+                                const val = parseFloat(elem.value);
+                                docById("myRangeFx" + m).value = val;
                                 docById("myspanFx" + m).textContent = elem.value;
 
                                 if (m === 0) {
-                                    instrumentsEffects[0][this.instrumentName]["rate"] = parseFloat(
-                                        elem.value
-                                    );
+                                    instrumentsEffects[0][this.instrumentName]["rate"] = val;
                                 }
 
                                 if (m === 1) {
-                                    instrumentsEffects[0][this.instrumentName]["octaves"] =
-                                        parseFloat(elem.value);
+                                    instrumentsEffects[0][this.instrumentName]["octaves"] = val;
                                 }
 
                                 if (m === 2) {
                                     instrumentsEffects[0][this.instrumentName]["baseFrequency"] =
-                                        parseFloat(elem.value);
+                                        val;
                                 }
 
-                                this._update(blockValue, parseFloat(elem.value), Number(m));
+                                this._update(blockValue, val, m);
                                 this._playNote("G4", 1 / 8);
                             });
                     }
@@ -2692,10 +2693,10 @@ class TimbreWidget {
 
                     document.getElementById("wrapperFx0").addEventListener("change", event => {
                         const elem = event.target;
-                        docById("myRangeFx0").value = parseFloat(elem.value);
+                        const val = parseFloat(elem.value);
+                        docById("myRangeFx0").value = val;
                         docById("myspanFx0").textContent = elem.value;
-                        instrumentsEffects[0][this.instrumentName]["distortionAmount"] =
-                            parseFloat(elem.value) / 100;
+                        instrumentsEffects[0][this.instrumentName]["distortionAmount"] = val / 100;
                         this._update(blockValue, elem.value, 0);
                         this._playNote("G4", 1 / 8);
                     });


### PR DESCRIPTION
This PR refactors the event listeners in `js/widgets/timbre.js` to fix silent logic bugs and improve code readability. 

### Changes Made:
- **Fixed Strict Equality Bug:** Casted the DOM ID suffix to a Number (`const m = Number(elem.id.slice(-1))`) before using it in strict equality checks (`m === 0`). Previously, this was returning a string, causing downstream parameter updates (like Tremolo depth/frequency) to fail silently.
- **DRY Improvements:** Extracted redundant `parseFloat(elem.value)` calls into a single `val` variable per event listener to prevent unnecessary re-parsing and clean up the code visually.


- [x] Bug Fix