### PR TITLE
refactor: migrate PIEMENUS to capability metadata

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -109,14 +109,21 @@ describe("Block Foundation", () => {
                     }
                 }
             },
-            blockList: []
+            blockList: [],
+            octaveNumber: jest.fn().mockReturnValue(false),
+            noteValueNumber: jest.fn().mockReturnValue(false),
+            octaveModifierNumber: jest.fn().mockReturnValue(false),
+            intervalModifierNumber: jest.fn().mockReturnValue(false)
         };
 
         mockProtoBlock = {
             name: "forward",
             image: "forward.svg",
             size: 1,
-            docks: [],
+            docks: [
+                [0, 0, 0],
+                [0, 0, 0]
+            ],
             hidden: false,
             capabilities: Object.create(null)
         };
@@ -256,6 +263,58 @@ describe("Block Foundation", () => {
 
             const block = new Block(mockProtoBlock, mockBlocks);
             expect(block.hasValueDrivenLabel()).toBe(false);
+        });
+
+        describe("discreteChoice capability and _usePiemenu()", () => {
+            it("hasCapability('discreteChoice') should return true when configured in metadata", () => {
+                mockProtoBlock.capabilities.discreteChoice = true;
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.hasCapability("discreteChoice")).toBe(true);
+                expect(block._usePiemenu()).toBe(true);
+            });
+
+            it("hasCapability('discreteChoice') should return false when not configured", () => {
+                mockProtoBlock.capabilities = Object.create(null);
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.hasCapability("discreteChoice")).toBe(false);
+                expect(block._usePiemenu()).toBe(false);
+            });
+
+            it("should support dynamic inherited pie menus based on parent connections", () => {
+                mockProtoBlock.name = "number";
+                mockProtoBlock.capabilities = Object.create(null);
+
+                const childBlock = new Block(mockProtoBlock, mockBlocks);
+                childBlock.blockIndex = 1;
+                childBlock.connections = [0, null];
+
+                const parentProtoBlock = {
+                    name: "tempo",
+                    capabilities: Object.create(null),
+                    piemenuValuesC1: [60, 120, 180]
+                };
+                const parentBlock = new Block(parentProtoBlock, mockBlocks);
+                parentBlock.blockIndex = 0;
+                parentBlock.connections = [null, 1];
+
+                mockBlocks.blockList = [parentBlock, childBlock];
+                mockBlocks.octaveNumber = jest.fn(() => false);
+                mockBlocks.noteValueNumber = jest.fn(() => false);
+                mockBlocks.octaveModifierNumber = jest.fn(() => false);
+                mockBlocks.intervalModifierNumber = jest.fn(() => false);
+
+                expect(childBlock.hasCapability("discreteChoice")).toBe(false);
+                expect(childBlock._usePiemenu()).toBe(true);
+            });
+
+            it("should handle empty/unpopulated connections array without throwing", () => {
+                mockProtoBlock.capabilities = Object.create(null);
+                const block = new Block(mockProtoBlock, mockBlocks);
+                block.connections = []; // connections[0] is undefined
+
+                expect(() => block._usePiemenu()).not.toThrow();
+                expect(block._usePiemenu()).toBe(false);
+            });
         });
 
         it("copySize() should sync size from protoblock", () => {

--- a/js/block.js
+++ b/js/block.js
@@ -150,34 +150,6 @@ const WIDENAMES = [
 const EXTRAWIDENAMES = [];
 
 /**
- * List of block types with pie menus.
- * @type {string[]}
- */
-const PIEMENUS = [
-    "solfege",
-    "eastindiansolfege",
-    "scaledegree2",
-    "notename",
-    "voicename",
-    "drumname",
-    "effectsname",
-    "accidentalname",
-    "invertmode",
-    "boolean",
-    "filtertype",
-    "oscillatortype",
-    "intervalname",
-    "modename",
-    "chordname",
-    "temperamentname",
-    "noisename",
-    "customNote",
-    "grid",
-    "outputtools",
-    "wrapmode"
-];
-
-/**
  * Async function to create bitmap from SVG data.
  * @param {string} data - SVG data.
  * @param {Function} callback - Callback function.
@@ -3698,7 +3670,7 @@ class Block {
         this._check_meter_block = null;
 
         // Special pie menus
-        if (PIEMENUS.includes(this.name)) {
+        if (this.hasCapability("discreteChoice")) {
             return true;
         }
 
@@ -3746,13 +3718,11 @@ class Block {
      * @returns {boolean} - Indicates whether a pie menu should be used.
      */
     _usePieNumberC1() {
-        // Return true if this number block plugs into Connection 1 of
-        // a block that uses a pie menu. Add block names to the list
-        // below and the switch statement in the _changeLabel
-        // function.
+        // Dynamic numeric pie menus are inherited from the connected parent
+        // block via piemenuValuesC1 metadata on its protoblock.
         const cblk = this.connections[0];
 
-        if (cblk === null) {
+        if (cblk === null || cblk === undefined) {
             return false;
         }
 
@@ -3771,13 +3741,11 @@ class Block {
      * @returns {boolean} - True if the block plugs into Connection 2 of a pie menu block, false otherwise.
      */
     _usePieNumberC2() {
-        // Return true if this number block plugs into Connection 2 of
-        // a block that uses a pie menu. Add block names to the list
-        // below and the switch statement in the _changeLabel
-        // function.
+        // Dynamic numeric pie menus are inherited from the connected parent
+        // block via piemenuValuesC2 metadata on its protoblock.
         const cblk = this.connections[0];
 
-        if (cblk === null) {
+        if (cblk === null || cblk === undefined) {
             return false;
         }
 
@@ -3796,13 +3764,11 @@ class Block {
      * @returns {boolean} - True if the block plugs into Connection 3 of a pie menu block, false otherwise.
      */
     _usePieNumberC3() {
-        // Return true if this number block plugs into Connection 3 of
-        // a block that uses a pie menu. Add block names to the list
-        // below and the switch statement in the _changeLabel
-        // function.
+        // Dynamic numeric pie menus are inherited from the connected parent
+        // block via piemenuValuesC3 metadata on its protoblock.
         const cblk = this.connections[0];
 
-        if (cblk === null) {
+        if (cblk === null || cblk === undefined) {
             return false;
         }
 

--- a/js/blocks/BooleanBlocks.js
+++ b/js/blocks/BooleanBlocks.js
@@ -986,6 +986,7 @@ function setupBooleanBlocks(activity) {
         constructor() {
             super("boolean");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             /**
              * Sets the palette for the block.

--- a/js/blocks/DrumBlocks.js
+++ b/js/blocks/DrumBlocks.js
@@ -31,6 +31,7 @@ function setupDrumBlocks(activity) {
             // Call the constructor of the parent class (ValueBlock)
             super("noisename", _("noise name"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             /**
              * Sets the palette for the block.
@@ -75,6 +76,7 @@ function setupDrumBlocks(activity) {
             // Call the constructor of the parent class (ValueBlock)
             super("drumname", _("drum name"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             /**
              * Sets the palette for the block.
@@ -120,6 +122,7 @@ function setupDrumBlocks(activity) {
             // Call the constructor of the parent class (ValueBlock)
             super("effectsname", _("effects name"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             /**
              * Sets the palette for the block.

--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -673,6 +673,7 @@ function setupExtrasBlocks(activity) {
         constructor() {
             super("grid");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("extras", activity);
             this.setHelpString();
             this.formBlock({ outType: "gridout" });

--- a/js/blocks/GraphicsBlocks.js
+++ b/js/blocks/GraphicsBlocks.js
@@ -1158,6 +1158,7 @@ function setupGraphicsBlocks(activity) {
             // Call the constructor of the parent class
             super("wrapmode");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             // Set the palette, activity, and form the block with specific parameters
             this.setPalette("graphics", activity);

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -93,6 +93,7 @@ function setupIntervalsBlocks(activity) {
             // Call the constructor of the parent class
             super("temperamentname", _("temperament name"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             // Set the palette, activity, extra width, and form the block with specific parameters
             this.setPalette("tone", activity);
@@ -119,6 +120,7 @@ function setupIntervalsBlocks(activity) {
             // Call the constructor of the parent class
             super("modename");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -141,6 +143,7 @@ function setupIntervalsBlocks(activity) {
             // Call the constructor of the parent class
             super("chordname");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -244,6 +247,7 @@ function setupIntervalsBlocks(activity) {
             // Call the constructor of the parent class
             super("intervalname");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -130,6 +130,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("invertmode");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.formBlock({ outType: "textout" });
             this.hidden = true;
@@ -423,6 +424,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("outputtools", _("pitch converter"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.beginnerBlock(true);
             this.extraWidth = 50;
@@ -880,6 +882,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("accidentalname", _("accidental selector"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _(
@@ -897,6 +900,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("eastindiansolfege", _("east indian solfege"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of ni dha pa ma ga re sa."),
@@ -912,6 +916,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("notename", _("note name"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of C D E F G A B."),
@@ -928,6 +933,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("solfege", _("solfege"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _("Pitch can be specified in terms of do re mi fa sol la ti."),
@@ -944,6 +950,7 @@ function setupPitchBlocks(activity) {
         constructor() {
             super("customNote");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.hidden = true;
         }
@@ -1850,6 +1857,7 @@ function setupPitchBlocks(activity) {
             //.TRANS: a numeric mapping of the notes in an octave based on the musical mode
             super("scaledegree2", _("scale degree"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("pitch", activity);
             this.extraWidth = 10;
             this.setHelpString([

--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -104,6 +104,7 @@ function setupToneBlocks(activity) {
         constructor() {
             super("filtertype");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("tone", activity);
             this.setHelpString();
             this.formBlock({ outType: "textout" });
@@ -124,6 +125,7 @@ function setupToneBlocks(activity) {
         constructor() {
             super("oscillatortype");
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("tone", activity);
             this.setHelpString();
             this.formBlock({ outType: "textout" });
@@ -922,6 +924,7 @@ function setupToneBlocks(activity) {
         constructor() {
             super("voicename", _("set instrument"));
             this.setCapability("valueDrivenLabel");
+            this.setCapability("discreteChoice");
             this.setPalette("tone", activity);
             this.setHelpString([
                 _(


### PR DESCRIPTION
Replaced the legacy global PIEMENUS array with the `discreteChoice` capability
registered directly on block definitions.

What changed
- Removed the global PIEMENUS array from `js/block.js`.
- Updated `_usePiemenu()` to use `this.hasCapability("discreteChoice")`.
- Registered the `discreteChoice` capability on all 21 affected block types across 7 block definition files.
- Updated `_usePieNumberC1()`, `_usePieNumberC2()`, and `_usePieNumberC3()` to safely handle both `null` and `undefined` connection slots while keeping the existing behavior unchanged.
- Added tests for capability detection, negative cases, dynamic parent-driven pie menus, and unattached blocks with empty connection arrays.

## PR category

- [x] feature
- [x] tests