### PR TITLE
fix: guard blk access in defineMode listener to prevent TypeError on …

### DIFF
--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -332,9 +332,15 @@ function setupIntervalsActions(activity) {
                     }
                 }
 
-                const cblk = activity.blocks.blockList[blk].connections[1];
-                if (activity.blocks.blockList[cblk].name === "text") {
-                    activity.blocks.updateBlockText(cblk);
+                if (blk !== undefined && blk in activity.blocks.blockList) {
+                    const cblk = activity.blocks.blockList[blk].connections[1];
+                    if (
+                        cblk !== undefined &&
+                        cblk in activity.blocks.blockList &&
+                        activity.blocks.blockList[cblk].name === "text"
+                    ) {
+                        activity.blocks.updateBlockText(cblk);
+                    }
                 }
 
                 tur.singer.inDefineMode = false;

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -508,6 +508,20 @@ describe("setupIntervalsActions", () => {
         expect(activity.errorMsg).toHaveBeenCalled();
     });
 
+    test("defineMode does not crash when blk is undefined (JS-Export path)", () => {
+        let listener;
+        logo.setTurtleListener.mockImplementation((_, __, fn) => (listener = fn));
+
+        // blk is not passed — simulates JS-Export / headless execution
+        Singer.IntervalsActions.defineMode("pentatonic", 0, undefined);
+
+        turtle.singer.defineMode.push(0, 2, 4, 7, 9);
+
+        // Should not throw a TypeError even though blk is undefined
+        expect(() => listener()).not.toThrow();
+        expect(MUSICALMODES.pentatonic).toBeDefined();
+    });
+
     test("setTemperament state changes", () => {
         Singer.IntervalsActions.setTemperament("equal", "C", 4);
         expect(logo.synth.inTemperament).toBe("equal");


### PR DESCRIPTION
Fixes #7888

## Problem

When `defineMode` runs via the JS-Export path, the `blk` parameter is
`undefined`. The `__listener` closure accessed
`activity.blocks.blockList[blk].connections[1]` without any guard,
causing:TypeError: Cannot read properties of undefined (reading 'connections')


## Fix

Added a guard in `__listener` to check `blk !== undefined && blk in activity.blocks.blockList` before accessing connections. Also added a secondary guard on `cblk` for defensive safety.

## Testing

Added a regression test: `"defineMode does not crash when blk is undefined (JS-Export path)"` in `IntervalsActions.test.js`. All 42 tests pass.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have run `npm test` and all tests pass
- [x] I have run `npx prettier --check` on modified files
- [x] I have added a test to cover the fix

**PR Category** (check at least one):
- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Testing
- [ ] Other