### PR TITLE
feat(widgets): attach dependency metadata to PhraseMaker widget definition

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1371,3 +1371,21 @@ describe("PhraseMaker Widget", () => {
         phraseMaker._blockReplace(0, 1);
     });
 });
+
+describe("PhraseMaker.dependencies", () => {
+    test("declares its AMD module dependencies as definition-attached metadata", () => {
+        expect(Array.isArray(PhraseMaker.dependencies)).toBe(true);
+        expect(PhraseMaker.dependencies).toEqual([
+            "widgets/PhraseMakerUtils",
+            "widgets/PhraseMakerGrid",
+            "widgets/PhraseMakerUI",
+            "widgets/PhraseMakerAudio",
+            "widgets/phrasemaker"
+        ]);
+    });
+
+    test("is not read by widget instances at construction time", () => {
+        const instance = new PhraseMaker({});
+        expect(instance.dependencies).toBeUndefined();
+    });
+});

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -69,13 +69,8 @@ class PhraseMaker {
     // stylePhraseMaker();
 
     /**
-     * Declarative list of this widget's AMD module dependencies, attached to
-     * the widget definition itself (mirrors the additive capability metadata
-     * on Protoblock in js/protoblocks.js). This is descriptive metadata only:
-     * WidgetBlocks.js's _ensureWidget() still receives its own explicit
-     * modules array and does not read this property. Keeping the two in sync
-     * is a manual step for now; a future change can have the loader consume
-     * this list directly instead of a hardcoded literal.
+     * This widget's AMD module dependencies, declared on the definition
+     * itself (mirrors the capability metadata on Protoblock).
      */
     static dependencies = [
         "widgets/PhraseMakerUtils",

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -69,6 +69,23 @@ class PhraseMaker {
     // stylePhraseMaker();
 
     /**
+     * Declarative list of this widget's AMD module dependencies, attached to
+     * the widget definition itself (mirrors the additive capability metadata
+     * on Protoblock in js/protoblocks.js). This is descriptive metadata only:
+     * WidgetBlocks.js's _ensureWidget() still receives its own explicit
+     * modules array and does not read this property. Keeping the two in sync
+     * is a manual step for now; a future change can have the loader consume
+     * this list directly instead of a hardcoded literal.
+     */
+    static dependencies = [
+        "widgets/PhraseMakerUtils",
+        "widgets/PhraseMakerGrid",
+        "widgets/PhraseMakerUI",
+        "widgets/PhraseMakerAudio",
+        "widgets/phrasemaker"
+    ];
+
+    /**
      * Constructs a new instance of the PhraseMaker.
      * @param {object} deps - Explicit dependencies for the widget
      */


### PR DESCRIPTION
## Description

This PR introduces dependency metadata for widgets by adding a static `dependencies` field to `PhraseMaker`, following the same definition-attached approach used by `ProtoBlock` capability metadata.

The goal is to colocate dependency information with the widget definition while keeping the existing loading mechanism unchanged. This serves as a small, backward-compatible proof of concept for a metadata-driven widget architecture.

## Changes

- Added a static `dependencies` array to `PhraseMaker` containing its AMD module IDs.
- Kept the existing `_ensureWidget()` loading logic unchanged.
- Left the dependency array in `WidgetBlocks.js` intact to preserve current runtime behaviour.
- Added unit tests verifying:
  - the `dependencies` metadata contains the expected module IDs.
  - `dependencies` is a static class property and is not copied onto widget instances.

## Why

Currently, widget dependency lists are defined separately from the widget implementation, requiring updates in multiple places whenever dependencies change.

By attaching dependency metadata directly to the widget definition:

- dependency information lives alongside the widget it describes,
- the architecture becomes more maintainable,
- future loader improvements become possible,
- and runtime behaviour remains completely unchanged.

This follows the same incremental migration strategy previously used for `ProtoBlock` capability metadata.

## Testing

- ✅ `phrasemaker.test.js` (71/71 passing)
- ✅ `WidgetBlocks` tests (29/29 passing)
- ✅ ESLint
- ✅ Prettier (modified files only)

## Future Work

This PR intentionally does **not** modify widget loading.

Future follow-up PRs can:

- update `_ensureWidget()` to consume `Widget.dependencies` instead of hardcoded dependency arrays,
- migrate additional widgets (e.g. `TimbreWidget`, `ModeWidget`, `MeterWidget`, `HelpWidget`) to the same metadata pattern,
- eventually remove duplicated dependency declarations once all widgets have been migrated.