### PR TITLE
fix(widgets): eliminate duplicate init() in status and reflection blocks

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -1847,12 +1847,6 @@ function setupWidgetBlocks(activity) {
             };
 
             const structuralFields = collectStatusFields();
-            if (!logo.statusMatrix.isOpen || logo.statusFields.length === 0) {
-                logo.statusFields = structuralFields.slice();
-            }
-
-            dedupeStatusFields();
-            logo.statusMatrix.init(activity);
             logo.statusFields = []; // Clear for the actual interpreter run
 
             logo.inStatusMatrix = true;
@@ -1982,7 +1976,6 @@ function setupWidgetBlocks(activity) {
             );
             if (interruption) return interruption;
 
-            logo.reflection.init(activity);
             logo.statusFields = [];
 
             logo.inReflectionMatrix = true;

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -154,7 +154,7 @@ global.PitchStaircase = jest.fn();
 global.PitchStaircase.dependencies = ["widgets/pitchstaircase"];
 global.RhythmRuler = jest.fn();
 global.RhythmRuler.dependencies = ["widgets/rhythmruler"];
-global.ReflectionMatrix = jest.fn();
+global.ReflectionMatrix = jest.fn(() => ({ init: jest.fn() }));
 global.ReflectionMatrix.dependencies = ["widgets/reflection"];
 global.LegoWidget = jest.fn();
 global.LegoWidget.dependencies = ["widgets/legobricks"];
@@ -594,7 +594,10 @@ describe("setupWidgetBlocks", () => {
 
             status.flow(["childBlk"], logo, 0, "statusBlk");
 
-            expect(initSnapshots[0]).toEqual(["3:outputtools", "6:beatvalue"]);
+            // The widget is only built once the listener fires at the end
+            // of the clamp, not eagerly inside flow() itself.
+            expect(logo.statusMatrix.init).not.toHaveBeenCalled();
+
             const listener = logo.setTurtleListener.mock.calls[0][2];
             logo.statusFields = [
                 [3, "outputtools"],
@@ -605,7 +608,8 @@ describe("setupWidgetBlocks", () => {
 
             listener();
 
-            expect(initSnapshots[1]).toEqual(["3:outputtools", "6:beatvalue"]);
+            expect(logo.statusMatrix.init).toHaveBeenCalledTimes(1);
+            expect(initSnapshots[0]).toEqual(["3:outputtools", "6:beatvalue"]);
         });
 
         it("rebuilds status fields from the stack when runtime registration is empty", () => {
@@ -642,14 +646,48 @@ describe("setupWidgetBlocks", () => {
 
             status.flow(["childBlk"], logo, 0, "statusBlk");
 
-            expect(initSnapshots[0]).toEqual(["field1:beatvalue"]);
+            // The widget is only built once the listener fires at the end
+            // of the clamp, not eagerly inside flow() itself.
+            expect(logo.statusMatrix.init).not.toHaveBeenCalled();
 
             const listener = logo.setTurtleListener.mock.calls[0][2];
             logo.statusFields = [];
 
             listener();
 
-            expect(initSnapshots[1]).toEqual(["field1:beatvalue"]);
+            expect(logo.statusMatrix.init).toHaveBeenCalledTimes(1);
+            expect(initSnapshots[0]).toEqual(["field1:beatvalue"]);
+        });
+    });
+
+    describe("ReflectionBlock", () => {
+        it("does not initialize the widget until its listener fires", () => {
+            const reflection = getBlock("reflection");
+
+            // First call: widget lazy-loads, flow() returns before reaching init().
+            reflection.flow(["childBlk"], logo, 0, "reflBlk", "received");
+            // Second call: widget is now cached, flow() proceeds.
+            reflection.flow(["childBlk"], logo, 0, "reflBlk");
+
+            expect(logo.reflection.init).not.toHaveBeenCalled();
+
+            const listener = logo.setTurtleListener.mock.calls[0][2];
+            listener();
+
+            expect(logo.reflection.init).toHaveBeenCalledTimes(1);
+        });
+
+        it("constructs the widget once and initializes once per open", () => {
+            const reflection = getBlock("reflection");
+
+            reflection.flow(["childBlk"], logo, 0, "reflBlk", "received");
+            reflection.flow(["childBlk"], logo, 0, "reflBlk");
+            const listener = logo.setTurtleListener.mock.calls[0][2];
+            listener();
+
+            expect(global.ReflectionMatrix).toHaveBeenCalledTimes(1);
+            expect(logo.reflection.init).toHaveBeenCalledTimes(1);
+            expect(logo.inReflectionMatrix).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Description

This PR fixes duplicate widget initialization for `StatusMatrix` and `ReflectionMatrix`.

During an audit of the widget initialization lifecycle, these two widget blocks were found to invoke `init()` twice during a single execution:
- once directly from `flow()`
- again from the registered turtle listener

Unlike the other `_ensureWidget()`-based widgets, this resulted in redundant initialization work within the same interpreter run.

## PR Category

- [x] Bug Fix – Eliminates unintended duplicate widget initialization while preserving existing behavior.

## Changes

- Removed the redundant `init()` call from `StatusBlock.flow()`.
- Removed the redundant `init()` call from `ReflectionBlock.flow()`.
- Kept initialization in the turtle listener, matching the existing pattern used by other widget blocks.
- Removed the now-unused `StatusBlock` field preparation logic that only supported the deleted initialization path.
- Added and updated Jest tests to verify that:
  - `init()` is not called before the listener executes.
  - `init()` is called exactly once.
  - Existing widget behavior remains unchanged.

## Why

`StatusMatrix` and `ReflectionMatrix` were the only widget blocks performing duplicate initialization during a single interpreter execution.

Removing the redundant call:

- eliminates unnecessary work,
- prevents duplicate initialization,
- avoids duplicate DOM/listener setup,
- aligns these widgets with the lifecycle already used throughout `WidgetBlocks.js`,
- preserves existing runtime behavior.

## Testing

- Updated existing `StatusBlock` tests.
- Added new `ReflectionBlock` initialization tests.
- Full Jest suite passing (`204/204` suites, `7226/7226` tests).
- ESLint passes.
- Prettier passes on modified files.

## Notes

This PR intentionally does **not** redesign the widget loading architecture. It only removes redundant initialization while preserving the existing lazy-loading and listener-based lifecycle.