### PR TITLE
refactor(rhythmruler): split init() and remove internal duplication

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -461,17 +461,37 @@ class RhythmRuler {
     }
 
     /**
-     * Initializes the temperament widget.
-     * @param {Activity} activity The activity instance associated with the widget.
+     * Replaces a button/cell's contents with a single header-icon <img>.
+     * Centralizes the icon markup shared by the toolbar and per-ruler play buttons.
+     * @private
+     * @param {HTMLElement} container - Element whose children are replaced with the icon.
+     * @param {string} iconFile - Filename under header-icons/ (e.g. "play-button.svg").
+     * @param {string} title - Used for both the title attribute and alt text.
+     * @param {boolean} [verticalAlign=true] - Whether to set style.verticalAlign = "middle".
+     * @returns {HTMLImageElement} The created image element.
+     */
+    _setButtonIcon(container, iconFile, title, verticalAlign = true) {
+        container.replaceChildren();
+        const img = document.createElement("img");
+        img.src = "header-icons/" + iconFile;
+        img.title = title;
+        img.alt = title;
+        img.height = RhythmRuler.ICONSIZE;
+        img.width = RhythmRuler.ICONSIZE;
+        if (verticalAlign) {
+            img.style.verticalAlign = "middle";
+        }
+        container.appendChild(img);
+        return img;
+    }
+
+    /**
+     * Resets playback/sync state and ensures at least one (default) drum/ruler
+     * exists. Called at the start of init().
+     * @private
      * @returns {void}
      */
-    init(activity) {
-        /**
-         * The activity instance associated with the widget.
-         * @type {Activity}
-         */
-        this.activity = activity;
-
+    _resetPlaybackState() {
         /**
          * Factor used in BPM calculations.
          * @type {number}
@@ -550,7 +570,16 @@ class RhythmRuler {
          * @private
          */
         this._cellScale = 1.0;
+    }
 
+    /**
+     * Creates the widget window, wires its close/maximize handlers, and adds
+     * the toolbar buttons (play all, save rhythms, save drum machine, dissect
+     * number input, undo, tap, clear, circular view toggle).
+     * @private
+     * @returns {WidgetWindow} The created widget window.
+     */
+    _createWidgetWindow() {
         /**
          * Size of the icons.
          * @type {number}
@@ -583,36 +612,7 @@ class RhythmRuler {
                 this.__pause();
             }
             this._clearWidgetTimers();
-            // Save the new dissect history.
-            const dissectHistory = [];
-            const drums = [];
-            for (let i = 0; i < this.Rulers.length; i++) {
-                if (this.Drums[i] === null) {
-                    continue;
-                }
-
-                const history = [];
-                for (let j = 0; j < this.Rulers[i][1].length; j++) {
-                    history.push(this.Rulers[i][1][j]);
-                }
-
-                this._dissectNumber.classList.add("hasKeyboard");
-                dissectHistory.push([history, this.Drums[i]]);
-                drums.push(this.Drums[i]);
-            }
-
-            // Look for any old entries that we may have missed.
-            // Use Set for O(1) lookup instead of Array.includes() O(n)
-            const drumsSet = new Set(drums);
-            for (let i = 0; i < this._dissectHistory.length; i++) {
-                const drum = this._dissectHistory[i][1];
-                if (!drumsSet.has(drum)) {
-                    const history = deepClone(this._dissectHistory[i][0]);
-                    dissectHistory.push([history, drum]);
-                }
-            }
-
-            this._dissectHistory = deepClone(dissectHistory);
+            this.saveDissectHistory();
 
             this._playing = false;
             this._playingOne = false;
@@ -767,6 +767,18 @@ class RhythmRuler {
             this._toggleCircularView();
         };
 
+        return widgetWindow;
+    }
+
+    /**
+     * Builds the <table> of rhythm rulers: one row per drum, each with a
+     * play button in the first column and that drum's ruler cells (one per
+     * note-value division) in the second.
+     * @private
+     * @param {WidgetWindow} widgetWindow - The widget window created by _createWidgetWindow().
+     * @returns {void}
+     */
+    _buildRulerTable(widgetWindow) {
         /**
          * Represents the table containing the rhythm rulers.
          * The table has an outer div for vertical scrolling and an inner div for horizontal scrolling.
@@ -798,29 +810,14 @@ class RhythmRuler {
                 }
             } else {
                 const drumcell = rhythmRulerTableRow.insertCell();
-                drumcell.replaceChildren();
-                const playImg = document.createElement("img");
-                playImg.src = "header-icons/play-button.svg";
-                playImg.title = _("Play");
-                playImg.alt = _("Play");
-                playImg.height = iconSize;
-                playImg.width = iconSize;
-                drumcell.appendChild(playImg);
+                this._setButtonIcon(drumcell, "play-button.svg", _("Play"), false);
                 drumcell.className = "headcol"; // Position fixed when scrolling horizontally
                 drumcell.style.cursor = "pointer";
                 drumcell.onclick = (id => {
                     return () => {
                         if (this._playing) {
                             if (this._rulerPlaying === id) {
-                                drumcell.replaceChildren();
-                                const playImg = document.createElement("img");
-                                playImg.src = "header-icons/play-button.svg";
-                                playImg.title = _("Play");
-                                playImg.alt = _("Play");
-                                playImg.height = iconSize;
-                                playImg.width = iconSize;
-                                playImg.style.verticalAlign = "middle";
-                                drumcell.appendChild(playImg);
+                                this._setButtonIcon(drumcell, "play-button.svg", _("Play"));
                                 this._playing = false;
                                 this._playingOne = false;
                                 this._playingAll = false;
@@ -841,15 +838,7 @@ class RhythmRuler {
                             this._cellCounter = 0;
                             this._startingTime = null;
                             this._rulerPlaying = id;
-                            drumcell.replaceChildren();
-                            const pauseImg = document.createElement("img");
-                            pauseImg.src = "header-icons/pause-button.svg";
-                            pauseImg.title = _("Pause");
-                            pauseImg.alt = _("Pause");
-                            pauseImg.height = iconSize;
-                            pauseImg.width = iconSize;
-                            pauseImg.style.verticalAlign = "middle";
-                            drumcell.appendChild(pauseImg);
+                            this._setButtonIcon(drumcell, "pause-button.svg", _("Pause"));
                             this._elapsedTimes[id] = 0;
                             this._offsets[id] = 0;
                             this._playOne();
@@ -914,8 +903,16 @@ class RhythmRuler {
             rhythmRulerTableRow.cells[0].style.maxHeight = rulerRow.offsetHeight + "px";
             rhythmRulerTableRow.cells[0].style.verticalAlign = "middle";
         }
+    }
 
-        // Restore dissect history.
+    /**
+     * Replays the saved dissect history onto the freshly built ruler cells
+     * (rests, dissects, divisions and ties), so a widget rebuilt by init()
+     * restores the edits made in a previous session.
+     * @private
+     * @returns {void}
+     */
+    _restoreDissectHistory() {
         let cell;
         for (let drum = 0; drum < this.Drums.length; drum++) {
             if (drum === null) {
@@ -979,6 +976,25 @@ class RhythmRuler {
                 }
             }
         }
+    }
+
+    /**
+     * Initializes the rhythm ruler widget.
+     * @param {Activity} activity The activity instance associated with the widget.
+     * @returns {void}
+     */
+    init(activity) {
+        /**
+         * The activity instance associated with the widget.
+         * @type {Activity}
+         */
+        this.activity = activity;
+
+        this._resetPlaybackState();
+
+        const widgetWindow = this._createWidgetWindow();
+        this._buildRulerTable(widgetWindow);
+        this._restoreDissectHistory();
 
         activity.textMsg(_("Click on the ruler to divide it."), 3000);
     }
@@ -1148,15 +1164,7 @@ class RhythmRuler {
                     this._tapMode = false;
                     this._tapTimes = [];
                     this._tapEndTime = null;
-                    this._tapButton.replaceChildren();
-                    const tapImg = document.createElement("img");
-                    tapImg.src = "header-icons/tap-button.svg";
-                    tapImg.title = _("tap a rhythm");
-                    tapImg.alt = _("tap a rhythm");
-                    tapImg.height = RhythmRuler.ICONSIZE;
-                    tapImg.width = RhythmRuler.ICONSIZE;
-                    tapImg.style.verticalAlign = "middle";
-                    this._tapButton.appendChild(tapImg);
+                    this._setButtonIcon(this._tapButton, "tap-button.svg", _("tap a rhythm"));
                     return;
                 }
 
@@ -1356,16 +1364,7 @@ class RhythmRuler {
         this._tapTimes = [];
         this._tapCell = null;
         this._tapEndTime = null;
-        // let iconSize = RhythmRuler.ICONSIZE;
-        this._tapButton.replaceChildren();
-        const tapImg = document.createElement("img");
-        tapImg.src = "header-icons/tap-button.svg";
-        tapImg.title = _("tap a rhythm");
-        tapImg.alt = _("tap a rhythm");
-        tapImg.height = RhythmRuler.ICONSIZE;
-        tapImg.width = RhythmRuler.ICONSIZE;
-        tapImg.style.verticalAlign = "middle";
-        this._tapButton.appendChild(tapImg);
+        this._setButtonIcon(this._tapButton, "tap-button.svg", _("tap a rhythm"));
     }
 
     /**
@@ -1977,16 +1976,7 @@ class RhythmRuler {
      */
     _tap() {
         this._tapMode = true;
-        const iconSize = RhythmRuler.ICONSIZE;
-        this._tapButton.replaceChildren();
-        const tapActiveImg = document.createElement("img");
-        tapActiveImg.src = "header-icons/tap-active-button.svg";
-        tapActiveImg.title = _("tap a rhythm");
-        tapActiveImg.alt = _("tap a rhythm");
-        tapActiveImg.height = iconSize;
-        tapActiveImg.width = iconSize;
-        tapActiveImg.style.verticalAlign = "middle";
-        this._tapButton.appendChild(tapActiveImg);
+        this._setButtonIcon(this._tapButton, "tap-active-button.svg", _("tap a rhythm"));
     }
 
     /**
@@ -2002,15 +1992,7 @@ class RhythmRuler {
         this._playingOne = false;
         this._rulerPlaying = -1;
         this._startingTime = null;
-        this._playAllCell.replaceChildren();
-        const playImg = document.createElement("img");
-        playImg.src = "header-icons/play-button.svg";
-        playImg.title = _("Play all");
-        playImg.alt = _("Play all");
-        playImg.height = RhythmRuler.ICONSIZE;
-        playImg.width = RhythmRuler.ICONSIZE;
-        playImg.style.verticalAlign = "middle";
-        this._playAllCell.appendChild(playImg);
+        this._setButtonIcon(this._playAllCell, "play-button.svg", _("Play all"));
         for (let r = 0; r < this.Rulers.length; r++) {
             this._rulerSelected = r;
             while (this.Rulers[r][1].length > 0) {
@@ -2027,15 +2009,7 @@ class RhythmRuler {
      * @returns {void}
      */
     __pause() {
-        this._playAllCell.replaceChildren();
-        const playImg = document.createElement("img");
-        playImg.src = "header-icons/play-button.svg";
-        playImg.title = _("Play all");
-        playImg.alt = _("Play all");
-        playImg.height = RhythmRuler.ICONSIZE;
-        playImg.width = RhythmRuler.ICONSIZE;
-        playImg.style.verticalAlign = "middle";
-        this._playAllCell.appendChild(playImg);
+        this._setButtonIcon(this._playAllCell, "play-button.svg", _("Play all"));
         this._playing = false;
         this._playingAll = false;
         this._playingOne = false;
@@ -2080,15 +2054,7 @@ class RhythmRuler {
      */
     __resume() {
         this._clearWidgetTimers();
-        this._playAllCell.replaceChildren();
-        const pauseImg = document.createElement("img");
-        pauseImg.src = "header-icons/pause-button.svg";
-        pauseImg.title = _("Pause");
-        pauseImg.alt = _("Pause");
-        pauseImg.height = RhythmRuler.ICONSIZE;
-        pauseImg.width = RhythmRuler.ICONSIZE;
-        pauseImg.style.verticalAlign = "middle";
-        this._playAllCell.appendChild(pauseImg);
+        this._setButtonIcon(this._playAllCell, "pause-button.svg", _("Pause"));
         this.activity.logo.turtleDelay = 0;
         this._playingAll = true;
         this._playing = true;
@@ -3105,6 +3071,28 @@ class RhythmRuler {
     }
 
     /**
+     * Computes the concentric-ring layout shared by _drawCircularView() and
+     * _hitTestCircular(), so the two stay in sync by construction.
+     * @private
+     * @param {number} size - The (square) canvas size in pixels.
+     * @param {number} rulerCount - Number of rulers (rings) to lay out.
+     * @returns {{innerHoleRadius: number, outerLimit: number, ringGap: number, ringThickness: number}}
+     */
+    _getRingGeometry(size, rulerCount) {
+        // Leave a hole in the center and space for labels.
+        const innerHoleRadius = size * 0.1;
+        const outerLimit = size * 0.47;
+        const ringGap = 2;
+        const totalRingSpace = outerLimit - innerHoleRadius;
+        const ringThickness =
+            rulerCount > 0
+                ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
+                : totalRingSpace;
+
+        return { innerHoleRadius, outerLimit, ringGap, ringThickness };
+    }
+
+    /**
      * Draws the circular (donut/pie) view on the canvas.
      * Each ruler is a concentric ring. Each note value is an arc slice
      * whose angle is proportional to its duration.
@@ -3134,15 +3122,10 @@ class RhythmRuler {
         const centerY = size / 2;
         const rulerCount = this.Rulers.length;
 
-        // Ring geometry: leave a hole in the center and space for labels.
-        const innerHoleRadius = size * 0.1;
-        const outerLimit = size * 0.47;
-        const ringGap = 2;
-        const totalRingSpace = outerLimit - innerHoleRadius;
-        const ringThickness =
-            rulerCount > 0
-                ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
-                : totalRingSpace;
+        const { innerHoleRadius, outerLimit, ringGap, ringThickness } = this._getRingGeometry(
+            size,
+            rulerCount
+        );
 
         const colors = [platformColor.selectorBackground, platformColor.selectorSelected];
 
@@ -3276,15 +3259,8 @@ class RhythmRuler {
         if (angle < 0) angle += 2 * Math.PI;
 
         const size = canvas.width;
-        const innerHoleRadius = size * 0.1;
-        const outerLimit = size * 0.47;
         const rulerCount = this.Rulers.length;
-        const ringGap = 2;
-        const totalRingSpace = outerLimit - innerHoleRadius;
-        const ringThickness =
-            rulerCount > 0
-                ? (totalRingSpace - ringGap * (rulerCount - 1)) / rulerCount
-                : totalRingSpace;
+        const { innerHoleRadius, ringGap, ringThickness } = this._getRingGeometry(size, rulerCount);
 
         // Find which ring (ruler) the pointer is in.
         let hitRuler = -1;


### PR DESCRIPTION
# Refactor: Improve RhythmRuler Maintainability

## Summary

This PR is a **behavior-preserving refactor** of `js/widgets/rhythmruler.js` that improves readability and maintainability by extracting large logical sections into focused private helper methods and removing duplicated internal code.

There are **no functional changes**, no public API changes, and no changes to widget-loading behavior.

## Changes

### 1. Split `init()` into focused helper methods

The original `init()` method (~523 lines) performed several unrelated tasks sequentially. It has been decomposed into smaller private methods while preserving the original execution order:

* `_resetPlaybackState()`
* `_createWidgetWindow()`
* `_buildRulerTable()`
* `_restoreDissectHistory()`

This makes the initialization flow significantly easier to understand without modifying behavior.

### 2. Remove duplicated toolbar icon creation

Nine nearly identical `<img>` creation blocks have been replaced with a shared helper:

* `_setButtonIcon()`

All existing behavior is preserved, including the one call site that required a different `verticalAlign` value.

### 3. Reuse existing dissect-history logic

`widgetWindow.onclose` previously reimplemented the same logic already present in `saveDissectHistory()`.

This duplication has been removed by calling the existing helper directly.

### 4. Share circular-view geometry calculations

Both:

* `_drawCircularView()`
* `_hitTestCircular()`

previously recomputed the same ring geometry independently.

The shared calculations have been extracted into:

* `_getRingGeometry()`

to eliminate duplicated logic and improve maintainability.

### 5. Documentation cleanup

Updated an outdated JSDoc comment:

* `"Initializes the temperament widget"` → `"Initializes the rhythm ruler widget"`

This is a documentation-only change with no runtime impact.

---

## Deliberately Not Changed

During the refactoring process, several additional opportunities for cleanup were investigated but intentionally left out of this PR.

### Hover handler consolidation

The hover logic inside:

* `__addCellEventHandlers()`
* `__toggleRestState()`

appears similar, but the implementations differ by an important `cell.parentNode === null` guard.

Combining them would introduce behavioral changes, so they were intentionally left untouched.

### Save/export pipeline

The approximately 700-line save/export implementation (`_save*`, `_saveDrumMachine`, `_saveVoiceMachine`) remains unchanged.

Although further modularization would improve readability, this code constructs exact block-ID graphs and currently lacks dedicated output-shape test coverage. Refactoring it deserves its own focused PR.

### Existing typo bug

A pre-existing typo in `__tie()` (`this._mouseDdownCell`) that can prevent `_mouseUpCell` from being recorded during certain cross-direction tie operations was identified but intentionally left unchanged, as fixing it would be a behavioral change rather than a pure refactor.

---

## Verification

### Tests

* ✅ `js/widgets/__tests__/rhythmruler.test.js` — **60 / 60 passing**
* ✅ `js/widgets/__tests__/` — **29 suites, 1458 / 1458 passing**

### Quality Checks

* ✅ `eslint js/widgets/rhythmruler.js`
* ✅ `prettier --check`

### Compatibility

Verified that external call sites remain unchanged, including:

* `WidgetBlocks.js`
* `piemenus.js`

The following interfaces continue to use their existing names and behavior:

* `init`
* `playAll`
* `Drums`
* `Rulers`
* `_dissectNumber`
* `.activity`

No public APIs were modified.
