### PR TITLE
fix(sampler): dispose Tone.Analyser nodes on close and prevent file listener accumulation

### DIFF
--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -921,8 +921,8 @@ describe("Sampler Widget", () => {
             widget.is_recording = true;
             widget.running = true;
             widget.pitchAnalysers = {
-                0: { getValue: jest.fn(() => [0, 0.5, -0.5]) },
-                1: { getValue: jest.fn(() => [0, 0.5, -0.5]) }
+                0: { getValue: jest.fn(() => [0, 0.5, -0.5]), dispose: jest.fn() },
+                1: { getValue: jest.fn(() => [0, 0.5, -0.5]), dispose: jest.fn() }
             };
             global.TunerUtils.frequencyToPitch.mockReturnValue(["A4", 0]);
             global.detectPitch = jest.fn(() => 440);
@@ -958,8 +958,8 @@ describe("Sampler Widget", () => {
             widget.drawVisualIDs = {};
             widget.running = true;
             widget.pitchAnalysers = {
-                0: { getValue: jest.fn(() => [0.1, -0.1]) },
-                1: { getValue: jest.fn(() => [0.2, -0.2]) }
+                0: { getValue: jest.fn(() => [0.1, -0.1]), dispose: jest.fn() },
+                1: { getValue: jest.fn(() => [0.2, -0.2]), dispose: jest.fn() }
             };
             widget.tunerDisplay = new global.TunerDisplay(
                 document.createElement("canvas"),

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -544,7 +544,23 @@ function SampleWidget() {
             if (this._octavesWheel !== undefined) {
                 this._octavesWheel.removeWheel();
             }
+            // Dispose Tone.Analyser nodes to free Web Audio resources
+            for (const key in this.pitchAnalysers) {
+                if (
+                    this.pitchAnalysers[key] &&
+                    typeof this.pitchAnalysers[key].dispose === "function"
+                ) {
+                    this.pitchAnalysers[key].dispose();
+                }
+            }
             this.pitchAnalysers = {};
+
+            // Remove any dangling file chooser listener
+            const fileChooser = docById("myOpenAll");
+            if (fileChooser && this._fileChangeHandler) {
+                fileChooser.removeEventListener("change", this._fileChangeHandler);
+                this._fileChangeHandler = null;
+            }
 
             if (this._dropZone) {
                 this._dropZone.removeEventListener("dragover", this._dragOverHandler);
@@ -588,14 +604,20 @@ function SampleWidget() {
                 stopTuner();
                 const fileChooser = docById("myOpenAll");
 
-                const __readerAction = function (event) {
+                // Remove any previously attached listener to prevent duplicates
+                if (that._fileChangeHandler) {
+                    fileChooser.removeEventListener("change", that._fileChangeHandler);
+                }
+
+                that._fileChangeHandler = function (event) {
                     window.scroll(0, 0);
                     const sampleFile = fileChooser.files[0];
                     that.handleFiles(sampleFile);
-                    fileChooser.removeEventListener("change", __readerAction);
+                    fileChooser.removeEventListener("change", that._fileChangeHandler);
+                    that._fileChangeHandler = null;
                 };
 
-                fileChooser.addEventListener("change", __readerAction, false);
+                fileChooser.addEventListener("change", that._fileChangeHandler, false);
                 fileChooser.focus();
                 fileChooser.click();
                 window.scroll(0, 0);


### PR DESCRIPTION
## Description

The Sampler widget has two cleanup issues that cause resource leaks over time.

**1. Tone.Analyser nodes never get disposed** — The Sampler creates two `Tone.Analyser` instances for pitch analysis, but when the widget is closed, `onclose` just does `this.pitchAnalysers = {}` without calling `.dispose()`. The underlying Web Audio AnalyserNodes stay alive in the audio graph. Opening and closing the Sampler repeatedly causes memory to grow.

**2. File upload listener stacks up on cancel** — The "Upload sample" button adds a `change` listener to the file input every time it's clicked. The listener only removes itself when a file is actually selected. If the user cancels the file picker, the listener stays and a new one stacks on top next time.

## Related Issue

This PR fixes #YOUR_ISSUE_NUMBER

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Call `.dispose()` on all `Tone.Analyser` instances in `onclose` before clearing `pitchAnalysers`
-   Remove any stale file chooser `change` listener before attaching a new one in the Upload handler
-   Clean up any leftover file listener in `onclose` as a safety net
-   Updated test mocks to include `dispose()` method

## Testing Performed

-   Opened Sampler widget, played a sample, closed it — no orphaned `AnalyserNode` in DevTools Memory snapshot
-   Opened Sampler → clicked Upload → cancelled the dialog 3-4 times → picked a file — `handleFiles()` fired only once
-   All 46 sampler tests pass: `npx jest js/widgets/__tests__/sampler.test.js`

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

This is my first contribution to the project. The fix is minimal and focused only touches the cleanup paths in `sampler.js` and adds `dispose` to the existing test mocks.