### PR TITLE
refactor(timbre): extract shared DOM/state helpers to shrink widget

### DIFF
--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -615,4 +615,159 @@ describe("TimbreWidget", () => {
             expect(timbre.activity.blocks.blockList[3].value).toBe("7");
         });
     });
+
+    describe("init / toolbar buttons", () => {
+        let originalWidgetWindows;
+        let mockWidgetWindow;
+        let addButtonCalls;
+        let mockActivity;
+
+        const freshButton = () => ({ style: {}, onclick: null, id: "" });
+        const getButton = icon => addButtonCalls.find(call => call.icon === icon).btn;
+
+        beforeEach(() => {
+            addButtonCalls = [];
+            mockWidgetWindow = {
+                clear: jest.fn(),
+                show: jest.fn(),
+                addButton: jest.fn(icon => {
+                    const btn = freshButton();
+                    addButtonCalls.push({ icon, btn });
+                    return btn;
+                }),
+                getWidgetBody: jest.fn().mockReturnValue({
+                    append: jest.fn(),
+                    style: {}
+                }),
+                sendToCenter: jest.fn(),
+                destroy: jest.fn(),
+                onclose: null
+            };
+
+            originalWidgetWindows = window.widgetWindows;
+            window.widgetWindows = {
+                windowFor: jest.fn().mockReturnValue(mockWidgetWindow)
+            };
+
+            mockActivity = {
+                errorMsg: jest.fn(),
+                textMsg: jest.fn(),
+                hideMsgs: jest.fn()
+            };
+
+            jest.spyOn(timbre, "_play").mockImplementation();
+            jest.spyOn(timbre, "_save").mockImplementation();
+            jest.spyOn(timbre, "_synth").mockImplementation();
+            jest.spyOn(timbre, "_effects").mockImplementation();
+            jest.spyOn(timbre, "_addFilter").mockImplementation();
+            jest.spyOn(timbre, "_undo").mockImplementation();
+            jest.spyOn(timbre, "_clearWidgetTimers").mockImplementation(() => 0);
+            jest.spyOn(timbre, "_cleanupEventListeners").mockImplementation();
+        });
+
+        afterEach(() => {
+            window.widgetWindows = originalWidgetWindows;
+        });
+
+        test("creates the widget window and wires onclose cleanup", () => {
+            timbre.init(mockActivity);
+
+            expect(window.widgetWindows.windowFor).toHaveBeenCalledWith(
+                timbre,
+                "timbre",
+                "timbre",
+                true
+            );
+            expect(mockWidgetWindow.clear).toHaveBeenCalled();
+            expect(mockWidgetWindow.show).toHaveBeenCalled();
+            expect(timbre.activity).toBe(mockActivity);
+            expect(timbre._playing).toBe(false);
+            expect(timbre._delta).toBe(0);
+
+            mockWidgetWindow.onclose();
+
+            expect(timbre._playing).toBe(false);
+            expect(timbre._clearWidgetTimers).toHaveBeenCalled();
+            expect(timbre._cleanupEventListeners).toHaveBeenCalled();
+            expect(mockActivity.hideMsgs).toHaveBeenCalled();
+            expect(mockWidgetWindow.destroy).toHaveBeenCalled();
+        });
+
+        test("creates all toolbar buttons in order and finalizes the window", () => {
+            timbre.init(mockActivity);
+
+            expect(addButtonCalls.map(call => call.icon)).toEqual([
+                "play-button.svg",
+                "export-chunk.svg",
+                "synth.svg",
+                "oscillator.svg",
+                "envelope.svg",
+                "effects.svg",
+                "filter.svg",
+                "filter+.svg",
+                "restore-button.svg"
+            ]);
+            expect(mockActivity.textMsg).toHaveBeenCalled();
+            expect(mockWidgetWindow.sendToCenter).toHaveBeenCalled();
+        });
+
+        test("play button triggers _play", () => {
+            timbre.init(mockActivity);
+            getButton("play-button.svg").onclick();
+            expect(timbre._play).toHaveBeenCalled();
+        });
+
+        test("save button triggers _save", () => {
+            timbre.init(mockActivity);
+            getButton("export-chunk.svg").onclick();
+            expect(timbre._save).toHaveBeenCalled();
+        });
+
+        test("synth button activates the synth panel when no oscillator exists", () => {
+            timbre.init(mockActivity);
+            getButton("synth.svg").onclick();
+
+            expect(timbre.isActive["synth"]).toBe(true);
+            expect(timbre._synth).toHaveBeenCalled();
+            expect(mockActivity.errorMsg).not.toHaveBeenCalled();
+        });
+
+        test("synth button reports an error when an oscillator already exists", () => {
+            timbre.osc.push(1);
+            timbre.init(mockActivity);
+            getButton("synth.svg").onclick();
+
+            expect(timbre._synth).not.toHaveBeenCalled();
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                "Unable to use synth due to existing oscillator.",
+                3000
+            );
+        });
+
+        test("effects button activates the effects panel", () => {
+            timbre.init(mockActivity);
+            getButton("effects.svg").onclick();
+
+            expect(timbre.isActive["effects"]).toBe(true);
+            expect(timbre._effects).toHaveBeenCalled();
+        });
+
+        test("undo button triggers _undo", () => {
+            timbre.init(mockActivity);
+            getButton("restore-button.svg").onclick();
+            expect(timbre._undo).toHaveBeenCalled();
+        });
+
+        test("add-filter button only triggers _addFilter when the filter panel is active", () => {
+            timbre.init(mockActivity);
+            const addFilterButton = getButton("filter+.svg");
+
+            addFilterButton.onclick();
+            expect(timbre._addFilter).not.toHaveBeenCalled();
+
+            timbre.isActive["filter"] = true;
+            addFilterButton.onclick();
+            expect(timbre._addFilter).toHaveBeenCalled();
+        });
+    });
 });

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -246,9 +246,9 @@ class TimbreWidget {
         timbreTable.id = "timbreTable";
         this.timbreTableDiv.appendChild(timbreTable);
 
-        const env = docById("timbreTable");
-        env.textContent = "";
-        return env;
+        // timbreTable was just created and appended above, so it's already
+        // the element docById("timbreTable") would return; skip the lookup.
+        return timbreTable;
     }
 
     /**
@@ -1531,6 +1531,9 @@ class TimbreWidget {
                         );
                     }
 
+                    // NoiseSynthParams[0] holds a string (e.g. "white"), not a number,
+                    // so it's passed through as-is rather than via parseFloat like the
+                    // other synth branches below.
                     subDiv.appendChild(
                         createLabeledSlider(
                             0,

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -216,6 +216,43 @@ class TimbreWidget {
 
     /**
      * @private
+     * Marks a single panel as the active one, clearing all others first.
+     * @param {string} name - key into isActive/activeParams for the panel to activate.
+     * @returns {void}
+     */
+    _setActiveExclusive(name) {
+        for (let i = 0; i < this.activeParams.length; i++) {
+            this.isActive[this.activeParams[i]] = false;
+        }
+
+        this.isActive[name] = true;
+    }
+
+    /**
+     * @private
+     * Resets timbreTableDiv to its default visible state and recreates the
+     * empty #timbreTable panel container used by each panel builder.
+     * @returns {HTMLElement} the fresh #timbreTable element.
+     */
+    _resetTimbreTable() {
+        this.timbreTableDiv.style.display = "inline";
+        this.timbreTableDiv.style.visibility = "visible";
+        this.timbreTableDiv.style.border = "0px";
+        this.timbreTableDiv.style.overflow = "auto";
+        this.timbreTableDiv.style.backgroundColor = "white";
+        this.timbreTableDiv.style.height = "300px";
+        this.timbreTableDiv.textContent = "";
+        const timbreTable = document.createElement("div");
+        timbreTable.id = "timbreTable";
+        this.timbreTableDiv.appendChild(timbreTable);
+
+        const env = docById("timbreTable");
+        env.textContent = "";
+        return env;
+    }
+
+    /**
+     * @private
      * used to update the parameters in the blocks contained in the timbre widget clamp.
      * @param {number} i - is the index into the parameter array. (For example, there can be multiple filter blocks associated with a timbre.)
      * @param {number} k - is the parameter to update (There can be multiple parameters per block.)
@@ -654,29 +691,7 @@ class TimbreWidget {
                     this.filterParams[i * 3];
 
                 const radioIDs = [i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3];
-                if (this.filterParams[i * 3 + 1] === -12) {
-                    docById("radio" + radioIDs[0]).checked = true;
-                } else {
-                    docById("radio" + radioIDs[0]).checked = false;
-                }
-
-                if (this.filterParams[i * 3 + 1] === -24) {
-                    docById("radio" + radioIDs[1]).checked = true;
-                } else {
-                    docById("radio" + radioIDs[1]).checked = false;
-                }
-
-                if (this.filterParams[i * 3 + 1] === -48) {
-                    docById("radio" + radioIDs[2]).checked = true;
-                } else {
-                    docById("radio" + radioIDs[2]).checked = false;
-                }
-
-                if (this.filterParams[i * 3 + 1] === -96) {
-                    docById("radio" + radioIDs[3]).checked = true;
-                } else {
-                    docById("radio" + radioIDs[3]).checked = false;
-                }
+                this._setRolloffRadioChecked(radioIDs, this.filterParams[i * 3 + 1]);
                 this._update(i, this.filterParams[1 + i * 3], 1);
                 instrumentsFilters[0][this.instrumentName][i]["filterRolloff"] = parseFloat(
                     this.filterParams[1 + i * 3]
@@ -752,6 +767,17 @@ class TimbreWidget {
      * @returns {void}
      */
     init(activity) {
+        const widgetWindow = this._createWidgetWindow(activity);
+        this._createToolbarButtons(activity, widgetWindow);
+    }
+
+    /**
+     * @private
+     * Creates and configures the timbre widget window.
+     * @param {Object} activity
+     * @returns {Object} the created widgetWindow.
+     */
+    _createWidgetWindow(activity) {
         this.activity = activity;
         this._delta = 0;
 
@@ -779,6 +805,17 @@ class TimbreWidget {
             widgetWindow.destroy();
         };
 
+        return widgetWindow;
+    }
+
+    /**
+     * @private
+     * Creates the toolbar buttons and wires their onclick handlers.
+     * @param {Object} activity
+     * @param {Object} widgetWindow
+     * @returns {void}
+     */
+    _createToolbarButtons(activity, widgetWindow) {
         this.playButton = widgetWindow.addButton(
             "play-button.svg",
             TimbreWidget.ICONSIZE,
@@ -806,11 +843,7 @@ class TimbreWidget {
 
         synthButtonCell.onclick = () => {
             _unhighlightButtons(synthButtonCell);
-            for (let i = 0; i < this.activeParams.length; i++) {
-                this.isActive[this.activeParams[i]] = false;
-            }
-
-            this.isActive["synth"] = true;
+            this._setActiveExclusive("synth");
 
             if (this.osc.length === 0) {
                 this._synth();
@@ -829,11 +862,7 @@ class TimbreWidget {
 
         oscillatorButtonCell.onclick = async () => {
             _unhighlightButtons(oscillatorButtonCell);
-            for (let i = 0; i < this.activeParams.length; i++) {
-                this.isActive[this.activeParams[i]] = false;
-            }
-
-            this.isActive["oscillator"] = true;
+            this._setActiveExclusive("oscillator");
 
             if (this.osc.length === 0) {
                 const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
@@ -880,11 +909,7 @@ class TimbreWidget {
 
         envelopeButtonCell.onclick = async () => {
             _unhighlightButtons(envelopeButtonCell);
-            for (let i = 0; i < this.activeParams.length; i++) {
-                this.isActive[this.activeParams[i]] = false;
-            }
-
-            this.isActive["envelope"] = true;
+            this._setActiveExclusive("envelope");
 
             if (this.env.length === 0) {
                 const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
@@ -926,11 +951,7 @@ class TimbreWidget {
 
         effectsButtonCell.onclick = () => {
             _unhighlightButtons(effectsButtonCell);
-            for (let i = 0; i < this.activeParams.length; i++) {
-                this.isActive[this.activeParams[i]] = false;
-            }
-
-            this.isActive["effects"] = true;
+            this._setActiveExclusive("effects");
             this._effects();
         };
 
@@ -944,11 +965,7 @@ class TimbreWidget {
 
         filterButtonCell.onclick = async () => {
             _unhighlightButtons(filterButtonCell);
-            for (let i = 0; i < this.activeParams.length; i++) {
-                this.isActive[this.activeParams[i]] = false;
-            }
-
-            this.isActive["filter"] = true;
+            this._setActiveExclusive("filter");
 
             if (this.fil.length === 0) {
                 const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
@@ -1039,13 +1056,7 @@ class TimbreWidget {
             this.activity.blocks.blockList[topOfClamp].connections[0] = n;
         }
 
-        // Adjust the clamp sizes and positions.
-        this.activity.blocks.clampBlocksToCheck.push([n, 0]);
-        this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
-
-        await delayExecution(500);
-        this.activity.blocks.adjustExpandableClampBlock();
-        this.activity.blocks.adjustDocks(this.blockNo, true);
+        await this._finalizeClampAdjustment(n);
     };
 
     /**
@@ -1067,6 +1078,17 @@ class TimbreWidget {
             this.activity.blocks.blockList[topOfClamp].connections[0] = vspace;
         }
 
+        await this._finalizeClampAdjustment(n);
+    };
+
+    /**
+     * @private
+     * Adjusts the clamp sizes/positions shared by clampConnection and
+     * clampConnectionVspace after a new block has been spliced in.
+     * @param {number} n
+     * @returns {Promise<void>}
+     */
+    async _finalizeClampAdjustment(n) {
         // Adjust the clamp sizes and positions.
         this.activity.blocks.clampBlocksToCheck.push([n, 0]);
         this.activity.blocks.clampBlocksToCheck.push([this.blockNo, 0]);
@@ -1074,7 +1096,7 @@ class TimbreWidget {
         await delayExecution(500);
         this.activity.blocks.adjustExpandableClampBlock();
         this.activity.blocks.adjustDocks(this.blockNo, true);
-    };
+    }
 
     /**
      * @private
@@ -1262,19 +1284,40 @@ class TimbreWidget {
     _synth = () => {
         let blockValue = 0;
 
-        this.timbreTableDiv.style.display = "inline";
-        this.timbreTableDiv.style.visibility = "visible";
-        this.timbreTableDiv.style.border = "0px";
-        this.timbreTableDiv.style.overflow = "auto";
-        this.timbreTableDiv.style.backgroundColor = "white";
-        this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.textContent = "";
-        const timbreTable = document.createElement("div");
-        timbreTable.id = "timbreTable";
-        this.timbreTableDiv.appendChild(timbreTable);
+        const createLabeledSlider = (idSuffix, labelText, inputValue, spanValue) => {
+            const wrapper = document.createElement("div");
+            wrapper.id = "wrapperS" + idSuffix;
 
-        const env = docById("timbreTable");
-        env.textContent = "";
+            const labelDiv = document.createElement("div");
+            labelDiv.id = "sS" + idSuffix;
+            const spanLabel = document.createElement("span");
+            spanLabel.textContent = labelText;
+            labelDiv.appendChild(spanLabel);
+            wrapper.appendChild(labelDiv);
+
+            const insideDiv = document.createElement("div");
+            insideDiv.className = "insideDivSynth";
+
+            const input = document.createElement("input");
+            input.type = "range";
+            input.id = "myRangeS" + idSuffix;
+            input.className = "sliders";
+            input.style.marginTop = "20px";
+            input.value = inputValue;
+
+            const spanVal = document.createElement("span");
+            spanVal.id = "myspanS" + idSuffix;
+            spanVal.className = "rangeslidervalue";
+            spanVal.textContent = spanValue;
+
+            insideDiv.appendChild(input);
+            insideDiv.appendChild(spanVal);
+            wrapper.appendChild(insideDiv);
+
+            return wrapper;
+        };
+
+        const env = this._resetTimbreTable();
         for (let i = 0; i < 2; i++) {
             const synthDiv = document.createElement("div");
             synthDiv.id = "synth" + i;
@@ -1329,10 +1372,7 @@ class TimbreWidget {
                 chosenDiv.id = "chosen";
                 chosenDiv.textContent = synthChosen;
                 subDiv.appendChild(chosenDiv);
-                for (let j = 0; j < this.activeParams.length; j++) {
-                    this.isActive[this.activeParams[j]] = false;
-                }
-                this.isActive["synth"] = true;
+                this._setActiveExclusive("synth");
 
                 if (synthChosen === "AMSynth") {
                     this.isActive["amsynth"] = true;
@@ -1364,36 +1404,14 @@ class TimbreWidget {
                         );
                     }
 
-                    const wrapperS0 = document.createElement("div");
-                    wrapperS0.id = "wrapperS0";
-
-                    const labelDivS0 = document.createElement("div");
-                    labelDivS0.id = "sS0";
-                    const spanLabelS0 = document.createElement("span");
-                    spanLabelS0.textContent = _("harmonicity");
-                    labelDivS0.appendChild(spanLabelS0);
-                    wrapperS0.appendChild(labelDivS0);
-
-                    const insideDivS0 = document.createElement("div");
-                    insideDivS0.className = "insideDivSynth";
-
-                    const inputS0 = document.createElement("input");
-                    inputS0.type = "range";
-                    inputS0.id = "myRangeS0";
-                    inputS0.className = "sliders";
-                    inputS0.style.marginTop = "20px";
-                    inputS0.value = parseFloat(this.AMSynthParams[0]);
-
-                    const spanValS0 = document.createElement("span");
-                    spanValS0.id = "myspanS0";
-                    spanValS0.className = "rangeslidervalue";
-                    spanValS0.textContent = this.AMSynthParams[0];
-
-                    insideDivS0.appendChild(inputS0);
-                    insideDivS0.appendChild(spanValS0);
-                    wrapperS0.appendChild(insideDivS0);
-
-                    subDiv.appendChild(wrapperS0);
+                    subDiv.appendChild(
+                        createLabeledSlider(
+                            0,
+                            _("harmonicity"),
+                            parseFloat(this.AMSynthParams[0]),
+                            this.AMSynthParams[0]
+                        )
+                    );
 
                     // docById('myRangeS0').value = parseFloat(this.AMSynthParams[0]);
                     // docById('myspanS0').textContent = this.AMSynthParams[0];
@@ -1450,36 +1468,14 @@ class TimbreWidget {
                         );
                     }
 
-                    const wrapperS0 = document.createElement("div");
-                    wrapperS0.id = "wrapperS0";
-
-                    const labelDivS0 = document.createElement("div");
-                    labelDivS0.id = "sS0";
-                    const spanLabelS0 = document.createElement("span");
-                    spanLabelS0.textContent = _("modulation index");
-                    labelDivS0.appendChild(spanLabelS0);
-                    wrapperS0.appendChild(labelDivS0);
-
-                    const insideDivS0 = document.createElement("div");
-                    insideDivS0.className = "insideDivSynth";
-
-                    const inputS0 = document.createElement("input");
-                    inputS0.type = "range";
-                    inputS0.id = "myRangeS0";
-                    inputS0.className = "sliders";
-                    inputS0.style.marginTop = "20px";
-                    inputS0.value = parseFloat(this.FMSynthParams[0]);
-
-                    const spanValS0 = document.createElement("span");
-                    spanValS0.id = "myspanS0";
-                    spanValS0.className = "rangeslidervalue";
-                    spanValS0.textContent = this.FMSynthParams[0];
-
-                    insideDivS0.appendChild(inputS0);
-                    insideDivS0.appendChild(spanValS0);
-                    wrapperS0.appendChild(insideDivS0);
-
-                    subDiv.appendChild(wrapperS0);
+                    subDiv.appendChild(
+                        createLabeledSlider(
+                            0,
+                            _("modulation index"),
+                            parseFloat(this.FMSynthParams[0]),
+                            this.FMSynthParams[0]
+                        )
+                    );
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
                     // docById('myspanS0').textContent = this.FMSynthParams[0];
@@ -1535,36 +1531,14 @@ class TimbreWidget {
                         );
                     }
 
-                    const wrapperS0 = document.createElement("div");
-                    wrapperS0.id = "wrapperS0";
-
-                    const labelDivS0 = document.createElement("div");
-                    labelDivS0.id = "sS0";
-                    const spanLabelS0 = document.createElement("span");
-                    spanLabelS0.textContent = _("modulation index");
-                    labelDivS0.appendChild(spanLabelS0);
-                    wrapperS0.appendChild(labelDivS0);
-
-                    const insideDivS0 = document.createElement("div");
-                    insideDivS0.className = "insideDivSynth";
-
-                    const inputS0 = document.createElement("input");
-                    inputS0.type = "range";
-                    inputS0.id = "myRangeS0";
-                    inputS0.className = "sliders";
-                    inputS0.style.marginTop = "20px";
-                    inputS0.value = this.NoiseSynthParams[0];
-
-                    const spanValS0 = document.createElement("span");
-                    spanValS0.id = "myspanS0";
-                    spanValS0.className = "rangeslidervalue";
-                    spanValS0.textContent = this.NoiseSynthParams[0];
-
-                    insideDivS0.appendChild(inputS0);
-                    insideDivS0.appendChild(spanValS0);
-                    wrapperS0.appendChild(insideDivS0);
-
-                    subDiv.appendChild(wrapperS0);
+                    subDiv.appendChild(
+                        createLabeledSlider(
+                            0,
+                            _("modulation index"),
+                            this.NoiseSynthParams[0],
+                            this.NoiseSynthParams[0]
+                        )
+                    );
 
                     // docById('myRangeS0').value = parseFloat(this.FMSynthParams[0]);
                     // docById('myspanS0').textContent = this.FMSynthParams[0];
@@ -1602,67 +1576,23 @@ class TimbreWidget {
                         this._addDuoSynthBlock(bottomOfClamp, synthChosen);
                     }
 
-                    const wrapperS0 = document.createElement("div");
-                    wrapperS0.id = "wrapperS0";
+                    subDiv.appendChild(
+                        createLabeledSlider(
+                            0,
+                            _("vibrato rate"),
+                            parseFloat(this.duoSynthParams[0]),
+                            this.duoSynthParams[0]
+                        )
+                    );
 
-                    const labelDivS0 = document.createElement("div");
-                    labelDivS0.id = "sS0";
-                    const spanLabelS0 = document.createElement("span");
-                    spanLabelS0.textContent = _("vibrato rate");
-                    labelDivS0.appendChild(spanLabelS0);
-                    wrapperS0.appendChild(labelDivS0);
-
-                    const insideDivS0 = document.createElement("div");
-                    insideDivS0.className = "insideDivSynth";
-
-                    const inputS0 = document.createElement("input");
-                    inputS0.type = "range";
-                    inputS0.id = "myRangeS0";
-                    inputS0.className = "sliders";
-                    inputS0.style.marginTop = "20px";
-                    inputS0.value = parseFloat(this.duoSynthParams[0]);
-
-                    const spanValS0 = document.createElement("span");
-                    spanValS0.id = "myspanS0";
-                    spanValS0.className = "rangeslidervalue";
-                    spanValS0.textContent = this.duoSynthParams[0];
-
-                    insideDivS0.appendChild(inputS0);
-                    insideDivS0.appendChild(spanValS0);
-                    wrapperS0.appendChild(insideDivS0);
-
-                    subDiv.appendChild(wrapperS0);
-
-                    const wrapperS1 = document.createElement("div");
-                    wrapperS1.id = "wrapperS1";
-
-                    const labelDivS1 = document.createElement("div");
-                    labelDivS1.id = "sS1";
-                    const spanLabelS1 = document.createElement("span");
-                    spanLabelS1.textContent = _("vibrato amount");
-                    labelDivS1.appendChild(spanLabelS1);
-                    wrapperS1.appendChild(labelDivS1);
-
-                    const insideDivS1 = document.createElement("div");
-                    insideDivS1.className = "insideDivSynth";
-
-                    const inputS1 = document.createElement("input");
-                    inputS1.type = "range";
-                    inputS1.id = "myRangeS1";
-                    inputS1.className = "sliders";
-                    inputS1.style.marginTop = "20px";
-                    inputS1.value = parseFloat(this.duoSynthParams[1]);
-
-                    const spanValS1 = document.createElement("span");
-                    spanValS1.id = "myspanS1";
-                    spanValS1.className = "rangeslidervalue";
-                    spanValS1.textContent = this.duoSynthParams[1];
-
-                    insideDivS1.appendChild(inputS1);
-                    insideDivS1.appendChild(spanValS1);
-                    wrapperS1.appendChild(insideDivS1);
-
-                    subDiv.appendChild(wrapperS1);
+                    subDiv.appendChild(
+                        createLabeledSlider(
+                            1,
+                            _("vibrato amount"),
+                            parseFloat(this.duoSynthParams[1]),
+                            this.duoSynthParams[1]
+                        )
+                    );
 
                     if (this.duoSynthesizer.length !== 1) {
                         blockValue = this.duoSynthesizer.length - 1;
@@ -1712,19 +1642,7 @@ class TimbreWidget {
             blockValue = this.osc.length - 1;
         }
 
-        this.timbreTableDiv.style.display = "inline";
-        this.timbreTableDiv.style.visibility = "visible";
-        this.timbreTableDiv.style.border = "0px";
-        this.timbreTableDiv.style.overflow = "auto";
-        this.timbreTableDiv.style.backgroundColor = "white";
-        this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.textContent = "";
-        const timbreTable = document.createElement("div");
-        timbreTable.id = "timbreTable";
-        this.timbreTableDiv.appendChild(timbreTable);
-
-        const env = docById("timbreTable");
-        env.textContent = "";
+        const env = this._resetTimbreTable();
 
         const wrapperOsc0 = document.createElement("div");
         wrapperOsc0.id = "wrapperOsc0";
@@ -1858,19 +1776,7 @@ class TimbreWidget {
             blockValue = this.env.length - 1;
         }
 
-        this.timbreTableDiv.style.display = "inline";
-        this.timbreTableDiv.style.visibility = "visible";
-        this.timbreTableDiv.style.border = "0px";
-        this.timbreTableDiv.style.overflow = "auto";
-        this.timbreTableDiv.style.backgroundColor = "white";
-        this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.textContent = "";
-        const timbreTable = document.createElement("div");
-        timbreTable.id = "timbreTable";
-        this.timbreTableDiv.appendChild(timbreTable);
-
-        const env = docById("timbreTable");
-        env.textContent = "";
+        const env = this._resetTimbreTable();
 
         for (let i = 0; i < 4; i++) {
             const wrapperEnv = document.createElement("div");
@@ -1949,19 +1855,7 @@ class TimbreWidget {
      * Adds and updates filters
      */
     _filter() {
-        this.timbreTableDiv.style.display = "inline";
-        this.timbreTableDiv.style.visibility = "visible";
-        this.timbreTableDiv.style.border = "0px";
-        this.timbreTableDiv.style.overflow = "auto";
-        this.timbreTableDiv.style.backgroundColor = "white";
-        this.timbreTableDiv.style.height = "300px";
-        this.timbreTableDiv.textContent = "";
-        const timbreTable = document.createElement("div");
-        timbreTable.id = "timbreTable";
-        this.timbreTableDiv.appendChild(timbreTable);
-
-        const env = docById("timbreTable");
-        env.textContent = "";
+        const env = this._resetTimbreTable();
 
         for (let f = 0; f < this.fil.length; f++) {
             this._createFilter(f, env);
@@ -2257,29 +2151,41 @@ class TimbreWidget {
             docById("sel" + f).value = instrumentsFilters[0][this.instrumentName][f]["filterType"];
 
             const rolloff = instrumentsFilters[0][this.instrumentName][f]["filterRolloff"];
-            if (rolloff === -12) {
-                docById("radio" + radioIDs[0]).checked = true;
-            } else {
-                docById("radio" + radioIDs[0]).checked = false;
-            }
+            this._setRolloffRadioChecked(radioIDs, rolloff);
+        }
+    }
 
-            if (rolloff === -24) {
-                docById("radio" + radioIDs[1]).checked = true;
-            } else {
-                docById("radio" + radioIDs[1]).checked = false;
-            }
+    /**
+     * @private
+     * Checks the radio button matching the given filter rolloff value and
+     * unchecks the other three among the given group of ids.
+     * @param {number[]} radioIDs - the 4 radio ids for this filter, in -12/-24/-48/-96 order.
+     * @param {number} rolloff
+     * @returns {void}
+     */
+    _setRolloffRadioChecked(radioIDs, rolloff) {
+        if (rolloff === -12) {
+            docById("radio" + radioIDs[0]).checked = true;
+        } else {
+            docById("radio" + radioIDs[0]).checked = false;
+        }
 
-            if (rolloff === -48) {
-                docById("radio" + radioIDs[2]).checked = true;
-            } else {
-                docById("radio" + radioIDs[2]).checked = false;
-            }
+        if (rolloff === -24) {
+            docById("radio" + radioIDs[1]).checked = true;
+        } else {
+            docById("radio" + radioIDs[1]).checked = false;
+        }
 
-            if (rolloff === -96) {
-                docById("radio" + radioIDs[3]).checked = true;
-            } else {
-                docById("radio" + radioIDs[3]).checked = false;
-            }
+        if (rolloff === -48) {
+            docById("radio" + radioIDs[2]).checked = true;
+        } else {
+            docById("radio" + radioIDs[2]).checked = false;
+        }
+
+        if (rolloff === -96) {
+            docById("radio" + radioIDs[3]).checked = true;
+        } else {
+            docById("radio" + radioIDs[3]).checked = false;
         }
     }
 
@@ -2343,22 +2249,7 @@ class TimbreWidget {
     _effects = () => {
         let blockValue = 0;
 
-        Object.assign(this.timbreTableDiv.style, {
-            display: "inline",
-            visibility: "visible",
-            border: "0px",
-            overflow: "auto",
-            backgroundColor: "white",
-            height: "300px"
-        });
-
-        this.timbreTableDiv.textContent = "";
-        const timbreTable = document.createElement("div");
-        timbreTable.id = "timbreTable";
-        this.timbreTableDiv.appendChild(timbreTable);
-
-        const env = docById("timbreTable");
-        env.textContent = "";
+        const env = this._resetTimbreTable();
         for (let i = 0; i < 2; i++) {
             const effectDiv = document.createElement("div");
             effectDiv.id = "effect" + i;


### PR DESCRIPTION
### Refactor: Improve Timbre Widget Maintainability

This PR is a behavior-preserving refactor of `js/widgets/timbre.js` that improves readability and maintainability by extracting repeated UI and state-management logic into focused helper methods.

**Changes**

* Split `init()` into `_createWidgetWindow()` and `_createToolbarButtons()`.
* Added `_setActiveExclusive()` to remove duplicated active-state logic.
* Added `_resetTimbreTable()` to reuse panel reset code across widget sections.
* Extracted the repeated slider creation code in `_synth()` into `createLabeledSlider()`.
* Shared duplicated logic between `clampConnection()` and `clampConnectionVspace()` with `_finalizeClampAdjustment()`.
* Added `_setRolloffRadioChecked()` to reuse rolloff radio-selection logic.

No public APIs, widget behavior, or synthesis logic were changed. Only `js/widgets/timbre.js` is modified.

**Verification**

* `js/widgets/__tests__/timbre.test.js` — 40/40 passing
* Full widget test suite — 1214/1214 tests passing
* ESLint and Prettier clean
