### PR TITLE
fix(musickeyboard): handle pitch row addition for Hertz-only and empty layouts

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -169,8 +169,8 @@ describe("MusicKeyboard add-row submenu", () => {
         expect(() => keyboard._menuWheel.navItems[0].navigateFunction()).not.toThrow();
         expect(loadNewBlocks).toHaveBeenCalledWith([
             [0, ["pitch", {}], 0, 0, [null, 1, 2, null]],
-            [1, ["solfege", { value: "do♯" }], 0, 0, [0]],
-            [2, ["number", { value: 392 }], 0, 0, [0]]
+            [1, ["solfege", { value: "do" }], 0, 0, [0]],
+            [2, ["number", { value: 4 }], 0, 0, [0]]
         ]);
     });
 

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -169,8 +169,60 @@ describe("MusicKeyboard add-row submenu", () => {
         expect(() => keyboard._menuWheel.navItems[0].navigateFunction()).not.toThrow();
         expect(loadNewBlocks).toHaveBeenCalledWith([
             [0, ["pitch", {}], 0, 0, [null, 1, 2, null]],
+            [1, ["solfege", { value: "do" }], 0, 0, [0]],
+            [2, ["number", { value: 4 }], 0, 0, [0]]
+        ]);
+    });
+
+    test("adds next sequential pitch when layout contains existing pitch rows and inherits octave", () => {
+        const loadNewBlocks = jest.fn();
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            blocks: {
+                blockList: [],
+                loadNewBlocks
+            }
+        });
+
+        keyboard.layout = [
+            { noteName: "do", noteOctave: 5, blockNumber: 100001 },
+            { noteName: "hertz", noteOctave: 440, blockNumber: 100002 }
+        ];
+
+        keyboard._createAddRowPieSubmenu();
+
+        expect(() => keyboard._menuWheel.navItems[0].navigateFunction()).not.toThrow();
+        // After 'do', next pitch in chromatic solfege is 'do♯', and octave 5 is inherited from previous pitch
+        expect(loadNewBlocks).toHaveBeenCalledWith([
+            [0, ["pitch", {}], 0, 0, [null, 1, 2, null]],
             [1, ["solfege", { value: "do♯" }], 0, 0, [0]],
-            [2, ["number", { value: 392 }], 0, 0, [0]]
+            [2, ["number", { value: 5 }], 0, 0, [0]]
+        ]);
+    });
+
+    test("increments octave when rolling over from the last pitch label", () => {
+        const loadNewBlocks = jest.fn();
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            blocks: {
+                blockList: [],
+                loadNewBlocks
+            }
+        });
+
+        // 'ti' is the 12th / last pitch label in default solfege scale
+        keyboard.layout = [{ noteName: "ti", noteOctave: 4, blockNumber: 100001 }];
+
+        keyboard._createAddRowPieSubmenu();
+
+        expect(() => keyboard._menuWheel.navItems[0].navigateFunction()).not.toThrow();
+        // When rolling over after 'ti', next is 'do' and octave increments from 4 to 5
+        expect(loadNewBlocks).toHaveBeenCalledWith([
+            [0, ["pitch", {}], 0, 0, [null, 1, 2, null]],
+            [1, ["solfege", { value: "do" }], 0, 0, [0]],
+            [2, ["number", { value: 5 }], 0, 0, [0]]
         ]);
     });
 

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2230,27 +2230,26 @@ function MusicKeyboard(activity) {
             const newBlock = this.activity.blocks.blockList.length;
 
             if (label === "pitch") {
-                let i;
-                for (i = 0; i < pitchLabels.length; i++) {
-                    let lastNote,
-                        c = this.layout.length - 1;
-                    while (c > -1) {
-                        if (this.layout[c].noteName !== "hertz") {
-                            break;
-                        }
-                        c--;
-                    }
+                let i = -1;
+                let lastNote = null,
+                    c = this.layout.length - 1;
+                while (c > -1) {
                     if (this.layout[c] && this.layout[c].noteName !== "hertz") {
                         lastNote = this.layout[c].noteName;
-                    } else {
-                        lastNote = null;
-                    }
-
-                    if (
-                        lastNote !== null &&
-                        (pitchLabels[i].includes(lastNote) || lastNote.includes(pitchLabels[i]))
-                    ) {
                         break;
+                    }
+                    c--;
+                }
+
+                if (lastNote !== null) {
+                    for (let idx = 0; idx < pitchLabels.length; idx++) {
+                        if (
+                            pitchLabels[idx].includes(lastNote) ||
+                            lastNote.includes(pitchLabels[idx])
+                        ) {
+                            i = idx;
+                            break;
+                        }
                     }
                 }
 
@@ -2266,16 +2265,16 @@ function MusicKeyboard(activity) {
                         break;
                     }
                 } while (this.layout.some(note => note.noteName === rLabel));
+
+                rArg = 4;
                 for (let j = this.layout.length; j > 0; j--) {
-                    rArg = this.layout[j - 1].noteOctave;
-                    if (isNaN(rArg)) {
-                        continue;
-                    }
-                    if (rArg > 0 && rArg < 9) {
+                    const oct = Number(this.layout[j - 1].noteOctave);
+                    if (!isNaN(oct) && oct >= 1 && oct <= 8) {
+                        rArg = oct;
                         break;
                     }
                 }
-                if ((i + 1) % pitchLabels.length === 0) {
+                if ((i + 1) % pitchLabels.length === 0 && rArg < 8) {
                     rArg += 1;
                 }
             } else {

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -2270,27 +2270,26 @@ function MusicKeyboard(activity) {
             const newBlock = this.activity.blocks.blockList.length;
 
             if (label === "pitch") {
-                let i;
-                for (i = 0; i < pitchLabels.length; i++) {
-                    let lastNote,
-                        c = this.layout.length - 1;
-                    while (c > -1) {
-                        if (this.layout[c].noteName !== "hertz") {
-                            break;
-                        }
-                        c--;
-                    }
+                let i = -1;
+                let lastNote = null,
+                    c = this.layout.length - 1;
+                while (c > -1) {
                     if (this.layout[c] && this.layout[c].noteName !== "hertz") {
                         lastNote = this.layout[c].noteName;
-                    } else {
-                        lastNote = null;
-                    }
-
-                    if (
-                        lastNote !== null &&
-                        (pitchLabels[i].includes(lastNote) || lastNote.includes(pitchLabels[i]))
-                    ) {
                         break;
+                    }
+                    c--;
+                }
+
+                if (lastNote !== null) {
+                    for (let idx = 0; idx < pitchLabels.length; idx++) {
+                        if (
+                            pitchLabels[idx].includes(lastNote) ||
+                            lastNote.includes(pitchLabels[idx])
+                        ) {
+                            i = idx;
+                            break;
+                        }
                     }
                 }
 
@@ -2306,16 +2305,16 @@ function MusicKeyboard(activity) {
                         break;
                     }
                 } while (this.layout.some(note => note.noteName === rLabel));
+
+                rArg = 4;
                 for (let j = this.layout.length; j > 0; j--) {
-                    rArg = this.layout[j - 1].noteOctave;
-                    if (isNaN(rArg)) {
-                        continue;
-                    }
-                    if (rArg > 0 && rArg < 9) {
+                    const oct = Number(this.layout[j - 1].noteOctave);
+                    if (!isNaN(oct) && oct >= 1 && oct <= 8) {
+                        rArg = oct;
                         break;
                     }
                 }
-                if ((i + 1) % pitchLabels.length === 0) {
+                if (lastNote !== null && i === 0 && rArg < 8) {
                     rArg += 1;
                 }
             } else {


### PR DESCRIPTION
## Description

The Music Keyboard widget previously failed when adding a pitch row to a layout containing only Hertz entries. Because `this.layout` contained no non-hertz note entries, `lastNote` remained `null`, resulting in loop index fallthrough and invalid octave assignments (carrying over Hertz frequencies like 392 as octaves).

## Related Issue

Fixes #7060

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

- `js/widgets/musickeyboard.js`:
  - Properly guard `lastNote` search and set initial index `i = -1` when no prior pitch exists.
  - Fall back to default octave `4` when searching `this.layout` for pitch octaves (`1..8`), ignoring Hertz frequency numbers.
- `js/widgets/__tests__/musickeyboard.test.js`:
  - Updated test expectations to verify clean pitch (`do`) and octave (`4`) assignment when adding a pitch row to a Hertz layout.

## Testing Performed

- `npx jest js/widgets/__tests__/musickeyboard.test.js` — 28/28 tests passing
- `npm run lint` — 0 errors
- `npx prettier --check` — All files formatted correctly

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
