### PR TITLE
fix(pitch-actions): apply accidental fallback instead of early return

### DIFF
--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -440,13 +440,13 @@ function setupPitchActions(activity) {
                 switch (accidental) {
                     case _("sharp"):
                         value = 1;
-                        return;
+                        break;
                     case _("flat"):
                         value = -1;
-                        return;
+                        break;
                     default:
                         value = 0;
-                        return;
+                        break;
                 }
             } else {
                 value = ACCIDENTALVALUES[i];

--- a/js/turtleactions/__tests__/PitchActions.test.js
+++ b/js/turtleactions/__tests__/PitchActions.test.js
@@ -387,11 +387,27 @@ describe("Tests for Singer.PitchActions setup", () => {
     });
 
     describe("Tests for setAccidental", () => {
-        test("named accidental path", () => {
-            Singer.PitchActions.setAccidental("sharp", 0, blkId);
+        test("named accidental from ACCIDENTALNAMES applies its value", () => {
+            Singer.PitchActions.setAccidental(ACCIDENTALNAMES[1], 0, blkId);
+            expect(turtle.singer.transposition).toBe(1);
         });
-        test("invalid accidental → default case", () => {
+        test("bare 'sharp' fallback applies +1 and registers a listener", () => {
+            const listenerSpy = jest.spyOn(activity.logo, "setTurtleListener");
+            Singer.PitchActions.setAccidental("sharp", 0, blkId);
+            expect(turtle.singer.transposition).toBe(1);
+            expect(listenerSpy).toHaveBeenCalledWith(
+                0,
+                "_accidental_0_" + blkId,
+                expect.any(Function)
+            );
+        });
+        test("bare 'flat' fallback applies -1", () => {
+            Singer.PitchActions.setAccidental("flat", 0, blkId);
+            expect(turtle.singer.transposition).toBe(-1);
+        });
+        test("invalid accidental → default case leaves transposition unchanged", () => {
             Singer.PitchActions.setAccidental("foo", 0, blkId);
+            expect(turtle.singer.transposition).toBe(0);
         });
     });
 
@@ -578,10 +594,14 @@ describe("Tests for Singer.PitchActions setup", () => {
             MusicBlocks.isRun = false;
         });
 
-        test('setAccidental early‑return for _("sharp") & _("flat")', () => {
+        test('setAccidental fallback for _("sharp") applies delta and registers a reversing listener', () => {
+            const callbacks = [];
+            activity.logo.setTurtleListener = (_turtle, _name, cb) => callbacks.push(cb);
             const before = turtle.singer.transposition;
             Singer.PitchActions.setAccidental(_("sharp"), 0, blkId);
-            Singer.PitchActions.setAccidental(_("flat"), 0, blkId);
+            expect(turtle.singer.transposition).toBe(before + 1);
+            expect(callbacks).toHaveLength(1);
+            callbacks[0]();
             expect(turtle.singer.transposition).toBe(before);
         });
 


### PR DESCRIPTION
## Description

`Singer.PitchActions.setAccidental` (`js/turtleactions/PitchActions.js`) has a fallback `switch` for accidental values that are not found in `ACCIDENTALNAMES` — but every branch assigned `value` and then immediately **`return`ed**:

-   `case _("sharp"): value = 1; return;`
-   `case _("flat"): value = -1; return;`
-   `default: value = 0; return;`

Because the function returned right there, the code below the switch — the actual transposition update (`tur.singer.transposition += ...`) and the registration of the listener that reverses the transposition when the clamp ends — **never ran**. The entire fallback path was dead code: it computed a value and threw it away.

This path is not hypothetical; it is shipped in the product. `ACCIDENTALNAMES` entries are compound strings like `"sharp ♯"` (`js/utils/musicutils.js`), so a bare `"sharp"` always misses the name table and lands in the broken switch. And `AccidentalBlock.flow` (`js/blocks/PitchBlocks.js`) falls back to exactly `arg = "sharp"` when the accidental block's value input is disconnected or non-string — then still runs the child flow.

**User-visible effect:** an accidental block with a disconnected value input (or a text block feeding it "sharp"/"flat") plays the contained notes completely unmodified — no semitone shift, no error — teaching kids the wrong musical result.

**Fix:** replace the three `return` statements with `break` so the computed `value` flows into the transposition update and listener registration, exactly as the named-accidental path does.

## Related Issue

No existing issue — found through code inspection while auditing `js/turtleactions/` for dead code and unreachable branches.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/turtleactions/PitchActions.js` — the three `return` statements in the fallback switch become `break` (a 3-line diff; no other logic touched).
-   `js/turtleactions/__tests__/PitchActions.test.js`:
    -   New behavioral tests: a named accidental from `ACCIDENTALNAMES` applies its value; bare `"sharp"` applies +1 **and** registers the `_accidental_<turtle>_<blk>` listener; bare `"flat"` applies −1; an unknown value leaves transposition unchanged.
    -   In the listener-callbacks suite: new test capturing the registered listener and asserting it reverses the applied delta (apply +1, invoke callback, back to original).
    -   Rewrote the old `'setAccidental early-return for _("sharp") & _("flat")'` test, which pinned the buggy behavior (it asserted that nothing happens).

## Testing Performed

-   Followed TDD: wrote the behavioral tests first and watched 3 of them fail on the old code (transposition stayed `0`, no listener registered), then pass after the fix. Also re-verified the other direction by stashing the production change: the same 3 tests fail again, 62 others unaffected.
-   `npx jest js/turtleactions/__tests__/PitchActions.test.js` — 65/65 pass.
-   All `js/turtleactions` suites + `PitchBlocks` + `turtle-singer` — 574/574 pass.
-   Full Jest suite: 7,296 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, verified independently of this change.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   The switch cases match against the **translated** `_("sharp")` / `_("flat")`, while `AccidentalBlock.flow`'s fallback passes the untranslated literal `"sharp"`. In English locales these coincide (which this PR fixes); in non-English locales the untranslated literal falls into the `default` case (value 0 — safe, but no shift). Matching both raw and translated names would be a sensible follow-up; kept out of scope here to keep the diff minimal.
-   The `default: value = 0` branch now also registers a (no-op) reversal listener, which is consistent with the named `"natural"` accidental (value 0) that always did.