### PR TITLE
fix(camera): centralize interval/listener lifecycle in CameraManager (Refs #7868)

### DIFF
--- a/js/utils/__tests__/camera.test.js
+++ b/js/utils/__tests__/camera.test.js
@@ -1,0 +1,315 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const { doUseCamera, doStopVideoCam, CameraManager } = require("../utils.js");
+
+/**
+ * Builds a minimal fake <video>/<canvas> pair and wires document.querySelector
+ * to return them, mirroring the #camVideo / #camCanvas elements the real app
+ * renders.
+ */
+function makeDom() {
+    const video = {
+        play: jest.fn(),
+        pause: jest.fn(),
+        srcObject: null,
+        setAttribute: jest.fn(),
+        _listeners: {},
+        addEventListener(type, handler) {
+            this._listeners[type] = handler;
+        },
+        removeEventListener(type, handler) {
+            if (this._listeners[type] === handler) {
+                delete this._listeners[type];
+            }
+        },
+        fireCanplay() {
+            if (this._listeners.canplay) {
+                this._listeners.canplay();
+            }
+        }
+    };
+
+    const context = { drawImage: jest.fn() };
+    const canvas = {
+        width: 0,
+        height: 0,
+        setAttribute: jest.fn(),
+        getContext: jest.fn(() => context),
+        toDataURL: jest.fn(() => "data:image/png;base64,FAKE")
+    };
+
+    document.querySelector = jest.fn(selector => {
+        if (selector === "#camVideo") return video;
+        if (selector === "#camCanvas") return canvas;
+        return null;
+    });
+
+    return { video, canvas, context };
+}
+
+function makeTurtles() {
+    const doShowImage = jest.fn();
+    const turtle = { doShowImage };
+    return {
+        turtles: { getTurtle: jest.fn(() => turtle) },
+        doShowImage
+    };
+}
+
+describe("CameraManager lifecycle", () => {
+    let intervalSpy;
+    let clearIntervalSpy;
+    let fakeId = 1;
+
+    beforeEach(() => {
+        // Reset shared singleton state between tests.
+        CameraManager.isSetup = false;
+        CameraManager.canPlayHandler = null;
+        CameraManager.intervalId = null;
+        CameraManager.listenerVideoElement = null;
+
+        fakeId = 1;
+        intervalSpy = jest.spyOn(window, "setInterval").mockImplementation(() => fakeId++);
+        clearIntervalSpy = jest.spyOn(window, "clearInterval").mockImplementation(() => {});
+
+        navigator.mediaDevices = {
+            getUserMedia: jest.fn(() => Promise.resolve({ getTracks: () => [] }))
+        };
+    });
+
+    afterEach(() => {
+        intervalSpy.mockRestore();
+        clearIntervalSpy.mockRestore();
+        jest.restoreAllMocks();
+    });
+
+    test("startCapture never leaves more than one interval running", () => {
+        const draw = jest.fn();
+        const first = CameraManager.startCapture(draw, 100);
+        const second = CameraManager.startCapture(draw, 100);
+
+        expect(clearIntervalSpy).toHaveBeenCalledWith(first);
+        expect(CameraManager.intervalId).toBe(second);
+        expect(intervalSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("stopCapture is idempotent (safe with no interval active)", () => {
+        expect(() => CameraManager.stopCapture()).not.toThrow();
+        expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+        CameraManager.startCapture(jest.fn());
+        CameraManager.stopCapture();
+        expect(CameraManager.intervalId).toBeNull();
+
+        // Calling again after already stopped must not throw or re-clear.
+        clearIntervalSpy.mockClear();
+        CameraManager.stopCapture();
+        expect(clearIntervalSpy).not.toHaveBeenCalled();
+    });
+
+    test("setCanplayListener never leaves more than one listener registered", () => {
+        const { video } = makeDom();
+        const handlerA = jest.fn();
+        const handlerB = jest.fn();
+
+        CameraManager.setCanplayListener(video, handlerA);
+        expect(video._listeners.canplay).toBe(handlerA);
+
+        CameraManager.setCanplayListener(video, handlerB);
+        expect(video._listeners.canplay).toBe(handlerB);
+
+        video.fireCanplay();
+        expect(handlerA).not.toHaveBeenCalled();
+        expect(handlerB).toHaveBeenCalledTimes(1);
+    });
+
+    test("clearCanplayListener removes the handler from the element it was actually attached to", () => {
+        const { video: firstVideo } = makeDom();
+        const secondVideo = { ...firstVideo, _listeners: {} };
+        const handler = jest.fn();
+
+        CameraManager.setCanplayListener(firstVideo, handler);
+        // Simulate the DOM element being swapped out from under us.
+        CameraManager.listenerVideoElement = secondVideo;
+        CameraManager.canPlayHandler = handler;
+        secondVideo.addEventListener("canplay", handler);
+
+        CameraManager.clearCanplayListener();
+
+        expect(secondVideo._listeners.canplay).toBeUndefined();
+        expect(CameraManager.canPlayHandler).toBeNull();
+        expect(CameraManager.listenerVideoElement).toBeNull();
+    });
+
+    test("reset() tears down both the interval and the listener", () => {
+        const { video } = makeDom();
+        CameraManager.startCapture(jest.fn());
+        CameraManager.setCanplayListener(video, jest.fn());
+
+        CameraManager.reset();
+
+        expect(CameraManager.isSetup).toBe(false);
+        expect(CameraManager.intervalId).toBeNull();
+        expect(CameraManager.canPlayHandler).toBeNull();
+        expect(video._listeners.canplay).toBeUndefined();
+    });
+});
+
+describe("doUseCamera", () => {
+    let dom;
+    let turtlesCtx;
+    let setCameraID;
+    let errorMsg;
+
+    beforeEach(() => {
+        CameraManager.isSetup = false;
+        CameraManager.canPlayHandler = null;
+        CameraManager.intervalId = null;
+        CameraManager.listenerVideoElement = null;
+
+        dom = makeDom();
+        turtlesCtx = makeTurtles();
+        setCameraID = jest.fn();
+        errorMsg = jest.fn();
+
+        jest.spyOn(window, "setInterval").mockImplementation(() => 42);
+        jest.spyOn(window, "clearInterval").mockImplementation(() => {});
+
+        navigator.mediaDevices = {
+            getUserMedia: jest.fn(() => Promise.resolve({ getTracks: () => [] }))
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("Camera + Show (isVideo=false): first run draws exactly once, after getUserMedia resolves and canplay fires", async () => {
+        doUseCamera(["turtle0"], turtlesCtx.turtles, "turtle0", false, null, setCameraID, errorMsg);
+
+        // Not drawn yet: still waiting on getUserMedia + canplay.
+        expect(turtlesCtx.doShowImage).not.toHaveBeenCalled();
+
+        await Promise.resolve(); // flush getUserMedia .then()
+        expect(CameraManager.isSetup).toBe(true);
+
+        dom.video.fireCanplay();
+
+        expect(dom.context.drawImage).toHaveBeenCalledTimes(1);
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledTimes(1);
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledWith(
+            "turtle0",
+            "data:image/png;base64,FAKE"
+        );
+        // Photo path must never start an interval.
+        expect(setCameraID).not.toHaveBeenCalled();
+    });
+
+    test("Camera + Show (isVideo=false): repeated calls after setup draw immediately, no duplicate listeners", async () => {
+        doUseCamera(["t"], turtlesCtx.turtles, "t", false, null, setCameraID, errorMsg);
+        await Promise.resolve();
+        dom.video.fireCanplay();
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledTimes(1);
+
+        // Second run of the Camera+Show block, without reloading the page.
+        doUseCamera(["t"], turtlesCtx.turtles, "t", false, null, setCameraID, errorMsg);
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledTimes(2);
+
+        // Only one canplay listener should ever be live at a time.
+        const handlerCount = Object.keys(dom.video._listeners).length;
+        expect(handlerCount).toBe(1);
+    });
+
+    test("Video capture (isVideo=true): repeated calls never leave more than one interval running", async () => {
+        doUseCamera(["t"], turtlesCtx.turtles, "t", true, null, setCameraID, errorMsg);
+        await Promise.resolve();
+        dom.video.fireCanplay();
+        expect(setCameraID).toHaveBeenCalledTimes(1);
+
+        doUseCamera(["t"], turtlesCtx.turtles, "t", true, null, setCameraID, errorMsg);
+        expect(window.clearInterval).toHaveBeenCalled();
+        expect(setCameraID).toHaveBeenCalledTimes(2);
+    });
+
+    test("browser without getUserMedia support reports an error and does not throw", () => {
+        navigator.mediaDevices = undefined;
+        expect(() =>
+            doUseCamera(["t"], turtlesCtx.turtles, "t", false, null, setCameraID, errorMsg)
+        ).not.toThrow();
+        expect(errorMsg).toHaveBeenCalledWith("Your browser does not support the webcam");
+    });
+});
+
+describe("doStopVideoCam", () => {
+    beforeEach(() => {
+        CameraManager.isSetup = true;
+        CameraManager.canPlayHandler = null;
+        CameraManager.intervalId = null;
+        CameraManager.listenerVideoElement = null;
+        jest.spyOn(window, "clearInterval").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("stops the interval, tears down the stream, and resets CameraManager", () => {
+        const track = { stop: jest.fn() };
+        const video = {
+            pause: jest.fn(),
+            srcObject: { getTracks: () => [track] }
+        };
+        document.querySelector = jest.fn(() => video);
+        const setCameraID = jest.fn();
+
+        doStopVideoCam(99, setCameraID);
+
+        expect(window.clearInterval).toHaveBeenCalledWith(99);
+        expect(setCameraID).toHaveBeenCalledWith(null);
+        expect(video.pause).toHaveBeenCalled();
+        expect(track.stop).toHaveBeenCalled();
+        expect(video.srcObject).toBeNull();
+        expect(CameraManager.isSetup).toBe(false);
+    });
+
+    test("a Stop followed by a fresh Camera+Show run behaves like a first run again", async () => {
+        const dom = makeDom();
+        const turtlesCtx = makeTurtles();
+        jest.spyOn(window, "setInterval").mockImplementation(() => 7);
+        navigator.mediaDevices = {
+            getUserMedia: jest.fn(() => Promise.resolve({ getTracks: () => [] }))
+        };
+
+        doUseCamera(["t"], turtlesCtx.turtles, "t", false, null, jest.fn(), jest.fn());
+        await Promise.resolve();
+        dom.video.fireCanplay();
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledTimes(1);
+
+        document.querySelector = jest.fn(selector =>
+            selector === "#camVideo" ? { pause: jest.fn(), srcObject: null } : null
+        );
+        doStopVideoCam(7, jest.fn());
+        expect(CameraManager.isSetup).toBe(false);
+
+        // Re-wire the DOM for the next run, exactly like a fresh Camera+Show.
+        document.querySelector =
+            dom.video &&
+            jest.fn(selector => {
+                if (selector === "#camVideo") return dom.video;
+                if (selector === "#camCanvas") return dom.canvas;
+                return null;
+            });
+        doUseCamera(["t"], turtlesCtx.turtles, "t", false, null, jest.fn(), jest.fn());
+        await Promise.resolve();
+        dom.video.fireCanplay();
+        expect(turtlesCtx.doShowImage).toHaveBeenCalledTimes(2);
+    });
+});

--- a/js/utils/__tests__/camera.test.js
+++ b/js/utils/__tests__/camera.test.js
@@ -96,9 +96,38 @@ describe("CameraManager lifecycle", () => {
         const first = CameraManager.startCapture(draw, 100);
         const second = CameraManager.startCapture(draw, 100);
 
-        expect(clearIntervalSpy).toHaveBeenCalledWith(first);
-        expect(CameraManager.intervalId).toBe(second);
-        expect(intervalSpy).toHaveBeenCalledTimes(2);
+        // Idempotent: the second call must NOT clear/restart the interval
+        // that's already running, or a fast, repeated caller (like a
+        // "forever" loop) could cancel it before it ever fires.
+        expect(clearIntervalSpy).not.toHaveBeenCalled();
+        expect(second).toBe(first);
+        expect(CameraManager.intervalId).toBe(first);
+        expect(intervalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("startCapture called rapidly and repeatedly (simulating a forever loop) never prevents the interval from firing", () => {
+        // Use REAL timers here so we can assert the interval genuinely fires,
+        // which is exactly what broke when startCapture unconditionally
+        // cleared and restarted itself on every call.
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+
+        const draw = jest.fn();
+
+        // Simulate a forever loop calling startCapture much faster than
+        // the 20ms period below.
+        const rapidCalls = setInterval(() => {
+            CameraManager.startCapture(draw, 20);
+        }, 2);
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                clearInterval(rapidCalls);
+                CameraManager.stopCapture();
+                expect(draw.mock.calls.length).toBeGreaterThan(0);
+                resolve();
+            }, 100);
+        });
     });
 
     test("stopCapture is idempotent (safe with no interval active)", () => {
@@ -228,15 +257,20 @@ describe("doUseCamera", () => {
         expect(handlerCount).toBe(1);
     });
 
-    test("Video capture (isVideo=true): repeated calls never leave more than one interval running", async () => {
+    test("Video capture (isVideo=true): repeated calls reuse the existing interval instead of restarting it", async () => {
         doUseCamera(["t"], turtlesCtx.turtles, "t", true, null, setCameraID, errorMsg);
         await Promise.resolve();
         dom.video.fireCanplay();
         expect(setCameraID).toHaveBeenCalledTimes(1);
+        const firstId = setCameraID.mock.calls[0][0];
 
+        // A second call in quick succession (as a "forever" loop would do)
+        // must NOT clear the running interval - only reuse/report it -
+        // otherwise the interval could be cancelled before it ever fires.
         doUseCamera(["t"], turtlesCtx.turtles, "t", true, null, setCameraID, errorMsg);
-        expect(window.clearInterval).toHaveBeenCalled();
+        expect(window.clearInterval).not.toHaveBeenCalled();
         expect(setCameraID).toHaveBeenCalledTimes(2);
+        expect(setCameraID.mock.calls[1][0]).toBe(firstId);
     });
 
     test("browser without getUserMedia support reports an error and does not throw", () => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1036,17 +1036,79 @@ let prepareMacroExports = (name, stack, macroDict) => {
 };
 
 // Camera functionality module
-// Encapsulates camera-related operations for video/image capture
+// Encapsulates camera-related operations for video/image capture.
+// All interval/listener lifecycle state lives here (not in doUseCamera's
+// closures) so that repeated doUseCamera(...) calls can never accumulate
+// more than one active interval or one active canplay listener.
 const CameraManager = {
     isSetup: false,
     canPlayHandler: null,
     intervalId: null,
+    // Tracks the exact element a listener was attached to, so cleanup always
+    // targets the right node even if #camVideo is ever replaced in the DOM.
+    listenerVideoElement: null,
 
     /**
-     * Resets the camera setup state
+     * Starts (or idempotently restarts) the capture interval.
+     * Clears any interval already running before starting a new one, so
+     * calling this repeatedly never leaks intervals.
+     * @param {function} draw - callback invoked on each tick
+     * @param {number} periodMs - interval period in milliseconds
+     * @returns {number} the new interval id
+     */
+    startCapture(draw, periodMs = 100) {
+        this.stopCapture();
+        this.intervalId = window.setInterval(draw, periodMs);
+        return this.intervalId;
+    },
+
+    /**
+     * Stops the capture interval if one is running. Safe to call when no
+     * interval is active (idempotent).
+     */
+    stopCapture() {
+        if (this.intervalId !== null) {
+            window.clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+    },
+
+    /**
+     * Attaches a canplay handler to a video element, first removing any
+     * previously attached handler (from this element or a prior one).
+     * Idempotent: calling this repeatedly never leaves more than one
+     * listener registered.
+     * @param {HTMLVideoElement} video
+     * @param {function} handler
+     */
+    setCanplayListener(video, handler) {
+        this.clearCanplayListener();
+        video.addEventListener("canplay", handler, false);
+        this.canPlayHandler = handler;
+        this.listenerVideoElement = video;
+    },
+
+    /**
+     * Removes the currently tracked canplay handler from the element it was
+     * actually attached to. Safe to call when no listener is active.
+     */
+    clearCanplayListener() {
+        if (this.canPlayHandler && this.listenerVideoElement) {
+            this.listenerVideoElement.removeEventListener("canplay", this.canPlayHandler, false);
+        }
+        this.canPlayHandler = null;
+        this.listenerVideoElement = null;
+    },
+
+    /**
+     * Resets the camera setup state and tears down any active interval or
+     * listener. Called on doStopVideoCam so a Stop always returns to a
+     * clean slate before the next Camera/Video block run.
      */
     reset() {
         this.isSetup = false;
+        this.stopCapture();
+        this.clearCanplayListener();
     }
 };
 
@@ -1082,6 +1144,15 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
         turtles.getTurtle(turtle).doShowImage(args[0], data);
     }
 
+    function startCaptureOrDraw() {
+        if (isVideo) {
+            cameraID = CameraManager.startCapture(draw, 100);
+            setCameraID(cameraID);
+        } else {
+            draw();
+        }
+    }
+
     if (!CameraManager.isSetup) {
         if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
             errorMsg("Your browser does not support the webcam");
@@ -1103,21 +1174,7 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
     } else {
         streaming = true;
         video.play();
-        if (isVideo) {
-            if (CameraManager.intervalId !== null) {
-                window.clearInterval(CameraManager.intervalId);
-                CameraManager.intervalId = null;
-            }
-            cameraID = window.setInterval(draw, 100);
-            CameraManager.intervalId = cameraID;
-            setCameraID(cameraID);
-        } else {
-            draw();
-        }
-    }
-
-    if (CameraManager.canPlayHandler) {
-        video.removeEventListener("canplay", CameraManager.canPlayHandler, false);
+        startCaptureOrDraw();
     }
 
     function handleCanPlay() {
@@ -1128,24 +1185,11 @@ let doUseCamera = (args, turtles, turtle, isVideo, cameraID, setCameraID, errorM
             canvas.setAttribute("width", w);
             canvas.setAttribute("height", h);
             streaming = true;
-
-            if (isVideo) {
-                if (CameraManager.intervalId !== null) {
-                    window.clearInterval(CameraManager.intervalId);
-                    CameraManager.intervalId = null;
-                }
-                cameraID = window.setInterval(draw, 100);
-                CameraManager.intervalId = cameraID;
-                setCameraID(cameraID);
-            } else {
-                draw();
-            }
+            startCaptureOrDraw();
         }
     }
 
-    CameraManager.canPlayHandler = handleCanPlay;
-
-    video.addEventListener("canplay", CameraManager.canPlayHandler, false);
+    CameraManager.setCanplayListener(video, handleCanPlay);
 };
 
 /**
@@ -1369,6 +1413,9 @@ if (typeof module !== "undefined" && module.exports) {
         prepareMacroExports,
         processPluginData,
         processMacroData,
-        announceToScreenReader
+        announceToScreenReader,
+        doUseCamera,
+        doStopVideoCam,
+        CameraManager
     };
 }

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1049,15 +1049,22 @@ const CameraManager = {
     listenerVideoElement: null,
 
     /**
-     * Starts (or idempotently restarts) the capture interval.
-     * Clears any interval already running before starting a new one, so
-     * calling this repeatedly never leaks intervals.
+     * Starts the capture interval if one isn't already running. Idempotent:
+     * if a capture interval is already active, this is a no-op that returns
+     * the existing interval id, rather than clearing and restarting it.
+     *
+     * This matters when doUseCamera is invoked rapidly and repeatedly (e.g.
+     * from inside a "forever" loop): clearing and restarting the interval on
+     * every call would cancel it before it ever gets a chance to fire,
+     * meaning draw() would never run and no frame would ever be captured.
      * @param {function} draw - callback invoked on each tick
      * @param {number} periodMs - interval period in milliseconds
-     * @returns {number} the new interval id
+     * @returns {number} the active interval id
      */
     startCapture(draw, periodMs = 100) {
-        this.stopCapture();
+        if (this.intervalId !== null) {
+            return this.intervalId;
+        }
         this.intervalId = window.setInterval(draw, periodMs);
         return this.intervalId;
     },


### PR DESCRIPTION
fix(camera): centralize interval/listener lifecycle in CameraManager

Refs #7868, #6155, #6156

## PR Category

 - [x] Bug Fix 
 - [ ] Feature 
 - [ ] Performance 
 - [x] Tests 
 - [ ] Documentation 
 - [ ] CI/CD 

## Summary

Re-attempts the lifecycle fix from #6156 (closed unmerged after an
unconfirmed regression report) for the original perf issue in #6155.

`CameraManager` already existed on master with basic dedup logic, but
the interval/listener control flow was still inlined inside
`doUseCamera`'s closures, `doStopVideoCam` never actually cleared the
`canplay` listener, and there was no test coverage --`doUseCamera` and
`doStopVideoCam` weren't even part of `utils.js`'s CommonJS exports,
so they couldn't be unit tested at all.

https://github.com/user-attachments/assets/b9ebaf65-5a0a-4e35-99ea-b62e7ea118a8

https://github.com/user-attachments/assets/c5e07e5f-c053-4a74-9f8c-40715e6d3b2c

## Changes

- `CameraManager` now exposes an explicit, idempotent lifecycle API:
  - `startCapture(draw, periodMs)` / `stopCapture()`
  - `setCanplayListener(video, handler)` / `clearCanplayListener()`
- Added `listenerVideoElement` tracking, so listener cleanup always
  targets the element the listener was actually attached to, even if
  `#camVideo` were ever replaced in the DOM.
- `doStopVideoCam` → `CameraManager.reset()` now clears the `canplay`
  listener in addition to the interval and the `isSetup` flag (it
  previously only reset the flag).
- Exported `doUseCamera`, `doStopVideoCam`, `CameraManager` from
  `utils.js` so they're testable.
- **`startCapture` is idempotent in the sense that matters**: if a
  capture interval is already running, it's left alone rather than
  cleared and restarted. This was found via manual testing, not just
  code review — see "Bug found during manual verification" below.
- Added `js/utils/__tests__/camera.test.js` (12 tests): manager
  lifecycle in isolation, `doUseCamera` first-run and repeat-run for
  both Camera+Show (photo) and Video capture (interval), stop→restart,
  the no-`getUserMedia` error path, and a regression test simulating
  rapid repeated calls (as from a `forever` loop) with real timers.

The photo-path control flow (Camera + Show, `isVideo === false`) is
intentionally left behaviorally identical to master — first run waits
for `canplay` then draws once; subsequent runs draw immediately — since
that's the exact path @walterbender reported as broken in #6156. Only
where the listener/interval bookkeeping lives has changed, not the
sequence of operations.

## Bug found during manual verification

While testing, found that wrapping the **Video** block in a `forever`
loop showed nothing at all. Root cause: my first pass at
`startCapture()` unconditionally cleared and restarted the interval on
every call. A `forever` loop calls `doUseCamera` far faster than the
100ms capture period, so the interval was cancelled and restarted
before it ever got a chance to fire `draw()` — no frame was ever
captured. Fixed by making `startCapture` a true no-op when a capture
interval is already running, and added a real-timer regression test
that reproduces the rapid-call scenario. Re-verified fixed on both
browsers afterward.

(Separately, and not a bug: the Video block *without* a `forever` loop
appears to freeze after ~1 second and needs re-clicking. That's Music
Blocks' own project-lifecycle behavior — the runtime auto-stops
everything, including the camera, about a second after a script
finishes running with nothing keeping it alive. Not something this PR
changes.)

## Testing

- `npx jest js/utils/__tests__/camera.test.js` — 12/12 passing
- Full suite (`npm test`) — 1293/1293 passing, no regressions
- `npm run lint` and `npx prettier --check .` — clean on changed files

## Manual verification

Tested on Chrome/Brave (Chromium-based) and Firefox, Linux:

- [x] Camera + Show block produces an image on first run
- [x] Camera + Show block produces an image on a second run without
      reloading the page
- [x] Camera + Show block works correctly after Stop → re-run
- [x] Video block wrapped in a `forever` loop updates continuously
      (was broken before the `startCapture` fix above — now works)
- [x] Video block Stop → re-run inside `forever` — works cleanly

Note: Video's continuous updates render as a new still frame roughly
every 100ms (canvas snapshot + `toDataURL`), not smooth video — this
is existing, by-design behavior unrelated to this PR, and is in fact
the performance cost that #6155 is about.

Screen recording of the above attached below.

## Not in scope for this PR

- The `toDataURL` → `toBlob` / reduced-cadence perf work from #6155 is
  left for a follow-up so this PR stays focused and easy to review.