### PR TITLE
fix: guard this.container in block.hide and block.show to prevent null TypeError

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -580,4 +580,56 @@ describe("Block Foundation", () => {
             expect(block.value).toBe("fallback-cached");
         });
     });
+
+    describe("hide", () => {
+        it("should not throw when container is null", () => {
+            const b = new Block(mockProtoBlock, mockBlocks);
+            b.container = null;
+            expect(() => b.hide()).not.toThrow();
+        });
+
+        it("should set container.visible to false when container exists", () => {
+            const b = new Block(mockProtoBlock, mockBlocks);
+            b.container = { visible: true };
+            b.hide();
+            expect(b.container.visible).toBe(false);
+        });
+
+        it("should guard collapsible fields that are null", () => {
+            const b = new Block(mockProtoBlock, mockBlocks);
+            b.name = "repeat";
+            b.collapseText = null;
+            b.expandButtonBitmap = null;
+            b.collapseButtonBitmap = null;
+            expect(() => b.hide()).not.toThrow();
+        });
+    });
+
+    describe("show", () => {
+        it("should not throw when container is null and not trashed", () => {
+            const b = new Block(mockProtoBlock, mockBlocks);
+            b.container = null;
+            b.trash = false;
+            b.inCollapsed = false;
+            expect(() => b.show()).not.toThrow();
+        });
+
+        it("should set container.visible to true when container exists", () => {
+            const b = new Block(mockProtoBlock, mockBlocks);
+            b.container = { visible: false };
+            b.trash = false;
+            b.inCollapsed = false;
+            b.bitmap = { visible: false };
+            b.highlightBitmap = { visible: true };
+            b.highlightCollapseBlockBitmap = { visible: false };
+            b.collapseBlockBitmap = { visible: false };
+            b.collapseText = null;
+            b.expandButtonBitmap = null;
+            b.collapseButtonBitmap = null;
+            b.disconnectedBitmap = null;
+            b.disconnectedHighlightBitmap = null;
+            b.show();
+            expect(b.container.visible).toBe(true);
+        });
+    });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -1953,6 +1953,9 @@ class Block {
      * @returns {void}
      */
     hide() {
+        if (!this.container) {
+            return;
+        }
         this.container.visible = false;
         if (this.isCollapsible()) {
             // Sometimes these fields are not set.
@@ -2015,7 +2018,7 @@ class Block {
      */
     show() {
         // If it is not in the trash and not in collapsed, then show it.
-        if (!this.trash && !this.inCollapsed) {
+        if (!this.trash && !this.inCollapsed && this.container) {
             this.container.visible = true;
             this._viewportVisible = true;
             if (this.isCollapsible()) {


### PR DESCRIPTION
## Description

`hide()` in `js/block.js` accesses `this.container.visible` without checking if `this.container` is null. `this.container` is initialized to `null` in the constructor (line 293) and may not yet be set when `hide()` is called during trash or drag operations, causing a TypeError crash. `show()` has the same unguarded access.

## Related Issue

Fixes #7894

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/block.js` `hide()`: early-return if `this.container` is null
- `js/block.js` `show()`: early-return if `this.container` is null
- `js/__tests__/block.test.js`: add tests for null-container guard in both methods, collapsible field safety, and normal hide/show behavior

## Testing Performed

- All 42 block tests pass
- `npx prettier --check` passes on modified files
- `npx eslint` passes with no errors
- Pre-commit hooks (lint + format) passed automatically

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
