### PR TITLE
test: add regression test for ratioEdit division-by-zero guard (#6978)

### DIFF
--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1193,6 +1193,35 @@ describe("TemperamentWidget basic tests", () => {
             expect(widget._playing).toBe(false);
             expect(widget._lastPlaybackIndex).toBe(0);
         });
+        test("ratioEdit shows error toast when ratioOut is 0", () => {
+            const inputValues = { ratioIn: "5", ratioOut: "0", recursion: "1" };
+            let capturedDivAppend;
+
+            global.docById = jest.fn(id => {
+                if (id in inputValues) {
+                    return { value: inputValues[id] };
+                }
+                if (id === "userEdit") {
+                    return {
+                        textContent: "",
+                        style: {},
+                        appendChild: jest.fn(),
+                        append: jest.fn(el => {
+                            capturedDivAppend = el;
+                        })
+                    };
+                }
+                return createMockElement(id);
+            });
+
+            widget.ratioEdit();
+            capturedDivAppend.onclick({ target: { textContent: "done" } });
+
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                expect.stringContaining("valid ratio"),
+                3000
+            );
+        });
     });
 
     describe("playAll play loop visual wheel coverage", () => {


### PR DESCRIPTION
## Summary
While confirming issue #6978, I found the underlying division-by-zero bug was already fixed on `master` in #7662 (the `divAppend.onclick` handler in `js/widgets/temperament.js` already validates `input2 <= 0` and shows an error toast instead of computing `Infinity`).

This PR adds the missing regression test for that exact scenario so it's formally verified and can't silently regress.

## Verification
- Manually reproduced the steps from #6978 (ratio `5:0`) in the running app — confirmed the error toast shows and nothing crashes.
- Added `ratioEdit shows error toast when ratioOut is 0` in `temperament.test.js` — passes along with all 54 existing tests.

Closes #6978
<img width="1372" height="892" alt="image" src="https://github.com/user-attachments/assets/7f95efa5-1e94-479c-a79c-ef4f1d896a08" />
- [x] Tests