### PR TITLE
fix: run stop callbacks and clear sounds on natural completion

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1684,6 +1684,50 @@ describe("Logo runFromBlockNow", () => {
             logo.runFromBlockNow(logo, 0, 0, 0, null);
             expect(mockActivity.errorMsg).toHaveBeenCalledWith("Playback is ready.", undefined);
         });
+
+        test("executes evalOnStopList callbacks on natural completion", () => {
+            logo.evalOnStopList = {
+                hookA: "code-a",
+                hookB: "code-b"
+            };
+            logo.safePluginExecute = jest.fn();
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.safePluginExecute).toHaveBeenCalledTimes(2);
+            expect(logo.safePluginExecute).toHaveBeenCalledWith("code-a", logo);
+            expect(logo.safePluginExecute).toHaveBeenCalledWith("code-b", logo);
+        });
+
+        test("clears stale sounds array on natural completion", () => {
+            const mockSound = { stop: jest.fn() };
+            logo.sounds = [mockSound];
+            logo.safePluginExecute = jest.fn();
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.sounds).toEqual([]);
+        });
+
+        test("does not execute evalOnStopList when turtles are still running", () => {
+            logo.safePluginExecute = jest.fn();
+            logo.evalOnStopList = { hookA: "code-a" };
+            mockActivity.turtles.running.mockReturnValue(true);
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.safePluginExecute).not.toHaveBeenCalled();
+        });
+
+        test("does not clear sounds when turtles are still running", () => {
+            logo.safePluginExecute = jest.fn();
+            logo.sounds = [{ stop: jest.fn() }];
+            mockActivity.turtles.running.mockReturnValue(true);
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.sounds).toHaveLength(1);
+        });
     });
 
     test("dispatches end-of-clamp signals and updates status matrix", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -2296,6 +2296,17 @@ class Logo {
                         }
                     }
 
+                    // Execute plugin stop callbacks so cleanup runs
+                    // consistently whether the user presses Stop or
+                    // playback finishes normally (mirrors doStopTurtles).
+                    for (const arg in logo.evalOnStopList) {
+                        logo.safePluginExecute(logo.evalOnStopList[arg], logo);
+                    }
+
+                    // Clear stale sound references left after natural
+                    // completion (mirrors doStopTurtles).
+                    logo.sounds = [];
+
                     // Give the last note time to play.
                     logo._lastNoteTimeout = logo._timerManager.setTimeout(() => {
                         logo._lastNoteTimeout = null;


### PR DESCRIPTION
## Description
When playback finished naturally, `evalOnStopList` callbacks were not executed, and `logo.sounds` retained references to completed sound objects. These cleanup steps were already performed when playback was stopped manually but were missing from the natural completion path.

This change executes `evalOnStopList` callbacks and clears `logo.sounds` when playback completes naturally, ensuring consistent cleanup without affecting playback timing, Tone.Transport, synth initialization, or timer management. Unit tests have been added to cover the new behavior.

## What this does not change (and why)

The remaining `doStopTurtles()` cleanup steps (timer cancellation, voice cleanup, transport stop/cancel, instrument disposal, and connection restoration) were investigated but intentionally left unchanged. They are either unnecessary after normal playback completes (for example, timers have already fired and transport events have already been processed) or are intentionally deferred until the next `runLogoCommands()` call to preserve the existing behavior (such as instrument reuse through `_synthsInitialized` and keeping the Transport running for timing continuity). Earlier attempts to add this cleanup introduced regressions, which was confirmed during the work on PR #7829 and ultimately led to those changes being reverted.

##   PR Category
- [X] Bug Fix