### PR TITLE
fix: regression in using note blocks in phrasemaker

### DIFF
--- a/js/blocks/RhythmBlocks.js
+++ b/js/blocks/RhythmBlocks.js
@@ -1182,6 +1182,10 @@ function setupRhythmBlocks(activity) {
             if (tur.singer.inNoteBlock.length > 0) {
                 tur.singer.delayedNotes.push([blk, value]);
             }
+            // If we are in the phrasemaker, we need to push a rhythm entry.
+            if (logo.inMatrix && value > 0) {
+                logo.tupletRhythms.push(["individual", 1, 1 / value]);
+            }
             Singer.RhythmActions.playNote(value, "newnote", turtle, blk, _callback);
             return [args[1], 1];
         }


### PR DESCRIPTION
## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior

This PR addresses a regression in the behavior of the PhraseMaker widget. Previously you could use Note blocks to define both pitches and rhythms, But that no longer works -- the pitch is registered, but the rhythm is ignored.

## What changed

In the NewNote flow, the note value is saved to the list of rhythms used by PhraseMaker if and only if the block is inside of a PhraseMaker block clamp. This parallels the behavior of tuplet blocks.

## How it was tested

<img width="986" height="706" alt="Screenshot From 2026-07-21 13-31-33" src="https://github.com/user-attachments/assets/90c306cf-7f25-4012-8db0-3718915e8b4d" />

The behavior of note blocks outside of PhraseMaker is unaffected.




