### PR TITLE
refactor: simplify TimbreWidget loops

### DIFF
--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -22,6 +22,7 @@
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
 const Blocks = jest.requireActual("../../blocks");
+global.setupBlockDragController = require("../../block-drag-controller").setupBlockDragController;
 
 global._ = s => s;
 global.NOINPUTERRORMSG = "NO_INPUT";

--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -614,5 +614,25 @@ describe("TimbreWidget", () => {
             expect(timbre.activity.blocks.blockList[2].value).toBe("12");
             expect(timbre.activity.blocks.blockList[3].value).toBe("7");
         });
+
+        test("updates envelope parameter when wrapperEnv range changes", () => {
+            timbre.isActive["envelope"] = true;
+            jest.spyOn(timbre, "_update").mockImplementation();
+            jest.spyOn(timbre, "_playNote").mockImplementation();
+            jest.spyOn(timbre.activity.logo.synth, "createSynth").mockImplementation();
+
+            timbre._envelope(false);
+
+            const changeEvent = new jsdomDocument.defaultView.Event("change", { bubbles: true });
+            const envSlider = jsdomDocument.getElementById("myRange0");
+            envSlider.value = "50";
+
+            envSlider.dispatchEvent(changeEvent);
+
+            expect(timbre.synthVals.envelope.attack).toBe(0.5);
+            expect(timbre._update).toHaveBeenCalled();
+            expect(timbre.activity.logo.synth.createSynth).toHaveBeenCalled();
+            expect(timbre._playNote).toHaveBeenCalledWith("G4", 1 / 8);
+        });
     });
 });

--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -614,6 +614,26 @@ describe("TimbreWidget", () => {
             expect(timbre.activity.blocks.blockList[2].value).toBe("12");
             expect(timbre.activity.blocks.blockList[3].value).toBe("7");
         });
+
+        test("updates envelope parameter when wrapperEnv range changes", () => {
+            timbre.isActive["envelope"] = true;
+            jest.spyOn(timbre, "_update").mockImplementation();
+            jest.spyOn(timbre, "_playNote").mockImplementation();
+            jest.spyOn(timbre.activity.logo.synth, "createSynth").mockImplementation();
+
+            timbre._envelope(false);
+
+            const changeEvent = new jsdomDocument.defaultView.Event("change", { bubbles: true });
+            const envSlider = jsdomDocument.getElementById("myRange0");
+            envSlider.value = "50";
+
+            envSlider.dispatchEvent(changeEvent);
+
+            expect(timbre.synthVals.envelope.attack).toBe(0.5);
+            expect(timbre._update).toHaveBeenCalled();
+            expect(timbre.activity.logo.synth.createSynth).toHaveBeenCalled();
+            expect(timbre._playNote).toHaveBeenCalledWith("G4", 1 / 8);
+        });
     });
 
     describe("init / toolbar buttons", () => {

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -1897,6 +1897,21 @@ class TimbreWidget {
             insideDivEnv.appendChild(spanEnv);
             wrapperEnv.appendChild(insideDivEnv);
 
+            wrapperEnv.addEventListener("change", event => {
+                const elem = event.target;
+                docById("myRange" + i).value = parseFloat(elem.value);
+                docById("myspan" + i).textContent = elem.value;
+                this.synthVals["envelope"][this.adsrMap[i]] = parseFloat(elem.value) / 100;
+                this._update(blockValue, parseFloat(elem.value), i);
+                this.activity.logo.synth.createSynth(
+                    0,
+                    this.instrumentName,
+                    this.synthVals["oscillator"]["source"],
+                    this.synthVals
+                );
+                this._playNote("G4", 1 / 8);
+            });
+
             env.appendChild(wrapperEnv);
         }
         const envAppend = document.createElement("div");
@@ -1910,24 +1925,6 @@ class TimbreWidget {
         for (let i = 0; i < 4; i++) {
             this.synthVals["envelope"][this.adsrMap[i]] = parseFloat(this.ENVs[i]) / 100;
             this._update(blockValue, this.ENVs[i], i);
-        }
-
-        for (let i = 0; i < 4; i++) {
-            document.getElementById("wrapperEnv" + i).addEventListener("change", event => {
-                const elem = event.target;
-                const m = elem.id.slice(-1);
-                docById("myRange" + m).value = parseFloat(elem.value);
-                docById("myspan" + m).textContent = elem.value;
-                this.synthVals["envelope"][this.adsrMap[m]] = parseFloat(elem.value) / 100;
-                this._update(blockValue, parseFloat(elem.value), m);
-                this.activity.logo.synth.createSynth(
-                    0,
-                    this.instrumentName,
-                    this.synthVals["oscillator"]["source"],
-                    this.synthVals
-                );
-                this._playNote("G4", 1 / 8);
-            });
         }
 
         if (newEnvelope) {

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -1810,6 +1810,22 @@ class TimbreWidget {
             insideDivEnv.appendChild(spanEnv);
             wrapperEnv.appendChild(insideDivEnv);
 
+            wrapperEnv.addEventListener("change", event => {
+                const elem = event.target;
+                const val = parseFloat(elem.value);
+                docById("myRange" + i).value = val;
+                docById("myspan" + i).textContent = elem.value;
+                this.synthVals["envelope"][this.adsrMap[i]] = val / 100;
+                this._update(blockValue, val, i);
+                this.activity.logo.synth.createSynth(
+                    0,
+                    this.instrumentName,
+                    this.synthVals["oscillator"]["source"],
+                    this.synthVals
+                );
+                this._playNote("G4", 1 / 8);
+            });
+
             env.appendChild(wrapperEnv);
         }
         const envAppend = document.createElement("div");
@@ -1823,25 +1839,6 @@ class TimbreWidget {
         for (let i = 0; i < 4; i++) {
             this.synthVals["envelope"][this.adsrMap[i]] = parseFloat(this.ENVs[i]) / 100;
             this._update(blockValue, this.ENVs[i], i);
-        }
-
-        for (let i = 0; i < 4; i++) {
-            document.getElementById("wrapperEnv" + i).addEventListener("change", event => {
-                const elem = event.target;
-                const m = Number(elem.id.slice(-1));
-                const val = parseFloat(elem.value);
-                docById("myRange" + m).value = val;
-                docById("myspan" + m).textContent = elem.value;
-                this.synthVals["envelope"][this.adsrMap[m]] = val / 100;
-                this._update(blockValue, val, m);
-                this.activity.logo.synth.createSynth(
-                    0,
-                    this.instrumentName,
-                    this.synthVals["oscillator"]["source"],
-                    this.synthVals
-                );
-                this._playNote("G4", 1 / 8);
-            });
         }
 
         if (newEnvelope) {


### PR DESCRIPTION

This PR refactors the ADSR envelope initialization in `TimbreWidget` to improve performance and code readability.

**Changes:**
- **Combined loops:** The event listeners are now attached directly to the `wrapperEnv` elements immediately upon creation. This completely removes the need for a redundant secondary loop and the intermediate `wrapperEnvs` array.
- **Leveraged block scope:** Replaced the string parsing of the DOM element ID (`elem.id.slice(-1)`) with the block-scoped `let i` variable from the loop, simplifying the closure.

These changes remove unnecessary state and DOM manipulations without altering existing behavior.


- [x] Chores