### PR TITLE
fix: halt doVibrato when intensity or rate validation fails

### DIFF
--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -135,11 +135,13 @@ function setupToneActions(activity) {
             if (intensity < 1 || intensity > 100) {
                 activity.errorMsg(_("Vibrato intensity must be between 1 and 100."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             if (rate <= 0) {
                 activity.errorMsg(_("Vibrato rate must be greater than 0."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -266,6 +266,8 @@ describe("setupToneActions", () => {
                 1
             );
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.vibratoIntensity).toEqual([]);
+            expect(targetTurtle.singer.vibratoRate).toEqual([]);
         });
 
         it("should show error for invalid vibrato rate", () => {
@@ -275,6 +277,7 @@ describe("setupToneActions", () => {
                 1
             );
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.vibratoRate).toEqual([]);
         });
 
         it("should use last vibrato intensity in timbre mode", () => {

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -277,6 +277,7 @@ describe("setupToneActions", () => {
                 1
             );
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.vibratoIntensity).toEqual([]);
             expect(targetTurtle.singer.vibratoRate).toEqual([]);
         });
 


### PR DESCRIPTION
### Description

This PR fixes #7921.

`Singer.ToneActions.doVibrato` validates the vibrato intensity and rate, but when either validation fails, the function only displays an error message and sets `activity.logo.stopTurtle = true`. Since execution does not stop immediately, the function continues and updates the turtle's vibrato state with invalid values.

This change adds early returns after both validation checks so that the function exits immediately when invalid input is detected.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] CI/CD — Changes to CI/CD workflows and automation

### Related Issue

Fixes #7921

### PR Category

* [x] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves performance
* [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates documentation

### Changes Made

* Added an early `return` after the invalid intensity validation in `Singer.ToneActions.doVibrato`.
* Added an early `return` after the invalid rate validation in `Singer.ToneActions.doVibrato`.
* Updated the existing Jest tests to verify that `vibratoIntensity` and `vibratoRate` remain unchanged when validation fails.

### Testing Performed

* Ran:

```bash
npx jest js/turtleactions/__tests__/ToneActions.test.js
```

* Verified that all tests pass.
* Confirmed that valid vibrato values continue to work as expected.
* Confirmed that invalid vibrato parameters display the existing error message and no longer modify the turtle's vibrato state.

### Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable. (Not applicable)
* [x] I have followed the project's coding style guidelines.
* [x] I have run the required linting/formatting checks.
* [x] I have addressed any applicable review feedback.
* [x] I have enabled "Allow edits from maintainers".

### Additional Notes for Reviewers

A similar fix was previously proposed in PR #7191 but was closed due to inactivity before it was merged. The underlying issue is still present on the current `master` branch, so this PR reapplies the fix against the latest codebase and preserves the regression test coverage.
