### PR TITLE
fix: Replace innerHTML with secure DOM methods in svgAssetSelector.js

### DIFF
--- a/js/svgAssetSelector.js
+++ b/js/svgAssetSelector.js
@@ -48,9 +48,14 @@ function openSvgAssetSelector(onSelectBuiltIn, onUploadFromDevice) {
             // Header
             const header = document.createElement("div");
             header.className = "svg-selector-header";
-            header.innerHTML =
-                "<h3>Choose an Image</h3>" +
-                '<button class="svg-selector-close" aria-label="Close">&times;</button>';
+            const headerTitle = document.createElement("h3");
+            headerTitle.textContent = "Choose an Image";
+            const closeBtn = document.createElement("button");
+            closeBtn.className = "svg-selector-close";
+            closeBtn.setAttribute("aria-label", "Close");
+            closeBtn.textContent = "×";
+            header.appendChild(headerTitle);
+            header.appendChild(closeBtn);
             modal.appendChild(header);
 
             // Tabs
@@ -60,14 +65,20 @@ function openSvgAssetSelector(onSelectBuiltIn, onUploadFromDevice) {
             const tabBuiltIn = document.createElement("button");
             tabBuiltIn.className = "svg-selector-tab active";
             tabBuiltIn.id = "svgTabBuiltIn";
-            tabBuiltIn.innerHTML =
-                '<span class="tab-icon material-icons">collections</span> Built-in Images';
+            const builtInIcon = document.createElement("span");
+            builtInIcon.className = "tab-icon material-icons";
+            builtInIcon.textContent = "collections";
+            tabBuiltIn.appendChild(builtInIcon);
+            tabBuiltIn.appendChild(document.createTextNode(" Built-in Images"));
 
             const tabUpload = document.createElement("button");
             tabUpload.className = "svg-selector-tab";
             tabUpload.id = "svgTabUpload";
-            tabUpload.innerHTML =
-                '<span class="tab-icon material-icons">file_upload</span> Upload from Device';
+            const uploadIcon = document.createElement("span");
+            uploadIcon.className = "tab-icon material-icons";
+            uploadIcon.textContent = "file_upload";
+            tabUpload.appendChild(uploadIcon);
+            tabUpload.appendChild(document.createTextNode(" Upload from Device"));
 
             tabBar.appendChild(tabBuiltIn);
             tabBar.appendChild(tabUpload);
@@ -127,7 +138,11 @@ function openSvgAssetSelector(onSelectBuiltIn, onUploadFromDevice) {
 
             const uploadBtn = document.createElement("button");
             uploadBtn.className = "svg-upload-btn";
-            uploadBtn.innerHTML = '<span class="material-icons">cloud_upload</span> Choose File';
+            const uploadBtnIcon = document.createElement("span");
+            uploadBtnIcon.className = "material-icons";
+            uploadBtnIcon.textContent = "cloud_upload";
+            uploadBtn.appendChild(uploadBtnIcon);
+            uploadBtn.appendChild(document.createTextNode(" Choose File"));
 
             const uploadHint = document.createElement("span");
             uploadHint.className = "svg-upload-hint";


### PR DESCRIPTION
## Description

This PR replaces all instances of `innerHTML` in `svgAssetSelector.js` with safer DOM manipulation methods (`document.createElement`, `textContent`, and `createTextNode`). This addresses potential XSS security vulnerabilities associated with using `innerHTML` to build tab headers and upload buttons.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Replaced `innerHTML` in the selector header with `createElement` and `textContent`.
- Replaced `innerHTML` for the built-in and upload tab buttons with `createElement("span")` for material icons and `createTextNode()`.
- Replaced `innerHTML` in the upload button for safer DOM generation.

## Testing Performed

- Ran `npm run lint` and `npx prettier --check .` with 0 errors related to these changes.
- Verified that all unit tests pass (6822 passed tests).
- Ensured the UI of the SVG Asset Selector functions exactly as before.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [ ] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The changes explicitly use `document.createElement("span")` for Material Icons and `document.createTextNode()` for textual content, fully removing `innerHTML` dependencies in `svgAssetSelector.js` as requested in PR #9.
