### PR TITLE
fix: resolve execution-depth leak in iteration-budget guard

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1717,6 +1717,31 @@ describe("Logo runFromBlockNow", () => {
             expect(global.performanceTracker.enterBlock).toHaveBeenCalledTimes(1);
         });
 
+        test("profiling exits the block when the iteration-budget guard trips", () => {
+            let now = 0;
+            global.performanceTracker = {
+                isEnabled: () => true,
+                enterBlock: jest.fn(),
+                exitBlock: jest.fn(),
+                disable: jest.fn()
+            };
+            global.performance = {
+                now: jest.fn(() => {
+                    now += 5;
+                    return now;
+                })
+            };
+
+            logo._iterationBudget = 1;
+            logo.blockList = [makeFlowBlock("noop")];
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+            expect(mockActivity.errorMsg).toHaveBeenCalled();
+            expect(global.performanceTracker.enterBlock).toHaveBeenCalledTimes(1);
+            expect(global.performanceTracker.exitBlock).toHaveBeenCalledTimes(1);
+        });
+
         test("profiling on exits the block when the flow does not return early", () => {
             global.performanceTracker = {
                 isEnabled: () => true,

--- a/js/logo.js
+++ b/js/logo.js
@@ -1837,6 +1837,7 @@ class Logo {
             logo._iterationBudget = logo._MAX_ITERATIONS + 1;
             if (profilingEnabled) {
                 Logo._recordBlockTiming(logo, blk, profilingStart);
+                performanceTracker.exitBlock();
             }
             return;
         }


### PR DESCRIPTION
Description

The performance profiler's execution-depth counter (used to compute
maxDepth in the dev-only performance stats) is incremented via
tracker.enterBlock() unconditionally at the top of runFromBlockNow() in
js/logo.js whenever profiling is enabled. Every return path in that
function is supposed to call the matching tracker.exitBlock() before
returning. The "infinite loop detected" guard (triggered when
logo._iterationBudget is exhausted) was missing this call, so the depth
counter leaked upward every time that guard fired and was never
decremented back down for the rest of the run -- silently corrupting the
maxDepth value reported in the performance console output.

Fix

* Added the missing `tracker.exitBlock()` call to the iteration-budget-
  exceeded early-return branch in runFromBlockNow() (js/logo.js), matching
  the enterBlock()/exitBlock() pairing used on every other return path in
  the function.

PR Category

- [x] Bug Fix

Changes Made

* Modified `js/logo.js` (added `tracker.exitBlock()` call in the
  infinite-loop-detection early-return branch of `runFromBlockNow()`)
* Modified `js/__tests__/logo.test.js` (added regression test
  "profiling exits the block when the iteration-budget guard trips" to
  the existing `profiling` describe block, verifying enterBlock/exitBlock
  stay balanced even when the infinite-loop guard trips)

Testing Performed

* `npm run lint` — passes with 0 errors
* `npx prettier --check .` — passes
* `npm test` — all tests passed, including the new regression test in
  `logo.test.js`; confirmed the new test fails on the pre-fix code and
  passes after the fix
