### PR TITLE
test: add memory tracking unit test to performanceTracker.test.js

### DIFF
--- a/js/utils/__tests__/performanceTracker.test.js
+++ b/js/utils/__tests__/performanceTracker.test.js
@@ -247,5 +247,122 @@ describe("performanceTracker", () => {
             global.performance = originalPerf;
         });
     });
-    describe("memory tracking", () => {});
+    describe("memory tracking", () => {
+        let originalGlobalPerformance;
+        let originalWindowPerformance;
+
+        beforeEach(() => {
+            originalGlobalPerformance = global.performance;
+            if (typeof window !== "undefined") {
+                originalWindowPerformance = window.performance;
+            }
+        });
+
+        afterEach(() => {
+            global.performance = originalGlobalPerformance;
+            if (typeof window !== "undefined") {
+                window.performance = originalWindowPerformance;
+            }
+        });
+
+        const setMockPerformance = mockPerf => {
+            global.performance = mockPerf;
+            if (typeof window !== "undefined") {
+                try {
+                    delete window.performance;
+                    window.performance = mockPerf;
+                } catch (e) {
+                    Object.defineProperty(window, "performance", {
+                        value: mockPerf,
+                        configurable: true,
+                        writable: true
+                    });
+                }
+            }
+        };
+
+        test("computes memoryDelta when performance.memory is available", () => {
+            let memoryUsage = 1000000;
+            const mockPerf = {
+                now: () => Date.now(),
+                memory: {
+                    get usedJSHeapSize() {
+                        return memoryUsage;
+                    }
+                }
+            };
+            setMockPerformance(mockPerf);
+
+            performanceTracker.enable();
+            performanceTracker.startRun();
+            memoryUsage = 1500000;
+            performanceTracker.endRun();
+
+            expect(performanceTracker.getStats().memoryDelta).toBe(500000);
+        });
+
+        test("handles negative memoryDelta when memory is freed by GC", () => {
+            let memoryUsage = 2000000;
+            const mockPerf = {
+                now: () => Date.now(),
+                memory: {
+                    get usedJSHeapSize() {
+                        return memoryUsage;
+                    }
+                }
+            };
+            setMockPerformance(mockPerf);
+
+            performanceTracker.enable();
+            performanceTracker.startRun();
+            memoryUsage = 1200000;
+            performanceTracker.endRun();
+
+            expect(performanceTracker.getStats().memoryDelta).toBe(-800000);
+        });
+
+        test("returns null memoryDelta if performance.memory getter throws error", () => {
+            const mockPerf = {
+                now: () => Date.now(),
+                get memory() {
+                    throw new Error("Access denied");
+                }
+            };
+            setMockPerformance(mockPerf);
+
+            performanceTracker.enable();
+            performanceTracker.startRun();
+            performanceTracker.endRun();
+
+            expect(performanceTracker.getStats().memoryDelta).toBeNull();
+        });
+
+        test("logStats displays formatted memory byte count when memory tracking is supported", () => {
+            const gcSpy = jest.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+            const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+            jest.spyOn(console, "groupEnd").mockImplementation(() => {});
+
+            let memoryUsage = 100000;
+            const mockPerf = {
+                now: () => Date.now(),
+                memory: {
+                    get usedJSHeapSize() {
+                        return memoryUsage;
+                    }
+                }
+            };
+            setMockPerformance(mockPerf);
+
+            performanceTracker.enable();
+            performanceTracker.startRun();
+            memoryUsage = 624288;
+            performanceTracker.endRun();
+            performanceTracker.logStats();
+
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("524288 bytes"));
+
+            gcSpy.mockRestore();
+            logSpy.mockRestore();
+        });
+    });
 });


### PR DESCRIPTION
## Description

Populates the empty `describe("memory tracking", () => {});` block in `js/utils/__tests__/performanceTracker.test.js` to provide full unit test coverage for heap size monitoring (`_getHeapSize()`), memory delta calculation, error handling resilience, and console output formatting.

`js/utils/performanceTracker.js` includes built-in memory tracking capabilities, but its test file previously lacked tests for memory heap snapshots and formatted logging.

## Related Issue

N/A

## PR Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/utils/__tests__/performanceTracker.test.js`**:
  - Added unit test verifying `getStats().memoryDelta` computes exact memory delta (`memoryEnd - memoryStart`) when `performance.memory` is available.
  - Added unit test verifying handling of negative memory delta when garbage collection frees memory during a run.
  - Added unit test verifying error resilience if accessing `performance.memory` throws an exception.
  - Added unit test verifying `logStats()` formats non-null memory byte counts in console output.

## Testing Performed

- Ran local Jest test suite: `npx.cmd jest js/utils/__tests__/performanceTracker.test.js --coverage=false`
- Verified all 26 unit tests pass cleanly (26/26 passed).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
