### PR TITLE
refactor: centralize Turtle/Music release configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/index.html
+++ b/index.html
@@ -110,6 +110,12 @@
 
         <!-- <script src="lib/mespeak.js"></script> -->
 
+        <!-- Release config: resolves Turtle/Music mode from URL/hostname and seeds
+     window._THIS_IS_*_ globals. Must load first, synchronously, before
+     loader.js and activity.js read those globals. -->
+        <script src="js/releaseconfig.js"></script>
+
+
         <script src="dist/vendor.min.js"></script>
         <link
             rel="preload"

--- a/js/__tests__/releaseconfig.test.js
+++ b/js/__tests__/releaseconfig.test.js
@@ -1,0 +1,20 @@
+describe("releaseconfig globals", () => {
+    beforeEach(() => {
+        jest.resetModules();
+        delete window._THIS_IS_MUSIC_BLOCKS_;
+        delete window._THIS_IS_TURTLE_BLOCKS_;
+        delete window.THIS_IS_MUSIC_BLOCKS;
+        delete window.THIS_IS_TURTLE_BLOCKS;
+    });
+
+    test("mirrors the turtle query param into the underscored globals", () => {
+        window.history.pushState({}, "", "/?turtle");
+
+        require("../releaseconfig");
+
+        expect(window._THIS_IS_MUSIC_BLOCKS_).toBe(false);
+        expect(window._THIS_IS_TURTLE_BLOCKS_).toBe(true);
+        expect(window.THIS_IS_MUSIC_BLOCKS).toBe(false);
+        expect(window.THIS_IS_TURTLE_BLOCKS).toBe(true);
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -73,8 +73,14 @@ try {
  */
 const LEADING = 0;
 const BLOCKSCALES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4];
-const _THIS_IS_MUSIC_BLOCKS_ = true;
-const _THIS_IS_TURTLE_BLOCKS_ = !_THIS_IS_MUSIC_BLOCKS_;
+const _THIS_IS_MUSIC_BLOCKS_ =
+    typeof window !== "undefined" && typeof window._THIS_IS_MUSIC_BLOCKS_ !== "undefined"
+        ? window._THIS_IS_MUSIC_BLOCKS_
+        : true;
+const _THIS_IS_TURTLE_BLOCKS_ =
+    typeof window !== "undefined" && typeof window._THIS_IS_TURTLE_BLOCKS_ !== "undefined"
+        ? window._THIS_IS_TURTLE_BLOCKS_
+        : !_THIS_IS_MUSIC_BLOCKS_;
 
 // Responsive breakpoint constants
 const RESPONSIVE_BREAKPOINT_TABLET = 768;

--- a/js/loader.js
+++ b/js/loader.js
@@ -345,10 +345,6 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
         window.Materialize = M;
     }
 
-    // Define essential globals for core modules
-    window._THIS_IS_MUSIC_BLOCKS_ = true;
-    window._THIS_IS_TURTLE_BLOCKS_ = false;
-
     // Load highlight optionally
     requirejs(
         ["highlight"],

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -1092,10 +1092,9 @@ class ProjectManager {
             } else {
                 if (urlParts[1].indexOf("=") > 0) {
                     args = urlParts[1].split("=");
-                }
-
-                if (args[0].toLowerCase() === "id") {
-                    that.projectID = args[1];
+                    if (args[0].toLowerCase() === "id") {
+                        that.projectID = args[1];
+                    }
                 }
             }
         }

--- a/js/releaseconfig.js
+++ b/js/releaseconfig.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Walter Bender
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+// Single source of truth for the Turtle Blocks vs Music Blocks release.
+// The flag is resolved from the URL first (so a single bundle can serve both
+// apps from different hostnames), with DEFAULT_IS_MUSIC_BLOCKS as the fallback
+// for localhost / file:// / unrecognized hosts.
+//
+// Resolution order:
+//   1. ?turtle or ?music query param  (handy for local testing)
+//   2. hostname contains "turtle" or "music"
+//   3. DEFAULT_IS_MUSIC_BLOCKS (build-time default)
+//
+// The fallback is intentionally Music Blocks so local development and
+// unrecognized hosts start in the Music Blocks experience by default.
+
+/* exported
+   THIS_IS_MUSIC_BLOCKS, THIS_IS_TURTLE_BLOCKS,
+   getSplashScreenSrc, RELEASE_TAB_TITLE, LOADING_TEXTS
+*/
+
+const DEFAULT_IS_MUSIC_BLOCKS = true;
+
+function resolveIsMusicBlocks() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("turtle")) return false;
+    if (params.has("music")) return true;
+
+    const host = window.location.hostname.toLowerCase();
+    if (host.includes("turtle")) return false;
+    if (host.includes("music")) return true;
+
+    return DEFAULT_IS_MUSIC_BLOCKS;
+}
+
+const THIS_IS_MUSIC_BLOCKS = resolveIsMusicBlocks();
+const THIS_IS_TURTLE_BLOCKS = !THIS_IS_MUSIC_BLOCKS;
+
+const TURTLE_SPLASH_SRC =
+    "data:image/svg+xml;base64,PHN2ZyBzdHJva2Utd2lkdGg9IjEuNSIgZmlsbD0iI2ZmZiIgc3Ryb2tlPSIjMDAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDU1IDU1IiB3aWR0aD0iMTAwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTUzLjQ4IDI4LjMxYy0uMjA5LTEuNTQ0LS42ODQtMy45NjMtMi40MzUtNC43OTktMS4xMS0uNTI5LTcuMTguNTM2LTExLjMxNi41ODguMTQ1IDIuNDg4LS43NzggNS4xNTUtMy45NCA5LjgwOS0xLjg4NiAzLjI0Mi0xMC40MTEgMy41MTYtMTAuOCAzLjQ5NGwtMjMuNTU4LS4xMDNjMS4xNjkgMS42NDggMy42ODYgMy43NjIgNi40NjcgNC4xMTItLjc0Ni42NTgtMy4wOTggMy4yNzctMy4yNzMgNi42ODEtLjAwNS4wNzYuMDAyLjQwOSAwIC40MDloNy40MzRjLjI1NS0xLjg1My45NzYtNS4yNzMgMi44OTYtNi41MTQgMS40MzItLjAwOCAyLjczOC0uMTY3IDMuNzU3LS4xMTYgMi4zNTIuMTE3IDcuMTEzLS4wNDcgMTAuMzE1LS4yNzYuMDI0LjAxMy4wMzkuMjczLjA2NC4yODggMi4wOTMgMS4xMDcgMi44NTMgNC43NjYgMy4xMTkgNi42MTloNy40MzRjLS4wMDEgMCAuMDA2LS4zMzQuMDAxLS40MDktLjE3My0zLjM2Mi0zLjE0NC02LjU2OS00LjE0Ny03LjUxMyAyLjgzNy0xLjI2MSA3LjEyMy01LjQ1OSA4LjI0My02LjY3OC4yOTUtLjMxOSAxLjM5MS0xLjY3OSAyLjIyNi0yLjMwMy43ODMtLjU4NSAzLjMzOC0uODk0IDQuMjk3LS45MzYuOTYxLS4wNDIgMyAuNDA4IDMgLjQwOCAwIDAgLjMwNy0yLjA2LjIxLTIuNzYzeiIgc3Ryb2tlLXdpZHRoPSIxLjkyNSIvPjxjaXJjbGUgY3k9IjM3LjIyIiByPSIxLjEwOSIgc3Ryb2tlLXdpZHRoPSIxLjE4NyIgY3g9IjU5LjQ4IiB0cmFuc2Zvcm09Im1hdHJpeCguOTI2NCAwIDAgLjkyNjQtNi45MTUtOC4zMDkpIi8+PGcgc3Ryb2tlLXdpZHRoPSIxLjkyNSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4wMzIwOSAwIDAgLjk5OTA1LS4xODQuMDI0KSI+PHBhdGggZD0ibTEwLjU3MiAzNi45Mmw1Ljc5OC0xNC4xNS01LjAxLTUuNTM1Yy0xLjQyMyAxLjcxOC0yLjQ4MSAzLjcxMS0yLjgxNSA1LjA1LS40NTEgMS43OTggMCA3Ljk2My41ODYgMTAuMTQ0bC0yLjgxOCA0LjU3MiA0LjA1MS0uMTQ4eiIgZmlsbD0iIzE4NmRlZSI+PGFuaW1hdGUgdmFsdWVzPSIjMTg2ZGVlOyNmZmI1MDQ7I2Q4NDMyZTsjMDA5YTU3OyMxODZkZWUiIGF0dHJpYnV0ZVR5cGU9IkNTUyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIGR1cj0iNHMiIGF0dHJpYnV0ZU5hbWU9ImZpbGwiLz48L3BhdGg+PHBhdGggZD0ibTE1LjgyNyAyMy4xNGwxMi42NDctLjMyNCAzLjExOS0zLjk3NmMtLjg3LTEuMjk5LTIuMDEtMi41NTgtMy40NzYtMy4zMTUtNC4zNTYtMi4yNTctOC4yNjktMy4xMS0xMy45NjYtLjI4MS0xLjMxMi42NTItMS45NjEgMS4xNTItMi43NzMgMS45MzV6IiBmaWxsPSIjZmZiNTA0Ij48YW5pbWF0ZSB2YWx1ZXM9IiNmZmI1MDQ7I2Q4NDMyZTsjMDA5YTU3OyMxODZkZWU7I2ZmYjUwNCIgYXR0cmlidXRlVHlwZT0iQ1NTIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgZHVyPSI0cyIgYXR0cmlidXRlTmFtZT0iZmlsbCIvPjwvcGF0aD48cGF0aCBkPSJtMjguODI4IDIyLjk0NWwtMTIuNDc3LjEwNS01LjY0NyAxNC4wOCAxOC4zOTEuMjA1YzMuNTA0LS4xMzUgNC41LTEuMDMyIDUuNDYyLTEuOTYzeiIgZmlsbD0iIzAwOWE1NyI+PGFuaW1hdGUgdmFsdWVzPSIjMDA5YTU3OyMxODZkZWU7I2ZmYjUwNDsjZDg0MzJlOyMwMDlhNTciIGF0dHJpYnV0ZVR5cGU9IkNTUyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIGR1cj0iNHMiIGF0dHJpYnV0ZU5hbWU9ImZpbGwiLz48L3BhdGg+PHBhdGggZD0ibTM0Ljk4MSAyMy43NjZjMCAwLTIuMDEtMi41MDUtMy4wOTgtNC40NDFsLTIuOTAyIDMuNzAxIDUuMzc1IDEyLjU1N2MuOTA4LS42MTYgMi4yNTYtMi41MTIgMi44OTgtMy40OTIgMi40MTktMy4yMzggMi42OTMtNy45OTkgMi42OTMtNy45OTl6IiBmaWxsPSIjZDg0MzJlIj48YW5pbWF0ZSB2YWx1ZXM9IiNkODQzMmU7IzAwOWE1NzsjMTg2ZGVlOyNmZmI1MDQ7I2Q4NDMyZSIgYXR0cmlidXRlVHlwZT0iQ1NTIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgZHVyPSI0cyIgYXR0cmlidXRlTmFtZT0iZmlsbCIvPjwvcGF0aD48L2c+PC9zdmc+";
+
+// Music Blocks splash. Replace with the MB asset on the MB release branch.
+// Falls back to images/logo.svg if undefined.
+const MUSIC_BLOCKS_SPLASH_SRC = "images/logo.svg";
+
+function getSplashScreenSrc() {
+    return THIS_IS_TURTLE_BLOCKS ? TURTLE_SPLASH_SRC : MUSIC_BLOCKS_SPLASH_SRC;
+}
+
+const RELEASE_TAB_TITLE = THIS_IS_TURTLE_BLOCKS ? "Turtle Blocks" : "Music Blocks";
+
+const LOADING_TEXTS = THIS_IS_TURTLE_BLOCKS
+    ? ["Loading Turtle Blocks...", "Stacking some blocks...", "Get ready to draw..."]
+    : ["Do, Re, Mi, Fa, Sol, La, Ti, Do", "Loading Music Blocks...", "Reading Music..."];

--- a/js/releaseconfig.js
+++ b/js/releaseconfig.js
@@ -29,6 +29,16 @@
 
 const DEFAULT_IS_MUSIC_BLOCKS = true;
 
+const setReleaseGlobals = () => {
+    const isMusicBlocks = resolveIsMusicBlocks();
+    const isTurtleBlocks = !isMusicBlocks;
+
+    window._THIS_IS_MUSIC_BLOCKS_ = isMusicBlocks;
+    window._THIS_IS_TURTLE_BLOCKS_ = isTurtleBlocks;
+    window.THIS_IS_MUSIC_BLOCKS = isMusicBlocks;
+    window.THIS_IS_TURTLE_BLOCKS = isTurtleBlocks;
+};
+
 function resolveIsMusicBlocks() {
     const params = new URLSearchParams(window.location.search);
     if (params.has("turtle")) return false;
@@ -44,15 +54,39 @@ function resolveIsMusicBlocks() {
 const THIS_IS_MUSIC_BLOCKS = resolveIsMusicBlocks();
 const THIS_IS_TURTLE_BLOCKS = !THIS_IS_MUSIC_BLOCKS;
 
+setReleaseGlobals();
+
+// Turtle Blocks splash: inline base64 SVG of the Turtle Blocks logo — a turtle
+// formed from four colored triangles (blue/yellow/green/red) whose fills cycle
+// on a 4s animation loop. Inline (not a file path) so it has no asset
+// dependency and travels with this config.
 const TURTLE_SPLASH_SRC =
     "data:image/svg+xml;base64,PHN2ZyBzdHJva2Utd2lkdGg9IjEuNSIgZmlsbD0iI2ZmZiIgc3Ryb2tlPSIjMDAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDU1IDU1IiB3aWR0aD0iMTAwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTUzLjQ4IDI4LjMxYy0uMjA5LTEuNTQ0LS42ODQtMy45NjMtMi40MzUtNC43OTktMS4xMS0uNTI5LTcuMTguNTM2LTExLjMxNi41ODguMTQ1IDIuNDg4LS43NzggNS4xNTUtMy45NCA5LjgwOS0xLjg4NiAzLjI0Mi0xMC40MTEgMy41MTYtMTAuOCAzLjQ5NGwtMjMuNTU4LS4xMDNjMS4xNjkgMS42NDggMy42ODYgMy43NjIgNi40NjcgNC4xMTItLjc0Ni42NTgtMy4wOTggMy4yNzctMy4yNzMgNi42ODEtLjAwNS4wNzYuMDAyLjQwOSAwIC40MDloNy40MzRjLjI1NS0xLjg1My45NzYtNS4yNzMgMi44OTYtNi41MTQgMS40MzItLjAwOCAyLjczOC0uMTY3IDMuNzU3LS4xMTYgMi4zNTIuMTE3IDcuMTEzLS4wNDcgMTAuMzE1LS4yNzYuMDI0LjAxMy4wMzkuMjczLjA2NC4yODggMi4wOTMgMS4xMDcgMi44NTMgNC43NjYgMy4xMTkgNi42MTloNy40MzRjLS4wMDEgMCAuMDA2LS4zMzQuMDAxLS40MDktLjE3My0zLjM2Mi0zLjE0NC02LjU2OS00LjE0Ny03LjUxMyAyLjgzNy0xLjI2MSA3LjEyMy01LjQ1OSA4LjI0My02LjY3OC4yOTUtLjMxOSAxLjM5MS0xLjY3OSAyLjIyNi0yLjMwMy43ODMtLjU4NSAzLjMzOC0uODk0IDQuMjk3LS45MzYuOTYxLS4wNDIgMyAuNDA4IDMgLjQwOCAwIDAgLjMwNy0yLjA2LjIxLTIuNzYzeiIgc3Ryb2tlLXdpZHRoPSIxLjkyNSIvPjxjaXJjbGUgY3k9IjM3LjIyIiByPSIxLjEwOSIgc3Ryb2tlLXdpZHRoPSIxLjE4NyIgY3g9IjU5LjQ4IiB0cmFuc2Zvcm09Im1hdHJpeCguOTI2NCAwIDAgLjkyNjQtNi45MTUtOC4zMDkpIi8+PGcgc3Ryb2tlLXdpZHRoPSIxLjkyNSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4wMzIwOSAwIDAgLjk5OTA1LS4xODQuMDI0KSI+PHBhdGggZD0ibTEwLjU3MiAzNi45Mmw1Ljc5OC0xNC4xNS01LjAxLTUuNTM1Yy0xLjQyMyAxLjcxOC0yLjQ4MSAzLjcxMS0yLjgxNSA1LjA1LS40NTEgMS43OTggMCA3Ljk2My41ODYgMTAuMTQ0bC0yLjgxOCA0LjU3MiA0LjA1MS0uMTQ4eiIgZmlsbD0iIzE4NmRlZSI+PGFuaW1hdGUgdmFsdWVzPSIjMTg2ZGVlOyNmZmI1MDQ7I2Q4NDMyZTsjMDA5YTU3OyMxODZkZWUiIGF0dHJpYnV0ZVR5cGU9IkNTUyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIGR1cj0iNHMiIGF0dHJpYnV0ZU5hbWU9ImZpbGwiLz48L3BhdGg+PHBhdGggZD0ibTE1LjgyNyAyMy4xNGwxMi42NDctLjMyNCAzLjExOS0zLjk3NmMtLjg3LTEuMjk5LTIuMDEtMi41NTgtMy40NzYtMy4zMTUtNC4zNTYtMi4yNTctOC4yNjktMy4xMS0xMy45NjYtLjI4MS0xLjMxMi42NTItMS45NjEgMS4xNTItMi43NzMgMS45MzV6IiBmaWxsPSIjZmZiNTA0Ij48YW5pbWF0ZSB2YWx1ZXM9IiNmZmI1MDQ7I2Q4NDMyZTsjMDA5YTU3OyMxODZkZWU7I2ZmYjUwNCIgYXR0cmlidXRlVHlwZT0iQ1NTIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgZHVyPSI0cyIgYXR0cmlidXRlTmFtZT0iZmlsbCIvPjwvcGF0aD48cGF0aCBkPSJtMjguODI4IDIyLjk0NWwtMTIuNDc3LjEwNS01LjY0NyAxNC4wOCAxOC4zOTEuMjA1YzMuNTA0LS4xMzUgNC41LTEuMDMyIDUuNDYyLTEuOTYzeiIgZmlsbD0iIzAwOWE1NyI+PGFuaW1hdGUgdmFsdWVzPSIjMDA5YTU3OyMxODZkZWU7I2ZmYjUwNDsjZDg0MzJlOyMwMDlhNTciIGF0dHJpYnV0ZVR5cGU9IkNTUyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIGR1cj0iNHMiIGF0dHJpYnV0ZU5hbWU9ImZpbGwiLz48L3BhdGg+PHBhdGggZD0ibTM0Ljk4MSAyMy43NjZjMCAwLTIuMDEtMi41MDUtMy4wOTgtNC40NDFsLTIuOTAyIDMuNzAxIDUuMzc1IDEyLjU1N2MuOTA4LS42MTYgMi4yNTYtMi41MTIgMi44OTgtMy40OTIgMi40MTktMy4yMzggMi42OTMtNy45OTkgMi42OTMtNy45OTl6IiBmaWxsPSIjZDg0MzJlIj48YW5pbWF0ZSB2YWx1ZXM9IiNkODQzMmU7IzAwOWE1NzsjMTg2ZGVlOyNmZmI1MDQ7I2Q4NDMyZSIgYXR0cmlidXRlVHlwZT0iQ1NTIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgZHVyPSI0cyIgYXR0cmlidXRlTmFtZT0iZmlsbCIvPjwvcGF0aD48L2c+PC9zdmc+";
 
-// Music Blocks splash. Replace with the MB asset on the MB release branch.
-// Falls back to images/logo.svg if undefined.
+// Music Blocks splash assets.
+// Falls back to images/logo.svg if the file is missing.
 const MUSIC_BLOCKS_SPLASH_SRC = "images/logo.svg";
+// Special splash shown when the UI language is Japanese.
+const MUSIC_BLOCKS_SPLASH_SRC_JA = "images/mb_logo_ja.svg";
+
+// Mirror the app's language resolution (see turtledefs.js): explicit user
+// preference first, then browser locale.
+function resolveLanguage() {
+    let language;
+    try {
+        language = localStorage.languagePreference;
+    } catch (e) {
+        language = undefined;
+    }
+    if (language === undefined || language === null) {
+        language = (typeof navigator !== "undefined" && navigator.language) || "";
+    }
+    return language;
+}
 
 function getSplashScreenSrc() {
-    return THIS_IS_TURTLE_BLOCKS ? TURTLE_SPLASH_SRC : MUSIC_BLOCKS_SPLASH_SRC;
+    if (THIS_IS_TURTLE_BLOCKS) return TURTLE_SPLASH_SRC;
+    return resolveLanguage() === "ja" ? MUSIC_BLOCKS_SPLASH_SRC_JA : MUSIC_BLOCKS_SPLASH_SRC;
 }
 
 const RELEASE_TAB_TITLE = THIS_IS_TURTLE_BLOCKS ? "Turtle Blocks" : "Music Blocks";


### PR DESCRIPTION



## PR Category

 - [X] Chore / Dependency update

## What
- Add `js/releaseconfig.js` : single source of truth for Turtle vs Music mode, resolved from URL param → hostname → `DEFAULT_IS_MUSIC_BLOCKS`.
- Load it synchronously as the first script in `index.html`.
- Drive `document.title`, splash, and loading texts from the flag instead of hardcoded values.
- Remove duplicate `THIS_IS_MUSIC_BLOCKS` / `THIS_IS_TURTLE_BLOCKS` declarations (now owned by releaseconfig.js).

## Why
Unifies both apps on the musicblocks codebase so runtime detection drives mode. Step toward retiring the standalone turtleblocks repo.