### PR TITLE
refactor(pitchdrummatrix): extract duplicated play-button icon construction

### DIFF
--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -287,6 +287,8 @@ describe("PitchDrumMatrix Widget", () => {
             expect(img.src).toContain("header-icons/play-button.svg");
             expect(img.title).toBe("Play");
             expect(img.alt).toBe("Play");
+            expect(img.getAttribute("height")).toBe(String(PitchDrumMatrix.ICONSIZE));
+            expect(img.getAttribute("width")).toBe(String(PitchDrumMatrix.ICONSIZE));
         });
 
         test("should create img element with correct stop attributes", () => {
@@ -302,6 +304,8 @@ describe("PitchDrumMatrix Widget", () => {
             expect(img.src).toContain("header-icons/stop-button.svg");
             expect(img.title).toBe("Stop");
             expect(img.alt).toBe("Stop");
+            expect(img.getAttribute("height")).toBe(String(PitchDrumMatrix.ICONSIZE));
+            expect(img.getAttribute("width")).toBe(String(PitchDrumMatrix.ICONSIZE));
         });
     });
 

--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -230,6 +230,81 @@ describe("PitchDrumMatrix Widget", () => {
         });
     });
 
+    // --- _setPlayButtonIcon Tests ---
+    describe("_setPlayButtonIcon", () => {
+        let mockActivity;
+
+        beforeEach(() => {
+            mockActivity = {
+                logo: {
+                    synth: { stop: jest.fn() },
+                    turtleDelay: 0
+                },
+                hideMsgs: jest.fn(),
+                textMsg: jest.fn()
+            };
+            pdm.init(mockActivity);
+        });
+
+        test("should set play icon when state is 'play'", () => {
+            const appendChildSpy = jest.fn();
+            pdm.playButton = {
+                textContent: "",
+                appendChild: appendChildSpy
+            };
+
+            pdm._setPlayButtonIcon("play");
+
+            // Should clear existing content first
+            expect(pdm.playButton.textContent).toBe("\u00A0\u00A0");
+            // Should append img and text node (2 calls)
+            expect(appendChildSpy).toHaveBeenCalledTimes(2);
+        });
+
+        test("should set stop icon when state is 'stop'", () => {
+            const appendChildSpy = jest.fn();
+            pdm.playButton = {
+                textContent: "",
+                appendChild: appendChildSpy
+            };
+
+            pdm._setPlayButtonIcon("stop");
+
+            expect(pdm.playButton.textContent).toBe("\u00A0\u00A0");
+            expect(appendChildSpy).toHaveBeenCalledTimes(2);
+        });
+
+        test("should create img element with correct play attributes", () => {
+            const appendedElements = [];
+            pdm.playButton = {
+                textContent: "",
+                appendChild: el => appendedElements.push(el)
+            };
+
+            pdm._setPlayButtonIcon("play");
+
+            const img = appendedElements[0];
+            expect(img.src).toContain("header-icons/play-button.svg");
+            expect(img.title).toBe("Play");
+            expect(img.alt).toBe("Play");
+        });
+
+        test("should create img element with correct stop attributes", () => {
+            const appendedElements = [];
+            pdm.playButton = {
+                textContent: "",
+                appendChild: el => appendedElements.push(el)
+            };
+
+            pdm._setPlayButtonIcon("stop");
+
+            const img = appendedElements[0];
+            expect(img.src).toContain("header-icons/stop-button.svg");
+            expect(img.title).toBe("Stop");
+            expect(img.alt).toBe("Stop");
+        });
+    });
+
     // --- Init & Close Cleanup Tests ---
     describe("onclose cleanup", () => {
         test("should set _playing to false and stop synth when closed", () => {

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -606,6 +606,32 @@ class PitchDrumMatrix {
     }
 
     /**
+     * Updates the play button icon to show "Play" or "Stop".
+     *
+     * @private
+     * @param {"play"|"stop"} state - Which icon to show.
+     * @returns {void}
+     */
+    _setPlayButtonIcon(state) {
+        const icon = this.playButton;
+        const isStop = state === "stop";
+        const src = isStop ? "header-icons/stop-button.svg" : "header-icons/play-button.svg";
+        const label = isStop ? _("Stop") : _("Play");
+
+        icon.textContent = "\u00A0\u00A0";
+        const img = document.createElement("img");
+        img.src = src;
+        img.title = label;
+        img.alt = label;
+        img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
+        img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
+        img.setAttribute("vertical-align", "middle");
+        img.setAttribute("align-content", "center");
+        icon.appendChild(img);
+        icon.appendChild(document.createTextNode("\u00A0\u00A0"));
+    }
+
+    /**
      * Handles the scaling of the widget.
      *
      * @private
@@ -640,31 +666,10 @@ class PitchDrumMatrix {
      */
     _playAll() {
         // Play all of the pitch/drum combinations in the matrix.
-        const icon = this.playButton;
         if (this._playing) {
-            icon.textContent = "\u00A0\u00A0";
-            const img = document.createElement("img");
-            img.src = "header-icons/stop-button.svg";
-            img.title = _("Stop");
-            img.alt = _("Stop");
-            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("vertical-align", "middle");
-            img.setAttribute("align-content", "center");
-            icon.appendChild(img);
-            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
+            this._setPlayButtonIcon("stop");
         } else {
-            icon.textContent = "\u00A0\u00A0";
-            const img = document.createElement("img");
-            img.src = "header-icons/play-button.svg";
-            img.title = _("Play");
-            img.alt = _("Play");
-            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("vertical-align", "middle");
-            img.setAttribute("align-content", "center");
-            icon.appendChild(img);
-            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
+            this._setPlayButtonIcon("play");
             this._playing = false;
             return;
         }
@@ -710,33 +715,13 @@ class PitchDrumMatrix {
                     return;
                 }
                 this._playing = false;
-                icon.textContent = "\u00A0\u00A0";
-                const img = document.createElement("img");
-                img.src = "header-icons/play-button.svg";
-                img.title = _("Play");
-                img.alt = _("Play");
-                img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
-                img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
-                img.setAttribute("vertical-align", "middle");
-                img.setAttribute("align-content", "center");
-                icon.appendChild(img);
-                icon.appendChild(document.createTextNode("\u00A0\u00A0"));
+                this._setPlayButtonIcon("play");
             }, pairs.length * 1000);
         } else {
             if (!this.widgetWindow._maximized) {
                 this.activity.textMsg(_("Click in the grid to map notes to drums."), 3000);
             }
-            icon.textContent = "\u00A0\u00A0";
-            const img = document.createElement("img");
-            img.src = "header-icons/play-button.svg";
-            img.title = _("Play");
-            img.alt = _("Play");
-            img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
-            img.setAttribute("vertical-align", "middle");
-            img.setAttribute("align-content", "center");
-            icon.appendChild(img);
-            icon.appendChild(document.createTextNode("\u00A0\u00A0"));
+            this._setPlayButtonIcon("play");
         }
     }
 


### PR DESCRIPTION
## Summary

Extract the play/stop button icon construction in `PitchDrumMatrix._playAll()` into a reusable `_setPlayButtonIcon(state)` helper.

## Problem

The `_playAll()` method contained **four nearly identical** 12-line blocks that construct a play or stop button icon. Each block:
- Clears the button's `textContent`
- Creates an `<img>` element with `src`, `title`, `alt`, and sizing attributes
- Appends the image and a trailing spacer text node

The only difference between copies is the icon source (`play-button.svg` vs `stop-button.svg`) and the label text (`"Play"` vs `"Stop"`).

## Changes

### `js/widgets/pitchdrummatrix.js`
- **New method:** `_setPlayButtonIcon(state)` — accepts `"play"` or `"stop"`, performs the icon construction once.
- **Simplified `_playAll()`** — replaced four copy-paste blocks with single-line calls to the new helper.
- **No behavioral change** — this is a pure refactoring.

### `js/widgets/__tests__/pitchdrummatrix.test.js`
- Added four focused tests for `_setPlayButtonIcon`:
  - Verifies DOM structure for both play and stop states.
  - Verifies correct `src`, `title`, and `alt` attributes.

## Verification
## PR Category
Please check at least one category:
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [x] Refactoring