### PR TITLE
fix: validate gif color table and fix RhythmBlocks test env

### DIFF
--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -22,9 +22,9 @@
 
 const { setupRhythmBlocks } = jest.requireActual("../RhythmBlocks");
 
-// Use the real BlockDragController so the Blocks constructor can attach
-// drag delegation methods (blocks.js calls setupBlockDragController(this)).
-global.setupBlockDragController = require("../../block-drag-controller").setupBlockDragController;
+global.setupBlockDragController = jest.requireActual(
+    "../../block-drag-controller"
+).setupBlockDragController;
 
 const Blocks = jest.requireActual("../../blocks");
 

--- a/lib/libgif.js
+++ b/lib/libgif.js
@@ -626,7 +626,10 @@
             var currIdx = frames.length;
 
             //ct = color table, gct = global color table
-            var ct = img.lctFlag ? img.lct : hdr.gct; // TODO: What if neither exists?
+            var ct = img.lctFlag ? img.lct : hdr.gct;
+            if (!ct) {
+                throw new Error('Invalid GIF format: No color table found.');
+            }
 
             /*
             Disposal method indicates the way in which the graphic is to


### PR DESCRIPTION

This PR addresses two minor improvements:
1. Replaced an old `TODO` with an explicit check that throws a clear `Error` (`Invalid GIF format: No color table found.`) when a GIF is missing both local and global color tables. This prevents cryptic `TypeError` exceptions later during parsing.
2. Updated the test suite to use `jest.requireActual` when setting up the global `BlockDragController` instead of a standard `require`. This ensures the tests run against the unmocked implementation.

### Verification
- [x] All 204 test suites pass locally (`npm run test`)
- [x] Linting passes with zero errors (`npm run lint`)


### Category
- [x] Bug Fix
- [x] Tests