### PR TITLE
test(blocks): add unit tests for block-constants.js

### DIFF
--- a/js/__tests__/block-constants.test.js
+++ b/js/__tests__/block-constants.test.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Music Blocks Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+const constants = require("../block-constants");
+
+describe("block-constants", () => {
+    test("module loads and exports an object", () => {
+        expect(constants).toBeDefined();
+        expect(typeof constants).toBe("object");
+    });
+
+    test("constants have correct values", () => {
+        expect(constants.MINIMUMDOCKDISTANCE).toBe(400);
+        expect(constants.LONGSTACK).toBe(300);
+        expect(constants.SPATIAL_GRID_CELL_SIZE).toBe(50);
+        expect(constants.CAMERAVALUE).toBe("##__CAMERA__##");
+        expect(constants.VIDEOVALUE).toBe("##__VIDEO__##");
+    });
+
+    test("exports exactly the expected set of keys", () => {
+        const expectedKeys = [
+            "MINIMUMDOCKDISTANCE",
+            "LONGSTACK",
+            "SPATIAL_GRID_CELL_SIZE",
+            "CAMERAVALUE",
+            "VIDEOVALUE"
+        ];
+        expect(Object.keys(constants).sort()).toEqual(expectedKeys.sort());
+    });
+
+    test("does not pollute the global scope", () => {
+        expect(global.MINIMUMDOCKDISTANCE).toBeUndefined();
+        expect(global.LONGSTACK).toBeUndefined();
+        expect(global.SPATIAL_GRID_CELL_SIZE).toBeUndefined();
+    });
+});

--- a/js/__tests__/block-constants.test.js
+++ b/js/__tests__/block-constants.test.js
@@ -36,5 +36,7 @@ describe("block-constants", () => {
         expect(global.MINIMUMDOCKDISTANCE).toBeUndefined();
         expect(global.LONGSTACK).toBeUndefined();
         expect(global.SPATIAL_GRID_CELL_SIZE).toBeUndefined();
+        expect(global.CAMERAVALUE).toBeUndefined();
+        expect(global.VIDEOVALUE).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Description

This PR introduces unit tests for `js/block-constants.js` to ensure the values of minimum dock distance, long stack limit, spatial grid cell size, and media block identifiers are exported and initialized correctly.

## Related Issue

None

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Created `js/__tests__/block-constants.test.js` to test and verify all constant values and export exports.

## Testing Performed

-   Ran the specific unit test suite: `npm test js/__tests__/block-constants.test.js` (Passed: 4/4 tests).
-   Ran the full Jest test suite: `npm test` (Passed).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** *(required for auto-rebase; this only affects the PR branch, not your fork)*.

## Additional Notes for Reviewers

These test cases bring test coverage for `js/block-constants.js` to 100%.
