### PR TITLE
fix: tag cells from notes with duplicate pitches

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2562,9 +2562,11 @@ class PhraseMaker {
             }
             this._markedColsInRow.push(thisRow);
         }
+
         // create a 'Set' object that contains only unique values
         const uniqueFrequencies = new Set();
         const sortableList = [];
+        const rowsWeSkipped = [];
         let drumName;
         // Make a list to sort, skipping drums and graphics.
         // frequency;label;arg;row index
@@ -2597,7 +2599,15 @@ class PhraseMaker {
                 ]);
 
                 uniqueFrequencies.add(frequencyKey);
+            } else {
+                // We need to track the rows we skip in case any cells should be marked.
+                rowsWeSkipped.push([[...uniqueFrequencies].indexOf(frequencyKey), i]);
             }
+        }
+
+        // Add the rows we skipped when capturing marked columns.
+        for (let i = 0; i < rowsWeSkipped.length; i++) {
+            this._markedColsInRow[rowsWeSkipped[i][0]].push(rowsWeSkipped[i][1]);
         }
 
         // Add the stuff we didn't sort.


### PR DESCRIPTION
## PR Category

-  [x] Bug Fix

Fixes: https://github.com/sugarlabs/musicblocks/issues/7877

## What was the issue?

Notes that repeat pitches from earlier notes were not tagged in the Phrasemaker grid.

## What was changed?

When building the list of pitches (frequencies) to sort, a map of duplicate pitches is maintained. After sorting, the map is used to fill in any missing entries in the _markedColsInRow array.

## How was it tested?

Before

<img width="1060" height="733" alt="Screenshot From 2026-07-22 08-14-53" src="https://github.com/user-attachments/assets/1a323b36-210e-4088-81ba-2fc57b79f54a" />

After

<img width="1060" height="733" alt="Screenshot From 2026-07-22 09-44-14" src="https://github.com/user-attachments/assets/12b9082e-c5a8-44d9-b22c-aacee97c2b74" />

