### PR TITLE
fix: use transpositionFloor instead of transposition in getNote

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -3160,6 +3160,21 @@ describe("getNote additional paths", () => {
             0
         ]);
     });
+
+    it("uses transpositionFloor (not raw transposition) for custom temperament note stepping", () => {
+        addTemperamentToDictionary("testtemp", {
+            pitchNumber: 12,
+            interval: TEMPERAMENT.equal.interval
+        });
+
+        // transposition = 2.5 → transpositionFloor = 2, cents = 50
+        // With the bug, deltaNote was 2.5 % 12 = 2.5 (fractional),
+        // causing incorrect interval lookup.
+        // With the fix, deltaNote is 2 % 12 = 2 (integer).
+        const result = getNote("C", 4, 2.5, "C major", false, undefined, undefined, "testtemp");
+        expect(result[0]).toBe("D");
+        expect(result[1]).toBe(4);
+    });
 });
 
 describe("scaleDegreeToPitchMapping extended modes", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -5234,7 +5234,7 @@ function getNote(
                 deltaNote = -(-transpositionFloor % octaveLength);
             } else {
                 deltaOctave = Math.floor(transpositionFloor / octaveLength);
-                deltaNote = transposition % octaveLength;
+                deltaNote = transpositionFloor % octaveLength;
             }
 
             octave += deltaOctave;


### PR DESCRIPTION
Fixes #7911 

## Problem

In `js/utils/musicutils.js`, the `getNote` function computes `transpositionFloor` (the integer part of transposition) and `transpositionCents` (the fractional part) early on. However, in the custom temperament branch (around line 5237), the positive-transposition path incorrectly uses the raw float `transposition` instead of `transpositionFloor`:
```js
// Bug (line 5237):
deltaNote = transposition % octaveLength;      // fractional!
// All other branches correctly use:
deltaNote = transpositionFloor % octaveLength;  // integer
When transposition has a fractional part (e.g., 2.5), deltaNote becomes 2.5 instead of 2, causing incorrect interval lookups and wrong pitch resolution.
```


## Fix

Changed transposition to transpositionFloor on line 5237, aligning it with all other branches in the function.

## Testing

Added a regression test in musicutils.test.js that calls getNote("C", 4, 2.5, "C major", false, undefined, undefined, "testtemp") with a custom 12-EDO temperament and verifies the result is D4 (not a broken lookup). All test cases passed.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I have run `npm test` and all tests pass
- [x] I have run `npx prettier --check` on modified files
- [x] I have added a test to cover the fix

**PR Category** (check at least one):
- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Testing
- [ ] Other