### PR TITLE
fix(trash): prevent crash when restoring action block with no argument

### DIFF
--- a/js/__tests__/trash-controller.test.js
+++ b/js/__tests__/trash-controller.test.js
@@ -259,6 +259,16 @@ describe("TrashController.restoreTrashById", () => {
         expect(activity.blocks.newNameddoBlock).toHaveBeenCalledWith("action2", false, false);
         expect(activity.palettes.updatePalettes).toHaveBeenCalledWith("action");
     });
+
+    test("restores a trashed action block with no argument block without throwing", () => {
+        const activity = makeActivity();
+        const block = makeBlock({ name: "action", connections: [null, null] });
+        activity.blocks.blockList.blk1 = block;
+        activity.blocks.trashStacks = ["blk1"];
+
+        const controller = new TrashController(activity);
+        expect(() => controller.restoreTrashById("blk1")).not.toThrow();
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -159,7 +159,8 @@ class TrashController {
             }
         } else if (restoredBlock.name === "action") {
             const actionArg = activity.blocks.blockList[restoredBlock.connections[1]];
-            if (actionArg !== null && actionArg !== undefined) {
+            // eslint-disable-next-line eqeqeq
+            if (actionArg != null) {
                 let label;
                 const oldName = actionArg.value;
                 restoredBlock.trash = true;

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -159,7 +159,7 @@ class TrashController {
             }
         } else if (restoredBlock.name === "action") {
             const actionArg = activity.blocks.blockList[restoredBlock.connections[1]];
-            if (actionArg !== null) {
+            if (actionArg !== null && actionArg !== undefined) {
                 let label;
                 const oldName = actionArg.value;
                 restoredBlock.trash = true;


### PR DESCRIPTION
### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore

---

### What does this PR do?
This PR fixes a `TypeError` crash in `TrashController` when restoring a trashed `action` definition block that has no parameter/argument blocks attached.

### Why is this change necessary?
When restoring an `action` block, the code looks up `connections[1]` to find its associated argument block:
```javascript
const actionArg = activity.blocks.blockList[restoredBlock.connections[1]];
