### PR TITLE
fix: disconnect and dispose Tone.Analyser in stopTuner to prevent audio node leak

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1255,14 +1255,46 @@ describe("Utility Functions (logic-only)", () => {
     describe("stopTuner", () => {
         it("should not throw when tunerMic is null", () => {
             Synth.tunerMic = null;
+            Synth.tunerAnalyser = null;
             expect(() => stopTuner()).not.toThrow();
         });
 
-        it("should call close on tunerMic when it exists", () => {
+        it("should call close on tunerMic and null it", () => {
             const mockClose = jest.fn();
             Synth.tunerMic = { close: mockClose };
+            Synth.tunerAnalyser = null;
             stopTuner();
             expect(mockClose).toHaveBeenCalledTimes(1);
+            expect(Synth.tunerMic).toBeNull();
+        });
+
+        it("should disconnect and dispose tunerAnalyser when both exist", () => {
+            const mockDisconnect = jest.fn();
+            const mockDispose = jest.fn();
+            const mockClose = jest.fn();
+            const analyser = { dispose: mockDispose };
+            Synth.tunerMic = { close: mockClose, disconnect: mockDisconnect };
+            Synth.tunerAnalyser = analyser;
+
+            stopTuner();
+
+            expect(mockDisconnect).toHaveBeenCalledWith(analyser);
+            expect(mockDispose).toHaveBeenCalled();
+            expect(mockClose).toHaveBeenCalled();
+            expect(Synth.tunerAnalyser).toBeNull();
+            expect(Synth.tunerMic).toBeNull();
+        });
+
+        it("should skip analyser disposal when tunerAnalyser is null", () => {
+            const mockDisconnect = jest.fn();
+            const mockClose = jest.fn();
+            Synth.tunerMic = { close: mockClose, disconnect: mockDisconnect };
+            Synth.tunerAnalyser = null;
+
+            stopTuner();
+
+            expect(mockDisconnect).not.toHaveBeenCalled();
+            expect(mockClose).toHaveBeenCalled();
         });
 
         it("should cancel any pending tuner animation frame", () => {
@@ -1272,6 +1304,7 @@ describe("Utility Functions (logic-only)", () => {
             Synth._tunerRafId = 123;
             Synth._tunerActive = true;
             Synth.tunerMic = null;
+            Synth.tunerAnalyser = null;
             stopTuner();
             expect(mockCancel).toHaveBeenCalledWith(123);
             expect(Synth._tunerRafId).toBeNull();

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -3626,9 +3626,14 @@ function Synth() {
         this._tunerRafId = null;
         this._tunerSegments = null;
         if (this.tunerMic) {
+            if (this.tunerAnalyser) {
+                this.tunerMic.disconnect(this.tunerAnalyser);
+                this.tunerAnalyser.dispose();
+            }
             this.tunerMic.close();
         }
         this.tunerAnalyser = null;
+        this.tunerMic = null;
     };
 
     const frequencyToNote = frequency => {


### PR DESCRIPTION
## Description

`stopTuner()` in `js/utils/synthutils.js` sets `this.tunerAnalyser = null` without calling `.dispose()` and closes `this.tunerMic` without disconnecting it from the analyser. This leaks the `Tone.Analyser` node (2048-sample buffer) in the Web Audio graph on every start/stop cycle — the same class of bug fixed in PRs #7843 (LiveWaveForm) and #7861 (oscilloscope).

## Related Issue

Fixes #7872

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/utils/synthutils.js` `stopTuner()`: disconnect `tunerMic` from `tunerAnalyser`, call `tunerAnalyser.dispose()`, set `tunerMic = null`
- `js/utils/__tests__/synthutils.test.js`: add tests for analyser disposal, mic nullification, and skip-when-null path

## Testing Performed

- All 124 project tests pass (`npm test`)
- `npx prettier --check` passes on modified files
- `npx eslint` passes with no errors
- Pre-commit hooks (lint + format) passed automatically

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
