### PR TITLE
fix(phrasemaker): refresh matrix after pitch block updates

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -193,6 +193,59 @@ describe("piemenus behavioral tests", () => {
         expect(mockBlock.blocks.setPitchOctave).toHaveBeenCalledWith("mock-id", 3);
     });
 
+    describe("Phrase Maker refresh on pitch change", () => {
+        const noteLabels = ["C", "D", "E", "F", "G", "A", "B"];
+        const noteValues = ["C", "D", "E", "F", "G", "A", "B"];
+
+        beforeEach(() => {
+            // hasOctaveWheel requires the parent block to be a "pitch"-family wrapper.
+            mockBlock.blocks.blockList["mock-id"].name = "pitch";
+        });
+
+        test("notifies an open Phrase Maker when the exit wheel commits a new pitch", () => {
+            const refreshRowForBlock = jest.fn();
+            mockBlock.activity.logo.phraseMaker = { refreshRowForBlock };
+
+            piemenuPitches(mockBlock, noteLabels, noteValues, ["♯", "♭"], "C", "");
+
+            // Select G (index 4), natural accidental, octave 5.
+            mockBlock._pitchWheel.selectedNavItemIndex = 4;
+            mockBlock._accidentalsWheel.selectedNavItemIndex = 2;
+            mockBlock._accidentalsWheel.navItems[2].title = "♮";
+            mockBlock._octavesWheel.selectedNavItemIndex = 3;
+
+            mockBlock._exitWheel.navItems[0].navigateFunction();
+
+            expect(refreshRowForBlock).toHaveBeenCalledWith("mock-id", "G", "♮", 5);
+        });
+
+        test("does not throw and does not touch unrelated widgets when no Phrase Maker is open", () => {
+            piemenuPitches(mockBlock, noteLabels, noteValues, ["♯", "♭"], "C", "");
+
+            mockBlock._pitchWheel.selectedNavItemIndex = 4;
+            mockBlock._accidentalsWheel.selectedNavItemIndex = 2;
+            mockBlock._octavesWheel.selectedNavItemIndex = 3;
+
+            expect(() => mockBlock._exitWheel.navItems[0].navigateFunction()).not.toThrow();
+        });
+
+        test("does not notify Phrase Maker for a scaledegree2 block", () => {
+            mockBlock.name = "scaledegree2";
+            const refreshRowForBlock = jest.fn();
+            mockBlock.activity.logo.phraseMaker = { refreshRowForBlock };
+
+            piemenuPitches(mockBlock, noteLabels, noteValues, ["♯", "♭"], "C", "");
+
+            mockBlock._pitchWheel.selectedNavItemIndex = 4;
+            mockBlock._accidentalsWheel.selectedNavItemIndex = 2;
+            mockBlock._octavesWheel.selectedNavItemIndex = 3;
+
+            mockBlock._exitWheel.navItems[0].navigateFunction();
+
+            expect(refreshRowForBlock).not.toHaveBeenCalled();
+        });
+    });
+
     describe("Block Help Menu", () => {
         it("should load help before opening the aux pie menu help widget", () => {
             expect(piemenusContent).toMatch(

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1008,6 +1008,24 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         // Refresh the block's cache
         that.updateCache();
+
+        // If this block is a tracked row in an already-open Phrase Maker,
+        // refresh that row so the matrix reflects the new pitch immediately.
+        if (hasOctaveWheel && that.name !== "scaledegree2") {
+            const phraseMaker = that.activity.logo.phraseMaker;
+            if (phraseMaker && typeof phraseMaker.refreshRowForBlock === "function") {
+                const newOctave = Number(
+                    that._octavesWheel.navItems[that._octavesWheel.selectedNavItemIndex].title
+                );
+                phraseMaker.refreshRowForBlock(
+                    that.connections[0],
+                    selectedNoteValue,
+                    selectedAccidental,
+                    newOctave
+                );
+            }
+        }
+
         // Hide the pie menu and remove the wheels
         hideWheelDiv();
         that._pitchWheel.removeWheel();

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1370,6 +1370,177 @@ describe("PhraseMaker Widget", () => {
 
         phraseMaker._blockReplace(0, 1);
     });
+
+    describe("refreshRowForBlock", () => {
+        const buildMockCell = () => ({
+            style: {},
+            textContent: "",
+            appendChild: jest.fn(),
+            setAttribute: jest.fn()
+        });
+
+        beforeEach(() => {
+            phraseMaker.blockNo = 42;
+            phraseMaker.activity = {
+                turtles: {
+                    ithTurtle: jest.fn(() => ({
+                        singer: { keySignature: 0 }
+                    }))
+                },
+                logo: { synth: { inTemperament: "equal" } },
+                errorMsg: jest.fn()
+            };
+            phraseMaker._rowBlocks = [7];
+            phraseMaker.rowLabels = ["sol"];
+            phraseMaker.rowArgs = [4];
+            phraseMaker._headcols = [buildMockCell()];
+            phraseMaker._labelcols = [buildMockCell()];
+            phraseMaker._noteStored = [];
+            phraseMaker._deps.getDrumName = jest.fn(() => null);
+            phraseMaker._deps.noteIsSolfege = jest.fn(() => false);
+            phraseMaker._deps.isCustomTemperament = jest.fn(() => false);
+            global.window.widgetWindows = {
+                isOpen: jest.fn(() => true)
+            };
+        });
+
+        test("updates the matching row and repaints only that row's cells, without a full rebuild", () => {
+            const initSpy = jest.spyOn(phraseMaker, "init");
+
+            phraseMaker.refreshRowForBlock(7, "la", "", 5);
+
+            expect(phraseMaker.rowLabels[0]).toBe("la");
+            expect(phraseMaker.rowArgs[0]).toBe(5);
+            expect(phraseMaker._labelcols[0].appendChild).toHaveBeenCalled();
+            expect(phraseMaker._noteStored[0]).toBe("la5");
+            // Reuses the existing row-scoped redraw; does not rebuild the whole matrix.
+            expect(initSpy).not.toHaveBeenCalled();
+        });
+
+        test("resolves the row through getNote when a non-natural accidental is selected", () => {
+            phraseMaker._deps.getNote = jest.fn(() => ["la#", 5]);
+
+            phraseMaker.refreshRowForBlock(7, "la", "♯", 5);
+
+            expect(phraseMaker._deps.getNote).toHaveBeenCalledWith(
+                "la♯",
+                5,
+                0,
+                0,
+                false,
+                null,
+                phraseMaker.activity.errorMsg,
+                "equal"
+            );
+            expect(phraseMaker.rowLabels[0]).toBe("la#");
+            expect(phraseMaker.rowArgs[0]).toBe(5);
+        });
+
+        test("is a no-op when the pitch block is not a tracked row", () => {
+            phraseMaker.refreshRowForBlock(999, "la", "", 5);
+
+            expect(phraseMaker.rowLabels).toEqual(["sol"]);
+            expect(phraseMaker.rowArgs).toEqual([4]);
+            expect(phraseMaker._labelcols[0].appendChild).not.toHaveBeenCalled();
+        });
+
+        test("is a no-op when Phrase Maker is not currently open", () => {
+            global.window.widgetWindows.isOpen = jest.fn(() => false);
+
+            phraseMaker.refreshRowForBlock(7, "la", "", 5);
+
+            expect(phraseMaker.rowLabels).toEqual(["sol"]);
+            expect(phraseMaker.rowArgs).toEqual([4]);
+        });
+
+        test("is a no-op when window.widgetWindows itself is unavailable", () => {
+            global.window.widgetWindows = undefined;
+
+            expect(() => phraseMaker.refreshRowForBlock(7, "la", "", 5)).not.toThrow();
+            expect(phraseMaker.rowLabels).toEqual(["sol"]);
+            expect(phraseMaker.rowArgs).toEqual([4]);
+        });
+
+        test("paints a drum icon in both the header and label cells when the note resolves to a drum name", () => {
+            phraseMaker._deps.getDrumName = jest.fn(label =>
+                label === "kick" ? "kick drum" : null
+            );
+
+            phraseMaker.refreshRowForBlock(7, "kick", "", 5);
+
+            expect(phraseMaker._headcols[0].appendChild).toHaveBeenCalled();
+            expect(phraseMaker._labelcols[0].textContent).toBe("kick drum");
+        });
+
+        test("paints a bellset icon in the header cell for a bellset note at octave 4", () => {
+            // "la" is a BELLSETIDX key; octave 4 is the bellset trigger condition.
+            phraseMaker.refreshRowForBlock(7, "la", "", 4);
+
+            expect(phraseMaker._headcols[0].appendChild).toHaveBeenCalledWith(
+                expect.objectContaining({ src: expect.stringContaining("8_bellset_key_") })
+            );
+        });
+
+        test("paints the top-C bellset icon in the header cell for note C at octave 5", () => {
+            phraseMaker.refreshRowForBlock(7, "C", "", 5);
+
+            // document.createElement runs against real jsdom here (the file-level
+            // `global.document` mock doesn't apply inside jsdom's test environment),
+            // so the appended node is a real <img>; only its src is asserted on.
+            const appendedImg = phraseMaker._headcols[0].appendChild.mock.calls[0][0];
+            expect(appendedImg.src).toContain("8_bellset_key_8.svg");
+        });
+
+        test("renders an i18n solfege label with an octave subscript when the note is solfege", () => {
+            phraseMaker._deps.noteIsSolfege = jest.fn(() => true);
+            phraseMaker._deps.i18nSolfege = jest.fn(label => `translated-${label}`);
+            phraseMaker._deps.getNote = jest.fn(() => ["la", 6]);
+
+            // Octave 6 avoids the unrelated bellset header branches (which trigger on 4/5).
+            phraseMaker.refreshRowForBlock(7, "la", "", 6);
+
+            const appendedTextNode = phraseMaker._labelcols[0].appendChild.mock.calls[0][0];
+            expect(appendedTextNode.textContent).toBe("translated-la");
+        });
+
+        test("renders the raw label plus a translated sub-note when using a custom temperament", () => {
+            phraseMaker._deps.isCustomTemperament = jest.fn(() => true);
+            phraseMaker._deps.getNote = jest.fn(() => ["la", 6]);
+
+            phraseMaker.refreshRowForBlock(7, "la", "", 6);
+
+            expect(phraseMaker._deps.getNote).toHaveBeenCalled();
+            const appendedTextNode = phraseMaker._labelcols[0].appendChild.mock.calls[0][0];
+            expect(appendedTextNode.textContent).toBe("la");
+        });
+
+        test("is idempotent across repeated refreshes with the same value", () => {
+            phraseMaker.refreshRowForBlock(7, "la", "", 5);
+            const callsAfterFirst = phraseMaker._labelcols[0].appendChild.mock.calls.length;
+
+            phraseMaker.refreshRowForBlock(7, "la", "", 5);
+
+            expect(phraseMaker.rowLabels[0]).toBe("la");
+            expect(phraseMaker.rowArgs[0]).toBe(5);
+            // Each call repaints the row the same way; it doesn't accumulate state.
+            expect(phraseMaker._labelcols[0].appendChild.mock.calls.length).toBe(
+                callsAfterFirst * 2
+            );
+        });
+
+        test("_repaintRowCells stores the drum name directly when called with a drumblocks condition", () => {
+            // refreshRowForBlock always uses "pitchblocks"; the "drumblocks" noteStored
+            // branch is only reachable via __selectionChanged's internal call, so it's
+            // exercised directly here per the private-helper carve-out.
+            phraseMaker._deps.getDrumName = jest.fn(() => "snare drum");
+            phraseMaker.rowLabels = ["snare"];
+            phraseMaker.rowArgs = [-1];
+
+            phraseMaker._repaintRowCells(0, "drumblocks");
+
+            expect(phraseMaker._noteStored[0]).toBe("snare drum");
+        });
+    });
 });
 
 describe("PhraseMaker.dependencies", () => {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -308,6 +308,187 @@ class PhraseMaker {
     }
 
     /**
+     * Refreshes a single matrix row after its pitch block's value changed
+     * outside the widget (e.g., via the block's own pie menu on the canvas),
+     * so an already-open matrix reflects the new pitch immediately.
+     * No-ops if the matrix is closed or the block is not a tracked row,
+     * matching the note resolution already used by the matrix's own
+     * pitch pie menu in _createColumnPieSubmenu.
+     *
+     * Takes the already-resolved note/accidental/octave rather than a
+     * block id, because the caller (piemenuPitches' exit handler) has
+     * those values on hand at the exact moment of commit; re-deriving
+     * them here would mean re-parsing an already-merged block.value
+     * string back into note+accidental, and would tie this method to
+     * one specific block layout ("pitch" wrapper + connections[1] leaf)
+     * instead of just "here is the row's new value."
+     * @param {number} pitchBlockIndex - Index of the pitch-wrapper block tracked in _rowBlocks.
+     * @param {string} noteValue - The newly selected note/solfege value, without accidental.
+     * @param {string} accidental - The newly selected accidental ("♮" or "" for natural).
+     * @param {number} octave - The newly selected octave.
+     * @returns {void}
+     */
+    refreshRowForBlock(pitchBlockIndex, noteValue, accidental, octave) {
+        if (!window.widgetWindows || !window.widgetWindows.isOpen(this.blockNo)) return;
+
+        const index = this._rowBlocks.indexOf(pitchBlockIndex);
+        if (index === -1) return;
+
+        let noteName = noteValue;
+        let noteOctave = octave;
+        if (accidental !== "♮" && accidental !== "") {
+            const noteObj = this._deps.getNote(
+                noteValue + accidental,
+                octave,
+                0,
+                this.activity.turtles.ithTurtle(0).singer.keySignature,
+                false,
+                null,
+                this.activity.errorMsg,
+                this.activity.logo.synth.inTemperament
+            );
+            noteName = noteObj[0];
+            noteOctave = noteObj[1];
+        }
+
+        this.rowLabels[index] = noteName;
+        this.rowArgs[index] = noteOctave;
+        this._repaintRowCells(index, "pitchblocks");
+    }
+
+    /**
+     * Repaints a single matrix row's header and label cells from the
+     * current rowLabels[index]/rowArgs[index], and refreshes the cached
+     * note text used for export/playback. This is the same row-scoped
+     * redraw already used by the matrix's own pitch/drum pie menu
+     * (see __selectionChanged in _createColumnPieSubmenu), factored out
+     * so it can also be reused by refreshRowForBlock without rebuilding
+     * the whole matrix.
+     * @private
+     * @param {number} index - Row index into rowLabels/rowArgs.
+     * @param {string} condition - "pitchblocks" or "drumblocks".
+     * @returns {void}
+     */
+    _repaintRowCells(index, condition) {
+        let noteObj = [this.rowLabels[index], this.rowArgs[index]];
+
+        let cell = this._headcols[index];
+        if (cell) {
+            const drumName = this._deps.getDrumName(this.rowLabels[index]);
+            const BELLSETIDX = {
+                C: 1,
+                D: 2,
+                E: 3,
+                F: 4,
+                G: 5,
+                A: 6,
+                B: 7,
+                do: 1,
+                re: 2,
+                mi: 3,
+                fa: 4,
+                sol: 5,
+                la: 6,
+                ti: 7
+            };
+            const noteName = this.rowLabels[index];
+            const w = window.innerWidth;
+            const iconSize = PhraseMaker.ICONSIZE * (w / 1200);
+            if (drumName !== null) {
+                cell.textContent = "\u00A0\u00A0";
+                const img = document.createElement("img");
+                img.src = this._deps.getDrumIcon(drumName);
+                img.title = this._(drumName);
+                img.alt = this._(drumName);
+                img.setAttribute("height", iconSize);
+                img.setAttribute("width", iconSize);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+                cell.appendChild(document.createTextNode("\u00A0\u00A0"));
+            } else if (noteName in BELLSETIDX && this.rowArgs[index] === 4) {
+                cell.textContent = "";
+                const img = document.createElement("img");
+                img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
+                img.setAttribute("width", cell.style.width);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+            } else if (noteName === "C" && this.rowArgs[index] === 5) {
+                cell.textContent = "";
+                const img = document.createElement("img");
+                img.src = "images/8_bellset_key_8.svg";
+                img.setAttribute("width", cell.style.width);
+                img.setAttribute("vertical-align", "middle");
+                cell.appendChild(img);
+            }
+        }
+
+        cell = this._labelcols[index];
+        if (cell) {
+            const drumName = this._deps.getDrumName(this.rowLabels[index]);
+            if (drumName !== null) {
+                cell.textContent = this._(drumName);
+                cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
+            } else if (
+                this._deps.noteIsSolfege(this.rowLabels[index]) &&
+                !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
+            ) {
+                cell.textContent = "";
+                cell.appendChild(
+                    document.createTextNode(this._deps.i18nSolfege(this.rowLabels[index]))
+                );
+                const subTitle1 = document.createElement("sub");
+                subTitle1.textContent = this.rowArgs[index].toString();
+                cell.appendChild(subTitle1);
+                noteObj = this._deps.getNote(
+                    this.rowLabels[index],
+                    this.rowArgs[index],
+                    0,
+                    this.activity.turtles.ithTurtle(0).singer.keySignature,
+                    false,
+                    null,
+                    this.activity.errorMsg,
+                    this.activity.logo.synth.inTemperament
+                );
+            } else {
+                if (this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)) {
+                    noteObj = this._deps.getNote(
+                        this.rowLabels[index],
+                        this.rowArgs[index],
+                        0,
+                        this.activity.turtles.ithTurtle(0).singer.keySignature,
+                        false,
+                        null,
+                        this.activity.errorMsg,
+                        this.activity.logo.synth.inTemperament
+                    );
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(this.rowLabels[index]));
+                    const subTitle2 = document.createElement("sub");
+                    subTitle2.textContent = this.rowArgs[index].toString();
+                    cell.appendChild(subTitle2);
+                } else {
+                    cell.textContent = "";
+                    cell.appendChild(document.createTextNode(this.rowLabels[index]));
+                    const subTitle3 = document.createElement("sub");
+                    subTitle3.textContent = this.rowArgs[index].toString();
+                    cell.appendChild(subTitle3);
+                    noteObj = [this.rowLabels[index], this.rowArgs[index]];
+                }
+            }
+        }
+
+        let noteStored = null;
+        const drumName2 = this._deps.getDrumName(this.rowLabels[index]);
+        if (condition === "pitchblocks") {
+            if (noteObj) noteStored = noteObj[0] + noteObj[1];
+        } else if (condition === "drumblocks") {
+            noteStored = drumName2;
+        }
+
+        this._noteStored[index] = noteStored;
+    }
+
+    /**
      * Adds a column block to the PhraseMaker matrix.
      * This method is called when encountering rhythm blocks during matrix creation.
      * @param {number} rhythmBlock - The rhythm block identifier to add to the matrix column.
@@ -2235,120 +2416,7 @@ class PhraseMaker {
                 this.rowLabels[index] = label;
             }
 
-            let cell = this._headcols[index];
-            if (cell) {
-                const drumName = this._deps.getDrumName(this.rowLabels[index]);
-                const BELLSETIDX = {
-                    C: 1,
-                    D: 2,
-                    E: 3,
-                    F: 4,
-                    G: 5,
-                    A: 6,
-                    B: 7,
-                    do: 1,
-                    re: 2,
-                    mi: 3,
-                    fa: 4,
-                    sol: 5,
-                    la: 6,
-                    ti: 7
-                };
-                const noteName = this.rowLabels[index];
-                const w = window.innerWidth;
-                const iconSize = PhraseMaker.ICONSIZE * (w / 1200);
-                if (drumName !== null) {
-                    cell.textContent = "\u00A0\u00A0";
-                    const img = document.createElement("img");
-                    img.src = this._deps.getDrumIcon(drumName);
-                    img.title = this._(drumName);
-                    img.alt = this._(drumName);
-                    img.setAttribute("height", iconSize);
-                    img.setAttribute("width", iconSize);
-                    img.setAttribute("vertical-align", "middle");
-                    cell.appendChild(img);
-                    cell.appendChild(document.createTextNode("\u00A0\u00A0"));
-                } else if (noteName in BELLSETIDX && this.rowArgs[index] === 4) {
-                    cell.textContent = "";
-                    const img = document.createElement("img");
-                    img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
-                    img.setAttribute("width", cell.style.width);
-                    img.setAttribute("vertical-align", "middle");
-                    cell.appendChild(img);
-                } else if (noteName === "C" && this.rowArgs[index] === 5) {
-                    cell.textContent = "";
-                    const img = document.createElement("img");
-                    img.src = "images/8_bellset_key_8.svg";
-                    img.setAttribute("width", cell.style.width);
-                    img.setAttribute("vertical-align", "middle");
-                    cell.appendChild(img);
-                }
-            }
-
-            cell = this._labelcols[index];
-            if (cell) {
-                const drumName = this._deps.getDrumName(this.rowLabels[index]);
-                if (drumName !== null) {
-                    cell.textContent = this._(drumName);
-                    cell.style.fontSize = Math.floor(this._cellScale * 14) + "px";
-                } else if (
-                    this._deps.noteIsSolfege(this.rowLabels[index]) &&
-                    !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
-                ) {
-                    cell.textContent = "";
-                    cell.appendChild(
-                        document.createTextNode(this._deps.i18nSolfege(this.rowLabels[index]))
-                    );
-                    const subTitle1 = document.createElement("sub");
-                    subTitle1.textContent = this.rowArgs[index].toString();
-                    cell.appendChild(subTitle1);
-                    noteObj = this._deps.getNote(
-                        this.rowLabels[index],
-                        this.rowArgs[index],
-                        0,
-                        this.activity.turtles.ithTurtle(0).singer.keySignature,
-                        false,
-                        null,
-                        this.activity.errorMsg,
-                        this.activity.logo.synth.inTemperament
-                    );
-                } else {
-                    if (this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)) {
-                        noteObj = this._deps.getNote(
-                            this.rowLabels[index],
-                            this.rowArgs[index],
-                            0,
-                            this.activity.turtles.ithTurtle(0).singer.keySignature,
-                            false,
-                            null,
-                            this.activity.errorMsg,
-                            this.activity.logo.synth.inTemperament
-                        );
-                        cell.textContent = "";
-                        cell.appendChild(document.createTextNode(this.rowLabels[index]));
-                        const subTitle2 = document.createElement("sub");
-                        subTitle2.textContent = this.rowArgs[index].toString();
-                        cell.appendChild(subTitle2);
-                    } else {
-                        cell.textContent = "";
-                        cell.appendChild(document.createTextNode(this.rowLabels[index]));
-                        const subTitle3 = document.createElement("sub");
-                        subTitle3.textContent = this.rowArgs[index].toString();
-                        cell.appendChild(subTitle3);
-                        noteObj = [this.rowLabels[index], this.rowArgs[index]];
-                    }
-                }
-            }
-
-            let noteStored = null;
-            const drumName2 = this._deps.getDrumName(this.rowLabels[index]);
-            if (condition === "pitchblocks") {
-                if (noteObj) noteStored = noteObj[0] + noteObj[1];
-            } else if (condition === "drumblocks") {
-                noteStored = drumName2;
-            }
-
-            this._noteStored[index] = noteStored;
+            this._repaintRowCells(index, condition);
         };
 
         const __pitchPreview = () => {


### PR DESCRIPTION
Phrase Maker rows are a snapshot captured when the matrix flow block runs; rowLabels/rowArgs are never re-derived afterwards. Changing a pitch block's value from its own canvas pie menu (piemenuPitches) committed the new value to the block but never notified an already-open Phrase Maker, so the matrix kept showing the stale pitch.

Phrase Maker already has a row-scoped redraw for exactly this: its own internal pitch pie menu (_createColumnPieSubmenu's __selectionChanged) resolves a note via getNote() and repaints just that row's header and label cells. That logic is factored out into _repaintRowCells() so it can be shared, and is reused by a new PhraseMaker.refreshRowForBlock(), which piemenuPitches' exit handler now calls when the edited block is a tracked row. This follows the existing refresh pattern already used elsewhere in PhraseMaker; no new redraw mechanism is introduced, and the whole matrix is not rebuilt.

refreshRowForBlock() no-ops unless the widget is currently open (window.widgetWindows.isOpen) and the block is one of its tracked rows (_rowBlocks), so no other widget or block type is affected.