### PR TITLE
fix: stop note counter from eating the rest of the program

### DIFF
--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -688,7 +688,6 @@ class Singer {
             cblk,
             true,
             actionArgs,
-            [],
             activity.turtles.getTurtle(turtle).queue.length
         );
         const returnValue = tur.singer.tallyNotes - saveState.tallyNotes;


### PR DESCRIPTION
- [x] Bug Fix
## What was going wrong

If you use the **note counter** block inside a loop, Music Blocks could stop almost immediately after printing the count. Notes that should play after the counter never show up, the loop doesn't finish, and Play flips back to Stop right away.

That matches what happens with a stack like:

```text
Start
 └── Repeat 4
      ├── Print ← note counter [ Note do, Note re ]
      ├── Note mi
      └── Note fa
```

You get a single `2` on screen, no **mi** / **fa**, and the run ends early.

## Root cause

`Singer.numberOfNotes()` calls `runFromBlockNow` with **seven** arguments, but that method only takes **six**. An extra `[]` was sitting in the `queueStart` slot, and the real value (`queue.length`) was ignored as a 7th argument.

`queueStart` is meant to mark how deep the turtle's queue already was, so the counting dry-run only processes work it added itself. With `[]` in that slot:

- comparisons like `queue.length > queueStart` treat the empty array like `0`, so the dry-run can walk the **caller's** queue too
- strict checks like `queueStart === 0` fail, so some completion cleanup doesn't run the way it should

The sibling method `noteCounter` ("sum note values") already passes the arguments correctly. Same pattern is used in places like interval measuring. This looks like a leftover from the state-cleanup refactor that introduced the stray `[]`.

## How to check in the UI

1. Open Music Blocks from this branch.
2. Build the stack above (Meter → **note counter**, not **sum note values**; Rhythm → **note**; Flow → **repeat**; Extras → **print**).
3. Hit Play.

**Before:** print `2` once, no mi/fa, run ends right away.  
**After:** print `2` four times, mi and fa play each time through the loop, program runs for a normal length.

Notes **inside** the counter still stay silent on purpose (they're only counted). The music after the counter should play again.
