### PR TITLE
test(rhythm): define setupBlockDragController in RhythmBlocks harness

### DIFF
--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -21,6 +21,11 @@
  */
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
+
+// Use the real BlockDragController so the Blocks constructor can attach
+// drag delegation methods (blocks.js calls setupBlockDragController(this)).
+global.setupBlockDragController = require("../../block-drag-controller").setupBlockDragController;
+
 const Blocks = jest.requireActual("../../blocks");
 
 global._ = s => s;


### PR DESCRIPTION
## Description

This PR fixes the failing Jest tests in `RhythmBlocks.test.js` after the block drag controller extraction.

Following the extraction of the block drag logic, the `Blocks` constructor now calls `setupBlockDragController(this)` during initialization. While the test setup in `blocks.test.js` was updated accordingly, the `RhythmBlocks` test harness was not, causing the note-container migration tests to fail with a `ReferenceError`.

This change updates `js/blocks/__tests__/RhythmBlocks.test.js` to initialize the real `setupBlockDragController` before loading `blocks.js`, matching the existing test setup and restoring the failing tests.

## Type of Change

- [x] Bug fix

## Testing

- Ran `npx prettier --write js/blocks/__tests__/RhythmBlocks.test.js`.
- Ran `npx jest js/blocks/__tests__/RhythmBlocks.test.js --coverage=false --ci`.
- All 73 tests in the `RhythmBlocks` test suite pass.