### PR TITLE
Add label-sync workflow for meaningful issue label colors

### DIFF
--- a/.github/ISSUE_TEMPLATE/ui_ux_improvement.md
+++ b/.github/ISSUE_TEMPLATE/ui_ux_improvement.md
@@ -2,7 +2,7 @@
 name: 🎨 UI/UX 
 about: Report UI or UX bugs, inconsistencies, or improvement suggestions
 title: "[UI/UX]"
-labels: "Issue-User-Experience"
+labels: "Issue-Design"
 assignees: ""
 ---
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,6 +5,10 @@
 # related concepts (e.g. "bug fix" on PRs and "Issue-Bug" on issues) share
 # the same color.
 #
+# Names must match the repo's existing labels EXACTLY (case-sensitive) or
+# the syncer will create duplicates instead of recoloring the originals.
+# Verified against github.com/sugarlabs/musicblocks/labels.
+#
 # To add or update a label: edit this file and open a PR. The sync
 # workflow will create/update the label in the repo automatically once
 # merged to master.
@@ -29,30 +33,22 @@
   color: EC4899
   description: UI/UX bugs, inconsistencies, or improvement suggestions
 
-- name: testing
+- name: Issue-Testing
   color: 3B82F6
   description: Adds or updates test coverage
 
-- name: good first issue
-  color: 7EE787
-  description: Good for newcomers
-
-- name: help wanted
-  color: FBCA04
-  description: Extra attention is needed
-
-- name: question
+- name: Issue-Question
   color: D876E3
   description: Further information is requested
 
-- name: needs discussion
-  color: 6E7781
-  description: Requires maintainer/community discussion before proceeding
-
-- name: wontfix
+- name: Issue-Wontfix
   color: FFFFFF
   description: This will not be worked on
 
-- name: duplicate
+- name: Issue-Duplicate
   color: CFD3D7
   description: This issue or pull request already exists
+
+- name: Good first issue
+  color: 7EE787
+  description: Good for newcomers

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -29,9 +29,7 @@
   color: F97316
   description: Improves performance (load time, memory, rendering)
 
-- name: Issue-User-Experience
-  color: EC4899
-  description: UI/UX bugs, inconsistencies, or improvement suggestions
+
 
 - name: Issue-Testing
   color: 3B82F6

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,58 @@
+# Label definitions synced to the repo by .github/workflows/label-sync.yml
+#
+# Colors are chosen to stay consistent with the palette already used for
+# PR-category labels in .github/workflows/pr-category-check.yml, so that
+# related concepts (e.g. "bug fix" on PRs and "Issue-Bug" on issues) share
+# the same color.
+#
+# To add or update a label: edit this file and open a PR. The sync
+# workflow will create/update the label in the repo automatically once
+# merged to master.
+
+- name: Issue-Bug
+  color: D73A4A
+  description: Fixes a bug or incorrect behavior
+
+- name: Issue-Enhancement
+  color: 9333EA
+  description: Adds new functionality or improves an existing feature
+
+- name: Issue-Documentation
+  color: 10B981
+  description: Updates to docs, comments, or README
+
+- name: Issue-Performance
+  color: F97316
+  description: Improves performance (load time, memory, rendering)
+
+- name: Issue-User-Experience
+  color: EC4899
+  description: UI/UX bugs, inconsistencies, or improvement suggestions
+
+- name: testing
+  color: 3B82F6
+  description: Adds or updates test coverage
+
+- name: good first issue
+  color: 7EE787
+  description: Good for newcomers
+
+- name: help wanted
+  color: FBCA04
+  description: Extra attention is needed
+
+- name: question
+  color: D876E3
+  description: Further information is requested
+
+- name: needs discussion
+  color: 6E7781
+  description: Requires maintainer/community discussion before proceeding
+
+- name: wontfix
+  color: FFFFFF
+  description: This will not be worked on
+
+- name: duplicate
+  color: CFD3D7
+  description: This issue or pull request already exists

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1
+        uses: micnncim/action-label-syncer@3abd5ab # v1.3.0
         with:
           manifest: .github/labels.yml
           prune: false

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,37 @@
+name: Label Sync
+
+# Keeps repository issue labels (name, color, description) in sync with
+# the definitions in .github/labels.yml. This lets contributors propose
+# label color/description changes via a normal PR, instead of requiring
+# repo Settings access.
+#
+# Related: #7910 (color coding for issue labels to improve discoverability)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/label-sync.yml"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    name: Sync labels from .github/labels.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+          prune: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync labels
-        uses: micnncim/action-label-syncer@3abd5ab # v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           manifest: .github/labels.yml
           prune: false


### PR DESCRIPTION
Addresses #7910

## Problem
Issue-type labels (Issue-Bug, Issue-Enhancement, etc.) all use GitHub's default gray color, making it hard to visually scan and triage issues. Label colors also can't be changed by contributors since they require repo Settings (admin) access.

## Solution
Adds a `.github/labels.yml` manifest defining names, colors, and descriptions for all issue-type labels (plus a few common OSS conventions like `good first issue`, `help wanted`). A new `.github/workflows/label-sync.yml` workflow uses `micnncim/action-label-syncer` to sync this manifest to the repo's actual labels whenever it changes on master (or via manual dispatch).

This means future label color/description changes can go through a normal PR review, rather than requiring direct repo Settings access.

Colors were chosen to stay consistent with the existing PR-category label palette already defined in `.github/workflows/pr-category-check.yml`, so related concepts (e.g. "bug fix" on PRs and "Issue-Bug" on issues) share the same color.

- [x] Feature