### PR TITLE
refactor(activity): extract trash controller from activity.js

### DIFF
--- a/js/__tests__/activity_helpful_wheel.test.js
+++ b/js/__tests__/activity_helpful_wheel.test.js
@@ -96,6 +96,7 @@ const loadActivityClass = () => {
         setupSearchController: jest.fn(),
         setupWorkspaceLayoutController: jest.fn(),
         setupSelectionController: jest.fn(),
+        setupTrashController: jest.fn(),
         hideDOMLabel: jest.fn(),
         setupActivityRecorder: jest.fn(),
         setupActivityAbcParser: jest.fn(),

--- a/js/__tests__/activity_toolbar_integration.test.js
+++ b/js/__tests__/activity_toolbar_integration.test.js
@@ -107,6 +107,7 @@ const loadActivityClass = () => {
         setupSearchController: jest.fn(),
         setupWorkspaceLayoutController: jest.fn(),
         setupSelectionController: jest.fn(),
+        setupTrashController: jest.fn(),
         hideDOMLabel: jest.fn(),
         setupActivityRecorder: jest.fn(),
         setupActivityAbcParser: jest.fn(),

--- a/js/__tests__/trash-controller.test.js
+++ b/js/__tests__/trash-controller.test.js
@@ -358,6 +358,15 @@ describe("TrashController click-outside handling", () => {
 // setupTrashController() — wiring onto the activity object
 // ---------------------------------------------------------------------------
 
+describe("TrashController construction", () => {
+    test("does not throw when the restoreIcon element is not present in the DOM", () => {
+        document.body.innerHTML = "";
+        const activity = makeActivity();
+
+        expect(() => new TrashController(activity)).not.toThrow();
+    });
+});
+
 describe("setupTrashController", () => {
     test("installs a trashController plus delegation stubs on the activity", () => {
         const activity = makeActivity();

--- a/js/__tests__/trash-controller.test.js
+++ b/js/__tests__/trash-controller.test.js
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+"use strict";
+
+if (typeof global._ !== "function") {
+    global._ = s => s;
+}
+
+const { setupTrashController, TrashController } = require("../trash-controller.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBlock({ name = "note", trash = true, connections = [] } = {}) {
+    return {
+        name,
+        trash,
+        value: null,
+        connections,
+        width: 40,
+        height: 40,
+        artwork: "<svg></svg>",
+        container: { cache: jest.fn(), bitmapCache: null },
+        regenerateArtwork: jest.fn(),
+        isCollapsible: jest.fn(() => false),
+        show: jest.fn()
+    };
+}
+
+/**
+ * Builds a minimal activity mock with a real blockList/dragGroup wiring so
+ * restoreTrashById exercises the same code paths as production.
+ */
+function makeActivity() {
+    const blockList = {};
+
+    const activity = {
+        blocks: {
+            trashStacks: [],
+            trashPreviews: {},
+            blockArt: {},
+            blockList,
+            dragGroup: [],
+            activeBlock: "something",
+            findDragGroup: jest.fn(blockId => {
+                activity.blocks.dragGroup = [blockId];
+            }),
+            moveBlockRelative: jest.fn(),
+            raiseStackToTop: jest.fn(),
+            findUniqueActionName: jest.fn(name => name),
+            newNameddoBlock: jest.fn(),
+            actionHasReturn: jest.fn(() => false),
+            actionHasArgs: jest.fn(() => false)
+        },
+        palettes: {
+            dict: {
+                foo: { hideMenu: jest.fn() }
+            },
+            updatePalettes: jest.fn()
+        },
+        turtles: {
+            getTurtle: jest.fn()
+        },
+        refreshCanvas: jest.fn(),
+        textMsg: jest.fn(),
+        cellSize: 10,
+        __tick: jest.fn()
+    };
+
+    return activity;
+}
+
+beforeEach(() => {
+    document.body.innerHTML =
+        '<div id="restoreIcon"></div>' +
+        '<div id="helpfulWheelDiv" style="display:none;"></div>' +
+        '<div id="trashList"></div>';
+});
+
+// ---------------------------------------------------------------------------
+// restoreTrash() — toolbar restore-icon handler
+// ---------------------------------------------------------------------------
+
+describe("TrashController.restoreTrash", () => {
+    test("shows an empty-trash message when there is nothing to restore", () => {
+        const activity = makeActivity();
+        const controller = new TrashController(activity);
+
+        controller.restoreTrash();
+
+        expect(activity.textMsg).toHaveBeenCalledWith("Trash can is empty.", 3000);
+    });
+
+    test("hides the helpful wheel when the trash is non-empty and the wheel is visible", () => {
+        const activity = makeActivity();
+        activity.blocks.trashStacks = ["blk1"];
+        document.getElementById("helpfulWheelDiv").style.display = "block";
+        const controller = new TrashController(activity);
+
+        controller.restoreTrash();
+
+        expect(document.getElementById("helpfulWheelDiv").style.display).toBe("none");
+        expect(activity.__tick).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// restoreLastFromTrash() — restores the most recently trashed block
+// ---------------------------------------------------------------------------
+
+describe("TrashController.restoreLastFromTrash", () => {
+    test("shows an empty-trash message when there is nothing to restore", () => {
+        const activity = makeActivity();
+        const controller = new TrashController(activity);
+
+        controller.restoreLastFromTrash();
+
+        expect(activity.textMsg).toHaveBeenCalledWith("Trash can is empty.", 3000);
+    });
+
+    test("restores the last block pushed to the trash stack", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.blockList.blk2 = makeBlock();
+        activity.blocks.trashStacks = ["blk1", "blk2"];
+        const controller = new TrashController(activity);
+        const spy = jest.spyOn(controller, "restoreTrashById");
+
+        controller.restoreLastFromTrash();
+
+        expect(spy).toHaveBeenCalledWith("blk2");
+        expect(activity.textMsg).toHaveBeenCalledWith("Item restored from the trash.", 3000);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// restoreTrashById() — restores a specific block by id
+// ---------------------------------------------------------------------------
+
+describe("TrashController.restoreTrashById", () => {
+    test("does nothing when the block id is not in the trash", () => {
+        const activity = makeActivity();
+        const controller = new TrashController(activity);
+
+        controller.restoreTrashById("missing");
+
+        expect(activity.refreshCanvas).not.toHaveBeenCalled();
+    });
+
+    test("removes the block from trashStacks, repositions it, and shows it", () => {
+        const activity = makeActivity();
+        const block = makeBlock({ name: "note" });
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+        const controller = new TrashController(activity);
+
+        controller.restoreTrashById("blk1");
+
+        expect(activity.blocks.trashStacks).not.toContain("blk1");
+        expect(block.trash).toBe(false);
+        expect(activity.blocks.moveBlockRelative).toHaveBeenCalledWith("blk1", 0, -30);
+        expect(block.show).toHaveBeenCalled();
+        expect(activity.blocks.raiseStackToTop).toHaveBeenCalledWith("blk1");
+        expect(activity.refreshCanvas).toHaveBeenCalled();
+    });
+
+    test("regenerates artwork and re-caches the container when they were freed by trashing", () => {
+        const activity = makeActivity();
+        const block = makeBlock();
+        block.container.bitmapCache = null;
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+        activity.blocks.blockArt.blk1 = undefined;
+        const controller = new TrashController(activity);
+
+        controller.restoreTrashById("blk1");
+
+        expect(block.regenerateArtwork).toHaveBeenCalledWith(false);
+        expect(block.container.cache).toHaveBeenCalledWith(0, 0, 40, 40);
+    });
+
+    test("restores the primary and companion turtle for a trashed start block", () => {
+        const activity = makeActivity();
+        const block = makeBlock({ name: "start" });
+        block.value = "turtle1";
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+
+        const companionTurtle = { inTrash: true, container: { visible: false } };
+        const primaryTurtle = {
+            inTrash: true,
+            container: { visible: false },
+            companionTurtle: "turtle2"
+        };
+        activity.turtles.getTurtle.mockImplementation(id => {
+            if (id === "turtle1") return primaryTurtle;
+            if (id === "turtle2") return companionTurtle;
+            return undefined;
+        });
+
+        const controller = new TrashController(activity);
+        controller.restoreTrashById("blk1");
+
+        expect(primaryTurtle.inTrash).toBe(false);
+        expect(primaryTurtle.container.visible).toBe(true);
+        expect(companionTurtle.inTrash).toBe(false);
+        expect(companionTurtle.container.visible).toBe(true);
+    });
+
+    test("restores a trashed start block with no companion turtle without throwing", () => {
+        const activity = makeActivity();
+        const block = makeBlock({ name: "start" });
+        block.value = "turtle1";
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+
+        const primaryTurtle = {
+            inTrash: true,
+            container: { visible: false },
+            companionTurtle: null
+        };
+        activity.turtles.getTurtle.mockImplementation(() => primaryTurtle);
+
+        const controller = new TrashController(activity);
+
+        expect(() => controller.restoreTrashById("blk1")).not.toThrow();
+        expect(primaryTurtle.inTrash).toBe(false);
+    });
+
+    test("re-registers a trashed action block under a unique name", () => {
+        const activity = makeActivity();
+        const actionArg = {
+            value: "action1",
+            text: { text: "" },
+            label: null,
+            container: { updateCache: jest.fn() }
+        };
+        activity.blocks.blockList.actionArgId = actionArg;
+        const block = makeBlock({ name: "action", connections: [null, "actionArgId"] });
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+        activity.blocks.findUniqueActionName.mockReturnValue("action2");
+
+        const controller = new TrashController(activity);
+        controller.restoreTrashById("blk1");
+
+        expect(activity.blocks.findUniqueActionName).toHaveBeenCalledWith("action1");
+        expect(actionArg.value).toBe("action2");
+        expect(activity.blocks.newNameddoBlock).toHaveBeenCalledWith("action2", false, false);
+        expect(activity.palettes.updatePalettes).toHaveBeenCalledWith("action");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderTrashView() — renders the trash panel
+// ---------------------------------------------------------------------------
+
+describe("TrashController.renderTrashView", () => {
+    test("does nothing when the trash is empty", () => {
+        const activity = makeActivity();
+        const controller = new TrashController(activity);
+
+        controller.renderTrashView();
+
+        expect(document.getElementById("trashView")).toBeNull();
+    });
+
+    test("renders one .trash-item per trashed block plus the restore controls", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock({ name: "note" });
+        activity.blocks.blockList.blk2 = makeBlock({ name: "pitch" });
+        activity.blocks.trashStacks = ["blk1", "blk2"];
+        const controller = new TrashController(activity);
+
+        controller.renderTrashView();
+
+        const trashView = document.getElementById("trashView");
+        expect(trashView).not.toBeNull();
+        expect(trashView.querySelectorAll(".trash-item").length).toBe(2);
+        expect(document.getElementById("restoreLastIcon")).not.toBeNull();
+        expect(document.getElementById("restoreAllIcon")).not.toBeNull();
+    });
+
+    test("replaces an existing trashView rather than appending a duplicate", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        const controller = new TrashController(activity);
+
+        controller.renderTrashView();
+        controller.renderTrashView();
+
+        expect(document.querySelectorAll("#trashView").length).toBe(1);
+    });
+
+    test("clicking a trash item restores that block", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        const controller = new TrashController(activity);
+        const spy = jest.spyOn(controller, "restoreTrashById");
+
+        controller.renderTrashView();
+        document.querySelector(".trash-item").dispatchEvent(new window.MouseEvent("click"));
+
+        expect(spy).toHaveBeenCalledWith("blk1");
+    });
+
+    test("restoreAllIcon restores every trashed block", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.blockList.blk2 = makeBlock();
+        activity.blocks.trashStacks = ["blk1", "blk2"];
+        const controller = new TrashController(activity);
+
+        controller.renderTrashView();
+        document.getElementById("restoreAllIcon").dispatchEvent(new window.MouseEvent("click"));
+
+        expect(activity.blocks.trashStacks.length).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Click-outside-to-close behavior
+// ---------------------------------------------------------------------------
+
+describe("TrashController click-outside handling", () => {
+    test("a second click outside the trash view hides it", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        const controller = new TrashController(activity);
+
+        controller.renderTrashView();
+        const trashView = document.getElementById("trashView");
+
+        // First document click after opening is ignored (the click that opened it).
+        document.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+        expect(trashView.style.display).not.toBe("none");
+
+        // A subsequent click outside the trash view closes it.
+        document.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+        expect(trashView.style.display).toBe("none");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setupTrashController() — wiring onto the activity object
+// ---------------------------------------------------------------------------
+
+describe("setupTrashController", () => {
+    test("installs a trashController plus delegation stubs on the activity", () => {
+        const activity = makeActivity();
+
+        const controller = setupTrashController(activity);
+
+        expect(activity.trashController).toBe(controller);
+        expect(typeof activity.restoreTrash).toBe("function");
+        expect(typeof activity.restoreTrashPop).toBe("function");
+        expect(typeof activity._restoreTrashById).toBe("function");
+        expect(typeof activity._renderTrashView).toBe("function");
+        expect(typeof activity._showTrashPreviewPopup).toBe("function");
+        expect(typeof activity._hideTrashPreviewPopup).toBe("function");
+    });
+
+    test("clicking the restoreIcon renders the trash view", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        setupTrashController(activity);
+
+        document.getElementById("restoreIcon").dispatchEvent(new window.MouseEvent("click"));
+
+        expect(document.getElementById("trashView")).not.toBeNull();
+    });
+
+    test("stubs delegate to the underlying controller", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        const controller = setupTrashController(activity);
+        const spy = jest.spyOn(controller, "restoreTrashById");
+
+        activity._restoreTrashById("blk1");
+
+        expect(spy).toHaveBeenCalledWith("blk1");
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -35,6 +35,7 @@ try {
    setupProjectManager,
    setupKeyboardController,
    setupSearchController, setupSearchUI, setupWorkspaceLayoutController, setupSelectionController,
+   setupTrashController,
    setupActivityAbcParser, setupActivityIdleWatcher,
    COLLAPSEBLOCKSBUTTON, COLLAPSEBUTTON, createDefaultStack,
    createHelpContent, createjs, DATAOBJS, DEFAULTBLOCKSCALE,
@@ -135,6 +136,7 @@ let MYDEFINES = [
     "palette/palette-loader",
     "activity/search-controller",
     "activity/workspace-layout-controller",
+    "activity/trash-controller",
     "search-ui",
     "keyboard-controller",
     "widgets/plugin-dialog",
@@ -2291,364 +2293,14 @@ class Activity {
             this._handleOrientationChangeResizeCanvas
         );
 
-        /*
-         * Restore last stack pushed to trashStack back onto canvas.
-         * Hides palettes before update
-         * Repositions blocks about trash area
-         */
-        const restoreTrash = activity => {
-            if (
-                !activity.blocks ||
-                !activity.blocks.trashStacks ||
-                activity.blocks.trashStacks.length === 0
-            ) {
-                activity.textMsg(_("Trash can is empty."), 3000);
-                return;
-            }
-
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-                activity.__tick();
-            }
-        };
-
-        const restoreTrashPop = activity => {
-            if (
-                !activity.blocks ||
-                !activity.blocks.trashStacks ||
-                activity.blocks.trashStacks.length === 0
-            ) {
-                activity.textMsg(_("Trash can is empty."), 3000);
-                return;
-            }
-            this._restoreTrashById(this.blocks.trashStacks[this.blocks.trashStacks.length - 1]);
-            activity.textMsg(_("Item restored from the trash."), 3000);
-
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-                activity.__tick();
-            }
-        };
-
-        this._restoreTrashById = blockId => {
-            const blockIndex = this.blocks.trashStacks.indexOf(blockId);
-            if (blockIndex === -1) return; // Block not found in trash
-
-            this.blocks.trashStacks.splice(blockIndex, 1); // Remove from trash
-
-            for (const name in this.palettes.dict) {
-                this.palettes.dict[name].hideMenu(true);
-            }
-            this.blocks.activeBlock = null;
-            this.refreshCanvas();
-
-            const dx = 0;
-            const dy = -this.cellSize * 3; // Reposition
-
-            // Restore drag group
-            this.blocks.findDragGroup(blockId);
-            for (let b = 0; b < this.blocks.dragGroup.length; b++) {
-                const blk = this.blocks.dragGroup[b];
-                this.blocks.blockList[blk].trash = false;
-                this.blocks.moveBlockRelative(blk, dx, dy);
-
-                const block = this.blocks.blockList[blk];
-
-                // Re-populate blocks.blockArt[blk] if it was deleted on trash.
-                // sendStackToTrash() and sendAllToTrash() both delete blockArt[blk]
-                // to free memory. Without regeneration, printBlockSVG() receives
-                // undefined here, passes it to DOMParser.parseFromString(undefined),
-                // and injects a <parsererror> node into every Save Block Artwork
-                // export (activity.js ~line 1394).
-                if (!this.blocks.blockArt[blk]) {
-                    block.regenerateArtwork(block.isCollapsible());
-                }
-
-                // Re-cache the container if it was uncached to save
-                // memory in sendStackToTrash().
-                if (block.container && !block.container.bitmapCache) {
-                    block.container.cache(
-                        0,
-                        0,
-                        Math.max(block.width, 1),
-                        Math.max(block.height, 1)
-                    );
-                }
-
-                this.blocks.blockList[blk].show();
-            }
-            this.blocks.raiseStackToTop(blockId);
-            const restoredBlock = this.blocks.blockList[blockId];
-
-            if (restoredBlock.name === "start" || restoredBlock.name === "drum") {
-                const turtle = restoredBlock.value;
-                const primaryTurtle = this.turtles.getTurtle(turtle);
-                primaryTurtle.inTrash = false;
-                primaryTurtle.container.visible = true;
-
-                // FIX: Restore the companion turtle if one exists.
-                // sendStackToTrash() in blocks.js (~line 7257) sets BOTH the primary
-                // and companion turtle to inTrash=true / visible=false when trashing a
-                // start/drum block. Without this mirror restore, the companion stays
-                // inTrash=true permanently, and logo.js (~line 1519) silently skips it:
-                //   if (!tur.inTrash) { tur.running = true; ... }
-                // This means onEveryBeatDo callbacks are dead after any trash+restore.
-                const comp = primaryTurtle.companionTurtle;
-                if (comp !== null && comp !== undefined) {
-                    const companionTurtle = this.turtles.getTurtle(comp);
-                    if (companionTurtle) {
-                        companionTurtle.inTrash = false;
-                        companionTurtle.container.visible = true;
-                    }
-                }
-            } else if (restoredBlock.name === "action") {
-                const actionArg = this.blocks.blockList[restoredBlock.connections[1]];
-                if (actionArg !== null) {
-                    let label;
-                    const oldName = actionArg.value;
-                    restoredBlock.trash = true;
-                    const uniqueName = this.blocks.findUniqueActionName(oldName);
-                    restoredBlock.trash = false;
-
-                    if (uniqueName !== actionArg) {
-                        actionArg.value = uniqueName;
-                        const translatedName = _(uniqueName);
-                        label =
-                            translatedName.length > 8
-                                ? translatedName.substr(0, 7) + "..."
-                                : translatedName;
-                        actionArg.text.text = label;
-
-                        if (actionArg.label !== null) {
-                            actionArg.label.value = translatedName;
-                        }
-                        actionArg.container.updateCache();
-                        for (let b = 0; b < this.blocks.dragGroup.length; b++) {
-                            const me = this.blocks.blockList[this.blocks.dragGroup[b]];
-                            if (
-                                ["nameddo", "nameddoArg", "namedcalc", "namedcalcArg"].includes(
-                                    me.name
-                                ) &&
-                                me.privateData === oldName
-                            ) {
-                                me.privateData = uniqueName;
-                                me.value = uniqueName;
-                                const translatedMeName = _(uniqueName);
-                                label =
-                                    translatedMeName.length > 8
-                                        ? translatedMeName.substr(0, 7) + "..."
-                                        : translatedMeName;
-                                me.text.text = label;
-                                me.overrideName = label;
-                                me.regenerateArtwork();
-                                me.container.updateCache();
-                            }
-                        }
-                    }
-
-                    // Re-add the action to the palette
-                    const actionName = actionArg.value;
-                    this.blocks.newNameddoBlock(
-                        actionName,
-                        this.blocks.actionHasReturn(blockId),
-                        this.blocks.actionHasArgs(blockId)
-                    );
-                    this.palettes.updatePalettes("action");
-                }
-            }
-            activity.textMsg(_("Item restored from the trash."), 3000);
-
-            this.refreshCanvas();
-        };
-
-        // Add event listener for trash icon click
-        document.getElementById("restoreIcon").addEventListener("click", () => {
-            this._renderTrashView();
-        });
-
-        // Store the click handler reference for proper cleanup
-        let trashViewClickHandler = null;
-
-        // function to hide trashView from canvas
-        function handleClickOutsideTrashView(trashView) {
-            // Remove existing listener to prevent duplicates
-            if (trashViewClickHandler) {
-                document.removeEventListener("click", trashViewClickHandler);
-            }
-
-            let firstClick = true;
-            trashViewClickHandler = event => {
-                if (firstClick) {
-                    firstClick = false;
-                    return;
-                }
-                if (!trashView.contains(event.target) && event.target !== trashView) {
-                    trashView.style.display = "none";
-                    // Clean up listener when trashView is hidden
-                    document.removeEventListener("click", trashViewClickHandler);
-                    trashViewClickHandler = null;
-                }
-            };
-            document.addEventListener("click", trashViewClickHandler);
-        }
-
-        this._renderTrashView = () => {
-            if (!this.blocks || !this.blocks.trashStacks || this.blocks.trashStacks.length === 0) {
-                return;
-            }
-            const trashList = document.getElementById("trashList");
-            const trashView = document.createElement("div");
-            trashView.id = "trashView";
-            trashView.classList.add("trash-view");
-
-            // Sticky icons
-            const buttonContainer = document.createElement("div");
-            buttonContainer.classList.add("button-container");
-
-            const restoreLastIcon = document.createElement("a");
-            restoreLastIcon.id = "restoreLastIcon";
-            restoreLastIcon.classList.add("restore-last-icon");
-            restoreLastIcon.innerHTML = '<i class="material-icons md-48">restore_from_trash</i>';
-            restoreLastIcon.addEventListener("click", () => {
-                this._restoreTrashById(this.blocks.trashStacks[this.blocks.trashStacks.length - 1]);
-                trashView.classList.add("hidden");
-            });
-
-            const restoreAllIcon = document.createElement("a");
-            restoreAllIcon.id = "restoreAllIcon";
-            restoreAllIcon.classList.add("restore-all-icon");
-            restoreAllIcon.innerHTML = '<i class="material-icons md-48">delete_sweep</i>';
-            restoreAllIcon.addEventListener("click", () => {
-                while (this.blocks.trashStacks.length > 0) {
-                    this._restoreTrashById(this.blocks.trashStacks[0]);
-                }
-                trashView.classList.add("hidden");
-            });
-            restoreLastIcon.setAttribute("title", _("Restore last item"));
-            restoreAllIcon.setAttribute("title", _("Restore all items"));
-
-            buttonContainer.appendChild(restoreLastIcon);
-            buttonContainer.appendChild(restoreAllIcon);
-            trashView.appendChild(buttonContainer);
-
-            // Render trash items
-            this.blocks.trashStacks.forEach(blockId => {
-                const block = this.blocks.blockList[blockId];
-                const listItem = document.createElement("div");
-                listItem.classList.add("trash-item");
-
-                const preview = this.blocks.trashPreviews[blockId];
-                let imgSrc;
-                if (preview) {
-                    imgSrc = preview;
-                } else {
-                    const svgData = block.artwork;
-                    imgSrc = "data:image/svg+xml;utf8," + encodeURIComponent(svgData);
-                }
-
-                const img = document.createElement("img");
-                img.src = imgSrc;
-                img.alt = "Block Icon";
-                img.classList.add("trash-item-icon");
-
-                const textNode = document.createTextNode(block.name);
-
-                listItem.appendChild(img);
-                listItem.appendChild(textNode);
-                listItem.dataset.blockId = blockId;
-
-                listItem.addEventListener("mouseover", () => {
-                    listItem.classList.add("hover");
-                });
-                listItem.addEventListener("mouseout", () => {
-                    listItem.classList.remove("hover");
-                });
-
-                img.addEventListener("mouseover", event => {
-                    this._showTrashPreviewPopup(imgSrc, event);
-                });
-                img.addEventListener("mousemove", event => {
-                    this._showTrashPreviewPopup(imgSrc, event);
-                });
-                img.addEventListener("mouseout", () => {
-                    this._hideTrashPreviewPopup();
-                });
-
-                listItem.addEventListener("click", () => {
-                    this._restoreTrashById(blockId);
-                    this._hideTrashPreviewPopup();
-                    trashView.classList.add("hidden");
-                });
-
-                trashView.appendChild(listItem);
-            });
-
-            // Attach outside-click listener once, after all items are rendered
-            handleClickOutsideTrashView(trashView);
-
-            const existingView = document.getElementById("trashView");
-            if (existingView) {
-                trashList.replaceChild(trashView, existingView);
-            } else {
-                trashList.appendChild(trashView);
-            }
-        };
-
-        /**
-         * Shows a larger preview popup for trashed items.
-         * @param {string} imgSrc - The source of the image.
-         * @param {MouseEvent} event - The mouse event.
-         * @private
-         */
-        this._showTrashPreviewPopup = (imgSrc, event) => {
-            let popup = document.getElementById("trashPreviewPopup");
-            if (!popup) {
-                popup = document.createElement("div");
-                popup.id = "trashPreviewPopup";
-                popup.classList.add("trash-preview-popup");
-                const img = document.createElement("img");
-                popup.appendChild(img);
-                document.body.appendChild(popup);
-            }
-            const img = popup.firstChild;
-            if (img.src !== imgSrc) {
-                img.src = imgSrc;
-            }
-            popup.style.display = "block";
-
-            // Position next to cursor
-            const xOffset = 20;
-            const yOffset = 20;
-            let x = event.clientX + xOffset;
-            let y = event.clientY + yOffset;
-
-            // Flip if near right edge
-            if (x + 300 > window.innerWidth) {
-                x = event.clientX - 320;
-            }
-            // Flip if near bottom edge
-            if (y + 300 > window.innerHeight) {
-                y = event.clientY - 320;
-            }
-
-            popup.style.left = x + "px";
-            popup.style.top = y + "px";
-        };
-
-        /**
-         * Hides the trash preview popup.
-         * @private
-         */
-        this._hideTrashPreviewPopup = () => {
-            const popup = document.getElementById("trashPreviewPopup");
-            if (popup) {
-                popup.style.display = "none";
-            }
-        };
+        // Sets up TrashController (js/trash-controller.js), which owns restoring
+        // blocks from the trash (individually, in bulk, or the most recent one),
+        // rendering the trash panel, and the restoreIcon click handling.
+        // this.restoreTrash, this.restoreTrashPop, this._restoreTrashById,
+        // this._renderTrashView, this._showTrashPreviewPopup, and
+        // this._hideTrashPreviewPopup are delegation stubs installed by
+        // setupTrashController() so external callers continue to work unchanged.
+        setupTrashController(this);
 
         /*
          * Open aux menu
@@ -3343,7 +2995,7 @@ class Activity {
                     label: "Restore",
                     icon: "imgsrc:header-icons/restore-from-trash.svg",
                     display: true,
-                    fn: restoreTrashPop
+                    fn: this.restoreTrashPop
                 });
 
             if (!this.helpfulWheelItems.find(ele => ele.label === "Turtle Wrap Off"))
@@ -4141,7 +3793,7 @@ class Activity {
             this.toolbar.renderRunStepIcon(doStepButton);
             this.toolbar.renderThemeSelectIcon(this.themeBox, this.themes);
             this.toolbar.renderMergeIcon(() => this.projectManager.doMergeLoad());
-            this.toolbar.renderRestoreIcon(restoreTrash);
+            this.toolbar.renderRestoreIcon(this.restoreTrash);
             if (_THIS_IS_MUSIC_BLOCKS_) {
                 this.toolbar.renderChooseKeyIcon(chooseKeyMenu);
             }

--- a/js/loader.js
+++ b/js/loader.js
@@ -150,7 +150,8 @@ requirejs.config({
                 "search-ui",
                 "project-manager",
                 "keyboard-controller",
-                "activity/selection-controller"
+                "activity/selection-controller",
+                "activity/trash-controller"
             ],
             exports: "Activity"
         },

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -1,0 +1,438 @@
+// Copyright (c) 2026 Sugarlabs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/* global _ */
+
+/* exported setupTrashController, TrashController */
+
+class TrashController {
+    /**
+     * @param {object} activity - The Activity instance.
+     */
+    constructor(activity) {
+        this.activity = activity;
+
+        // Stores the click handler reference for proper cleanup of the
+        // click-outside-to-close listener attached to the trash view.
+        this._trashViewClickHandler = null;
+
+        // Add event listener for trash icon click
+        document.getElementById("restoreIcon").addEventListener("click", () => {
+            this.renderTrashView();
+        });
+    }
+
+    /**
+     * Restore last stack pushed to trashStack back onto canvas.
+     * Hides palettes before update
+     * Repositions blocks about trash area
+     */
+    restoreTrash() {
+        const activity = this.activity;
+        if (
+            !activity.blocks ||
+            !activity.blocks.trashStacks ||
+            activity.blocks.trashStacks.length === 0
+        ) {
+            activity.textMsg(_("Trash can is empty."), 3000);
+            return;
+        }
+
+        // Cache DOM element reference for performance
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        if (helpfulWheelDiv.style.display !== "none") {
+            helpfulWheelDiv.style.display = "none";
+            activity.__tick();
+        }
+    }
+
+    /**
+     * Restore the most recently deleted block from the trash.
+     */
+    restoreLastFromTrash() {
+        const activity = this.activity;
+        if (
+            !activity.blocks ||
+            !activity.blocks.trashStacks ||
+            activity.blocks.trashStacks.length === 0
+        ) {
+            activity.textMsg(_("Trash can is empty."), 3000);
+            return;
+        }
+        this.restoreTrashById(activity.blocks.trashStacks[activity.blocks.trashStacks.length - 1]);
+        activity.textMsg(_("Item restored from the trash."), 3000);
+
+        // Cache DOM element reference for performance
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        if (helpfulWheelDiv.style.display !== "none") {
+            helpfulWheelDiv.style.display = "none";
+            activity.__tick();
+        }
+    }
+
+    /**
+     * Restores a specific block (and its drag group) from the trash by id.
+     * @param {number} blockId
+     */
+    restoreTrashById(blockId) {
+        const activity = this.activity;
+        const blockIndex = activity.blocks.trashStacks.indexOf(blockId);
+        if (blockIndex === -1) return; // Block not found in trash
+
+        activity.blocks.trashStacks.splice(blockIndex, 1); // Remove from trash
+
+        for (const name in activity.palettes.dict) {
+            activity.palettes.dict[name].hideMenu(true);
+        }
+        activity.blocks.activeBlock = null;
+        activity.refreshCanvas();
+
+        const dx = 0;
+        const dy = -activity.cellSize * 3; // Reposition
+
+        // Restore drag group
+        activity.blocks.findDragGroup(blockId);
+        for (let b = 0; b < activity.blocks.dragGroup.length; b++) {
+            const blk = activity.blocks.dragGroup[b];
+            activity.blocks.blockList[blk].trash = false;
+            activity.blocks.moveBlockRelative(blk, dx, dy);
+
+            const block = activity.blocks.blockList[blk];
+
+            // Re-populate blocks.blockArt[blk] if it was deleted on trash.
+            // sendStackToTrash() and sendAllToTrash() both delete blockArt[blk]
+            // to free memory. Without regeneration, printBlockSVG() receives
+            // undefined here, passes it to DOMParser.parseFromString(undefined),
+            // and injects a <parsererror> node into every Save Block Artwork
+            // export (activity.js ~line 1394).
+            if (!activity.blocks.blockArt[blk]) {
+                block.regenerateArtwork(block.isCollapsible());
+            }
+
+            // Re-cache the container if it was uncached to save
+            // memory in sendStackToTrash().
+            if (block.container && !block.container.bitmapCache) {
+                block.container.cache(0, 0, Math.max(block.width, 1), Math.max(block.height, 1));
+            }
+
+            activity.blocks.blockList[blk].show();
+        }
+        activity.blocks.raiseStackToTop(blockId);
+        const restoredBlock = activity.blocks.blockList[blockId];
+
+        if (restoredBlock.name === "start" || restoredBlock.name === "drum") {
+            const turtle = restoredBlock.value;
+            const primaryTurtle = activity.turtles.getTurtle(turtle);
+            primaryTurtle.inTrash = false;
+            primaryTurtle.container.visible = true;
+
+            // FIX: Restore the companion turtle if one exists.
+            // sendStackToTrash() in blocks.js (~line 7257) sets BOTH the primary
+            // and companion turtle to inTrash=true / visible=false when trashing a
+            // start/drum block. Without this mirror restore, the companion stays
+            // inTrash=true permanently, and logo.js (~line 1519) silently skips it:
+            //   if (!tur.inTrash) { tur.running = true; ... }
+            // This means onEveryBeatDo callbacks are dead after any trash+restore.
+            const comp = primaryTurtle.companionTurtle;
+            if (comp !== null && comp !== undefined) {
+                const companionTurtle = activity.turtles.getTurtle(comp);
+                if (companionTurtle) {
+                    companionTurtle.inTrash = false;
+                    companionTurtle.container.visible = true;
+                }
+            }
+        } else if (restoredBlock.name === "action") {
+            const actionArg = activity.blocks.blockList[restoredBlock.connections[1]];
+            if (actionArg !== null) {
+                let label;
+                const oldName = actionArg.value;
+                restoredBlock.trash = true;
+                const uniqueName = activity.blocks.findUniqueActionName(oldName);
+                restoredBlock.trash = false;
+
+                if (uniqueName !== actionArg) {
+                    actionArg.value = uniqueName;
+                    const translatedName = _(uniqueName);
+                    label =
+                        translatedName.length > 8
+                            ? translatedName.substr(0, 7) + "..."
+                            : translatedName;
+                    actionArg.text.text = label;
+
+                    if (actionArg.label !== null) {
+                        actionArg.label.value = translatedName;
+                    }
+                    actionArg.container.updateCache();
+                    for (let b = 0; b < activity.blocks.dragGroup.length; b++) {
+                        const me = activity.blocks.blockList[activity.blocks.dragGroup[b]];
+                        if (
+                            ["nameddo", "nameddoArg", "namedcalc", "namedcalcArg"].includes(
+                                me.name
+                            ) &&
+                            me.privateData === oldName
+                        ) {
+                            me.privateData = uniqueName;
+                            me.value = uniqueName;
+                            const translatedMeName = _(uniqueName);
+                            label =
+                                translatedMeName.length > 8
+                                    ? translatedMeName.substr(0, 7) + "..."
+                                    : translatedMeName;
+                            me.text.text = label;
+                            me.overrideName = label;
+                            me.regenerateArtwork();
+                            me.container.updateCache();
+                        }
+                    }
+                }
+
+                // Re-add the action to the palette
+                const actionName = actionArg.value;
+                activity.blocks.newNameddoBlock(
+                    actionName,
+                    activity.blocks.actionHasReturn(blockId),
+                    activity.blocks.actionHasArgs(blockId)
+                );
+                activity.palettes.updatePalettes("action");
+            }
+        }
+        activity.textMsg(_("Item restored from the trash."), 3000);
+
+        activity.refreshCanvas();
+    }
+
+    /**
+     * Hides trashView when a click occurs outside of it.
+     * @private
+     * @param {HTMLElement} trashView
+     */
+    _handleClickOutsideTrashView(trashView) {
+        // Remove existing listener to prevent duplicates
+        if (this._trashViewClickHandler) {
+            document.removeEventListener("click", this._trashViewClickHandler);
+        }
+
+        let firstClick = true;
+        this._trashViewClickHandler = event => {
+            if (firstClick) {
+                firstClick = false;
+                return;
+            }
+            if (!trashView.contains(event.target) && event.target !== trashView) {
+                trashView.style.display = "none";
+                // Clean up listener when trashView is hidden
+                document.removeEventListener("click", this._trashViewClickHandler);
+                this._trashViewClickHandler = null;
+            }
+        };
+        document.addEventListener("click", this._trashViewClickHandler);
+    }
+
+    /**
+     * Renders the trash panel listing every trashed block, with controls
+     * to restore the last item, restore all items, or restore a single item.
+     */
+    renderTrashView() {
+        const activity = this.activity;
+        if (
+            !activity.blocks ||
+            !activity.blocks.trashStacks ||
+            activity.blocks.trashStacks.length === 0
+        ) {
+            return;
+        }
+        const trashList = document.getElementById("trashList");
+        const trashView = document.createElement("div");
+        trashView.id = "trashView";
+        trashView.classList.add("trash-view");
+
+        // Sticky icons
+        const buttonContainer = document.createElement("div");
+        buttonContainer.classList.add("button-container");
+
+        const restoreLastIcon = document.createElement("a");
+        restoreLastIcon.id = "restoreLastIcon";
+        restoreLastIcon.classList.add("restore-last-icon");
+        restoreLastIcon.innerHTML = '<i class="material-icons md-48">restore_from_trash</i>';
+        restoreLastIcon.addEventListener("click", () => {
+            this.restoreTrashById(
+                activity.blocks.trashStacks[activity.blocks.trashStacks.length - 1]
+            );
+            trashView.classList.add("hidden");
+        });
+
+        const restoreAllIcon = document.createElement("a");
+        restoreAllIcon.id = "restoreAllIcon";
+        restoreAllIcon.classList.add("restore-all-icon");
+        restoreAllIcon.innerHTML = '<i class="material-icons md-48">delete_sweep</i>';
+        restoreAllIcon.addEventListener("click", () => {
+            while (activity.blocks.trashStacks.length > 0) {
+                this.restoreTrashById(activity.blocks.trashStacks[0]);
+            }
+            trashView.classList.add("hidden");
+        });
+        restoreLastIcon.setAttribute("title", _("Restore last item"));
+        restoreAllIcon.setAttribute("title", _("Restore all items"));
+
+        buttonContainer.appendChild(restoreLastIcon);
+        buttonContainer.appendChild(restoreAllIcon);
+        trashView.appendChild(buttonContainer);
+
+        // Render trash items
+        activity.blocks.trashStacks.forEach(blockId => {
+            const block = activity.blocks.blockList[blockId];
+            const listItem = document.createElement("div");
+            listItem.classList.add("trash-item");
+
+            const preview = activity.blocks.trashPreviews[blockId];
+            let imgSrc;
+            if (preview) {
+                imgSrc = preview;
+            } else {
+                const svgData = block.artwork;
+                imgSrc = "data:image/svg+xml;utf8," + encodeURIComponent(svgData);
+            }
+
+            const img = document.createElement("img");
+            img.src = imgSrc;
+            img.alt = "Block Icon";
+            img.classList.add("trash-item-icon");
+
+            const textNode = document.createTextNode(block.name);
+
+            listItem.appendChild(img);
+            listItem.appendChild(textNode);
+            listItem.dataset.blockId = blockId;
+
+            listItem.addEventListener("mouseover", () => {
+                listItem.classList.add("hover");
+            });
+            listItem.addEventListener("mouseout", () => {
+                listItem.classList.remove("hover");
+            });
+
+            img.addEventListener("mouseover", event => {
+                this._showTrashPreviewPopup(imgSrc, event);
+            });
+            img.addEventListener("mousemove", event => {
+                this._showTrashPreviewPopup(imgSrc, event);
+            });
+            img.addEventListener("mouseout", () => {
+                this._hideTrashPreviewPopup();
+            });
+
+            listItem.addEventListener("click", () => {
+                this.restoreTrashById(blockId);
+                this._hideTrashPreviewPopup();
+                trashView.classList.add("hidden");
+            });
+
+            trashView.appendChild(listItem);
+        });
+
+        // Attach outside-click listener once, after all items are rendered
+        this._handleClickOutsideTrashView(trashView);
+
+        const existingView = document.getElementById("trashView");
+        if (existingView) {
+            trashList.replaceChild(trashView, existingView);
+        } else {
+            trashList.appendChild(trashView);
+        }
+    }
+
+    /**
+     * Shows a larger preview popup for trashed items.
+     * @private
+     * @param {string} imgSrc - The source of the image.
+     * @param {MouseEvent} event - The mouse event.
+     * @returns {void}
+     */
+    _showTrashPreviewPopup(imgSrc, event) {
+        let popup = document.getElementById("trashPreviewPopup");
+        if (!popup) {
+            popup = document.createElement("div");
+            popup.id = "trashPreviewPopup";
+            popup.classList.add("trash-preview-popup");
+            const img = document.createElement("img");
+            popup.appendChild(img);
+            document.body.appendChild(popup);
+        }
+        const img = popup.firstChild;
+        if (img.src !== imgSrc) {
+            img.src = imgSrc;
+        }
+        popup.style.display = "block";
+
+        // Position next to cursor
+        const xOffset = 20;
+        const yOffset = 20;
+        let x = event.clientX + xOffset;
+        let y = event.clientY + yOffset;
+
+        // Flip if near right edge
+        if (x + 300 > window.innerWidth) {
+            x = event.clientX - 320;
+        }
+        // Flip if near bottom edge
+        if (y + 300 > window.innerHeight) {
+            y = event.clientY - 320;
+        }
+
+        popup.style.left = x + "px";
+        popup.style.top = y + "px";
+    }
+
+    /**
+     * Hides the trash preview popup.
+     * @private
+     * @returns {void}
+     */
+    _hideTrashPreviewPopup() {
+        const popup = document.getElementById("trashPreviewPopup");
+        if (popup) {
+            popup.style.display = "none";
+        }
+    }
+}
+
+/**
+ * Creates a TrashController and attaches it, plus delegation stubs,
+ * to the activity so external callers continue to work unchanged.
+ * @param {object} activity - The Activity instance.
+ */
+const setupTrashController = activity => {
+    const controller = new TrashController(activity);
+    activity.trashController = controller;
+
+    activity.restoreTrash = () => controller.restoreTrash();
+    activity.restoreTrashPop = () => controller.restoreLastFromTrash();
+    activity._restoreTrashById = blockId => controller.restoreTrashById(blockId);
+    activity._renderTrashView = () => controller.renderTrashView();
+    activity._showTrashPreviewPopup = (imgSrc, event) =>
+        controller._showTrashPreviewPopup(imgSrc, event);
+    activity._hideTrashPreviewPopup = () => controller._hideTrashPreviewPopup();
+
+    return controller;
+};
+
+// All browser execution goes through RequireJS (AMD). The module.exports branch
+// is present solely for Jest/Node test environments and is never exercised at
+// runtime in the browser.
+if (typeof define === "function" && define.amd) {
+    define(function () {
+        window.setupTrashController = setupTrashController;
+        return { setupTrashController, TrashController };
+    });
+} else if (typeof module !== "undefined" && module.exports) {
+    // Jest / Node environment
+    module.exports = { setupTrashController, TrashController };
+}

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -25,9 +25,25 @@ class TrashController {
         this._trashViewClickHandler = null;
 
         // Add event listener for trash icon click
-        document.getElementById("restoreIcon").addEventListener("click", () => {
-            this.renderTrashView();
-        });
+        const restoreIcon = document.getElementById("restoreIcon");
+        if (restoreIcon) {
+            restoreIcon.addEventListener("click", () => {
+                this.renderTrashView();
+            });
+        }
+    }
+
+    /**
+     * @private
+     * @returns {boolean} true if there is nothing in the trash to restore.
+     */
+    _isTrashEmpty() {
+        const activity = this.activity;
+        return (
+            !activity.blocks ||
+            !activity.blocks.trashStacks ||
+            activity.blocks.trashStacks.length === 0
+        );
     }
 
     /**
@@ -37,11 +53,7 @@ class TrashController {
      */
     restoreTrash() {
         const activity = this.activity;
-        if (
-            !activity.blocks ||
-            !activity.blocks.trashStacks ||
-            activity.blocks.trashStacks.length === 0
-        ) {
+        if (this._isTrashEmpty()) {
             activity.textMsg(_("Trash can is empty."), 3000);
             return;
         }
@@ -59,11 +71,7 @@ class TrashController {
      */
     restoreLastFromTrash() {
         const activity = this.activity;
-        if (
-            !activity.blocks ||
-            !activity.blocks.trashStacks ||
-            activity.blocks.trashStacks.length === 0
-        ) {
+        if (this._isTrashEmpty()) {
             activity.textMsg(_("Trash can is empty."), 3000);
             return;
         }
@@ -242,11 +250,7 @@ class TrashController {
      */
     renderTrashView() {
         const activity = this.activity;
-        if (
-            !activity.blocks ||
-            !activity.blocks.trashStacks ||
-            activity.blocks.trashStacks.length === 0
-        ) {
+        if (this._isTrashEmpty()) {
             return;
         }
         const trashList = document.getElementById("trashList");


### PR DESCRIPTION
## Summary

This PR extracts the trash management logic from `activity.js` into a dedicated `TrashController`, reducing the responsibilities of `Activity` while preserving the existing behavior.

The extraction includes:

- Restore last deleted block
- Restore a specific block from the trash
- Trash view rendering
- Trash preview popup handling
- Click-outside handling for the trash view
- Restore icon event wiring

`Activity` now delegates these operations to `TrashController` through thin wrapper methods, so all existing call sites continue to work without modification.

## Changes

- Added `js/trash-controller.js`
- Introduced `setupTrashController(activity)`
- Moved the following logic from `activity.js`:
  - `restoreTrash()`
  - `restoreTrashPop()` → `restoreLastFromTrash()`
  - `_restoreTrashById()`
  - `_renderTrashView()`
  - `_showTrashPreviewPopup()`
  - `_hideTrashPreviewPopup()`
  - `handleClickOutsideTrashView()`
  - Restore icon click listener setup
- Replaced the original implementations in `activity.js` with delegation wrappers.

## Behavior

This is a **refactoring-only** PR.

No functional or user-visible behavior is intended to change.

The extraction preserves:

- Restore ordering
- Companion turtle restoration
- Action block re-registration and unique naming
- Artwork regeneration and cache updates
- Palette updates
- Canvas refresh behavior
- Toolbar restore functionality
- Helpful Wheel integration
- Existing messages and event handling

## Testing

- Added `js/__tests__/trash-controller.test.js`
- Added coverage for:
  - Restore last deleted block
  - Restore by block ID
  - Companion turtle restoration
  - Action block restoration and renaming
  - Trash view rendering
  - Restore-all workflow
  - Click-outside-to-close behavior
  - `setupTrashController()` wiring
- Updated existing Activity integration tests with the required controller mock.
- Full Jest test suite passes.
- ESLint passes.
- Prettier passes on modified files.

## Refactoring Impact

- **activity.js:** ~360 lines removed (12 lines added for delegation)
- **New module:** `js/trash-controller.js` (~438 lines)

This refactor reduces the size of `Activity` while keeping the trash subsystem self-contained and easier to maintain.