### PR TITLE
fix: halt doChorus, doTremolo, doDistortion when depth/distortion validation fails

### DIFF
--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -192,6 +192,7 @@ function setupToneActions(activity) {
             if (chorusDepth < 0 || chorusDepth > 1) {
                 activity.errorMsg(_("Depth is out of range."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);
@@ -265,6 +266,7 @@ function setupToneActions(activity) {
                 //.TRANS: Depth is the intesity of the tremolo or chorus effect.
                 activity.errorMsg(_("Depth is out of range."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);
@@ -301,6 +303,7 @@ function setupToneActions(activity) {
             if (distortion < 0 || distortion > 1) {
                 activity.errorMsg(_("Distortion must be from 0 to 100."), blk);
                 activity.logo.stopTurtle = true;
+                return;
             }
 
             const tur = activity.turtles.ithTurtle(turtle);

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -332,12 +332,18 @@ describe("setupToneActions", () => {
             Singer.ToneActions.doChorus(1.5, 20, 150, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Depth is out of range.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.chorusRate).toEqual([]);
+            expect(targetTurtle.singer.delayTime).toEqual([]);
+            expect(targetTurtle.singer.chorusDepth).toEqual([]);
         });
 
         it("should show error for negative chorus depth", () => {
             Singer.ToneActions.doChorus(1.5, 20, -10, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Depth is out of range.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.chorusRate).toEqual([]);
+            expect(targetTurtle.singer.delayTime).toEqual([]);
+            expect(targetTurtle.singer.chorusDepth).toEqual([]);
         });
 
         it("should NOT register a mouse listener when blk is undefined", () => {
@@ -410,12 +416,16 @@ describe("setupToneActions", () => {
             Singer.ToneActions.doTremolo(5, 150, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Depth is out of range.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.tremoloFrequency).toEqual([]);
+            expect(targetTurtle.singer.tremoloDepth).toEqual([]);
         });
 
         it("should show error for negative tremolo depth", () => {
             Singer.ToneActions.doTremolo(5, -50, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Depth is out of range.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.tremoloFrequency).toEqual([]);
+            expect(targetTurtle.singer.tremoloDepth).toEqual([]);
         });
 
         it("should NOT register a mouse listener when blk is undefined", () => {
@@ -452,12 +462,14 @@ describe("setupToneActions", () => {
             Singer.ToneActions.doDistortion(150, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Distortion must be from 0 to 100.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.distortionAmount).toEqual([]);
         });
 
         it("should show error for negative distortion amount", () => {
             Singer.ToneActions.doDistortion(-10, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith("Distortion must be from 0 to 100.", 1);
             expect(activity.logo.stopTurtle).toBe(true);
+            expect(targetTurtle.singer.distortionAmount).toEqual([]);
         });
 
         it("should NOT register a mouse listener when blk is undefined", () => {


### PR DESCRIPTION
## Description

`Singer.ToneActions.doChorus`, `doTremolo`, and `doDistortion` validate their depth/distortion parameter, but when validation fails, each function only displays an error message and sets `activity.logo.stopTurtle = true`. Since execution does not stop immediately, the function continues and updates the turtle's singer state with the invalid value, and registers a playback listener regardless.

This change adds early returns after each validation check so that the functions exit immediately when invalid input is detected.

## Related Issue

This PR fixes #7978 

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Added an early `return` after the invalid depth validation in `Singer.ToneActions.doChorus`.
-   Added an early `return` after the invalid depth validation in `Singer.ToneActions.doTremolo`.
-   Added an early `return` after the invalid distortion validation in `Singer.ToneActions.doDistortion`.
-   Strengthened the existing Jest tests for all three functions to assert that the relevant singer state arrays remain empt when validation fails
    (previously the tests only checked that `errorMsg` fired and `stopTurtle` was set, so they passed even with the fall-through bug in place).

## Testing Performed

-   Ran: npx jest js/turtleactions/tests/ToneActions.test.js


-   Confirmed the new/updated assertions fail against the unpatched functions
    (proving they catch the leak), and pass after adding the `return`s.
-   Confirmed valid chorus/tremolo/distortion values still work as expected.
-   Confirmed invalid parameters display the existing error message and no
    longer modify turtle state or register a listener.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable. (Not applicable)
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [x] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled "Allow edits from maintainers".

## Additional Notes for Reviewers

Same root cause as #7921, fixed for `doVibrato` in #7922 — this PR applies the identical fix to three sibling effect functions in the same file (`js/turtleactions/ToneActions.js`) discovered while auditing for similar `stopTurtle = true`-without-`return` patterns.