### PR TITLE
refactor(platformstyle): remove dead header color ternary

### DIFF
--- a/js/utils/platformstyle.js
+++ b/js/utils/platformstyle.js
@@ -245,7 +245,7 @@ const platformThemes = {
         },
 
         disconnected: "#C4C4C4", // disconnected block color
-        header: platform.FF ? "#4DA6FF" : "#4DA6FF",
+        header: "#4DA6FF",
         aux: "#1A8CFF",
         sub: "#8CC6FF",
         doHeaderShadow: !platform.FF,


### PR DESCRIPTION
## Description

This PR removes a redundant ternary expression in the light platform theme.

Both branches of the conditional return the same header color (`#4DA6FF`), so the condition has no effect. Replacing it with the constant value simplifies the code without changing behavior.

## Changes

- Removed the redundant ternary expression for the light theme header color.

## Testing

- [x] ESLint
- [x] Prettier

## PR category

- [x] Chore / Refactor