### PR TITLE
ci(commitlint): exempt dependabot commit bodies from lint rules

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,6 +9,11 @@
 
 module.exports = {
     extends: ["@commitlint/config-conventional"],
+    // Skip linting for automated bot commits. Dependabot generates commit
+    // bodies with long changelog URLs and an `updated-dependencies:` trailer
+    // that exceed body-max-line-length; those messages are not hand-authored
+    // and should not be held to the Conventional Commits body rules.
+    ignores: [(message) => /Signed-off-by: dependabot\[bot\]/.test(message)],
     rules: {
         // Allowed commit types. Extend this list if the project needs more.
         "type-enum": [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,7 +13,7 @@ module.exports = {
     // bodies with long changelog URLs and an `updated-dependencies:` trailer
     // that exceed body-max-line-length; those messages are not hand-authored
     // and should not be held to the Conventional Commits body rules.
-    ignores: [(message) => /Signed-off-by: dependabot\[bot\]/.test(message)],
+    ignores: [message => /Signed-off-by: dependabot\[bot\]/.test(message)],
     rules: {
         // Allowed commit types. Extend this list if the project needs more.
         "type-enum": [


### PR DESCRIPTION
## PR Category
- [x] Bug Fix (CI)

## Summary

The `Lint commit messages` CI job fails on Dependabot PRs because Dependabot's commit body contains long changelog/compare URLs and an `updated-dependencies:` trailer that exceed commitlint's `body-max-line-length` (100). This blocks every multi-dependency security update — e.g. PR #7825 (`chore(deps): bump qs and @cypress/request`), whose only failing check is:

```
✖  body's lines must not be longer than 100 characters [body-max-line-length]
✖  found 1 problems, 0 warnings
```

The commit header itself is a valid Conventional Commit (`chore(deps): …`) — only the auto-generated body trips the rule, and that body is not hand-authored, so holding it to the body rules adds no value.

## Change

Add an `ignores` predicate to `commitlint.config.js` that skips linting for commits carrying Dependabot's `Signed-off-by: dependabot[bot]` trailer. Human commits are unaffected and remain fully linted.

## Verification

- Config parses as valid JS (`require()`).
- Predicate behavior (unit-checked against the real #7825 commit body):
  - Dependabot commit body → **ignored** ✅
  - Human commit, short → linted (not ignored) ✅
  - Human commit with a >100-char body line → linted, still fails as before ✅

## Impact

- Unblocks Dependabot security PRs (starting with #7825) without weakening commit hygiene for contributors.
- No production code touched.
