### PR TITLE
fix(test): resolve RhythmBlocks test failure

### DIFF
--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -23,6 +23,7 @@
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
 const Blocks = jest.requireActual("../../blocks");
 
+global.setupBlockDragController = require("../../block-drag-controller").setupBlockDragController;
 global._ = s => s;
 global.NOINPUTERRORMSG = "NO_INPUT";
 global.DEFAULTDRUM = "kick";


### PR DESCRIPTION
## PR Category
<!-- Please select the category that best describes this PR by putting an 'x' in the brackets -->
- [x] Bug Fix - Fixes a bug or incorrect behavior

## Description
This PR fixes the failing Jest tests in `RhythmBlocks.test.js`. 
The `setupBlockDragController` function was missing from the global mock environment, which caused a `ReferenceError` during test execution. It is now properly mocked, and the tests pass successfully.

