### PR TITLE
fix: correct custom pitch pie menu order, rotation and preview

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -1058,6 +1058,11 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
 
     showWheelDiv();
 
+    // Set the customID up front so the preview synth can resolve a
+    // frequency even before the user has clicked the temperament tab
+    // (e.g. when there is only one custom temperament defined).
+    block.customID = selectedCustom;
+
     // Some blocks have both pitch and octave, so we can modify
     // both at once.
     const hasOctaveWheel =
@@ -1092,7 +1097,6 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
     block._customWheel.sliceInitPathCustom = block._customWheel.slicePathCustom;
     block._customWheel.titleRotateAngle = 0;
     block._customWheel.animatetime = 0; // 300;
-    block._customWheel.clickModeRotate = false;
     block._customWheel.createWheel(customLabels);
 
     block._cusNoteWheel.colors = platformColor.intervalWheelcolors;
@@ -1133,8 +1137,8 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
         block._octavesWheel.createWheel(octaveLabels);
     }
 
-    //Disable rotation, set navAngle and create the menus
-    block._cusNoteWheel.clickModeRotate = false;
+    // Set navAngle and create the menus. Rotation is left enabled so
+    // the custom note wheel behaves like the regular pitch wheels.
     block._cusNoteWheel.titleRotateAngle = 180;
     block._cusNoteWheel.animatetime = 0; // 300;
     const labelsDict = {};
@@ -1174,6 +1178,11 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
             // labels.push("");
         }
         blockCustom = 0;
+
+        // Notes are collected low-to-high (pitch number order). Reverse
+        // so they display high-to-low, matching the regular pitch wheels
+        // (e.g. solfege is laid out "ti la sol fa mi re do").
+        labelsDict[t].reverse();
     }
     if (!(selectedCustom in labelsDict)) {
         selectedCustom = labelsDict[0];
@@ -1314,7 +1323,12 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
     }
 
     if (typeof j === "number" && !isNaN(j)) {
-        block._cusNoteWheel.navigateWheel(max * customLabels.indexOf(selectedCustom) + j);
+        // j is the ascending pitch-number index; the note wheel is laid
+        // out high-to-low, so convert to the reversed display index.
+        const reversedIndex = labelsDict[selectedCustom].length - 1 - j;
+        block._cusNoteWheel.navigateWheel(
+            max * customLabels.indexOf(selectedCustom) + reversedIndex
+        );
     }
 
     const __exitMenu = () => {


### PR DESCRIPTION
## Summary

Fixes the three custom pitch pie menu problems described in #2255:

1. **Reversed order** - the note wheel was built straight from the temperament's pitch-number order (low to high). Every other pitch wheel in the app lists notes high to low (solfege is built as "ti la sol fa mi re do"), so the custom pitch wheel looked backwards next to them. Fixed by reversing the label array when it's built, and adjusting the initial-selection index math to match.

2. **No rotation** - `clickModeRotate` was explicitly set to `false` on both the temperament wheel and the note wheel in `piemenuCustomNotes`. Nothing else in the regular pitch pie menu does this (only the exit button disables rotation), so dragging to rotate the custom pitch wheel never worked. Removed both assignments.

3. **No pitch preview** - `block.customID` was only ever set inside the temperament tab's `navigateFunction`, so it stayed `null` until the user clicked a temperament tab. With only one custom temperament defined (the common case), the first note click called `getCustomFrequency(notes, null)`, which can't find a match and falls through to returning the raw note name (e.g. `"do"`) instead of a frequency. That string then got handed to `triggerAttackRelease`, which can't play it, so there was no preview sound. Fixed by setting `block.customID` from the selected temperament as soon as the menu opens.

## Changes

- `js/piemenus.js`: reverse note label order in `piemenuCustomNotes`, drop `clickModeRotate = false` for `_customWheel`/`_cusNoteWheel`, initialize `block.customID` up front, fix initial wheel navigation index to account for the reversed order.

## Testing

- `npx eslint js/piemenus.js`
- `npx jest js/__tests__/piemenus.test.js --runInBand --coverage=false` (8/8 passing)
- `npx jest js/blocks/__tests__/PitchBlocks.test.js js/utils/__tests__/synthutils.test.js --runInBand --coverage=false` (199/199 passing)

Fixes #2255