### PR TITLE
fix(synth): stop custom timbre from disposing the default voice

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -1201,8 +1201,14 @@ class Logo {
                 tur.singer.killAllVoices();
             }
 
+            // One bad instrument must not abort the rest of the teardown below,
+            // which is what disposes instruments and resets _synthsInitialized.
             for (const instrumentName in this.deps.instruments[turtle]) {
-                this.synth.stopSound(turtle, instrumentName);
+                try {
+                    this.synth.stopSound(turtle, instrumentName);
+                } catch (e) {
+                    console.debug("Error stopping instrument " + instrumentName + ":", e);
+                }
             }
             const comp = this.turtles.getTurtle(turtle).companionTurtle;
             if (comp) {

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1676,6 +1676,39 @@ describe("Utility Functions (logic-only)", () => {
             jest.useRealTimers();
         });
     });
+
+    describe("default voice is independent of the custom voice", () => {
+        beforeEach(() => {
+            instruments[turtle] = {};
+        });
+
+        it("gives 'electronic synth' and 'custom' separate synth instances", () => {
+            createDefaultSynth(turtle);
+
+            expect(instruments[turtle]["electronic synth"]).toBeDefined();
+            expect(instruments[turtle]["custom"]).toBeDefined();
+            expect(instruments[turtle]["custom"]).not.toBe(instruments[turtle]["electronic synth"]);
+        });
+
+        it("keeps the default voice usable after the custom voice is rebuilt", async () => {
+            createDefaultSynth(turtle);
+            const defaultVoice = instruments[turtle]["electronic synth"];
+
+            // "custom" is in BUILTIN_SYNTHS, so this disposes and rebuilds that key.
+            await createSynth(turtle, "custom", "custom", null);
+
+            expect(defaultVoice.disposed).toBe(false);
+            expect(instruments[turtle]["electronic synth"]).toBe(defaultVoice);
+            expect(() => defaultVoice.triggerAttackRelease("C4", 0.5)).not.toThrow();
+        });
+
+        it("does not throw when stopping an already disposed instrument", () => {
+            createDefaultSynth(turtle);
+            instruments[turtle]["electronic synth"].dispose();
+
+            expect(() => stopSound(turtle, "electronic synth")).not.toThrow();
+        });
+    });
 });
 
 describe("Tuner Utilities (Audio Test Functions)", () => {

--- a/js/utils/__tests__/tonemock.js
+++ b/js/utils/__tests__/tonemock.js
@@ -119,9 +119,23 @@ class PolySynth {
     constructor(synth, count) {
         this.synth = synth;
         this.count = count;
-        this.triggerAttack = jest.fn().mockReturnThis();
-        this.start = jest.fn().mockReturnThis();
-        this.triggerAttackRelease = jest.fn().mockReturnThis();
+        // Mirrors Tone.js: dispose() flips `disposed`, and triggering a disposed
+        // node throws "Synth was already disposed". Without this the mock silently
+        // tolerates use-after-dispose and such bugs pass unnoticed.
+        this.disposed = false;
+        this.dispose = jest.fn().mockImplementation(() => {
+            this.disposed = true;
+            return this;
+        });
+        const assertLive = () => {
+            if (this.disposed) {
+                throw new Error("Synth was already disposed");
+            }
+        };
+        this.triggerAttack = jest.fn().mockImplementation(assertLive);
+        this.start = jest.fn().mockImplementation(assertLive);
+        this.triggerRelease = jest.fn().mockImplementation(assertLive);
+        this.triggerAttackRelease = jest.fn().mockImplementation(assertLive);
         this.volume = {
             value: 0,
             cancelScheduledValues: jest.fn().mockReturnThis(),

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1410,10 +1410,16 @@ function Synth() {
      */
     this.createDefaultSynth = turtle => {
         console.debug("create default poly/default/custom synth for turtle " + turtle);
-        const default_synth = new Tone.PolySynth(Tone.AMSynth, POLYCOUNT).toDestination();
-        instruments[turtle]["electronic synth"] = default_synth;
+        // "electronic synth" and "custom" must be separate instances. "custom" is a
+        // member of BUILTIN_SYNTHS, so ___createSynth disposes whatever sits under
+        // that key before rebuilding it. Sharing one node meant that rebuilding
+        // "custom" also destroyed the synth "electronic synth" was still pointing at.
+        instruments[turtle]["electronic synth"] = new Tone.PolySynth(
+            Tone.AMSynth,
+            POLYCOUNT
+        ).toDestination();
         instrumentsSource["electronic synth"] = [0, "electronic synth"];
-        instruments[turtle]["custom"] = default_synth;
+        instruments[turtle]["custom"] = new Tone.PolySynth(Tone.AMSynth, POLYCOUNT).toDestination();
         instrumentsSource["custom"] = [0, "custom"];
     };
 
@@ -2429,6 +2435,9 @@ function Synth() {
 
     this.stopSound = (turtle, instrumentName, note) => {
         if (!instrumentsSource[instrumentName] || !instruments[turtle]?.[instrumentName]) return;
+        // A disposed node is still truthy and its key is still present, so the guard
+        // above lets it through. Calling into Tone at that point throws.
+        if (instruments[turtle][instrumentName].disposed) return;
         const flag = instrumentsSource[instrumentName][0];
         switch (flag) {
             case 1: // drum


### PR DESCRIPTION
## Description

If you use `set instrument` with the `custom` voice, the default voice dies and never comes back.

The cause is in `createDefaultSynth`. It was storing the same PolySynth object under two keys, `electronic synth` and `custom`. So they were never really two synths, just one object with two names on it. And because `custom` is listed in `BUILTIN_SYNTHS`, `___createSynth` disposes whatever sits under that key before rebuilding it. That disposal also killed the node the default voice was still pointing at.

The silence is not even the worst part. At the end of a run, `_cleanupAfterCompletion` loops over every instrument and calls `stopSound` on it. It reaches the dead one and throws. Nothing catches that, so cleanup stops right there and never reaches `disposeAllInstruments()`. Instruments are never freed, `_synthsInitialized` stays `true`, and on the next Play `prepSynths` hits its early return and skips the rebuild. That is why it never recovers on its own.

## Steps to reproduce

1. Open Music Blocks and switch to Advanced mode. The `custom` voice is hidden in Beginner mode.
2. Open the browser console so you can see the error.
3. Build this stack:

    ```
    start
      set instrument (custom)
        note 1/4
          pitch sol 4
    ```

4. Press Play once and let it finish on its own. Do not press Stop.
5. The console throws `Uncaught Error: Synth was already disposed`, coming out of `logo.js:1205`.

To check that the cleanup really did get skipped, run this in the console straight after:

```js
console.log(activity.logo._synthsInitialized);
console.log(Object.keys(instruments[0]));
```

Before the fix you get `true` and `["electronic synth", "custom"]`, which means the teardown never ran. After the fix you get `false` and `[]`.

## PR Category

-   [x] Bug Fix

## Changes Made

-   `createDefaultSynth` now builds two separate PolySynth instances instead of putting one object under both keys
-   `stopSound` returns early if the node has already been disposed
-   the `stopSound` loop in `_cleanupAfterCompletion` is wrapped in try/catch, so one broken instrument cannot take down the rest of the teardown
-   added `dispose()` and `disposed` to the Tone mock. It had neither, which is why the test suite could never catch this

