### PR TITLE
fix(browser-utils): correct Edge and Opera browser detection in fnBrowserDetect

### DIFF
--- a/js/utils/__tests__/browser-utils.test.js
+++ b/js/utils/__tests__/browser-utils.test.js
@@ -45,7 +45,15 @@ describe("fnBrowserDetect()", () => {
         ["firefox", "Mozilla/5.0 FxiOS/121.0"],
         ["safari", "Mozilla/5.0 Safari/605.1.15"],
         ["opera", "Mozilla/5.0 OPR/106.0"],
-        ["edge", "Mozilla/5.0 Edg/120.0"]
+        [
+            "opera",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
+        ],
+        ["edge", "Mozilla/5.0 Edg/120.0"],
+        [
+            "edge",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+        ]
     ])("detects %s from %s", (expected, userAgent) => {
         setUserAgent(userAgent);
         expect(fnBrowserDetect()).toBe(expected);

--- a/js/utils/browser-utils.js
+++ b/js/utils/browser-utils.js
@@ -34,16 +34,16 @@ function fnBrowserDetect() {
     const userAgent = navigator.userAgent;
     let browserName;
 
-    if (userAgent.match(/chrome|chromium|crios/i)) {
+    if (userAgent.match(/edg/i)) {
+        browserName = "edge";
+    } else if (userAgent.match(/opr\//i)) {
+        browserName = "opera";
+    } else if (userAgent.match(/chrome|chromium|crios/i)) {
         browserName = "chrome";
     } else if (userAgent.match(/firefox|fxios/i)) {
         browserName = "firefox";
     } else if (userAgent.match(/safari/i)) {
         browserName = "safari";
-    } else if (userAgent.match(/opr\//i)) {
-        browserName = "opera";
-    } else if (userAgent.match(/edg/i)) {
-        browserName = "edge";
     } else {
         browserName = "No browser detection";
     }


### PR DESCRIPTION
## Description

Fixes browser detection logic in `fnBrowserDetect()` inside `js/utils/browser-utils.js`. Real-world Chromium-based Edge and Opera user-agent strings contain `Chrome/x.x.x.x`. Because `chrome` was checked first in `fnBrowserDetect()`, Edge and Opera browsers were misidentified as `"chrome"`.

## Related Issue

N/A (Discovered during codebase audit and testing)

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Reordered regex checks in `fnBrowserDetect()` so `/edg/i` (Edge) and `/opr\//i` (Opera) are evaluated before `/chrome|chromium|crios/i`.
- Added test matrix entries in `js/utils/__tests__/browser-utils.test.js` covering realistic Chromium-based Edge and Opera user-agent strings.

## Testing Performed

- Ran `npx jest js/utils/__tests__/browser-utils.test.js` (All 37 test cases passed).
- Ran `npx eslint js/utils/browser-utils.js js/utils/__tests__/browser-utils.test.js` (0 errors, 0 warnings).
- Formatted with `npx prettier --write`.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

"Note: Security audit CI step failure is due to repository-wide package advisories in immutable / svgo on master."