### PR TITLE
fix(plugin-dialog): resolve file picker blocked by user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,6 +512,15 @@
                         <!-- <button id="submitPDF"></button></p> -->
                     </div>
                 </dialog>
+                <div id="pluginNameModal" class="modal" tabindex="-1">
+                    <div class="modal-content" tabindex="-1">
+                        <span class="close" id="pluginModalClose">&times;</span>
+                        <div id="pluginNameText"></div>
+                        <input type="text" id="pluginNameInput" tabindex="-1" />
+                        <p></p>
+                        <button class="confirm-button" id="submitPluginName"></button>
+                    </div>
+                </div>
                 <div class="materialize-iso" tabindex="-1">
                     <nav id="toolbars" class="nav-wrapper">
                         <div class="blue nav-wrapper" tabindex="-1">

--- a/js/widgets/__tests__/plugin-dialog.test.js
+++ b/js/widgets/__tests__/plugin-dialog.test.js
@@ -157,74 +157,116 @@ describe("PluginDialog", () => {
     });
 
     describe("openPlugin", () => {
+        let mockModal, mockInput, mockSubmitBtn, mockCloseBtn, mockText;
+
+        beforeEach(() => {
+            mockModal = document.createElement("div");
+            mockModal.id = "pluginNameModal";
+            document.body.appendChild(mockModal);
+
+            mockText = document.createElement("div");
+            mockText.id = "pluginNameText";
+            document.body.appendChild(mockText);
+
+            mockInput = document.createElement("input");
+            mockInput.id = "pluginNameInput";
+            document.body.appendChild(mockInput);
+
+            mockSubmitBtn = document.createElement("button");
+            mockSubmitBtn.id = "submitPluginName";
+            document.body.appendChild(mockSubmitBtn);
+
+            mockCloseBtn = document.createElement("span");
+            mockCloseBtn.id = "pluginModalClose";
+            document.body.appendChild(mockCloseBtn);
+        });
+
+        afterEach(() => {
+            [mockModal, mockText, mockInput, mockSubmitBtn, mockCloseBtn].forEach(el => {
+                if (el.parentNode) el.parentNode.removeChild(el);
+            });
+        });
+
         it("calls closeAuxToolbar with showHideAuxMenu if closeAuxToolbar is a function", () => {
             const closeAuxToolbar = jest.fn();
             const showHideAuxMenu = jest.fn();
             const dialog = new PluginDialog({ closeAuxToolbar, showHideAuxMenu });
-
-            window.prompt.mockReturnValue(null);
 
             dialog.openPlugin();
 
             expect(closeAuxToolbar).toHaveBeenCalledWith(showHideAuxMenu);
         });
 
-        it("stops execution if prompt returns null", () => {
-            const onLoadBuiltIn = jest.fn();
-            const dialog = new PluginDialog({ onLoadBuiltIn });
-
-            window.prompt.mockReturnValue(null);
-
-            const clickSpy = jest.spyOn(mockPluginChooser, "click");
-
-            dialog.openPlugin();
-
-            expect(onLoadBuiltIn).not.toHaveBeenCalled();
-            expect(clickSpy).not.toHaveBeenCalled();
-        });
-
-        it("calls onLoadBuiltIn with trimmed lowercase name if prompt input is not empty", () => {
-            const onLoadBuiltIn = jest.fn();
-            const dialog = new PluginDialog({ onLoadBuiltIn });
-
-            window.prompt.mockReturnValue("  MyPlugin  ");
-
-            dialog.openPlugin();
-
-            expect(onLoadBuiltIn).toHaveBeenCalledWith("myplugin");
-        });
-
-        it("does not call onLoadBuiltIn if input is not empty but onLoadBuiltIn is not a function", () => {
-            const dialog = new PluginDialog({ onLoadBuiltIn: "not a function" });
-
-            window.prompt.mockReturnValue("  MyPlugin  ");
-
-            const clickSpy = jest.spyOn(mockPluginChooser, "click");
-
-            dialog.openPlugin();
-
-            expect(clickSpy).not.toHaveBeenCalled(); // Make sure it also didn't fall through to the else branch
-        });
-
-        it("clicks pluginChooser if prompt input is empty string", () => {
+        it("shows the modal when opened", () => {
             const dialog = new PluginDialog();
-            window.prompt.mockReturnValue("   ");
-
-            const clickSpy = jest.spyOn(mockPluginChooser, "click");
-
             dialog.openPlugin();
 
-            expect(clickSpy).toHaveBeenCalled();
+            expect(mockModal.style.display).toBe("block");
         });
 
-        it("does not crash if prompt input is empty string and pluginChooser is null", () => {
-            document.body.removeChild(mockPluginChooser);
+        it("does not crash if required modal elements are missing", () => {
+            document.body.removeChild(mockModal);
             const dialog = new PluginDialog();
-            window.prompt.mockReturnValue("");
 
             expect(() => {
                 dialog.openPlugin();
             }).not.toThrow();
+        });
+
+        it("calls onLoadBuiltIn with trimmed lowercase name on submit if input is not empty", () => {
+            const onLoadBuiltIn = jest.fn();
+            const dialog = new PluginDialog({ onLoadBuiltIn });
+
+            dialog.openPlugin();
+            mockInput.value = "  MyPlugin  ";
+            mockSubmitBtn.onclick();
+
+            expect(onLoadBuiltIn).toHaveBeenCalledWith("myplugin");
+            expect(mockModal.style.display).toBe("none");
+        });
+
+        it("does not call onLoadBuiltIn on submit if onLoadBuiltIn is not a function", () => {
+            const dialog = new PluginDialog({ onLoadBuiltIn: "not a function" });
+            dialog.openPlugin();
+            mockInput.value = "MyPlugin";
+
+            const clickSpy = jest.spyOn(mockPluginChooser, "click");
+            mockSubmitBtn.onclick();
+
+            expect(clickSpy).not.toHaveBeenCalled();
+        });
+
+        it("clicks pluginChooser on submit if input is empty string", () => {
+            const dialog = new PluginDialog();
+            dialog.openPlugin();
+            mockInput.value = "   ";
+
+            const clickSpy = jest.spyOn(mockPluginChooser, "click");
+            mockSubmitBtn.onclick();
+
+            expect(clickSpy).toHaveBeenCalled();
+        });
+
+        it("does not crash on submit with empty input if pluginChooser is null", () => {
+            document.body.removeChild(mockPluginChooser);
+            const dialog = new PluginDialog();
+            dialog.openPlugin();
+            mockInput.value = "";
+
+            expect(() => {
+                mockSubmitBtn.onclick();
+            }).not.toThrow();
+        });
+
+        it("closes the modal without side effects when close button is clicked", () => {
+            const onLoadBuiltIn = jest.fn();
+            const dialog = new PluginDialog({ onLoadBuiltIn });
+            dialog.openPlugin();
+
+            mockCloseBtn.onclick();
+
+            expect(mockModal.style.display).toBe("none");
+            expect(onLoadBuiltIn).not.toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/plugin-dialog.js
+++ b/js/widgets/plugin-dialog.js
@@ -72,22 +72,42 @@ class PluginDialog {
             this.options.closeAuxToolbar(this.options.showHideAuxMenu);
         }
 
-        const rawName = prompt(
-            _("Enter the name of a built-in plugin, or leave blank to upload a plugin file:")
-        );
-        if (rawName === null) {
-            return; // User cancelled the operation
+        const modal = document.getElementById("pluginNameModal");
+        const input = document.getElementById("pluginNameInput");
+        const submitBtn = document.getElementById("submitPluginName");
+        const closeBtn = document.getElementById("pluginModalClose");
+
+        if (!modal || !input || !submitBtn) {
+            return;
         }
 
-        const name = rawName.trim().toLowerCase();
-        if (name !== "") {
-            if (typeof this.options.onLoadBuiltIn === "function") {
-                this.options.onLoadBuiltIn(name);
-            }
-        } else {
-            if (this.pluginChooser) {
+        document.getElementById("pluginNameText").textContent = _(
+            "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
+        );
+        input.value = "";
+        modal.style.display = "block";
+        input.focus();
+
+        const cleanup = () => {
+            modal.style.display = "none";
+            submitBtn.onclick = null;
+            if (closeBtn) closeBtn.onclick = null;
+        };
+
+        submitBtn.onclick = () => {
+            const name = input.value.trim().toLowerCase();
+            cleanup();
+            if (name !== "") {
+                if (typeof this.options.onLoadBuiltIn === "function") {
+                    this.options.onLoadBuiltIn(name);
+                }
+            } else if (this.pluginChooser) {
                 this.pluginChooser.click();
             }
+        };
+
+        if (closeBtn) {
+            closeBtn.onclick = () => cleanup();
         }
     }
 


### PR DESCRIPTION
Fixes #7893

## PR Category 
- [x] Bug Fix 
- [ ] Feature 
- [ ] Performance 
- [ ] Tests 
- [ ] Documentation 
- [ ] CI/CD 

## Root cause
`openPlugin()` in `js/widgets/plugin-dialog.js` called a blocking
`window.prompt()`, then immediately called `.click()` on the hidden plugin
file input if the field was left blank. Chrome invalidates transient user
activation once a native `prompt()` dialog closes, so the follow-up
`.click()` was rejected with "File chooser dialog can only be shown with a
user activation."

## Fix
Replaced `window.prompt()` with a non-blocking custom modal (`#pluginNameModal`
in `index.html`), matching the existing `lilypondModal` pattern already used
elsewhere in the codebase. The file input's `.click()` now fires from inside
the modal's own submit-button click handler, which is always a valid, fresh
user gesture — so it can't be invalidated the way a native dialog's return
value can.

## Testing
- Manually verified all three flows in Chrome: leaving the field blank opens
  the file picker, entering a built-in plugin name still calls `onLoadBuiltIn`,
  and closing the modal cancels cleanly with no side effects.
- Rewrote the `openPlugin` test block in `plugin-dialog.test.js` to match the
  new modal-based flow (8 tests, all passing).
- Ran the full test suite: 203 suites / 7144 tests, all passing.

## Note on reproduction
I could not reproduce the original console warning on Chrome 148 / Linux —
the file picker opened successfully even with the old code. The reporter was
on Chrome 150 / Windows 10, so this may be OS-dependent in exact timing. The
fix removes the underlying blocking-dialog-then-click pattern regardless of
platform, since that pattern is inherently fragile per Chrome's documented
user-activation behavior.