### PR TITLE
Refactor: Migrate ARG_LIKE_BLOCKS to argumentLike capability metadata

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -265,6 +265,44 @@ describe("Block Foundation", () => {
             expect(block.hasValueDrivenLabel()).toBe(false);
         });
 
+        describe("isArgumentLikeBlock()", () => {
+            it("should return true for a normal value block (style 'value' / isArgBlock())", () => {
+                mockProtoBlock.name = "number";
+                mockProtoBlock.style = "value";
+                mockProtoBlock.capabilities = Object.create(null);
+
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.isArgumentLikeBlock()).toBe(true);
+            });
+
+            it("should return false for a normal command block", () => {
+                mockProtoBlock.name = "forward";
+                mockProtoBlock.style = "command";
+                mockProtoBlock.capabilities = Object.create(null);
+
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.isArgumentLikeBlock()).toBe(false);
+            });
+
+            it("should return true for doArg block which has argumentLike capability", () => {
+                mockProtoBlock.name = "doArg";
+                mockProtoBlock.style = "flow";
+                mockProtoBlock.capabilities = { argumentLike: true };
+
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.isArgumentLikeBlock()).toBe(true);
+            });
+
+            it("should return true for makeblock block which has argumentLike capability", () => {
+                mockProtoBlock.name = "makeblock";
+                mockProtoBlock.style = "left";
+                mockProtoBlock.capabilities = { argumentLike: true };
+
+                const block = new Block(mockProtoBlock, mockBlocks);
+                expect(block.isArgumentLikeBlock()).toBe(true);
+            });
+        });
+
         describe("discreteChoice capability and _usePiemenu()", () => {
             it("hasCapability('discreteChoice') should return true when configured in metadata", () => {
                 mockProtoBlock.capabilities.discreteChoice = true;

--- a/js/block.js
+++ b/js/block.js
@@ -120,13 +120,6 @@ const COLLAPSIBLES = [
 ];
 
 /**
- * List of blocks that behave like argument blocks even though they are not
- * strictly classified as arg/value blocks.
- * @type {string[]}
- */
-const ARG_LIKE_BLOCKS = ["doArg", "calcArg", "namedcalcArg", "makeblock"];
-
-/**
  * List of block types whose names should be widened.
  * @type {string[]}
  */
@@ -2119,7 +2112,7 @@ class Block {
      * @returns {boolean} - True if the block is argument-like, false otherwise.
      */
     isArgumentLikeBlock() {
-        return this.isArgBlock() || ARG_LIKE_BLOCKS.includes(this.name);
+        return this.isArgBlock() || this.hasCapability("argumentLike");
     }
 
     /**

--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -505,6 +505,7 @@ function setupActionBlocks(activity) {
          */
         constructor() {
             super("namedcalcArg");
+            this.setCapability("argumentLike");
 
             /**
              * Sets the palette for the block.
@@ -597,6 +598,7 @@ function setupActionBlocks(activity) {
          */
         constructor() {
             super("doArg");
+            this.setCapability("argumentLike");
 
             /**
              * Sets the palette for the block.
@@ -692,6 +694,7 @@ function setupActionBlocks(activity) {
          */
         constructor() {
             super("calcArg");
+            this.setCapability("argumentLike");
 
             /**
              * Sets the palette for the block.

--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -1140,6 +1140,7 @@ function setupProgramBlocks(activity) {
          */
         constructor() {
             super("makeblock");
+            this.setCapability("argumentLike");
             this.setPalette("program", activity);
             this.setHelpString([
                 _("The Make block block creates a new block."),

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -42,6 +42,15 @@ class BaseBlock {
         this.size = 1;
         this.lang = "en";
         this.hidden = false;
+        this.capabilities = {};
+    }
+
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    getCapability(name) {
+        return this.capabilities[name];
     }
 
     setPalette(palette) {

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -48,6 +48,15 @@ class BaseBlock {
         this.size = 1;
         this.lang = "en";
         this.hidden = false;
+        this.capabilities = {};
+    }
+
+    setCapability(name, value = true) {
+        this.capabilities[name] = !!value;
+    }
+
+    getCapability(name) {
+        return this.capabilities[name];
     }
 
     setPalette(palette) {


### PR DESCRIPTION
## Summary

This PR migrates the legacy `ARG_LIKE_BLOCKS` list to the `argumentLike` capability.

### Changes

- Removed the `ARG_LIKE_BLOCKS` list.
- Added the `argumentLike` capability to the corresponding block definitions.
- Updated `isArgumentLikeBlock()` to use capability metadata.
- Added and updated unit tests. 

## PR Category
- [x] feature
- [x] tests 