### PR TITLE
refactor: remove dead doPaste submit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,7 +485,6 @@
                             tabindex="-1"
                         />
                         <ul class="matches"></ul>
-                        <input onkeypress="doPaste()" type="submit" value="" tabindex="-1" />
                     </div>
 
                     <div id="myProgress" tabindex="-1">


### PR DESCRIPTION
## Summary

This removes the dead submit button from the paste section in `index.html`. 

As noted in PR #7929, the `doPaste()` function is not defined anywhere in the codebase. The submit button itself was invisible (`value=""`) and unreachable via keyboard (`tabindex="-1"`). The actual paste functionality works perfectly without it since it's driven by `keyboard-controller.js` (catching Ctrl+V) and `pastebox.js` (the canvas UI).

## PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [x] Chore

## Testing

- [x] `npx prettier --check index.html` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 204 suites, 7,206 tests, 0 failures
