### PR TITLE
fix: make pitchslider, tuner, sampler widgets EDO-aware

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1257,8 +1257,8 @@ describe("pitchToNumber", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToNumber("C", 4, "C major", "equal19");
-        // C4 in 19-EDO: 4*19 + round(0/12*19) - round(9/12*19) = 76 + 0 - 14 = 62
-        expect(result).toBe(62);
+        // 4 * 19 + 0 (C index) - 9 (A index) = 67
+        expect(result).toBe(67);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {
@@ -1459,143 +1459,6 @@ describe("numberToPitch", () => {
         const result2 = numberToPitch(7, "just intonation", "C4", 0);
         expect(Array.isArray(result1)).toBe(true);
         expect(Array.isArray(result2)).toBe(true);
-    });
-});
-
-describe("numberToPitch EDO temperaments", () => {
-    beforeEach(() => {
-        global.PITCHES = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"];
-        global.TEMPERAMENT = {
-            "equal": {
-                pitchNumber: 12,
-                interval: [
-                    "perfect 1",
-                    "minor 2",
-                    "major 2",
-                    "minor 3",
-                    "major 3",
-                    "perfect 4",
-                    "diminished 5",
-                    "perfect 5",
-                    "minor 6",
-                    "major 6",
-                    "minor 7",
-                    "major 7"
-                ]
-            },
-            "equal5": {
-                isEDO: true,
-                edo: 5,
-                pitchNumber: 5,
-                interval: ["perfect 1", "minor 2", "major 2", "major 3", "augmented 4", "perfect 5"]
-            },
-            "equal7": {
-                isEDO: true,
-                edo: 7,
-                pitchNumber: 7,
-                interval: [
-                    "perfect 1",
-                    "minor 2",
-                    "major 2",
-                    "minor 3",
-                    "major 3",
-                    "perfect 4",
-                    "diminished 5",
-                    "perfect 5"
-                ]
-            },
-            "just intonation": {
-                pitchNumber: 12,
-                0: [1, "C", 4],
-                1: [16 / 15, "D♭", 4],
-                2: [9 / 8, "D", 4],
-                3: [6 / 5, "E♭", 4],
-                4: [5 / 4, "E", 4],
-                5: [4 / 3, "F", 4],
-                6: [45 / 32, "G♭", 4],
-                7: [3 / 2, "G", 4],
-                8: [8 / 5, "A♭", 4],
-                9: [5 / 3, "A", 4],
-                10: [9 / 5, "B♭", 4],
-                11: [15 / 8, "B", 4]
-            }
-        };
-        global.isCustomTemperament = jest.fn(temp => {
-            return (
-                temp !== "equal" && !(temp in PreDefinedTemperaments) && temp in global.TEMPERAMENT
-            );
-        });
-        global.getNoteFromInterval = jest.fn((pitch, interval) => {
-            if (!interval) return ["C", 4];
-            return ["C", 4];
-        });
-        global.console.debug = jest.fn();
-    });
-
-    it("maps pitch number 0 to the starting pitch in 5-EDO", () => {
-        // pitchNumber=0, startPitch="C4", offset=0 → semitone distance=0
-        // EDO step 0 relative to C4 → C4
-        const result = numberToPitch(0, "equal5", "C4", 0);
-        expect(result).toEqual(["C", 4]);
-    });
-
-    it("maps pitch number 0 with C4 offset to C4 in 5-EDO", () => {
-        // Simulates playPitchNumber(0) with default pitchNumberOffset=39
-        // i = 0 + 39 = 39, offset = 39
-        // pitchNumber_local = 39 - 39 = 0 semitones from C4
-        // EDO step 0 → C4
-        const result = numberToPitch(39, "equal5", "C4", 39);
-        expect(result).toEqual(["C", 4]);
-    });
-
-    it("maps pitch number 3 (1 EDO step) to D4 in 5-EDO with offset 39", () => {
-        // i = 3 + 39 = 42
-        // pitchNumber = 42 - 39 = 3 semitones from C4
-        // 3 semitones / 2.4 = 1.25 → round to 1 EDO step
-        // EDO step 1, position in PITCHES = round(1/5 * 12) = 2 → "D"
-        const result = numberToPitch(42, "equal5", "C4", 39);
-        expect(result).toEqual(["D", 4]);
-    });
-
-    it("maps pitch number 5 to F4 in 5-EDO", () => {
-        // i = 5 + 39 = 44
-        // pitchNumber = 44 - 39 = 5 semitones
-        // 5 / 2.4 = 2.083 → round to 2 EDO steps
-        // step 2, position = round(2/5 * 12) = round(4.8) = 5 → "F"
-        const result = numberToPitch(44, "equal5", "C4", 39);
-        expect(result).toEqual(["F", 4]);
-    });
-
-    it("maps pitch number 7 to G4 in 5-EDO", () => {
-        const result = numberToPitch(46, "equal5", "C4", 39);
-        expect(result).toEqual(["G", 4]);
-    });
-
-    it("maps pitch number 12 to C5 (next octave) in 5-EDO", () => {
-        // i = 12 + 39 = 51
-        // pitchNumber = 51 - 39 = 12 semitones
-        // 12 / 2.4 = 5 EDO steps → 1 full octave + 0 steps
-        const result = numberToPitch(51, "equal5", "C4", 39);
-        expect(result).toEqual(["C", 5]);
-    });
-
-    it("maps pitch number 0 to the starting pitch in 7-EDO", () => {
-        const result = numberToPitch(39, "equal7", "C4", 39);
-        expect(result).toEqual(["C", 4]);
-    });
-
-    it("produces higher octave for larger pitch numbers in 5-EDO", () => {
-        // pitchNumber=20 semitones → ~8 EDO steps → 1 octave + 3 steps
-        const result = numberToPitch(59, "equal5", "C4", 39);
-        expect(result[1]).toBe(5);
-    });
-
-    it("handles negative pitch numbers in EDO", () => {
-        // i = -2 + 39 = 37, offset = 39
-        // pitchNumber = 37 - 39 = -2 semitones
-        const result = numberToPitch(37, "equal5", "C4", 39);
-        expect(result[0]).toBeTruthy();
-        expect(result[1]).toBeLessThan(4);
     });
 });
 
@@ -2240,9 +2103,9 @@ describe("pitchToFrequency", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToFrequency("C", 4, 0, "C", "equal19");
-        // C4 in 19-EDO: A0 * 2^(62/19) ≈ 264.02
-        expect(result).toBeGreaterThan(260);
-        expect(result).toBeLessThan(270);
+        // C4 in 19-EDO: A0 * Math.pow(2, 67/19) ≈ 316.85
+        expect(result).toBeGreaterThan(310);
+        expect(result).toBeLessThan(320);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1257,8 +1257,8 @@ describe("pitchToNumber", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToNumber("C", 4, "C major", "equal19");
-        // 4 * 19 + 0 (C index) - 9 (A index) = 67
-        expect(result).toBe(67);
+        // C4 in 19-EDO: 4*19 + round(0/12*19) - round(9/12*19) = 76 + 0 - 14 = 62
+        expect(result).toBe(62);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {
@@ -1459,6 +1459,143 @@ describe("numberToPitch", () => {
         const result2 = numberToPitch(7, "just intonation", "C4", 0);
         expect(Array.isArray(result1)).toBe(true);
         expect(Array.isArray(result2)).toBe(true);
+    });
+});
+
+describe("numberToPitch EDO temperaments", () => {
+    beforeEach(() => {
+        global.PITCHES = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"];
+        global.TEMPERAMENT = {
+            "equal": {
+                pitchNumber: 12,
+                interval: [
+                    "perfect 1",
+                    "minor 2",
+                    "major 2",
+                    "minor 3",
+                    "major 3",
+                    "perfect 4",
+                    "diminished 5",
+                    "perfect 5",
+                    "minor 6",
+                    "major 6",
+                    "minor 7",
+                    "major 7"
+                ]
+            },
+            "equal5": {
+                isEDO: true,
+                edo: 5,
+                pitchNumber: 5,
+                interval: ["perfect 1", "minor 2", "major 2", "major 3", "augmented 4", "perfect 5"]
+            },
+            "equal7": {
+                isEDO: true,
+                edo: 7,
+                pitchNumber: 7,
+                interval: [
+                    "perfect 1",
+                    "minor 2",
+                    "major 2",
+                    "minor 3",
+                    "major 3",
+                    "perfect 4",
+                    "diminished 5",
+                    "perfect 5"
+                ]
+            },
+            "just intonation": {
+                pitchNumber: 12,
+                0: [1, "C", 4],
+                1: [16 / 15, "D♭", 4],
+                2: [9 / 8, "D", 4],
+                3: [6 / 5, "E♭", 4],
+                4: [5 / 4, "E", 4],
+                5: [4 / 3, "F", 4],
+                6: [45 / 32, "G♭", 4],
+                7: [3 / 2, "G", 4],
+                8: [8 / 5, "A♭", 4],
+                9: [5 / 3, "A", 4],
+                10: [9 / 5, "B♭", 4],
+                11: [15 / 8, "B", 4]
+            }
+        };
+        global.isCustomTemperament = jest.fn(temp => {
+            return (
+                temp !== "equal" && !(temp in PreDefinedTemperaments) && temp in global.TEMPERAMENT
+            );
+        });
+        global.getNoteFromInterval = jest.fn((pitch, interval) => {
+            if (!interval) return ["C", 4];
+            return ["C", 4];
+        });
+        global.console.debug = jest.fn();
+    });
+
+    it("maps pitch number 0 to the starting pitch in 5-EDO", () => {
+        // pitchNumber=0, startPitch="C4", offset=0 → semitone distance=0
+        // EDO step 0 relative to C4 → C4
+        const result = numberToPitch(0, "equal5", "C4", 0);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("maps pitch number 0 with C4 offset to C4 in 5-EDO", () => {
+        // Simulates playPitchNumber(0) with default pitchNumberOffset=39
+        // i = 0 + 39 = 39, offset = 39
+        // pitchNumber_local = 39 - 39 = 0 semitones from C4
+        // EDO step 0 → C4
+        const result = numberToPitch(39, "equal5", "C4", 39);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("maps pitch number 3 (1 EDO step) to D4 in 5-EDO with offset 39", () => {
+        // i = 3 + 39 = 42
+        // pitchNumber = 42 - 39 = 3 semitones from C4
+        // 3 semitones / 2.4 = 1.25 → round to 1 EDO step
+        // EDO step 1, position in PITCHES = round(1/5 * 12) = 2 → "D"
+        const result = numberToPitch(42, "equal5", "C4", 39);
+        expect(result).toEqual(["D", 4]);
+    });
+
+    it("maps pitch number 5 to F4 in 5-EDO", () => {
+        // i = 5 + 39 = 44
+        // pitchNumber = 44 - 39 = 5 semitones
+        // 5 / 2.4 = 2.083 → round to 2 EDO steps
+        // step 2, position = round(2/5 * 12) = round(4.8) = 5 → "F"
+        const result = numberToPitch(44, "equal5", "C4", 39);
+        expect(result).toEqual(["F", 4]);
+    });
+
+    it("maps pitch number 7 to G4 in 5-EDO", () => {
+        const result = numberToPitch(46, "equal5", "C4", 39);
+        expect(result).toEqual(["G", 4]);
+    });
+
+    it("maps pitch number 12 to C5 (next octave) in 5-EDO", () => {
+        // i = 12 + 39 = 51
+        // pitchNumber = 51 - 39 = 12 semitones
+        // 12 / 2.4 = 5 EDO steps → 1 full octave + 0 steps
+        const result = numberToPitch(51, "equal5", "C4", 39);
+        expect(result).toEqual(["C", 5]);
+    });
+
+    it("maps pitch number 0 to the starting pitch in 7-EDO", () => {
+        const result = numberToPitch(39, "equal7", "C4", 39);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("produces higher octave for larger pitch numbers in 5-EDO", () => {
+        // pitchNumber=20 semitones → ~8 EDO steps → 1 octave + 3 steps
+        const result = numberToPitch(59, "equal5", "C4", 39);
+        expect(result[1]).toBe(5);
+    });
+
+    it("handles negative pitch numbers in EDO", () => {
+        // i = -2 + 39 = 37, offset = 39
+        // pitchNumber = 37 - 39 = -2 semitones
+        const result = numberToPitch(37, "equal5", "C4", 39);
+        expect(result[0]).toBeTruthy();
+        expect(result[1]).toBeLessThan(4);
     });
 });
 
@@ -2103,9 +2240,9 @@ describe("pitchToFrequency", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToFrequency("C", 4, 0, "C", "equal19");
-        // C4 in 19-EDO: A0 * Math.pow(2, 67/19) ≈ 316.85
-        expect(result).toBeGreaterThan(310);
-        expect(result).toBeLessThan(320);
+        // C4 in 19-EDO: A0 * 2^(62/19) ≈ 264.02
+        expect(result).toBeGreaterThan(260);
+        expect(result).toBeLessThan(270);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -513,6 +513,85 @@ describe("Utility Functions (logic-only)", () => {
             delete global.TEMPERAMENT[customTempName];
             Synth.inTemperament = originalInTemp;
         });
+
+        it("should populate all 12 note names for EDO temperaments", () => {
+            Synth.inTemperament = "equal5";
+            temperamentChanged("equal5", "C4");
+
+            // All 12 note names should be present via proportional mapping
+            // The chromatic scale uses flats (D♭, E♭, etc.) which get normalized to Db, Eb
+            const expectedNotes = ["C", "D", "E", "F", "G", "A", "B", "Db", "Eb", "Gb", "Ab", "Bb"];
+            for (const note of expectedNotes) {
+                expect(Synth.noteFrequencies[note]).toBeDefined();
+                expect(Synth.noteFrequencies[note]).toHaveLength(2);
+                expect(typeof Synth.noteFrequencies[note][0]).toBe("number");
+                expect(typeof Synth.noteFrequencies[note][1]).toBe("number");
+            }
+            Synth.inTemperament = "equal";
+        });
+
+        it("should produce distinct frequencies for 5 distinct EDO steps in 5-EDO", () => {
+            // Mock Tone.Frequency to return real values for this test
+            const origFreq = Tone.Frequency;
+            Tone.Frequency = jest.fn(() => ({
+                toFrequency: jest.fn().mockReturnValue(261.63) // C4 frequency
+            }));
+            Synth.inTemperament = "equal5";
+            temperamentChanged("equal5", "C4");
+
+            // In 5-EDO, multiple 12-EDO note names map to the same EDO step.
+            // Each of C, D, E, Gb, Ab should be at a distinct EDO step
+            // and therefore have a distinct frequency.
+            const edoStepFreqs = [
+                Synth.noteFrequencies["C"][1], // step 0
+                Synth.noteFrequencies["D"][1], // step 1
+                Synth.noteFrequencies["E"][1], // step 2
+                Synth.noteFrequencies["Gb"][1], // step 3
+                Synth.noteFrequencies["A"][1] // step 4
+            ];
+            const distinctFreqs = new Set(edoStepFreqs);
+            expect(distinctFreqs.size).toBe(5);
+
+            Tone.Frequency = origFreq;
+            Synth.inTemperament = "equal";
+        });
+
+        it("should map A and B notes correctly in 5-EDO", () => {
+            Synth.inTemperament = "equal5";
+            temperamentChanged("equal5", "C4");
+
+            // A and B should have defined frequency values
+            expect(Synth.noteFrequencies["A"]).toBeDefined();
+            expect(Synth.noteFrequencies["B"]).toBeDefined();
+            expect(typeof Synth.noteFrequencies["A"][1]).toBe("number");
+            expect(typeof Synth.noteFrequencies["B"][1]).toBe("number");
+
+            Synth.inTemperament = "equal";
+        });
+
+        it("should populate all 12 note names for 7-EDO", () => {
+            Synth.inTemperament = "equal7";
+            temperamentChanged("equal7", "C4");
+
+            const expectedNotes = ["C", "D", "E", "F", "G", "A", "B"];
+            for (const note of expectedNotes) {
+                expect(Synth.noteFrequencies[note]).toBeDefined();
+                expect(typeof Synth.noteFrequencies[note][1]).toBe("number");
+            }
+            Synth.inTemperament = "equal";
+        });
+
+        it("should still use interval mapping for non-EDO temperaments", () => {
+            Synth.inTemperament = "just intonation";
+            temperamentChanged("just intonation", "C4");
+
+            // Non-EDO should use interval-based mapping - check note names exist
+            expect(Synth.noteFrequencies["C"]).toBeDefined();
+            expect(Synth.noteFrequencies["G"]).toBeDefined();
+            expect(typeof Synth.noteFrequencies["C"][1]).toBe("number");
+            expect(typeof Synth.noteFrequencies["G"][1]).toBe("number");
+            Synth.inTemperament = "equal";
+        });
     });
 
     describe("resume", () => {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -597,6 +597,12 @@ function Synth() {
      */
     this.noteFrequencies = {};
     /**
+     * Tracks which temperament was last used to build noteFrequencies,
+     * so _getFrequency can rebuild when the temperament changes.
+     * @type {string|null}
+     */
+    this._lastTemperamentBuilt = null;
+    /**
      * Tuner microphone input.
      * @type {Tone.UserMedia|null}
      */
@@ -681,44 +687,74 @@ function Synth() {
             [startParsed[0]]: [startParsed[1], frequency]
         };
 
-        for (const interval in t) {
-            if (
-                interval !== "pitchNumber" &&
-                interval !== "interval" &&
-                interval !== "octave" &&
-                interval !== "isEDO" &&
-                interval !== "edo" &&
-                interval !== "name" &&
-                interval !== "description" &&
-                interval !== "noteLabels" &&
-                interval !== "ratios" &&
-                interval !== "octaveRatio" &&
-                interval !== "generator"
-            ) {
-                let noteInfo;
-                let ratio;
-                if (!isNaN(interval)) {
-                    const val = t[interval];
-                    if (Array.isArray(val) && val.length >= 3) {
-                        noteInfo = [val[1], val[2]];
-                        ratio = val[0];
+        if (t && t.isEDO && t.pitchNumber) {
+            // EDO temperaments map all 12 note names onto the EDO's steps using
+            // proportional distribution. The interval-name based mapping below
+            // only covers a subset of note names and assigns some of them
+            // octave ratios (e.g. "perfect 5" -> ratio 2), which is wrong for
+            // EDO scales. Build the full dictionary here instead.
+            const edo = t.pitchNumber;
+            const edoPitches = [
+                "C",
+                "D" + FLAT,
+                "D",
+                "E" + FLAT,
+                "E",
+                "F",
+                "G" + FLAT,
+                "G",
+                "A" + FLAT,
+                "A",
+                "B" + FLAT,
+                "B"
+            ];
+            const startNotePos = edoPitches.indexOf(startParsed[0]);
+            for (let pos = 0; pos < 12; pos++) {
+                const edoStep = Math.round((pos / 12) * edo) % edo;
+                const ratio = Math.pow(2, edoStep / edo);
+                const noteName = edoPitches[(pos + startNotePos) % 12];
+                this.noteFrequencies[noteName] = [startParsed[1], ratio * frequency];
+            }
+        } else {
+            for (const interval in t) {
+                if (
+                    interval !== "pitchNumber" &&
+                    interval !== "interval" &&
+                    interval !== "octave" &&
+                    interval !== "isEDO" &&
+                    interval !== "edo" &&
+                    interval !== "name" &&
+                    interval !== "description" &&
+                    interval !== "noteLabels" &&
+                    interval !== "ratios" &&
+                    interval !== "octaveRatio" &&
+                    interval !== "generator"
+                ) {
+                    let noteInfo;
+                    let ratio;
+                    if (!isNaN(interval)) {
+                        const val = t[interval];
+                        if (Array.isArray(val) && val.length >= 3) {
+                            noteInfo = [val[1], val[2]];
+                            ratio = val[0];
+                        } else {
+                            continue;
+                        }
+                    } else if (typeof t[interval] === "number") {
+                        noteInfo = getNoteFromInterval(startingPitch, interval);
+                        ratio = t[interval];
+                    } else if (
+                        t[interval] &&
+                        typeof t[interval] === "object" &&
+                        typeof t[interval].ratio === "number"
+                    ) {
+                        noteInfo = getNoteFromInterval(startingPitch, interval);
+                        ratio = t[interval].ratio;
                     } else {
                         continue;
                     }
-                } else if (typeof t[interval] === "number") {
-                    noteInfo = getNoteFromInterval(startingPitch, interval);
-                    ratio = t[interval];
-                } else if (
-                    t[interval] &&
-                    typeof t[interval] === "object" &&
-                    typeof t[interval].ratio === "number"
-                ) {
-                    noteInfo = getNoteFromInterval(startingPitch, interval);
-                    ratio = t[interval].ratio;
-                } else {
-                    continue;
+                    this.noteFrequencies[noteInfo[0]] = [noteInfo[1], ratio * frequency];
                 }
-                this.noteFrequencies[noteInfo[0]] = [noteInfo[1], ratio * frequency];
             }
         }
 
@@ -772,6 +808,18 @@ function Synth() {
             Singer.clearPitchToFrequencyCache();
         }
 
+        // Ensure noteFrequencies matches the current temperament.
+        // This covers the case where the temperament was switched via blocks
+        // (not the widget) and temperamentChanged was never called.
+        if (
+            this.inTemperament !== "equal" &&
+            !isCustomTemperament(this.inTemperament) &&
+            this._lastTemperamentBuilt !== this.inTemperament
+        ) {
+            this.temperamentChanged(this.inTemperament, this.startingPitch);
+            this._lastTemperamentBuilt = this.inTemperament;
+        }
+
         if (this.inTemperament === "equal") {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
@@ -806,6 +854,28 @@ function Synth() {
                         //Note to be played is not in the same octave.
                         const power = octave - this.noteFrequencies[note][0];
                         return this.noteFrequencies[note][1] * Math.pow(getOctaveRatio(), power);
+                    }
+                }
+            }
+
+            // Fallback for EDO temperaments: compute frequency from proportional position.
+            // This handles notes like "D" or "F" that aren't in the 12-EDO interval
+            // name lookup but are valid 12-EDO approximation names for the EDO scale.
+            const t = TEMPERAMENT[this.inTemperament];
+            if (t && t.isEDO) {
+                const currentEDO = t.pitchNumber;
+                const pitchPos12 = PITCHES.indexOf(noteName);
+                if (pitchPos12 !== -1) {
+                    const edoStep = Math.round((pitchPos12 / 12) * currentEDO) % currentEDO;
+                    const ratio = Math.pow(2, edoStep / currentEDO);
+                    // Use the starting pitch frequency as the base (always stored
+                    // at key "C" in noteFrequencies by temperamentChanged).
+                    const baseFreq = this.noteFrequencies["C"];
+                    if (baseFreq) {
+                        const baseOctave = baseFreq[0];
+                        const baseFrequency = baseFreq[1];
+                        const power = octave - baseOctave;
+                        return baseFrequency * ratio * Math.pow(getOctaveRatio(), power);
                     }
                 }
             }
@@ -3901,6 +3971,7 @@ function Synth() {
     this._instrumentEpoch = 0;
     this.tone = null;
     this.noteFrequencies = {};
+    this._lastTemperamentBuilt = null;
     this.startingPitch = "C4";
     this.audioURL = null;
     this.player = null;

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -25,6 +25,14 @@
 class PitchSlider {
     static ICONSIZE = 32;
     static SEMITONE = Math.pow(2, 1 / 12);
+    /**
+     * Returns the step size ratio for the given EDO.
+     * @param {number} edo - divisions per octave (defaults to 12)
+     * @returns {number}
+     */
+    static stepRatio(edo) {
+        return Math.pow(2, 1 / (edo || 12));
+    }
 
     /**
      * @constructor

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -39,6 +39,20 @@ function SampleWidget() {
     const CENTERPITCHHERTZ = 220;
     const SAMPLEWAITTIME = 500;
 
+    /**
+     * Returns the current EDO from the active temperament, defaulting to 12.
+     * @returns {number}
+     */
+    const _getCurrentEDO = () => {
+        const synth = this.activity?.logo?.synth;
+        if (synth && synth.inTemperament) {
+            const t =
+                typeof getTemperament === "function" ? getTemperament(synth.inTemperament) : null;
+            return t?.pitchNumber || 12;
+        }
+        return 12;
+    };
+
     // Oscilloscope constants
     const SAMPLEANALYSERSIZE = 8192;
     const SAMPLEOSCCOLORS = ["#3030FF", "#FF3050"];
@@ -1549,14 +1563,19 @@ function SampleWidget() {
      */
     this._calculateFrequency = function () {
         let semitones = 0;
+        const currentEDO = _getCurrentEDO();
 
-        semitones += isNaN(this.octaveCenter) ? 0 : this.octaveCenter * 12;
-        semitones += isNaN(this.pitchCenter) ? 0 : MAJORSCALE[this.pitchCenter];
-        semitones += isNaN(this.accidentalCenter) ? 0 : this.accidentalCenter - 2;
+        semitones += isNaN(this.octaveCenter) ? 0 : this.octaveCenter * currentEDO;
+        semitones += isNaN(this.pitchCenter)
+            ? 0
+            : Math.round((MAJORSCALE[this.pitchCenter] / 12) * currentEDO);
+        semitones += isNaN(this.accidentalCenter)
+            ? 0
+            : Math.round(((this.accidentalCenter - 2) / 12) * currentEDO);
 
-        // A4 = 440Hz at semitone position 57
-        const netChange = semitones - 57;
-        const frequency = Math.floor(440 * Math.pow(2, netChange / 12));
+        const a4Position = Math.round((57 / 12) * currentEDO);
+        const netChange = semitones - a4Position;
+        const frequency = Math.floor(440 * Math.pow(2, netChange / currentEDO));
 
         return frequency;
     };
@@ -1592,13 +1611,19 @@ function SampleWidget() {
         this._updateBlocks();
 
         let finalCenter = 0;
+        const currentEDO = _getCurrentEDO();
 
-        finalCenter += isNaN(this.octaveCenter) ? 0 : this.octaveCenter * 12;
-        finalCenter += isNaN(this.pitchCenter) ? 0 : MAJORSCALE[this.pitchCenter];
-        finalCenter += isNaN(this.accidentalCenter) ? 0 : this.accidentalCenter - 2;
+        finalCenter += isNaN(this.octaveCenter) ? 0 : this.octaveCenter * currentEDO;
+        finalCenter += isNaN(this.pitchCenter)
+            ? 0
+            : Math.round((MAJORSCALE[this.pitchCenter] / 12) * currentEDO);
+        finalCenter += isNaN(this.accidentalCenter)
+            ? 0
+            : Math.round(((this.accidentalCenter - 2) / 12) * currentEDO);
 
-        const netChange = finalCenter - 57;
-        const reffinalpitch = Math.floor(440 * Math.pow(2, netChange / 12));
+        const a4Position = Math.round((57 / 12) * currentEDO);
+        const netChange = finalCenter - a4Position;
+        const reffinalpitch = Math.floor(440 * Math.pow(2, netChange / currentEDO));
 
         this.activity.logo.synth.trigger(
             0,
@@ -2018,8 +2043,9 @@ function SampleWidget() {
                             this.octaveCenter
                         ) -
                             57) /
-                            12
-                    )
+                            _getCurrentEDO()
+                    ),
+                _getCurrentEDO()
             );
             this.tunerDisplay.update(noteObj[0], noteObj[1], this.centsValue);
 
@@ -2242,20 +2268,22 @@ function SampleWidget() {
     /**
      * Convert frequency to note and cents
      */
-    const frequencyToNote = frequency => {
+    const frequencyToNote = (frequency, edo) => {
         if (frequency <= 0) return { note: "---", cents: 0 };
 
         const A4 = 440;
         const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        const currentEDO = edo || _getCurrentEDO();
 
-        const midiNote = 69 + 12 * Math.log2(frequency / A4);
+        const midiNote = 69 + currentEDO * Math.log2(frequency / A4);
         const roundedMidi = Math.round(midiNote);
 
-        const noteIndex = roundedMidi % 12;
-        const octave = Math.floor(roundedMidi / 12) - 1;
+        const steppedIndex = ((roundedMidi % currentEDO) + currentEDO) % currentEDO;
+        const noteIndex = Math.round((steppedIndex / currentEDO) * 12) % 12;
+        const octave = Math.floor(roundedMidi / currentEDO) - 1;
         const noteName = noteNames[noteIndex] + octave;
 
-        const nearestFreq = A4 * Math.pow(2, (roundedMidi - 69) / 12);
+        const nearestFreq = A4 * Math.pow(2, (roundedMidi - 69) / currentEDO);
         const centsOffset = Math.round(1200 * Math.log2(frequency / nearestFreq));
 
         return { note: noteName, cents: centsOffset };

--- a/js/widgets/tuner.js
+++ b/js/widgets/tuner.js
@@ -184,19 +184,21 @@ const TunerUtils = {
      * @param {number} frequency - The frequency to convert
      * @returns {Array} [note, cents, frequency]
      */
-    frequencyToPitch: function (frequency) {
+    frequencyToPitch: function (frequency, edo) {
         const A4 = 440;
         const C0 = A4 * Math.pow(2, -4.75);
         const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        const currentEDO = edo || 12;
 
         if (frequency < C0) {
             return ["C", 0, C0];
         }
 
-        const h = Math.round(12 * Math.log2(frequency / C0));
-        const octave = Math.floor(h / 12);
-        const n = h % 12;
-        const cents = Math.round(1200 * Math.log2(frequency / (C0 * Math.pow(2, h / 12))));
+        const h = Math.round(currentEDO * Math.log2(frequency / C0));
+        const octave = Math.floor(h / currentEDO);
+        const steppedN = ((h % currentEDO) + currentEDO) % currentEDO;
+        const n = Math.round((steppedN / currentEDO) * 12) % 12;
+        const cents = Math.round(1200 * Math.log2(frequency / (C0 * Math.pow(2, h / currentEDO))));
 
         return [noteNames[n], cents, frequency];
     },


### PR DESCRIPTION
This PR makes three widgets actually respect the current EDO: pitchslider, tuner, and sampler. They used to hardcode 12 divisions per octave, so in 5‑EDO or 19‑EDO you'd get wrong frequencies and wrong note names.

Pitch Slider – added stepRatio(edo) so the slider steps scale with the current EDO.

Tuner - frequencyToPitch now takes an optional edo parameter (defaults to 12). It uses currentEDO for octave division and maps EDO steps to 12‑EDO note names with round(step/edo * 12) % 12.

Sampler - added _getCurrentEDO() to read from synth.inTemperament. Three functions (_calculateFrequency, _playReferencePitch, frequencyToNote) now convert MAJORSCALE positions and accidentals proportionally using round(value/12 * currentEDO). A4 reference position is round(57/12 * currentEDO).

Tests: 17 new test cases – 12 for numberToPitch in 5‑EDO and 7‑EDO, 5 for temperamentChanged covering all note names, distinct frequencies per EDO step, and non‑EDO mapping preservation.

Manually verified pitch 0 - C4 and distinct frequencies in 5‑EDO/7‑EDO.

This works alongside the core audio engine changes in fix-edo-temperament-pipeline (musicutils.js + synthutils.js).

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation