### PR TITLE
fix(project-storage): stop swallowing save failures, show quota warning

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -481,6 +481,42 @@ describe("PlanetInterface", () => {
         global._ = saved_;
     });
 
+    it("saveLocally shows the storage warning when the save promise rejects with QuotaExceededError", async () => {
+        const saved_ = global._;
+        global._ = jest.fn(str => str);
+        global.doSVG.mockReturnValue("");
+        mockActivity.prepareExport.mockReturnValue("DATA");
+        const quotaError = Object.assign(new Error("quota"), { name: "QuotaExceededError" });
+        planetInterface.planet = {
+            ProjectStorage: { saveLocally: jest.fn().mockRejectedValue(quotaError) }
+        };
+
+        await planetInterface.saveLocally();
+
+        expect(mockActivity.textMsg).toHaveBeenCalledWith(
+            "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+        );
+        global._ = saved_;
+    });
+
+    it("saveLocally shows a generic error message when the save promise rejects", async () => {
+        const saved_ = global._;
+        global._ = jest.fn(str => str);
+        global.doSVG.mockReturnValue("");
+        mockActivity.prepareExport.mockReturnValue("DATA");
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        planetInterface.planet = {
+            ProjectStorage: { saveLocally: jest.fn().mockRejectedValue(new Error("boom")) }
+        };
+
+        await planetInterface.saveLocally();
+
+        expect(mockActivity.textMsg).toHaveBeenCalledWith("Could not save your project.");
+        expect(consoleSpy).toHaveBeenCalledWith(expect.any(Error));
+        consoleSpy.mockRestore();
+        global._ = saved_;
+    });
+
     it("saveLocally rethrows unexpected errors and logs them", () => {
         global.doSVG.mockReturnValue("");
         mockActivity.prepareExport.mockReturnValue("DATA");

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -236,9 +236,27 @@ class PlanetInterface {
                 240,
                 320 / this.activity.canvas.width
             );
+            const handleSaveError = e => {
+                if (
+                    e?.name === "QuotaExceededError" ||
+                    e?.code === DOMException.QUOTA_EXCEEDED_ERR ||
+                    e?.message === "Not enough space to save locally"
+                ) {
+                    this.activity.textMsg(
+                        _(
+                            "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+                        )
+                    );
+                } else {
+                    console.error(e);
+                    this.activity.textMsg(_("Could not save your project."));
+                }
+            };
             try {
                 if (svgData === null || svgData === undefined || svgData === "") {
-                    return Promise.resolve(this.planet.ProjectStorage.saveLocally(data, null));
+                    return Promise.resolve(
+                        this.planet.ProjectStorage.saveLocally(data, null)
+                    ).catch(handleSaveError);
                 } else {
                     const fallbackImage =
                         typeof this.planet.ProjectStorage.getCurrentProjectImage === "function"
@@ -246,7 +264,7 @@ class PlanetInterface {
                             : null;
                     const savePromise = Promise.resolve(
                         this.planet.ProjectStorage.saveLocally(data, fallbackImage)
-                    );
+                    ).catch(handleSaveError);
                     const img = new Image();
                     const t = this;
                     img.onload = () => {
@@ -259,9 +277,7 @@ class PlanetInterface {
                                     data,
                                     bitmap.bitmapCache.getCacheDataURL()
                                 )
-                            ).catch(error => {
-                                console.error(error);
-                            });
+                            ).catch(handleSaveError);
                         } catch (error) {
                             console.error(error);
                         }

--- a/planet/js/ProjectStorage.js
+++ b/planet/js/ProjectStorage.js
@@ -198,7 +198,7 @@ class ProjectStorage {
     }
 
     async save() {
-        this._saveQueue = this._saveQueue.then(async () => {
+        const run = this._saveQueue.then(async () => {
             this._saveInProgress = true;
             try {
                 // Write backup of current persisted data before overwriting primary.
@@ -207,16 +207,20 @@ class ProjectStorage {
                     await this.set(this.BackupStorageKey, existing);
                 }
 
-                this.TimeLastSaved = Date.now();
                 await this.set(this.LocalStorageKey, this.data);
-            } catch (e) {
-                console.error("[ProjectStorage] Save failed:", e);
+                this.TimeLastSaved = Date.now();
             } finally {
                 this._saveInProgress = false;
             }
         });
 
-        return this._saveQueue;
+        // Keep the queue chain alive for later saves; callers observe the
+        // failure through the returned promise.
+        this._saveQueue = run.catch(e => {
+            console.error("[ProjectStorage] Save failed:", e);
+        });
+
+        return run;
     }
 
     async restore() {

--- a/planet/js/__tests__/ProjectStorage.test.js
+++ b/planet/js/__tests__/ProjectStorage.test.js
@@ -134,18 +134,39 @@ describe("ProjectStorage", () => {
             expect(primary).toEqual({ Projects: { 1: { ProjectName: "Updated" } } });
         });
 
-        it("should not crash when save encounters an error", async () => {
+        it("should reject and log when the write fails", async () => {
             const consoleSpy = jest.spyOn(console, "error").mockImplementation();
             storage.data = { Projects: {} };
-            // Make setItem throw
             mockLocalforage.setItem.mockRejectedValueOnce(new Error("Disk full"));
 
-            // Should not throw
-            await storage.save();
+            await expect(storage.save()).rejects.toThrow("Disk full");
             expect(consoleSpy).toHaveBeenCalledWith(
                 "[ProjectStorage] Save failed:",
                 expect.any(Error)
             );
+        });
+
+        it("should not advance TimeLastSaved when the write fails", async () => {
+            jest.spyOn(console, "error").mockImplementation();
+            storage.data = { Projects: {} };
+            mockLocalforage.setItem.mockRejectedValueOnce(new Error("Disk full"));
+
+            await storage.save().catch(() => {});
+            expect(storage.TimeLastSaved).toBe(-1);
+        });
+
+        it("should keep accepting saves after a failed save", async () => {
+            jest.spyOn(console, "error").mockImplementation();
+            storage.data = { Projects: { 1: { ProjectName: "First" } } };
+            mockLocalforage.setItem.mockRejectedValueOnce(new Error("Disk full"));
+
+            await storage.save().catch(() => {});
+
+            storage.data = { Projects: { 1: { ProjectName: "Second" } } };
+            await storage.save();
+
+            const saved = await storage.get(storage.LocalStorageKey);
+            expect(saved).toEqual({ Projects: { 1: { ProjectName: "Second" } } });
         });
 
         it("should queue concurrent saves instead of dropping them", async () => {


### PR DESCRIPTION
## Description

`ProjectStorage.save()` (`planet/js/ProjectStorage.js`) is the single funnel for **every** persistence path — `saveLocally`, `initialiseNewProject`, `renameProject`, `addPublishedData`, `deleteProject`, `like`, `report` — including the autosave of the currently open project. It had three related defects:

1. **Failures were silently swallowed.** The `catch` block only did `console.error`, so the queued promise always resolved and no caller could ever observe a failed write. When storage is full (shared school machines) or unavailable (private browsing), every save fails with zero indication — the kid keeps working and closing the tab loses the session.
2. **`this.TimeLastSaved = Date.now()` ran *before* `await this.set(...)`.** A failed write still advanced the "last saved" timestamp, so the app's own bookkeeping claimed the save succeeded.
3. **The user-facing quota warning was dead code.** `js/planetInterface.js` has a translated "ran out of local storage" message, but it sat in a *synchronous* `try/catch` wrapped around *async* work — an async rejection can never reach a sync catch, and `save()` never rejected anyway. The message was unreachable.

Notably, the autosave timer in `ProjectStorage.startAutoSave()` already wraps `await this.save()` in its own `try/catch` — evidence that `save()` rejecting on failure was the intended contract all along.

## Related Issue

No existing issue — found through code inspection while auditing the project save/load pipeline for silently swallowed errors.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `planet/js/ProjectStorage.js` — `save()` now:
    -   sets `TimeLastSaved` only **after** the write succeeds;
    -   propagates the failure to the caller through the returned promise;
    -   keeps the internal save queue alive after a failure (the queue chains on a caught copy of the run promise, so one failed save no longer risks wedging subsequent saves — and the queue-level `console.error` log is preserved).
-   `js/planetInterface.js` — `saveLocally()` gets a shared `handleSaveError` attached via `.catch` to all three async save paths (no-image save, fallback-image save, and the deferred `img.onload` re-save). On quota errors it shows the **existing** translated quota message — now actually reachable — matching by the modern `e.name === "QuotaExceededError"` in addition to the deprecated `e.code === DOMException.QUOTA_EXCEEDED_ERR` form; other failures log and show a generic "Could not save your project." message instead of disappearing.
-   Tests: 5 added/updated across `planet/js/__tests__/ProjectStorage.test.js` and `js/__tests__/planetInterface.test.js` (details below).

## Testing Performed

-   Followed TDD: wrote the behavioral tests first and confirmed all four fail on the old code for the expected reasons ("Received promise resolved instead of rejected"; `TimeLastSaved` advanced despite a failed write; both rejection paths surfaced as unhandled rejections instead of user messages), then pass after the fix.
-   New/updated tests:
    -   `save()` rejects and logs when the write fails (replaces the old test that pinned the swallow behavior);
    -   `save()` does **not** advance `TimeLastSaved` when the write fails;
    -   the save queue keeps accepting saves after a failed save;
    -   `saveLocally()` shows the storage warning when the save promise rejects with `QuotaExceededError`;
    -   `saveLocally()` shows a generic error message on other rejections.
-   `npx jest planet/js/__tests__/ProjectStorage.test.js js/__tests__/planetInterface.test.js` — 85/85 pass, including the pre-existing queue-concurrency, backup-before-overwrite, autosave, and sync-throw tests.
-   All 17 planet suites — 481 passing, no new failures.
-   Full Jest suite: 7,247 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface` Lilypond-clipboard tests) are pre-existing on `master` — verified by stashing this change and re-running them on a clean tree.
-   `npx eslint` on all four changed files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   **Design choice:** `save()` rejects to its direct caller, but the internal queue chains on a caught copy — so the caller observes the failure while the queue stays healthy for subsequent saves. Without this, one rejection would leave `_saveQueue` permanently rejected and silently skip every later save.
-   Fire-and-forget call sites elsewhere in the Planet UI (e.g. `GlobalCard.like`, `LocalCard.renameProject`, `LocalPlanet.deleteProject`) will now surface storage failures as unhandled-rejection console entries instead of pretending success. That is strictly more honest than the old behavior; giving each of those flows its own user-facing feedback is a natural follow-up PR.
-   `"Could not save your project."` is one new msgid for the translation pipeline; the quota message reuses the existing translated string.