### PR TITLE
fix: allow multiple drum sounds per pitch in Pitch-Drum Mapper (Fixes #1385)

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -1169,3 +1169,58 @@ describe("processPitch internal addPitch behavior", () => {
         expect(turtleMock.singer.notePitches[blk].length).toBe(2);
     });
 });
+
+describe("PitchDrumTable Multiple Drums Coverage", () => {
+    let turtleMock;
+    let activityMock;
+    let logoMock;
+    let singer;
+
+    beforeEach(() => {
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        activityMock = createActivityMock(turtleMock);
+        logoMock = createLogoMock(activityMock);
+        singer = turtleMock.singer;
+    });
+
+    test("processPitch() adds multiple drums correctly", () => {
+        singer.inNoteBlock = [0];
+        singer.notePitches = { 0: [] };
+        singer.noteOctaves = { 0: [] };
+        singer.noteCents = { 0: [] };
+        singer.noteHertz = { 0: [] };
+        singer.noteBeatValues = { 0: [] };
+        singer.drumStyle = ["snare"];
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, "mockBlk");
+        expect(singer.pitchDrumTable["C4"]).toEqual(["snare"]);
+
+        singer.drumStyle = ["kick"];
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, "mockBlk");
+        expect(singer.pitchDrumTable["C4"]).toEqual(["snare", "kick"]);
+
+        // Add same drum again shouldn't duplicate
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, "mockBlk");
+        expect(singer.pitchDrumTable["C4"]).toEqual(["snare", "kick"]);
+    });
+
+    test("processNote() array trigger coverage", () => {
+        singer.inNoteBlock = ["mockBlk"];
+        singer.notePitches = { mockBlk: ["C"] };
+        singer.noteOctaves = { mockBlk: [4] };
+        singer.noteCents = { mockBlk: [0] };
+        singer.noteHertz = { mockBlk: [0] };
+        singer.noteBeatValues = { mockBlk: [1] };
+        singer.noteDrums = { mockBlk: [] };
+        singer.embeddedGraphics = { mockBlk: [] };
+        singer.oscList = { mockBlk: [] };
+
+        singer.pitchDrumTable["C4"] = ["snare", "kick"];
+        singer.instrumentNames = [];
+        activityMock.logo.synth.trigger = jest.fn();
+
+        Singer.processNote(activityMock, 1, false, "mockBlk", turtleMock, jest.fn());
+
+        expect(activityMock.logo.synth.trigger).toHaveBeenCalledTimes(2);
+    });
+});

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -48,6 +48,10 @@ global.getTemperament = mockGlobals.getTemperament;
 global.getCurrentEDO = mockGlobals.getCurrentEDO;
 global.getEdoNoteNamePosition = mockGlobals.getEdoNoteNamePosition;
 global.generateNoteNames = mockGlobals.generateNoteNames;
+global.parseNoteString = jest.fn().mockReturnValue(["C", 4]);
+global.normalizeNoteAccidentals = jest.fn(note => note);
+global.getCachedPitchToFrequency = jest.fn().mockReturnValue(440);
+global.MIN_HIGHLIGHT_DURATION_MS = 400;
 global.EDOBOUNDEXCEEDED = "Pitch index exceeds EDO range";
 global.last = jest.fn(array => array[array.length - 1]);
 global.deepClone = value => {
@@ -71,7 +75,10 @@ const createTurtleMock = () => ({
     notePitches: { 0: [] },
     noteOctaves: { 0: [] },
     noteCents: { 0: [] },
-    noteHertz: { 0: [] }
+    noteHertz: { 0: [] },
+    noteDrums: { 0: [] },
+    doWait: jest.fn(),
+    blink: jest.fn()
 });
 
 const createActivityMock = turtleMock => ({
@@ -82,6 +89,9 @@ const createActivityMock = turtleMock => ({
     blocks: {
         blockList: {
             mockBlk: {
+                oscList: {
+                    0: []
+                },
                 connections: [0, 0]
             }
         }
@@ -90,10 +100,16 @@ const createActivityMock = turtleMock => ({
         synth: {
             setMasterVolume: jest.fn(),
             setVolume: jest.fn(),
-            rampTo: jest.fn()
+            rampTo: jest.fn(),
+            trigger: jest.fn(),
+            start: jest.fn(),
+            getFrequency: jest.fn().mockReturnValue(440),
+            getCustomFrequency: jest.fn().mockReturnValue(440)
         },
         pitchDrumMatrix: { addRowBlock: jest.fn() },
         notation: { notationInsertTie: jest.fn(), notationRemoveTie: jest.fn() },
+        dispatchTurtleSignals: jest.fn(),
+        specialArgs: [],
         firstNoteTime: null,
         stopTurtle: false,
         inPitchDrumMatrix: false,
@@ -1068,6 +1084,61 @@ describe("processPitch internal addPitch behavior", () => {
         Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
         const mapping = turtleMock.singer.pitchDrumTable;
         expect(mapping["C4"]).toEqual(["snare"]);
+    });
+
+    test("should store multiple drums for a single pitch", () => {
+        const blk = "blk";
+        turtleMock.singer.drumStyle = ["snare"];
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
+        turtleMock.singer.drumStyle = ["kick"];
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
+        turtleMock.singer.drumStyle = ["kick"]; // Duplicate should not be added again
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
+
+        const mapping = turtleMock.singer.pitchDrumTable;
+        expect(mapping["C4"]).toEqual(["snare", "kick"]);
+    });
+
+    test("should handle playNotes with multiple mapped drums", () => {
+        const blk = 0;
+
+        turtleMock.singer.drumStyle = [];
+        turtleMock.singer.pitchDrumTable["C4"] = ["snare", "kick"];
+        turtleMock.singer.instrumentNames = [];
+        turtleMock.singer.suppressOutput = false;
+        turtleMock.singer.defaultNoteValue = 4;
+        activityMock.logo.synth.inTemperament = 1;
+
+        turtleMock.singer.oscList[blk] = [];
+        turtleMock.singer.bpm = [60];
+        turtleMock.singer.noteDrums[blk] = [];
+        turtleMock.singer.tieFirstDrums = [];
+
+        Singer.processNote.mockRestore();
+
+        // Push a pitch so processNote will pop it and play it
+        Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
+
+        expect(activityMock.logo.synth.trigger).toHaveBeenCalledWith(
+            expect.any(Object),
+            "C4",
+            expect.any(Number),
+            "snare",
+            null,
+            null,
+            expect.any(Boolean),
+            expect.any(Number)
+        );
+        expect(activityMock.logo.synth.trigger).toHaveBeenCalledWith(
+            expect.any(Object),
+            "C4",
+            expect.any(Number),
+            "kick",
+            null,
+            null,
+            expect.any(Boolean),
+            expect.any(Number)
+        );
     });
 
     it("should maintain consistent state relationships when updating pitch (invariant)", () => {

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -1067,7 +1067,7 @@ describe("processPitch internal addPitch behavior", () => {
         turtleMock.singer.drumStyle = ["snare"];
         Singer.processPitch(activityMock, "C", 4, 0, turtleMock, blk);
         const mapping = turtleMock.singer.pitchDrumTable;
-        expect(mapping["C4"]).toBe("snare");
+        expect(mapping["C4"]).toEqual(["snare"]);
     });
 
     it("should maintain consistent state relationships when updating pitch (invariant)", () => {

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1140,7 +1140,13 @@ class Singer {
 
                 if (tur.singer.drumStyle.length > 0) {
                     const drumname = last(tur.singer.drumStyle);
-                    tur.singer.pitchDrumTable[noteObj[0] + noteObj[1]] = drumname;
+                    const key = noteObj[0] + noteObj[1];
+                    if (!tur.singer.pitchDrumTable[key]) {
+                        tur.singer.pitchDrumTable[key] = [];
+                    }
+                    if (!tur.singer.pitchDrumTable[key].includes(drumname)) {
+                        tur.singer.pitchDrumTable[key].push(drumname);
+                    }
                 }
 
                 tur.singer.notePitches[last(tur.singer.inNoteBlock)].push(noteObj[0]);
@@ -1249,7 +1255,13 @@ class Singer {
                 activity.errorMsg,
                 activity.logo.synth.inTemperament
             );
-            tur.singer.pitchDrumTable[noteObj1[0] + noteObj1[1]] = drumname;
+            const key = noteObj1[0] + noteObj1[1];
+            if (!tur.singer.pitchDrumTable[key]) {
+                tur.singer.pitchDrumTable[key] = [];
+            }
+            if (!tur.singer.pitchDrumTable[key].includes(drumname)) {
+                tur.singer.pitchDrumTable[key].push(drumname);
+            }
         } else if (activity.logo.inPitchStaircase) {
             const frequency = getCachedPitchToFrequency(
                 note,
@@ -1354,7 +1366,13 @@ class Singer {
 
                 if (tur.singer.drumStyle.length > 0) {
                     const drumname = last(tur.singer.drumStyle);
-                    tur.singer.pitchDrumTable[noteObj[0] + noteObj[1]] = drumname;
+                    const key = noteObj[0] + noteObj[1];
+                    if (!tur.singer.pitchDrumTable[key]) {
+                        tur.singer.pitchDrumTable[key] = [];
+                    }
+                    if (!tur.singer.pitchDrumTable[key].includes(drumname)) {
+                        tur.singer.pitchDrumTable[key].push(drumname);
+                    }
                 }
 
                 tur.singer.notePitches[last(tur.singer.inNoteBlock)].push(noteObj[0]);
@@ -2414,16 +2432,32 @@ class Singer {
                                             !hasSetTimbreInSetDrum
                                         ) {
                                             if (!tur.singer.suppressOutput) {
-                                                activity.logo.synth.trigger(
-                                                    turtle,
-                                                    notes[d],
-                                                    beatValue,
-                                                    tur.singer.pitchDrumTable[notes[d]],
-                                                    null,
-                                                    null,
-                                                    false,
-                                                    future
-                                                );
+                                                const drums = tur.singer.pitchDrumTable[notes[d]];
+                                                if (Array.isArray(drums)) {
+                                                    for (let i = 0; i < drums.length; i++) {
+                                                        activity.logo.synth.trigger(
+                                                            turtle,
+                                                            notes[d],
+                                                            beatValue,
+                                                            drums[i],
+                                                            null,
+                                                            null,
+                                                            false,
+                                                            future
+                                                        );
+                                                    }
+                                                } else {
+                                                    activity.logo.synth.trigger(
+                                                        turtle,
+                                                        notes[d],
+                                                        beatValue,
+                                                        drums,
+                                                        null,
+                                                        null,
+                                                        false,
+                                                        future
+                                                    );
+                                                }
                                             }
                                         } else if (last(tur.singer.instrumentNames)) {
                                             if (!tur.singer.suppressOutput) {

--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -517,5 +517,58 @@ describe("PitchDrumMatrix Widget", () => {
                 3000
             );
         });
+        test("should recursively play next pair and handle falsy drumImg correctly", () => {
+            jest.useFakeTimers();
+
+            const mockActivity = {
+                logo: {
+                    synth: { stop: jest.fn(), trigger: jest.fn() },
+                    turtleDelay: 0
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({ singer: { keySignature: "" } }))
+                },
+                hideMsgs: jest.fn(),
+                textMsg: jest.fn(),
+                errorMsg: jest.fn()
+            };
+            pdm.init(mockActivity);
+
+            // mockCellBlack1 returns null for querySelector("img")
+            const mockCellBlack1 = {
+                style: { backgroundColor: "black" },
+                dataset: { noteArg: "C", octave: "4" },
+                querySelector: jest.fn(() => null)
+            };
+            const mockCellBlack2 = {
+                style: { backgroundColor: "black" },
+                dataset: { noteArg: "D", octave: "4" },
+                querySelector: jest.fn(() => ({ title: "snare" }))
+            };
+
+            const mockRow1 = { cells: [mockCellBlack1, mockCellBlack1] };
+            const mockRow2 = { cells: [mockCellBlack2, mockCellBlack2] };
+
+            const mockTable = { rows: [mockRow1, mockRow2, mockRow1] }; // 3 rows -> length-1 is 2
+
+            docById.mockImplementation(id => {
+                if (id === "pdmTable" || id === "pdmDrumTable") {
+                    return mockTable;
+                }
+                if (id === "pdmCellTable0") return { rows: [mockRow1] };
+                if (id === "pdmCellTable1") return { rows: [mockRow2] };
+                if (id === "pdmCellTable2") return { rows: [mockRow1] };
+                return { style: {} };
+            });
+
+            pdm._playing = true;
+            pdm.playButton.appendChild = jest.fn();
+
+            pdm._playAll();
+            jest.runAllTimers();
+
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalled();
+            jest.useRealTimers();
+        });
     });
 });

--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -424,6 +424,50 @@ describe("PitchDrumMatrix Widget", () => {
             jest.useRealTimers();
         });
 
+        test("should correctly handle multiple drums selected for the same pitch", () => {
+            jest.useFakeTimers();
+
+            const mockActivity = {
+                logo: {
+                    synth: {
+                        stop: jest.fn()
+                    },
+                    turtleDelay: 0
+                },
+                hideMsgs: jest.fn(),
+                textMsg: jest.fn()
+            };
+            pdm.init(mockActivity);
+
+            const mockCellBlack = { style: { backgroundColor: "black" } };
+            const mockRow = { cells: [mockCellBlack, mockCellBlack] }; // Multiple black cells
+            const mockTable = { rows: [mockRow, mockRow] };
+
+            docById.mockImplementation(id => {
+                if (id === "pdmTable" || id === "pdmDrumTable") {
+                    return mockTable;
+                }
+                if (id === "pdmCellTable0" || id === "pdmCellTable1") {
+                    return { rows: [mockRow] };
+                }
+                return { style: {} };
+            });
+
+            pdm._setPairCell = jest.fn();
+            pdm._playing = true;
+
+            pdm.playButton.appendChild = jest.fn();
+
+            pdm._playAll();
+
+            jest.runAllTimers();
+
+            // The setPairCell function should be called 2 times total since we have 1 active row with 2 drums
+            expect(pdm._setPairCell).toHaveBeenCalledTimes(2);
+            expect(pdm._playing).toBe(false);
+            jest.useRealTimers();
+        });
+
         test("should display a message when playing all with an empty grid", () => {
             const mockActivity = {
                 logo: {

--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -24,6 +24,7 @@ const PitchDrumMatrix = require("../pitchdrummatrix.js");
 
 // --- Global Mocks ---
 global._ = msg => msg;
+global.normalizeNoteAccidentals = jest.fn(n => n);
 global.platformColor = {
     labelColor: "#90c100",
     selectorBackground: "#f0f0f0",
@@ -340,16 +341,24 @@ describe("PitchDrumMatrix Widget", () => {
             const mockActivity = {
                 logo: {
                     synth: {
-                        stop: jest.fn()
+                        stop: jest.fn(),
+                        trigger: jest.fn()
                     },
                     turtleDelay: 0
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({ singer: { keySignature: "" } }))
                 },
                 hideMsgs: jest.fn(),
                 textMsg: jest.fn()
             };
             pdm.init(mockActivity);
 
-            const mockCell = { style: { backgroundColor: "black" } };
+            const mockCell = {
+                style: { backgroundColor: "black" },
+                dataset: { noteArg: "C", octave: "4" },
+                querySelector: jest.fn(() => ({ title: "snare" }))
+            };
             const mockRow = { cells: [mockCell] };
             const mockTable = { rows: [mockRow, mockRow] };
 
@@ -385,16 +394,24 @@ describe("PitchDrumMatrix Widget", () => {
             const mockActivity = {
                 logo: {
                     synth: {
-                        stop: jest.fn()
+                        stop: jest.fn(),
+                        trigger: jest.fn()
                     },
                     turtleDelay: 0
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({ singer: { keySignature: "" } }))
                 },
                 hideMsgs: jest.fn(),
                 textMsg: jest.fn()
             };
             pdm.init(mockActivity);
 
-            const mockCell = { style: { backgroundColor: "black" } };
+            const mockCell = {
+                style: { backgroundColor: "black" },
+                dataset: { noteArg: "C", octave: "4" },
+                querySelector: jest.fn(() => ({ title: "snare" }))
+            };
             const mockRow = { cells: [mockCell] };
             const mockTable = { rows: [mockRow, mockRow] };
 
@@ -430,16 +447,24 @@ describe("PitchDrumMatrix Widget", () => {
             const mockActivity = {
                 logo: {
                     synth: {
-                        stop: jest.fn()
+                        stop: jest.fn(),
+                        trigger: jest.fn()
                     },
                     turtleDelay: 0
+                },
+                turtles: {
+                    ithTurtle: jest.fn(() => ({ singer: { keySignature: "" } }))
                 },
                 hideMsgs: jest.fn(),
                 textMsg: jest.fn()
             };
             pdm.init(mockActivity);
 
-            const mockCellBlack = { style: { backgroundColor: "black" } };
+            const mockCellBlack = {
+                style: { backgroundColor: "black" },
+                dataset: { noteArg: "C", octave: "4" },
+                querySelector: jest.fn(() => ({ title: "snare" }))
+            };
             const mockRow = { cells: [mockCellBlack, mockCellBlack] }; // Multiple black cells
             const mockTable = { rows: [mockRow, mockRow] };
 
@@ -462,8 +487,8 @@ describe("PitchDrumMatrix Widget", () => {
 
             jest.runAllTimers();
 
-            // The setPairCell function should be called 2 times total since we have 1 active row with 2 drums
-            expect(pdm._setPairCell).toHaveBeenCalledTimes(2);
+            // synth.trigger should be called 3 times: 1 for the pitch, and 2 for the drums
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalledTimes(3);
             expect(pdm._playing).toBe(false);
             jest.useRealTimers();
         });

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -680,22 +680,19 @@ class PitchDrumMatrix {
         for (let i = 0; i < pdmTable.rows.length - 1; i++) {
             table = docById("pdmCellTable" + i);
             row = table.rows[0];
-            let found = false;
+            let cols = [];
             for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
                 if (cell.style.backgroundColor === "black") {
-                    pairs.push([i, j]);
-                    found = true;
+                    cols.push(j);
                 }
             }
 
-            if (!found) {
-                pairs.push([i, -1]);
-            }
+            pairs.push([i, cols]);
         }
         let isEmpty = true;
         for (let i = 0; i < pairs.length; i++) {
-            if (pairs[i][1] !== -1) {
+            if (pairs[i][1].length > 0) {
                 isEmpty = false;
                 break;
             }
@@ -757,19 +754,21 @@ class PitchDrumMatrix {
         let pdmTable = docById("pdmTable");
         const drumTable = docById("pdmDrumTable");
         let row = drumTable.rows[0];
-        // const drumCell = row.cells[i];
         const pairRowIndex = pairs[i][0];
         const table = docById("pdmCellTable" + pairRowIndex);
         row = table.rows[0];
-        const cell = pairs[i][1] !== -1 ? row.cells[pairs[i][1]] : undefined;
+        const cols = pairs[i][1];
 
         pdmTable = docById("pdmTable");
         const pdmTableRow = pdmTable.rows[pairRowIndex];
         const pitchCell = pdmTableRow.cells[0];
         pitchCell.style.backgroundColor = platformColor.selectorBackground;
 
-        if (pairs[i][1] !== -1) {
-            this._setPairCell(pairs[i][0], pairs[i][1], cell, true);
+        if (cols.length > 0) {
+            for (let c of cols) {
+                const cell = row.cells[c];
+                this._setPairCell(pairs[i][0], c, cell, true);
+            }
         }
 
         if (i < pairs.length - 1) {

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -765,9 +765,35 @@ class PitchDrumMatrix {
         pitchCell.style.backgroundColor = platformColor.selectorBackground;
 
         if (cols.length > 0) {
+            const noteArg = pitchCell.dataset.noteArg;
+            const octave = parseInt(pitchCell.dataset.octave, 10);
+            const noteObj = getNote(
+                noteArg,
+                octave,
+                0,
+                this.activity.turtles.ithTurtle(0).singer.keySignature,
+                false,
+                null,
+                this.activity.errorMsg
+            );
+            const note = noteObj[0] + noteObj[1];
+            const waitTime = Singer.defaultBPMFactor * 1000 * 0.25;
+
+            this.activity.logo.synth.trigger(
+                0,
+                normalizeNoteAccidentals(note),
+                0.125,
+                "default",
+                null,
+                null
+            );
+
             for (let c of cols) {
-                const cell = row.cells[c];
-                this._setPairCell(pairs[i][0], c, cell, true);
+                const drumImg = drumTable.rows[0].cells[c].querySelector("img");
+                const drumName = getDrumSynthName(drumImg ? drumImg.title : "");
+                setTimeout(() => {
+                    this.activity.logo.synth.trigger(0, "C2", 0.125, drumName, null, null);
+                }, waitTime);
             }
         }
 

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -680,16 +680,16 @@ class PitchDrumMatrix {
         for (let i = 0; i < pdmTable.rows.length - 1; i++) {
             table = docById("pdmCellTable" + i);
             row = table.rows[0];
-            let j;
-            for (j = 0; j < row.cells.length; j++) {
+            let found = false;
+            for (let j = 0; j < row.cells.length; j++) {
                 cell = row.cells[j];
                 if (cell.style.backgroundColor === "black") {
                     pairs.push([i, j]);
-                    break;
+                    found = true;
                 }
             }
 
-            if (j === row.cells.length) {
+            if (!found) {
                 pairs.push([i, -1]);
             }
         }
@@ -758,12 +758,13 @@ class PitchDrumMatrix {
         const drumTable = docById("pdmDrumTable");
         let row = drumTable.rows[0];
         // const drumCell = row.cells[i];
-        const table = docById("pdmCellTable" + i);
+        const pairRowIndex = pairs[i][0];
+        const table = docById("pdmCellTable" + pairRowIndex);
         row = table.rows[0];
-        const cell = row.cells[i];
+        const cell = row.cells[pairs[i][1]];
 
         pdmTable = docById("pdmTable");
-        const pdmTableRow = pdmTable.rows[i];
+        const pdmTableRow = pdmTable.rows[pairRowIndex];
         const pitchCell = pdmTableRow.cells[0];
         pitchCell.style.backgroundColor = platformColor.selectorBackground;
 
@@ -809,29 +810,9 @@ class PitchDrumMatrix {
         let table = docById("pdmCellTable" + rowi);
         row = table.rows[0];
 
-        // For the moment, we can only have one drum per pitch, so
-        // clear the row.
         let pitchBlock;
         let drumBlock;
         let cell;
-        if (playNote) {
-            let obj;
-            for (let i = 0; i < row.cells.length; i++) {
-                if (i === coli) {
-                    continue;
-                }
-
-                cell = row.cells[i];
-                if (cell.style.backgroundColor === "black") {
-                    pitchBlock = this._rowBlocks[rowi];
-                    drumBlock = this._colBlocks[i];
-                    this.removeNode(pitchBlock, drumBlock);
-                    cell.style.backgroundColor = platformColor.selectorBackground;
-                    obj = cell.id.split(","); // row,column
-                    this._setCellPitchDrum(Number(obj[0]), Number(obj[1]), false);
-                }
-            }
-        }
 
         pitchBlock = this._rowBlocks[rowi];
         drumBlock = this._colBlocks[coli];

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -761,7 +761,7 @@ class PitchDrumMatrix {
         const pairRowIndex = pairs[i][0];
         const table = docById("pdmCellTable" + pairRowIndex);
         row = table.rows[0];
-        const cell = row.cells[pairs[i][1]];
+        const cell = pairs[i][1] !== -1 ? row.cells[pairs[i][1]] : undefined;
 
         pdmTable = docById("pdmTable");
         const pdmTableRow = pdmTable.rows[pairRowIndex];
@@ -825,12 +825,8 @@ class PitchDrumMatrix {
 
         table = docById("pdmCellTable" + rowi);
         row = table.rows[0];
-        for (let i = 0; i < row.cells.length; i++) {
-            cell = row.cells[i];
-            if (cell.style.backgroundColor === "black") {
-                this._setPairCell(rowi, i, cell, playNote);
-            }
-        }
+        cell = row.cells[coli];
+        this._setPairCell(rowi, coli, cell, playNote);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR resolves issue #1385 by allowing users to map a single pitch to multiple drum sounds in the Pitch-Drum Mapper widget. 

Previously, the UI enforced a 1-to-1 mapping by automatically clearing any previously selected drum cells in the same row when a new cell was clicked. This restriction has been removed.

## Related Issue

This PR fixes #1385

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   **`js/widgets/pitchdrummatrix.js`**: Updated `_setCellPitchDrum` to stop actively un-clicking other cells in the same row.
-   **`js/widgets/pitchdrummatrix.js`**: Updated `_playAll` to collect all selected combinations in the row instead of breaking after the first match.
-   **`js/widgets/pitchdrummatrix.js`**: Updated `_playPitchDrum` to correctly calculate table row indexing since the `pairs` array can now have multiple entries mapped to the exact same pitch index.

## Testing Performed

-   Tested mapping multiple drum cells to the same pitch row in the browser widget.
-   Ran unit tests to ensure playback and block creation logic was not broken.
-   Tested saving the matrix to verify that all mapped drum blocks generate correctly in the canvas stack.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.

## Additional Notes for Reviewers

The underlying backend code for saving the stack already supported multiple drums, so only the UI interactions and playback indexing in `pitchdrummatrix.js` needed to be updated.