### PR TITLE
chore: refresh code ownership paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,19 +40,30 @@
 /js/planetInterface.js @zealot-zew
 /js/SaveInterface.js @zealot-zew
 
-# Tests and CI infrastructure. These rules come after source rules so test
-# files do not fall back to Walter or Devin.
+# Tests and CI infrastructure. These rules come after source rules so shared
+# test paths do not fall back to Walter or Devin.
 /.github/workflows/ @omsuneri @Ashutoshx7
 /.husky/ @omsuneri @Ashutoshx7
 /cypress/ @omsuneri @Ashutoshx7
+/test/ @omsuneri @Ashutoshx7
 /cypress.config.js @omsuneri @Ashutoshx7
 /jest.config.js @omsuneri @Ashutoshx7
-/jest.setup.js @omsuneri @Ashutoshx7
 /eslint.config.mjs @omsuneri @Ashutoshx7
+/commitlint.config.js @omsuneri @Ashutoshx7
+/lighthouserc.js @omsuneri @Ashutoshx7
+/.prettierignore @omsuneri @Ashutoshx7
+/.prettierrc @omsuneri @Ashutoshx7
 /js/__tests__/ @omsuneri @Ashutoshx7
+/js/activity/__tests__/ @omsuneri @Ashutoshx7
+/js/palette/__tests__/ @omsuneri @Ashutoshx7
 /js/utils/__tests__/ @omsuneri @Ashutoshx7
 /js/widgets/__tests__/ @omsuneri @Ashutoshx7
 /js/turtleactions/__tests__/ @omsuneri @Ashutoshx7
+
+# Planet feature tests that live outside the Planet directory.
+/js/__tests__/planetInterface.test.js @zealot-zew
+/js/__tests__/SaveInterface.test.js @zealot-zew
+
 /js/blocks/__tests__/DrumBlocks*.test.js @omsuneri @Ashutoshx7
 /js/blocks/__tests__/EnsembleBlocks*.test.js @omsuneri @Ashutoshx7
 /js/blocks/__tests__/IntervalsBlocks*.test.js @omsuneri @Ashutoshx7

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -33,6 +33,7 @@
 - Check whether failures are pre-existing or introduced by this PR.
 - Verify that mock property names in tests match the source code.
 - Thoroughly check folder structure especially for tests — new test files are sometimes created when tests could have been added to existing files instead (e.g. `js/__tests__/` and `js/widgets/__tests__/` are different).
+- When a PR adds a new test or CI path, or moves or removes a directory, check whether `.github/CODEOWNERS` needs updating.
 - If the PR description lists regression-testing steps, spot-check that they were actually followed.
 
   **Security and approval**


### PR DESCRIPTION
#7944 showed that /test/ was still falling back to Walter, so did and audit of the CODEOWNERS paths too. found a few similar gaps--fixed them too.

Also a small note for reviewers to check CODEOWNERS when paths change. 
The ownership model itself stays the same.