### PR TITLE
fix: named-calc-blocks

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -686,7 +686,7 @@ class Block {
                 // block is hidden, so do nothing.
                 return;
             }
-        } else if ((this.bitmap === null) | !this.bitmap.visible) {
+        } else if (this.bitmap === null || !this.bitmap.visible) {
             return;
         }
 

--- a/js/block.js
+++ b/js/block.js
@@ -686,7 +686,7 @@ class Block {
                 // block is hidden, so do nothing.
                 return;
             }
-        } else if (!this.bitmap.visible) {
+        } else if ((this.bitmap === null) | !this.bitmap.visible) {
             return;
         }
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -774,6 +774,7 @@ class Blocks {
          */
         this._getBlockSize = blk => {
             const myBlock = this.blockList[blk];
+            if (myBlock === undefined) return 0;
             /** Special case for collapsed note blocks. */
             if (["newnote", "interval", "osctime"].includes(myBlock.name) && myBlock.collapsed) {
                 return 1;

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -21,6 +21,11 @@
  */
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
+
+// Use the real BlockDragController so the Blocks constructor can attach
+// drag delegation methods (blocks.js calls setupBlockDragController(this)).
+global.setupBlockDragController = require("../../block-drag-controller").setupBlockDragController;
+
 const Blocks = jest.requireActual("../../blocks");
 
 global._ = s => s;


### PR DESCRIPTION
Fixes: https://github.com/sugarlabs/musicblocks/issues/7865

PR Category
 - [x] Bug Fix


Two unrelated "block undefined" errors were preventing named calc blocks from loading. Both are now guarded and the loading issues are gone.

Before:

<img width="1076" height="643" alt="Screenshot From 2026-07-20 15-28-28" src="https://github.com/user-attachments/assets/dd07f149-ee74-45d4-81b0-2ed7b9448f80" />

After:

<img width="825" height="723" alt="Screenshot From 2026-07-20 15-08-08" src="https://github.com/user-attachments/assets/38af7786-a4d7-4f39-8ea2-87e22dc7af35" />

Code runs as expected as well.