### PR TITLE
test(planet): add unit tests for main.js

### DIFF
--- a/planet/js/__tests__/main.test.js
+++ b/planet/js/__tests__/main.test.js
@@ -7,7 +7,6 @@
 
 "use strict";
 
-// Mock the Planet class
 class PlanetMock {
     constructor(isMusicBlocks, storage) {
         this.isMusicBlocks = isMusicBlocks;
@@ -23,7 +22,6 @@ class PlanetMock {
 PlanetMock.instances = [];
 global.Planet = PlanetMock;
 
-// Mock window.parent as a separate object for the security origin check
 const mockParent = {};
 Object.defineProperty(window, "parent", {
     value: mockParent,
@@ -31,8 +29,6 @@ Object.defineProperty(window, "parent", {
     configurable: true
 });
 
-// Require the file under test. This executes the top-level script,
-// including registering the window.message event listener.
 require("../main.js");
 
 describe("main.js", () => {
@@ -64,7 +60,7 @@ describe("main.js", () => {
         it("should ignore events not originating from window.parent", () => {
             const event = new MessageEvent("message", {
                 data: { type: "MB_PLATFORM_COLOR", payload: { orange: "#ff5722" } },
-                source: window // not window.parent
+                source: window
             });
             window.dispatchEvent(event);
 
@@ -73,7 +69,7 @@ describe("main.js", () => {
 
         it("should ignore messages with empty or invalid type", () => {
             const event = new MessageEvent("message", {
-                data: { payload: { orange: "#ff5722" } }, // missing type
+                data: { payload: { orange: "#ff5722" } },
                 source: window.parent
             });
             window.dispatchEvent(event);
@@ -122,6 +118,44 @@ describe("main.js", () => {
             expect(document.body.classList.contains("another-class")).toBe(true);
             expect(document.body.classList.contains("new-theme")).toBe(true);
             expect(document.body.classList.contains("extra-class")).toBe(true);
+        });
+
+        it("should ignore MB_PLATFORM_COLOR messages with missing or null payloads", () => {
+            const event = new MessageEvent("message", {
+                data: { type: "MB_PLATFORM_COLOR", payload: null },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbPlatformColor).toBeUndefined();
+        });
+
+        it("should ignore MB_BLOCK_NAMES messages with missing or null payloads", () => {
+            const event = new MessageEvent("message", {
+                data: { type: "MB_BLOCK_NAMES", payload: null },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbBlockDisplayNames).toBeUndefined();
+        });
+
+        it("should handle MB_APPLY_THEME safely if add/remove are non-arrays or missing", () => {
+            document.body.classList.add("baseline-theme");
+
+            const event = new MessageEvent("message", {
+                data: {
+                    type: "MB_APPLY_THEME",
+                    payload: {
+                        add: "not-an-array"
+                    }
+                },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(document.body.classList.contains("baseline-theme")).toBe(true);
+            expect(document.body.classList.contains("not-an-array")).toBe(false);
         });
     });
 });

--- a/planet/js/__tests__/main.test.js
+++ b/planet/js/__tests__/main.test.js
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Music Blocks Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+
+"use strict";
+
+// Mock the Planet class
+class PlanetMock {
+    constructor(isMusicBlocks, storage) {
+        this.isMusicBlocks = isMusicBlocks;
+        this.storage = storage;
+        this.initCalled = false;
+        PlanetMock.instances.push(this);
+    }
+
+    async init() {
+        this.initCalled = true;
+    }
+}
+PlanetMock.instances = [];
+global.Planet = PlanetMock;
+
+// Mock window.parent as a separate object for the security origin check
+const mockParent = {};
+Object.defineProperty(window, "parent", {
+    value: mockParent,
+    writable: true,
+    configurable: true
+});
+
+// Require the file under test. This executes the top-level script,
+// including registering the window.message event listener.
+require("../main.js");
+
+describe("main.js", () => {
+    beforeEach(() => {
+        PlanetMock.instances = [];
+        window.p = undefined;
+        window._ = undefined;
+        window._mbPlatformColor = undefined;
+        window._mbBlockDisplayNames = undefined;
+        document.body.className = "";
+    });
+
+    describe("makePlanet", () => {
+        it("should initialize window.p as a Planet instance and call init", async () => {
+            const mockStorage = { get: jest.fn(), set: jest.fn() };
+            const mockTranslationFn = jest.fn(str => str);
+
+            await window.makePlanet(true, mockStorage, mockTranslationFn);
+
+            expect(window._).toBe(mockTranslationFn);
+            expect(window.p).toBeInstanceOf(PlanetMock);
+            expect(window.p.isMusicBlocks).toBe(true);
+            expect(window.p.storage).toBe(mockStorage);
+            expect(window.p.initCalled).toBe(true);
+        });
+    });
+
+    describe("message event listener", () => {
+        it("should ignore events not originating from window.parent", () => {
+            const event = new MessageEvent("message", {
+                data: { type: "MB_PLATFORM_COLOR", payload: { orange: "#ff5722" } },
+                source: window // not window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbPlatformColor).toBeUndefined();
+        });
+
+        it("should ignore messages with empty or invalid type", () => {
+            const event = new MessageEvent("message", {
+                data: { payload: { orange: "#ff5722" } }, // missing type
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbPlatformColor).toBeUndefined();
+        });
+
+        it("should handle MB_PLATFORM_COLOR type messages", () => {
+            const colorPayload = { orange: "#ff5722", blue: "#0000ff" };
+            const event = new MessageEvent("message", {
+                data: { type: "MB_PLATFORM_COLOR", payload: colorPayload },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbPlatformColor).toEqual(colorPayload);
+        });
+
+        it("should handle MB_BLOCK_NAMES type messages", () => {
+            const displayNames = { note: "Play Note", drum: "Play Drum" };
+            const event = new MessageEvent("message", {
+                data: { type: "MB_BLOCK_NAMES", payload: displayNames },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(window._mbBlockDisplayNames).toEqual(displayNames);
+        });
+
+        it("should handle MB_APPLY_THEME type messages to add and remove classes", () => {
+            document.body.classList.add("old-theme", "another-class");
+
+            const event = new MessageEvent("message", {
+                data: {
+                    type: "MB_APPLY_THEME",
+                    payload: {
+                        add: ["new-theme", "extra-class"],
+                        remove: ["old-theme"]
+                    }
+                },
+                source: window.parent
+            });
+            window.dispatchEvent(event);
+
+            expect(document.body.classList.contains("old-theme")).toBe(false);
+            expect(document.body.classList.contains("another-class")).toBe(true);
+            expect(document.body.classList.contains("new-theme")).toBe(true);
+            expect(document.body.classList.contains("extra-class")).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR introduces unit tests for `planet/js/main.js` which previously had 0% test coverage.

## Related Issue

None

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Created `planet/js/__tests__/main.test.js` to cover initialization, message origin checks, and postMessage event handlers.
-   Verified that `window.makePlanet` correctly instantiates the `Planet` class and initializes it.
-   Verified that the message event listener processes `MB_PLATFORM_COLOR`, `MB_BLOCK_NAMES`, and `MB_APPLY_THEME` payload types correctly while ignoring messages that do not originate from `window.parent`.

## Testing Performed

-   Ran the specific unit tests locally: `npm test planet/js/__tests__/main.test.js` (Passed: 6/6 tests).
-   Ran the full test suite locally: `npm test` (Passed: 6956/6956 tests).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** *(required for auto-rebase; this only affects the PR branch, not your fork)*.

## Additional Notes for Reviewers

These test cases bring statement, function, and line coverage for `planet/js/main.js` to 100%.
