### PR TITLE
fix: stop audio and reset icon when clearing pitch staircase during scale playback

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -631,6 +631,37 @@ describe("PitchStaircase Widget", () => {
             expect(psc._undo).toHaveBeenCalledTimes(3);
         });
 
+        test("Clear button stops scale playback and resets icon before undoing", () => {
+            // Simulate that a scale is currently playing when Clear is clicked.
+            psc._isPlayingScale = true;
+            psc._scaleTimeout = 123;
+            psc._undo = jest.fn().mockReturnValue(false);
+
+            buttons["Clear"].onclick();
+
+            // Playback state should be fully reset.
+            expect(psc._scaleStopped).toBe(true);
+            expect(psc._isPlayingScale).toBe(false);
+            expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
+
+            // The Play scale button icon should reset back to "Play scale".
+            const img = buttons["Play scale"].replaceChildren.mock.calls.at(-1)[0];
+            expect(img.getAttribute("src")).toBe("header-icons/play-scale.svg");
+
+            // Clear should still run its normal undo loop.
+            expect(psc._undo).toHaveBeenCalled();
+        });
+
+        test("Clear button does not touch scale state when nothing is playing", () => {
+            psc._isPlayingScale = false;
+            psc._undo = jest.fn().mockReturnValue(false);
+
+            buttons["Clear"].onclick();
+
+            expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
+            expect(psc._undo).toHaveBeenCalled();
+        });
+
         test("Save button saves once and holds a debounce lock", () => {
             jest.useFakeTimers();
             psc._save = jest.fn();

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -796,6 +796,13 @@ class PitchStaircase {
 
         widgetWindow.addButton("erase-button.svg", PitchStaircase.ICONSIZE, _("Clear")).onclick =
             () => {
+                if (this._isPlayingScale) {
+                    this._scaleStopped = true;
+                    clearTimeout(this._scaleTimeout);
+                    this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));
+                    this._isPlayingScale = false;
+                }
+                this.activity.logo.synth.stop();
                 while (this._undo());
             };
 


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

## Problem
In the Pitch Staircase widget, clicking **Clear** while **Play scale** is running stops the audible sound, but the Play scale button's icon stays stuck on the "Stop" icon instead of resetting back to "Play scale". The internal playing state is also left inconsistent, since nothing resets `_isPlayingScale` or cancels the pending scale playback timeout.

## Root Cause
The Clear button's `onclick` handler only calls `while (this._undo());` to remove all stairs. It never checks whether a scale is currently playing, so it doesn't cancel `_scaleTimeout`, doesn't reset `_isPlayingScale`, and doesn't restore the button icon via `_setButtonIcon`. This mirrors the same pattern already handled correctly in the `_playScaleButton.onclick` handler and `onclose`, which both stop playback and reset state before proceeding , Clear was simply missing this step.

## Fix
In the Clear button's `onclick` handler, stop any in-progress scale playback and reset its state before running the existing undo loop:
- `this._scaleStopped = true;`
- `clearTimeout(this._scaleTimeout);`
- `this._setButtonIcon(this._playScaleButton, "play-scale.svg", _("Play scale"));`
- `this._isPlayingScale = false;`
- `this.activity.logo.synth.stop();`

This ensures Clear leaves the widget in a consistent state, regardless of whether scale playback was active when it was clicked.

## Testing
1. Open Pitch Staircase widget.
2. Click **Play scale**.
3. Click **Clear** while scale playback is still running.
4. Before fix: sound stops, but the Play scale button icon stays on "Stop".
5. After fix: sound stops and the Play scale button icon correctly resets to "Play scale".
6. Verified normal Clear behavior (no playback active) still works with no regressions.
7. Verified Play/Play chord/Play scale/Stop still function normally after Clear.
8. Added unit tests covering both the active-playback and no-playback Clear paths; full pitchstaircase test suite passes (58/58).