### PR TITLE
fix(phrasemaker): correct isInitial typo, drop dead field, dedupe lastConnection guard

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1195,158 +1195,51 @@ describe("PhraseMaker Widget", () => {
         phraseMaker.lyricsON = true;
         phraseMaker._save();
 
-        // Pin down [blockType, connections] for every pushed block, in order,
-        // for both runs. This locks in the exact lastConnection wiring
-        // produced by the (currently duplicated) null-vs-thisBlock+offset
-        // guard, so a later extraction of that guard into a helper can be
-        // verified byte-for-byte.
-        const toSignature = newStack =>
-            newStack.map(entry => [Array.isArray(entry[1]) ? entry[1][0] : entry[1], entry[4]]);
+        // Narrow, non-brittle signature: for every block whose connections
+        // array is wired up by _computeLastConnection (hertz/playdrum/arc/
+        // forward/pitch — the 6 call sites the helper replaced), record only
+        // [blockType, lastConnection]. This pins down exactly what the
+        // extraction must preserve without hardcoding the surrounding
+        // newnote/vspace/divide/number scaffolding, which is unrelated to
+        // this refactor and would make the test brittle against unrelated
+        // future changes to _save()'s block-building logic.
+        const LAST_CONNECTION_TYPES = ["hertz", "playdrum", "arc", "forward", "pitch"];
+        const toLastConnectionSignature = newStack =>
+            newStack
+                .filter(entry => LAST_CONNECTION_TYPES.includes(entry[1]))
+                .map(entry => [entry[1], entry[4][entry[4].length - 1]]);
 
         const [lyricsOffCall, lyricsOnCall] = phraseMaker.activity.blocks.loadNewBlocks.mock.calls;
-        const signatureLyricsOff = toSignature(lyricsOffCall[0]);
-        const signatureLyricsOn = toSignature(lyricsOnCall[0]);
 
-        // lyricsON = false, every note[0] is length 1: the guard's
-        // `(note[0].length === 1 || ...)` half is always true, so
-        // lastConnection is null for every pitch/drum/graphics block.
-        expect(signatureLyricsOff).toEqual([
-            ["action", [null, 1, 2, null]],
-            ["text", [0]],
-            ["newnote", [0, 4, 3, 9]],
-            ["vspace", [2, 7]],
-            ["divide", [2, 5, 6]],
-            ["number", [4]],
-            ["number", [4]],
-            ["hertz", [3, 8, null]],
-            ["number", [7]],
-            ["newnote", [2, 11, 10, 16]],
-            ["vspace", [9, 14]],
-            ["divide", [9, 12, 13]],
-            ["number", [11]],
-            ["number", [11]],
-            ["playdrum", [10, 15, null]],
-            ["drumname", [14]],
-            ["newnote", [9, 18, 17, 23]],
-            ["vspace", [16, 21]],
-            ["divide", [16, 19, 20]],
-            ["number", [18]],
-            ["number", [18]],
-            ["playdrum", [17, 22, null]],
-            ["text", [21]],
-            ["newnote", [16, 25, 24, 31]],
-            ["vspace", [23, 28]],
-            ["divide", [23, 26, 27]],
-            ["number", [25]],
-            ["number", [25]],
-            ["arc", [24, 29, 30, null]],
-            ["number", [28]],
-            ["number", [28]],
-            ["newnote", [23, 33, 32, 38]],
-            ["vspace", [31, 36]],
-            ["divide", [31, 34, 35]],
-            ["number", [33]],
-            ["number", [33]],
-            ["forward", [32, 37, null]],
-            ["number", [36]],
-            ["newnote", [31, 40, 39, 46]],
-            ["vspace", [38, 43]],
-            ["divide", [38, 41, 42]],
-            ["number", [40]],
-            ["number", [40]],
-            ["pitch", [39, 44, 45, null]],
-            ["solfege", [43]],
-            ["number", [43]],
-            ["newnote", [38, 48, 47, null]],
-            ["vspace", [46, 51]],
-            ["divide", [46, 49, 50]],
-            ["number", [48]],
-            ["number", [48]],
-            ["pitch", [47, 52, 53, 54]],
-            ["solfege", [51]],
-            ["number", [51]],
-            ["pitch", [51, 55, 56, null]],
-            ["solfege", [54]],
-            ["number", [54]]
+        // lyricsON = false, every note[0] is length 1 except the trailing
+        // multi-pitch note: the guard's `(note[0].length === 1 || ...)` half
+        // is true for every single-length note, so lastConnection is null
+        // there; the multi-pitch note's non-last pitch (C4) still resolves
+        // to thisBlock+3 via the `j === note[0].length - 1` half being false.
+        expect(toLastConnectionSignature(lyricsOffCall[0])).toEqual([
+            ["hertz", null],
+            ["playdrum", null], // kick
+            ["playdrum", null], // http url
+            ["arc", null],
+            ["forward", null],
+            ["pitch", null], // single-length E4
+            ["pitch", 54], // multi-pitch C4, j=0, not last -> thisBlock(51)+3
+            ["pitch", null] // multi-pitch G4, j=1, last
         ]);
 
         // lyricsON = true: the guard's `!this.lyricsON` half is always
         // false, so lastConnection is thisBlock+offset for every block,
         // regardless of position — pinning down each type's exact offset
-        // (hertz/playdrum/playdrum-url/1-arg-graphics: +2,
-        // 2-arg-graphics/pitch: +3).
-        expect(signatureLyricsOn).toEqual([
-            ["action", [null, 1, 2, null]],
-            ["text", [0]],
-            ["newnote", [0, 4, 3, 11]],
-            ["vspace", [2, 7]],
-            ["divide", [2, 5, 6]],
-            ["number", [4]],
-            ["number", [4]],
-            ["hertz", [3, 8, 9]],
-            ["number", [7]],
-            ["print", [7, 10, null]],
-            ["text", [9]],
-            ["newnote", [2, 13, 12, 20]],
-            ["vspace", [11, 16]],
-            ["divide", [11, 14, 15]],
-            ["number", [13]],
-            ["number", [13]],
-            ["playdrum", [12, 17, 18]],
-            ["drumname", [16]],
-            ["print", [16, 19, null]],
-            ["text", [18]],
-            ["newnote", [11, 22, 21, 29]],
-            ["vspace", [20, 25]],
-            ["divide", [20, 23, 24]],
-            ["number", [22]],
-            ["number", [22]],
-            ["playdrum", [21, 26, 27]],
-            ["text", [25]],
-            ["print", [25, 28, null]],
-            ["text", [27]],
-            ["newnote", [20, 31, 30, 39]],
-            ["vspace", [29, 34]],
-            ["divide", [29, 32, 33]],
-            ["number", [31]],
-            ["number", [31]],
-            ["arc", [30, 35, 36, 37]],
-            ["number", [34]],
-            ["number", [34]],
-            ["print", [34, 38, null]],
-            ["text", [37]],
-            ["newnote", [29, 41, 40, 48]],
-            ["vspace", [39, 44]],
-            ["divide", [39, 42, 43]],
-            ["number", [41]],
-            ["number", [41]],
-            ["forward", [40, 45, 46]],
-            ["number", [44]],
-            ["print", [44, 47, null]],
-            ["text", [46]],
-            ["newnote", [39, 50, 49, 58]],
-            ["vspace", [48, 53]],
-            ["divide", [48, 51, 52]],
-            ["number", [50]],
-            ["number", [50]],
-            ["pitch", [49, 54, 55, 56]],
-            ["solfege", [53]],
-            ["number", [53]],
-            ["print", [53, 57, null]],
-            ["text", [56]],
-            ["newnote", [48, 60, 59, null]],
-            ["vspace", [58, 63]],
-            ["divide", [58, 61, 62]],
-            ["number", [60]],
-            ["number", [60]],
-            ["pitch", [59, 64, 65, 66]],
-            ["solfege", [63]],
-            ["number", [63]],
-            ["pitch", [63, 67, 68, 69]],
-            ["solfege", [66]],
-            ["number", [66]],
-            ["print", [66, 70, null]],
-            ["text", [69]]
+        // (hertz/playdrum/forward: +2, arc/pitch: +3).
+        expect(toLastConnectionSignature(lyricsOnCall[0])).toEqual([
+            ["hertz", 9], // thisBlock(7)+2
+            ["playdrum", 18], // kick, thisBlock(16)+2
+            ["playdrum", 27], // http url, thisBlock(25)+2
+            ["arc", 37], // thisBlock(34)+3
+            ["forward", 46], // thisBlock(44)+2
+            ["pitch", 56], // single-length E4, thisBlock(53)+3
+            ["pitch", 66], // multi-pitch C4, j=0, thisBlock(63)+3
+            ["pitch", 69] // multi-pitch G4, j=1, thisBlock(66)+3
         ]);
 
         expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalledTimes(2);

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -1143,6 +1143,214 @@ describe("PhraseMaker Widget", () => {
 
         expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalled();
     });
+    test("_save wires lastConnection identically across all block types (characterization)", () => {
+        global.PhraseMakerAudio = { collectNotesToPlay: jest.fn() };
+
+        phraseMaker._rows = [];
+        phraseMaker._rowBlocks = [];
+        phraseMaker._colBlocks = [];
+        phraseMaker._blockMap = {};
+        phraseMaker._rowMap = [];
+        phraseMaker._rowOffset = [];
+
+        phraseMaker.lyricsON = false;
+
+        phraseMaker._notesToPlay = [
+            [["440"], 4], // hertz
+            [["kick"], 4], // drum
+            [["http://x.wav"], 4], // drum url
+            [["arc: 50: 90"], 4], // 2-arg graphics
+            [["forward: 100"], 4], // 1-arg graphics
+            [["E4"], 4], // plain pitch, single-length note
+            [["C4", "G4"], 4] // multi pitch: exercises j !== length-1 vs j === length-1
+        ];
+        phraseMaker._outputAsTuplet = Array(7).fill([1, 4]);
+
+        phraseMaker._deps.getDrumName = jest.fn(n => (n === "kick" ? "kick" : null));
+        phraseMaker._deps.toFraction = jest.fn(() => [1, 4]);
+        phraseMaker._deps.isCustomTemperament = jest.fn(() => false);
+        phraseMaker._deps.SOLFEGECONVERSIONTABLE = { C: "do", G: "so" };
+
+        global.PhraseMakerUtils = {
+            MATRIXGRAPHICS: ["forward"],
+            MATRIXGRAPHICS2: ["arc"],
+            MATRIXSYNTHS: []
+        };
+
+        phraseMaker.activity = {
+            blocks: {
+                palettes: { dict: {} },
+                loadNewBlocks: jest.fn()
+            },
+            refreshCanvas: jest.fn(),
+            textMsg: jest.fn(),
+            logo: { synth: { inTemperament: "equal" } }
+        };
+
+        phraseMaker._save();
+
+        // Second run with lyricsON = true so the guard's `!this.lyricsON`
+        // half is false, forcing every block into the thisBlock+offset
+        // branch (the null branch is already exercised above).
+        phraseMaker.lyricsON = true;
+        phraseMaker._save();
+
+        // Pin down [blockType, connections] for every pushed block, in order,
+        // for both runs. This locks in the exact lastConnection wiring
+        // produced by the (currently duplicated) null-vs-thisBlock+offset
+        // guard, so a later extraction of that guard into a helper can be
+        // verified byte-for-byte.
+        const toSignature = newStack =>
+            newStack.map(entry => [Array.isArray(entry[1]) ? entry[1][0] : entry[1], entry[4]]);
+
+        const [lyricsOffCall, lyricsOnCall] = phraseMaker.activity.blocks.loadNewBlocks.mock.calls;
+        const signatureLyricsOff = toSignature(lyricsOffCall[0]);
+        const signatureLyricsOn = toSignature(lyricsOnCall[0]);
+
+        // lyricsON = false, every note[0] is length 1: the guard's
+        // `(note[0].length === 1 || ...)` half is always true, so
+        // lastConnection is null for every pitch/drum/graphics block.
+        expect(signatureLyricsOff).toEqual([
+            ["action", [null, 1, 2, null]],
+            ["text", [0]],
+            ["newnote", [0, 4, 3, 9]],
+            ["vspace", [2, 7]],
+            ["divide", [2, 5, 6]],
+            ["number", [4]],
+            ["number", [4]],
+            ["hertz", [3, 8, null]],
+            ["number", [7]],
+            ["newnote", [2, 11, 10, 16]],
+            ["vspace", [9, 14]],
+            ["divide", [9, 12, 13]],
+            ["number", [11]],
+            ["number", [11]],
+            ["playdrum", [10, 15, null]],
+            ["drumname", [14]],
+            ["newnote", [9, 18, 17, 23]],
+            ["vspace", [16, 21]],
+            ["divide", [16, 19, 20]],
+            ["number", [18]],
+            ["number", [18]],
+            ["playdrum", [17, 22, null]],
+            ["text", [21]],
+            ["newnote", [16, 25, 24, 31]],
+            ["vspace", [23, 28]],
+            ["divide", [23, 26, 27]],
+            ["number", [25]],
+            ["number", [25]],
+            ["arc", [24, 29, 30, null]],
+            ["number", [28]],
+            ["number", [28]],
+            ["newnote", [23, 33, 32, 38]],
+            ["vspace", [31, 36]],
+            ["divide", [31, 34, 35]],
+            ["number", [33]],
+            ["number", [33]],
+            ["forward", [32, 37, null]],
+            ["number", [36]],
+            ["newnote", [31, 40, 39, 46]],
+            ["vspace", [38, 43]],
+            ["divide", [38, 41, 42]],
+            ["number", [40]],
+            ["number", [40]],
+            ["pitch", [39, 44, 45, null]],
+            ["solfege", [43]],
+            ["number", [43]],
+            ["newnote", [38, 48, 47, null]],
+            ["vspace", [46, 51]],
+            ["divide", [46, 49, 50]],
+            ["number", [48]],
+            ["number", [48]],
+            ["pitch", [47, 52, 53, 54]],
+            ["solfege", [51]],
+            ["number", [51]],
+            ["pitch", [51, 55, 56, null]],
+            ["solfege", [54]],
+            ["number", [54]]
+        ]);
+
+        // lyricsON = true: the guard's `!this.lyricsON` half is always
+        // false, so lastConnection is thisBlock+offset for every block,
+        // regardless of position — pinning down each type's exact offset
+        // (hertz/playdrum/playdrum-url/1-arg-graphics: +2,
+        // 2-arg-graphics/pitch: +3).
+        expect(signatureLyricsOn).toEqual([
+            ["action", [null, 1, 2, null]],
+            ["text", [0]],
+            ["newnote", [0, 4, 3, 11]],
+            ["vspace", [2, 7]],
+            ["divide", [2, 5, 6]],
+            ["number", [4]],
+            ["number", [4]],
+            ["hertz", [3, 8, 9]],
+            ["number", [7]],
+            ["print", [7, 10, null]],
+            ["text", [9]],
+            ["newnote", [2, 13, 12, 20]],
+            ["vspace", [11, 16]],
+            ["divide", [11, 14, 15]],
+            ["number", [13]],
+            ["number", [13]],
+            ["playdrum", [12, 17, 18]],
+            ["drumname", [16]],
+            ["print", [16, 19, null]],
+            ["text", [18]],
+            ["newnote", [11, 22, 21, 29]],
+            ["vspace", [20, 25]],
+            ["divide", [20, 23, 24]],
+            ["number", [22]],
+            ["number", [22]],
+            ["playdrum", [21, 26, 27]],
+            ["text", [25]],
+            ["print", [25, 28, null]],
+            ["text", [27]],
+            ["newnote", [20, 31, 30, 39]],
+            ["vspace", [29, 34]],
+            ["divide", [29, 32, 33]],
+            ["number", [31]],
+            ["number", [31]],
+            ["arc", [30, 35, 36, 37]],
+            ["number", [34]],
+            ["number", [34]],
+            ["print", [34, 38, null]],
+            ["text", [37]],
+            ["newnote", [29, 41, 40, 48]],
+            ["vspace", [39, 44]],
+            ["divide", [39, 42, 43]],
+            ["number", [41]],
+            ["number", [41]],
+            ["forward", [40, 45, 46]],
+            ["number", [44]],
+            ["print", [44, 47, null]],
+            ["text", [46]],
+            ["newnote", [39, 50, 49, 58]],
+            ["vspace", [48, 53]],
+            ["divide", [48, 51, 52]],
+            ["number", [50]],
+            ["number", [50]],
+            ["pitch", [49, 54, 55, 56]],
+            ["solfege", [53]],
+            ["number", [53]],
+            ["print", [53, 57, null]],
+            ["text", [56]],
+            ["newnote", [48, 60, 59, null]],
+            ["vspace", [58, 63]],
+            ["divide", [58, 61, 62]],
+            ["number", [60]],
+            ["number", [60]],
+            ["pitch", [59, 64, 65, 66]],
+            ["solfege", [63]],
+            ["number", [63]],
+            ["pitch", [63, 67, 68, 69]],
+            ["solfege", [66]],
+            ["number", [66]],
+            ["print", [66, 70, null]],
+            ["text", [69]]
+        ]);
+
+        expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalledTimes(2);
+    });
     test("_save covers 7-block tuplet branch", () => {
         phraseMaker._rows = [];
         phraseMaker._rowBlocks = [];
@@ -1277,6 +1485,98 @@ describe("PhraseMaker Widget", () => {
         phraseMaker.init(mockActivity);
 
         expect(mockActivity.textMsg).toHaveBeenCalled();
+    });
+    test("isInitial ensures the first-open message fires only once across repeated init() calls", () => {
+        const mockActivity = {
+            turtles: {
+                ithTurtle: jest.fn(() => ({
+                    singer: {
+                        beatsPerMeasure: 4,
+                        noteValuePerBeat: 4,
+                        keySignature: 0
+                    }
+                }))
+            },
+            logo: {
+                tupletRhythms: [["notes", 0, 4]],
+                synth: {
+                    inTemperament: "equal",
+                    stopSound: jest.fn(),
+                    stop: jest.fn(),
+                    loadSynth: jest.fn()
+                }
+            },
+            blocks: {
+                protoBlockDict: {
+                    forward: { staticLabels: ["Forward"] }
+                }
+            },
+            canvas: { width: 800, height: 600 },
+            getStageScale: jest.fn(() => 1),
+            hideMsgs: jest.fn(),
+            textMsg: jest.fn()
+        };
+
+        phraseMaker._rows = [];
+        phraseMaker._headcols = [];
+        phraseMaker._labelcols = [];
+        phraseMaker._blockMap = {};
+        phraseMaker.blockNo = 0;
+        phraseMaker.rowLabels = ["C", "kick", "forward"];
+        phraseMaker.rowArgs = [4, 4, 100];
+        phraseMaker._deps.getDrumName = jest.fn(name => (name === "kick" ? "kick" : null));
+        phraseMaker.lyricsON = true;
+
+        global.PhraseMakerUtils = {
+            MATRIXGRAPHICS: ["forward"],
+            MATRIXGRAPHICS2: [],
+            MATRIXSYNTHS: []
+        };
+
+        global.window.widgetWindows = {
+            windowFor: jest.fn().mockReturnValue({
+                clear: jest.fn(),
+                show: jest.fn(),
+                addButton: jest.fn().mockReturnValue({
+                    onclick: null,
+                    innerHTML: "",
+                    style: {},
+                    setAttribute: jest.fn()
+                }),
+                getWidgetBody: jest.fn().mockReturnValue({
+                    appendChild: jest.fn(),
+                    append: jest.fn()
+                }),
+                sendToCenter: jest.fn(),
+                destroy: jest.fn()
+            })
+        };
+        global.PhraseMakerUI = {
+            calculateNoteWidth: jest.fn(() => 80),
+            resetMatrix: jest.fn()
+        };
+
+        expect(phraseMaker.isInitial).toBe(true);
+
+        phraseMaker.init(mockActivity);
+
+        expect(mockActivity.textMsg).toHaveBeenCalledTimes(1);
+        expect(mockActivity.textMsg).toHaveBeenCalledWith("Click on the table to add notes.", 3000);
+        expect(phraseMaker.isInitial).toBe(false);
+
+        // init() itself doesn't clear row-building state between calls (the
+        // real caller always builds a fresh matrix); reset just enough of it
+        // here so a second call completes, to prove the first-open message
+        // does not repeat once isInitial has flipped to false.
+        phraseMaker._rows = [];
+        phraseMaker._headcols = [];
+        phraseMaker._labelcols = [];
+        phraseMaker._blockMap = {};
+
+        phraseMaker.init(mockActivity);
+
+        expect(mockActivity.textMsg).toHaveBeenCalledTimes(1);
+        expect(phraseMaker.isInitial).toBe(false);
     });
     test("_createColumnPieSubmenu executes", () => {
         phraseMaker.platformColor = {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -261,7 +261,6 @@ class PhraseMaker {
         this._blockMap = {};
 
         this.blockNo = null;
-        this.notesBlockMap = [];
         this._blockMapHelper = [];
         this.columnBlocksMap = [];
 
@@ -1195,7 +1194,7 @@ class PhraseMaker {
         if (this.isInitial) {
             activity.textMsg(this._("Click on the table to add notes."), 3000);
             this.widgetWindow.sendToCenter();
-            this.inInitial = false;
+            this.isInitial = false;
         }
     }
 
@@ -4648,6 +4647,25 @@ class PhraseMaker {
     }
 
     /**
+     * Computes the lastConnection value for a pitch/drum/graphics block being
+     * pushed inside _save()'s note loop: null if it is the final block in the
+     * note (and lyrics are off), otherwise thisBlock + offset.
+     * @param {Array} note - the note entry currently being processed.
+     * @param {number} j - index into note[0] for the current pitch/drum entry.
+     * @param {number} thisBlock - the block index the connection is relative to.
+     * @param {number} offset - block-index offset to the next sibling block.
+     * @returns {number|null}
+     * @private
+     */
+    _computeLastConnection(note, j, thisBlock, offset) {
+        // The last connection in last pitch block is null.
+        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
+            return null;
+        }
+        return thisBlock + offset;
+    }
+
+    /**
      * Saves the current matrix state as an action stack consisting of note and pitch blocks.
      * @private
      */
@@ -4788,12 +4806,7 @@ class PhraseMaker {
 
                     if (obj === null) {
                         // add a hertz block
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 2;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 2);
 
                         newStack.push([
                             thisBlock,
@@ -4813,12 +4826,7 @@ class PhraseMaker {
                         previousBlock = thisBlock - 2;
                     } else if (drumName !== null) {
                         // add a playdrum block
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 2;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 2);
 
                         newStack.push([
                             thisBlock,
@@ -4838,12 +4846,7 @@ class PhraseMaker {
                         previousBlock = thisBlock - 2;
                     } else if (note[0][j].slice(0, 4) === "http") {
                         // add a playdrum block with URL
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 2;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 2);
 
                         newStack.push([
                             thisBlock,
@@ -4863,12 +4866,7 @@ class PhraseMaker {
                         previousBlock = thisBlock - 2;
                     } else if (obj.length > 2) {
                         // add a 2-arg graphics block
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 3;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 3);
 
                         newStack.push([
                             thisBlock,
@@ -4895,12 +4893,7 @@ class PhraseMaker {
                         previousBlock = thisBlock - 3;
                     } else if (obj.length > 1) {
                         // add a 1-arg graphics block
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 2;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 2);
 
                         newStack.push([
                             thisBlock,
@@ -4920,12 +4913,7 @@ class PhraseMaker {
                         previousBlock = thisBlock - 2;
                     } else {
                         // add a pitch block
-                        // The last connection in last pitch block is null.
-                        if (!this.lyricsON && (note[0].length === 1 || j === note[0].length - 1)) {
-                            lastConnection = null;
-                        } else {
-                            lastConnection = thisBlock + 3;
-                        }
+                        lastConnection = this._computeLastConnection(note, j, thisBlock, 3);
 
                         if (note[0][j][1] === "♯") {
                             if (


### PR DESCRIPTION
## Summary

This PR performs a small maintenance-focused cleanup of `phrasemaker.js` by fixing two pre-existing issues, removing dead code, and extracting a small duplicated helper from `_save()` without changing behavior.

## Changes

### Fix `isInitial` initialization bug

- Fixed a typo where `this.isInitial` was initialized in the constructor, but `init()` updated `this.inInitial` instead.
- As a result, the first-time onboarding message and `sendToCenter()` were executed on every initialization instead of only the first.
- The assignment now correctly updates `this.isInitial`.

### Remove unused property

- Removed the unused `this.notesBlockMap` constructor property.
- Verified that this property had no references anywhere else in the repository.

### Reduce duplication in `_save()`

- Extracted the repeated `lastConnection` calculation into a shared helper.
- The helper preserves the existing control flow and behavior while eliminating six identical code blocks that differed only by the connection offset.
- No functional changes were introduced.

## Tests

Added regression tests covering the extracted logic and bug fixes:

- Verify `_save()` generates identical connection structures before and after the refactor for all affected block types.
- Verify the first-time onboarding message is shown only once by ensuring `isInitial` is correctly updated after the first initialization.

All existing tests continue to pass.

## Notes

This PR intentionally does **not** refactor the larger `init()` or `_save()` methods or modify the wheel navigation builders. Those areas are still under active development and require additional characterization tests before larger structural changes can be made. This change is limited to safe cleanup and maintenance improvements with no intended behavioral changes beyond the `isInitial` bug fix.