### PR TITLE
fix: resolve PhraseMaker note division crash

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -699,7 +699,7 @@ describe("PhraseMaker Widget", () => {
 
         expect(phraseMaker.activity.blocks.sendStackToTrash).toHaveBeenCalled();
     });
-    test("_addRhythmBlock loads new rhythm blocks safely", () => {
+    test("_addRhythmBlock loads new rhythm blocks safely", async () => {
         phraseMaker.blockNo = 0;
 
         phraseMaker._deps.toFraction = jest.fn(v => v);
@@ -715,21 +715,59 @@ describe("PhraseMaker Widget", () => {
             refreshCanvas: jest.fn()
         };
 
-        phraseMaker._addRhythmBlock([1, 4], 2);
+        await phraseMaker._addRhythmBlock([1, 4], 2);
 
         expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalled();
         expect(phraseMaker.blockConnection).toHaveBeenCalled();
     });
-    test("_readjustNotesBlocks updates and adds blocks", () => {
+    test("_addRhythmBlock loads new rhythm blocks safely (non-vspace)", async () => {
+        phraseMaker.blockNo = 0;
+
+        phraseMaker._deps.toFraction = jest.fn(v => v);
+        phraseMaker.blockConnection = jest.fn();
+        jest.spyOn(global, "setTimeout").mockImplementation(fn => fn());
+
+        phraseMaker.activity = {
+            blocks: {
+                blockList: [{ connections: [null, 1] }, { name: "action", connections: [] }],
+                findBottomBlock: jest.fn(() => 1),
+                loadNewBlocks: jest.fn()
+            },
+            refreshCanvas: jest.fn()
+        };
+
+        await phraseMaker._addRhythmBlock([1, 4], 2);
+
+        expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalled();
+        expect(phraseMaker.blockConnection).toHaveBeenCalledWith(7, 1);
+    });
+    test("_readjustNotesBlocks awaits sequentially to prevent concurrency regressions", async () => {
         phraseMaker._mapNotesBlocks = jest.fn(() => [0]);
-        phraseMaker.recalculateBlocks = jest.fn(() => [[[1, 4], 2]]);
+        // Provide multiple blocks to recalculate to test loop concurrency
+        phraseMaker.recalculateBlocks = jest.fn(() => [
+            [[1, 4], 2],
+            [[1, 8], 1],
+            [[1, 4], 2]
+        ]);
         phraseMaker._update = jest.fn();
-        phraseMaker._addRhythmBlock = jest.fn();
         phraseMaker._deleteRhythmBlock = jest.fn();
 
-        phraseMaker._readjustNotesBlocks();
+        let activeCalls = 0;
+        let maxConcurrentCalls = 0;
+        phraseMaker._addRhythmBlock = jest.fn(async () => {
+            activeCalls++;
+            maxConcurrentCalls = Math.max(maxConcurrentCalls, activeCalls);
+            // Yield back to the microtask queue to allow other promises to run if they were started concurrently
+            await Promise.resolve();
+            activeCalls--;
+        });
+
+        await phraseMaker._readjustNotesBlocks();
 
         expect(phraseMaker._update).toHaveBeenCalled();
+        expect(phraseMaker._addRhythmBlock).toHaveBeenCalledTimes(2);
+        // Ensures `await` is executed sequentially; if Promise.all were used, this would be 2
+        expect(maxConcurrentCalls).toBe(1);
     });
     test("_restartGrid regenerates grid", () => {
         phraseMaker.init = jest.fn();
@@ -772,7 +810,7 @@ describe("PhraseMaker Widget", () => {
 
         expect(phraseMaker._setNotes).toHaveBeenCalled();
     });
-    test("_divideNotes modifies tupletRhythms", () => {
+    test("_divideNotes modifies tupletRhythms", async () => {
         phraseMaker._readjustNotesBlocks = jest.fn();
         phraseMaker._syncMarkedBlocks = jest.fn();
         phraseMaker._restartGrid = jest.fn();
@@ -785,7 +823,7 @@ describe("PhraseMaker Widget", () => {
 
         phraseMaker._colBlocks = [[0, 0]];
 
-        phraseMaker._divideNotes(0, 2);
+        await phraseMaker._divideNotes(0, 2);
 
         expect(phraseMaker._readjustNotesBlocks).toHaveBeenCalled();
     });
@@ -836,7 +874,7 @@ describe("PhraseMaker Widget", () => {
 
         expect(phraseMaker._update).toHaveBeenCalled();
     });
-    test("_tieNotes merges note durations", () => {
+    test("_tieNotes merges note durations", async () => {
         phraseMaker._readjustNotesBlocks = jest.fn();
         phraseMaker._syncMarkedBlocks = jest.fn();
         phraseMaker._restartGrid = jest.fn();
@@ -857,7 +895,7 @@ describe("PhraseMaker Widget", () => {
             }
         };
 
-        phraseMaker._tieNotes({ id: 0 }, { id: 2 });
+        await phraseMaker._tieNotes({ id: 0 }, { id: 2 });
 
         expect(phraseMaker._readjustNotesBlocks).toHaveBeenCalled();
     });

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -3501,37 +3501,45 @@ class PhraseMaker {
      * @private
      */
     _addRhythmBlock(value, times) {
-        let RHYTHMOBJ = [];
-        value = this._deps.toFraction(value);
-        const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[1];
-        const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
-        if (this.activity.blocks.blockList[bottomOfClamp].name === "vspace") {
-            RHYTHMOBJ = [
-                [0, ["rhythm2", {}], 0, 0, [null, 1, 2, 5]],
-                [1, ["number", { value: times }], 0, 0, [0]],
-                [2, ["divide", {}], 0, 0, [0, 3, 4]],
-                [3, ["number", { value: value[1] }], 0, 0, [2]],
-                [4, ["number", { value: value[0] }], 0, 0, [2]],
-                [5, ["vspace", {}], 0, 0, [0, null]]
-            ];
-        } else {
-            RHYTHMOBJ = [
-                [0, "vspace", 0, 0, [null, 1]],
-                [1, ["rhythm2", {}], 0, 0, [0, 2, 3, 6]],
-                [2, ["number", { value: times }], 0, 0, [1]],
-                [3, ["divide", {}], 0, 0, [1, 4, 5]],
-                [4, ["number", { value: value[1] }], 0, 0, [3]],
-                [5, ["number", { value: value[0] }], 0, 0, [3]],
-                [6, ["vspace", {}], 0, 0, [1, null]]
-            ];
-        }
-        this.activity.blocks.loadNewBlocks(RHYTHMOBJ);
-        if (this.activity.blocks.blockList[bottomOfClamp].name === "vspace") {
-            setTimeout(() => this.blockConnection(6, bottomOfClamp), 500);
-        } else {
-            setTimeout(() => this.blockConnection(7, bottomOfClamp), 500);
-        }
-        this.activity.refreshCanvas();
+        return new Promise(resolve => {
+            let RHYTHMOBJ = [];
+            value = this._deps.toFraction(value);
+            const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[1];
+            const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
+            if (this.activity.blocks.blockList[bottomOfClamp].name === "vspace") {
+                RHYTHMOBJ = [
+                    [0, ["rhythm2", {}], 0, 0, [null, 1, 2, 5]],
+                    [1, ["number", { value: times }], 0, 0, [0]],
+                    [2, ["divide", {}], 0, 0, [0, 3, 4]],
+                    [3, ["number", { value: value[1] }], 0, 0, [2]],
+                    [4, ["number", { value: value[0] }], 0, 0, [2]],
+                    [5, ["vspace", {}], 0, 0, [0, null]]
+                ];
+            } else {
+                RHYTHMOBJ = [
+                    [0, "vspace", 0, 0, [null, 1]],
+                    [1, ["rhythm2", {}], 0, 0, [0, 2, 3, 6]],
+                    [2, ["number", { value: times }], 0, 0, [1]],
+                    [3, ["divide", {}], 0, 0, [1, 4, 5]],
+                    [4, ["number", { value: value[1] }], 0, 0, [3]],
+                    [5, ["number", { value: value[0] }], 0, 0, [3]],
+                    [6, ["vspace", {}], 0, 0, [1, null]]
+                ];
+            }
+            this.activity.blocks.loadNewBlocks(RHYTHMOBJ);
+            if (this.activity.blocks.blockList[bottomOfClamp].name === "vspace") {
+                setTimeout(() => {
+                    this.blockConnection(6, bottomOfClamp);
+                    resolve();
+                }, 500);
+            } else {
+                setTimeout(() => {
+                    this.blockConnection(7, bottomOfClamp);
+                    resolve();
+                }, 500);
+            }
+            this.activity.refreshCanvas();
+        });
     }
 
     /**
@@ -3614,7 +3622,7 @@ class PhraseMaker {
      * This method updates, adds, or deletes rhythm notes blocks as necessary to match the adjusted notes.
      * @private
      */
-    _readjustNotesBlocks() {
+    async _readjustNotesBlocks() {
         let notesBlockMap = this._mapNotesBlocks("rhythm2");
         const adjustedNotes = this.recalculateBlocks();
 
@@ -3631,11 +3639,12 @@ class PhraseMaker {
         }
 
         for (let i = 0; i < n; i++) {
-            this._addRhythmBlock(
+            await this._addRhythmBlock(
                 adjustedNotes[notesBlockMap.length + i][0],
                 adjustedNotes[notesBlockMap.length + i][1]
             );
         }
+
         for (let i = n; i < 0; i++) {
             this._deleteRhythmBlock(notesBlockMap[notesBlockMap.length + i]);
         }
@@ -3695,7 +3704,7 @@ class PhraseMaker {
      * @param {number} notesToAdd - The number of notes to add to the divided section.
      * @private
      */
-    _addNotes(noteToDivide, notesToAdd) {
+    async _addNotes(noteToDivide, notesToAdd) {
         noteToDivide = parseInt(noteToDivide, 10);
         this._blockMapHelper = [];
         for (let i = 0; i <= noteToDivide; i++) {
@@ -3709,7 +3718,7 @@ class PhraseMaker {
                 .slice(0, noteToDivide + i + 1)
                 .concat(this.activity.logo.tupletRhythms.slice(noteToDivide + i));
         }
-        this._readjustNotesBlocks();
+        await this._readjustNotesBlocks();
         this._syncMarkedBlocks();
         this._restartGrid.call(this);
     }
@@ -3719,7 +3728,7 @@ class PhraseMaker {
      * @param {number} noteToDivide - The index of the note to delete.
      * @private
      */
-    _deleteNotes(noteToDivide) {
+    async _deleteNotes(noteToDivide) {
         if (this.activity.logo.tupletRhythms.length === 1) {
             return;
         }
@@ -3734,7 +3743,7 @@ class PhraseMaker {
         this.activity.logo.tupletRhythms = this.activity.logo.tupletRhythms
             .slice(0, noteToDivide)
             .concat(this.activity.logo.tupletRhythms.slice(noteToDivide + 1));
-        this._readjustNotesBlocks();
+        await this._readjustNotesBlocks();
         this._syncMarkedBlocks();
         this._restartGrid.call(this);
     }
@@ -3745,7 +3754,7 @@ class PhraseMaker {
      * @param {number} divideNoteBy - The factor to divide the note by.
      * @private
      */
-    _divideNotes(noteToDivide, divideNoteBy) {
+    async _divideNotes(noteToDivide, divideNoteBy) {
         noteToDivide = parseInt(noteToDivide, 10);
         this._blockMapHelper = [];
         for (let i = 0; i < noteToDivide; i++) {
@@ -3777,7 +3786,7 @@ class PhraseMaker {
             j++;
             this._blockMapHelper.push([this._colBlocks[i], [j]]);
         }
-        this._readjustNotesBlocks();
+        await this._readjustNotesBlocks();
         this._syncMarkedBlocks();
         this._restartGrid.call(this);
     }
@@ -3788,7 +3797,7 @@ class PhraseMaker {
      * @param {Object} mouseUpCell - The ending cell of the selection.
      * @private
      */
-    _tieNotes(mouseDownCell, mouseUpCell) {
+    async _tieNotes(mouseDownCell, mouseUpCell) {
         let downCellId = null;
         let upCellId = null;
         if (mouseDownCell.id < mouseUpCell.id) {
@@ -3830,7 +3839,7 @@ class PhraseMaker {
             ])
             .concat(this.activity.logo.tupletRhythms.slice(parseInt(upCellId, 10) + 1));
 
-        this._readjustNotesBlocks();
+        await this._readjustNotesBlocks();
         this._syncMarkedBlocks();
         this._restartGrid.call(this);
     }


### PR DESCRIPTION
## Description

When dividing a note in Phrase Maker, the `_addRhythmBlock` function used a 500ms `setTimeout` to connect blocks. However, the next step executed synchronously, causing the internal column array to miss the new block and crashing the UI on interaction.

### Changes
- Refactored `_addRhythmBlock` to return a Promise that resolves after the timeout.
- Updated `_readjustNotesBlocks` to await rhythm block additions sequentially to prevent chunked/async concurrency bugs.
- Updated event handlers (`_divideNotes`, `_addNotes`, `_deleteNotes`, `_tieNotes`) to be async.
- Strengthened async tests to ensure sequential ordering.

### PR Category

- [x] Bug Fix

## Checks
- [x] Tested locally and confirmed bug no longer exists
- [x] Ran `npx prettier --write .`
- [x] Ran `npm run lint` and verified no errors
- [x] Ran `npm test` and verified no errors