### PR TITLE
fix(blocks): add null guard for hideContents.click() in sendStackToTrash

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -776,4 +776,73 @@ describe("Blocks Foundation", () => {
             expect(spy).toHaveBeenCalledWith(0);
         });
     });
+
+    describe("sendStackToTrash DOM safety", () => {
+        it("should safely complete sendStackToTrash when #hideContents element is missing from DOM", () => {
+            const mockActivity = {
+                palettes: { dict: {} },
+                refreshCanvas: jest.fn(),
+                trashcan: { stopHighlightAnimation: jest.fn() }
+            };
+            const blocksInstance = new Blocks(mockActivity);
+
+            const mockBlock = {
+                blockIndex: 1,
+                connections: [null],
+                container: { uncache: jest.fn() },
+                protoblock: { style: "normal", parameter: false, staticLabels: ["test"] },
+                hide: jest.fn()
+            };
+
+            blocksInstance.blockList[1] = mockBlock;
+            blocksInstance.captureStackPreview = jest.fn().mockReturnValue(null);
+            blocksInstance._cleanupStacks = jest.fn();
+
+            const originalGetElementById = document.getElementById;
+            document.getElementById = jest.fn().mockReturnValue(null);
+
+            try {
+                expect(() => blocksInstance.sendStackToTrash(mockBlock)).not.toThrow();
+            } finally {
+                document.getElementById = originalGetElementById;
+            }
+        });
+
+        it("should click #hideContents when it exists in DOM", () => {
+            const mockActivity = {
+                palettes: { dict: {} },
+                refreshCanvas: jest.fn(),
+                trashcan: { stopHighlightAnimation: jest.fn() }
+            };
+            const blocksInstance = new Blocks(mockActivity);
+
+            const mockBlock = {
+                blockIndex: 1,
+                connections: [null],
+                container: { uncache: jest.fn() },
+                protoblock: { style: "normal", parameter: false, staticLabels: ["test"] },
+                hide: jest.fn()
+            };
+
+            blocksInstance.blockList[1] = mockBlock;
+            blocksInstance.captureStackPreview = jest.fn().mockReturnValue(null);
+            blocksInstance._cleanupStacks = jest.fn();
+
+            const mockClick = jest.fn();
+            const originalGetElementById = document.getElementById;
+            document.getElementById = jest.fn().mockImplementation(id => {
+                if (id === "hideContents") {
+                    return { click: mockClick };
+                }
+                return null;
+            });
+
+            try {
+                blocksInstance.sendStackToTrash(mockBlock);
+                expect(mockClick).toHaveBeenCalled();
+            } finally {
+                document.getElementById = originalGetElementById;
+            }
+        });
+    });
 });

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1295,4 +1295,73 @@ describe("Blocks Foundation", () => {
             expect(normalBlock.text.text.length).toBeLessThan(longLabel.length);
         });
     });
+
+    describe("sendStackToTrash DOM safety", () => {
+        it("should safely complete sendStackToTrash when #hideContents element is missing from DOM", () => {
+            const mockActivity = {
+                palettes: { dict: {} },
+                refreshCanvas: jest.fn(),
+                trashcan: { stopHighlightAnimation: jest.fn() }
+            };
+            const blocksInstance = new Blocks(mockActivity);
+
+            const mockBlock = {
+                blockIndex: 1,
+                connections: [null],
+                container: { uncache: jest.fn() },
+                protoblock: { style: "normal", parameter: false, staticLabels: ["test"] },
+                hide: jest.fn()
+            };
+
+            blocksInstance.blockList[1] = mockBlock;
+            blocksInstance.captureStackPreview = jest.fn().mockReturnValue(null);
+            blocksInstance._cleanupStacks = jest.fn();
+
+            const originalGetElementById = document.getElementById;
+            document.getElementById = jest.fn().mockReturnValue(null);
+
+            try {
+                expect(() => blocksInstance.sendStackToTrash(mockBlock)).not.toThrow();
+            } finally {
+                document.getElementById = originalGetElementById;
+            }
+        });
+
+        it("should click #hideContents when it exists in DOM", () => {
+            const mockActivity = {
+                palettes: { dict: {} },
+                refreshCanvas: jest.fn(),
+                trashcan: { stopHighlightAnimation: jest.fn() }
+            };
+            const blocksInstance = new Blocks(mockActivity);
+
+            const mockBlock = {
+                blockIndex: 1,
+                connections: [null],
+                container: { uncache: jest.fn() },
+                protoblock: { style: "normal", parameter: false, staticLabels: ["test"] },
+                hide: jest.fn()
+            };
+
+            blocksInstance.blockList[1] = mockBlock;
+            blocksInstance.captureStackPreview = jest.fn().mockReturnValue(null);
+            blocksInstance._cleanupStacks = jest.fn();
+
+            const mockClick = jest.fn();
+            const originalGetElementById = document.getElementById;
+            document.getElementById = jest.fn().mockImplementation(id => {
+                if (id === "hideContents") {
+                    return { click: mockClick };
+                }
+                return null;
+            });
+
+            try {
+                blocksInstance.sendStackToTrash(mockBlock);
+                expect(mockClick).toHaveBeenCalled();
+            } finally {
+                document.getElementById = originalGetElementById;
+            }
+        });
+    });
 });

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6740,7 +6740,10 @@ class Blocks {
             }
             this.activity.refreshCanvas();
             this.activity.trashcan.stopHighlightAnimation();
-            document.getElementById("hideContents").click();
+            const hideContents = document.getElementById("hideContents");
+            if (hideContents && typeof hideContents.click === "function") {
+                hideContents.click();
+            }
         };
 
         /***

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6769,7 +6769,10 @@ class Blocks {
             }
             this.activity.refreshCanvas();
             this.activity.trashcan.stopHighlightAnimation();
-            document.getElementById("hideContents").click();
+            const hideContents = document.getElementById("hideContents");
+            if (hideContents && typeof hideContents.click === "function") {
+                hideContents.click();
+            }
         };
 
         /***


### PR DESCRIPTION
## Description

Deleting a block stack previously called `document.getElementById("hideContents").click()` without a null guard in `js/blocks.js`. When running in headless environments, custom UI shells, or DOM states where `#hideContents` is absent, this threw a `TypeError: Cannot read properties of null (reading 'click')`, interrupting the trash cleanup flow.

## Related Issue

Fixes #7158

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/blocks.js`: Added a null and function guard before invoking `hideContents.click()` inside `sendStackToTrash`.
- `js/__tests__/blocks.test.js`: Added unit tests verifying `sendStackToTrash` DOM safety both when `#hideContents` is missing and when it is present.

## Testing Performed

- `npx jest js/__tests__/blocks.test.js` — All 26 tests passing
- `npm run lint` — 0 errors
- `npx prettier --check` — All files formatted correctly

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
