### PR TITLE
docs: add guide for shared test infrastructure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,8 @@ understanding of the codebase.
 
 ### Before You Push
 
+For detailed testing guidance, including the shared test infrastructure and reusable test utilities, see the [Testing Guide](Docs/TESTING.md#shared-test-infrastructure).
+
 Run these commands locally before submitting a PR:
 
 ```bash

--- a/Docs/TESTING.md
+++ b/Docs/TESTING.md
@@ -10,6 +10,179 @@ npm test -- path/to/file.test.js           # Run specific test file
 npm test -- --coverage                      # Run with coverage report
 ```
 
+## Shared Test Infrastructure
+
+Music Blocks provides a shared test infrastructure to reduce duplication, improve consistency, and make test suites easier to maintain.
+
+Before adding new mocks or setup code, check whether similar functionality already exists in the shared test infrastructure.
+
+### Project Structure
+
+```text
+test/
+├── setup/
+│   └── globalSetup.js
+├── utils/
+│   ├── activityFactory.js
+│   ├── domFactory.js
+│   ├── domMocks.js
+│   ├── imageMock.js
+│   └── svgMock.js
+└── setupTests.js
+```
+
+### `test/setupTests.js`
+
+`test/setupTests.js` is loaded automatically before every test suite through Jest using `setupFilesAfterEnv`.
+
+Use this file only for test infrastructure that should be available to every test suite.
+
+Examples include:
+
+- Common Jest lifecycle hooks.
+- Browser API polyfills.
+- Shared browser mocks.
+- Common Music Blocks globals and constants.
+- Project-wide test environment initialization.
+
+Example:
+
+```javascript
+afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+});
+```
+
+Avoid placing widget-specific or feature-specific mocks in this file.
+
+---
+
+### `test/setup/`
+
+The `test/setup/` directory contains reusable setup helpers for initializing shared test state.
+
+If multiple test suites require the same setup logic, extract it into a helper in this directory instead of duplicating it.
+
+Example:
+
+```javascript
+const { setupGlobalEnvironment } = require("../../test/setup/globalSetup");
+
+beforeEach(() => {
+    setupGlobalEnvironment();
+});
+```
+
+---
+
+### `test/utils/`
+
+The `test/utils/` directory contains reusable mock factories and helper utilities.
+
+If the same mock or helper is needed by multiple test suites, prefer creating or reusing a helper here instead of duplicating the implementation.
+
+#### Activity helper
+
+Use `activityFactory.js` to create mock activity objects.
+
+```javascript
+const { createMockActivity } = require("../../test/utils/activityFactory");
+
+const activity = createMockActivity({
+    beginnerMode: true
+});
+```
+
+Instead of manually creating the same activity object in every test.
+
+---
+
+#### DOM helpers
+
+Use `domFactory.js` and `domMocks.js` when tests require reusable DOM structures or `docById` mocks.
+
+```javascript
+const { createMockDOM } = require("../../test/utils/domFactory");
+const { mockDocById } = require("../../test/utils/domMocks");
+
+const { container, body } = createMockDOM();
+
+mockDocById({
+    palette: container,
+    PaletteBody: body
+});
+```
+
+Instead of manually recreating the same DOM structure across multiple test files.
+
+---
+
+#### SVG and Image helpers
+
+Use the shared helpers instead of redefining `SVG` or `Image` mocks in every test file.
+
+```javascript
+const { setupSVGMock } = require("../../test/utils/svgMock");
+const { setupImageMock } = require("../../test/utils/imageMock");
+
+beforeEach(() => {
+    setupSVGMock();
+    setupImageMock();
+});
+```
+
+---
+
+### When should I add to the shared infrastructure?
+
+Move code into the shared infrastructure when:
+
+- The same setup is duplicated across multiple test files.
+- The helper is generic and reusable.
+- The helper represents common testing infrastructure instead of application behavior.
+
+Examples include:
+
+- Activity factories.
+- Generic DOM helpers.
+- Shared browser mocks.
+- Common setup functions.
+
+---
+
+### When should setup remain inside a test?
+
+Keep setup local to the test file when it represents behavior specific to a single widget, block, or feature.
+
+Examples include:
+
+- Widget-specific DOM structure.
+- Feature-specific event listeners.
+- Mocks whose behavior differs between test suites.
+- Test data that is only meaningful for a particular component.
+
+For example:
+
+```javascript
+jest.spyOn(document, "getElementsByClassName")
+    .mockReturnValue([{ style: {} }]);
+```
+
+If a mock or setup is only required by a single test suite, it should remain in that test file. Move it into the shared infrastructure only when it becomes generic enough to be reused across multiple test suites.
+
+---
+
+### General Guidelines
+
+Before introducing new setup code:
+
+1. Check whether a shared helper already exists.
+2. Reuse existing helpers whenever possible.
+3. Create a new shared helper only when the logic is generic and reusable across multiple test suites.
+4. Keep feature-specific setup local to the corresponding test file.
+5. Prefer small, focused helper modules over large, test-specific utilities.
+
 ## Testing Blocks
 
 Block files (in `js/blocks/`) need specific mocks. Copy this template and modify for your block:


### PR DESCRIPTION
## What does this PR do?

PR #6368 introduced a shared test infrastructure to reduce duplicated test setup and improve consistency across test suites by:

- Centralizing common test initialization in `test/setupTests.js`.
- Introducing reusable helpers under `test/setup/` and `test/utils/`.
- Encouraging reusable test utilities while keeping feature-specific setup local to individual test suites.

This PR documents that infrastructure by explaining:

- The purpose of each shared testing component.
- When contributors should reuse existing helpers.
- When to extend the shared infrastructure.
- When setup should remain within individual test files.

It also includes practical examples to help contributors write consistent and maintainable tests.

## Why is this useful?

Without documentation, contributors may duplicate setup code or be unsure where new test helpers belong.

This guide provides clear guidelines for using and extending the shared test infrastructure introduced in #6368, making it easier to write consistent tests and maintain the testing codebase over time.

## PR Category

- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation