### PR TITLE
fix: guard against missing language dropdown elements in toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,6 +931,9 @@
                         <li><a id="enUK" role="button" tabindex="0"></a></li>
                         <li><a id="es" role="button" tabindex="0"></a></li>
                         <li><a id="pt" role="button" tabindex="0"></a></li>
+                        <li><a id="fr" role="button" tabindex="0"></a></li>
+                        <li><a id="it" role="button" tabindex="0"></a></li>
+                        <li><a id="de" role="button" tabindex="0"></a></li>
                         <li><a id="ja" role="button" tabindex="0"></a></li>
                         <li><a id="kana" role="button" tabindex="0"></a></li>
                         <li><a id="ko" role="button" tabindex="0"></a></li>
@@ -941,6 +944,7 @@
                         <li><a id="quz" role="button" tabindex="0"></a></li>
                         <li><a id="gug" role="button" tabindex="0"></a></li>
                         <li><a id="hi" role="button" tabindex="0"></a></li>
+                        <li><a id="ta" role="button" tabindex="0"></a></li>
                         <li><a id="te" role="button" tabindex="0"></a></li>
                         <li><a id="ibo" role="button" tabindex="0"></a></li>
                         <li><a id="ar" role="button" tabindex="0"></a></li>

--- a/js/__tests__/language-dropdown.test.js
+++ b/js/__tests__/language-dropdown.test.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const readFile = relPath => fs.readFileSync(path.resolve(__dirname, relPath), "utf8");
+
+const getDropdownIds = () => {
+    const html = readFile("../../index.html");
+    const dropdown = html.match(/<ul[^>]*id="languagedropdown"[^>]*>([\s\S]*?)<\/ul>/);
+    expect(dropdown).not.toBeNull();
+
+    return [...dropdown[1].matchAll(/<a\s+id="([^"]+)"/g)].map(match => match[1]);
+};
+
+const getToolbarLanguages = () => {
+    const source = readFile("../toolbar-ui.js");
+    const list = source.match(/renderLanguageSelectIcon[\s\S]*?const languages = \[([\s\S]*?)\]/);
+    expect(list).not.toBeNull();
+
+    return [...list[1].matchAll(/"([^"]+)"/g)].map(match => match[1]);
+};
+
+describe("language dropdown", () => {
+    test("every language in toolbar-ui.js has an entry in index.html", () => {
+        const missing = getToolbarLanguages().filter(lang => !getDropdownIds().includes(lang));
+
+        expect(missing).toEqual([]);
+    });
+
+    test("every entry in index.html is listed in toolbar-ui.js", () => {
+        const languages = getToolbarLanguages();
+        const orphaned = getDropdownIds().filter(id => !languages.includes(id));
+
+        expect(orphaned).toEqual([]);
+    });
+
+    test("every language has an onclick handler in languagebox.js", () => {
+        const source = readFile("../languagebox.js");
+        const missing = getToolbarLanguages().filter(lang => !source.includes(`${lang}_onclick(`));
+
+        expect(missing).toEqual([]);
+    });
+});

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -1717,7 +1717,13 @@ class ToolbarUI {
 
             // Set up click handlers for each language
             languages.forEach(lang => {
-                docById(lang).onclick = () => {
+                const langElem = docById(lang);
+                // Some entries in `languages` may not have a matching dropdown
+                // element in the DOM (e.g. languages present in this list but not
+                // rendered in the menu). Guard against null so the whole loop does
+                // not abort partway through and leave later languages unwired.
+                if (!langElem) return;
+                langElem.onclick = () => {
                     // Update highlight to newly selected language
                     updateSelectedLanguageHighlight(lang);
 

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -1718,11 +1718,11 @@ class ToolbarUI {
             // Set up click handlers for each language
             languages.forEach(lang => {
                 const langElem = docById(lang);
-                // Some entries in `languages` may not have a matching dropdown
-                // element in the DOM (e.g. languages present in this list but not
-                // rendered in the menu). Guard against null so the whole loop does
-                // not abort partway through and leave later languages unwired.
-                if (!langElem) return;
+                if (!langElem) {
+                    console.warn(`No entry for "${lang}" in #languagedropdown`);
+                    return;
+                }
+
                 langElem.onclick = () => {
                     // Update highlight to newly selected language
                     updateSelectedLanguageHighlight(lang);


### PR DESCRIPTION
- [x] Bug Fix
## What

`renderLanguageSelectIcon()` in `js/toolbar-ui.js` iterates over a hardcoded `languages` list and assigns an `onclick` handler to each entry via `docById(lang).onclick`. Several codes in that list (`fr`, `it`, `de`, `ta`) have **no matching `<a id>` element** in the language dropdown, so `docById(lang)` returns `null`.

This throws on every language-button click:

```
Uncaught TypeError: can't access property "onclick", docById(...) is null
    at toolbar-ui.js:1720
```

Because `forEach` aborts on the throw, every language listed **after** the first missing one (`fr`) never gets its click handler wired either.

## Fix

Add a `null` guard before assigning `onclick`, matching the guard that already exists in the `updateSelectedLanguageHighlight` loop just above. Missing entries are skipped and the remaining languages are wired correctly.

## How to reproduce

1. Open Music Blocks, open DevTools → Console.
2. Click the language (globe) button in the toolbar's auxiliary menu.
3. Before this fix: `TypeError: ... docById(...) is null` at `toolbar-ui.js`.

## Before:

https://github.com/user-attachments/assets/8113070d-fcab-408f-848f-fe35ea85b160




## After:



https://github.com/user-attachments/assets/e489354b-e170-4c42-a390-d5035020fcf3

