### PR TITLE
fix(security): guard plugin loading against prototype pollution via for...in

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -31,7 +31,8 @@ const {
     escapeHTML,
     unescapeHTML,
     deepClone,
-    isSafeUrl
+    isSafeUrl,
+    isUnsafeObjectKey
 } = require("../utils-logic.js");
 
 describe("Utility Logic Functions", () => {
@@ -336,6 +337,20 @@ describe("Utility Logic Functions", () => {
             expect(isSafeUrl("java\tscript:alert(1)")).toBe(false);
             expect(isSafeUrl("jav\rascript:alert(1)")).toBe(false);
             expect(isSafeUrl(" javascript:alert(1)")).toBe(false);
+        });
+    });
+
+    describe("isUnsafeObjectKey()", () => {
+        it("flags reserved prototype-related keys", () => {
+            expect(isUnsafeObjectKey("__proto__")).toBe(true);
+            expect(isUnsafeObjectKey("constructor")).toBe(true);
+            expect(isUnsafeObjectKey("prototype")).toBe(true);
+        });
+
+        it("allows ordinary keys", () => {
+            expect(isUnsafeObjectKey("myPlugin")).toBe(false);
+            expect(isUnsafeObjectKey("FLOWPLUGINS")).toBe(false);
+            expect(isUnsafeObjectKey("")).toBe(false);
         });
     });
 });

--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -31,7 +31,8 @@ const {
     escapeHTML,
     unescapeHTML,
     deepClone,
-    isSafeUrl
+    isSafeUrl,
+    isUnsafeObjectKey
 } = require("../utils-logic.js");
 
 describe("Utility Logic Functions", () => {
@@ -380,6 +381,20 @@ describe("Utility Logic Functions", () => {
             expect(isSafeUrl("java\tscript:alert(1)")).toBe(false);
             expect(isSafeUrl("jav\rascript:alert(1)")).toBe(false);
             expect(isSafeUrl(" javascript:alert(1)")).toBe(false);
+        });
+    });
+
+    describe("isUnsafeObjectKey()", () => {
+        it("flags reserved prototype-related keys", () => {
+            expect(isUnsafeObjectKey("__proto__")).toBe(true);
+            expect(isUnsafeObjectKey("constructor")).toBe(true);
+            expect(isUnsafeObjectKey("prototype")).toBe(true);
+        });
+
+        it("allows ordinary keys", () => {
+            expect(isUnsafeObjectKey("myPlugin")).toBe(false);
+            expect(isUnsafeObjectKey("FLOWPLUGINS")).toBe(false);
+            expect(isUnsafeObjectKey("")).toBe(false);
         });
     });
 });

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -160,3 +160,53 @@ describe("processPluginData script cleanup", () => {
         debugSpy.mockRestore();
     });
 });
+
+describe("processPluginData - prototype pollution guard", () => {
+    let processPluginData;
+
+    beforeEach(() => {
+        jest.resetModules();
+        global._ = msg => msg;
+        global.PALETTEICONS = {};
+        global.PALETTEFILLCOLORS = {};
+        global.PALETTESTROKECOLORS = {};
+        global.PALETTEHIGHLIGHTCOLORS = {};
+        global.HIGHLIGHTSTROKECOLORS = {};
+        global.MULTIPALETTES = [[], [], []];
+        global.platformColor = { paletteColors: {} };
+        ({ processPluginData } = require("../utils.js"));
+    });
+
+    it("skips __proto__ and constructor keys in every plugin-data section", async () => {
+        const activity = createActivity();
+
+        const unsafe = '{"__proto__": {"polluted": true}, "constructor": {"polluted": true}}';
+        const maliciousData = `{
+            "PALETTEPLUGINS": ${unsafe}, "IMAGES": ${unsafe}, "FLOWPLUGINS": ${unsafe},
+            "ARGPLUGINS": ${unsafe}, "MACROPLUGINS": ${unsafe}, "SETTERPLUGINS": ${unsafe},
+            "BLOCKPLUGINS": ${unsafe}, "PARAMETERPLUGINS": ${unsafe}, "ONLOAD": ${unsafe},
+            "ONSTART": ${unsafe}, "ONSTOP": ${unsafe}
+        }`;
+
+        await processPluginData(activity, maliciousData, "plugins/test.json");
+
+        expect(Object.prototype.polluted).toBeUndefined();
+        expect({}.polluted).toBeUndefined();
+
+        const targets = [
+            PALETTEICONS,
+            activity.pluginsImages,
+            activity.logo.evalFlowDict,
+            activity.logo.evalArgDict,
+            activity.palettes.pluginMacros,
+            activity.logo.evalSetterDict,
+            activity.logo.evalParameterDict,
+            activity.logo.evalOnStartList,
+            activity.logo.evalOnStopList
+        ];
+        for (const dict of targets) {
+            expect(Object.prototype.hasOwnProperty.call(dict, "__proto__")).toBe(false);
+            expect(Object.prototype.hasOwnProperty.call(dict, "constructor")).toBe(false);
+        }
+    });
+});

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -210,3 +210,54 @@ describe("processPluginData - prototype pollution guard", () => {
         }
     });
 });
+
+describe("updatePluginObj - prototype pollution guard", () => {
+    let updatePluginObj;
+
+    beforeEach(() => {
+        jest.resetModules();
+        global._ = msg => msg;
+        ({ updatePluginObj } = require("../utils.js"));
+    });
+
+    it("skips __proto__ and constructor keys when merging into activity.pluginObjs", () => {
+        const activity = {
+            pluginObjs: {
+                PALETTEPLUGINS: {},
+                PALETTEFILLCOLORS: {},
+                PALETTESTROKECOLORS: {},
+                PALETTEHIGHLIGHTCOLORS: {},
+                FLOWPLUGINS: {},
+                ARGPLUGINS: {},
+                BLOCKPLUGINS: {},
+                MACROPLUGINS: {},
+                ONLOAD: {},
+                ONSTART: {},
+                ONSTOP: {}
+            }
+        };
+
+        const unsafe = '{"__proto__": {"polluted": true}, "constructor": {"polluted": true}}';
+        const maliciousObj = JSON.parse(`{
+            "PALETTEPLUGINS": ${unsafe}, "PALETTEFILLCOLORS": ${unsafe},
+            "PALETTESTROKECOLORS": ${unsafe}, "PALETTEHIGHLIGHTCOLORS": ${unsafe},
+            "FLOWPLUGINS": ${unsafe}, "ARGPLUGINS": ${unsafe}, "BLOCKPLUGINS": ${unsafe},
+            "MACROPLUGINS": ${unsafe}, "ONLOAD": ${unsafe}, "ONSTART": ${unsafe},
+            "ONSTOP": ${unsafe}
+        }`);
+
+        updatePluginObj(activity, maliciousObj);
+
+        expect(Object.prototype.polluted).toBeUndefined();
+        expect({}.polluted).toBeUndefined();
+
+        for (const section of Object.keys(activity.pluginObjs)) {
+            expect(
+                Object.prototype.hasOwnProperty.call(activity.pluginObjs[section], "__proto__")
+            ).toBe(false);
+            expect(
+                Object.prototype.hasOwnProperty.call(activity.pluginObjs[section], "constructor")
+            ).toBe(false);
+        }
+    });
+});

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -1162,6 +1162,23 @@ describe("processMacroData()", () => {
         expect(palettes.makePalettes).not.toHaveBeenCalled();
         spy.mockRestore();
     });
+
+    it("does not pollute Object.prototype when macroData contains a __proto__ key", () => {
+        const macroDict = {};
+        const palettes = { add: jest.fn(), makePalettes: jest.fn() };
+        const blocks = { addToMyPalette: jest.fn() };
+        const maliciousData = JSON.stringify({
+            __proto__: { polluted: true },
+            constructor: { polluted: true }
+        });
+
+        processMacroData(maliciousData, palettes, blocks, macroDict);
+
+        expect({}.polluted).toBeUndefined();
+        expect(Object.prototype.polluted).toBeUndefined();
+        expect(Object.prototype.hasOwnProperty.call(macroDict, "__proto__")).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(macroDict, "constructor")).toBe(false);
+    });
 });
 
 describe("prepareMacroExports()", () => {

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -1166,6 +1166,23 @@ describe("processMacroData()", () => {
         expect(palettes.makePalettes).not.toHaveBeenCalled();
         spy.mockRestore();
     });
+
+    it("does not pollute Object.prototype when macroData contains a __proto__ key", () => {
+        const macroDict = {};
+        const palettes = { add: jest.fn(), makePalettes: jest.fn() };
+        const blocks = { addToMyPalette: jest.fn() };
+        const maliciousData = JSON.stringify({
+            __proto__: { polluted: true },
+            constructor: { polluted: true }
+        });
+
+        processMacroData(maliciousData, palettes, blocks, macroDict);
+
+        expect({}.polluted).toBeUndefined();
+        expect(Object.prototype.polluted).toBeUndefined();
+        expect(Object.prototype.hasOwnProperty.call(macroDict, "__proto__")).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(macroDict, "constructor")).toBe(false);
+    });
 });
 
 describe("prepareMacroExports()", () => {

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -18,7 +18,7 @@
  */
 
 /* exported
-   deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, last,
+   deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, isUnsafeObjectKey, last,
    mixedNumber, nearestBeat, oneHundredToFraction, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, unescapeHTML, escapeHTML,
    rationalToFraction, GCD, LCD, resolveObject
@@ -187,6 +187,19 @@ var safeSVG = text => {
     if (typeof text !== "string") return text;
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 };
+
+/**
+ * Reserved property names that must never be used as keys when copying
+ * externally-supplied data onto a plain object. Assigning to these keys
+ * via bracket notation can reach Object.prototype (prototype pollution)
+ * or overwrite the target's own constructor reference.
+ */
+var RESERVED_OBJECT_KEYS = ["__proto__", "constructor", "prototype"];
+
+/**
+ * Checks whether a key is unsafe to assign onto a plain object.
+ */
+var isUnsafeObjectKey = key => RESERVED_OBJECT_KEYS.includes(key);
 
 /**
  * Formats a number to at most two decimal places.
@@ -604,6 +617,7 @@ var UtilsLogic = {
     unescapeHTML,
     isSafeUrl,
     safeSVG,
+    isUnsafeObjectKey,
     toFixed2,
     rationalToFraction,
     GCD,

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -18,7 +18,7 @@
  */
 
 /* exported
-   deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, last,
+   deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, isUnsafeObjectKey, last,
    mixedNumber, nearestBeat, oneHundredToFraction, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, unescapeHTML, escapeHTML,
    rationalToFraction, GCD, LCD, resolveObject, clampNumber
@@ -187,6 +187,19 @@ var safeSVG = text => {
     if (typeof text !== "string") return text;
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 };
+
+/**
+ * Reserved property names that must never be used as keys when copying
+ * externally-supplied data onto a plain object. Assigning to these keys
+ * via bracket notation can reach Object.prototype (prototype pollution)
+ * or overwrite the target's own constructor reference.
+ */
+var RESERVED_OBJECT_KEYS = ["__proto__", "constructor", "prototype"];
+
+/**
+ * Checks whether a key is unsafe to assign onto a plain object.
+ */
+var isUnsafeObjectKey = key => RESERVED_OBJECT_KEYS.includes(key);
 
 /**
  * Formats a number to at most two decimal places.
@@ -635,6 +648,7 @@ var UtilsLogic = {
     unescapeHTML,
     isSafeUrl,
     safeSVG,
+    isUnsafeObjectKey,
     toFixed2,
     rationalToFraction,
     GCD,

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1345,7 +1345,6 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 
         // Loop for all variables of class type's instance
         for (const name of Object.keys(obj.added)) {
-            if (isUnsafeObjectKey(name)) continue;
             obj[name] = obj.added[name];
 
             // Remove variable entry from obj (removing each entry right after

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -521,7 +521,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     let newPalette = false,
         paletteName = null;
     if ("PALETTEPLUGINS" in obj) {
-        for (const name in obj["PALETTEPLUGINS"]) {
+        for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
             paletteName = name;
             PALETTEICONS[name] = obj["PALETTEPLUGINS"][name];
             let fillColor = "#ff0066";
@@ -589,7 +589,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
 
     // Define the image blocks
     if ("IMAGES" in obj) {
-        for (const blkName in obj["IMAGES"]) {
+        for (const blkName of Object.keys(obj["IMAGES"])) {
             activity.pluginsImages[blkName] = obj["IMAGES"][blkName];
         }
     }
@@ -597,7 +597,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     // Populate the flow-block dictionary, i.e., the code that is
     // compiled into a function for hot-path execution.
     if ("FLOWPLUGINS" in obj) {
-        for (const flow in obj["FLOWPLUGINS"]) {
+        for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
             // Pre-compile trusted plugins for performance.
             // UNTRUSTED plugins (if any made it past confirmation) are stored as strings
             // and handled via whitelist in safePluginExecute.
@@ -618,7 +618,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, rec
 
     // Populate the arg-block dictionary
     if ("ARGPLUGINS" in obj) {
-        for (const arg in obj["ARGPLUGINS"]) {
+        for (const arg of Object.keys(obj["ARGPLUGINS"])) {
             if (isVettedPlugin(pluginSource)) {
                 const argCode = obj["ARGPLUGINS"][arg];
                 const registryName = `arg_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -637,7 +637,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // Populate the macro dictionary, i.e., the code that is
     // eval'd by this block.
     if ("MACROPLUGINS" in obj) {
-        for (const macro in obj["MACROPLUGINS"]) {
+        for (const macro of Object.keys(obj["MACROPLUGINS"])) {
             try {
                 activity.palettes.pluginMacros[macro] = JSON.parse(obj["MACROPLUGINS"][macro]);
             } catch (e) {
@@ -650,7 +650,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
 
     // Populate the setter dictionary
     if ("SETTERPLUGINS" in obj) {
-        for (const setter in obj["SETTERPLUGINS"]) {
+        for (const setter of Object.keys(obj["SETTERPLUGINS"])) {
             if (isVettedPlugin(pluginSource)) {
                 const setterCode = obj["SETTERPLUGINS"][setter];
                 const registryName = `setter_${setter}_${Math.random().toString(36).substr(2, 9)}`;
@@ -673,7 +673,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
     // let g = (function() { return this ? this : typeof self !== 'undefined' ? self : undefined})() || Function("return this")();
 
     if ("BLOCKPLUGINS" in obj) {
-        for (const block in obj["BLOCKPLUGINS"]) {
+        for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
             console.debug("adding plugin block " + block);
             safeEval(obj["BLOCKPLUGINS"][block], "BLOCKPLUGINS:" + block);
         }
@@ -685,7 +685,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
     }
 
     if ("PARAMETERPLUGINS" in obj) {
-        for (const parameter in obj["PARAMETERPLUGINS"]) {
+        for (const parameter of Object.keys(obj["PARAMETERPLUGINS"])) {
             if (isVettedPlugin(pluginSource)) {
                 const paramCode = obj["PARAMETERPLUGINS"][parameter];
                 const registryName = `param_${parameter}_${Math.random()
@@ -705,14 +705,14 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
 
     // Code to execute when plugin is loaded
     if ("ONLOAD" in obj) {
-        for (const arg in obj["ONLOAD"]) {
+        for (const arg of Object.keys(obj["ONLOAD"])) {
             safeEval(obj["ONLOAD"][arg], "ONLOAD:" + arg);
         }
     }
 
     // Code to execute when turtle code is started
     if ("ONSTART" in obj) {
-        for (const arg in obj["ONSTART"]) {
+        for (const arg of Object.keys(obj["ONSTART"])) {
             if (isVettedPlugin(pluginSource)) {
                 const onStartCode = obj["ONSTART"][arg];
                 const registryName = `onstart_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -730,7 +730,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo) {
 
     // Code to execute when turtle code is stopped
     if ("ONSTOP" in obj) {
-        for (const arg in obj["ONSTOP"]) {
+        for (const arg of Object.keys(obj["ONSTOP"])) {
             if (isVettedPlugin(pluginSource)) {
                 const onStopCode = obj["ONSTOP"][arg];
                 const registryName = `onstop_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -920,36 +920,36 @@ const updatePluginObj = (activity, obj) => {
         return;
     }
 
-    for (const name in obj["PALETTEPLUGINS"]) {
+    for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
         activity.pluginObjs["PALETTEPLUGINS"][name] = obj["PALETTEPLUGINS"][name];
     }
 
-    for (const name in obj["PALETTEFILLCOLORS"]) {
+    for (const name of Object.keys(obj["PALETTEFILLCOLORS"])) {
         activity.pluginObjs["PALETTEFILLCOLORS"][name] = obj["PALETTEFILLCOLORS"][name];
     }
 
-    for (const name in obj["PALETTESTROKECOLORS"]) {
+    for (const name of Object.keys(obj["PALETTESTROKECOLORS"])) {
         activity.pluginObjs["PALETTESTROKECOLORS"][name] = obj["PALETTESTROKECOLORS"][name];
     }
 
-    for (const name in obj["PALETTEHIGHLIGHTCOLORS"]) {
+    for (const name of Object.keys(obj["PALETTEHIGHLIGHTCOLORS"])) {
         activity.pluginObjs["PALETTEHIGHLIGHTCOLORS"][name] = obj["PALETTEHIGHLIGHTCOLORS"][name];
     }
 
-    for (const flow in obj["FLOWPLUGINS"]) {
+    for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
         activity.pluginObjs["FLOWPLUGINS"][flow] = obj["FLOWPLUGINS"][flow];
     }
 
-    for (const arg in obj["ARGPLUGINS"]) {
+    for (const arg of Object.keys(obj["ARGPLUGINS"])) {
         activity.pluginObjs["ARGPLUGINS"][arg] = obj["ARGPLUGINS"][arg];
     }
 
-    for (const block in obj["BLOCKPLUGINS"]) {
+    for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
         activity.pluginObjs["BLOCKPLUGINS"][block] = obj["BLOCKPLUGINS"][block];
     }
 
     if ("MACROPLUGINS" in obj) {
-        for (const macro in obj["MACROPLUGINS"]) {
+        for (const macro of Object.keys(obj["MACROPLUGINS"])) {
             activity.pluginObjs["MACROPLUGINS"][macro] = obj["MACROPLUGINS"][macro];
         }
     }
@@ -965,15 +965,15 @@ const updatePluginObj = (activity, obj) => {
         activity.pluginObjs["IMAGES"] = obj["IMAGES"];
     }
 
-    for (const name in obj["ONLOAD"]) {
+    for (const name of Object.keys(obj["ONLOAD"])) {
         activity.pluginObjs["ONLOAD"][name] = obj["ONLOAD"][name];
     }
 
-    for (const name in obj["ONSTART"]) {
+    for (const name of Object.keys(obj["ONSTART"])) {
         activity.pluginObjs["ONSTART"][name] = obj["ONSTART"][name];
     }
 
-    for (const name in obj["ONSTOP"]) {
+    for (const name of Object.keys(obj["ONSTOP"])) {
         activity.pluginObjs["ONSTOP"][name] = obj["ONSTOP"][name];
     }
 };
@@ -1005,7 +1005,7 @@ let processMacroData = (macroData, palettes, blocks, macroDict) => {
             const obj = JSON.parse(macroData);
             palettes.add("myblocks", "black", "#a0a0a0");
 
-            for (const name in obj) {
+            for (const name of Object.keys(obj)) {
                 // console.debug("adding " + name + " to macroDict");
                 macroDict[name] = obj[name];
                 blocks.addToMyPalette(name, macroDict[name]);

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -27,7 +27,7 @@
     - js/utils/platformstyle.js
         platformColor
     - js/utils/utils-logic.js
-        resolveObject
+        resolveObject, isUnsafeObjectKey
     - js/utils/browser-utils.js
         canvasPixelRatio, doBrowserCheck, fnBrowserDetect, windowHeight, windowWidth
 */
@@ -36,7 +36,7 @@ if (typeof module !== "undefined" && module.exports) {
     var UtilsLogic =
         (typeof window !== "undefined" && window.UtilsLogic) ||
         (typeof require !== "undefined" ? require("./utils-logic") : {});
-    var { resolveObject } = UtilsLogic;
+    var { resolveObject, isUnsafeObjectKey } = UtilsLogic;
 
     var DomHelpers =
         (typeof window !== "undefined" && window.DomHelpers) ||
@@ -522,6 +522,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
         paletteName = null;
     if ("PALETTEPLUGINS" in obj) {
         for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
+            if (isUnsafeObjectKey(name)) continue;
             paletteName = name;
             PALETTEICONS[name] = obj["PALETTEPLUGINS"][name];
             let fillColor = "#ff0066";
@@ -590,6 +591,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     // Define the image blocks
     if ("IMAGES" in obj) {
         for (const blkName of Object.keys(obj["IMAGES"])) {
+            if (isUnsafeObjectKey(blkName)) continue;
             activity.pluginsImages[blkName] = obj["IMAGES"][blkName];
         }
     }
@@ -598,6 +600,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     // compiled into a function for hot-path execution.
     if ("FLOWPLUGINS" in obj) {
         for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
+            if (isUnsafeObjectKey(flow)) continue;
             // Pre-compile trusted plugins for performance.
             // UNTRUSTED plugins (if any made it past confirmation) are stored as strings
             // and handled via whitelist in safePluginExecute.
@@ -619,6 +622,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, rec
     // Populate the arg-block dictionary
     if ("ARGPLUGINS" in obj) {
         for (const arg of Object.keys(obj["ARGPLUGINS"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const argCode = obj["ARGPLUGINS"][arg];
                 const registryName = `arg_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -638,6 +642,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // eval'd by this block.
     if ("MACROPLUGINS" in obj) {
         for (const macro of Object.keys(obj["MACROPLUGINS"])) {
+            if (isUnsafeObjectKey(macro)) continue;
             try {
                 activity.palettes.pluginMacros[macro] = JSON.parse(obj["MACROPLUGINS"][macro]);
             } catch (e) {
@@ -651,6 +656,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // Populate the setter dictionary
     if ("SETTERPLUGINS" in obj) {
         for (const setter of Object.keys(obj["SETTERPLUGINS"])) {
+            if (isUnsafeObjectKey(setter)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const setterCode = obj["SETTERPLUGINS"][setter];
                 const registryName = `setter_${setter}_${Math.random().toString(36).substr(2, 9)}`;
@@ -674,6 +680,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
 
     if ("BLOCKPLUGINS" in obj) {
         for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
+            if (isUnsafeObjectKey(block)) continue;
             console.debug("adding plugin block " + block);
             safeEval(obj["BLOCKPLUGINS"][block], "BLOCKPLUGINS:" + block);
         }
@@ -686,6 +693,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
 
     if ("PARAMETERPLUGINS" in obj) {
         for (const parameter of Object.keys(obj["PARAMETERPLUGINS"])) {
+            if (isUnsafeObjectKey(parameter)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const paramCode = obj["PARAMETERPLUGINS"][parameter];
                 const registryName = `param_${parameter}_${Math.random()
@@ -706,6 +714,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
     // Code to execute when plugin is loaded
     if ("ONLOAD" in obj) {
         for (const arg of Object.keys(obj["ONLOAD"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             safeEval(obj["ONLOAD"][arg], "ONLOAD:" + arg);
         }
     }
@@ -713,6 +722,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
     // Code to execute when turtle code is started
     if ("ONSTART" in obj) {
         for (const arg of Object.keys(obj["ONSTART"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const onStartCode = obj["ONSTART"][arg];
                 const registryName = `onstart_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -731,6 +741,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo) {
     // Code to execute when turtle code is stopped
     if ("ONSTOP" in obj) {
         for (const arg of Object.keys(obj["ONSTOP"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const onStopCode = obj["ONSTOP"][arg];
                 const registryName = `onstop_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -921,35 +932,43 @@ const updatePluginObj = (activity, obj) => {
     }
 
     for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEPLUGINS"][name] = obj["PALETTEPLUGINS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTEFILLCOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEFILLCOLORS"][name] = obj["PALETTEFILLCOLORS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTESTROKECOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTESTROKECOLORS"][name] = obj["PALETTESTROKECOLORS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTEHIGHLIGHTCOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEHIGHLIGHTCOLORS"][name] = obj["PALETTEHIGHLIGHTCOLORS"][name];
     }
 
     for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
+        if (isUnsafeObjectKey(flow)) continue;
         activity.pluginObjs["FLOWPLUGINS"][flow] = obj["FLOWPLUGINS"][flow];
     }
 
     for (const arg of Object.keys(obj["ARGPLUGINS"])) {
+        if (isUnsafeObjectKey(arg)) continue;
         activity.pluginObjs["ARGPLUGINS"][arg] = obj["ARGPLUGINS"][arg];
     }
 
     for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
+        if (isUnsafeObjectKey(block)) continue;
         activity.pluginObjs["BLOCKPLUGINS"][block] = obj["BLOCKPLUGINS"][block];
     }
 
     if ("MACROPLUGINS" in obj) {
         for (const macro of Object.keys(obj["MACROPLUGINS"])) {
+            if (isUnsafeObjectKey(macro)) continue;
             activity.pluginObjs["MACROPLUGINS"][macro] = obj["MACROPLUGINS"][macro];
         }
     }
@@ -966,14 +985,17 @@ const updatePluginObj = (activity, obj) => {
     }
 
     for (const name of Object.keys(obj["ONLOAD"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONLOAD"][name] = obj["ONLOAD"][name];
     }
 
     for (const name of Object.keys(obj["ONSTART"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONSTART"][name] = obj["ONSTART"][name];
     }
 
     for (const name of Object.keys(obj["ONSTOP"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONSTOP"][name] = obj["ONSTOP"][name];
     }
 };
@@ -1006,6 +1028,7 @@ let processMacroData = (macroData, palettes, blocks, macroDict) => {
             palettes.add("myblocks", "black", "#a0a0a0");
 
             for (const name of Object.keys(obj)) {
+                if (isUnsafeObjectKey(name)) continue;
                 // console.debug("adding " + name + " to macroDict");
                 macroDict[name] = obj[name];
                 blocks.addToMyPalette(name, macroDict[name]);
@@ -1322,6 +1345,7 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 
         // Loop for all variables of class type's instance
         for (const name of Object.keys(obj.added)) {
+            if (isUnsafeObjectKey(name)) continue;
             obj[name] = obj.added[name];
 
             // Remove variable entry from obj (removing each entry right after

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -27,7 +27,7 @@
     - js/utils/platformstyle.js
         platformColor
     - js/utils/utils-logic.js
-        resolveObject
+        resolveObject, isUnsafeObjectKey
     - js/utils/browser-utils.js
         canvasPixelRatio, doBrowserCheck, fnBrowserDetect, windowHeight, windowWidth
 */
@@ -36,7 +36,7 @@ if (typeof module !== "undefined" && module.exports) {
     var UtilsLogic =
         (typeof window !== "undefined" && window.UtilsLogic) ||
         (typeof require !== "undefined" ? require("./utils-logic") : {});
-    var { resolveObject } = UtilsLogic;
+    var { resolveObject, isUnsafeObjectKey } = UtilsLogic;
 
     var DomHelpers =
         (typeof window !== "undefined" && window.DomHelpers) ||
@@ -522,6 +522,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
         paletteName = null;
     if ("PALETTEPLUGINS" in obj) {
         for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
+            if (isUnsafeObjectKey(name)) continue;
             paletteName = name;
             PALETTEICONS[name] = obj["PALETTEPLUGINS"][name];
             let fillColor = "#ff0066";
@@ -590,6 +591,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     // Define the image blocks
     if ("IMAGES" in obj) {
         for (const blkName of Object.keys(obj["IMAGES"])) {
+            if (isUnsafeObjectKey(blkName)) continue;
             activity.pluginsImages[blkName] = obj["IMAGES"][blkName];
         }
     }
@@ -598,6 +600,7 @@ const processPluginData = async (activity, pluginData, pluginSource) => {
     // compiled into a function for hot-path execution.
     if ("FLOWPLUGINS" in obj) {
         for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
+            if (isUnsafeObjectKey(flow)) continue;
             // Pre-compile trusted plugins for performance.
             // UNTRUSTED plugins (if any made it past confirmation) are stored as strings
             // and handled via whitelist in safePluginExecute.
@@ -619,6 +622,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, rec
     // Populate the arg-block dictionary
     if ("ARGPLUGINS" in obj) {
         for (const arg of Object.keys(obj["ARGPLUGINS"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const argCode = obj["ARGPLUGINS"][arg];
                 const registryName = `arg_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -638,6 +642,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // eval'd by this block.
     if ("MACROPLUGINS" in obj) {
         for (const macro of Object.keys(obj["MACROPLUGINS"])) {
+            if (isUnsafeObjectKey(macro)) continue;
             try {
                 activity.palettes.pluginMacros[macro] = JSON.parse(obj["MACROPLUGINS"][macro]);
             } catch (e) {
@@ -651,6 +656,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk, par
     // Populate the setter dictionary
     if ("SETTERPLUGINS" in obj) {
         for (const setter of Object.keys(obj["SETTERPLUGINS"])) {
+            if (isUnsafeObjectKey(setter)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const setterCode = obj["SETTERPLUGINS"][setter];
                 const registryName = `setter_${setter}_${Math.random().toString(36).substr(2, 9)}`;
@@ -674,6 +680,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
 
     if ("BLOCKPLUGINS" in obj) {
         for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
+            if (isUnsafeObjectKey(block)) continue;
             console.debug("adding plugin block " + block);
             safeEval(obj["BLOCKPLUGINS"][block], "BLOCKPLUGINS:" + block);
         }
@@ -686,6 +693,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, blk, value, turt
 
     if ("PARAMETERPLUGINS" in obj) {
         for (const parameter of Object.keys(obj["PARAMETERPLUGINS"])) {
+            if (isUnsafeObjectKey(parameter)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const paramCode = obj["PARAMETERPLUGINS"][parameter];
                 const registryName = `param_${parameter}_${Math.random()
@@ -706,6 +714,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
     // Code to execute when plugin is loaded
     if ("ONLOAD" in obj) {
         for (const arg of Object.keys(obj["ONLOAD"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             safeEval(obj["ONLOAD"][arg], "ONLOAD:" + arg);
         }
     }
@@ -713,6 +722,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo, turtle, blk) {
     // Code to execute when turtle code is started
     if ("ONSTART" in obj) {
         for (const arg of Object.keys(obj["ONSTART"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const onStartCode = obj["ONSTART"][arg];
                 const registryName = `onstart_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -731,6 +741,7 @@ window.__mb_plugin_registry["${registryName}"] = function(logo) {
     // Code to execute when turtle code is stopped
     if ("ONSTOP" in obj) {
         for (const arg of Object.keys(obj["ONSTOP"])) {
+            if (isUnsafeObjectKey(arg)) continue;
             if (isVettedPlugin(pluginSource)) {
                 const onStopCode = obj["ONSTOP"][arg];
                 const registryName = `onstop_${arg}_${Math.random().toString(36).substr(2, 9)}`;
@@ -921,35 +932,43 @@ const updatePluginObj = (activity, obj) => {
     }
 
     for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEPLUGINS"][name] = obj["PALETTEPLUGINS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTEFILLCOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEFILLCOLORS"][name] = obj["PALETTEFILLCOLORS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTESTROKECOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTESTROKECOLORS"][name] = obj["PALETTESTROKECOLORS"][name];
     }
 
     for (const name of Object.keys(obj["PALETTEHIGHLIGHTCOLORS"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["PALETTEHIGHLIGHTCOLORS"][name] = obj["PALETTEHIGHLIGHTCOLORS"][name];
     }
 
     for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
+        if (isUnsafeObjectKey(flow)) continue;
         activity.pluginObjs["FLOWPLUGINS"][flow] = obj["FLOWPLUGINS"][flow];
     }
 
     for (const arg of Object.keys(obj["ARGPLUGINS"])) {
+        if (isUnsafeObjectKey(arg)) continue;
         activity.pluginObjs["ARGPLUGINS"][arg] = obj["ARGPLUGINS"][arg];
     }
 
     for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
+        if (isUnsafeObjectKey(block)) continue;
         activity.pluginObjs["BLOCKPLUGINS"][block] = obj["BLOCKPLUGINS"][block];
     }
 
     if ("MACROPLUGINS" in obj) {
         for (const macro of Object.keys(obj["MACROPLUGINS"])) {
+            if (isUnsafeObjectKey(macro)) continue;
             activity.pluginObjs["MACROPLUGINS"][macro] = obj["MACROPLUGINS"][macro];
         }
     }
@@ -966,14 +985,17 @@ const updatePluginObj = (activity, obj) => {
     }
 
     for (const name of Object.keys(obj["ONLOAD"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONLOAD"][name] = obj["ONLOAD"][name];
     }
 
     for (const name of Object.keys(obj["ONSTART"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONSTART"][name] = obj["ONSTART"][name];
     }
 
     for (const name of Object.keys(obj["ONSTOP"])) {
+        if (isUnsafeObjectKey(name)) continue;
         activity.pluginObjs["ONSTOP"][name] = obj["ONSTOP"][name];
     }
 };
@@ -1006,6 +1028,7 @@ let processMacroData = (macroData, palettes, blocks, macroDict) => {
             palettes.add("myblocks", "black", "#a0a0a0");
 
             for (const name of Object.keys(obj)) {
+                if (isUnsafeObjectKey(name)) continue;
                 // console.debug("adding " + name + " to macroDict");
                 macroDict[name] = obj[name];
                 blocks.addToMyPalette(name, macroDict[name]);
@@ -1373,6 +1396,7 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 
         // Loop for all variables of class type's instance
         for (const name of Object.keys(obj.added)) {
+            if (isUnsafeObjectKey(name)) continue;
             obj[name] = obj.added[name];
 
             // Remove variable entry from obj (removing each entry right after

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1443,6 +1443,7 @@ if (typeof module !== "undefined" && module.exports) {
         prepareMacroExports,
         processPluginData,
         processMacroData,
+        updatePluginObj,
         announceToScreenReader,
         doUseCamera,
         doStopVideoCam,

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1396,7 +1396,6 @@ let importMembers = (obj, className, modelArgs, viewArgs) => {
 
         // Loop for all variables of class type's instance
         for (const name of Object.keys(obj.added)) {
-            if (isUnsafeObjectKey(name)) continue;
             obj[name] = obj.added[name];
 
             // Remove variable entry from obj (removing each entry right after


### PR DESCRIPTION
## What this fixes
The plugin loading system in `js/utils/utils.js` iterates over plugin JSON objects with unguarded `for...in` loops when copying properties into global configuration objects (palette icons, colors, macros, flow/arg/setter/block/parameter plugins, onload/onstart/onstop handlers). Because `for...in` walks the full prototype chain with no `hasOwnProperty` check, a crafted plugin containing a `__proto__` or `constructor` key could pollute `Object.prototype` and corrupt every object in the runtime.

This PR does two things together, since neither is sufficient alone:
- Replaces every affected `for...in` loop with `Object.keys()`, so iteration only ever touches the object's own enumerable keys (stops inherited/leaked properties from an already-polluted prototype elsewhere in the runtime from propagating further).
- Adds a new `isUnsafeObjectKey()` helper (`js/utils/utils-logic.js`) that explicitly rejects `__proto__`, `constructor`, and `prototype` as key names, and skips them in every loop. This is the part that actually stops a plugin from using one of these names as a **genuine own key** straight out of `JSON.parse` — `Object.keys()` by itself still returns `"__proto__"` when it's a real own property, so it doesn't catch this case on its own.

## Related issues
- Fixes #6962
- Supersedes #6965, which stalled and was closed due to significant drift in `js/utils/utils.js` since it was opened

## Changes
- `js/utils/utils-logic.js`: added `RESERVED_OBJECT_KEYS` (`__proto__`, `constructor`, `prototype`) and `isUnsafeObjectKey()`, exported for use in `utils.js`
- `processPluginData`: converted loops over `PALETTEPLUGINS`, `IMAGES`, `FLOWPLUGINS`, `ARGPLUGINS`, `MACROPLUGINS`, `SETTERPLUGINS`, `BLOCKPLUGINS`, `PARAMETERPLUGINS`, `ONLOAD`, `ONSTART`, and `ONSTOP` to `Object.keys()`, each with an `isUnsafeObjectKey()` guard that skips reserved keys
- `updatePluginObj`: same conversion + guard applied across all plugin dictionary merges (`PALETTEPLUGINS`, `PALETTEFILLCOLORS`, `PALETTESTROKECOLORS`, `PALETTEHIGHLIGHTCOLORS`, `FLOWPLUGINS`, `ARGPLUGINS`, `BLOCKPLUGINS`, `MACROPLUGINS`, `ONLOAD`, `ONSTART`, `ONSTOP`)
- `processMacroData`: converted the macro dictionary loop to `Object.keys()` with the same guard
- Added regression tests: `js/utils/__tests__/utils-logic.test.js` (unit tests for `isUnsafeObjectKey()`) and `js/utils/__tests__/utils.test.js` (verifies `processMacroData` doesn't pollute `Object.prototype` or copy `__proto__`/`constructor` as own keys when fed malicious macro data)

No behavioral changes for well-formed plugin data — this only removes the ability for a malicious key to reach the prototype chain.

## Testing
- Added Jest tests covering `isUnsafeObjectKey()` directly and `processMacroData()`'s handling of a malicious `__proto__`/`constructor` payload — both pass
- Loaded `plugins/maths.json` locally: the Maths palette icon registers and renders correctly, matching pre-fix behavior for well-formed plugin data
- Note: clicking into the Maths palette currently shows no blocks under it. I've confirmed this reproduces identically on unmodified `master`, so it's a pre-existing issue unrelated to this change, not a regression introduced here — still looking into it separately
- `npm run lint` and `npx prettier --check .` pass
- No existing tests broken

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto rebase; this only affects the PR branch, not your fork).