### PR TITLE
fix(i18n): map enUS/enUK to their locale files

### DIFF
--- a/js/__tests__/loader.test.js
+++ b/js/__tests__/loader.test.js
@@ -142,6 +142,28 @@ describe("loader.js coverage", () => {
         );
     });
 
+    test("Maps enUS to the en locale file", async () => {
+        global.window.localStorage.languagePreference = "enUS";
+
+        await loadScript();
+
+        expect(mockI18next.init).toHaveBeenCalledWith(
+            expect.objectContaining({ lng: "en" }),
+            expect.any(Function)
+        );
+    });
+
+    test("Maps enUK to the en_GB locale file", async () => {
+        global.window.localStorage.languagePreference = "enUK";
+
+        await loadScript();
+
+        expect(mockI18next.init).toHaveBeenCalledWith(
+            expect.objectContaining({ lng: "en_GB" }),
+            expect.any(Function)
+        );
+    });
+
     test("Handles i18next initialization error", async () => {
         await loadScript({ initError: true });
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -396,6 +396,13 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
                     window.localStorage.setItem("kanaPreference", "kanji");
                     return "ja";
                 }
+                // The language menu stores enUS/enUK, but the locale files are en/en_GB.
+                if (savedLanguage === "enUS") {
+                    return "en";
+                }
+                if (savedLanguage === "enUK") {
+                    return "en_GB";
+                }
                 return savedLanguage.startsWith("ja") ? "ja" : savedLanguage;
             }
         } catch (e) {


### PR DESCRIPTION
## Description

Picking **English (United Kingdom)** from the language menu did nothing. The menu stores `enUK`, and i18next builds the locale path straight from that code, so it requested `locales/enUK.json`- that file doesn't exist, the translations are in `en_GB.json`. It 404'd and fell back to English, so the British spellings never showed up. Same for `enUS`, where the file is `en.json`.

Mapped both to their real filenames in `resolveInitialLanguage()`, next to the `ja-kanji`/`ja-kana` cases that already do this. The stored preference is left alone so the menu highlight keeps working.

## PR Category

-   [x] Bug Fix  


<img width="726" height="583" alt="Screenshot 2026-08-07 at 11 09 49 PM" src="https://github.com/user-attachments/assets/61867ab1-fa13-43e4-923f-6babf0717d4b" />


