### PR TITLE
fix(utils-logic): support leading hash prefix and sanitize input in hex2rgb

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -249,6 +249,16 @@ describe("Utility Logic Functions", () => {
         it("converts hex to rgba string", () => {
             expect(hex2rgb("ff0000")).toBe("rgba(255,0,0,1)");
         });
+
+        it("handles leading hash prefix", () => {
+            expect(hex2rgb("#ff0000")).toBe("rgba(255,0,0,1)");
+            expect(hex2rgb("#00ff00")).toBe("rgba(0,255,0,1)");
+        });
+
+        it("returns fallback rgba for invalid or non-string inputs", () => {
+            expect(hex2rgb(null)).toBe("rgba(0,0,0,1)");
+            expect(hex2rgb("invalid")).toBe("rgba(0,0,0,1)");
+        });
     });
 
     describe("resolveObject()", () => {

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -354,6 +354,10 @@ describe("Utility Functions (logic-only)", () => {
         it("converts hex to rgba string", () => {
             expect(hex2rgb("ff0000")).toBe("rgba(255,0,0,1)");
         });
+
+        it("handles leading hash prefix", () => {
+            expect(hex2rgb("#ff0000")).toBe("rgba(255,0,0,1)");
+        });
     });
 
     describe("format() function logic", () => {

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -552,7 +552,10 @@ var hexToRGB = hex => {
  * Converts a hexcode to RGBA format.
  */
 var hex2rgb = hex => {
-    const bigint = parseInt(hex, 16);
+    if (typeof hex !== "string") return "rgba(0,0,0,1)";
+    const cleanHex = hex.startsWith("#") ? hex.slice(1) : hex;
+    const bigint = parseInt(cleanHex, 16);
+    if (Number.isNaN(bigint)) return "rgba(0,0,0,1)";
     const r = (bigint >> 16) & 255;
     const g = (bigint >> 8) & 255;
     const b = bigint & 255;


### PR DESCRIPTION
## Description

This pull request updates `hex2rgb()` in `js/utils/utils-logic.js` to strip leading `#` prefixes if present when converting hex strings to RGBA format. Previously, passing standard CSS hex colors with a leading hash (e.g. `"#ff0000"`) caused `parseInt` to evaluate to `NaN`, incorrectly resulting in `rgba(0,0,0,1)` (black). It also adds defensive input validation so invalid/non-string inputs safely return `"rgba(0,0,0,1)"`.

## Related Issue

N/A

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Stripped leading `#` prefix from input parameter in `hex2rgb()` before passing to `parseInt`.
- Added safety check to handle non-string / unparseable values gracefully by returning fallback `"rgba(0,0,0,1)"`.
- Added test cases covering leading `#` hex codes, standard hex strings, and invalid inputs in `js/utils/__tests__/utils-logic.test.js` and `js/utils/__tests__/utils.test.js`.

## Testing Performed

- Ran Jest unit tests for utility modules: `npx jest js/utils/__tests__/utils-logic.test.js js/utils/__tests__/utils.test.js --coverage=false` (All 194 tests passed cleanly).
- Ran ESLint linter: `npx eslint js/utils/utils-logic.js js/utils/__tests__/utils-logic.test.js js/utils/__tests__/utils.test.js` (0 errors, 0 warnings).
- Formatted with Prettier: `npx prettier --write js/utils/utils-logic.js js/utils/__tests__/utils-logic.test.js js/utils/__tests__/utils.test.js`.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

- This fix ensures `hex2rgb` and `hexToRGB` handle `#` prefixes consistently across the utility library.
