### PR TITLE
fix: support non-12 EDO temperaments in audio engine

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1257,8 +1257,8 @@ describe("pitchToNumber", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToNumber("C", 4, "C major", "equal19");
-        // 4 * 19 + 0 (C index) - 9 (A index) = 67
-        expect(result).toBe(67);
+        // C4 in 19-EDO: 4*19 + round(0/12*19) - round(9/12*19) = 76 + 0 - 14 = 62
+        expect(result).toBe(62);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {
@@ -1459,6 +1459,143 @@ describe("numberToPitch", () => {
         const result2 = numberToPitch(7, "just intonation", "C4", 0);
         expect(Array.isArray(result1)).toBe(true);
         expect(Array.isArray(result2)).toBe(true);
+    });
+});
+
+describe("numberToPitch EDO temperaments", () => {
+    beforeEach(() => {
+        global.PITCHES = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"];
+        global.TEMPERAMENT = {
+            "equal": {
+                pitchNumber: 12,
+                interval: [
+                    "perfect 1",
+                    "minor 2",
+                    "major 2",
+                    "minor 3",
+                    "major 3",
+                    "perfect 4",
+                    "diminished 5",
+                    "perfect 5",
+                    "minor 6",
+                    "major 6",
+                    "minor 7",
+                    "major 7"
+                ]
+            },
+            "equal5": {
+                isEDO: true,
+                edo: 5,
+                pitchNumber: 5,
+                interval: ["perfect 1", "minor 2", "major 2", "major 3", "augmented 4", "perfect 5"]
+            },
+            "equal7": {
+                isEDO: true,
+                edo: 7,
+                pitchNumber: 7,
+                interval: [
+                    "perfect 1",
+                    "minor 2",
+                    "major 2",
+                    "minor 3",
+                    "major 3",
+                    "perfect 4",
+                    "diminished 5",
+                    "perfect 5"
+                ]
+            },
+            "just intonation": {
+                pitchNumber: 12,
+                0: [1, "C", 4],
+                1: [16 / 15, "D♭", 4],
+                2: [9 / 8, "D", 4],
+                3: [6 / 5, "E♭", 4],
+                4: [5 / 4, "E", 4],
+                5: [4 / 3, "F", 4],
+                6: [45 / 32, "G♭", 4],
+                7: [3 / 2, "G", 4],
+                8: [8 / 5, "A♭", 4],
+                9: [5 / 3, "A", 4],
+                10: [9 / 5, "B♭", 4],
+                11: [15 / 8, "B", 4]
+            }
+        };
+        global.isCustomTemperament = jest.fn(temp => {
+            return (
+                temp !== "equal" && !(temp in PreDefinedTemperaments) && temp in global.TEMPERAMENT
+            );
+        });
+        global.getNoteFromInterval = jest.fn((pitch, interval) => {
+            if (!interval) return ["C", 4];
+            return ["C", 4];
+        });
+        global.console.debug = jest.fn();
+    });
+
+    it("maps pitch number 0 to the starting pitch in 5-EDO", () => {
+        // pitchNumber=0, startPitch="C4", offset=0 → semitone distance=0
+        // EDO step 0 relative to C4 → C4
+        const result = numberToPitch(0, "equal5", "C4", 0);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("maps pitch number 0 with C4 offset to C4 in 5-EDO", () => {
+        // Simulates playPitchNumber(0) with default pitchNumberOffset=39
+        // i = 0 + 39 = 39, offset = 39
+        // pitchNumber_local = 39 - 39 = 0 semitones from C4
+        // EDO step 0 → C4
+        const result = numberToPitch(39, "equal5", "C4", 39);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("maps pitch number 3 (1 EDO step) to D4 in 5-EDO with offset 39", () => {
+        // i = 3 + 39 = 42
+        // pitchNumber = 42 - 39 = 3 semitones from C4
+        // 3 semitones / 2.4 = 1.25 → round to 1 EDO step
+        // EDO step 1, position in PITCHES = round(1/5 * 12) = 2 → "D"
+        const result = numberToPitch(42, "equal5", "C4", 39);
+        expect(result).toEqual(["D", 4]);
+    });
+
+    it("maps pitch number 5 to F4 in 5-EDO", () => {
+        // i = 5 + 39 = 44
+        // pitchNumber = 44 - 39 = 5 semitones
+        // 5 / 2.4 = 2.083 → round to 2 EDO steps
+        // step 2, position = round(2/5 * 12) = round(4.8) = 5 → "F"
+        const result = numberToPitch(44, "equal5", "C4", 39);
+        expect(result).toEqual(["F", 4]);
+    });
+
+    it("maps pitch number 7 to G4 in 5-EDO", () => {
+        const result = numberToPitch(46, "equal5", "C4", 39);
+        expect(result).toEqual(["G", 4]);
+    });
+
+    it("maps pitch number 12 to C5 (next octave) in 5-EDO", () => {
+        // i = 12 + 39 = 51
+        // pitchNumber = 51 - 39 = 12 semitones
+        // 12 / 2.4 = 5 EDO steps → 1 full octave + 0 steps
+        const result = numberToPitch(51, "equal5", "C4", 39);
+        expect(result).toEqual(["C", 5]);
+    });
+
+    it("maps pitch number 0 to the starting pitch in 7-EDO", () => {
+        const result = numberToPitch(39, "equal7", "C4", 39);
+        expect(result).toEqual(["C", 4]);
+    });
+
+    it("produces higher octave for larger pitch numbers in 5-EDO", () => {
+        // pitchNumber=20 semitones → ~8 EDO steps → 1 octave + 3 steps
+        const result = numberToPitch(59, "equal5", "C4", 39);
+        expect(result[1]).toBe(5);
+    });
+
+    it("handles negative pitch numbers in EDO", () => {
+        // i = -2 + 39 = 37, offset = 39
+        // pitchNumber = 37 - 39 = -2 semitones
+        const result = numberToPitch(37, "equal5", "C4", 39);
+        expect(result[0]).toBeTruthy();
+        expect(result[1]).toBeLessThan(4);
     });
 });
 
@@ -2103,9 +2240,9 @@ describe("pitchToFrequency", () => {
     it("should work with equal19 temperament", () => {
         global.TEMPERAMENT = { equal19: [] };
         const result = pitchToFrequency("C", 4, 0, "C", "equal19");
-        // C4 in 19-EDO: A0 * Math.pow(2, 67/19) ≈ 316.85
-        expect(result).toBeGreaterThan(310);
-        expect(result).toBeLessThan(320);
+        // C4 in 19-EDO: A0 * 2^(62/19) ≈ 264.02
+        expect(result).toBeGreaterThan(260);
+        expect(result).toBeLessThan(270);
     });
 
     it("should fallback to 12-EDO for undefined temperament", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4087,8 +4087,15 @@ const pitchToNumber = (pitch, octave, keySignature, temperament) => {
             }
         }
     }
-    // We start at A0.
-    return octave * currentEDO + pitchNumber - PITCHES.indexOf("A") + transposition;
+    // For EDO temperaments, convert the 12-EDO pitch position to the
+    // current EDO's step position so pitchToNumber ↔ numberToPitch round-trip.
+    if (currentEDO !== 12) {
+        pitchNumber = Math.round((pitchNumber / 12) * currentEDO);
+    }
+    // We start at A0. For EDO temperaments the offset must be proportional
+    // to the current EDO so that pitchToNumber ↔ numberToPitch are inverses.
+    const offset = Math.round((PITCHES.indexOf("A") / 12) * currentEDO);
+    return octave * currentEDO + pitchNumber - offset + transposition;
 };
 
 /**
@@ -4542,13 +4549,40 @@ const numberToPitch = (i, temperament, startPitch, offset, activity) => {
             return [TEMPERAMENT[temperament][pitchNumber][1], o];
         }
     } else {
-        const intervalArray = TEMPERAMENT[temperament]["interval"];
-        const idx =
-            ((pitchNumber % intervalArray.length) + intervalArray.length) % intervalArray.length;
-        const octaveOffset = Math.floor(pitchNumber / intervalArray.length);
-        interval = intervalArray[idx];
-        const noteObj = getNoteFromInterval(startPitch, interval);
-        return [noteObj[0], noteObj[1] + octaveOffset];
+        const t = TEMPERAMENT[temperament];
+        if (t && t.isEDO) {
+            // pitchNumber is the semitone distance from the starting pitch
+            // (i - offset). Convert it to EDO steps relative to startPitch so
+            // that the notes are distributed across the current EDO's scale
+            // instead of being pushed to ultrasonic octaves.
+            const startParsed = parseNoteString(startPitch);
+            const startNotePos = PITCHES.indexOf(startParsed[0]);
+            const semitonesPerEdoStep = 12 / currentEDO;
+            const stepsFromStart = Math.round(pitchNumber / semitonesPerEdoStep);
+
+            let idx = stepsFromStart;
+            if (idx < 0) {
+                while (idx < 0) {
+                    idx += currentEDO;
+                    n += 1;
+                }
+            }
+
+            const stepInOctave = ((idx % currentEDO) + currentEDO) % currentEDO;
+            const nameIndex = Math.round((stepInOctave / currentEDO) * 12) % 12;
+            const noteName = PITCHES[(nameIndex + startNotePos) % 12];
+            const octave = startParsed[1] + Math.floor(idx / currentEDO) - n;
+            return [noteName, octave];
+        } else {
+            const intervalArray = TEMPERAMENT[temperament]["interval"];
+            const idx =
+                ((pitchNumber % intervalArray.length) + intervalArray.length) %
+                intervalArray.length;
+            const octaveOffset = Math.floor(pitchNumber / intervalArray.length);
+            interval = intervalArray[idx];
+            const noteObj = getNoteFromInterval(startPitch, interval);
+            return [noteObj[0], noteObj[1] + octaveOffset];
+        }
     }
 };
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -597,6 +597,12 @@ function Synth() {
      */
     this.noteFrequencies = {};
     /**
+     * Tracks which temperament was last used to build noteFrequencies,
+     * so _getFrequency can rebuild when the temperament changes.
+     * @type {string|null}
+     */
+    this._lastTemperamentBuilt = null;
+    /**
      * Tuner microphone input.
      * @type {Tone.UserMedia|null}
      */
@@ -681,44 +687,74 @@ function Synth() {
             [startParsed[0]]: [startParsed[1], frequency]
         };
 
-        for (const interval in t) {
-            if (
-                interval !== "pitchNumber" &&
-                interval !== "interval" &&
-                interval !== "octave" &&
-                interval !== "isEDO" &&
-                interval !== "edo" &&
-                interval !== "name" &&
-                interval !== "description" &&
-                interval !== "noteLabels" &&
-                interval !== "ratios" &&
-                interval !== "octaveRatio" &&
-                interval !== "generator"
-            ) {
-                let noteInfo;
-                let ratio;
-                if (!isNaN(interval)) {
-                    const val = t[interval];
-                    if (Array.isArray(val) && val.length >= 3) {
-                        noteInfo = [val[1], val[2]];
-                        ratio = val[0];
+        if (t && t.isEDO && t.pitchNumber) {
+            // EDO temperaments map all 12 note names onto the EDO's steps using
+            // proportional distribution. The interval-name based mapping below
+            // only covers a subset of note names and assigns some of them
+            // octave ratios (e.g. "perfect 5" -> ratio 2), which is wrong for
+            // EDO scales. Build the full dictionary here instead.
+            const edo = t.pitchNumber;
+            const edoPitches = [
+                "C",
+                "D" + FLAT,
+                "D",
+                "E" + FLAT,
+                "E",
+                "F",
+                "G" + FLAT,
+                "G",
+                "A" + FLAT,
+                "A",
+                "B" + FLAT,
+                "B"
+            ];
+            const startNotePos = edoPitches.indexOf(startParsed[0]);
+            for (let pos = 0; pos < 12; pos++) {
+                const edoStep = Math.round((pos / 12) * edo) % edo;
+                const ratio = Math.pow(2, edoStep / edo);
+                const noteName = edoPitches[(pos + startNotePos) % 12];
+                this.noteFrequencies[noteName] = [startParsed[1], ratio * frequency];
+            }
+        } else {
+            for (const interval in t) {
+                if (
+                    interval !== "pitchNumber" &&
+                    interval !== "interval" &&
+                    interval !== "octave" &&
+                    interval !== "isEDO" &&
+                    interval !== "edo" &&
+                    interval !== "name" &&
+                    interval !== "description" &&
+                    interval !== "noteLabels" &&
+                    interval !== "ratios" &&
+                    interval !== "octaveRatio" &&
+                    interval !== "generator"
+                ) {
+                    let noteInfo;
+                    let ratio;
+                    if (!isNaN(interval)) {
+                        const val = t[interval];
+                        if (Array.isArray(val) && val.length >= 3) {
+                            noteInfo = [val[1], val[2]];
+                            ratio = val[0];
+                        } else {
+                            continue;
+                        }
+                    } else if (typeof t[interval] === "number") {
+                        noteInfo = getNoteFromInterval(startingPitch, interval);
+                        ratio = t[interval];
+                    } else if (
+                        t[interval] &&
+                        typeof t[interval] === "object" &&
+                        typeof t[interval].ratio === "number"
+                    ) {
+                        noteInfo = getNoteFromInterval(startingPitch, interval);
+                        ratio = t[interval].ratio;
                     } else {
                         continue;
                     }
-                } else if (typeof t[interval] === "number") {
-                    noteInfo = getNoteFromInterval(startingPitch, interval);
-                    ratio = t[interval];
-                } else if (
-                    t[interval] &&
-                    typeof t[interval] === "object" &&
-                    typeof t[interval].ratio === "number"
-                ) {
-                    noteInfo = getNoteFromInterval(startingPitch, interval);
-                    ratio = t[interval].ratio;
-                } else {
-                    continue;
+                    this.noteFrequencies[noteInfo[0]] = [noteInfo[1], ratio * frequency];
                 }
-                this.noteFrequencies[noteInfo[0]] = [noteInfo[1], ratio * frequency];
             }
         }
 
@@ -772,6 +808,18 @@ function Synth() {
             Singer.clearPitchToFrequencyCache();
         }
 
+        // Ensure noteFrequencies matches the current temperament.
+        // This covers the case where the temperament was switched via blocks
+        // (not the widget) and temperamentChanged was never called.
+        if (
+            this.inTemperament !== "equal" &&
+            !isCustomTemperament(this.inTemperament) &&
+            this._lastTemperamentBuilt !== this.inTemperament
+        ) {
+            this.temperamentChanged(this.inTemperament, this.startingPitch);
+            this._lastTemperamentBuilt = this.inTemperament;
+        }
+
         if (this.inTemperament === "equal") {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
@@ -806,6 +854,28 @@ function Synth() {
                         //Note to be played is not in the same octave.
                         const power = octave - this.noteFrequencies[note][0];
                         return this.noteFrequencies[note][1] * Math.pow(getOctaveRatio(), power);
+                    }
+                }
+            }
+
+            // Fallback for EDO temperaments: compute frequency from proportional position.
+            // This handles notes like "D" or "F" that aren't in the 12-EDO interval
+            // name lookup but are valid 12-EDO approximation names for the EDO scale.
+            const t = TEMPERAMENT[this.inTemperament];
+            if (t && t.isEDO) {
+                const currentEDO = t.pitchNumber;
+                const pitchPos12 = PITCHES.indexOf(noteName);
+                if (pitchPos12 !== -1) {
+                    const edoStep = Math.round((pitchPos12 / 12) * currentEDO) % currentEDO;
+                    const ratio = Math.pow(2, edoStep / currentEDO);
+                    // Use the starting pitch frequency as the base (always stored
+                    // at key "C" in noteFrequencies by temperamentChanged).
+                    const baseFreq = this.noteFrequencies["C"];
+                    if (baseFreq) {
+                        const baseOctave = baseFreq[0];
+                        const baseFrequency = baseFreq[1];
+                        const power = octave - baseOctave;
+                        return baseFrequency * ratio * Math.pow(getOctaveRatio(), power);
                     }
                 }
             }
@@ -3901,6 +3971,7 @@ function Synth() {
     this._instrumentEpoch = 0;
     this.tone = null;
     this.noteFrequencies = {};
+    this._lastTemperamentBuilt = null;
     this.startingPitch = "C4";
     this.audioURL = null;
     this.player = null;


### PR DESCRIPTION
This PR fixes pitch mapping for non-12 EDO temperaments. The main bug: numberToPitch was using A0-based semitone arithmetic for EDO cases – so pitch 0 in 5-EDO gave you octave 9-10 instead of C4. Also fixed temperamentChanged not rebuilding note frequencies when temperament changed via blocks (it only worked via the widget).

musicutils.js – numberToPitch EDO branch

Replaced the A0-based semitone arithmetic with a startPitch-relative formula. Now it converts semitone distance to EDO steps via round(pitchNumber / (12/edo)), then maps back to a 12-EDO note name.

synthutils.js – temperamentChanged + _getFrequency

Added an EDO-specific code path that populates all 12 note names via proportional mapping: edoStep = round(pos/12 * currentEDO). Also added _lastTemperamentBuilt tracking so _getFrequency rebuilds noteFrequencies when temperament changes via blocks, not just the widget. And added proportional EDO fallback in _getFrequency for notes not found in the table.

pitch 0 now maps to C4 in 5-EDO (was octave 9-10 before).

Works alongside the widget fixes in fix-edo-widgets-and-tests.

PR Category
 
- [ ] Feature
- [ ] Tests
- [x] Bug Fix
- [ ] Performance
- [ ] Documentation