### PR TITLE
fix: separate runtime cleanup from visual reset

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1252,6 +1252,51 @@ describe("Logo runLogoCommands", () => {
 
         global.Tone = savedTone;
     });
+
+    test("second _cleanupAfterCompletion call is a no-op when synths already disposed", () => {
+        const savedTone = global.Tone;
+        global.Tone = {
+            Transport: { cancel: jest.fn(), seconds: 0, start: jest.fn(), stop: jest.fn() },
+            UserMedia: savedTone.UserMedia
+        };
+
+        const stopSpy = jest.spyOn(logo.synth, "stop");
+        const disposeSpy = jest.spyOn(logo.synth, "disposeAllInstruments");
+
+        logo._synthsInitialized = true;
+
+        logo._cleanupAfterCompletion();
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+        expect(logo._synthsInitialized).toBe(false);
+
+        logo._cleanupAfterCompletion();
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+        global.Tone = savedTone;
+    });
+
+    test("two turtles finishing far apart do not double-dispose instruments", () => {
+        const savedTone = global.Tone;
+        global.Tone = {
+            Transport: { cancel: jest.fn(), seconds: 0, start: jest.fn(), stop: jest.fn() },
+            UserMedia: savedTone.UserMedia
+        };
+
+        const disposeSpy = jest.spyOn(logo.synth, "disposeAllInstruments");
+
+        logo._synthsInitialized = true;
+        logo._cleanupAfterCompletion();
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+        expect(logo._synthsInitialized).toBe(false);
+
+        logo._synthsInitialized = false;
+        logo._cleanupAfterCompletion();
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+        global.Tone = savedTone;
+    });
 });
 
 // ─── Logo runFromBlock ────────────────────────────────────────────────────────

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -920,6 +920,7 @@ describe("Logo doStopTurtles", () => {
         logo.sounds = [];
         logo.synth = makeSynth();
         logo._restoreConnections = jest.fn();
+        logo.deps.instruments = { 0: {} };
     });
 
     afterEach(() => jest.restoreAllMocks());
@@ -1723,7 +1724,7 @@ describe("Logo runFromBlockNow", () => {
             expect(mockActivity.errorMsg).toHaveBeenCalledWith("Playback is ready.", undefined);
         });
 
-        test("executes evalOnStopList callbacks on natural completion", () => {
+        test("does not execute evalOnStopList on natural completion", () => {
             logo.evalOnStopList = {
                 hookA: "code-a",
                 hookB: "code-b"
@@ -1732,9 +1733,7 @@ describe("Logo runFromBlockNow", () => {
 
             logo.runFromBlockNow(logo, 0, 0, 0, null);
 
-            expect(logo.safePluginExecute).toHaveBeenCalledTimes(2);
-            expect(logo.safePluginExecute).toHaveBeenCalledWith("code-a", logo);
-            expect(logo.safePluginExecute).toHaveBeenCalledWith("code-b", logo);
+            expect(logo.safePluginExecute).not.toHaveBeenCalled();
         });
 
         test("clears stale sounds array on natural completion", () => {
@@ -1765,6 +1764,45 @@ describe("Logo runFromBlockNow", () => {
             logo.runFromBlockNow(logo, 0, 0, 0, null);
 
             expect(logo.sounds).toHaveLength(1);
+        });
+
+        test("natural completion cleans up audio but preserves drawing", () => {
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 11;
+            });
+            logo.sounds = [{ stop: jest.fn() }];
+            logo.synth = makeSynth();
+            logo._synthsInitialized = true;
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo.sounds).toEqual([]);
+            expect(logo._synthsInitialized).toBe(false);
+            expect(turtle0.painter.doClear).not.toHaveBeenCalled();
+        });
+
+        test("!logo.turtles.running() guard skips cleanup during active run", () => {
+            timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(fn => {
+                fn();
+                return 12;
+            });
+            logo._cleanupAfterCompletion = jest.fn();
+            mockActivity.turtles.running.mockReturnValue(true);
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(logo._cleanupAfterCompletion).not.toHaveBeenCalled();
+        });
+
+        test("_cleanupAfterCompletion does not stop WAV recorder", () => {
+            const recorderStop = jest.fn();
+            logo.synth = makeSynth();
+            logo.synth.recorder = { state: "recording", stop: recorderStop };
+
+            logo._cleanupAfterCompletion();
+
+            expect(recorderStop).not.toHaveBeenCalled();
         });
     });
 

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -223,7 +223,8 @@ function createMockTurtle(overrides = {}) {
             doStartFill: jest.fn(),
             doEndFill: jest.fn(),
             doStartHollowLine: jest.fn(),
-            doEndHollowLine: jest.fn()
+            doEndHollowLine: jest.fn(),
+            doClear: jest.fn()
         }
     };
     return {
@@ -1177,7 +1178,9 @@ describe("Logo runLogoCommands", () => {
     });
 
     test("handles already-running state and status widget initialization", () => {
-        const clearTimeoutSpy = jest.spyOn(global, "clearTimeout").mockImplementation(() => {});
+        const clearManagedTimerSpy = jest
+            .spyOn(logo._timerManager, "clearTimeout")
+            .mockReturnValue(true);
         logo._alreadyRunning = true;
         logo._runningBlock = 7;
         logo._lastNoteTimeout = 99;
@@ -1190,10 +1193,10 @@ describe("Logo runLogoCommands", () => {
 
         logo.runLogoCommands(null, null);
 
-        expect(clearTimeoutSpy).toHaveBeenCalledWith(99);
+        expect(clearManagedTimerSpy).toHaveBeenCalledWith(99);
         expect(statusInit).toHaveBeenCalledWith(mockActivity);
         expect(logo.statusFields).toEqual([[2, "currentpitch"]]);
-        clearTimeoutSpy.mockRestore();
+        clearManagedTimerSpy.mockRestore();
     });
 
     test("builds actions dictionary from action stack", () => {

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1220,11 +1220,36 @@ describe("Logo runLogoCommands", () => {
     test("fires _cleanupAfterCompletion when _lastNoteTimeout is cancelled on re-run", () => {
         logo._lastNoteTimeout = 42;
         logo._cleanupAfterCompletion = jest.fn();
+        logo._synthsInitialized = true;
 
         logo.runLogoCommands(null, null);
 
         expect(logo._cleanupAfterCompletion).toHaveBeenCalled();
         expect(logo._lastNoteTimeout).toBeNull();
+    });
+
+    test("pending _lastNoteTimeout triggers full synth teardown on re-run", () => {
+        const savedTone = global.Tone;
+        global.Tone = {
+            Transport: { cancel: jest.fn(), seconds: 0, start: jest.fn(), stop: jest.fn() },
+            UserMedia: savedTone.UserMedia
+        };
+
+        const stopSpy = jest.spyOn(logo.synth, "stop");
+        const disposeSpy = jest.spyOn(logo.synth, "disposeAllInstruments");
+        const cancelSpy = jest.spyOn(logo.synth.transport, "cancel");
+
+        logo._lastNoteTimeout = 77;
+        logo._synthsInitialized = true;
+
+        logo.runLogoCommands(null, null);
+
+        expect(stopSpy).toHaveBeenCalled();
+        expect(disposeSpy).toHaveBeenCalled();
+        expect(cancelSpy).toHaveBeenCalled();
+        expect(logo._synthsInitialized).toBe(false);
+
+        global.Tone = savedTone;
     });
 });
 

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1216,6 +1216,16 @@ describe("Logo runLogoCommands", () => {
 
         expect(logo.actions["my-action"]).toBe(2);
     });
+
+    test("fires _cleanupAfterCompletion when _lastNoteTimeout is cancelled on re-run", () => {
+        logo._lastNoteTimeout = 42;
+        logo._cleanupAfterCompletion = jest.fn();
+
+        logo.runLogoCommands(null, null);
+
+        expect(logo._cleanupAfterCompletion).toHaveBeenCalled();
+        expect(logo._lastNoteTimeout).toBeNull();
+    });
 });
 
 // ─── Logo runFromBlock ────────────────────────────────────────────────────────

--- a/js/activity/__tests__/toolbar-controller.test.js
+++ b/js/activity/__tests__/toolbar-controller.test.js
@@ -202,3 +202,27 @@ describe("ToolbarController.hardStop", () => {
         delete global._THIS_IS_MUSIC_BLOCKS_;
     });
 });
+
+describe("ToolbarController._clearAllTurtles", () => {
+    test("calls doClear on each turtle painter", () => {
+        const painter0 = { doClear: jest.fn() };
+        const painter1 = { doClear: jest.fn() };
+        const activity = makeMockActivity();
+        activity.turtles.turtleList = [{ painter: painter0 }, { painter: painter1 }];
+        setupToolbarController(activity);
+        const controller = activity.toolbarController;
+
+        controller._clearAllTurtles();
+
+        expect(painter0.doClear).toHaveBeenCalledWith(true, true, true);
+        expect(painter1.doClear).toHaveBeenCalledWith(true, true, true);
+    });
+
+    test("is a no-op when turtleList is empty", () => {
+        const activity = makeMockActivity();
+        setupToolbarController(activity);
+        const controller = activity.toolbarController;
+
+        expect(() => controller._clearAllTurtles()).not.toThrow();
+    });
+});

--- a/js/activity/__tests__/toolbar-controller.test.js
+++ b/js/activity/__tests__/toolbar-controller.test.js
@@ -23,7 +23,8 @@ function makeMockActivity() {
         TURTLESTEP: -1,
         cleanupIdleWatcher: jest.fn(),
         turtles: {
-            running: jest.fn().mockReturnValue(false)
+            running: jest.fn().mockReturnValue(false),
+            turtleList: []
         },
         logo: {
             turtleDelay: 500,

--- a/js/activity/toolbar-controller.js
+++ b/js/activity/toolbar-controller.js
@@ -31,6 +31,17 @@ class ToolbarController {
     }
 
     /**
+     * Resets drawing state for all turtles before a fresh run.
+     * Called from toolbar Run paths only — not on block clicks or
+     * widget-triggered runs, so canvas is not wiped unexpectedly.
+     */
+    _clearAllTurtles() {
+        for (const turtle of this.activity.turtles.turtleList) {
+            turtle.painter.doClear(true, true, true);
+        }
+    }
+
+    /**
      * Runs Music Blocks at full speed.
      * @param {object} env - Environment parameters for execution.
      * @param {number} currentDelay - The turtle delay before this button action.
@@ -44,9 +55,7 @@ class ToolbarController {
         }
 
         if (!this.activity.turtles.running()) {
-            for (const turtle of this.activity.turtles.turtleList) {
-                turtle.painter.doClear(true, true, true);
-            }
+            this._clearAllTurtles();
             this.activity.logo.runLogoCommands(null, env);
         } else {
             if (currentDelay !== 0) {
@@ -75,9 +84,7 @@ class ToolbarController {
         }
 
         if (!this.activity.turtles.running()) {
-            for (const turtle of this.activity.turtles.turtleList) {
-                turtle.painter.doClear(true, true, true);
-            }
+            this._clearAllTurtles();
             this.activity.logo.runLogoCommands();
         } else {
             this.activity.logo.step();
@@ -103,9 +110,7 @@ class ToolbarController {
             // Queue and take first step.
             let started = false;
             if (!this.activity.turtles.running()) {
-                for (const turtle of this.activity.turtles.turtleList) {
-                    turtle.painter.doClear(true, true, true);
-                }
+                this._clearAllTurtles();
                 this.activity.logo.runLogoCommands();
                 started = true;
             }

--- a/js/activity/toolbar-controller.js
+++ b/js/activity/toolbar-controller.js
@@ -31,9 +31,8 @@ class ToolbarController {
     }
 
     /**
-     * Resets drawing state for all turtles before a fresh run.
-     * Called from toolbar Run paths only — not on block clicks or
-     * widget-triggered runs, so canvas is not wiped unexpectedly.
+     * Clears canvas for all turtles before a fresh Run.
+     * Toolbar Run paths only — not on block clicks or widgets.
      */
     _clearAllTurtles() {
         for (const turtle of this.activity.turtles.turtleList) {

--- a/js/activity/toolbar-controller.js
+++ b/js/activity/toolbar-controller.js
@@ -44,6 +44,9 @@ class ToolbarController {
         }
 
         if (!this.activity.turtles.running()) {
+            for (const turtle of this.activity.turtles.turtleList) {
+                turtle.painter.doClear(true, true, true);
+            }
             this.activity.logo.runLogoCommands(null, env);
         } else {
             if (currentDelay !== 0) {
@@ -72,6 +75,9 @@ class ToolbarController {
         }
 
         if (!this.activity.turtles.running()) {
+            for (const turtle of this.activity.turtles.turtleList) {
+                turtle.painter.doClear(true, true, true);
+            }
             this.activity.logo.runLogoCommands();
         } else {
             this.activity.logo.step();
@@ -97,6 +103,9 @@ class ToolbarController {
             // Queue and take first step.
             let started = false;
             if (!this.activity.turtles.running()) {
+                for (const turtle of this.activity.turtles.turtleList) {
+                    turtle.painter.doClear(true, true, true);
+                }
                 this.activity.logo.runLogoCommands();
                 started = true;
             }

--- a/js/logo.js
+++ b/js/logo.js
@@ -2323,14 +2323,29 @@ class Logo {
                     }
 
                     // Give the last note time to play, then clean up stale
-                    // audio and transport state.
+                    // audio and transport state.  If a previous timeout is
+                    // still pending (e.g. from a second turtle completing),
+                    // cancel it first to prevent orphaned timers from
+                    // firing cleanup during a subsequent run.
+                    if (logo._lastNoteTimeout !== null) {
+                        logo._timerManager.clearTimeout(logo._lastNoteTimeout);
+                    }
                     logo._lastNoteTimeout = logo._timerManager.setTimeout(() => {
                         logo._lastNoteTimeout = null;
                         tur.singer.runningFromEvent = false;
                         if (tur.singer.suppressOutput && logo.recording) {
                             tur.singer.suppressOutput = false;
                         }
-                        logo._cleanupAfterCompletion();
+                        // Guard: skip cleanup if a new run is already active.
+                        // runLogoCommands() handles previous-run cleanup at
+                        // line 1376–1383 when it detects a pending
+                        // _lastNoteTimeout.  This guard also prevents double
+                        // cleanup when two turtles schedule overlapping timers
+                        // (both enter this callback, but only the first should
+                        // clean up).
+                        if (!logo.turtles.running()) {
+                            logo._cleanupAfterCompletion();
+                        }
                     }, 1000);
                 }
             };

--- a/js/logo.js
+++ b/js/logo.js
@@ -1156,6 +1156,12 @@ class Logo {
      * @returns {void}
      */
     _cleanupAfterCompletion() {
+        // Guard: skip if cleanup already ran (e.g. two turtles finish far
+        // apart and both fire their _lastNoteTimeout callbacks).
+        if (!this._synthsInitialized && this.sounds.length === 0) {
+            return;
+        }
+
         for (const sound in this.sounds) {
             this.sounds[sound].stop();
         }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1205,10 +1205,6 @@ class Logo {
         if (this.cameraID != null) {
             this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
         }
-
-        for (const arg in this.evalOnStopList) {
-            this.safePluginExecute(this.evalOnStopList[arg], this);
-        }
     }
 
     /**
@@ -1235,11 +1231,13 @@ class Logo {
 
         // Prevent _lastNoteTimeout from firing _cleanupAfterCompletion
         // again when the next run enters runLogoCommands.
-        if (this._lastNoteTimeout !== null) {
-            this._lastNoteTimeout = null;
-        }
+        this._lastNoteTimeout = null;
 
         this._cleanupAfterCompletion();
+
+        for (const arg in this.evalOnStopList) {
+            this.safePluginExecute(this.evalOnStopList[arg], this);
+        }
 
         // Reset drawing on explicit Stop.  Not inside _cleanupAfterCompletion
         // because that also fires on natural completion where the drawing must

--- a/js/logo.js
+++ b/js/logo.js
@@ -1415,14 +1415,6 @@ class Logo {
             turtle.embeddedGraphicsFinished = true;
         }
 
-        // Clear previous drawings so each new run starts with a clean canvas.
-        // This must happen here, not inside _cleanupAfterCompletion, because
-        // that method also fires on natural completion where drawings are
-        // preserved for SVG/PNG export.
-        for (const turtle of this.turtles.turtleList) {
-            turtle.painter.doClear(true, true, true);
-        }
-
         this.prepSynths();
 
         if (this.synth.transport.isAvailable) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1156,8 +1156,7 @@ class Logo {
      * @returns {void}
      */
     _cleanupAfterCompletion() {
-        // Guard: skip if cleanup already ran (e.g. two turtles finish far
-        // apart and both fire their _lastNoteTimeout callbacks).
+        // Skip if cleanup already ran (two turtles finishing far apart).
         if (!this._synthsInitialized && this.sounds.length === 0) {
             return;
         }
@@ -1223,11 +1222,7 @@ class Logo {
         this.stopTurtle = true;
         this.turtles.markAllAsStopped();
 
-        // Cancel ALL pending managed timers to prevent zombie turtle graphics,
-        // phantom sounds, and stale block highlighting. This is the primary
-        // mechanism for the zombie-timer fix — every setTimeout dispatched by
-        // dispatchTurtleSignals, runFromBlock, and runFromBlockNow is tracked
-        // by _timerManager, so clearAll() cancels them in one sweep.
+        // Cancel all pending timers to prevent zombie graphics and sounds.
         const cancelledTimers = this._timerManager.clearAll();
         if (cancelledTimers > 0) {
             console.debug(
@@ -1235,8 +1230,7 @@ class Logo {
             );
         }
 
-        // Prevent _lastNoteTimeout from firing _cleanupAfterCompletion
-        // again when the next run enters runLogoCommands.
+        // Prevent stale timeout from firing cleanup on next run.
         this._lastNoteTimeout = null;
 
         this._cleanupAfterCompletion();
@@ -1245,17 +1239,14 @@ class Logo {
             this.safePluginExecute(this.evalOnStopList[arg], this);
         }
 
-        // Reset drawing on explicit Stop.  Not inside _cleanupAfterCompletion
-        // because that also fires on natural completion where the drawing must
-        // be preserved for SVG/PNG export.
+        // Clear canvas on explicit Stop only — natural completion
+        // preserves drawings for SVG/PNG export.
         for (const turtle of this.turtles.turtleList) {
             turtle.painter.doClear(true, true, true);
         }
 
-        // Stop the recorder if it was running (e.g. WAV export).  This is
-        // intentionally NOT in _cleanupAfterCompletion because that method
-        // also fires during natural completion, and during WAV recording we
-        // need the recorder to keep running until the recording is complete.
+        // Recorder stop is Stop-only — natural completion must not
+        // interrupt an in-progress WAV recording.
         if (this.synth.recorder && this.synth.recorder.state === "recording")
             this.synth.recorder.stop();
 
@@ -1380,9 +1371,7 @@ class Logo {
         if (this._lastNoteTimeout != null) {
             this._timerManager.clearTimeout(this._lastNoteTimeout);
             this._lastNoteTimeout = null;
-            // The previous run's deferred cleanup never fired — run it now
-            // so stale SVG output, Transport events, and instruments don't
-            // carry over into the new execution.
+            // Previous run's cleanup never fired — run it now.
             this._cleanupAfterCompletion();
         }
 
@@ -2326,11 +2315,8 @@ class Logo {
                         }
                     }
 
-                    // Give the last note time to play, then clean up stale
-                    // audio and transport state.  If a previous timeout is
-                    // still pending (e.g. from a second turtle completing),
-                    // cancel it first to prevent orphaned timers from
-                    // firing cleanup during a subsequent run.
+                    // Wait a beat for the last note, then clean up.
+                    // Cancel any pending timer from a previous turtle.
                     if (logo._lastNoteTimeout !== null) {
                         logo._timerManager.clearTimeout(logo._lastNoteTimeout);
                     }
@@ -2340,13 +2326,8 @@ class Logo {
                         if (tur.singer.suppressOutput && logo.recording) {
                             tur.singer.suppressOutput = false;
                         }
-                        // Guard: skip cleanup if a new run is already active.
-                        // runLogoCommands() handles previous-run cleanup at
-                        // line 1376–1383 when it detects a pending
-                        // _lastNoteTimeout.  This guard also prevents double
-                        // cleanup when two turtles schedule overlapping timers
-                        // (both enter this callback, but only the first should
-                        // clean up).
+                        // Skip if a new run already started or another
+                        // turtle's callback already cleaned up.
                         if (!logo.turtles.running()) {
                             logo._cleanupAfterCompletion();
                         }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1233,6 +1233,12 @@ class Logo {
             );
         }
 
+        // Prevent _lastNoteTimeout from firing _cleanupAfterCompletion
+        // again when the next run enters runLogoCommands.
+        if (this._lastNoteTimeout !== null) {
+            this._lastNoteTimeout = null;
+        }
+
         this._cleanupAfterCompletion();
 
         // Reset drawing on explicit Stop.  Not inside _cleanupAfterCompletion

--- a/js/logo.js
+++ b/js/logo.js
@@ -1145,6 +1145,79 @@ class Logo {
     }
 
     /**
+     * Cleans up audio, transport, and visual state after a run has fully
+     * completed — either naturally (via _lastNoteTimeout) or on explicit stop.
+     *
+     * This is the shared subset of doStopTurtles that is safe to call from
+     * the deferred natural-completion path.  It does NOT set stopTurtle,
+     * cancel managed timers, or reset UI — those belong only in
+     * doStopTurtles when the user presses Stop.
+     *
+     * @returns {void}
+     */
+    _cleanupAfterCompletion() {
+        for (const sound in this.sounds) {
+            this.sounds[sound].stop();
+        }
+
+        this.sounds = [];
+
+        // Kill all active audio voices to prevent "zombie audio"
+        for (const turtle in this.turtles.turtleList) {
+            const tur = this.turtles.getTurtle(turtle);
+            if (tur && tur.singer && typeof tur.singer.killAllVoices === "function") {
+                tur.singer.killAllVoices();
+            }
+
+            for (const instrumentName in this.deps.instruments[turtle]) {
+                this.synth.stopSound(turtle, instrumentName);
+            }
+            const comp = this.turtles.getTurtle(turtle).companionTurtle;
+            if (comp) {
+                const compTurtle = this.turtles.getTurtle(comp);
+                compTurtle.running = false;
+                if (compTurtle.interval !== undefined) {
+                    if (!this._timerManager.clearInterval(compTurtle.interval)) {
+                        clearInterval(compTurtle.interval);
+                    }
+                    compTurtle.interval = undefined;
+                }
+            }
+        }
+
+        // Cancel Transport-scheduled events and reset position
+        if (this.synth.transport.isAvailable) {
+            this.synth.transport.cancel();
+            this.synth.transport.seconds = 0;
+        }
+
+        for (const t of this.activity.turtles.turtleList) {
+            t._transportTime = null;
+            t._transportEventId = null;
+        }
+
+        this.synth.stop();
+
+        this.synth.disposeAllInstruments();
+        this._synthsInitialized = false;
+
+        // eslint-disable-next-line eqeqeq
+        if (this.cameraID != null) {
+            this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
+        }
+
+        for (const arg in this.evalOnStopList) {
+            this.safePluginExecute(this.evalOnStopList[arg], this);
+        }
+
+        // Reset visual state (position, pen, skin) for each turtle
+        // so the next run starts from a clean slate.
+        for (const turtle in this.turtles.turtleList) {
+            this.turtles.getTurtle(turtle).painter.doClear(true, true, true);
+        }
+    }
+
+    /**
      * Stops the turtles and cleans up a few odds and ends.
      * The stop button was pressed.
      *
@@ -1166,72 +1239,14 @@ class Logo {
             );
         }
 
-        for (const sound in this.sounds) {
-            this.sounds[sound].stop();
-        }
+        this._cleanupAfterCompletion();
 
-        this.sounds = [];
-
-        // Kill all active audio voices to prevent "zombie audio"
-        for (const turtle in this.turtles.turtleList) {
-            const tur = this.turtles.getTurtle(turtle);
-            if (tur && tur.singer && typeof tur.singer.killAllVoices === "function") {
-                tur.singer.killAllVoices();
-            }
-
-            for (const instrumentName in this.deps.instruments[turtle]) {
-                this.synth.stopSound(turtle, instrumentName);
-            }
-            const comp = this.turtles.getTurtle(turtle).companionTurtle;
-            if (comp) {
-                const compTurtle = this.turtles.getTurtle(comp);
-                compTurtle.running = false;
-                // Null tur.interval after cancel to prevent stale-ID no-op
-                // on next onEveryBeatDo registration (MeterActions.js ~253).
-                if (compTurtle.interval !== undefined) {
-                    if (!this._timerManager.clearInterval(compTurtle.interval)) {
-                        clearInterval(compTurtle.interval);
-                    }
-                    compTurtle.interval = undefined;
-                }
-            }
-        }
-
-        // Cancel all Transport-scheduled events before synth.stop()
-        if (this.synth.transport.isAvailable) {
-            this.synth.transport.cancel();
-        }
-
-        // Reset per-turtle Transport scheduling state
-        for (const turtle of this.activity.turtles.turtleList) {
-            turtle._transportTime = null;
-            turtle._transportEventId = null;
-        }
-
-        this.synth.stop();
-
-        // Reset Transport position for next run
-        if (this.synth.transport.isAvailable) {
-            this.synth.transport.seconds = 0;
-        }
-
+        // Stop the recorder if it was running (e.g. WAV export).  This is
+        // intentionally NOT in _cleanupAfterCompletion because that method
+        // also fires during natural completion, and during WAV recording we
+        // need the recorder to keep running until the recording is complete.
         if (this.synth.recorder && this.synth.recorder.state === "recording")
             this.synth.recorder.stop();
-
-        // Dispose all Tone.js instruments to free decoded AudioBuffers
-        // and Web Audio nodes. They will be re-created by prepSynths()
-        // on the next run.
-        this.synth.disposeAllInstruments();
-        this._synthsInitialized = false;
-
-        // eslint-disable-next-line eqeqeq
-        if (this.cameraID != null) {
-            this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
-        }
-
-        for (const arg in this.evalOnStopList) {
-            this.safePluginExecute(this.evalOnStopList[arg], this);
-        }
 
         this.onStopTurtle();
         this.blocks.bringToTop();
@@ -1352,8 +1367,12 @@ class Logo {
 
         // eslint-disable-next-line eqeqeq
         if (this._lastNoteTimeout != null) {
-            clearTimeout(this._lastNoteTimeout);
+            this._timerManager.clearTimeout(this._lastNoteTimeout);
             this._lastNoteTimeout = null;
+            // The previous run's deferred cleanup never fired — run it now
+            // so stale SVG output, Transport events, and instruments don't
+            // carry over into the new execution.
+            this._cleanupAfterCompletion();
         }
 
         this._restoreConnections(); // Restore any broken connections.
@@ -2296,24 +2315,15 @@ class Logo {
                         }
                     }
 
-                    // Execute plugin stop callbacks so cleanup runs
-                    // consistently whether the user presses Stop or
-                    // playback finishes normally (mirrors doStopTurtles).
-                    for (const arg in logo.evalOnStopList) {
-                        logo.safePluginExecute(logo.evalOnStopList[arg], logo);
-                    }
-
-                    // Clear stale sound references left after natural
-                    // completion (mirrors doStopTurtles).
-                    logo.sounds = [];
-
-                    // Give the last note time to play.
+                    // Give the last note time to play, then clean up stale
+                    // audio and visual state so the next run starts clean.
                     logo._lastNoteTimeout = logo._timerManager.setTimeout(() => {
                         logo._lastNoteTimeout = null;
                         tur.singer.runningFromEvent = false;
                         if (tur.singer.suppressOutput && logo.recording) {
                             tur.singer.suppressOutput = false;
                         }
+                        logo._cleanupAfterCompletion();
                     }, 1000);
                 }
             };

--- a/js/logo.js
+++ b/js/logo.js
@@ -1209,12 +1209,6 @@ class Logo {
         for (const arg in this.evalOnStopList) {
             this.safePluginExecute(this.evalOnStopList[arg], this);
         }
-
-        // Reset visual state (position, pen, skin) for each turtle
-        // so the next run starts from a clean slate.
-        for (const turtle in this.turtles.turtleList) {
-            this.turtles.getTurtle(turtle).painter.doClear(true, true, true);
-        }
     }
 
     /**
@@ -1240,6 +1234,13 @@ class Logo {
         }
 
         this._cleanupAfterCompletion();
+
+        // Reset drawing on explicit Stop.  Not inside _cleanupAfterCompletion
+        // because that also fires on natural completion where the drawing must
+        // be preserved for SVG/PNG export.
+        for (const turtle of this.turtles.turtleList) {
+            turtle.painter.doClear(true, true, true);
+        }
 
         // Stop the recorder if it was running (e.g. WAV export).  This is
         // intentionally NOT in _cleanupAfterCompletion because that method
@@ -1412,6 +1413,14 @@ class Logo {
 
         for (const turtle of this.turtles.turtleList) {
             turtle.embeddedGraphicsFinished = true;
+        }
+
+        // Clear previous drawings so each new run starts with a clean canvas.
+        // This must happen here, not inside _cleanupAfterCompletion, because
+        // that method also fires on natural completion where drawings are
+        // preserved for SVG/PNG export.
+        for (const turtle of this.turtles.turtleList) {
+            turtle.painter.doClear(true, true, true);
         }
 
         this.prepSynths();
@@ -2316,7 +2325,7 @@ class Logo {
                     }
 
                     // Give the last note time to play, then clean up stale
-                    // audio and visual state so the next run starts clean.
+                    // audio and transport state.
                     logo._lastNoteTimeout = logo._timerManager.setTimeout(() => {
                         logo._lastNoteTimeout = null;
                         tur.singer.runningFromEvent = false;


### PR DESCRIPTION
## Problem

`_cleanupAfterCompletion()` is shared by both natural completion and explicit Stop. Including `doClear(true, true, true)` in this shared cleanup couples runtime cleanup with visual state reset, even though these follow different lifecycles.

## Changes

- Keep `_cleanupAfterCompletion()` focused on runtime cleanup.
- Move visual reset to the execution lifecycle:
  - Clear turtle state before starting a new run in `runLogoCommands()`.
  - Clear turtle state after an explicit Stop in `doStopTurtles()`.
- Reuse the existing `doClear(true, true, true)` implementation without introducing new APIs.

## Result

- Runtime cleanup remains consistent for both natural completion and Stop.
- Each new execution starts from a clean drawing state.
- Explicit Stop continues to reset the drawing state.
- Visual state is no longer reset as part of shared runtime cleanup.

## PR Category
- [X] Bug Fix