### PR TITLE
fix(trash-controller): add null check for helpfulWheelDiv in restoreTrash methods

### DIFF
--- a/js/__tests__/trash-controller.test.js
+++ b/js/__tests__/trash-controller.test.js
@@ -112,6 +112,15 @@ describe("TrashController.restoreTrash", () => {
         expect(document.getElementById("helpfulWheelDiv").style.display).toBe("none");
         expect(activity.__tick).toHaveBeenCalled();
     });
+
+    test("does not throw when helpfulWheelDiv is not present in the DOM", () => {
+        const activity = makeActivity();
+        activity.blocks.trashStacks = ["blk1"];
+        document.getElementById("helpfulWheelDiv").remove();
+        const controller = new TrashController(activity);
+
+        expect(() => controller.restoreTrash()).not.toThrow();
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -140,6 +149,16 @@ describe("TrashController.restoreLastFromTrash", () => {
 
         expect(spy).toHaveBeenCalledWith("blk2");
         expect(activity.textMsg).toHaveBeenCalledWith("Item restored from the trash.", 3000);
+    });
+
+    test("does not throw when helpfulWheelDiv is not present in the DOM", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList.blk1 = makeBlock();
+        activity.blocks.trashStacks = ["blk1"];
+        document.getElementById("helpfulWheelDiv").remove();
+        const controller = new TrashController(activity);
+
+        expect(() => controller.restoreLastFromTrash()).not.toThrow();
     });
 });
 

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -60,7 +60,7 @@ class TrashController {
 
         // Cache DOM element reference for performance
         const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv.style.display !== "none") {
+        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
             helpfulWheelDiv.style.display = "none";
             activity.__tick();
         }
@@ -80,7 +80,7 @@ class TrashController {
 
         // Cache DOM element reference for performance
         const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv.style.display !== "none") {
+        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
             helpfulWheelDiv.style.display = "none";
             activity.__tick();
         }


### PR DESCRIPTION
## Description

Fixes a potential null pointer crash in `TrashController` (`js/trash-controller.js`). In `restoreTrash()` and `restoreLastFromTrash()`, `document.getElementById("helpfulWheelDiv")` was called to hide the wheel overlay without verifying that the element exists in the DOM. If `helpfulWheelDiv` is absent (such as in headless testing, minimal UI, or before DOM rendering), accessing `helpfulWheelDiv.style` threw an unhandled `TypeError: Cannot read properties of null (reading 'style')`.

## Related Issue

N/A

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added `helpfulWheelDiv &&` null check in `restoreTrash()` and `restoreLastFromTrash()` before accessing `.style.display`.
- Added unit tests in `js/__tests__/trash-controller.test.js` asserting that restoring trash when `helpfulWheelDiv` is absent from the DOM runs safely without throwing errors.

## Testing Performed

- Ran unit tests: `npx jest js/__tests__/trash-controller.test.js --coverage=false` (All 22 tests passed).
- Ran ESLint: `npx eslint js/trash-controller.js js/__tests__/trash-controller.test.js` (0 errors, 0 warnings).
- Formatted with Prettier: `npx prettier --write js/trash-controller.js js/__tests__/trash-controller.test.js`.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

- Keeps `TrashController`'s DOM handling consistent with `BlockScaleController` (`js/block-scale-controller.js`).
