### PR TITLE
refactor(utils): extract browser detection helpers into browser-utils.js

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -58,8 +58,16 @@ requirejs.config({
         "utils/dom-helpers": {
             exports: "DomHelpers"
         },
+        "utils/browser-utils": {
+            exports: "BrowserUtils"
+        },
         "utils/utils": {
-            deps: ["utils/platformstyle", "utils/utils-logic", "utils/dom-helpers"],
+            deps: [
+                "utils/platformstyle",
+                "utils/utils-logic",
+                "utils/dom-helpers",
+                "utils/browser-utils"
+            ],
             exports: "_"
         },
         "utils/retryWithBackoff": {

--- a/js/utils/__tests__/browser-utils.global-load.test.js
+++ b/js/utils/__tests__/browser-utils.global-load.test.js
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * browser-utils.test.js reaches the module through require(). In the
+ * application these files are evaluated as classic scripts, where `module` is
+ * undefined and the helpers reach their callers as window globals, so the two
+ * paths can regress independently.
+ *
+ * These tests evaluate the files as classic scripts and assert the loader
+ * configuration separately. They do not run RequireJS itself; the real
+ * resolution order is exercised by the Cypress E2E suite.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const UTILS_DIR = path.resolve(__dirname, "..");
+const LOADER = path.resolve(__dirname, "../../loader.js");
+
+const HELPERS = [
+    "fnBrowserDetect",
+    "doBrowserCheck",
+    "canvasPixelRatio",
+    "windowHeight",
+    "windowWidth"
+];
+
+/**
+ * Evaluates project files as classic scripts in a scope where `window` is the
+ * global object and `module` does not exist, so top-level declarations become
+ * globals and the CommonJS branches are skipped.
+ * @param {string[]} files - Basenames in js/utils, evaluated in order.
+ * @param {string} userAgent - The user agent the fake navigator reports.
+ * @returns {Object} The scope after evaluation.
+ */
+const loadAsScripts = (files, userAgent = "Mozilla/5.0 Chrome/120.0") => {
+    const scope = { navigator: { userAgent } };
+    scope.window = scope;
+    vm.createContext(scope);
+
+    for (const file of files) {
+        const full = path.join(UTILS_DIR, `${file}.js`);
+        vm.runInContext(fs.readFileSync(full, "utf8"), scope, { filename: full });
+    }
+    return scope;
+};
+
+describe("browser-utils.js evaluated as a classic script", () => {
+    it("skips the CommonJS branch and publishes BrowserUtils", () => {
+        const scope = loadAsScripts(["browser-utils"]);
+
+        expect(typeof scope.module).toBe("undefined");
+        expect(Object.keys(scope.BrowserUtils).sort()).toEqual([...HELPERS].sort());
+    });
+
+    it.each(HELPERS)("exposes %s as a window global", helper => {
+        const scope = loadAsScripts(["browser-utils"]);
+
+        expect(scope[helper]).toBe(scope.BrowserUtils[helper]);
+    });
+
+    it("returns working results through the globals", () => {
+        const scope = loadAsScripts(["browser-utils"], "Mozilla/5.0 Firefox/121.0");
+        scope.jQuery = {};
+
+        expect(scope.fnBrowserDetect()).toBe("firefox");
+
+        scope.doBrowserCheck();
+        expect(scope.jQuery.browser.mozilla).toBe(true);
+    });
+
+    it("survives utils.js being evaluated afterwards", () => {
+        // utils.js hoists `var BrowserUtils` from a `typeof module` branch that
+        // never runs in the browser; that must not reset the published global.
+        const scope = loadAsScripts(["utils-logic", "dom-helpers", "browser-utils", "utils"]);
+
+        expect(Object.keys(scope.BrowserUtils).sort()).toEqual([...HELPERS].sort());
+        expect(scope.fnBrowserDetect()).toBe("chrome");
+    });
+});
+
+describe("loader.js shim registration", () => {
+    /**
+     * Runs loader.js far enough to capture the object it passes to
+     * requirejs.config(), so these assertions read the real configuration.
+     * @returns {Object} The captured configuration object.
+     */
+    const captureRequireConfig = () => {
+        let captured = null;
+        const scope = {
+            requirejs: { config: cfg => (captured = cfg), defined: () => false },
+            define: () => {},
+            location: { protocol: "https:" }
+        };
+        scope.window = scope;
+        vm.createContext(scope);
+        try {
+            vm.runInContext(fs.readFileSync(LOADER, "utf8"), scope, { filename: LOADER });
+        } catch (e) {
+            // loader.js continues into a bootstrap needing real RequireJS after
+            // calling config(); only the captured config matters here.
+        }
+        return captured;
+    };
+
+    it("registers utils/browser-utils with BrowserUtils as its export", () => {
+        expect(captureRequireConfig().shim["utils/browser-utils"]).toEqual({
+            exports: "BrowserUtils"
+        });
+    });
+
+    it("orders browser-utils ahead of utils/utils via its deps", () => {
+        expect(captureRequireConfig().shim["utils/utils"].deps).toContain("utils/browser-utils");
+    });
+});

--- a/js/utils/__tests__/browser-utils.test.js
+++ b/js/utils/__tests__/browser-utils.test.js
@@ -1,0 +1,275 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const BrowserUtils = require("../browser-utils");
+
+const { fnBrowserDetect, doBrowserCheck, canvasPixelRatio, windowHeight, windowWidth } =
+    BrowserUtils;
+
+/**
+ * Overrides navigator.userAgent for the duration of a single test.
+ * @param {string} value - The user agent string to report.
+ */
+const setUserAgent = value => {
+    Object.defineProperty(navigator, "userAgent", { value, configurable: true });
+};
+
+const ORIGINAL_USER_AGENT = navigator.userAgent;
+
+afterEach(() => {
+    setUserAgent(ORIGINAL_USER_AGENT);
+});
+
+describe("fnBrowserDetect()", () => {
+    it.each([
+        ["chrome", "Mozilla/5.0 Chrome/120.0"],
+        ["chrome", "Mozilla/5.0 CriOS/120.0"],
+        ["chrome", "Mozilla/5.0 Chromium/120.0"],
+        ["firefox", "Mozilla/5.0 Firefox/121.0"],
+        ["firefox", "Mozilla/5.0 FxiOS/121.0"],
+        ["safari", "Mozilla/5.0 Safari/605.1.15"],
+        ["opera", "Mozilla/5.0 OPR/106.0"],
+        ["edge", "Mozilla/5.0 Edg/120.0"]
+    ])("detects %s from %s", (expected, userAgent) => {
+        setUserAgent(userAgent);
+        expect(fnBrowserDetect()).toBe(expected);
+    });
+
+    it("returns the fallback string for an unrecognized user agent", () => {
+        setUserAgent("CustomBot/1.0");
+        expect(fnBrowserDetect()).toBe("No browser detection");
+    });
+
+    it("prefers chrome over safari when both tokens are present", () => {
+        setUserAgent("Mozilla/5.0 AppleWebKit/537.36 Chrome/120.0 Safari/537.36");
+        expect(fnBrowserDetect()).toBe("chrome");
+    });
+});
+
+describe("doBrowserCheck()", () => {
+    let jQueryStub;
+
+    beforeEach(() => {
+        jQueryStub = {};
+        global.jQuery = jQueryStub;
+    });
+
+    afterEach(() => {
+        delete global.jQuery;
+    });
+
+    it("installs a uaMatch helper on jQuery", () => {
+        setUserAgent("Mozilla/5.0 Chrome/120.0");
+        doBrowserCheck();
+        expect(typeof jQueryStub.uaMatch).toBe("function");
+    });
+
+    it("sets webkit alongside chrome", () => {
+        setUserAgent("Mozilla/5.0 Chrome/120.0");
+        doBrowserCheck();
+        expect(jQueryStub.browser).toEqual({
+            chrome: true,
+            webkit: true,
+            version: "120.0"
+        });
+    });
+
+    it("sets safari alongside webkit when chrome is absent", () => {
+        setUserAgent("Mozilla/5.0 AppleWebKit/537.36");
+        doBrowserCheck();
+        expect(jQueryStub.browser.webkit).toBe(true);
+        expect(jQueryStub.browser.safari).toBe(true);
+        expect(jQueryStub.browser.chrome).toBeUndefined();
+    });
+
+    it("records mozilla and its rv version", () => {
+        setUserAgent("Mozilla/5.0 (X11; Linux) rv:109.0");
+        doBrowserCheck();
+        expect(jQueryStub.browser.mozilla).toBe(true);
+        expect(jQueryStub.browser.version).toBe("109.0");
+    });
+
+    it("ignores mozilla when the user agent claims compatibility", () => {
+        setUserAgent("Mozilla/5.0 (compatible; SomeBot/1.0)");
+        doBrowserCheck();
+        expect(jQueryStub.browser).toEqual({});
+    });
+
+    it("yields an empty browser object for an unmatched user agent", () => {
+        setUserAgent("CustomBot/1.0");
+        doBrowserCheck();
+        expect(jQueryStub.browser).toEqual({});
+    });
+
+    it("parses the msie branch and records its version", () => {
+        setUserAgent("Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1)");
+        doBrowserCheck();
+        expect(jQueryStub.browser.msie).toBe(true);
+        expect(jQueryStub.browser.version).toBe("9.0");
+    });
+
+    it("reports an empty browser name and a version of 0 for unparseable input", () => {
+        setUserAgent("CustomBot/1.0");
+        doBrowserCheck();
+        expect(jQueryStub.uaMatch("CustomBot/1.0")).toEqual({ browser: "", version: "0" });
+    });
+
+    it("lowercases the user agent before matching", () => {
+        setUserAgent("MOZILLA/5.0 CHROME/120.0");
+        doBrowserCheck();
+        expect(jQueryStub.browser.chrome).toBe(true);
+        expect(jQueryStub.browser.version).toBe("120.0");
+    });
+});
+
+describe("canvasPixelRatio()", () => {
+    const originalQuerySelector = document.querySelector;
+    const originalDevicePixelRatio = window.devicePixelRatio;
+
+    /**
+     * Stubs #myCanvas so getContext("2d") returns the supplied context.
+     * @param {Object} context - The fake 2d rendering context.
+     */
+    const stubCanvas = context => {
+        document.querySelector = jest.fn(() => ({ getContext: jest.fn(() => context) }));
+    };
+
+    afterEach(() => {
+        document.querySelector = originalQuerySelector;
+        window.devicePixelRatio = originalDevicePixelRatio;
+    });
+
+    it("divides the device pixel ratio by the backing store ratio", () => {
+        window.devicePixelRatio = 3;
+        stubCanvas({ backingStorePixelRatio: 2 });
+        expect(canvasPixelRatio()).toBe(1.5);
+    });
+
+    it("falls back to 1 when devicePixelRatio is undefined", () => {
+        window.devicePixelRatio = undefined;
+        stubCanvas({});
+        expect(canvasPixelRatio()).toBe(1);
+    });
+
+    it("falls back to a backing store ratio of 1 when none is reported", () => {
+        window.devicePixelRatio = 2;
+        stubCanvas({});
+        expect(canvasPixelRatio()).toBe(2);
+    });
+
+    it.each([
+        "webkitBackingStorePixelRatio",
+        "mozBackingStorePixelRatio",
+        "msBackingStorePixelRatio",
+        "oBackingStorePixelRatio",
+        "backingStorePixelRatio"
+    ])("honours the vendor-prefixed %s property", property => {
+        window.devicePixelRatio = 4;
+        stubCanvas({ [property]: 2 });
+        expect(canvasPixelRatio()).toBe(2);
+    });
+});
+
+// Distinct literals so an inner/outer mix-up cannot produce a passing assertion.
+const OUTER_HEIGHT = 901;
+const INNER_HEIGHT = 602;
+const OUTER_WIDTH = 903;
+const INNER_WIDTH = 604;
+
+describe("viewport helpers", () => {
+    const saved = {};
+
+    beforeEach(() => {
+        for (const key of ["outerHeight", "innerHeight", "outerWidth", "innerWidth"]) {
+            saved[key] = window[key];
+        }
+        Object.defineProperty(window, "outerHeight", {
+            value: OUTER_HEIGHT,
+            configurable: true
+        });
+        Object.defineProperty(window, "innerHeight", {
+            value: INNER_HEIGHT,
+            configurable: true
+        });
+        Object.defineProperty(window, "outerWidth", { value: OUTER_WIDTH, configurable: true });
+        Object.defineProperty(window, "innerWidth", { value: INNER_WIDTH, configurable: true });
+    });
+
+    afterEach(() => {
+        for (const [key, value] of Object.entries(saved)) {
+            Object.defineProperty(window, key, { value, configurable: true });
+        }
+    });
+
+    describe("windowHeight()", () => {
+        it("returns outerHeight on Android", () => {
+            setUserAgent("Mozilla/5.0 (Linux; Android 13; Pixel 7)");
+            expect(windowHeight()).toBe(OUTER_HEIGHT);
+        });
+
+        it("returns innerHeight everywhere else", () => {
+            setUserAgent("Mozilla/5.0 Chrome/120.0");
+            expect(windowHeight()).toBe(INNER_HEIGHT);
+        });
+
+        it("matches Android case-insensitively", () => {
+            setUserAgent("mozilla/5.0 (linux; android 13)");
+            expect(windowHeight()).toBe(OUTER_HEIGHT);
+        });
+    });
+
+    describe("windowWidth()", () => {
+        it("returns outerWidth on Android", () => {
+            setUserAgent("Mozilla/5.0 (Linux; Android 13; Pixel 7)");
+            expect(windowWidth()).toBe(OUTER_WIDTH);
+        });
+
+        it("returns innerWidth everywhere else", () => {
+            setUserAgent("Mozilla/5.0 Chrome/120.0");
+            expect(windowWidth()).toBe(INNER_WIDTH);
+        });
+
+        it("matches Android case-insensitively", () => {
+            setUserAgent("mozilla/5.0 (linux; android 13)");
+            expect(windowWidth()).toBe(OUTER_WIDTH);
+        });
+    });
+});
+
+describe("compatibility surface", () => {
+    it("exposes every helper on the module export object", () => {
+        expect(Object.keys(BrowserUtils).sort()).toEqual([
+            "canvasPixelRatio",
+            "doBrowserCheck",
+            "fnBrowserDetect",
+            "windowHeight",
+            "windowWidth"
+        ]);
+    });
+
+    it("re-exports the identical function references through utils.js", () => {
+        const utils = require("../utils");
+
+        expect(utils.fnBrowserDetect).toBe(BrowserUtils.fnBrowserDetect);
+        expect(utils.doBrowserCheck).toBe(BrowserUtils.doBrowserCheck);
+        expect(utils.canvasPixelRatio).toBe(BrowserUtils.canvasPixelRatio);
+        expect(utils.windowHeight).toBe(BrowserUtils.windowHeight);
+        expect(utils.windowWidth).toBe(BrowserUtils.windowWidth);
+    });
+});

--- a/js/utils/browser-utils.js
+++ b/js/utils/browser-utils.js
@@ -149,6 +149,12 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 if (typeof window !== "undefined") {
+    // BrowserUtils is what the RequireJS shim reads via `exports`. The
+    // individual globals are required for compatibility: the callers are
+    // classic scripts that invoke these by bare name (fnBrowserDetect() in
+    // js/toolbar-ui.js, doBrowserCheck() in js/activity.js) rather than
+    // receiving an injected module, so removing them would break the app.
+    // This matches how utils-logic.js and dom-helpers.js publish their own.
     window.BrowserUtils = BrowserUtils;
     Object.assign(window, BrowserUtils);
 }

--- a/js/utils/browser-utils.js
+++ b/js/utils/browser-utils.js
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/*
+   globals
+
+   jQuery
+*/
+
+/*
+ * doBrowserCheck() uses the global jQuery instance initialized by the
+ * application before RequireJS modules are bootstrapped. The global is
+ * accessed only when the function is called, not during module loading.
+ */
+
+/* exported
+   canvasPixelRatio, doBrowserCheck, fnBrowserDetect, windowHeight, windowWidth
+*/
+
+/**
+ * Detects the current browser name.
+ * @function
+ * @returns {string} The name of the detected browser.
+ */
+function fnBrowserDetect() {
+    const userAgent = navigator.userAgent;
+    let browserName;
+
+    if (userAgent.match(/chrome|chromium|crios/i)) {
+        browserName = "chrome";
+    } else if (userAgent.match(/firefox|fxios/i)) {
+        browserName = "firefox";
+    } else if (userAgent.match(/safari/i)) {
+        browserName = "safari";
+    } else if (userAgent.match(/opr\//i)) {
+        browserName = "opera";
+    } else if (userAgent.match(/edg/i)) {
+        browserName = "edge";
+    } else {
+        browserName = "No browser detection";
+    }
+    return browserName;
+}
+
+/**
+ * Checks the browser type and version.
+ * Sets properties in the jQuery.browser object based on the user agent.
+ * @function
+ */
+function doBrowserCheck() {
+    jQuery.uaMatch = ua => {
+        ua = ua.toLowerCase();
+
+        const match =
+            /(chrome)[ /]([\w.]+)/.exec(ua) ||
+            /(webkit)[ /]([\w.]+)/.exec(ua) ||
+            /(opera)(?:.*version|)[ /]([\w.]+)/.exec(ua) ||
+            /(msie) ([\w.]+)/.exec(ua) ||
+            (ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)) ||
+            [];
+
+        return {
+            browser: match[1] || "",
+            version: match[2] || "0"
+        };
+    };
+
+    const matched = jQuery.uaMatch(navigator.userAgent);
+    const browser = {};
+
+    if (matched.browser) {
+        browser[matched.browser] = true;
+        browser.version = matched.version;
+    }
+
+    if (browser.chrome) {
+        browser.webkit = true;
+    } else if (browser.webkit) {
+        browser.safari = true;
+    }
+
+    jQuery.browser = browser;
+}
+
+/**
+ * Returns the pixel ratio of the canvas for high-resolution displays.
+ * @function
+ * @returns {number} The canvas pixel ratio.
+ */
+function canvasPixelRatio() {
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const context = document.querySelector("#myCanvas").getContext("2d");
+    const backingStoreRatio =
+        context.webkitBackingStorePixelRatio ||
+        context.mozBackingStorePixelRatio ||
+        context.msBackingStorePixelRatio ||
+        context.oBackingStorePixelRatio ||
+        context.backingStorePixelRatio ||
+        1;
+    return devicePixelRatio / backingStoreRatio;
+}
+
+/**
+ * Returns the height of the window, accounting for Android-specific behavior.
+ * @function
+ * @returns {number} The window height.
+ */
+function windowHeight() {
+    const onAndroid = /Android/i.test(navigator.userAgent);
+    if (onAndroid) {
+        return window.outerHeight;
+    } else {
+        return window.innerHeight;
+    }
+}
+
+/**
+ * Returns the width of the window, accounting for Android-specific behavior.
+ * @function
+ * @returns {number} The window width.
+ */
+function windowWidth() {
+    const onAndroid = /Android/i.test(navigator.userAgent);
+    if (onAndroid) {
+        return window.outerWidth;
+    } else {
+        return window.innerWidth;
+    }
+}
+
+var BrowserUtils = {
+    fnBrowserDetect,
+    doBrowserCheck,
+    canvasPixelRatio,
+    windowHeight,
+    windowWidth
+};
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = BrowserUtils;
+}
+
+if (typeof window !== "undefined") {
+    window.BrowserUtils = BrowserUtils;
+    Object.assign(window, BrowserUtils);
+}

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -28,6 +28,8 @@
         platformColor
     - js/utils/utils-logic.js
         resolveObject
+    - js/utils/browser-utils.js
+        canvasPixelRatio, doBrowserCheck, fnBrowserDetect, windowHeight, windowWidth
 */
 
 if (typeof module !== "undefined" && module.exports) {
@@ -39,16 +41,19 @@ if (typeof module !== "undefined" && module.exports) {
     var DomHelpers =
         (typeof window !== "undefined" && window.DomHelpers) ||
         (typeof require !== "undefined" ? require("./dom-helpers") : {});
+
+    var BrowserUtils =
+        (typeof window !== "undefined" && window.BrowserUtils) ||
+        (typeof require !== "undefined" ? require("./browser-utils") : {});
 }
 
 /* exported
-   announceToScreenReader,canvasPixelRatio, changeImage, closeBlkWidgets,
-   delayExecution, doBrowserCheck,
+   announceToScreenReader, changeImage, closeBlkWidgets,
+   delayExecution,
    doPublish, doStopVideoCam, doSVG,
    doUseCamera, format, getTextWidth, httpGet, httpPost, HttpRequest,
    importMembers, isSVGEmpty, prepareMacroExports, preparePluginExports,
-   processMacroData, processPluginData, processRawPluginData, windowHeight, windowWidth,
-   fnBrowserDetect, waitForReadiness
+   processMacroData, processPluginData, processRawPluginData, waitForReadiness
 */
 
 /**
@@ -170,77 +175,6 @@ let format = (str, data) => {
 };
 
 /**
- * Detects the current browser name.
- * @function
- * @returns {string} The name of the detected browser.
- */
-function fnBrowserDetect() {
-    const userAgent = navigator.userAgent;
-    let browserName;
-
-    if (userAgent.match(/chrome|chromium|crios/i)) {
-        browserName = "chrome";
-    } else if (userAgent.match(/firefox|fxios/i)) {
-        browserName = "firefox";
-    } else if (userAgent.match(/safari/i)) {
-        browserName = "safari";
-    } else if (userAgent.match(/opr\//i)) {
-        browserName = "opera";
-    } else if (userAgent.match(/edg/i)) {
-        browserName = "edge";
-    } else {
-        browserName = "No browser detection";
-    }
-    return browserName;
-}
-
-/**
- * Returns the pixel ratio of the canvas for high-resolution displays.
- * @function
- * @returns {number} The canvas pixel ratio.
- */
-function canvasPixelRatio() {
-    const devicePixelRatio = window.devicePixelRatio || 1;
-    const context = document.querySelector("#myCanvas").getContext("2d");
-    const backingStoreRatio =
-        context.webkitBackingStorePixelRatio ||
-        context.mozBackingStorePixelRatio ||
-        context.msBackingStorePixelRatio ||
-        context.oBackingStorePixelRatio ||
-        context.backingStorePixelRatio ||
-        1;
-    return devicePixelRatio / backingStoreRatio;
-}
-
-/**
- * Returns the height of the window, accounting for Android-specific behavior.
- * @function
- * @returns {number} The window height.
- */
-function windowHeight() {
-    const onAndroid = /Android/i.test(navigator.userAgent);
-    if (onAndroid) {
-        return window.outerHeight;
-    } else {
-        return window.innerHeight;
-    }
-}
-
-/**
- * Returns the width of the window, accounting for Android-specific behavior.
- * @function
- * @returns {number} The window width.
- */
-function windowWidth() {
-    const onAndroid = /Android/i.test(navigator.userAgent);
-    if (onAndroid) {
-        return window.outerWidth;
-    } else {
-        return window.innerWidth;
-    }
-}
-
-/**
  * Performs an HTTP GET request to retrieve data from the server.
  * Uses async fetch to avoid blocking the UI during network requests.
  * @param {string|null} projectName - The name of the project (or null for the base URL).
@@ -339,46 +273,6 @@ function HttpRequest(url, loadCallback, userCallback) {
 
         this.request = this.handler = this.userCallback = null;
     }
-}
-
-/**
- * Checks the browser type and version.
- * Sets properties in the jQuery.browser object based on the user agent.
- * @function
- */
-function doBrowserCheck() {
-    jQuery.uaMatch = ua => {
-        ua = ua.toLowerCase();
-
-        const match =
-            /(chrome)[ /]([\w.]+)/.exec(ua) ||
-            /(webkit)[ /]([\w.]+)/.exec(ua) ||
-            /(opera)(?:.*version|)[ /]([\w.]+)/.exec(ua) ||
-            /(msie) ([\w.]+)/.exec(ua) ||
-            (ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)) ||
-            [];
-
-        return {
-            browser: match[1] || "",
-            version: match[2] || "0"
-        };
-    };
-
-    const matched = jQuery.uaMatch(navigator.userAgent);
-    const browser = {};
-
-    if (matched.browser) {
-        browser[matched.browser] = true;
-        browser.version = matched.version;
-    }
-
-    if (browser.chrome) {
-        browser.webkit = true;
-    } else if (browser.webkit) {
-        browser.safari = true;
-    }
-
-    jQuery.browser = browser;
 }
 
 /**
@@ -1458,6 +1352,7 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         ...UtilsLogic,
         ...DomHelpers,
+        ...BrowserUtils,
         extractProjectDataFromHTML,
         _,
         format,
@@ -1465,10 +1360,6 @@ if (typeof module !== "undefined" && module.exports) {
         closeBlkWidgets,
         importMembers,
         changeImage,
-        fnBrowserDetect,
-        canvasPixelRatio,
-        windowHeight,
-        windowWidth,
         httpGet,
         httpPost,
         HttpRequest,


### PR DESCRIPTION
## Description

This PR extracts browser-related utility functions from `js/utils/utils.js` into a dedicated module, `js/utils/browser-utils.js`.

The extraction is a refactoring only and preserves the existing behavior and public API. `utils.js` continues to re-export the extracted functions so existing callers and tests remain unchanged.

This change:
- Moves browser utility functions into `js/utils/browser-utils.js`.
- Updates `utils.js` to import and re-export the extracted utilities.
- Registers the new module in the RequireJS loader and activity initialization.
- Preserves compatibility for both browser and Jest/Node environments.

## Type of Change
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change

## Testing

- Ran ESLint on the modified files.
- Ran `npx prettier --check` on the modified files.
- Verified the relevant utility and toolbar test suites pass.
- Verified there are no behavioral changes introduced by this refactoring. The remaining `RhythmBlocks.test.js` failures are pre-existing on `upstream/master` and unrelated to this change.