### PR TITLE
Feat/unify widget loading

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -115,6 +115,28 @@ function setupWidgetBlocks(activity) {
     }
 
     /**
+     * Deferred widget loader for construction inside a turtle listener rather
+     * than directly in flow(). Unlike _ensureWidget, there is no "loading"
+     * guard or interruption signal: listener bodies already run once, after
+     * the interpreter has moved on, so there is nothing for an interruption
+     * to interrupt. Shares the same (logo, widgetKey, modules, factory, ...)
+     * argument shape as _ensureWidget so the two loading paths read the same
+     * way at the call site.
+     *
+     * @param {object} logo - The logo object.
+     * @param {string} widgetKey - The key for the widget in the logo object.
+     * @param {string[]} modules - The modules to require.
+     * @param {Function} factory - Builds the widget instance.
+     * @param {Function} [onReady] - Optional callback run after assignment.
+     */
+    function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady) {
+        _lazyRequire(modules, function () {
+            logo[widgetKey] = factory();
+            if (onReady) onReady();
+        });
+    }
+
+    /**
      * Represents a block for controlling sound envelope (ADSR).
      * @extends FlowBlock
      */
@@ -615,10 +637,15 @@ function setupWidgetBlocks(activity) {
             logo.setDispatchBlock(blk, turtle, listenerName);
 
             const __listener = () => {
-                _lazyRequire(MeterWidget.dependencies, function () {
-                    logo.meterWidget = new MeterWidget(activity, blk);
-                    logo.insideMeterWidget = false;
-                });
+                _lazyLoadWidget(
+                    logo,
+                    "meterWidget",
+                    MeterWidget.dependencies,
+                    () => new MeterWidget(activity, blk),
+                    () => {
+                        logo.insideMeterWidget = false;
+                    }
+                );
             };
 
             logo.setTurtleListener(turtle, listenerName, __listener);
@@ -687,10 +714,15 @@ function setupWidgetBlocks(activity) {
             logo.setDispatchBlock(blk, turtle, listenerName);
 
             const __listener = () => {
-                _lazyRequire(Oscilloscope.dependencies, function () {
-                    logo.Oscilloscope = new Oscilloscope(activity);
-                    logo.inOscilloscope = false;
-                });
+                _lazyLoadWidget(
+                    logo,
+                    "Oscilloscope",
+                    Oscilloscope.dependencies,
+                    () => new Oscilloscope(activity),
+                    () => {
+                        logo.inOscilloscope = false;
+                    }
+                );
             };
 
             logo.setTurtleListener(turtle, listenerName, __listener);
@@ -746,10 +778,15 @@ function setupWidgetBlocks(activity) {
             logo.setDispatchBlock(blk, turtle, listenerName);
 
             const __listener = () => {
-                _lazyRequire(ModeWidget.dependencies, function () {
-                    logo.modeWidget = new ModeWidget(activity);
-                    logo.insideModeWidget = false;
-                });
+                _lazyLoadWidget(
+                    logo,
+                    "modeWidget",
+                    ModeWidget.dependencies,
+                    () => new ModeWidget(activity),
+                    () => {
+                        logo.insideModeWidget = false;
+                    }
+                );
             };
 
             logo.setTurtleListener(turtle, listenerName, __listener);

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -132,7 +132,7 @@ function setupWidgetBlocks(activity) {
     function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady) {
         _lazyRequire(modules, function () {
             logo[widgetKey] = factory();
-            if (onReady) onReady();
+            onReady?.();
         });
     }
 

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -654,23 +654,25 @@ describe("setupWidgetBlocks", () => {
     });
 
     describe("Widget dependency metadata wiring", () => {
-        // _ensureWidget()/_lazyRequire() are local closures inside
+        // _ensureWidget()/_lazyLoadWidget() are local closures inside
         // setupWidgetBlocks() and aren't exported, so their `modules`
         // argument can't be intercepted at runtime without changing the
         // loader itself, and in this non-AMD test environment `_lazyRequire`
-        // ignores `modules` entirely, so no behavioural test can observe it
-        // either. As a last resort, a single source-text check confirms
-        // every call site reads modules from the widget's own static
-        // `dependencies` rather than a hardcoded literal; kept to one test
-        // (not one per widget) since it's the wiring itself being checked,
-        // not per-widget behaviour -- the behavioural tests below cover that.
+        // (which both of them delegate to) ignores `modules` entirely, so no
+        // behavioural test can observe it either. As a last resort, a single
+        // source-text check confirms every call site reads modules from the
+        // widget's own static `dependencies` rather than a hardcoded
+        // literal; kept to one test (not one per widget) since it's the
+        // wiring itself being checked, not per-widget behaviour -- the
+        // behavioural tests below cover that.
         //
         // Caveat: this relies on source-text matching, which can become
         // brittle during future refactors (e.g. reformatting the
-        // _ensureWidget calls). If dependency resolution is ever exposed
-        // through a helper or otherwise made observable behaviourally,
-        // prefer replacing these regex assertions with behavioural tests.
-        it("every _ensureWidget/_lazyRequire call site reads modules from its widget's dependencies", () => {
+        // _ensureWidget/_lazyLoadWidget calls). If dependency resolution is
+        // ever exposed through a helper or otherwise made observable
+        // behaviourally, prefer replacing these regex assertions with
+        // behavioural tests.
+        it("every _ensureWidget/_lazyLoadWidget call site reads modules from its widget's dependencies", () => {
             const widgetBlocksSource = require("fs").readFileSync(
                 require("path").join(__dirname, "..", "WidgetBlocks.js"),
                 "utf8"
@@ -692,7 +694,11 @@ describe("setupWidgetBlocks", () => {
                 ["legoWidget", "LegoWidget"],
                 ["aiDebugger", "AIDebuggerWidget"]
             ];
-            const lazyRequireSites = ["MeterWidget", "Oscilloscope", "ModeWidget"];
+            const lazyLoadWidgetSites = [
+                ["meterWidget", "MeterWidget"],
+                ["Oscilloscope", "Oscilloscope"],
+                ["modeWidget", "ModeWidget"]
+            ];
 
             const notWired = [];
             for (const [widgetKey, className] of ensureWidgetSites) {
@@ -705,14 +711,13 @@ describe("setupWidgetBlocks", () => {
                     );
                 }
             }
-            for (const className of lazyRequireSites) {
-                if (
-                    !new RegExp(`_lazyRequire\\(${className}\\.dependencies,`).test(
-                        widgetBlocksSource
-                    )
-                ) {
+            for (const [widgetKey, className] of lazyLoadWidgetSites) {
+                const callSite = new RegExp(
+                    `_lazyLoadWidget\\(\\s*logo,\\s*"${widgetKey}",\\s*${className}\\.dependencies,`
+                );
+                if (!callSite.test(widgetBlocksSource)) {
                     notWired.push(
-                        `_lazyRequire(...) for ${className} should read ${className}.dependencies`
+                        `_lazyLoadWidget("${widgetKey}") should read ${className}.dependencies`
                     );
                 }
             }

--- a/js/widgets/README.md
+++ b/js/widgets/README.md
@@ -25,11 +25,35 @@ imported in `js/activity.js`.
 
 3. **Declare the widget's lazy-load dependencies:**
    If your widget is loaded lazily by `js/blocks/WidgetBlocks.js` (via
-   `_ensureWidget()` or `_lazyRequire()`), declare its AMD module id(s) as a
+   `_ensureWidget()` or `_lazyLoadWidget()`), declare its AMD module id(s) as a
    `dependencies` property on the widget definition itself, rather than
    passing a literal array at the call site. The widget definition is the
    single source of truth for this list — `WidgetBlocks.js` reads
    `Widget.dependencies` instead of maintaining its own copy.
+
+    `WidgetBlocks.js` offers two loading helpers, both sharing the same
+    `(logo, widgetKey, modules, factory, ...)` argument shape and both
+    built on the same AMD/CommonJS-aware `_lazyRequire()` primitive
+    underneath — pick whichever matches where your block constructs its
+    widget:
+
+    - **`_ensureWidget(logo, widgetKey, modules, factory, turtle, blk, receivedArg)`**
+      — for widgets constructed directly in `flow()`. Guards against
+      concurrent loads, returns an interruption signal `[null, 0, true]`
+      while the widget is loading, and calls `logo.runFromBlockNow(...)`
+      once it's ready so the interpreter re-enters the block. Use this when
+      the rest of the block's `flow()` logic depends on the widget already
+      existing.
+    - **`_lazyLoadWidget(logo, widgetKey, modules, factory, onReady)`**
+      — for widgets constructed inside a turtle listener (registered via
+      `logo.setTurtleListener`) rather than in `flow()` itself. No guard or
+      interruption signal: the listener already runs once, after the
+      interpreter has moved on, so there's nothing for an interruption to
+      interrupt. `onReady` runs after the widget is assigned to `logo`, for
+      any cleanup that used to follow the assignment inline.
+
+    Do not write a third, ad hoc lazy-loading pattern at a new call site —
+    route through one of these two.
 
     For an ES6 class widget, use a `static` field:
 

--- a/js/widgets/README.md
+++ b/js/widgets/README.md
@@ -43,14 +43,17 @@ imported in `js/activity.js`.
       while the widget is loading, and calls `logo.runFromBlockNow(...)`
       once it's ready so the interpreter re-enters the block. Use this when
       the rest of the block's `flow()` logic depends on the widget already
-      existing.
+      existing. This is the standard loading path — most widgets use it,
+      e.g. `TemperamentWidget`.
     - **`_lazyLoadWidget(logo, widgetKey, modules, factory, onReady)`**
       — for widgets constructed inside a turtle listener (registered via
       `logo.setTurtleListener`) rather than in `flow()` itself. No guard or
       interruption signal: the listener already runs once, after the
       interpreter has moved on, so there's nothing for an interruption to
       interrupt. `onReady` runs after the widget is assigned to `logo`, for
-      any cleanup that used to follow the assignment inline.
+      any cleanup that used to follow the assignment inline. Used by
+      listener-deferred widgets that load only once their turtle listener
+      fires, e.g. `MeterWidget`, `Oscilloscope`, and `ModeWidget`.
 
     Do not write a third, ad hoc lazy-loading pattern at a new call site —
     route through one of these two.


### PR DESCRIPTION
## Description

This PR continues the widget loading refactor by standardising the loading path for widgets that already expose dependency metadata.

The dependency metadata architecture was introduced previously, and `WidgetBlocks.js` now consumes that metadata. This PR builds on that work by unifying the remaining listener-deferred widget loading logic while preserving existing runtime behaviour.

## PR Category

- Refactor - Improves maintainability with no functional changes

## Changes

- Introduced a shared `_lazyLoadWidget()` helper for listener-deferred widget loading.
- Migrated `MeterWidget`, `Oscilloscope`, and `ModeWidget` from duplicated `_lazyRequire()` blocks to `_lazyLoadWidget()`.
- Preserved the existing loading behaviour, lazy loading, and AMD/CommonJS compatibility.
- Updated `WidgetBlocks` tests to verify the new loading helper usage.
- Updated `js/widgets/README.md` to document the supported widget loading patterns.

## Scope

This PR intentionally only affects the 18 widgets that already expose `.dependencies` metadata.

The following remain intentionally out of scope:

- `StatusMatrix`
- `HelpWidget`
- `JSEditor`
- `StatsWindow`
- `PluginDialog`
- `TunerDisplay`

These widgets are not part of the current WidgetBlocks lazy-loading architecture and do not expose dependency metadata. Bringing them into the same system would require introducing new metadata and expanding the scope beyond this refactor.

The existing `AIWidget` listener-based loading path is also intentionally unchanged because it represents a separate behavioural issue rather than a loading-path duplication.

## Why

Previously, listener-deferred widgets duplicated the same `_lazyRequire()` loading pattern inline.

By introducing a dedicated helper:

- duplicated loading logic is removed,
- listener-based widget loading becomes consistent,
- future maintenance becomes simpler,
- runtime behaviour remains unchanged.

## Testing

- Full Jest widget and WidgetBlocks test suite passes.
- ESLint passes on all modified files.
- Existing loading behaviour is preserved.
- Updated tests verify the unified loading helper.

## Notes

This PR intentionally does **not** redesign the widget loading architecture or introduce new dependency metadata. It is a small, incremental refactor that standardises the existing listener-deferred loading path while preserving behaviour.