### PR TITLE
fix(utils): add null safety guards to canvasPixelRatio

### DIFF
--- a/js/utils/__tests__/browser-utils.test.js
+++ b/js/utils/__tests__/browser-utils.test.js
@@ -192,6 +192,18 @@ describe("canvasPixelRatio()", () => {
         stubCanvas({ [property]: 2 });
         expect(canvasPixelRatio()).toBe(2);
     });
+
+    it("safely returns devicePixelRatio when #myCanvas is not present in DOM", () => {
+        window.devicePixelRatio = 2;
+        document.querySelector = jest.fn(() => null);
+        expect(canvasPixelRatio()).toBe(2);
+    });
+
+    it("safely returns devicePixelRatio when canvas.getContext returns null", () => {
+        window.devicePixelRatio = 2;
+        document.querySelector = jest.fn(() => ({ getContext: jest.fn(() => null) }));
+        expect(canvasPixelRatio()).toBe(2);
+    });
 });
 
 // Distinct literals so an inner/outer mix-up cannot produce a passing assertion.

--- a/js/utils/browser-utils.js
+++ b/js/utils/browser-utils.js
@@ -97,7 +97,14 @@ function doBrowserCheck() {
  */
 function canvasPixelRatio() {
     const devicePixelRatio = window.devicePixelRatio || 1;
-    const context = document.querySelector("#myCanvas").getContext("2d");
+    const canvas = document.querySelector("#myCanvas");
+    if (!canvas) {
+        return devicePixelRatio;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+        return devicePixelRatio;
+    }
     const backingStoreRatio =
         context.webkitBackingStorePixelRatio ||
         context.mozBackingStorePixelRatio ||


### PR DESCRIPTION
## Description

Refactors `canvasPixelRatio()` in `js/utils/browser-utils.js` to include null-safety guards for missing `#myCanvas` DOM element or `getContext("2d")` returning `null`.

Previously, `canvasPixelRatio()` executed `document.querySelector("#myCanvas").getContext("2d")` directly. If `#myCanvas` was not present in the DOM (e.g. before full DOM load or in headless test/embedded canvas environments), calling `.getContext("2d")` threw an unhandled `TypeError: Cannot read properties of null (reading 'getContext')`.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/utils/browser-utils.js`**:
  - Updated `canvasPixelRatio()` with null checks for `document.querySelector("#myCanvas")` and `canvas.getContext("2d")`, returning `devicePixelRatio` as a fallback.
- **`js/utils/__tests__/browser-utils.test.js`**:
  - Added unit test verifying `canvasPixelRatio()` safely returns `devicePixelRatio` when `#myCanvas` is not present in DOM.
  - Added unit test verifying `canvasPixelRatio()` safely returns `devicePixelRatio` when `canvas.getContext("2d")` returns `null`.

## Testing Performed

- Ran local Jest test suite: `npx.cmd jest js/utils/__tests__/browser-utils.test.js --coverage=false`
- Verified all 39 unit tests pass cleanly (39/39 passed).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
