### PR TITLE
chore(deps): update package overrides for high severity security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4821,19 +4821,34 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -4854,6 +4869,22 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/boolbase": {
@@ -8578,7 +8609,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -13060,12 +13093,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -13485,7 +13520,9 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.1",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -108,8 +108,9 @@
             "ajv": "^8.0.0"
         },
         "@isaacs/brace-expansion": "^5.0.1",
-        "immutable": "^5.1.5",
-        "svgo": "^4.0.1",
+        "immutable": "^5.1.9",
+        "svgo": "^4.0.2",
+        "body-parser": "^2.3.0",
         "@xmldom/xmldom": "^0.8.13",
         "@gulp-sourcemaps/identity-map": {
             "postcss": "^8.4.31"


### PR DESCRIPTION
## Description
Updates `package.json` overrides for `immutable` (5.1.9), `svgo` (4.0.2), and `body-parser` (2.3.0) to resolve high-severity npm security advisories.

## PR Category
- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring

## Changes Made
- Bumped `immutable` to `5.1.9` in `package.json` overrides (resolving GHSA-v56q-mh7h-f735).
- Bumped `svgo` to `4.0.2` in `package.json` overrides (resolving GHSA-2p49-hgcm-8545).
- Added `body-parser` `2.3.0` override (resolving GHSA-v422-hmwv-36x6).

## Testing Performed
- Ran `npm audit --omit=dev --audit-level=high` (0 high/critical vulnerabilities).
- Ran `npm test` (All 203 test suites / 7,127 tests passed).
