### PR TITLE
feat(edo): wire EDO temperament consumers and fix scalar transposition

### DIFF
--- a/js/__tests__/lilypond.test.js
+++ b/js/__tests__/lilypond.test.js
@@ -49,6 +49,7 @@ global.NOTATIONDOTCOUNT = NOTATIONDOTCOUNT;
 
 global._ = jest.fn(str => str);
 global.last = jest.fn(array => array[array.length - 1]);
+global.getCurrentEDO = jest.fn(() => 12);
 
 const { getLilypondHeader, processLilypondNotes, saveLilypondOutput } = require("../lilypond");
 
@@ -77,6 +78,9 @@ describe("processLilypondNotes", () => {
                 notationStaging: {
                     [turtle]: [[["G4"], 4, 0, null, 0, -1, false], "meter", 4, 4]
                 }
+            },
+            synth: {
+                inTemperament: "equal"
             }
         };
         lilypond = "";
@@ -378,7 +382,10 @@ describe("saveLilypondOutput", () => {
                 notationOutput: "",
                 guitarOutputHead: "",
                 guitarOutputEnd: "",
-                MIDIOutput: ""
+                MIDIOutput: "",
+                synth: {
+                    inTemperament: "equal"
+                }
             },
             turtles: {
                 turtleList: {
@@ -617,7 +624,7 @@ describe("saveLilypondOutput", () => {
         };
         const result = saveLilypondOutput(activity);
         expect(result).toBeDefined();
-        expect(frequencyToPitch).toHaveBeenCalledWith(440);
+        expect(frequencyToPitch).toHaveBeenCalledWith(440, "equal");
     });
     test("should handle short name collision for names without spaces (longer loop)", () => {
         activity.turtles.turtleList = {

--- a/js/lilypond.js
+++ b/js/lilypond.js
@@ -15,7 +15,7 @@
    _, toFraction, last, SHARP, FLAT, frequencyToPitch, NATURAL,
    DOUBLESHARP, DOUBLEFLAT, getScaleAndHalfSteps, NOTATIONTUPLETVALUE,
    NOTATIONNOTE, NOTATIONDURATION, NOTATIONROUNDDOWN, NOTATIONSTACCATO,
-   NOTATIONDOTCOUNT
+   NOTATIONDOTCOUNT, getCurrentEDO
  */
 
 /*
@@ -23,8 +23,9 @@
      - lib/wheelnav
          slicePath, wheelnav
      
-     - js/utils/musicutils.js
-         toFraction, frequencyToPitch, NATURAL, DOUBLESHARP, DOUBLEFLAT, getScaleAndHalfSteps
+      - js/utils/musicutils.js
+          toFraction, frequencyToPitch, NATURAL, DOUBLESHARP, DOUBLEFLAT, getScaleAndHalfSteps,
+          getCurrentEDO
      
      - js/utils/utils.js
          _, last
@@ -62,7 +63,7 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
 
         // Convert frequencies here.
         if (typeof note === "number") {
-            const pitchObj = frequencyToPitch(note);
+            const pitchObj = frequencyToPitch(note, logo.synth.inTemperament);
             note = pitchObj[0] + pitchObj[1];
         }
 
@@ -269,63 +270,73 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
                     ) {
                         logo.notationNotes[turtle] += " \\key " + key + " \\" + mode + "\n";
                     } else {
-                        obj = getScaleAndHalfSteps(keySignature);
-                        // Check to see if it is possible to construct the mode.
-                        // freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
-                        // (3 . ,NATURAL) (4 . ,NATURAL) (5 . ,FLAT) (6 . ,FLAT))
-                        let modeDef = "\n" + mode.replace(/ /g, "_") + " = #`(";
-                        let prevNote = "";
-                        let n,
-                            nn = -1;
-                        for (let ii = 0; ii < obj[1].length; ii++) {
-                            if (obj[1][ii] !== "") {
-                                // Are we repeating notes, e.g., Db and D?
-                                if (obj[0][ii].substr(0, 1) === prevNote) {
-                                    modeDef = "";
-                                    break;
-                                } else {
-                                    prevNote = obj[0][ii].substr(0, 1);
-                                }
-
-                                n = ["C", "D", "E", "F", "G", "A", "B"].indexOf(
-                                    obj[0][ii].substr(0, 1)
-                                );
-
-                                // Did we skip any notes?
-                                if (n > nn) {
-                                    if (n - nn > 1) {
-                                        for (let j = nn + 1; j < n; j++) {
-                                            modeDef += "(" + j + " . ,NATURAL) ";
-                                        }
-                                    }
-
-                                    nn = n;
-
-                                    if (obj[0][ii].length === 1) {
-                                        modeDef += "(" + n + " . ,NATURAL) ";
-                                    } else {
-                                        if (obj[0][ii].substr(1, 1) === FLAT) {
-                                            modeDef += "(" + n + " . ,FLAT) ";
-                                        } else {
-                                            modeDef += "(" + n + " . ,SHARP) ";
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if (modeDef !== "") {
-                            if (n < 6) {
-                                for (let j = n + 1; j < 7; j++) {
-                                    modeDef += "(" + j + " . ,NATURAL) ";
-                                }
-                            }
-
-                            modeDef += ")\n";
-
-                            lilypond.freygish += modeDef;
+                        const currentEDO = getCurrentEDO(logo.synth.inTemperament);
+                        if (currentEDO !== 12) {
                             logo.notationNotes[turtle] +=
-                                " \\key " + key + " \\" + mode.replace(/ /g, "_") + "\n";
+                                '% Custom mode "' +
+                                mode +
+                                '" not supported in ' +
+                                currentEDO +
+                                "-EDO\n";
+                        } else {
+                            obj = getScaleAndHalfSteps(keySignature);
+                            // Check to see if it is possible to construct the mode.
+                            // freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
+                            // (3 . ,NATURAL) (4 . ,NATURAL) (5 . ,FLAT) (6 . ,FLAT))
+                            let modeDef = "\n" + mode.replace(/ /g, "_") + " = #`(";
+                            let prevNote = "";
+                            let n,
+                                nn = -1;
+                            for (let ii = 0; ii < obj[1].length; ii++) {
+                                if (obj[1][ii] !== "") {
+                                    // Are we repeating notes, e.g., Db and D?
+                                    if (obj[0][ii].substr(0, 1) === prevNote) {
+                                        modeDef = "";
+                                        break;
+                                    } else {
+                                        prevNote = obj[0][ii].substr(0, 1);
+                                    }
+
+                                    n = ["C", "D", "E", "F", "G", "A", "B"].indexOf(
+                                        obj[0][ii].substr(0, 1)
+                                    );
+
+                                    // Did we skip any notes?
+                                    if (n > nn) {
+                                        if (n - nn > 1) {
+                                            for (let j = nn + 1; j < n; j++) {
+                                                modeDef += "(" + j + " . ,NATURAL) ";
+                                            }
+                                        }
+
+                                        nn = n;
+
+                                        if (obj[0][ii].length === 1) {
+                                            modeDef += "(" + n + " . ,NATURAL) ";
+                                        } else {
+                                            if (obj[0][ii].substr(1, 1) === FLAT) {
+                                                modeDef += "(" + n + " . ,FLAT) ";
+                                            } else {
+                                                modeDef += "(" + n + " . ,SHARP) ";
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (modeDef !== "") {
+                                if (n < 6) {
+                                    for (let j = n + 1; j < 7; j++) {
+                                        modeDef += "(" + j + " . ,NATURAL) ";
+                                    }
+                                }
+
+                                modeDef += ")\n";
+
+                                lilypond.freygish += modeDef;
+                                logo.notationNotes[turtle] +=
+                                    " \\key " + key + " \\" + mode.replace(/ /g, "_") + "\n";
+                            }
                         }
                     }
                     i += 2;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -579,10 +579,13 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                       )
                     : true)))
     ) {
-        if (scale[6 - i][0] === FIXEDSOLFEGE[note] || scale[6 - i][0] === note) {
-            accidental = scale[6 - i].substr(1);
+        if (
+            scale[scale.length - 1 - i][0] === FIXEDSOLFEGE[note] ||
+            scale[scale.length - 1 - i][0] === note
+        ) {
+            accidental = scale[scale.length - 1 - i].substr(1);
         } else {
-            accidental = EQUIVALENTACCIDENTALS[scale[6 - i]].substr(1);
+            accidental = EQUIVALENTACCIDENTALS[scale[scale.length - 1 - i]].substr(1);
         }
         block.value = block.value
             .replace(SHARP, "")

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -331,8 +331,8 @@ class Singer {
                 noteObj[0],
                 noteObj[1],
                 steps > 0
-                    ? getStepSizeUp(tur.singer.keySignature, noteObj[0], steps, temperament)
-                    : getStepSizeDown(tur.singer.keySignature, noteObj[0], steps, temperament),
+                    ? getStepSizeUp(tur.singer.keySignature, noteObj[0], steps, temperament, edo)
+                    : getStepSizeDown(tur.singer.keySignature, noteObj[0], steps, temperament, edo),
                 tur.singer.keySignature,
                 tur.singer.movable,
                 null,
@@ -346,8 +346,20 @@ class Singer {
             for (let i = 0; i < Math.abs(steps); i++) {
                 const stepEdo =
                     steps > 0
-                        ? getStepSizeUp(tur.singer.keySignature, noteObj[0], undefined, curTemp)
-                        : getStepSizeDown(tur.singer.keySignature, noteObj[0], undefined, curTemp);
+                        ? getStepSizeUp(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              curTemp,
+                              edo
+                          )
+                        : getStepSizeDown(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              curTemp,
+                              edo
+                          );
                 noteObj = getNote(
                     noteObj[0],
                     noteObj[1],
@@ -365,48 +377,36 @@ class Singer {
             const curTemp = temperament;
 
             const curEDO = edo;
-            if (curEDO === 12) {
-                for (let i = 0; i < Math.abs(steps); i++) {
-                    const stepEdo =
-                        steps > 0
-                            ? getStepSizeUp(tur.singer.keySignature, noteObj[0], undefined, curTemp)
-                            : getStepSizeDown(
-                                  tur.singer.keySignature,
-                                  noteObj[0],
-                                  undefined,
-                                  curTemp
-                              );
+            for (let i = 0; i < Math.abs(steps); i++) {
+                const stepEdo =
+                    steps > 0
+                        ? getStepSizeUp(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              curTemp,
+                              curEDO
+                          )
+                        : getStepSizeDown(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              curTemp,
+                              curEDO
+                          );
 
-                    noteObj = getNote(
-                        noteObj[0],
-                        noteObj[1],
-                        stepEdo,
-                        tur.singer.keySignature,
-                        tur.singer.movable,
-                        null,
-                        activity.errorMsg,
-                        curTemp,
-                        true,
-                        false // allow octave wrap
-                    );
-                }
-            } else {
-                for (let i = 0; i < Math.abs(steps); i++) {
-                    const stepEdo = steps > 0 ? 1 : -1;
-
-                    noteObj = getNote(
-                        noteObj[0],
-                        noteObj[1],
-                        stepEdo,
-                        tur.singer.keySignature,
-                        tur.singer.movable,
-                        null,
-                        activity.errorMsg,
-                        curTemp,
-                        true,
-                        false // allow octave wrap
-                    );
-                }
+                noteObj = getNote(
+                    noteObj[0],
+                    noteObj[1],
+                    stepEdo,
+                    tur.singer.keySignature,
+                    tur.singer.movable,
+                    null,
+                    activity.errorMsg,
+                    curTemp,
+                    true,
+                    false // allow octave wrap
+                );
             }
         }
 
@@ -443,11 +443,12 @@ class Singer {
         let n2 = lastNote + tur.singer.pitchNumberOffset;
 
         const temp = activity.logo.synth.inTemperament;
+        const edo = getCurrentEDO(temp);
 
         let i = 0;
         let noteObj = numberToPitch(n2, temp, undefined, tur.singer.pitchNumberOffset, activity);
         while (i++ < 100) {
-            n2 += getStepSizeUp(tur.singer.keySignature, noteObj[0], 1, temp);
+            n2 += getStepSizeUp(tur.singer.keySignature, noteObj[0], 1, temp, edo);
             if (n2 >= n1) break;
             noteObj = numberToPitch(n2, temp, undefined, tur.singer.pitchNumberOffset, activity);
         }
@@ -803,6 +804,7 @@ class Singer {
      */
     static processPitch(activity, note, octave, cents, turtle, blk) {
         const tur = activity.turtles.ithTurtle(turtle);
+        const edo = getCurrentEDO(activity.logo.synth.inTemperament);
         let noteObj = Singer.addScalarTransposition(
             activity.logo,
             turtle,
@@ -925,7 +927,13 @@ class Singer {
                     activity.logo.synth.inTemperament
                 );
                 nnote[0] = noteIsSolfege(note)
-                    ? getSolfege(nnote[0], tur.singer.keySignature, tur.singer.movable)
+                    ? getSolfege(
+                          nnote[0],
+                          tur.singer.keySignature,
+                          tur.singer.movable,
+                          activity.logo.synth.inTemperament,
+                          edo
+                      )
                     : nnote[0];
 
                 if (tur.singer.drumStyle.length > 0) {
@@ -975,7 +983,9 @@ class Singer {
                     noteObj[0] = getSolfege(
                         noteObj[0],
                         tur.singer.keySignature,
-                        tur.singer.movable
+                        tur.singer.movable,
+                        activity.logo.synth.inTemperament,
+                        edo
                     );
                 }
 
@@ -1042,7 +1052,9 @@ class Singer {
                     noteObj[0] = getSolfege(
                         noteObj[0],
                         tur.singer.keySignature,
-                        tur.singer.movable
+                        tur.singer.movable,
+                        activity.logo.synth.inTemperament,
+                        edo
                     );
                 }
 
@@ -1086,7 +1098,8 @@ class Singer {
                             getInterval(
                                 tur.singer.arpeggio[tur.singer.arpeggioIndex][0],
                                 tur.singer.keySignature,
-                                noteObj[0]
+                                noteObj[0],
+                                edo
                             ) + tur.singer.arpeggio[tur.singer.arpeggioIndex][1];
                         atrans += arpeggioTrans;
 
@@ -1167,7 +1180,7 @@ class Singer {
                 const noteObj2 = getNote(
                     noteObj1[0],
                     noteObj1[1],
-                    getInterval(intervals[i], tur.singer.keySignature, noteObj1[0]),
+                    getInterval(intervals[i], tur.singer.keySignature, noteObj1[0], edo),
                     tur.singer.keySignature,
                     tur.singer.movable,
                     null,
@@ -1200,7 +1213,7 @@ class Singer {
                 const noteObj2 = getNote(
                     noteObj1[0],
                     noteObj1[1],
-                    getInterval(chordInterval[0], tur.singer.keySignature, noteObj1[0]) +
+                    getInterval(chordInterval[0], tur.singer.keySignature, noteObj1[0], edo) +
                         chordInterval[1],
                     tur.singer.keySignature,
                     tur.singer.movable,
@@ -1316,7 +1329,13 @@ class Singer {
                 activity.logo.synth.inTemperament
             );
             nnote[0] = noteIsSolfege(note)
-                ? getSolfege(nnote[0], tur.singer.keySignature, tur.singer.movable)
+                ? getSolfege(
+                      nnote[0],
+                      tur.singer.keySignature,
+                      tur.singer.movable,
+                      activity.logo.synth.inTemperament,
+                      edo
+                  )
                 : nnote[0];
 
             if (tur.singer.drumStyle.length === 0) {
@@ -1381,7 +1400,7 @@ class Singer {
                 const noteObj2 = getNote(
                     noteObj1[0],
                     noteObj1[1],
-                    getInterval(intervals[i], tur.singer.keySignature, noteObj1[0]),
+                    getInterval(intervals[i], tur.singer.keySignature, noteObj1[0], edo),
                     tur.singer.keySignature,
                     tur.singer.movable,
                     null,

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -312,7 +312,7 @@ class Singer {
 
         const activity = logo.activity;
         const tur = activity.turtles.ithTurtle(turtle);
-        const temperament = logo.synth.inTemperament;
+        const temperament = logo && logo.synth && logo.synth.inTemperament;
         const edo = getCurrentEDO(temperament);
 
         let noteObj = getNote(

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -21,7 +21,8 @@
 
 /*
    global _, NOINPUTERRORMSG, Singer, MUSICALMODES, MusicBlocks, Mouse, getNote,
-   getModeLength, isCustomTemperament, TEMPERAMENT, getCurrentEDO, EDOBOUNDEXCEEDED
+   getModeLength, isCustomTemperament, TEMPERAMENT, getCurrentEDO, EDOBOUNDEXCEEDED,
+   pitchToNumber
 */
 
 /*
@@ -33,7 +34,7 @@
     js/utils/musicutils.js
          MUSICALMODES, MODE_PIE_MENUS, getNote, getModeLength, NOTESTEP,
          GetNotesForInterval,ALLNOTESTEP,NOTENAMES,SEMITONETOINTERVALMAP,
-         isCustomTemperament, TEMPERAMENT, getCurrentEDO
+         isCustomTemperament, TEMPERAMENT, getCurrentEDO, pitchToNumber
     js/turtle-singer.js
         Singer
     js/js-export/export.js
@@ -89,7 +90,11 @@ function setupIntervalsActions(activity) {
         static GetIntervalNumber(turtle) {
             const tur = activity.turtles.ithTurtle(turtle);
             let { firstNote, secondNote, octave } = GetNotesForInterval(tur);
-            let totalIntervals = Math.abs(ALLNOTESTEP[firstNote] - ALLNOTESTEP[secondNote]);
+            const temperament = activity.logo.synth.inTemperament;
+            const keySig = tur.singer.keySignature;
+            const firstStep = pitchToNumber(firstNote, 0, keySig, temperament);
+            const secondStep = pitchToNumber(secondNote, 0, keySig, temperament);
+            let totalIntervals = Math.abs(firstStep - secondStep);
 
             // Use dynamic temperament length for custom tunings
             const temperamentLength = this.getTemperamentLength();
@@ -97,9 +102,7 @@ function setupIntervalsActions(activity) {
             // Handle octave boundary wrap-around for enharmonic equivalents
             // For cases like B (12) to B#/Cb (0), the raw difference is 12 but should be 1
             // Calculate forward distance across octave boundary using modular arithmetic
-            const forwardDiff =
-                (ALLNOTESTEP[secondNote] - ALLNOTESTEP[firstNote] + temperamentLength) %
-                temperamentLength;
+            const forwardDiff = (secondStep - firstStep + temperamentLength) % temperamentLength;
             // When notes are at octave boundary (forwardDiff === 0), use 1 semitone
             // Otherwise use the shorter of raw difference or forward distance
             totalIntervals = forwardDiff === 0 ? 1 : Math.min(totalIntervals, forwardDiff);

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -23,9 +23,9 @@
 /*
    globals Singer, pitchToNumber, getStepSizeUp, getStepSizeDown, calcOctave, last, getNote,
    nthDegreeToPitch, SHARP, FLAT, pitchToFrequency, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
-   numberToPitch, ACCIDENTALNAMES, ACCIDENTALVALUES, NOTESFLAT, NOTESSHARP, NOTESTEP, MUSICALMODES,
+   numberToPitch, ACCIDENTALNAMES, ACCIDENTALVALUES, NOTESFLAT, NOTESSHARP, NOTESTEP,
    keySignatureToMode, getInterval, EFFECTSNAMES, NANERRORMSG, frequencyToPitch,
-   MusicBlocks, Mouse, isCustomTemperament, getCurrentEDO
+   MusicBlocks, Mouse, isCustomTemperament, getCurrentEDO, getModeLength
 */
 
 /*
@@ -187,11 +187,7 @@ function setupPitchActions(activity) {
             const obj = keySignatureToMode(tur.singer.keySignature);
             let modeLength;
 
-            if (isCustomTemperament(activity.logo.synth.inTemperament)) {
-                modeLength = Singer.IntervalsActions.getTemperamentLength();
-            } else {
-                modeLength = MUSICALMODES[obj[1]].length;
-            }
+            modeLength = getModeLength(tur.singer.keySignature);
             let scaleDegree;
 
             // Reference position of the key note within the octave, in EDO steps (0-based).
@@ -237,7 +233,11 @@ function setupPitchActions(activity) {
                 scaleDegree = (number % modeLength) + 1;
             }
 
-            const [note, _offset] = nthDegreeToPitch(tur.singer.keySignature, scaleDegree);
+            const [note, _offset] = nthDegreeToPitch(
+                tur.singer.keySignature,
+                scaleDegree,
+                getCurrentEDO(temperament)
+            );
             let semitones = ref;
             // EDO-aware position lookup instead of hardcoded 12-EDO NOTESFLAT/NOTESSHARP.
             const notePos =

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -69,6 +69,10 @@ describe("setupIntervalsActions", () => {
             "B#": 0
         };
 
+        global.pitchToNumber = jest.fn((note, octave, keySig, temperament) => {
+            return global.ALLNOTESTEP[note] || 0;
+        });
+
         global.GetNotesForInterval = jest.fn(() => ({
             firstNote: "C",
             secondNote: "G",

--- a/js/turtleactions/__tests__/PitchActions.test.js
+++ b/js/turtleactions/__tests__/PitchActions.test.js
@@ -44,7 +44,8 @@ Object.assign(global, {
     MUSICALMODES: musicUtils.MUSICALMODES,
     SHARP: musicUtils.SHARP,
     FLAT: musicUtils.FLAT,
-    getCurrentEDO: musicUtils.getCurrentEDO
+    getCurrentEDO: musicUtils.getCurrentEDO,
+    getModeLength: musicUtils.getModeLength
 });
 
 global.NANERRORMSG = require("../../logo").NANERRORMSG;


### PR DESCRIPTION
EDO Consumers & Crash-Free LilyPond MVP. This connects the dynamic EDO engine from #7986 to the UI consumers – turtle-singer.js, lilypond.js, IntervalsActions.js, and piemenus.js.

Also fixes a long-standing bug in addScalarTransposition: scalar steps were moving chromatically (by semitones) instead of following scale degrees. That's now fixed.

Changes:

- turtle-singer.js
Removed the curEDO === 12 special case. All scalar transposition now uses getStepSizeUp/getStepSizeDown for every temperament.
scalar step (+1) now moves to the next scale degree – C → D in C Major (12-EDO), C → E♭ in C Major (19-EDO). No more chromatic stepping.
Added a null guard (logo && logo.synth && logo.synth.inTemperament) before calling getCurrentEDO() to avoid TypeError in tests.
Threaded edo through getInterval, getSolfege, and getStepSizeUp/Down.

- lilypond.js
Threaded logo.synth.inTemperament into frequencyToPitch calls in __toLilynote.
Added a guard for non-12 EDO exports – emits a comment instead of generating broken Scheme.
IntervalsActions.js
Swapped the legacy ALLNOTESTEP lookup for EDO-aware pitchToNumber calculations.

- piemenus.js
Replaced scale[6 - i] with scale[scale.length - 1 - i] to handle variable-length scales.

this is the test i used to test my changes: 
[testPR10.html](https://github.com/user-attachments/files/30857651/testPR10.html)

Part of: #7171

PR Category
 
- [x] Feature
- [ ] Tests
- [ ] Bug Fix
- [ ] Performance
- [ ] Documentation