### PR TITLE
fix(modewidget): refuse to save a mode with nothing but the tonic selected

### DIFF
--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -61,6 +61,20 @@ global.normalizeNoteAccidentals = jest.fn().mockImplementation(n => n);
 global.MUSICALMODES = {
     ionian: [2, 2, 1, 2, 2, 2, 1]
 };
+global.NOTESTABLE = {
+    0: "ti",
+    1: "do",
+    2: "do♯",
+    3: "re",
+    4: "re♯",
+    5: "mi",
+    6: "fa",
+    7: "fa♯",
+    8: "sol",
+    9: "sol♯",
+    10: "la",
+    11: "la♯"
+};
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -277,6 +291,35 @@ describe("ModeWidget", () => {
         for (let i = 1; i < 12; i++) {
             expect(modeWidget._selectedNotes[i]).toBe(false);
         }
+    });
+
+    test("should not save a mode when only the root is selected", () => {
+        modeWidget.blocks.loadNewBlocks = jest.fn();
+        modeWidget.storage.custommode = JSON.stringify([2, 2, 1, 2, 2, 2, 1]);
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._selectedNotes[0] = true;
+
+        modeWidget._save();
+
+        // The previously saved custom mode is left untouched and no
+        // action block is generated.
+        expect(modeWidget.storage.custommode).toBe(JSON.stringify([2, 2, 1, 2, 2, 2, 1]));
+        expect(modeWidget.blocks.loadNewBlocks).not.toHaveBeenCalled();
+        expect(mockActivity.textMsg).toHaveBeenCalledWith(
+            "Please select at least one note before saving.",
+            3000
+        );
+    });
+
+    test("should save a mode when notes other than the root are selected", () => {
+        modeWidget.blocks.loadNewBlocks = jest.fn();
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._selectedNotes[0] = true;
+        modeWidget._selectedNotes[7] = true;
+
+        modeWidget._save();
+
+        expect(modeWidget.blocks.loadNewBlocks).toHaveBeenCalled();
     });
 
     test("should trigger synth when playing a note", () => {

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -509,6 +509,21 @@ describe("ModeWidget", () => {
         expect(modeWidget._modeLabelCell.textContent).toBe("C ionian");
     });
 
+    test("should refuse to save a mode with nothing but the tonic selected", () => {
+        // The state left behind by Clear: _calculateMode() returns [12].
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._selectedNotes[0] = true;
+
+        const result = modeWidget._saveCustomMode("emptyMode", modeWidget._calculateMode());
+
+        expect(result).toBe(false);
+        expect(MUSICALMODES["emptyMode"]).toBeUndefined();
+        expect(getSavedCustomModes().some(m => m.name === "emptyMode")).toBe(false);
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+            expect.stringContaining("Please select at least one note")
+        );
+    });
+
     test("should refuse to overwrite a built-in mode on save", () => {
         const originalIonian = MUSICALMODES.ionian;
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -902,6 +902,16 @@ class ModeWidget {
      * @returns {void}
      */
     _save() {
+        // The tonic is always selected, so a mode with a single
+        // interval is one where nothing else has been selected, e.g.
+        // just after Clear. Saving it would overwrite any custom mode
+        // the user has already stored with a degenerate [12] and
+        // generate a meaningless "custom" action block.
+        if (this._calculateMode().length < 2) {
+            this.textMsg(_("Please select at least one note before saving."), 3000);
+            return;
+        }
+
         const table = docById("modeTable");
         const n = table.rows.length - 1;
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -457,6 +457,14 @@ class ModeWidget {
     }
 
     _saveCustomMode(name, pattern) {
+        // The tonic is always selected, so a single-interval pattern means
+        // nothing else is on the wheel -- the state left behind by Clear.
+        // Saving it would register a note-less mode and generate a
+        // meaningless single-pitch action block.
+        if (pattern.length < 2) {
+            this.errorMsg(_("Please select at least one note before saving."));
+            return false;
+        }
         const modes = getSavedCustomModes();
         const existing = modes.findIndex(m => m.name === name);
         // Refuse to overwrite a built-in mode; only registered customs may be updated.


### PR DESCRIPTION
## Description

Rebased onto current `master`, and the scope of this PR has changed — please read before reviewing.

Since this PR was opened, #8059 (`refactor(mode-widget): overhaul scalar builder UI and multi-EDO state sync`) landed and removed the code this PR originally fixed. `_save()` no longer writes `storage.custommode` at all; custom modes are now a named list in `localStorage.customModes`, written through `_saveCustomMode(name, pattern)`, and saving requires entering a name.

**That means the destructive behaviour this PR was written to fix no longer exists.** #8059 resolved it — a note-less save can no longer clobber an unrelated saved custom mode. My original description of the bug is now obsolete and I've rewritten it here rather than leave it standing.

What is still reachable on `master`: after pressing **Clear**, entering a name and pressing **Save** registers a degenerate `[12]` pattern as a real custom mode and generates an action block containing a single pitch. That is no longer destructive, just a mode with no notes in it. This PR now guards only that.

## Related Issue

**Refs:** #7217

(Deliberately not `Fixes` — see below. The issue's stated root cause is inaccurate and its destructive symptom is already gone.)

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

One guard in `_saveCustomMode()`, placed alongside the existing built-in-mode guard and following the same `errorMsg` + `return false` shape:

```js
_saveCustomMode(name, pattern) {
    if (pattern.length < 2) {
        this.errorMsg(_("Please select at least one note before saving."));
        return false;
    }
```

The Save handler already bails on `!this._saveCustomMode(...)`, so nothing is registered and no action block is generated.

`_saveCustomMode()` is the right seam rather than `_save()`: it is the function that actually persists the pattern, it covers the same state reached by X-ing out every note manually (not just via Clear), and it is directly unit-testable.

**Down from +53 to +23 lines** against the previous revision of this PR.

### On the fix the issue proposes

I still have not applied #7217's suggested one-line change (`_clear()`'s loop from `i = 1` to `i = 0`), and #8059 did not change that judgement — the tonic-always-selected invariant survived the refactor intact:

- `_clear()` still starts at `i = 1`
- `_calculateMode()` still measures intervals from the tonic (`for (let i = 1; i < n; i++)`), so it cannot represent a tonic-less selection
- `should return [12] when only root is selected` still codifies that as intended behaviour

If maintainers do want Clear to blank the wheel entirely, that is a larger change than the issue implies and should be scoped deliberately.

---

## Testing Performed

- `npx jest js/widgets/__tests__/modewidget.test.js` — **20/20 pass**, including the new `should refuse to save a mode with nothing but the tonic selected`
- `npx jest js/blocks/__tests__/WidgetBlocks.test.js` — 31/31 pass (the other suite touching this widget)
- `npx eslint js/widgets/modewidget.js js/widgets/__tests__/modewidget.test.js` — clean
- `npx prettier --check` on both files — clean

The new test mirrors the existing `should refuse to overwrite a built-in mode on save`. It uses a distinct mode name because `customModes` and `MUSICALMODES` carry across tests in this suite.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

@021nirav-blip — conflict resolved, but flagging that your refactor absorbed the substantive part of this PR. What is left is a small hygiene guard. **If you would rather I just close this, say the word and I will** — no attachment to landing it.

Also worth noting for #7217 separately: its stated root cause (the `_clear()` off-by-one) is not the actual defect, and the destructive symptom it reports is now fixed by #8059.
