### PR TITLE
fix: dispose previous Tone.Analyser in LiveWaveForm to prevent audio node leak

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2692,6 +2692,10 @@ function Synth() {
      * @memberof Synth
      */
     this.LiveWaveForm = () => {
+        if (this.analyser) {
+            this.mic.disconnect(this.analyser);
+            this.analyser.dispose();
+        }
         this.analyser = new Tone.Analyser("waveform", 8192);
         this.mic.connect(this.analyser);
     };
@@ -3844,6 +3848,16 @@ function Synth() {
         this._instrumentEpoch++;
         _disposeRecordingPlayer();
         _revokeRecordingURL();
+
+        if (this.analyser) {
+            try {
+                this.mic.disconnect(this.analyser);
+                this.analyser.dispose();
+            } catch (e) {
+                console.debug("Error disposing analyser:", e);
+            }
+            this.analyser = null;
+        }
 
         for (const turtle in instruments) {
             for (const instrumentName in instruments[turtle]) {


### PR DESCRIPTION
## Description

`LiveWaveForm()` in `js/utils/synthutils.js` creates a new `Tone.Analyser` (8192-sample buffer) on every call without disposing or disconnecting the previous instance, leaking audio nodes and accumulating orphaned Web Audio connections from `this.mic`.

This PR fixes the leak by disposing and disconnecting the existing analyser before creating a new one, and adds cleanup in `disposeAllInstruments()`.

## Related Issue

Fixes #7842

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/utils/synthutils.js` `LiveWaveForm()`: dispose and disconnect previous `this.analyser` before creating a new one
- `js/utils/synthutils.js` `disposeAllInstruments()`: clean up `this.analyser` on playback stop

## Testing Performed

- All 6870 project tests pass (`npm test`)
- `npx prettier --check` passes on modified files
- `npx eslint` passes with no errors
- Pre-commit hooks (lint + format) passed automatically

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
