### PR TITLE
fix: prevent notes from firing twice with "On every note do"

### DIFF
--- a/js/__tests__/noteclamp-beat-doublequeue.test.js
+++ b/js/__tests__/noteclamp-beat-doublequeue.test.js
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Regression coverage for the note-clamp double-queue.
+ *
+ * When a beat event is registered (everybeat / on-beat / offbeat / every-beat-N),
+ * `playNote` used to call `_enqueue()` (js/turtleactions/RhythmActions.js), which pushed
+ * the note clamp's child flow onto the turtle queue. The note block's flow() ALSO returns
+ * `[childFlow, 1]`, which makes `runFromBlockNow` step (3) (js/logo.js) push the SAME child
+ * flow a second time. Because the queue is FILO, the clamp then ran twice per note and
+ * pushed its content (e.g. a `playdrum` block) onto the note twice, so every note triggered
+ * two drums.
+ *
+ * `playNote` now only dispatches the beat event and lets the interpreter queue the clamp
+ * exactly once. This test drives the real `Singer.RhythmActions.playNote` and the real
+ * `Singer.DrumActions.playDrum` through the real `Logo.runFromBlockNow` and asserts that the
+ * clamp child runs exactly once, with or without a beat event, and that the note is still
+ * played with a single drum.
+ */
+
+// Setup global mocks BEFORE requiring the module (mirror of logo.test.js).
+global._ = str => str;
+global.Notation = jest.fn().mockImplementation(() => ({
+    notationStaging: {},
+    notationDrumStaging: {},
+    pickupPoint: {},
+    pickupPOW2: {},
+    doUpdateNotation: jest.fn(),
+    notationInsertTie: jest.fn()
+}));
+global.Synth = jest.fn().mockImplementation(() => ({
+    newTone: jest.fn(),
+    createDefaultSynth: jest.fn(),
+    loadSynth: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    stopSound: jest.fn(),
+    disposeAllInstruments: jest.fn(),
+    changeInTemperament: false,
+    recorder: null,
+    transport: {
+        get isAvailable() {
+            return false;
+        },
+        cancel: jest.fn(),
+        get seconds() {
+            return 0;
+        },
+        set seconds(v) {}
+    }
+}));
+global.Singer = {
+    processNote: jest.fn(),
+    setSynthVolume: jest.fn(),
+    setMasterVolume: jest.fn(),
+    clearPitchToFrequencyCache: jest.fn(),
+    masterBPM: 90,
+    defaultBPMFactor: 1
+};
+global.instruments = {};
+global.instrumentsFilters = {};
+global.instrumentsEffects = {};
+global.DEFAULTVOICE = "electronic synth";
+global.DEFAULTDRUM = "kick";
+global.DEFAULTVOLUME = 100;
+global.PREVIEWVOLUME = 80;
+global.DRUMNAMES = { "cup drum": ["cup drum", "cup drum"] };
+global.NOISENAMES = {};
+global.StatusMatrix = jest.fn();
+global.last = arr => arr[arr.length - 1];
+global.getIntervalDirection = jest.fn(() => 1);
+global.getIntervalNumber = jest.fn(() => 5);
+global.mixedNumber = jest.fn(n => n.toString());
+global.rationalToFraction = jest.fn(n => [1, Math.round(1 / n)]);
+global.doStopVideoCam = jest.fn();
+global.CAMERAVALUE = "camera:";
+global.VIDEOVALUE = "video:";
+global.doUseCamera = jest.fn();
+global.delayExecution = jest.fn(() => Promise.resolve());
+global.getStatsFromNotation = jest.fn();
+global.MusicBlocks = { isRun: false };
+global.Mouse = {
+    getMouseFromTurtle: jest.fn(() => ({ MB: { listeners: [] } }))
+};
+global.Tone = {
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+};
+
+jest.mock("tone", () => ({
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+}));
+
+global.EmbeddedGraphicsScheduler =
+    require("../embedded-graphics-scheduler").EmbeddedGraphicsScheduler;
+
+const logoconstants = require("../logoconstants");
+Object.assign(global, logoconstants);
+
+const { Queue, Logo } = require("../logo");
+
+const setupRhythmActions = require("../turtleactions/RhythmActions");
+const setupDrumActions = require("../turtleactions/DrumActions");
+
+function createTurtle() {
+    return {
+        id: 0,
+        singer: {
+            inNoteBlock: [],
+            notesPlayed: [0, 1],
+            pickup: 0,
+            noteValuePerBeat: 1,
+            beatsPerMeasure: 4,
+            beatFactor: 1,
+            beatList: [],
+            factorList: [],
+            currentBeat: null,
+            currentMeasure: null,
+            multipleVoices: false,
+            inNeighbor: [],
+            neighborArgBeat: [],
+            neighborArgCurrentBeat: [],
+            neighborNoteValue: 1,
+            noteValue: {},
+            oscList: {},
+            noteBeat: {},
+            noteBeatValues: {},
+            notePitches: {},
+            noteOctaves: {},
+            noteCents: {},
+            noteHertz: {},
+            noteDrums: {},
+            embeddedGraphics: {},
+            delayedNotes: [],
+            inDuplicate: false,
+            backward: [],
+            suppressOutput: true,
+            justCounting: [],
+            drumStyle: [],
+            synthVolume: {},
+            crescendoInitialVolume: {}
+        },
+        painter: {
+            color: 50,
+            penState: true,
+            closeSVG: jest.fn()
+        },
+        queue: [],
+        parentFlowQueue: [],
+        unhighlightQueue: [],
+        parameterQueue: [],
+        listeners: {},
+        endOfClampSignals: {},
+        waitTime: 0,
+        doWait: jest.fn(),
+        container: { x: 0, y: 0 },
+        x: 0,
+        y: 0,
+        running: false,
+        inTrash: false,
+        companionTurtle: null
+    };
+}
+
+function createActivity(turtle) {
+    return {
+        blocks: {
+            blockList: [],
+            findStacks: jest.fn(),
+            stackList: [],
+            unhighlightAll: jest.fn(),
+            bringToTop: jest.fn(),
+            showBlocks: jest.fn(),
+            unhighlight: jest.fn(),
+            highlight: jest.fn(),
+            clearParameterBlocks: jest.fn(),
+            updateParameterBlock: jest.fn(),
+            sameGeneration: jest.fn(() => false),
+            visible: false
+        },
+        turtles: {
+            turtleList: [turtle],
+            ithTurtle: jest.fn(() => turtle),
+            getTurtle: jest.fn(() => turtle),
+            getTurtleCount: jest.fn(() => 1),
+            turtleCount: jest.fn(() => 1),
+            turtleX2screenX: jest.fn(x => x),
+            turtleY2screenY: jest.fn(y => y),
+            add: jest.fn(),
+            addTurtle: jest.fn(),
+            markAllAsStopped: jest.fn(),
+            running: jest.fn(() => false)
+        },
+        stage: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(name => {
+                if (typeof name === "string" && turtle.listeners[name]) {
+                    turtle.listeners[name]();
+                }
+            }),
+            update: jest.fn()
+        },
+        errorMsg: jest.fn(),
+        textMsg: jest.fn(),
+        hideMsgs: jest.fn(),
+        saveLocally: jest.fn(),
+        refreshCanvas: jest.fn(),
+        showBlocksAfterRun: false,
+        onStopTurtle: jest.fn(),
+        onRunTurtle: jest.fn(),
+        meSpeak: { speak: jest.fn() },
+        save: {
+            afterSaveLilypond: jest.fn(),
+            afterSaveAbc: jest.fn(),
+            afterSaveMxml: jest.fn(),
+            afterSaveMIDI: jest.fn()
+        },
+        statsWindow: { displayInfo: jest.fn() }
+    };
+}
+
+function makeFlowBlock(name, connections, flow, dockTypes, args) {
+    return {
+        name,
+        connections,
+        protoblock: {
+            args: args || 0,
+            dockTypes: dockTypes || [null],
+            flow: flow || (() => null)
+        },
+        isValueBlock: () => false,
+        isArgBlock: () => false
+    };
+}
+
+describe("note clamp + beat event double queue", () => {
+    let logo;
+    let turtle;
+    let activity;
+    let drumCount;
+    let drumsAtNotePlay;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.document.body.style.cursor = "default";
+        turtle = createTurtle();
+        activity = createActivity(turtle);
+        logo = new Logo(activity);
+        activity.logo = logo;
+        logo.notation = { notationVoices: jest.fn() };
+        drumCount = 0;
+        drumsAtNotePlay = null;
+
+        Singer.processNote.mockImplementation((_activity, _noteValue, _isOsc, blk, t) => {
+            const tur = _activity.turtles.ithTurtle(t);
+            drumsAtNotePlay = [...tur.singer.noteDrums[blk]];
+        });
+
+        setupRhythmActions(activity);
+        setupDrumActions(activity);
+
+        // newnote (0): connections [prev, value, clampEntry, hidden]
+        // value (1):   number 1/3 (a one-third note, e.g. divide 1 / left with left = 3)
+        // vspace (2):  connections [prev, drum]
+        // drum (3):    playdrum cup drum, flow increments drumCount
+        // hidden (4):  connections [prev, null]
+        const hidden = makeFlowBlock("hidden", [0, null], null);
+        const drum = makeFlowBlock("drum", [2, null], (args, l, t, blk) => {
+            drumCount++;
+            Singer.DrumActions.playDrum("cup drum", t, blk);
+            return null;
+        });
+        const vspace = makeFlowBlock("vspace", [0, 3], null);
+        const newnote = makeFlowBlock(
+            "newnote",
+            [null, 1, 2, 4],
+            (args, l, t, blk, receivedArg) => {
+                const tur = l.turtles.ithTurtle(t);
+                const _callback = () => {
+                    const queueBlock = new Queue(args[1], 1, blk, receivedArg);
+                    tur.parentFlowQueue.push(blk);
+                    tur.queue.push(queueBlock);
+                };
+                Singer.RhythmActions.playNote(args[0], "newnote", t, blk, _callback);
+                return [args[1], 1];
+            },
+            [null, "numberin", "in", "in"],
+            3
+        );
+        const value = {
+            name: "number",
+            value: 1 / 3,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+
+        const blocks = [newnote, value, vspace, drum, hidden];
+        logo.blockList = blocks;
+        activity.blocks.blockList = blocks;
+    });
+
+    test("without a beat event the clamp child runs once and the note plays with one drum", () => {
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+        expect(drumCount).toBe(1);
+        expect(Singer.processNote).toHaveBeenCalledTimes(1);
+        expect(Singer.processNote).toHaveBeenCalledWith(activity, 3, false, 0, 0);
+        expect(drumsAtNotePlay).toEqual(["cup drum"]);
+    });
+
+    test("with everybeat the clamp child still runs once and the note plays with one drum", () => {
+        turtle.singer.beatList = ["everybeat"];
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+        expect(drumCount).toBe(1);
+        expect(Singer.processNote).toHaveBeenCalledTimes(1);
+        expect(Singer.processNote).toHaveBeenCalledWith(activity, 3, false, 0, 0);
+        expect(drumsAtNotePlay).toEqual(["cup drum"]);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__everybeat_0__");
+    });
+});

--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -47,13 +47,16 @@ function setupRhythmActions(activity) {
          * @param {String} blkName - note block type name
          * @param {Object} turtle - Turtle object
          * @param {Object} blk - corresponding Block object index in blocks.blockList or custom block number
-         * @param {Function} _enqueue - callback
+         * @param {Function} _enqueue - callback, no longer invoked by playNote. The note clamp's
+         *     child flow is queued by the interpreter from the flow block's `[childFlow, 1]` return
+         *     value (runFromBlockNow step 3); kept for signature compatibility.
          * @returns {void}
          */
         static playNote(value, blkName, turtle, blk, _enqueue) {
             /**
-             * We queue up the child flow of the note clamp and once all of the children are run, we
-             * trigger a _playnote_ event, then wait for the note to play. The note can be specified
+             * The interpreter queues the child flow of the note clamp from the flow block's
+             * `[childFlow, 1]` return value and, once all of the children are run, triggers a
+             * _playnote_ event, then waits for the note to play. The note can be specified
              * by pitch or synth blocks. The osctime block specifies the duration in milleseconds
              * while the note block specifies duration as a beat value.
              *
@@ -79,23 +82,26 @@ function setupRhythmActions(activity) {
                 tur.singer.currentMeasure = measureValue;
 
                 /**
-                 * Queue any beat actions.
-                 * Put the childFlow into the queue before the beat action so logo the beat action is
-                 * at the end of the FILO.
+                 * Dispatch any beat actions (everybeat / on-beat / offbeat / every-beat-N).
+                 *
+                 * The note clamp's child flow is queued by the interpreter instead: the note
+                 * blocks (newnote / note / osctime) return `[childFlow, 1]`, which makes
+                 * `runFromBlockNow` step (3) push the clamp onto the turtle queue exactly once.
+                 * Calling `_enqueue()` here as well queued the same child flow a second time
+                 * whenever a beat event was registered, so the clamp ran twice per note. The
+                 * second run executed after the note was consumed, re-triggering clamp content
+                 * (e.g. drums) outside of the note context and overwriting the note's timing.
                  * Note: The offbeat cannot be Beat 1.
                  */
                 const turtleID = tur.id;
 
                 if (tur.singer.beatList.includes("everybeat")) {
-                    _enqueue();
                     activity.stage.dispatchEvent("__everybeat_" + turtleID + "__");
                 }
 
                 if (tur.singer.beatList.includes(beatValue)) {
-                    _enqueue();
                     activity.stage.dispatchEvent("__beat_" + beatValue + "_" + turtleID + "__");
                 } else if (beatValue > 1 && tur.singer.beatList.includes("offbeat")) {
-                    _enqueue();
                     activity.stage.dispatchEvent("__offbeat_" + turtleID + "__");
                 }
 
@@ -103,7 +109,6 @@ function setupRhythmActions(activity) {
                     beatValue + tur.singer.beatsPerMeasure * (tur.singer.currentMeasure - 1);
                 for (let f = 0; f < tur.singer.factorList.length; f++) {
                     if (thisBeat % tur.singer.factorList[f] === 0) {
-                        _enqueue();
                         const eventName =
                             "__beat_" + tur.singer.factorList[f] + "_" + turtleID + "__";
                         activity.stage.dispatchEvent(eventName);
@@ -146,7 +151,9 @@ function setupRhythmActions(activity) {
                         const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
                         if (nextBeat <= 0 || !isFinite(nextBeat)) {
                             activity.errorMsg(
-                                _("Neighbor note value is too large for the current note duration."),
+                                _(
+                                    "Neighbor note value is too large for the current note duration."
+                                ),
                                 blk
                             );
                         } else {

--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -131,7 +131,7 @@ describe("setupRhythmActions", () => {
 
         Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
 
-        expect(enqueue).toHaveBeenCalled();
+        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__everybeat_0__");
     });
 
@@ -150,7 +150,7 @@ describe("setupRhythmActions", () => {
         Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
 
         expect(targetTurtle.singer.currentBeat).toBe(2);
-        expect(enqueue).toHaveBeenCalled();
+        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_2_0__");
     });
 
@@ -169,7 +169,7 @@ describe("setupRhythmActions", () => {
         Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
 
         expect(targetTurtle.singer.currentBeat).toBe(2);
-        expect(enqueue).toHaveBeenCalled();
+        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__offbeat_0__");
     });
     it("triggers factorList beat event when beat matches factor", () => {
@@ -186,7 +186,7 @@ describe("setupRhythmActions", () => {
 
         Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
 
-        expect(enqueue).toHaveBeenCalled();
+        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_2_0__");
     });
     it("adds rest note when inside a note block", () => {


### PR DESCRIPTION
This fixes an issue where notes were being executed twice whenever an **"On every note do"** (or other beat-event) block was used. The note clamp was being queued both by `Singer.RhythmActions.playNote()` and by the interpreter, even though the note blocks (`newnote`, `note`, and `osctime`) already return the clamp for the interpreter to queue. As a result, each note clamp ran twice, causing `playdrum` to fire twice, producing duplicate drum hits and disrupting the intended note timing and polyrhythms. This change removes the redundant `_enqueue()` call from `playNote()`, leaving the interpreter as the single place responsible for queuing the note clamp so each note executes exactly once while preserving the expected playback behavior.

## PR Category
- [X] Bug Fix
