### PR TITLE
refactor(utils): extract DOM helpers from utils.js

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -96,6 +96,7 @@ let MYDEFINES = [
     // on demand when the widget is opened, saving ~3-5 MB of heap memory.
     // "Chart",
     "utils/utils-logic",
+    "utils/dom-helpers",
     "utils/utils",
     "utils/retryWithBackoff",
     "utils/error-handler",

--- a/js/activity.js
+++ b/js/activity.js
@@ -96,7 +96,6 @@ let MYDEFINES = [
     // on demand when the widget is opened, saving ~3-5 MB of heap memory.
     // "Chart",
     "utils/utils-logic",
-    "utils/dom-helpers",
     "utils/utils",
     "utils/retryWithBackoff",
     "utils/error-handler",

--- a/js/loader.js
+++ b/js/loader.js
@@ -55,8 +55,11 @@ requirejs.config({
         "utils/utils-logic": {
             exports: "UtilsLogic"
         },
+        "utils/dom-helpers": {
+            exports: "DomHelpers"
+        },
         "utils/utils": {
-            deps: ["utils/platformstyle", "utils/utils-logic"],
+            deps: ["utils/platformstyle", "utils/utils-logic", "utils/dom-helpers"],
             exports: "_"
         },
         "utils/retryWithBackoff": {

--- a/js/utils/__tests__/dom-helpers.test.js
+++ b/js/utils/__tests__/dom-helpers.test.js
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const {
+    docByClass,
+    docByTagName,
+    docById,
+    docByName,
+    docBySelector,
+    hideDOMLabel,
+    displayMsg,
+    closeWidgets
+} = require("../dom-helpers.js");
+
+describe("DOM query helpers", () => {
+    beforeEach(() => {
+        document.getElementById = jest.fn(() => null);
+        document.getElementsByClassName = jest.fn(() => []);
+        document.getElementsByTagName = jest.fn(() => []);
+        document.getElementsByName = jest.fn(() => []);
+        document.querySelector = jest.fn(() => null);
+    });
+
+    it("docById delegates to getElementById", () => {
+        docById("test");
+        expect(document.getElementById).toHaveBeenCalledWith("test");
+    });
+
+    it("docByClass delegates to getElementsByClassName", () => {
+        docByClass("myClass");
+        expect(document.getElementsByClassName).toHaveBeenCalledWith("myClass");
+    });
+
+    it("docByTagName delegates to getElementsByTagName", () => {
+        docByTagName("div");
+        expect(document.getElementsByTagName).toHaveBeenCalledWith("div");
+    });
+
+    it("docByName delegates to getElementsByName", () => {
+        docByName("field");
+        expect(document.getElementsByName).toHaveBeenCalledWith("field");
+    });
+
+    it("docBySelector delegates to querySelector", () => {
+        docBySelector("#app > .main");
+        expect(document.querySelector).toHaveBeenCalledWith("#app > .main");
+    });
+});
+
+describe("hideDOMLabel()", () => {
+    it("hides textLabel, numberLabel, and wheelDiv when they exist", () => {
+        const textLabel = { style: { display: "block" } };
+        const numberLabel = { style: { display: "block" } };
+        const piemenu = { style: { display: "block" } };
+        document.getElementById = jest.fn(id => {
+            if (id === "textLabel") return textLabel;
+            if (id === "numberLabel") return numberLabel;
+            if (id === "wheelDiv") return piemenu;
+            return null;
+        });
+        hideDOMLabel();
+        expect(textLabel.style.display).toBe("none");
+        expect(numberLabel.style.display).toBe("none");
+        expect(piemenu.style.display).toBe("none");
+    });
+
+    it("does not throw when elements are missing", () => {
+        document.getElementById = jest.fn(() => null);
+        expect(() => hideDOMLabel()).not.toThrow();
+    });
+});
+
+describe("displayMsg()", () => {
+    it("is a no-op that returns undefined", () => {
+        expect(displayMsg()).toBeUndefined();
+    });
+});
+
+describe("closeWidgets()", () => {
+    beforeEach(() => {
+        window.widgetWindows = {
+            openWindows: { RhythmRuler: {}, PhraseMarker: {} },
+            closeWindow: jest.fn()
+        };
+    });
+
+    it("closes every open widget window", () => {
+        closeWidgets();
+        expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("RhythmRuler");
+        expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("PhraseMarker");
+        expect(window.widgetWindows.closeWindow).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not throw when openWindows is empty", () => {
+        window.widgetWindows.openWindows = {};
+        expect(() => closeWidgets()).not.toThrow();
+    });
+});
+
+describe("compatibility export via utils.js", () => {
+    // utils.js re-exports these helpers (`...DomHelpers` in its own
+    // module.exports) so existing `require("../utils")` consumers keep
+    // working. Assert identity, not just equivalence, so a future change
+    // that accidentally re-implements rather than re-exports gets caught.
+    const utils = require("../utils.js");
+
+    it("utils.docById is the same function as dom-helpers' docById", () => {
+        expect(utils.docById).toBe(docById);
+    });
+
+    it("utils.docByClass is the same function as dom-helpers' docByClass", () => {
+        expect(utils.docByClass).toBe(docByClass);
+    });
+
+    it("utils.docByTagName is the same function as dom-helpers' docByTagName", () => {
+        expect(utils.docByTagName).toBe(docByTagName);
+    });
+
+    it("utils.docByName is the same function as dom-helpers' docByName", () => {
+        expect(utils.docByName).toBe(docByName);
+    });
+
+    it("utils.docBySelector is the same function as dom-helpers' docBySelector", () => {
+        expect(utils.docBySelector).toBe(docBySelector);
+    });
+
+    it("utils.hideDOMLabel is the same function as dom-helpers' hideDOMLabel", () => {
+        expect(utils.hideDOMLabel).toBe(hideDOMLabel);
+    });
+
+    it("utils.displayMsg is the same function as dom-helpers' displayMsg", () => {
+        expect(utils.displayMsg).toBe(displayMsg);
+    });
+
+    it("utils.closeWidgets is the same function as dom-helpers' closeWidgets", () => {
+        expect(utils.closeWidgets).toBe(closeWidgets);
+    });
+});

--- a/js/utils/__tests__/dom-helpers.test.js
+++ b/js/utils/__tests__/dom-helpers.test.js
@@ -29,29 +29,43 @@ describe("DOM query helpers", () => {
         document.querySelector = jest.fn(() => null);
     });
 
-    it("docById delegates to getElementById", () => {
-        docById("test");
+    it("docById delegates to getElementById and returns its result", () => {
+        const element = { id: "test" };
+        document.getElementById = jest.fn(() => element);
+        expect(docById("test")).toBe(element);
         expect(document.getElementById).toHaveBeenCalledWith("test");
     });
 
-    it("docByClass delegates to getElementsByClassName", () => {
-        docByClass("myClass");
+    it("docByClass delegates to getElementsByClassName and returns its result", () => {
+        const elements = [{ className: "myClass" }];
+        document.getElementsByClassName = jest.fn(() => elements);
+        expect(docByClass("myClass")).toBe(elements);
         expect(document.getElementsByClassName).toHaveBeenCalledWith("myClass");
     });
 
-    it("docByTagName delegates to getElementsByTagName", () => {
-        docByTagName("div");
+    it("docByTagName delegates to getElementsByTagName and returns its result", () => {
+        const elements = [{ tagName: "DIV" }];
+        document.getElementsByTagName = jest.fn(() => elements);
+        expect(docByTagName("div")).toBe(elements);
         expect(document.getElementsByTagName).toHaveBeenCalledWith("div");
     });
 
-    it("docByName delegates to getElementsByName", () => {
-        docByName("field");
+    it("docByName delegates to getElementsByName and returns its result", () => {
+        const elements = [{ name: "field" }];
+        document.getElementsByName = jest.fn(() => elements);
+        expect(docByName("field")).toBe(elements);
         expect(document.getElementsByName).toHaveBeenCalledWith("field");
     });
 
-    it("docBySelector delegates to querySelector", () => {
-        docBySelector("#app > .main");
+    it("docBySelector delegates to querySelector and returns its result", () => {
+        const element = { matches: "#app > .main" };
+        document.querySelector = jest.fn(() => element);
+        expect(docBySelector("#app > .main")).toBe(element);
         expect(document.querySelector).toHaveBeenCalledWith("#app > .main");
+    });
+
+    it("docById returns null when getElementById finds nothing", () => {
+        expect(docById("missing")).toBeNull();
     });
 });
 

--- a/js/utils/__tests__/dom-helpers.test.js
+++ b/js/utils/__tests__/dom-helpers.test.js
@@ -9,6 +9,7 @@
  * (at your option) any later version.
  */
 
+const DomHelpers = require("../dom-helpers.js");
 const {
     docByClass,
     docByTagName,
@@ -18,7 +19,7 @@ const {
     hideDOMLabel,
     displayMsg,
     closeWidgets
-} = require("../dom-helpers.js");
+} = DomHelpers;
 
 describe("DOM query helpers", () => {
     beforeEach(() => {
@@ -126,35 +127,18 @@ describe("compatibility export via utils.js", () => {
     // that accidentally re-implements rather than re-exports gets caught.
     const utils = require("../utils.js");
 
-    it("utils.docById is the same function as dom-helpers' docById", () => {
-        expect(utils.docById).toBe(docById);
-    });
-
-    it("utils.docByClass is the same function as dom-helpers' docByClass", () => {
-        expect(utils.docByClass).toBe(docByClass);
-    });
-
-    it("utils.docByTagName is the same function as dom-helpers' docByTagName", () => {
-        expect(utils.docByTagName).toBe(docByTagName);
-    });
-
-    it("utils.docByName is the same function as dom-helpers' docByName", () => {
-        expect(utils.docByName).toBe(docByName);
-    });
-
-    it("utils.docBySelector is the same function as dom-helpers' docBySelector", () => {
-        expect(utils.docBySelector).toBe(docBySelector);
-    });
-
-    it("utils.hideDOMLabel is the same function as dom-helpers' hideDOMLabel", () => {
-        expect(utils.hideDOMLabel).toBe(hideDOMLabel);
-    });
-
-    it("utils.displayMsg is the same function as dom-helpers' displayMsg", () => {
-        expect(utils.displayMsg).toBe(displayMsg);
-    });
-
-    it("utils.closeWidgets is the same function as dom-helpers' closeWidgets", () => {
-        expect(utils.closeWidgets).toBe(closeWidgets);
+    [
+        "docById",
+        "docByClass",
+        "docByTagName",
+        "docByName",
+        "docBySelector",
+        "hideDOMLabel",
+        "displayMsg",
+        "closeWidgets"
+    ].forEach(name => {
+        it(`utils.${name} is the same function as dom-helpers' ${name}`, () => {
+            expect(utils[name]).toBe(DomHelpers[name]);
+        });
     });
 });

--- a/js/utils/dom-helpers.js
+++ b/js/utils/dom-helpers.js
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Migration note:
+ * These DOM helper functions were extracted from js/utils/utils.js so that
+ * document-access utilities live in one place, separate from the pure logic
+ * functions in js/utils/utils-logic.js. They are loaded as a RequireJS
+ * dependency of utils/utils and assigned to window globals, matching the
+ * existing utils-logic.js pattern.
+ */
+
+/* exported
+   closeWidgets, displayMsg, docByClass, docById, docByName, docBySelector,
+   docByTagName, hideDOMLabel
+*/
+
+/**
+ * Retrieves a collection of elements by class name.
+ * @param {string} classname - The class name to search for.
+ * @returns {HTMLCollectionOf<Element>} A collection of elements with the specified class name.
+ */
+function docByClass(classname) {
+    return document.getElementsByClassName(classname);
+}
+
+/**
+ * Retrieves a collection of elements by tag name.
+ * @param {string} tag - The tag name to search for.
+ * @returns {NodeList} A collection of elements with the specified tag name.
+ */
+function docByTagName(tag) {
+    return document.getElementsByTagName(tag);
+}
+
+/**
+ * Retrieves an element by its ID.
+ * @param {string} id - The ID of the element to retrieve.
+ * @returns {HTMLElement|null} The element with the specified ID, or null if not found.
+ */
+function docById(id) {
+    return document.getElementById(id);
+}
+
+/**
+ * Retrieves a collection of elements by name.
+ * @param {string} name - The name attribute value to search for.
+ * @returns {NodeListOf<Element>} A collection of elements with the specified name attribute.
+ */
+function docByName(name) {
+    return document.getElementsByName(name);
+}
+
+/**
+ * Retrieves the first element that matches a specified CSS selector.
+ * @param {string} selector - A CSS selector string.
+ * @returns {Element|null} The first element that matches the selector, or null if not found.
+ */
+function docBySelector(selector) {
+    return document.querySelector(selector);
+}
+
+/**
+ * Hides certain DOM elements related to labels.
+ */
+function hideDOMLabel() {
+    const textLabel = docById("textLabel");
+    if (textLabel !== null) {
+        textLabel.style.display = "none";
+    }
+
+    const numberLabel = docById("numberLabel");
+    if (numberLabel !== null) {
+        numberLabel.style.display = "none";
+    }
+
+    const piemenu = docById("wheelDiv");
+    if (piemenu !== null) {
+        piemenu.style.display = "none";
+    }
+}
+
+/**
+ * Displays a message (currently unused).
+ * @returns {undefined}
+ */
+function displayMsg(/*blocks, text*/) {
+    /*
+    let msgContainer = blocks.msgText.parent;
+    msgContainer.visible = true;
+    blocks.msgText.text = text;
+    msgContainer.updateCache();
+    blocks.stage.setChildIndex(msgContainer, blocks.stage.getNumChildren() - 1);
+    */
+    return;
+}
+
+/**
+ * Closes all widgets in the window.
+ *
+ * @returns {void}
+ */
+function closeWidgets() {
+    const names = Object.keys(window.widgetWindows.openWindows);
+    names.forEach(name => window.widgetWindows.closeWindow(name));
+}
+
+const DomHelpers = {
+    docByClass,
+    docByTagName,
+    docById,
+    docByName,
+    docBySelector,
+    hideDOMLabel,
+    displayMsg,
+    closeWidgets
+};
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = DomHelpers;
+}
+
+// Only attach these functions to `window` when running as a plain browser
+// script (no CommonJS module system). In Node/Jest, code that needs them
+// gets them via `require("./dom-helpers")` (directly, or re-exported from
+// utils.js) instead — unconditionally assigning to `window`/`global` here
+// would clobber `global.docById`-style mocks that tests set up before
+// requiring the module under test.
+if (typeof window !== "undefined" && (typeof module === "undefined" || !module.exports)) {
+    window.DomHelpers = DomHelpers;
+    Object.assign(window, DomHelpers);
+}

--- a/js/utils/dom-helpers.js
+++ b/js/utils/dom-helpers.js
@@ -10,12 +10,15 @@
  */
 
 /**
- * Migration note:
- * These DOM helper functions were extracted from js/utils/utils.js so that
- * document-access utilities live in one place, separate from the pure logic
- * functions in js/utils/utils-logic.js. They are loaded as a RequireJS
- * dependency of utils/utils and assigned to window globals, matching the
- * existing utils-logic.js pattern.
+ * DOM utility helpers used throughout Music Blocks: element lookups
+ * (docById, docByClass, docByName, docBySelector, docByTagName) and a
+ * couple of small widget/label helpers (hideDOMLabel, closeWidgets) that
+ * are grouped here for the same reason. displayMsg is a legacy no-op that
+ * predates the current message/alert system; it's kept alongside these
+ * rather than in utils.js because its original implementation was a DOM
+ * helper (toggling a message container's visibility) even though it does
+ * nothing today. Loaded as a RequireJS dependency of utils/utils and
+ * assigned to window globals, matching the utils-logic.js pattern.
  */
 
 /* exported
@@ -113,7 +116,7 @@ function closeWidgets() {
     names.forEach(name => window.widgetWindows.closeWindow(name));
 }
 
-const DomHelpers = {
+var DomHelpers = {
     docByClass,
     docByTagName,
     docById,

--- a/js/utils/dom-helpers.js
+++ b/js/utils/dom-helpers.js
@@ -136,5 +136,12 @@ if (typeof module !== "undefined" && module.exports) {
 // requiring the module under test.
 if (typeof window !== "undefined" && (typeof module === "undefined" || !module.exports)) {
     window.DomHelpers = DomHelpers;
-    Object.assign(window, DomHelpers);
+    window.docByClass = docByClass;
+    window.docByTagName = docByTagName;
+    window.docById = docById;
+    window.docByName = docByName;
+    window.docBySelector = docBySelector;
+    window.hideDOMLabel = hideDOMLabel;
+    window.displayMsg = displayMsg;
+    window.closeWidgets = closeWidgets;
 }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -35,13 +35,17 @@ if (typeof module !== "undefined" && module.exports) {
         (typeof window !== "undefined" && window.UtilsLogic) ||
         (typeof require !== "undefined" ? require("./utils-logic") : {});
     var { resolveObject } = UtilsLogic;
+
+    var DomHelpers =
+        (typeof window !== "undefined" && window.DomHelpers) ||
+        (typeof require !== "undefined" ? require("./dom-helpers") : {});
 }
 
 /* exported
-   announceToScreenReader,canvasPixelRatio, changeImage, closeBlkWidgets, closeWidgets,
-   delayExecution, displayMsg, doBrowserCheck, docByClass, docByName,
-   docBySelector, docByTagName, doPublish, doStopVideoCam, doSVG,
-   doUseCamera, format, getTextWidth, hideDOMLabel, httpGet, httpPost, HttpRequest,
+   announceToScreenReader,canvasPixelRatio, changeImage, closeBlkWidgets,
+   delayExecution, doBrowserCheck,
+   doPublish, doStopVideoCam, doSVG,
+   doUseCamera, format, getTextWidth, httpGet, httpPost, HttpRequest,
    importMembers, isSVGEmpty, prepareMacroExports, preparePluginExports,
    processMacroData, processPluginData, processRawPluginData, windowHeight, windowWidth,
    fnBrowserDetect, waitForReadiness
@@ -439,50 +443,8 @@ function waitForReadiness(callback, options = {}) {
     requestAnimationFrame(check);
 }
 
-/**
- * Retrieves a collection of elements by class name.
- * @param {string} classname - The class name to search for.
- * @returns {HTMLCollectionOf<Element>} A collection of elements with the specified class name.
- */
-function docByClass(classname) {
-    return document.getElementsByClassName(classname);
-}
-
-/**
- * Retrieves a collection of elements by tag name.
- * @param {string} tag - The tag name to search for.
- * @returns {NodeList} A collection of elements with the specified tag name.
- */
-function docByTagName(tag) {
-    return document.getElementsByTagName(tag);
-}
-
-/**
- * Retrieves an element by its ID.
- * @param {string} id - The ID of the element to retrieve.
- * @returns {HTMLElement|null} The element with the specified ID, or null if not found.
- */
-function docById(id) {
-    return document.getElementById(id);
-}
-
-/**
- * Retrieves a collection of elements by name.
- * @param {string} name - The name attribute value to search for.
- * @returns {NodeListOf<Element>} A collection of elements with the specified name attribute.
- */
-function docByName(name) {
-    return document.getElementsByName(name);
-}
-
-/**
- * Retrieves the first element that matches a specified CSS selector.
- * @param {string} selector - A CSS selector string.
- * @returns {Element|null} The first element that matches the selector, or null if not found.
- */
-function docBySelector(selector) {
-    return document.querySelector(selector);
-}
+// docByClass(), docByTagName(), docById(), docByName(), docBySelector()
+// moved to js/utils/dom-helpers.js
 
 // last() and deepClone() moved to js/utils/utils-logic.js
 
@@ -1315,40 +1277,7 @@ function doStopVideoCam(cameraID, setCameraID) {
     CameraManager.reset();
 }
 
-/**
- * Hides certain DOM elements related to labels.
- */
-function hideDOMLabel() {
-    const textLabel = docById("textLabel");
-    if (textLabel !== null) {
-        textLabel.style.display = "none";
-    }
-
-    const numberLabel = docById("numberLabel");
-    if (numberLabel !== null) {
-        numberLabel.style.display = "none";
-    }
-
-    const piemenu = docById("wheelDiv");
-    if (piemenu !== null) {
-        piemenu.style.display = "none";
-    }
-}
-
-/**
- * Displays a message (currently unused).
- * @returns {undefined}
- */
-function displayMsg(/*blocks, text*/) {
-    /*
-    let msgContainer = blocks.msgText.parent;
-    msgContainer.visible = true;
-    blocks.msgText.text = text;
-    msgContainer.updateCache();
-    blocks.stage.setChildIndex(msgContainer, blocks.stage.getNumChildren() - 1);
-    */
-    return;
-}
+// hideDOMLabel() and displayMsg() moved to js/utils/dom-helpers.js
 
 // safeSVG() and toFixed2() moved to js/utils/utils-logic.js
 
@@ -1370,15 +1299,7 @@ let delayExecution = duration => {
     });
 };
 
-/**
- * Closes all widgets in the window.
- *
- * @returns {void}
- */
-function closeWidgets() {
-    const names = Object.keys(window.widgetWindows.openWindows);
-    names.forEach(name => window.widgetWindows.closeWindow(name));
-}
+// closeWidgets() moved to js/utils/dom-helpers.js
 
 /**
  * Closes a specific widget by its name.
@@ -1536,11 +1457,11 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         ...UtilsLogic,
+        ...DomHelpers,
         extractProjectDataFromHTML,
         _,
         format,
         delayExecution,
-        closeWidgets,
         closeBlkWidgets,
         importMembers,
         changeImage,
@@ -1551,19 +1472,12 @@ if (typeof module !== "undefined" && module.exports) {
         httpGet,
         httpPost,
         HttpRequest,
-        docByClass,
-        docByTagName,
-        docById,
-        docByName,
-        docBySelector,
         getTextWidth,
         doSVG,
         isSVGEmpty,
         prepareMacroExports,
         processPluginData,
         processMacroData,
-        hideDOMLabel,
-        displayMsg,
         announceToScreenReader
     };
 }

--- a/planet/index.html
+++ b/planet/index.html
@@ -41,6 +41,7 @@
     <script type="text/javascript" src="js/LocalPlanet.js"></script>
 
     <script type="text/javascript" src="../js/utils/utils-logic.js"></script>
+    <script type="text/javascript" src="../js/utils/dom-helpers.js"></script>
     <script type="text/javascript" src="../js/utils/utils.js"></script>
     <script type="text/javascript" src="js/GlobalTag.js"></script>
     <script type="text/javascript" src="js/GlobalCard.js"></script>


### PR DESCRIPTION
## Description

This PR extracts common DOM helper utilities from `js/utils/utils.js` into a dedicated module, `js/utils/dom-helpers.js`.

The extraction is a refactoring only and does not introduce any behavioral changes. The existing public API is preserved by re-exporting the extracted helpers from `utils.js`, ensuring existing callers continue to work without modification.

This change:
- Moves the DOM helper functions into `js/utils/dom-helpers.js`.
- Updates `utils.js` to import and re-export the extracted helpers.
- Registers the new module in the RequireJS loader and Planet build.
- Preserves compatibility for both browser and Jest/Node environments.

## Type of Change

- [x] Refactoring 

