### PR TITLE
fix: event listener leak in helper.js

### DIFF
--- a/planet/js/__tests__/helper.test.js
+++ b/planet/js/__tests__/helper.test.js
@@ -231,6 +231,24 @@ describe("helper.js", () => {
 
             expect(document.getElementById("target").style.display).toBe("block");
         });
+
+        it("should remove previous listener when hideOnClickOutside is called again for the same anchor element", () => {
+            document.body.innerHTML = `
+                <div id="container"><div id="inner">Inside</div></div>
+                <div id="target" style="display:block;">Target</div>
+            `;
+
+            const container = document.getElementById("container");
+            const spyRemove = jest.spyOn(document, "removeEventListener");
+
+            hideOnClickOutside([container], "target");
+            hideOnClickOutside([container], "target");
+            hideOnClickOutside([container], "target");
+
+            expect(spyRemove).toHaveBeenCalledTimes(2);
+
+            spyRemove.mockRestore();
+        });
     });
 
     describe("updateCheckboxes", () => {

--- a/planet/js/helper.js
+++ b/planet/js/helper.js
@@ -92,19 +92,37 @@ function toggleExpandable(id, c) {
     el.className = el.className === `${c} open` ? c : `${c} open`;
 }
 
+const outsideClickListeners = new WeakMap();
+
 function hideOnClickOutside(eles, other) {
+    const validEles = (Array.isArray(eles) ? eles : [eles]).filter(Boolean);
+    if (validEles.length === 0) return;
+
+    const anchor = validEles[0];
+
+    if (anchor && outsideClickListeners.has(anchor)) {
+        const prevListener = outsideClickListeners.get(anchor);
+        document.removeEventListener("click", prevListener);
+        outsideClickListeners.delete(anchor);
+    }
+
     // if click not in id, hide
     const outsideClickListener = event => {
-        const path =
-            event.path ||
-            (event.composedPath && event.composedPath()) ||
-            event.composedPath(event.target);
+        const path = event.path || (event.composedPath && event.composedPath()) || [];
         let ok = false;
 
-        for (let i = 0; i < eles.length; i++) if (path.includes(eles[i])) ok = true;
+        for (let i = 0; i < validEles.length; i++) {
+            if (path.includes(validEles[i])) {
+                ok = true;
+                break;
+            }
+        }
 
         if (ok === false) {
-            document.getElementById(other).style.display = "none";
+            const otherEl = document.getElementById(other);
+            if (otherEl) {
+                otherEl.style.display = "none";
+            }
 
             removeClickListener();
         }
@@ -112,7 +130,14 @@ function hideOnClickOutside(eles, other) {
 
     const removeClickListener = () => {
         document.removeEventListener("click", outsideClickListener);
+        if (anchor) {
+            outsideClickListeners.delete(anchor);
+        }
     };
+
+    if (anchor) {
+        outsideClickListeners.set(anchor, outsideClickListener);
+    }
 
     document.addEventListener("click", outsideClickListener);
 }


### PR DESCRIPTION
## Description

This pr fixes an event listener leak in planet/js/helper.js.

Each time hideOnClickOutside() was called for the same anchor element it added a new document click listener without removing the previous one, due to this duplicate listeners stacked unnecessarily.

I added a module scoped WeakMap to track the active listener for each anchor element.
Before adding a new listener, the existing one is removed which ensure only one outside click listener exists per anchor at a time.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Testing Performed

Before: repeatedly opening and closing the share boxes kept adding new document click listeners
<img width="547" height="234" alt="image" src="https://github.com/user-attachments/assets/768b9f9f-64df-426b-9d98-54f204ed8e22" />

After: listener count consistently stayed at the baseline
<img width="368" height="162" alt="image" src="https://github.com/user-attachments/assets/3f642b67-dc6d-407e-bd4b-1bcf2d3049db" />

## Additional Notes for Reviewers
-   The baseline of three document click listeners on initial page load is expected and comes from existing application initialization (materialize css and core tab handlers)
-   The WeakMap garbage collection ensures memory safety when DOM elements are removed.

