### PR TITLE
refactor: migrate SPECIALINPUTS to ProtoBlock capability metadata

### DIFF
--- a/js/__tests__/IntervalsBlocks.test.js
+++ b/js/__tests__/IntervalsBlocks.test.js
@@ -23,6 +23,7 @@ class GenericMockBlock {
         this.label = label;
         this.connections = ["connKey"];
         this.lang = typeof global._mockLang !== "undefined" ? global._mockLang : "en";
+        this.capabilities = Object.create(null);
     }
     setPalette(p) {
         this.palette = p;
@@ -49,6 +50,15 @@ class GenericMockBlock {
     setup(activity) {
         if (activity && activity.addBlock) activity.addBlock(this);
         return this;
+    }
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 }
 

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -82,7 +82,6 @@ global.document = {
 // Mock Constants
 global.STANDARDBLOCKHEIGHT = 20;
 global.DEFAULTBLOCKSCALE = 1.0;
-global.SPECIALINPUTS = ["number", "text", "boolean"];
 global.COLLAPSIBLES = ["repeat", "forever", "if"];
 global.INLINECOLLAPSIBLES = ["newnote", "interval", "osctime"];
 global.platformColor = {
@@ -234,6 +233,29 @@ describe("Block Foundation", () => {
 
             const block = new Block(mockProtoBlock, mockBlocks);
             expect(block.isNoteContainer()).toBe(false);
+        });
+
+        it("hasValueDrivenLabel() should return true from capability metadata", () => {
+            mockProtoBlock.capabilities.valueDrivenLabel = true;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasValueDrivenLabel()).toBe(true);
+        });
+
+        it("hasValueDrivenLabel() should respect explicit false metadata", () => {
+            mockProtoBlock.name = "number";
+            mockProtoBlock.capabilities.valueDrivenLabel = false;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasValueDrivenLabel()).toBe(false);
+        });
+
+        it("hasValueDrivenLabel() should return false for ordinary blocks", () => {
+            mockProtoBlock.name = "forward";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasValueDrivenLabel()).toBe(false);
         });
 
         it("copySize() should sync size from protoblock", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -83,7 +83,6 @@ global.setupBlockDragController = require("../block-drag-controller").setupBlock
 // Mock Constants
 global.DEFAULTBLOCKSCALE = 1.0;
 global.STANDARDBLOCKHEIGHT = 20;
-global.SPECIALINPUTS = ["number", "text", "boolean"];
 global.COLLAPSIBLES = ["repeat", "forever", "if"];
 global.INLINECOLLAPSIBLES = ["newnote", "interval", "osctime"];
 global.DEFAULTACCIDENTAL = "natural";

--- a/js/activity.js
+++ b/js/activity.js
@@ -55,7 +55,7 @@ try {
    piemenuKey, POLAR, preparePluginExports, processMacroData,
    processPluginData, processRawPluginData, SaveInterface,
    SHOWBLOCKSBUTTON, SMALLERBUTTON, SMALLERDISABLEBUTTON, SOPRANO,
-   SPECIALINPUTS, STANDARDBLOCKHEIGHT, StatsWindow, STROKECOLORS,
+   STANDARDBLOCKHEIGHT, StatsWindow, STROKECOLORS,
    TENOR, TITLESTRING, Toolbar, Trashcan, TREBLE, TURTLESVG,
    updatePluginObj, ZERODIVIDEERRORMSG, GRAND_G, GRAND_F,
    SHARP, FLAT, buildScale, TREBLE_F, TREBLE_G, GIFAnimator,

--- a/js/activity/__tests__/exporters.test.js
+++ b/js/activity/__tests__/exporters.test.js
@@ -15,32 +15,6 @@
 // Global mocks required by exporters.js
 // ---------------------------------------------------------------------------
 
-global.SPECIALINPUTS = [
-    "text",
-    "number",
-    "solfege",
-    "eastindiansolfege",
-    "scaledegree2",
-    "notename",
-    "voicename",
-    "modename",
-    "chordname",
-    "drumname",
-    "effectsname",
-    "filtertype",
-    "oscillatortype",
-    "boolean",
-    "intervalname",
-    "invertmode",
-    "accidentalname",
-    "temperamentname",
-    "noisename",
-    "customNote",
-    "grid",
-    "outputtools",
-    "wrapmode"
-];
-
 global.INLINECOLLAPSIBLES = ["newnote", "interval", "osctime", "definemode"];
 
 // Minimal SVG-like strings for collapse/expand buttons (split on "><")
@@ -105,7 +79,8 @@ function makeBlock(overrides = {}) {
         collapsed: overrides.collapsed || false,
         value: overrides.value !== undefined ? overrides.value : "",
         ignore: overrides.ignore || jest.fn(() => false),
-        isCollapsible: overrides.isCollapsible || jest.fn(() => false)
+        isCollapsible: overrides.isCollapsible || jest.fn(() => false),
+        hasValueDrivenLabel: overrides.hasValueDrivenLabel || jest.fn(() => false)
     };
 }
 
@@ -284,7 +259,7 @@ describe("printBlockSVG", () => {
         expect(result).toContain("svg");
     });
 
-    test("handles SPECIALINPUTS blocks with value injection", () => {
+    test("handles value-driven-label blocks with value injection", () => {
         const specialSVG =
             '<svg xmlns="http://www.w3.org/2000/svg">' +
             "<text><tspan>label</tspan><tspan></tspan></text>" +
@@ -296,7 +271,8 @@ describe("printBlockSVG", () => {
             y: 5,
             width: 60,
             height: 30,
-            value: 42
+            value: 42,
+            hasValueDrivenLabel: jest.fn(() => true)
         });
 
         const activity = makeActivity([block], {
@@ -310,7 +286,7 @@ describe("printBlockSVG", () => {
         expect(decoded).toContain("42");
     });
 
-    test("handles SPECIALINPUTS blocks with string value and gettext", () => {
+    test("handles value-driven-label blocks with string value and gettext", () => {
         const specialSVG =
             '<svg xmlns="http://www.w3.org/2000/svg">' + "<text><tspan></tspan></text>" + "</svg>";
 
@@ -324,7 +300,8 @@ describe("printBlockSVG", () => {
             y: 0,
             width: 60,
             height: 30,
-            value: "hello"
+            value: "hello",
+            hasValueDrivenLabel: jest.fn(() => true)
         });
 
         const activity = makeActivity([block], {
@@ -340,7 +317,7 @@ describe("printBlockSVG", () => {
         global._ = originalTranslate;
     });
 
-    test("handles SPECIALINPUTS with last tspan fallback (no empty tspan)", () => {
+    test("handles value-driven-label blocks with last tspan fallback (no empty tspan)", () => {
         const specialSVG =
             '<svg xmlns="http://www.w3.org/2000/svg">' +
             "<text><tspan>existing</tspan><tspan>last</tspan></text>" +
@@ -352,7 +329,8 @@ describe("printBlockSVG", () => {
             y: 0,
             width: 60,
             height: 30,
-            value: 99
+            value: 99,
+            hasValueDrivenLabel: jest.fn(() => true)
         });
 
         const activity = makeActivity([block], {
@@ -365,7 +343,7 @@ describe("printBlockSVG", () => {
         expect(decoded).toContain("99");
     });
 
-    test("handles SPECIALINPUTS with text element fallback (no tspan)", () => {
+    test("handles value-driven-label blocks with text element fallback (no tspan)", () => {
         const specialSVG =
             '<svg xmlns="http://www.w3.org/2000/svg">' + "<text>old value</text>" + "</svg>";
 
@@ -375,7 +353,8 @@ describe("printBlockSVG", () => {
             y: 0,
             width: 60,
             height: 30,
-            value: "true"
+            value: "true",
+            hasValueDrivenLabel: jest.fn(() => true)
         });
 
         const activity = makeActivity([block], {
@@ -388,7 +367,7 @@ describe("printBlockSVG", () => {
         expect(decoded).toContain("true");
     });
 
-    test("removes dropshadow filter from SPECIALINPUTS SVG", () => {
+    test("removes dropshadow filter from value-driven-label SVG", () => {
         const specialSVG =
             '<svg xmlns="http://www.w3.org/2000/svg">' +
             '<g style="filter:url(#dropshadow)">' +
@@ -402,7 +381,8 @@ describe("printBlockSVG", () => {
             y: 0,
             width: 60,
             height: 30,
-            value: 7
+            value: 7,
+            hasValueDrivenLabel: jest.fn(() => true)
         });
 
         const activity = makeActivity([block], {

--- a/js/activity/exporters.js
+++ b/js/activity/exporters.js
@@ -10,7 +10,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* global DOMParser, XMLSerializer, SPECIALINPUTS, _, INLINECOLLAPSIBLES, EXPANDBUTTON, COLLAPSEBUTTON, TURTLESVG, FILLCOLORS, STROKECOLORS */
+/* global DOMParser, XMLSerializer, _, INLINECOLLAPSIBLES, EXPANDBUTTON, COLLAPSEBUTTON, TURTLESVG, FILLCOLORS, STROKECOLORS */
 
 const extractSVGInner = svgString => {
     const parser = new DOMParser();
@@ -69,7 +69,7 @@ const printBlockSVG = activity => {
                 ')">'
         );
 
-        if (!SPECIALINPUTS.includes(activity.blocks.blockList[i].name)) {
+        if (!activity.blocks.blockList[i].hasValueDrivenLabel()) {
             svgParts.push(extractSVGInner(rawSVG));
         } else {
             // Safer SVG manipulation using DOM instead of string splitting

--- a/js/block.js
+++ b/js/block.js
@@ -127,36 +127,6 @@ const COLLAPSIBLES = [
 const ARG_LIKE_BLOCKS = ["doArg", "calcArg", "namedcalcArg", "makeblock"];
 
 /**
- * List of special input types.
- * @type {string[]}
- */
-const SPECIALINPUTS = [
-    "text",
-    "number",
-    "solfege",
-    "eastindiansolfege",
-    "scaledegree2",
-    "notename",
-    "voicename",
-    "modename",
-    "chordname",
-    "drumname",
-    "effectsname",
-    "filtertype",
-    "oscillatortype",
-    "boolean",
-    "intervalname",
-    "invertmode",
-    "accidentalname",
-    "temperamentname",
-    "noisename",
-    "customNote",
-    "grid",
-    "outputtools",
-    "wrapmode"
-];
-
-/**
  * List of block types whose names should be widened.
  * @type {string[]}
  */
@@ -1412,7 +1382,7 @@ class Block {
             }
         } else if (this.protoblock.staticLabels.length > 0 && !this.protoblock.image) {
             // Label should be defined inside _().
-            if (SPECIALINPUTS.includes(this.name)) {
+            if (this.hasValueDrivenLabel()) {
                 block_label = "";
             } else {
                 block_label = this.protoblock.staticLabels[0];
@@ -1470,7 +1440,7 @@ class Block {
         // const thisBlock = this.blockIndex;
         let proto, obj, label, attr;
         // Value blocks get a modifiable text label.
-        if (SPECIALINPUTS.includes(this.name)) {
+        if (this.hasValueDrivenLabel()) {
             if (this.value === null) {
                 switch (this.name) {
                     case "text":
@@ -2145,6 +2115,14 @@ class Block {
         }
 
         return false;
+    }
+
+    /**
+     * Checks if the block derives its visible inline label from its value.
+     * @returns {boolean} - True if the block has value-driven label behavior.
+     */
+    hasValueDrivenLabel() {
+        return this.hasCapability("valueDrivenLabel");
     }
 
     /**
@@ -3021,7 +2999,7 @@ class Block {
         this.text.y = Math.floor((TEXTY * blockScale) / 2 + 0.5);
 
         // Some special cases
-        if (SPECIALINPUTS.includes(this.name)) {
+        if (this.hasValueDrivenLabel()) {
             this.text.textAlign = "center";
             this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 10.0);
             if (EXTRAWIDENAMES.includes(this.name)) {
@@ -3214,7 +3192,7 @@ class Block {
             } else if ((!window.hasMouse && getInput) || (window.hasMouse && !moved)) {
                 if (["media", "audiofile", "loadFile"].includes(that.name)) {
                     that._doOpenMedia(thisBlock);
-                } else if (SPECIALINPUTS.includes(that.name)) {
+                } else if (that.hasValueDrivenLabel()) {
                     if (!that.trash) {
                         if (that._triggerLongPress) {
                             that._triggerLongPress = false;
@@ -3666,7 +3644,7 @@ class Block {
                 // apart). Still need to get to the root cause.
                 this.blocks.adjustDocks(this.blockIndex, true);
             }
-        } else if (SPECIALINPUTS.includes(this.name) || ["media", "loadFile"].includes(this.name)) {
+        } else if (this.hasValueDrivenLabel() || ["media", "loadFile"].includes(this.name)) {
             if (!haveClick) {
                 // Simulate click on Android.
                 if (new Date().getTime() - this.blocks.mouseDownTime < 500) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -17,7 +17,7 @@
    DEFAULTFILTERTYPE, DEFAULTINTERVAL, DEFAULTINVERT, DEFAULTMODE,
    DEFAULTNOISE, DEFAULTOSCILLATORTYPE, DEFAULTTEMPERAMENT,
    DEFAULTVOICE, INLINECOLLAPSIBLES, NATURAL, NUMBERBLOCKDEFAULT,
-    SPECIALINPUTS, STANDARDBLOCKHEIGHT, STRINGLEN, TEXTWIDTH,
+    STANDARDBLOCKHEIGHT, STRINGLEN, TEXTWIDTH,
     WESTERN2EISOLFEGENAMES, WIDENAMES, addTemperamentToDictionary,
    Block, closeBlkWidgets, ConnectionValidator, createjs, delayExecution, DEFAULTCHORD,
    deleteTemperamentFromList, getDrumSynthName, getNoiseName,
@@ -510,7 +510,7 @@ class Blocks {
             const firstConnection = blkObj.connections[0];
             let connectionIdx;
 
-            if (!SPECIALINPUTS.includes(blkObj.name)) {
+            if (!blkObj.hasValueDrivenLabel()) {
                 const clampList = [];
                 this.findNestedClampBlocks(blk, clampList);
 

--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -985,6 +985,7 @@ function setupBooleanBlocks(activity) {
          */
         constructor() {
             super("boolean");
+            this.setCapability("valueDrivenLabel");
 
             /**
              * Sets the palette for the block.

--- a/js/blocks/DrumBlocks.js
+++ b/js/blocks/DrumBlocks.js
@@ -30,6 +30,7 @@ function setupDrumBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class (ValueBlock)
             super("noisename", _("noise name"));
+            this.setCapability("valueDrivenLabel");
 
             /**
              * Sets the palette for the block.
@@ -73,6 +74,7 @@ function setupDrumBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class (ValueBlock)
             super("drumname", _("drum name"));
+            this.setCapability("valueDrivenLabel");
 
             /**
              * Sets the palette for the block.
@@ -117,6 +119,7 @@ function setupDrumBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class (ValueBlock)
             super("effectsname", _("effects name"));
+            this.setCapability("valueDrivenLabel");
 
             /**
              * Sets the palette for the block.
@@ -213,7 +216,7 @@ function setupDrumBlocks(activity) {
          */
         flow(args, logo, turtle, blk) {
             let arg = args[0];
-            if (args.length !== 1 || arg == null || typeof arg !== "string") {
+            if (args.length !== 1 || arg === null || arg === undefined || typeof arg !== "string") {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 arg = "noise1";
             }
@@ -535,7 +538,7 @@ function setupDrumBlocks(activity) {
             /**
              * Validate input and handle errors.
              */
-            if (args.length !== 1 || arg == null || typeof arg !== "string") {
+            if (args.length !== 1 || arg === null || arg === undefined || typeof arg !== "string") {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 arg = DEFAULTDRUM;
             }
@@ -576,8 +579,8 @@ function setupDrumBlocks(activity) {
                 logo.musicKeyboard.addRowBlock(blk);
             } else if (
                 tur.singer.inNoteBlock.length > 0 ||
-                (activity.blocks.blockList[blk].connections[0] == null &&
-                    last(activity.blocks.blockList[blk].connections) == null)
+                (activity.blocks.blockList[blk].connections[0] === null &&
+                    last(activity.blocks.blockList[blk].connections) === null)
             ) {
                 // Handle other contexts
                 Singer.DrumActions.playDrum(args[0], turtle, blk);

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -672,6 +672,7 @@ function setupExtrasBlocks(activity) {
          */
         constructor() {
             super("grid");
+            this.setCapability("valueDrivenLabel");
             this.setPalette("extras", activity);
             this.setHelpString();
             this.formBlock({ outType: "gridout" });

--- a/js/blocks/GraphicsBlocks.js
+++ b/js/blocks/GraphicsBlocks.js
@@ -101,7 +101,7 @@ function setupGraphicsBlocks(activity) {
             const parentId = connections[0] ?? null;
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -186,7 +186,7 @@ function setupGraphicsBlocks(activity) {
             const parentId = connections[0] ?? null;
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -272,7 +272,7 @@ function setupGraphicsBlocks(activity) {
             const parentId = connections[0] ?? null;
             if (
                 logo.inStatusMatrix &&
-                parentId != null &&
+                parentId !== null &&
                 parentId in activity.blocks.blockList &&
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
@@ -612,7 +612,7 @@ function setupGraphicsBlocks(activity) {
             const isWrap = activity.turtles.ithTurtle(turtle).painter.wrap;
 
             if (args.length === 2) {
-                if ((args[1] > 5000 || args[1] < -5000) && (isWrap === false || isWrap == null)) {
+                if ((args[1] > 5000 || args[1] < -5000) && (isWrap === false || isWrap === null)) {
                     activity.errorMsg(
                         _("Value must be within -5000 to 5000 when Wrap Mode is off."),
                         blk
@@ -767,7 +767,7 @@ function setupGraphicsBlocks(activity) {
             if (args.length === 2) {
                 if (
                     (args[0] > 5000 || args[1] > 5000 || args[0] < -5000 || args[1] < -5000) &&
-                    (isWrap === false || isWrap == null)
+                    (isWrap === false || isWrap === null)
                 ) {
                     activity.errorMsg(
                         _("Value must be within -5000 to 5000 when Wrap Mode is off."),
@@ -1020,7 +1020,7 @@ function setupGraphicsBlocks(activity) {
             const isWrap = activity.turtles.ithTurtle(turtle).painter.wrap;
 
             if (args.length === 1) {
-                if ((args[0] > 5000 || args[0] < -5000) && (isWrap === false || isWrap == null)) {
+                if ((args[0] > 5000 || args[0] < -5000) && (isWrap === false || isWrap === null)) {
                     activity.errorMsg(
                         _("Value must be within -5000 to 5000 when Wrap Mode is off."),
                         blk
@@ -1109,7 +1109,7 @@ function setupGraphicsBlocks(activity) {
             const isWrap = activity.turtles.ithTurtle(turtle).painter.wrap;
 
             if (args.length === 1) {
-                if ((args[0] > 5000 || args[0] < -5000) && (isWrap === false || isWrap == null)) {
+                if ((args[0] > 5000 || args[0] < -5000) && (isWrap === false || isWrap === null)) {
                     activity.errorMsg(
                         _("Value must be within -5000 to 5000 when Wrap Mode is off."),
                         blk
@@ -1157,6 +1157,7 @@ function setupGraphicsBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("wrapmode");
+            this.setCapability("valueDrivenLabel");
 
             // Set the palette, activity, and form the block with specific parameters
             this.setPalette("graphics", activity);

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -92,6 +92,7 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("temperamentname", _("temperament name"));
+            this.setCapability("valueDrivenLabel");
 
             // Set the palette, activity, extra width, and form the block with specific parameters
             this.setPalette("tone", activity);
@@ -117,6 +118,7 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("modename");
+            this.setCapability("valueDrivenLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -138,6 +140,7 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("chordname");
+            this.setCapability("valueDrivenLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -240,6 +243,7 @@ function setupIntervalsBlocks(activity) {
         constructor() {
             // Call the constructor of the parent class
             super("intervalname");
+            this.setCapability("valueDrivenLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);

--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -742,7 +742,7 @@ function setupMediaBlocks(activity) {
          * @param {Logo} logo - The logo object.
          */
         flow(args, logo) {
-            if (logo.cameraID != null) {
+            if (logo.cameraID !== null) {
                 doStopVideoCam(logo.cameraID, logo.setCameraID);
             }
         }
@@ -1044,6 +1044,7 @@ function setupMediaBlocks(activity) {
          */
         constructor() {
             super("text", _("text"));
+            this.setCapability("valueDrivenLabel");
 
             // Set extra width for the block
             this.extraWidth = 30;

--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -926,6 +926,7 @@ function setupNumberBlocks(activity) {
     class NumberBlock extends ValueBlock {
         constructor() {
             super("number", _("number"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("number", activity);
             this.beginnerBlock(true);
 

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -129,6 +129,7 @@ function setupPitchBlocks(activity) {
     class InvertModeBlock extends ValueBlock {
         constructor() {
             super("invertmode");
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.formBlock({ outType: "textout" });
             this.hidden = true;
@@ -421,6 +422,7 @@ function setupPitchBlocks(activity) {
     class OutputToolsBlocks extends LeftBlock {
         constructor() {
             super("outputtools", _("pitch converter"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.beginnerBlock(true);
             this.extraWidth = 50;
@@ -877,6 +879,7 @@ function setupPitchBlocks(activity) {
     class AccidentalNameBlock extends ValueBlock {
         constructor() {
             super("accidentalname", _("accidental selector"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _(
@@ -893,6 +896,7 @@ function setupPitchBlocks(activity) {
     class EastIndianSolfegeBlock extends ValueBlock {
         constructor() {
             super("eastindiansolfege", _("east indian solfege"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of ni dha pa ma ga re sa."),
@@ -907,6 +911,7 @@ function setupPitchBlocks(activity) {
     class NoteNameBlock extends ValueBlock {
         constructor() {
             super("notename", _("note name"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of C D E F G A B."),
@@ -922,6 +927,7 @@ function setupPitchBlocks(activity) {
     class SolfegeBlock extends ValueBlock {
         constructor() {
             super("solfege", _("solfege"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of do re mi fa sol la ti."),
@@ -937,6 +943,7 @@ function setupPitchBlocks(activity) {
     class CustomNoteBlock extends ValueBlock {
         constructor() {
             super("customNote");
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.hidden = true;
         }
@@ -1842,6 +1849,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             //.TRANS: a numeric mapping of the notes in an octave based on the musical mode
             super("scaledegree2", _("scale degree"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("pitch", activity);
             this.extraWidth = 10;
             this.setHelpString([

--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -103,6 +103,7 @@ function setupToneBlocks(activity) {
          */
         constructor() {
             super("filtertype");
+            this.setCapability("valueDrivenLabel");
             this.setPalette("tone", activity);
             this.setHelpString();
             this.formBlock({ outType: "textout" });
@@ -122,6 +123,7 @@ function setupToneBlocks(activity) {
          */
         constructor() {
             super("oscillatortype");
+            this.setCapability("valueDrivenLabel");
             this.setPalette("tone", activity);
             this.setHelpString();
             this.formBlock({ outType: "textout" });
@@ -919,6 +921,7 @@ function setupToneBlocks(activity) {
          */
         constructor() {
             super("voicename", _("set instrument"));
+            this.setCapability("valueDrivenLabel");
             this.setPalette("tone", activity);
             this.setHelpString([
                 _(

--- a/js/blocks/__tests__/BooleanBlocks.test.js
+++ b/js/blocks/__tests__/BooleanBlocks.test.js
@@ -24,9 +24,19 @@ const { setupBooleanBlocks } = require("../BooleanBlocks");
 global._ = jest.fn(str => str);
 global.BooleanBlock = jest.fn().mockImplementation(type => ({
     type,
+    capabilities: Object.create(null),
     setPalette: jest.fn(),
     setHelpString: jest.fn(),
     formBlock: jest.fn(),
+    setCapability: jest.fn(function (name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }),
+    getCapability: jest.fn(function (name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
+    }),
     updateParameter: jest.fn(function (logo, turtle, blk) {
         if (mockActivity.blocks.blockList[blk].value) {
             return _("true");
@@ -381,6 +391,7 @@ describe("real BooleanBlock instances - direct method coverage", () => {
             constructor(type) {
                 this.type = type;
                 instances[type] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -389,6 +400,15 @@ describe("real BooleanBlock instances - direct method coverage", () => {
             setup() {}
             updateParameter() {}
             arg() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupBooleanBlocks(mockActivity);
         global.BooleanBlock = origBooleanBlock;
@@ -448,6 +468,7 @@ describe("BooleanBlocks error-handling paths (try-catch coverage)", () => {
             constructor(type) {
                 this.type = type;
                 instances[type] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -456,6 +477,15 @@ describe("BooleanBlocks error-handling paths (try-catch coverage)", () => {
             setup() {}
             updateParameter() {}
             arg() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupBooleanBlocks(mockActivity);
         global.BooleanBlock = origBooleanBlock;
@@ -554,6 +584,7 @@ describe("BooleanBlocks edge-case inputs", () => {
             constructor(type) {
                 this.type = type;
                 instances[type] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -562,6 +593,15 @@ describe("BooleanBlocks edge-case inputs", () => {
             setup() {}
             updateParameter() {}
             arg() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupBooleanBlocks(mockActivity);
         global.BooleanBlock = origBooleanBlock;
@@ -702,6 +742,7 @@ describe("StaticBooleanBlock edge cases", () => {
             constructor(type) {
                 this.type = type;
                 instances[type] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -710,6 +751,15 @@ describe("StaticBooleanBlock edge cases", () => {
             setup() {}
             updateParameter() {}
             arg() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupBooleanBlocks(mockActivity);
         global.BooleanBlock = origBooleanBlock;
@@ -775,6 +825,10 @@ describe("StaticBooleanBlock edge cases", () => {
         const result = instances["boolean"].arg(mockLogo, "turtle1", "blkRandom", null);
         expect(result).toBe(false);
     });
+
+    test("StaticBooleanBlock declares the valueDrivenLabel capability", () => {
+        expect(instances["boolean"].getCapability("valueDrivenLabel")).toBe(true);
+    });
 });
 
 describe("BooleanBlocks single null connection edge cases", () => {
@@ -787,6 +841,7 @@ describe("BooleanBlocks single null connection edge cases", () => {
             constructor(type) {
                 this.type = type;
                 instances[type] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -795,6 +850,15 @@ describe("BooleanBlocks single null connection edge cases", () => {
             setup() {}
             updateParameter() {}
             arg() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupBooleanBlocks(mockActivity);
         global.BooleanBlock = origBooleanBlock;

--- a/js/blocks/__tests__/DrumBlocks.test.js
+++ b/js/blocks/__tests__/DrumBlocks.test.js
@@ -37,12 +37,22 @@ global.Singer = {
 global.FlowBlock = jest.fn().mockImplementation((name, displayName) => ({
     name,
     displayName,
+    capabilities: Object.create(null),
     setPalette: jest.fn().mockReturnThis(),
     setHelpString: jest.fn().mockReturnThis(),
     formBlock: jest.fn().mockReturnThis(),
     makeMacro: jest.fn().mockReturnThis(),
     setup: jest.fn().mockReturnThis(),
     beginnerBlock: jest.fn().mockReturnThis(),
+    setCapability: jest.fn(function (capability, value = true) {
+        this.capabilities[capability] = !!value;
+        return this;
+    }),
+    getCapability: jest.fn(function (capability) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, capability)
+            ? this.capabilities[capability]
+            : undefined;
+    }),
     flow: jest.fn()
 }));
 global.ValueBlock = jest.fn().mockImplementation((name, displayName) => ({
@@ -256,7 +266,12 @@ describe("setupDrumBlocks", () => {
         const playNoiseBlock = new (class extends global.FlowBlock {
             flow = args => {
                 const arg = args[0];
-                if (args.length !== 1 || arg == null || typeof arg !== "string") {
+                if (
+                    args.length !== 1 ||
+                    arg === null ||
+                    arg === undefined ||
+                    typeof arg !== "string"
+                ) {
                     activity.errorMsg(global.NOINPUTERRORMSG, 0);
                 }
             };
@@ -322,7 +337,7 @@ describe("setupDrumBlocks", () => {
         setupDrumBlocks(activity);
         const playDrumBlock = new (class extends global.FlowBlock {
             flow = args => {
-                if (args.length !== 1 || args[0] == null) {
+                if (args.length !== 1 || args[0] === null || args[0] === undefined) {
                     console.debug("PLAY DRUM ERROR: missing context");
                 }
             };
@@ -339,7 +354,12 @@ describe("setupDrumBlocks", () => {
         const playDrumBlock = new (class extends global.FlowBlock {
             flow = args => {
                 let arg = args[0];
-                if (args.length !== 1 || arg == null || typeof arg !== "string") {
+                if (
+                    args.length !== 1 ||
+                    arg === null ||
+                    arg === undefined ||
+                    typeof arg !== "string"
+                ) {
                     activity.errorMsg(global.NOINPUTERRORMSG, 0);
                     arg = global.DEFAULTDRUM;
                 }
@@ -364,7 +384,12 @@ describe("setupDrumBlocks", () => {
         const playDrumBlock = new (class extends global.FlowBlock {
             flow = args => {
                 let arg = args[0];
-                if (args.length !== 1 || arg == null || typeof arg !== "string") {
+                if (
+                    args.length !== 1 ||
+                    arg === null ||
+                    arg === undefined ||
+                    typeof arg !== "string"
+                ) {
                     activity.errorMsg(global.NOINPUTERRORMSG, 0);
                     arg = global.DEFAULTDRUM;
                 }
@@ -391,7 +416,12 @@ describe("setupDrumBlocks", () => {
         const playDrumBlock = new (class extends global.FlowBlock {
             flow = args => {
                 let arg = args[0];
-                if (args.length !== 1 || arg == null || typeof arg !== "string") {
+                if (
+                    args.length !== 1 ||
+                    arg === null ||
+                    arg === undefined ||
+                    typeof arg !== "string"
+                ) {
                     activity.errorMsg(global.NOINPUTERRORMSG, 0);
                     arg = global.DEFAULTDRUM;
                 }
@@ -428,7 +458,12 @@ describe("setupDrumBlocks", () => {
         const playDrumBlock = new (class extends global.FlowBlock {
             flow = args => {
                 let arg = args[0];
-                if (args.length !== 1 || arg == null || typeof arg !== "string") {
+                if (
+                    args.length !== 1 ||
+                    arg === null ||
+                    arg === undefined ||
+                    typeof arg !== "string"
+                ) {
                     activity.errorMsg(global.NOINPUTERRORMSG, 0);
                     arg = global.DEFAULTDRUM;
                 }
@@ -496,6 +531,7 @@ describe("real DrumBlocks instances - direct method coverage", () => {
             constructor(name) {
                 this.name = name;
                 instances[name] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -503,6 +539,15 @@ describe("real DrumBlocks instances - direct method coverage", () => {
             setup() {}
             beginnerBlock() {}
             makeMacro() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         global.FlowClampBlock = class {
             constructor(name) {
@@ -520,6 +565,7 @@ describe("real DrumBlocks instances - direct method coverage", () => {
             constructor(name) {
                 this.name = name;
                 instances[name] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -527,6 +573,15 @@ describe("real DrumBlocks instances - direct method coverage", () => {
             setup() {}
             beginnerBlock() {}
             makeMacro() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
 
         setupDrumBlocks(activity);

--- a/js/blocks/__tests__/ExtrasBlocks.test.js
+++ b/js/blocks/__tests__/ExtrasBlocks.test.js
@@ -17,6 +17,9 @@
  */
 
 global.LeftBlock = class {
+    constructor() {
+        this.capabilities = Object.create(null);
+    }
     setPalette = jest.fn();
     setHelpString = jest.fn();
     formBlock = jest.fn();
@@ -24,6 +27,15 @@ global.LeftBlock = class {
     makeMacro = jest.fn();
     beginnerBlock = jest.fn();
     updateDockValue = jest.fn();
+    setCapability = jest.fn(function (name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    });
+    getCapability = jest.fn(function (name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
+    });
 
     flow = jest.fn().mockImplementation(function (args = [], logo = {}, turtle) {
         if (args.includes("test.abc")) {
@@ -540,6 +552,7 @@ describe("real ExtrasBlocks instances - direct method coverage", () => {
         global.LeftBlock = class {
             constructor() {
                 instances[this.constructor.name] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -548,10 +561,20 @@ describe("real ExtrasBlocks instances - direct method coverage", () => {
             beginnerBlock() {}
             makeMacro() {}
             updateDockValue() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         global.FlowBlock = class {
             constructor() {
                 instances[this.constructor.name] = this;
+                this.capabilities = Object.create(null);
             }
             setPalette() {}
             setHelpString() {}
@@ -560,6 +583,15 @@ describe("real ExtrasBlocks instances - direct method coverage", () => {
             beginnerBlock() {}
             makeMacro() {}
             updateDockValue() {}
+            setCapability(name, value = true) {
+                this.capabilities[name] = !!value;
+                return this;
+            }
+            getCapability(name) {
+                return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                    ? this.capabilities[name]
+                    : undefined;
+            }
         };
         setupExtrasBlocks(activity);
         global.LeftBlock = origLeftBlock;

--- a/js/blocks/__tests__/GraphicsBlocks.test.js
+++ b/js/blocks/__tests__/GraphicsBlocks.test.js
@@ -31,11 +31,21 @@ global.toFixed2 = jest.fn(n => n);
 global.ValueBlock = class {
     constructor(name) {
         this.name = name;
+        this.capabilities = Object.create(null);
     }
     setPalette = jest.fn();
     setHelpString = jest.fn();
     formBlock = jest.fn();
     beginnerBlock = jest.fn();
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
+    }
 
     setup(activity) {
         activity.blocks[this.name] = this.constructor;
@@ -303,6 +313,10 @@ describe("GraphicsBlocks", () => {
     describe("WrapModeBlock (wrapmode)", () => {
         test("WrapModeBlock is registered", () => {
             expect(activity.blocks.wrapmode).toBeDefined();
+        });
+        test("WrapModeBlock declares the valueDrivenLabel capability", () => {
+            const block = new activity.blocks.wrapmode();
+            expect(block.getCapability("valueDrivenLabel")).toBe(true);
         });
         test("arg returns true when wrap is on", () => {
             turtleObj.painter.wrap = true;

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -33,6 +33,7 @@ describe("setupIntervalsBlocks", () => {
         constructor(name) {
             this.name = name;
             createdBlocks[name] = this;
+            this.capabilities = Object.create(null);
         }
         setPalette() {
             return this;
@@ -52,6 +53,15 @@ describe("setupIntervalsBlocks", () => {
         }
         setup() {
             return this;
+        }
+        setCapability(name, value = true) {
+            this.capabilities[name] = !!value;
+            return this;
+        }
+        getCapability(name) {
+            return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                ? this.capabilities[name]
+                : undefined;
         }
     }
 
@@ -175,6 +185,22 @@ describe("setupIntervalsBlocks", () => {
 
         turtleIndex = 0;
         setupIntervalsBlocks(activity);
+    });
+
+    describe("valueDrivenLabel capability", () => {
+        it("marks temperamentname as value-driven", () => {
+            expect(createdBlocks["temperamentname"].getCapability("valueDrivenLabel")).toBe(true);
+        });
+
+        it("marks modename as value-driven", () => {
+            expect(createdBlocks["modename"].getCapability("valueDrivenLabel")).toBe(true);
+        });
+
+        it("does not mark intervalnumber as value-driven", () => {
+            expect(
+                createdBlocks["intervalnumber"].getCapability("valueDrivenLabel")
+            ).toBeUndefined();
+        });
     });
 
     describe("Setup", () => {

--- a/js/blocks/__tests__/MediaBlocks.test.js
+++ b/js/blocks/__tests__/MediaBlocks.test.js
@@ -59,6 +59,7 @@ class DummyValueBlock {
         this.displayName = displayName || name;
         createdBlocks[name] = this;
         this.extraWidth = 0;
+        this.capabilities = Object.create(null);
     }
     setPalette(palette, activity) {
         return this;
@@ -79,6 +80,15 @@ class DummyValueBlock {
     }
     setup(activity) {
         return this;
+    }
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
     arg(logo, turtle, blk) {
         return global.activity.blocks.blockList[blk].value;
@@ -480,6 +490,10 @@ describe("setupMediaBlocks", () => {
     });
 
     describe("TextBlock", () => {
+        it("declares the valueDrivenLabel capability", () => {
+            expect(createdBlocks["text"].getCapability("valueDrivenLabel")).toBe(true);
+        });
+
         it("should return its value from blockList", () => {
             activity.blocks.blockList[620] = { value: "hello world" };
             const textBlock = createdBlocks["text"];

--- a/js/blocks/__tests__/NumberBlocks.test.js
+++ b/js/blocks/__tests__/NumberBlocks.test.js
@@ -59,6 +59,7 @@ class DummyValueBlock {
         this.displayName = displayName || name;
         createdBlocks[name] = this;
         this.extraWidth = 0;
+        this.capabilities = Object.create(null);
     }
     setPalette(palette, activity) {
         return this;
@@ -79,6 +80,15 @@ class DummyValueBlock {
     }
     setup(activity) {
         return this;
+    }
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
     arg(logo, turtle, blk) {
         return global.activity.blocks.blockList[blk].value;
@@ -967,6 +977,10 @@ describe("setupNumberBlocks", () => {
     });
 
     describe("NumberBlock", () => {
+        it("declares the valueDrivenLabel capability", () => {
+            expect(createdBlocks["number"].getCapability("valueDrivenLabel")).toBe(true);
+        });
+
         it("should return the block's numeric value", () => {
             activity.blocks.blockList[230] = { value: "123.45" };
             const numberBlock = createdBlocks["number"];

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -37,6 +37,7 @@ describe("setupPitchBlocks", () => {
             createdBlocks[name] = this;
             this.connections = [null, null, null, null, null];
             this.value = null;
+            this.capabilities = Object.create(null);
         }
         setPalette() {
             return this;
@@ -55,6 +56,15 @@ describe("setupPitchBlocks", () => {
         }
         makeMacro() {
             return this;
+        }
+        setCapability(name, value = true) {
+            this.capabilities[name] = !!value;
+            return this;
+        }
+        getCapability(name) {
+            return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+                ? this.capabilities[name]
+                : undefined;
         }
         flow() {
             return this;
@@ -873,6 +883,15 @@ describe("setupPitchBlocks", () => {
                     expect(createdBlocks[name]).toBeDefined();
                 }
             });
+        });
+
+        it("marks solfege and customNote as value-driven labels", () => {
+            expect(createdBlocks["solfege"].getCapability("valueDrivenLabel")).toBe(true);
+            expect(createdBlocks["customNote"].getCapability("valueDrivenLabel")).toBe(true);
+        });
+
+        it("does not mark pitchnumber as a value-driven label block", () => {
+            expect(createdBlocks["pitchnumber"].getCapability("valueDrivenLabel")).toBeUndefined();
         });
     });
 

--- a/js/blocks/__tests__/ToneBlocks.test.js
+++ b/js/blocks/__tests__/ToneBlocks.test.js
@@ -33,6 +33,7 @@ class DummyFlowBlock {
     constructor(type, label) {
         this.type = type;
         this.label = label;
+        this.capabilities = Object.create(null);
     }
     setPalette(palette, activity) {
         this.palette = palette;
@@ -57,6 +58,15 @@ class DummyFlowBlock {
     }
     makeMacro(fn) {
         this.macro = fn;
+    }
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+        return this;
+    }
+    getCapability(name) {
+        return Object.prototype.hasOwnProperty.call(this.capabilities, name)
+            ? this.capabilities[name]
+            : undefined;
     }
 }
 


### PR DESCRIPTION
This change moves the old SPECIALINPUTS classification into intrinsic ProtoBlock metadata using the new valueDrivenLabel capability.

## What changed
- Added valueDrivenLabel to the exact blocks that were previously in SPECIALINPUTS.
- Added Block.hasValueDrivenLabel() as a thin wrapper over ProtoBlock capability metadata.
- Replaced every production SPECIALINPUTS.includes(...) check with the new helper.
- Kept all existing behavior unchanged for:rendering
         1] label suppression
         2] default value initialization
         3] text positioning
         4] click editing
         5] mobile click editing
         6] extraction
         7] SVG export
         8] serialization

- Updated tests to check capability metadata and confirm behavior stays the same.
- Removed the old SPECIALINPUTS source of truth after migration.

### Additional unrelated cleanup:
Fixed a few existing eqeqeq lint warnings in touched files and the affected drum block test file so the pre-commit hook passes cleanly.

- Verified representative value-driven label blocks (text, number, pitch, instrument, customNote) render and edit correctly through manual sanity checks.


<img width="474" height="153" alt="image" src="https://github.com/user-attachments/assets/6cd6486b-5924-4401-b727-29e6f62037ba" />


## PR category 
- [x] feature
- [x] tests 