### PR TITLE
test(plugin): add invalid json test for processPluginData

### DIFF
--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -145,4 +145,18 @@ describe("processPluginData script cleanup", () => {
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
         expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");
     });
+
+    it("returns null and logs error when plugin data is invalid JSON", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+        const result = await processPluginData(createActivity(), "{invalid", "plugins/test.json");
+
+        expect(result).toBeNull();
+        expect(errorSpy).toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalledWith("Malformed plugin data:", "{invalid");
+
+        errorSpy.mockRestore();
+        debugSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
 **What:** The testing gap where the error handling for invalid JSON string in `processPluginData` was missing coverage has been addressed.
 **Coverage:** Now tests the scenario where an invalid JSON is passed into `processPluginData`, making sure it returns `null` gracefully and outputs the expected `console.error` and `console.debug`.
 **Result:** Test coverage for `utils.js` (specifically the `processPluginData` function error branch) is improved, ensuring reliability when encountering malformed plugin data..


- [x] Tests