### PR TITLE
Fix getNote: use transpositionFloor instead of raw transposition

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -5234,7 +5234,7 @@ function getNote(
                 deltaNote = -(-transpositionFloor % octaveLength);
             } else {
                 deltaOctave = Math.floor(transpositionFloor / octaveLength);
-                deltaNote = transposition % octaveLength;
+                deltaNote = transpositionFloor % octaveLength;
             }
 
             octave += deltaOctave;


### PR DESCRIPTION
Fixes #7911

## Problem
In `getNote` (js/utils/musicutils.js), the custom temperament branch for positive transposition values calculated `deltaNote` using the raw float `transposition` instead of the already-computed `transpositionFloor`. This caused fractional transposition values (e.g. 2.5 semitones) to produce a non-integer `deltaNote`, breaking the interval lookup which expects integer keys.

## Fix
Changed `deltaNote = transposition % octaveLength;` to `deltaNote = transpositionFloor % octaveLength;`, matching the pattern already used in the negative-transposition branch above it.

## Testing
Verified the fix resolves the reported repro case: `getNote("C", 4, 2.5, "C major", false, undefined, undefined, "equal")` no longer produces a fractional deltaNote.
- [x] Bug Fix