### PR TITLE
fix: dispose Tone.Analyser nodes in oscilloscope close to prevent audio leak

### DIFF
--- a/js/widgets/__tests__/oscilloscope.test.js
+++ b/js/widgets/__tests__/oscilloscope.test.js
@@ -442,6 +442,30 @@ describe("Oscilloscope", () => {
             expect(osc.pitchAnalysers).toEqual({});
         });
 
+        test("disposes Tone.Analyser nodes in pitchAnalysers on close", () => {
+            const osc = createOscilloscope();
+            const dispose0 = jest.fn();
+            const dispose1 = jest.fn();
+            osc.pitchAnalysers = {
+                0: { dispose: dispose0 },
+                1: { dispose: dispose1 }
+            };
+
+            osc.close();
+
+            expect(dispose0).toHaveBeenCalled();
+            expect(dispose1).toHaveBeenCalled();
+            expect(osc.pitchAnalysers).toEqual({});
+        });
+
+        test("skips non-disposable pitchAnalyser entries on close", () => {
+            const osc = createOscilloscope();
+            osc.pitchAnalysers = { 0: {}, 1: null, 2: undefined };
+
+            expect(() => osc.close()).not.toThrow();
+            expect(osc.pitchAnalysers).toEqual({});
+        });
+
         test("calls widgetWindow.destroy", () => {
             const osc = createOscilloscope();
 

--- a/js/widgets/oscilloscope.js
+++ b/js/widgets/oscilloscope.js
@@ -183,6 +183,15 @@ class Oscilloscope {
 
         document.removeEventListener("visibilitychange", this._handleVisibilityChange);
 
+        for (const key of Object.keys(this.pitchAnalysers)) {
+            if (
+                this.pitchAnalysers[key] &&
+                typeof this.pitchAnalysers[key].dispose === "function"
+            ) {
+                this.pitchAnalysers[key].dispose();
+            }
+        }
+
         this.drawVisualIDs = {};
         this._canvasState = {};
         this.pitchAnalysers = {};


### PR DESCRIPTION
## Description

`close()` in `js/widgets/oscilloscope.js` clears `this.pitchAnalysers` by assigning an empty object without calling `.dispose()` on each `Tone.Analyser` instance. Each analyser holds an 8192-sample buffer and active synth connections in the Web Audio graph. Reopening the widget creates new analysers while old ones linger as orphaned audio nodes.

## Related Issue

Fixes #7860

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/widgets/oscilloscope.js` `close()`: iterate `this.pitchAnalysers` and call `.dispose()` on each `Tone.Analyser` before clearing the dictionary

## Testing Performed

- All 6870 project tests pass (`npm test`)
- All 82 oscilloscope tests pass
- `npx prettier --check` passes on modified files
- `npx eslint` passes with no errors
- Pre-commit hooks (lint + format) passed automatically

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
