### PR TITLE
chore: fix high-severity production vulnerabilities via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4821,19 +4821,34 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -5063,6 +5078,8 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -8578,7 +8595,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -11336,6 +11355,8 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -12386,10 +12407,13 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.2",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -13060,12 +13084,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -13078,6 +13104,8 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -13092,6 +13120,8 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -13108,6 +13138,8 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -13485,7 +13517,9 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.1",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -108,12 +108,14 @@
             "ajv": "^8.0.0"
         },
         "@isaacs/brace-expansion": "^5.0.1",
-        "immutable": "^5.1.5",
-        "svgo": "^4.0.1",
+        "immutable": "5.1.9",
+        "svgo": "4.0.2",
         "@xmldom/xmldom": "^0.8.13",
         "@gulp-sourcemaps/identity-map": {
             "postcss": "^8.4.31"
-        }
+        },
+        "body-parser": "2.3.0",
+        "qs": "6.15.3"
     },
     "lint-staged": {
         "*.{js,mjs}": [


### PR DESCRIPTION
### Description
This PR fixes the failing GitHub CI security audit by resolving high-severity vulnerabilities in our production dependencies. 

Since a blanket `npm audit fix --force` would cause massive unwanted mutations to the dependency tree, I surgically patched the affected transitive dependencies using `overrides` in `package.json` and cleanly updated the `package-lock.json`.

### Packages Updated (via overrides):
* `body-parser` bumped to `2.3.0`
* `immutable` bumped to `5.1.9`
* `qs` bumped to `6.15.3`
* `svgo` bumped to `4.0.2`

### Important Note for Reviewers:
The moderate vulnerability regarding `materialize-css` is intentionally left untouched in this PR. There is currently no direct fix available for it, and it will require a separate, maintainer-approved migration or replacement PR. 

### Verification:
* [x] `npm audit --omit=dev --audit-level=high` now returns 0 high-severity vulnerabilities.
* [x] `npm test` passes completely (7,148 tests passed).
* [x] The lockfile was updated strictly for these packages without rewriting unrelated dependencies.

---

### PR Category
- [ ] Bug fix
- [ ] New feature
- [x] Chore / Dependency update
- [x] Security fix
- [ ] Documentation update

Before the Fix :
<img width="1470" height="956" alt="Screenshot 2026-07-24 at 8 53 47 PM" src="https://github.com/user-attachments/assets/905a3c38-f2b8-4423-bd90-d6b7af095212" />

After the Fix:
<img width="1470" height="956" alt="Screenshot 2026-07-25 at 12 30 30 AM" src="https://github.com/user-attachments/assets/affb903b-5914-4f1a-83b2-80b930c3361d" />

