### PR TITLE
fix: release getDisplayMedia tracks in recordScreenWithTools

### DIFF
--- a/js/activity/__tests__/recorder.test.js
+++ b/js/activity/__tests__/recorder.test.js
@@ -254,9 +254,10 @@ describe("recorder", () => {
             const mockTrack = { stop: jest.fn(), addEventListener: jest.fn() };
             const mockDisplayStream = { getTracks: () => [mockTrack] };
 
-            global.navigator.mediaDevices = {
-                getDisplayMedia: jest.fn().mockResolvedValue(mockDisplayStream)
-            };
+            Object.defineProperty(global.navigator, "mediaDevices", {
+                value: { getDisplayMedia: jest.fn().mockResolvedValue(mockDisplayStream) },
+                configurable: true
+            });
             global.localStorage = { getItem: jest.fn(() => null) };
 
             const { doRecordButton, setupActivityRecorder } = require("../recorder");
@@ -271,9 +272,7 @@ describe("recorder", () => {
 
             // Fire the click handler recording() registered - this drives
             // recordScreen() -> recordScreenWithTools() -> createRecorder()
-            const startHandler = mockStart.addEventListener.mock.calls.find(
-                c => c[0] === "click"
-            )[1];
+            const startHandler = mockStart._recordHandler;
             await startHandler();
 
             // Fire the stop handler that gets armed once recording begins
@@ -281,6 +280,7 @@ describe("recorder", () => {
                 .filter(c => c[0] === "click")
                 .pop()[1];
             stopHandler();
+            jest.runOnlyPendingTimers();
 
             expect(mockTrack.stop).toHaveBeenCalled();
         });

--- a/js/activity/__tests__/recorder.test.js
+++ b/js/activity/__tests__/recorder.test.js
@@ -248,4 +248,41 @@ describe("recorder", () => {
             expect(mockTrack.stop).toHaveBeenCalled();
         });
     });
+
+    describe("recordScreenWithTools", () => {
+        it("stops the getDisplayMedia tracks after recording is stopped", async () => {
+            const mockTrack = { stop: jest.fn(), addEventListener: jest.fn() };
+            const mockDisplayStream = { getTracks: () => [mockTrack] };
+
+            global.navigator.mediaDevices = {
+                getDisplayMedia: jest.fn().mockResolvedValue(mockDisplayStream)
+            };
+            global.localStorage = { getItem: jest.fn(() => null) };
+
+            const { doRecordButton, setupActivityRecorder } = require("../recorder");
+            const instance = {
+                textMsg: jest.fn(),
+                canvas: { height: 600 },
+                _onResize: jest.fn(),
+                logo: { synth: { tone: null } }
+            };
+            setupActivityRecorder(instance);
+            doRecordButton(instance);
+
+            // Fire the click handler recording() registered - this drives
+            // recordScreen() -> recordScreenWithTools() -> createRecorder()
+            const startHandler = mockStart.addEventListener.mock.calls.find(
+                c => c[0] === "click"
+            )[1];
+            await startHandler();
+
+            // Fire the stop handler that gets armed once recording begins
+            const stopHandler = mockStart.addEventListener.mock.calls
+                .filter(c => c[0] === "click")
+                .pop()[1];
+            stopHandler();
+
+            expect(mockTrack.stop).toHaveBeenCalled();
+        });
+    });
 });

--- a/js/activity/recorder.js
+++ b/js/activity/recorder.js
@@ -139,7 +139,7 @@ const setupActivityRecorder = activityInstance => {
             flag = 1;
 
             try {
-                return await navigator.mediaDevices.getDisplayMedia({
+                const stream = await navigator.mediaDevices.getDisplayMedia({
                     preferCurrentTab: "True",
                     systemAudio: "include",
                     audio: "True",
@@ -152,6 +152,8 @@ const setupActivityRecorder = activityInstance => {
                     },
                     preferredVideoCodecs: "auto"
                 });
+                currentStream = stream;
+                return stream;
             } catch (error) {
                 ErrorHandler.capture(error, { operation: "screenCapture" });
                 flag = 0;

--- a/js/activity/recorder.js
+++ b/js/activity/recorder.js
@@ -139,7 +139,7 @@ const setupActivityRecorder = activityInstance => {
             flag = 1;
 
             try {
-                const stream = await navigator.mediaDevices.getDisplayMedia({
+                currentStream = await navigator.mediaDevices.getDisplayMedia({
                     preferCurrentTab: "True",
                     systemAudio: "include",
                     audio: "True",
@@ -152,8 +152,7 @@ const setupActivityRecorder = activityInstance => {
                     },
                     preferredVideoCodecs: "auto"
                 });
-                currentStream = stream;
-                return stream;
+                return currentStream;
             } catch (error) {
                 ErrorHandler.capture(error, { operation: "screenCapture" });
                 flag = 0;


### PR DESCRIPTION
## Description

`recordScreenWithTools()` in `js/activity/recorder.js` never assigns its `getDisplayMedia()` stream to the shared `currentStream` variable, unlike `recordCanvasOnly()` which does this correctly. Because `cleanupStreams()` and `stopRec()` both gate their track-stopping logic on `currentStream` being set, the tab/screen capture from "tools" mode is never actually released — the browser's sharing indicator stays on after the recording is stopped.

This PR adds the missing assignment so both recording modes clean up their streams the same way.

## Related Issue

This PR fixes #7940 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- Assign the resolved stream to `currentStream` inside `recordScreenWithTools()`, matching the existing pattern in `recordCanvasOnly()`.
- Add a test that mocks `getDisplayMedia()` and asserts the resulting stream's tracks are stopped via `cleanupStreams()`/`stopRec()`, since no existing test exercised this path.

## Testing Performed

- Added a unit test for `recordScreenWithTools()` that fails on current `master` (track's `.stop()` never called) and passes with this fix.
- Ran the full existing suite (`recorder.test.js`) to confirm no regressions in the canvas-only path.
- Manually verified in Chrome: started a "tools" mode recording, stopped it, and confirmed the tab-sharing indicator clears immediately instead of staying active.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.

## Additional Notes for Reviewers

Found this while reviewing the recording flow for PR #7884 — it's a separate, independent bug from the toolbar/icon regression that PR addresses, so I'm filing it on its own rather than bundling it in.