### PR TITLE
fix: prevent crash when dragging blocks after rapidly creating projects

### DIFF
--- a/js/__tests__/block-drag-controller.test.js
+++ b/js/__tests__/block-drag-controller.test.js
@@ -895,6 +895,23 @@ describe("BlockDragController", () => {
 
             debugSpy.mockRestore();
         });
+        it("guards against a connection pointing at a not-yet-populated slot in blockList", () => {
+            // blockList is pre-sized for the whole incoming batch (as blocks.js's
+            // chunked loader does via `_loadCounter = blockObjs.length`), but a
+            // later chunk hasn't been written into it yet, so index 1 is a genuine
+            // array hole (undefined) rather than an explicit null placeholder.
+            // Regression test for the "Cannot read properties of undefined
+            // (reading 'connections')" crash on rapid next-project + play.
+            const blockList = [];
+            blockList[0] = { connections: [null, 1] };
+            blockList.length = 3;
+            const blocks = makeBlocks(blockList);
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+            expect(() => blocks.findDragGroup(0)).not.toThrow();
+
+            debugSpy.mockRestore();
+        });
 
         it("_calculateDragGroup stops recursing once the loop counter exceeds the block list length", () => {
             const blockList = [

--- a/js/block-drag-controller.js
+++ b/js/block-drag-controller.js
@@ -124,9 +124,12 @@ class BlockDragController {
         }
 
         const myBlock = blocks.blockList[blk];
-        /** If this happens, something is really broken. */
-        if (myBlock === null) {
-            console.debug("null block encountered... this is bad. " + blk);
+        /** If this happens, something is really broken.
+         *  Covers both an explicit null entry and an undefined one (e.g. an
+         *  index that points past the currently-loaded portion of
+         *  blockList, or a block removed from the array). */
+        if (!myBlock) {
+            console.debug("null/missing block encountered... this is bad. " + blk);
             return;
         }
 


### PR DESCRIPTION
## Summary

Fixes a crash that could occur when repeatedly using **New Project** and then **Play** before dragging a block onto the workspace.

The drag controller could encounter an uninitialised/undefined entry in `blockList` and attempt to read its `connections` property. This PR adds a guard in `_calculateDragGroup` so invalid block entries are safely ignored.

## Changes

- Guard `_calculateDragGroup` against undefined `blockList` entries.
- Preserve handling for both `null` and `undefined` blocks.
- Add a regression test for the undefined-block scenario.

## Testing

- Reproduced the issue by clicking **Next Project** and **Play** repeatedly, then dragging a block.
- Verified the app no longer crashes.
- Ran the relevant test suite successfully.
- I corrected the typo and added exact reproduction steps to the PR description.

Quick verification:
1. Open Music Blocks.
2. Rapidly create several projects using **New Project**.
3. Open the latest project.
4. Drag any palette block onto the workspace.

Before this fix, this could crash. With this PR, the block is added normally.

<img width="1470" height="956" alt="Screenshot 2026-08-07 at 4 12 47 PM" src="https://github.com/user-attachments/assets/b6dae869-67b2-4539-89ae-7fca9c418eca" />
## Category

- [x] Bug fix