### PR TITLE
fix(a11y): add accessible name to paste button

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,7 +485,13 @@
                             tabindex="-1"
                         />
                         <ul class="matches"></ul>
-                        <input onkeypress="doPaste()" type="submit" value="" tabindex="-1" />
+                        <input
+                            onkeypress="doPaste()"
+                            type="submit"
+                            value=""
+                            tabindex="-1"
+                            aria-label="Paste"
+                        />
                     </div>
 
                     <div id="myProgress" tabindex="-1">


### PR DESCRIPTION
## Summary

The paste submit button in `index.html` had `value=""` with no `aria-label`
or associated label. Screen readers announced it as an unlabeled button.

Added `aria-label="Paste"` to give the button a discernible name
(WCAG 4.1.2 — Name, Role, Value).

Removed the CSS change from this PR per review feedback — the global
`*:focus-visible` rule already uses `!important`, so the `outline: none`
in `#search:focus` was never overriding it.

Related to #6608

## PR Category
- [x] Bug fix
- [ ] New feature
- [ ] Documentation/Localization
- [ ] Code Refactor
- [ ] Test

## Testing

- [x] `npx prettier --check index.html` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 204 suites, 7,177 tests, 0 failures
