### PR TITLE
test: add unit tests for _createCache and updateCache in block and turtle

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -66,8 +66,11 @@ global._ = jest.fn(str => str);
 global.last = jest.fn(arr => (arr && arr.length > 0 ? arr[arr.length - 1] : null));
 global.delayExecution = jest.fn().mockResolvedValue(null);
 global.getTextWidth = jest.fn().mockReturnValue(100);
-global.base64Encode = jest.fn(str => str);
-global.retryWithBackoff = jest.fn(({ onSuccess }) => onSuccess());
+global.retryWithBackoff = jest.fn(async ({ check, onSuccess }) => {
+    const res = check ? check() : true;
+    if (onSuccess) await onSuccess(res);
+    return res;
+});
 
 // Mock window/global helpers
 global.window = {
@@ -727,6 +730,69 @@ describe("Block Foundation", () => {
             b.disconnectedHighlightBitmap = null;
             b.show();
             expect(b.container.visible).toBe(true);
+        });
+    });
+
+    describe("Cache Management (_createCache & updateCache)", () => {
+        it("_createCache should query container bounds, cache container, and call callback", async () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            const mockBounds = { x: 10, y: 20, width: 200, height: 100 };
+            block.container = {
+                getBounds: jest.fn().mockReturnValue(mockBounds),
+                cache: jest.fn()
+            };
+            const callback = jest.fn();
+            const args = ["arg1", "arg2"];
+
+            await block._createCache(callback, args);
+
+            expect(block.bounds).toEqual(mockBounds);
+            expect(block.container.cache).toHaveBeenCalledWith(10, 20, 200, 100);
+            expect(callback).toHaveBeenCalledWith(block, args);
+        });
+
+        it("_createCache should trigger regenerateArtwork on retry callback", async () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            block.regenerateArtwork = jest.fn();
+
+            // Mock retryWithBackoff to invoke onRetry
+            global.retryWithBackoff.mockImplementationOnce(async ({ onRetry, onSuccess }) => {
+                if (onRetry) onRetry();
+                if (onSuccess) await onSuccess({ x: 0, y: 0, width: 50, height: 50 });
+            });
+
+            block.container = {
+                getBounds: jest.fn().mockReturnValue({ x: 0, y: 0, width: 50, height: 50 }),
+                cache: jest.fn()
+            };
+
+            await block._createCache(jest.fn(), []);
+
+            expect(block.regenerateArtwork).toHaveBeenCalledWith(true, []);
+        });
+
+        it("updateCache should resolve immediately if container has no bitmapCache", async () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            block.container = { bitmapCache: null };
+
+            const result = await block.updateCache();
+
+            expect(result).toBeUndefined();
+            expect(global.retryWithBackoff).not.toHaveBeenCalled();
+        });
+
+        it("updateCache should update container cache and refresh canvas on success", async () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            block.bounds = { x: 0, y: 0, width: 100, height: 50 };
+            block.container = {
+                bitmapCache: {},
+                updateCache: jest.fn()
+            };
+
+            await block.updateCache();
+
+            expect(block.container.updateCache).toHaveBeenCalled();
+            expect(mockBlocks.activity.refreshCanvas).toHaveBeenCalled();
         });
     });
 });

--- a/js/__tests__/turtle.test.js
+++ b/js/__tests__/turtle.test.js
@@ -249,4 +249,41 @@ describe("Turtle", () => {
             expect(turtle.butNotThese).toEqual({});
         });
     });
+
+    describe("Cache Management (_createCache & updateCache)", () => {
+        beforeEach(() => {
+            global.retryWithBackoff = jest.fn(async ({ check, onSuccess, onRetry }) => {
+                const res = check ? check() : true;
+                if (onRetry) onRetry(0);
+                if (onSuccess) await onSuccess(res);
+                return res;
+            });
+        });
+
+        it("_createCache should get bounds and cache container", async () => {
+            const mockBounds = { x: 5, y: 15, width: 80, height: 80 };
+            turtle.container = {
+                getBounds: jest.fn().mockReturnValue(mockBounds),
+                cache: jest.fn()
+            };
+
+            await turtle._createCache();
+
+            expect(turtle.bounds).toEqual(mockBounds);
+            expect(turtle.container.cache).toHaveBeenCalledWith(5, 15, 80, 80);
+        });
+
+        it("updateCache should update container cache and refresh canvas", async () => {
+            turtle.bounds = { x: 0, y: 0, width: 100, height: 100 };
+            turtle.container = {
+                bitmapCache: {},
+                updateCache: jest.fn()
+            };
+
+            await turtle.updateCache();
+
+            expect(turtle.container.updateCache).toHaveBeenCalled();
+            expect(mockActivity.refreshCanvas).toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
## Description

Adds dedicated unit tests for `_createCache()` and `updateCache()` in `js/__tests__/block.test.js` and `js/__tests__/turtle.test.js`. 

While `retryWithBackoff.js` provides shared exponential backoff retry mechanics for canvas rendering and container bounds checks, its core callers (`Block` in `js/block.js` and `Turtle` in `js/turtle.js`) previously lacked unit test coverage for their caching methods.

## Related Issue

N/A

## PR Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/__tests__/block.test.js`**:
  - Added unit test suite `describe("Cache Management (_createCache & updateCache)")` testing `_createCache()` (bounds query, container caching, callback execution, and retry artwork regeneration).
  - Added unit test coverage for `updateCache()` (handling freed container bitmapCache, updating cache, and refreshing canvas).
  - Updated global `retryWithBackoff` test mock to execute `check()` logic and pass results to `onSuccess`.
- **`js/__tests__/turtle.test.js`**:
  - Added `global.retryWithBackoff` test mock.
  - Added unit test suite `describe("Cache Management (_createCache & updateCache)")` testing `Turtle._createCache()` and `Turtle.updateCache()`.

## Testing Performed

- Ran target Jest test suites: `npx.cmd jest js/__tests__/block.test.js js/__tests__/turtle.test.js --coverage=false`
- Verified all 79 unit tests in `block.test.js` and `turtle.test.js` pass cleanly (79/79 passed).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

Note: Running individual test files with default `--coverage` checks can trigger Jest global coverage threshold warnings due to isolated file scope. Running with `--coverage=false` or running the full test suite (`npm test`) completes successfully with all 204 test suites passing.
