### PR TITLE
test(utils): add tests for base64Utils large payloads and ErrorHandler exception handling

### DIFF
--- a/js/__tests__/base64Utils.test.js
+++ b/js/__tests__/base64Utils.test.js
@@ -64,6 +64,13 @@ describe("base64Utils", () => {
         expect(decoded).toBe(longString);
     });
 
+    test("base64Encode should handle inputs exceeding 128KB without call stack overflow", () => {
+        const largeString = "x".repeat(150000);
+        const encoded = base64Utils.base64Encode(largeString);
+        const decoded = base64Utils.base64Decode(encoded);
+        expect(decoded).toBe(largeString);
+    });
+
     test("base64Encode and base64Decode should be reversible for Unicode", () => {
         const original = "Hello 世界 🎵 こんにちは नमस्ते";
         const encoded = base64Utils.base64Encode(original);

--- a/js/utils/__tests__/error-handler.test.js
+++ b/js/utils/__tests__/error-handler.test.js
@@ -123,5 +123,31 @@ describe("ErrorHandler", () => {
 
             delete global.window.ActivityContext;
         });
+
+        it("catches and suppresses errors if getActivity throws", () => {
+            global.window.ActivityContext = {
+                getActivity: () => {
+                    throw new Error("Activity not ready");
+                }
+            };
+
+            expect(() => {
+                ErrorHandler.userFacing("fail", { operation: "save" }, "ui msg");
+            }).not.toThrow();
+
+            delete global.window.ActivityContext;
+        });
+
+        it("handles case where activity exists but errorMsg is not a function", () => {
+            global.window.ActivityContext = {
+                getActivity: () => ({ errorMsg: "not a function" })
+            };
+
+            expect(() => {
+                ErrorHandler.userFacing("fail", { operation: "save" }, "ui msg");
+            }).not.toThrow();
+
+            delete global.window.ActivityContext;
+        });
     });
 });


### PR DESCRIPTION
## Description

Adds unit tests for utility functions to improve test coverage and verify edge-case robustness:
1. Validates that `base64Encode` handles string payloads larger than 128KB without throwing V8 call stack overflow errors.
2. Adds branch coverage for `ErrorHandler.userFacing()` when `window.ActivityContext.getActivity()` throws an exception or when `errorMsg` is not a function.

## Related Issue

N/A (Test suite coverage improvement)

## PR Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added large payload string encoding test to `js/__tests__/base64Utils.test.js`.
- Added `getActivity()` exception handling and invalid `errorMsg` type tests to `js/utils/__tests__/error-handler.test.js`.

## Testing Performed

- Ran `npx jest js/__tests__/base64Utils.test.js js/utils/__tests__/error-handler.test.js` (All 25 test cases passed).
- Ran `npx eslint js/__tests__/base64Utils.test.js js/utils/__tests__/error-handler.test.js` (0 errors, 0 warnings).
- Formatted with `npx prettier --write`.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

N/A
