### PR TITLE
refactor(widgets): defer TemperamentWidget DOM creation to init()

### DIFF
--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -268,6 +268,42 @@ describe("TemperamentWidget basic tests", () => {
     });
 
     test("edit sets editMode to null and prepares UI", () => {
+        // edit() reads temperamentTableDiv, which only exists once init(activity)
+        // has run, so the widget must be initialized first (matching production
+        // usage, where edit() is only reachable via a button created in init()).
+        global.window.widgetWindows = {
+            windowFor: jest.fn(() => ({
+                clear: jest.fn(),
+                show: jest.fn(),
+                getWidgetBody: jest.fn(() => ({ append: jest.fn(), style: {} })),
+                addButton: jest.fn(() => ({
+                    onclick: null,
+                    getElementsByTagName: jest.fn(() => [{}])
+                })),
+                sendToCenter: jest.fn()
+            }))
+        };
+        global.buildScale = jest.fn(() => [["C"], []]);
+        global.getNoteFromInterval = jest.fn(() => ["C", 4]);
+        global.getTemperament = jest.fn(() => ({
+            interval: [],
+            pitchNumber: 1,
+            0: 1,
+            1: 2
+        }));
+
+        widget.inTemperament = "equal";
+        widget.scale = ["C", "Major"];
+        widget.init({
+            errorMsg: jest.fn(),
+            logo: {
+                synth: {
+                    startingPitch: "C4",
+                    _getFrequency: jest.fn(() => 440)
+                }
+            }
+        });
+
         widget._logo = {
             synth: {
                 setMasterVolume: jest.fn(),
@@ -608,6 +644,43 @@ describe("TemperamentWidget basic tests", () => {
     });
 
     test("_graphOfNotes renders table view", () => {
+        // _graphOfNotes() reads temperamentTableDiv, which only exists once
+        // init(activity) has run, so the widget must be initialized first
+        // (matching production usage, where _graphOfNotes() is only reachable
+        // via a button created in init()).
+        global.window.widgetWindows = {
+            windowFor: jest.fn(() => ({
+                clear: jest.fn(),
+                show: jest.fn(),
+                getWidgetBody: jest.fn(() => ({ append: jest.fn(), style: {} })),
+                addButton: jest.fn(() => ({
+                    onclick: null,
+                    getElementsByTagName: jest.fn(() => [{}])
+                })),
+                sendToCenter: jest.fn()
+            }))
+        };
+        global.buildScale = jest.fn(() => [["C"], []]);
+        global.getNoteFromInterval = jest.fn(() => ["C", 4]);
+        global.getTemperament = jest.fn(() => ({
+            interval: [],
+            pitchNumber: 1,
+            0: 1,
+            1: 2
+        }));
+
+        widget.inTemperament = "equal";
+        widget.scale = ["C", "Major"];
+        widget.init({
+            errorMsg: jest.fn(),
+            logo: {
+                synth: {
+                    startingPitch: "C4",
+                    _getFrequency: jest.fn(() => 440)
+                }
+            }
+        });
+
         widget.toggleNotesButton = jest.fn();
         widget.notesCircle = {
             removeWheel: jest.fn()

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -53,10 +53,12 @@ function TemperamentWidget() {
     const ICONSIZE = 32;
 
     /**
-     * Reference to the temperament table div.
+     * Reference to the temperament table div. Created in init() since it
+     * is not needed (and should not be attached to the DOM) until the
+     * widget is actually opened.
      * @type {HTMLElement}
      */
-    const temperamentTableDiv = document.createElement("div");
+    let temperamentTableDiv;
 
     /**
      * Reference to the temperament cell.
@@ -2591,6 +2593,8 @@ function TemperamentWidget() {
 
         const w = window.innerWidth;
         this._cellScale = w / 1200;
+
+        temperamentTableDiv = document.createElement("div");
 
         const widgetWindow = window.widgetWindows.windowFor(this, "temperament");
         this.widgetWindow = widgetWindow;


### PR DESCRIPTION
## Description

This PR continues the widget lifecycle cleanup by making `TemperamentWidget` follow the same constructor/`init(activity)` separation already used by many other widgets.

Previously, the constructor eagerly created a detached DOM element (`temperamentTableDiv`) even though it was only used after `init(activity)` was called. This PR defers that DOM creation into `init(activity)`, keeping the constructor focused on state initialization while preserving runtime behavior.

## PR Category

**Refactor** Improves maintainability with no functional changes.

## Changes

- Moved creation of `temperamentTableDiv` from the constructor into `init(activity)`.
- Kept the constructor responsible only for state initialization.
- Updated `TemperamentWidget` tests to initialize the widget before calling `edit()` and `_graphOfNotes()`, matching the production lifecycle.
- Preserved existing widget loading and runtime behavior.

## Why

The widget lifecycle audit found that `TemperamentWidget` was the only widget with a small, low-risk lifecycle improvement.

Previously:
- Constructor performed DOM creation.
- `init(activity)` attached the element and completed widget initialization.

Now:
- Constructor initializes state only.
- `init(activity)` performs DOM creation together with the rest of the UI setup.

This aligns `TemperamentWidget` with the project's preferred widget lifecycle while keeping behavior unchanged.

## Testing

- ✅ `temperament.test.js` — 54/54 tests passing
- ✅ Full widget test suite — 29 suites, 1459 tests passing
- ✅ Full Jest suite — 204 suites, 7224 tests passing
- ✅ ESLint clean
- ✅ Prettier clean

## Notes

Production behavior is unchanged because all runtime code paths initialize the widget through `init(activity)` before any methods that depend on `temperamentTableDiv` are invoked. The updated tests now reflect this intended lifecycle rather than relying on constructor-side DOM creation.