### PR TITLE
refactor: migrate note blocks to capability metadata

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -213,6 +213,29 @@ describe("Block Foundation", () => {
             expect(block.isNoHitBlock()).toBe(false);
         });
 
+        it("isNoteContainer() should return true from capability metadata", () => {
+            mockProtoBlock.capabilities.noteContainer = true;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(true);
+        });
+
+        it("isNoteContainer() should respect explicit false metadata", () => {
+            mockProtoBlock.name = "newnote";
+            mockProtoBlock.capabilities.noteContainer = false;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(false);
+        });
+
+        it("isNoteContainer() should return false for ordinary blocks", () => {
+            mockProtoBlock.name = "forward";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.isNoteContainer()).toBe(false);
+        });
+
         it("copySize() should sync size from protoblock", () => {
             mockProtoBlock.size = 5;
             const block = new Block(mockProtoBlock, mockBlocks);

--- a/js/block.js
+++ b/js/block.js
@@ -2131,6 +2131,19 @@ class Block {
     }
 
     /**
+     * Checks if the block is a note container.
+     * @returns {boolean} - True if the block is a note container, false otherwise.
+     */
+    isNoteContainer() {
+        const noteContainerCapability = this.getCapability("noteContainer");
+        if (noteContainerCapability !== undefined) {
+            return !!noteContainerCapability;
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if the block is an argument block.
      * @returns {boolean} - True if the block is an argument block, false otherwise.
      */

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -61,7 +61,6 @@
 */
 // Constants moved to js/block-constants.js
 
-const NOTEBLOCKS = ["newnote", "osctime"];
 const PITCHBLOCKS = ["pitch", "steppitch", "hertz", "pitchnumber", "nthmodalpitch", "playdrum"];
 
 /**
@@ -1523,7 +1522,7 @@ class Blocks {
                         oldBlock
                     ]);
                 }
-            } else if (NOTEBLOCKS.includes(this.blockList[parentblk].name)) {
+            } else if (this.blockList[parentblk].isNoteContainer()) {
                 cblk = this.blockList[parentblk].connections[2];
                 if (cblk === null) {
                     const newVspaceBlock = this.makeBlock("vspace", "__NOARG__");
@@ -1562,7 +1561,7 @@ class Blocks {
             let counter = 0;
 
             while (true) {
-                if (NOTEBLOCKS.includes(this.blockList[c].name)) {
+                if (this.blockList[c].isNoteContainer()) {
                     break;
                 }
 
@@ -1695,7 +1694,7 @@ class Blocks {
             } else {
                 while (thisBlockobj.connections[0] !== null) {
                     const i = thisBlockobj.connections[0];
-                    if (NOTEBLOCKS.includes(this.blockList[i].name)) {
+                    if (this.blockList[i].isNoteContainer()) {
                         break;
                     } else if (this.blockList[i].name === "rest2") {
                         const silenceBlock = i;
@@ -4883,7 +4882,7 @@ class Blocks {
                         /** Connection 1 of a note block is not inside the clamp. */
                         return null;
                     } else {
-                        if (NOTEBLOCKS.includes(this.blockList[cblk].name)) {
+                        if (this.blockList[cblk].isNoteContainer()) {
                             return cblk;
                         } else {
                             return null;
@@ -4896,7 +4895,7 @@ class Blocks {
         };
 
         this._isConnectedToNoteValue = blk => {
-            if (NOTEBLOCKS.includes(this.blockList[blk].name)) {
+            if (this.blockList[blk].isNoteContainer()) {
                 return true;
             } else if (this.blockList[blk].connections[0] === null) {
                 return false;

--- a/js/blocks/RhythmBlocks.js
+++ b/js/blocks/RhythmBlocks.js
@@ -67,7 +67,8 @@ function setupRhythmBlocks(activity) {
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
+                parentId !== undefined &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -118,7 +119,8 @@ function setupRhythmBlocks(activity) {
             const parentId = connections?.[0];
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
+                parentId !== undefined &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -140,6 +142,7 @@ function setupRhythmBlocks(activity) {
          */
         constructor() {
             super("osctime");
+            this.setCapability("noteContainer");
             this.setPalette("rhythm", activity);
             this.setHelpString([
                 _(
@@ -1115,6 +1118,7 @@ function setupRhythmBlocks(activity) {
          */
         constructor() {
             super("newnote");
+            this.setCapability("noteContainer");
             this.setPalette("rhythm", activity);
             this.beginnerBlock(true);
             this.setHelpString([

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -21,8 +21,15 @@
  */
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
+const Blocks = jest.requireActual("../../blocks");
 
 global._ = s => s;
+global.NOINPUTERRORMSG = "NO_INPUT";
+global.DEFAULTDRUM = "kick";
+global.DEFAULTBLOCKSCALE = 1.0;
+global.COLLAPSIBLES = ["repeat", "forever", "if"];
+global.INLINECOLLAPSIBLES = ["newnote", "interval", "osctime"];
+global.last = arr => (arr && arr.length > 0 ? arr[arr.length - 1] : null);
 global.NOINPUTERRORMSG = "NO_INPUT";
 global.DEFAULTDRUM = "kick";
 global.mixedNumber = jest.fn(val => val);
@@ -50,10 +57,21 @@ global.Queue = class Queue {
 class BaseBlock {
     constructor(name) {
         this.name = name;
+        this.capabilities = Object.create(null);
         this.dockTypes = [null];
         this.size = 1;
         this.lang = "en";
         this.hidden = false;
+    }
+
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 
     setPalette(palette) {
@@ -113,6 +131,57 @@ global.BaseBlock = BaseBlock;
 global.FlowBlock = FlowBlock;
 global.FlowClampBlock = FlowClampBlock;
 global.ValueBlock = ValueBlock;
+
+const createBlocksHarness = () => {
+    const blocks = new Blocks({
+        storage: {},
+        trashcan: {},
+        turtles: {},
+        boundary: {},
+        macroDict: {},
+        palettes: {
+            dict: {}
+        },
+        logo: {
+            synth: {
+                loadSynth: jest.fn()
+            }
+        },
+        blocksContainer: { x: 0, y: 0 },
+        canvas: { width: 800, height: 600 },
+        refreshCanvas: jest.fn(),
+        errorMsg: jest.fn(),
+        setSelectionMode: jest.fn(),
+        stopLoadAnimation: jest.fn(),
+        setHomeContainers: jest.fn(),
+        __tick: jest.fn()
+    });
+    blocks.activity = {
+        errorMsg: jest.fn(),
+        palettes: {
+            dict: {}
+        }
+    };
+    blocks.blockList = [];
+    blocks._blockInStack = jest.fn().mockReturnValue(false);
+    blocks.makeBlock = jest.fn((name, value) => {
+        const index = blocks.blockList.length;
+        blocks.blockList.push({
+            name,
+            value,
+            connections: [null, null, null],
+            hide: jest.fn(),
+            trash: false,
+            isNoteContainer: jest.fn().mockReturnValue(false),
+            isExpandableBlock: jest.fn().mockReturnValue(false),
+            isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+            isLeftClampBlock: jest.fn().mockReturnValue(false)
+        });
+        return index;
+    });
+
+    return blocks;
+};
 
 describe("RhythmBlocks", () => {
     let activity;
@@ -852,6 +921,137 @@ describe("RhythmBlocks", () => {
             listener({});
             expect(turtle.singer.swing.length).toBe(1);
             expect(turtle.singer.swingTarget.length).toBe(1);
+        });
+    });
+
+    describe("noteContainer capability", () => {
+        test("newnote declares noteContainer capability", () => {
+            expect(getBlock("newnote").getCapability("noteContainer")).toBe(true);
+        });
+
+        test("osctime declares noteContainer capability", () => {
+            expect(getBlock("osctime").getCapability("noteContainer")).toBe(true);
+        });
+    });
+
+    describe("Blocks note-container migration", () => {
+        test("addDefaultBlock() adds vspace and rest2 inside a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                name: "newnote",
+                connections: [null, null, null],
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            blocks.addDefaultBlock(0, 1, false);
+
+            expect(blocks.blockList[0].connections[2]).toBe(1);
+            expect(blocks.blockList[1].name).toBe("vspace");
+            expect(blocks.blockList[1].connections[0]).toBe(0);
+            expect(blocks.blockList[1].connections[1]).toBe(2);
+            expect(blocks.blockList[2].name).toBe("rest2");
+            expect(blocks.blockList[2].connections[0]).toBe(1);
+            expect(blocks.blockList[2].connections[1]).toBeNull();
+        });
+
+        test("deletePreviousDefault() keeps pitch cleanup inside a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks._blockInStack.mockReturnValue(true);
+            blocks.blockList[0] = {
+                name: "rest2",
+                connections: [1, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                name: "newnote",
+                connections: [null, null, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks.deletePreviousDefault(0)).toBe(1);
+        });
+
+        test("deletePreviousDefault() stops when the next ancestor is a note container", () => {
+            const blocks = createBlocksHarness();
+            blocks._blockInStack.mockReturnValue(false);
+            blocks.blockList[0] = {
+                name: "vspace",
+                connections: [1],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                name: "newnote",
+                connections: [null, null, null],
+                hide: jest.fn(),
+                trash: false,
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks.deletePreviousDefault(0)).toBe(1);
+        });
+
+        test("_insideNoteBlock() returns the note container ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [null, 2, 3],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBe(1);
+        });
+
+        test("_insideNoteBlock() returns null for a non-container expandable ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [null, 2, 3],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBeNull();
+        });
+
+        test("_insideNoteBlock() recurses through a non-expandable ancestor", () => {
+            const blocks = createBlocksHarness();
+            blocks.blockList[0] = {
+                connections: [1],
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[1] = {
+                connections: [2],
+                isExpandableBlock: jest.fn().mockReturnValue(false),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(false)
+            };
+            blocks.blockList[2] = {
+                connections: [null, 3, 4],
+                isExpandableBlock: jest.fn().mockReturnValue(true),
+                isArgFlowClampBlock: jest.fn().mockReturnValue(false),
+                isLeftClampBlock: jest.fn().mockReturnValue(false),
+                isNoteContainer: jest.fn().mockReturnValue(true)
+            };
+
+            expect(blocks._insideNoteBlock(0)).toBe(2);
         });
     });
 });


### PR DESCRIPTION
## Summary

This PR migrates the legacy `NOTEBLOCKS` classification to capability metadata.

### Changes

- Added the `noteContainer` capability to `NewNoteBlock` and `MillisecondsBlock`.
- Added `Block.isNoteContainer()` to query the capability.
- Replaced all `NOTEBLOCKS.includes(...)` checks with `isNoteContainer()`.
- Removed the legacy `NOTEBLOCKS` list.
- Added tests covering capability declaration and helper behavior.

Additionally, while updating `RhythmBlocks.js`, I fixed two `eqeqeq` lint warnings (`!=` → `!==`) that appeared during the pre-commit checks. These are unrelated to the migration and do not change behavior.

## Testing

<img width="369" height="72" alt="Screenshot 2026-07-19 042748" src="https://github.com/user-attachments/assets/19377255-711b-4f70-88c2-715161af608d" />


<img width="444" height="68" alt="Screenshot 2026-07-19 042833" src="https://github.com/user-attachments/assets/0c09f648-33fd-499e-987a-ef5bad825a8e" />


<img width="272" height="74" alt="Screenshot 2026-07-19 042857" src="https://github.com/user-attachments/assets/18c05409-528d-4678-8068-7d03675a1389" />


## PR category

- [x] feature
- [x] tests