### PR TITLE
chore: fix high-severity nanoid vulnerability via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11036,7 +11036,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         }
     },
     "overrides": {
+        "nanoid": "^3.3.17",
         "electron": "40.8.5",
         "flatted": "3.4.2",
         "lodash": "4.18.1",


### PR DESCRIPTION
## Description
This PR fixes the high-severity security vulnerability in `nanoid` (<=3.3.16) flagged by the `Security audit` CI check.

The vulnerable package was brought in deeply via `postcss`. Rather than waiting for a nested dependency bump, this PR uses the `package.json` `"overrides"` feature to forcibly bump `nanoid` to the patched secure version (`^3.3.17`) throughout the dependency tree.

### Changes
- **`package.json`**: Added `"nanoid": "^3.3.17"` to `"overrides"`.
- **`package-lock.json`**: Generated updated lockfile to ensure the new version is strictly resolved by CI.

### Verification
- [x] Ran `npm audit --omit=dev --audit-level=high` and verified the high-severity `nanoid` vulnerability is completely resolved.

- [x] Bug Fix