### PR TITLE
Fix queue depth handling in numberOfNotes for turtle-singer

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -817,6 +817,19 @@ describe("numberOfNotes — state restoration and tally logic", () => {
         expect(turtleMock.singer.tallyNotes).toBe(2);
         expect(turtleMock.painter.doPenUp).toHaveBeenCalled();
     });
+
+    test("passes the queue depth as queueStart (6th argument) to runFromBlockNow", () => {
+        // Regression: a stray [] used to occupy the queueStart slot, pushing the
+        // computed queue depth into a nonexistent 7th parameter. queueStart then
+        // coerced to 0 and the counting run unwound the entire turtle queue.
+        activityMock.turtles.getTurtle = jest.fn().mockReturnValue({ queue: [10, 11, 12] });
+
+        Singer.numberOfNotes(logoMock, 0, 123);
+
+        const callArgs = activityMock.logo.runFromBlockNow.mock.calls[0];
+        expect(callArgs).toHaveLength(6);
+        expect(callArgs[5]).toBe(3);
+    });
 });
 
 describe("processPitch — note block execution path", () => {

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -688,7 +688,6 @@ class Singer {
             cblk,
             true,
             actionArgs,
-            [],
             activity.turtles.getTurtle(turtle).queue.length
         );
         const returnValue = tur.singer.tallyNotes - saveState.tallyNotes;


### PR DESCRIPTION
## Description

`Singer.numberOfNotes` — the engine behind the **"tally notes"** counter block — calls `runFromBlockNow` with **seven** arguments, while the function signature (`js/logo.js:1809`) has only **six** parameters: `runFromBlockNow(logo, turtle, blk, isflow, receivedArg, queueStart)`.

A stray `[]` occupied the `queueStart` slot, so the carefully computed `activity.turtles.getTurtle(turtle).queue.length` fell off the end and was silently discarded. Downstream, `queueStart` is compared numerically (`tur.queue.length > queueStart` at `js/logo.js:2085`), and `[]` coerces to `0` — so the silent counting run unwound the **entire turtle queue** instead of stopping at the pre-call depth, consuming flows that belong to the enclosing program. The strict `queueStart === 0` checks (`js/logo.js:2240`, `:2266`) are also `false` for `[]`, changing end-of-run behavior.

**User-visible effect:** using the "tally notes" block anywhere but the very start of a stack could make the program skip or double-run sections after the count returns, with no error shown.

The sibling `Singer.noteCounter` (`js/turtle-singer.js:589-596`) and `IntervalsBlocks.js` both pass `queue.length` correctly as the 6th argument, confirming the intended call shape. I also audited all 23 `runFromBlockNow` call sites in the codebase — this was the only one with the extra argument.

## Related Issue

No existing issue — found through code inspection while auditing the interpreter's `runFromBlockNow` call sites.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/turtle-singer.js`: removed the stray `[]` from the `runFromBlockNow` call in `Singer.numberOfNotes`, so the queue depth lands in the `queueStart` parameter (matching `Singer.noteCounter`).
-   `js/__tests__/turtle-singer.test.js`: added a regression test asserting the call receives exactly 6 arguments with the turtle's queue depth in the `queueStart` slot.

## Testing Performed

-   Wrote the regression test **first** and confirmed it fails on the old code (`Expected length: 6, Received length: 7`), then passes after the fix.
-   `npx jest js/__tests__/turtle-singer.test.js` — 123/123 tests pass.
-   Ran the related suites (`logo`, `MeterBlocks`, `IntervalsBlocks`) — 243/243 pass.
-   Full Jest suite: 7,244 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master` — verified by stashing this change and re-running them on a clean tree.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The fix is intentionally minimal (one line). While auditing, I noticed the three `butNotThese` encodings are inconsistent (`turtle-singer.js:575-580` pushes signal values, `:679` pushes string keys, while the consumer at `logo.js:2225` checks numeric indices) — left out of scope here to keep the change atomic; happy to follow up in a separate PR.