### PR TITLE
ci(lighthouse): run audit as pull_request so fork PRs can be checked out

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,7 +1,11 @@
 name: Lighthouse CI
 
 on:
-  pull_request_target:
+  # This workflow builds and executes the PR's own code (npm ci runs lifecycle
+  # scripts from the branch, and Lighthouse loads the built app). That must not
+  # happen in the trusted pull_request_target context, so it runs as
+  # pull_request: an unprivileged, read-only context with no repository secrets.
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches: [master]
@@ -103,7 +107,10 @@ jobs:
           echo "SEO_EMOJI=$(get_emoji '${{ steps.parse.outputs.SEO_SCORE }}')" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        # Fork PRs get a read-only GITHUB_TOKEN under pull_request, so posting a
+        # comment would fail. Scores stay available to every PR through the
+        # uploaded .lighthouseci/ artifact below.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |


### PR DESCRIPTION
GitHub now refuses actions/checkout of fork PR code inside a pull_request_target workflow, so both Lighthouse jobs fail at the first step with "Refusing to check out fork pull request code" before any audit runs.

The workflow builds and executes the PR's own code: npm ci runs lifecycle scripts from the branch and Lighthouse loads the resulting app. Enabling allow-unsafe-pr-checkout would keep doing that in a context holding the base repository's token and write permissions, which is the pwn-request pattern the new guard exists to prevent. Running as pull_request instead gives the job an unprivileged, read-only context with no secrets, which is all the audit needs.

The Comment on PR step was already inert: it required github.event_name == 'pull_request' while the workflow only ever fired on pull_request_target and push, so it has always been skipped. Restrict it to same-repo pull requests so the event change does not newly activate a step that cannot succeed with a fork's read-only token. Lighthouse scores remain available to every PR through the uploaded .lighthouseci/ artifact.

No job configuration, permissions, matrix presets, or audit steps are otherwise changed.