### PR TITLE
fix: touch listeners stacking on canvas when horizontal scrolling is toggled

### DIFF
--- a/js/__tests__/activity_listeners.test.js
+++ b/js/__tests__/activity_listeners.test.js
@@ -7,11 +7,13 @@ describe("Activity Event Listener Management", () => {
     let activity;
     let target;
     let listener;
+    let setupBlocksContainerEventsBody;
 
     beforeAll(() => {
         // Load activity.js manually to bypass RequireJS/Global complexity
         const activityPath = path.resolve(__dirname, "../activity.js");
         let code = fs.readFileSync(activityPath, "utf8");
+        const fullSource = code;
 
         // Strip the instantiation and require calls at the end to prevent side effects
         // We look for 'const activity = new Activity();'
@@ -19,6 +21,30 @@ describe("Activity Event Listener Management", () => {
         if (splitPoint !== -1) {
             code = code.substring(0, splitPoint);
         }
+
+        // _setupBlocksContainerEvents is assigned inside the constructor, so the
+        // short-circuited constructor below never reaches it. Extract its source
+        // via bracket matching so it can be attached to the test instance directly.
+        const setupBlocksContainerEventsMarker = "this._setupBlocksContainerEvents = () => {";
+        const setupStart = fullSource.indexOf(setupBlocksContainerEventsMarker);
+        if (setupStart === -1) {
+            throw new Error(
+                "Could not find _setupBlocksContainerEvents in activity.js; " +
+                    "it may have been refactored, update this extraction."
+            );
+        }
+        let setupEnd = setupStart + setupBlocksContainerEventsMarker.length;
+        let braceDepth = 1;
+        while (braceDepth > 0) {
+            if (fullSource[setupEnd] === "{") braceDepth++;
+            else if (fullSource[setupEnd] === "}") braceDepth--;
+            setupEnd++;
+        }
+        const setupBody = fullSource.slice(
+            setupStart + setupBlocksContainerEventsMarker.length,
+            setupEnd - 1
+        );
+        setupBlocksContainerEventsBody = new Function(setupBody);
 
         // Short-circuit the constructor to avoid dependencies
         code = code.replace(
@@ -104,10 +130,24 @@ describe("Activity Event Listener Management", () => {
         // Mock a DOM element as target
         target = document.createElement("div");
         listener = jest.fn();
+
+        // Collaborators used by _setupBlocksContainerEvents; not under test,
+        // just need to exist so setup doesn't throw.
+        activity.stage = { on: jest.fn() };
+        activity.resizeDebounce = false;
+        activity.scrollBlockContainer = false;
+        activity.blocksContainer = { x: 0, y: 0 };
+        activity.refreshCanvas = jest.fn();
+        activity.doLargerBlocks = jest.fn();
+        activity.doSmallerBlocks = jest.fn();
+        activity._setupBlocksContainerEvents = setupBlocksContainerEventsBody.bind(activity);
+
+        document.body.innerHTML = '<canvas id="myCanvas"></canvas>';
     });
 
     afterEach(() => {
         activity.cleanupEventListeners();
+        document.body.innerHTML = "";
     });
 
     test("should track listeners when added", () => {
@@ -165,5 +205,38 @@ describe("Activity Event Listener Management", () => {
         activity.removeEventListener(target, "click", listener, { capture: true });
 
         expect(activity._listeners).toHaveLength(0);
+    });
+
+    test("should not stack touch/wheel listeners across repeated _setupBlocksContainerEvents calls", () => {
+        activity._setupBlocksContainerEvents();
+        activity._setupBlocksContainerEvents();
+        activity._setupBlocksContainerEvents();
+
+        const myCanvas = document.getElementById("myCanvas");
+        const countByType = type =>
+            activity._listeners.filter(l => l.type === type && l.target === myCanvas).length;
+
+        expect(countByType("touchstart")).toBe(1);
+        expect(countByType("touchmove")).toBe(1);
+        expect(countByType("touchend")).toBe(1);
+        expect(countByType("wheel")).toBe(1);
+    });
+
+    test("should remove previous touch listeners before adding new ones on rerun", () => {
+        const removeSpy = jest.spyOn(activity, "removeEventListener");
+        const myCanvas = document.getElementById("myCanvas");
+
+        activity._setupBlocksContainerEvents();
+        expect(removeSpy).not.toHaveBeenCalled();
+
+        activity._setupBlocksContainerEvents();
+
+        expect(removeSpy).toHaveBeenCalledWith(myCanvas, "touchstart", expect.any(Function), {
+            passive: true
+        });
+        expect(removeSpy).toHaveBeenCalledWith(myCanvas, "touchmove", expect.any(Function), {
+            passive: false
+        });
+        expect(removeSpy).toHaveBeenCalledWith(myCanvas, "touchend", expect.any(Function));
     });
 });

--- a/js/activity.js
+++ b/js/activity.js
@@ -1202,21 +1202,29 @@ class Activity {
              * Handles touch start event on the canvas.
              * @param {TouchEvent} event - The touch event object.
              */
-            myCanvas.addEventListener(
-                "touchstart",
-                event => {
-                    if (event.touches.length === 2) {
-                        for (let i = 0; i < 2; i++) {
-                            initialTouches[i][0] = event.touches[i].clientY;
-                            initialTouches[i][1] = event.touches[i].clientX;
-                        }
-                        const dx = event.touches[0].clientX - event.touches[1].clientX;
-                        const dy = event.touches[0].clientY - event.touches[1].clientY;
-                        initialPinchDistance = Math.hypot(dx, dy);
+            const __touchStartHandler = event => {
+                if (event.touches.length === 2) {
+                    for (let i = 0; i < 2; i++) {
+                        initialTouches[i][0] = event.touches[i].clientY;
+                        initialTouches[i][1] = event.touches[i].clientX;
                     }
-                },
-                { passive: true }
-            );
+                    const dx = event.touches[0].clientX - event.touches[1].clientX;
+                    const dy = event.touches[0].clientY - event.touches[1].clientY;
+                    initialPinchDistance = Math.hypot(dx, dy);
+                }
+            };
+
+            // Remove previous touchstart event listener if it exists
+            if (this._touchStartHandler) {
+                this.removeEventListener(myCanvas, "touchstart", this._touchStartHandler, {
+                    passive: true
+                });
+            }
+
+            // Store the handler reference for future cleanup
+            this._touchStartHandler = __touchStartHandler;
+
+            this.addEventListener(myCanvas, "touchstart", __touchStartHandler, { passive: true });
 
             myCanvas.style.touchAction = "none";
 
@@ -1224,76 +1232,94 @@ class Activity {
              * Handles touch move event on the canvas.
              * @param {TouchEvent} event - The touch event object.
              */
-            myCanvas.addEventListener(
-                "touchmove",
-                event => {
-                    if (event.touches.length === 2) {
-                        event.preventDefault();
-                        const dx = event.touches[0].clientX - event.touches[1].clientX;
-                        const dy = event.touches[0].clientY - event.touches[1].clientY;
-                        const currentPinchDistance = Math.hypot(dx, dy);
+            const __touchMoveHandler = event => {
+                if (event.touches.length === 2) {
+                    event.preventDefault();
+                    const dx = event.touches[0].clientX - event.touches[1].clientX;
+                    const dy = event.touches[0].clientY - event.touches[1].clientY;
+                    const currentPinchDistance = Math.hypot(dx, dy);
 
-                        if (initialPinchDistance !== null && !that.resizeDebounce) {
-                            const pinchDelta = currentPinchDistance - initialPinchDistance;
-                            if (Math.abs(pinchDelta) > 20) {
-                                if (pinchDelta > 0) {
-                                    that.doLargerBlocks();
-                                } else {
-                                    that.doSmallerBlocks();
-                                }
-                                initialPinchDistance = currentPinchDistance;
+                    if (initialPinchDistance !== null && !that.resizeDebounce) {
+                        const pinchDelta = currentPinchDistance - initialPinchDistance;
+                        if (Math.abs(pinchDelta) > 20) {
+                            if (pinchDelta > 0) {
+                                that.doLargerBlocks();
+                            } else {
+                                that.doSmallerBlocks();
                             }
+                            initialPinchDistance = currentPinchDistance;
                         }
-
-                        let totalDeltaY = 0;
-                        let totalDeltaX = 0;
-                        let count = 0;
-
-                        for (let i = 0; i < 2; i++) {
-                            const touchY = event.touches[i].clientY;
-                            const touchX = event.touches[i].clientX;
-
-                            if (initialTouches[i][0] !== null && initialTouches[i][1] !== null) {
-                                totalDeltaY += touchY - initialTouches[i][0];
-                                totalDeltaX += touchX - initialTouches[i][1];
-                                count++;
-                            }
-
-                            initialTouches[i][0] = touchY;
-                            initialTouches[i][1] = touchX;
-                        }
-
-                        if (count > 0) {
-                            const avgDeltaY = totalDeltaY / count;
-                            const avgDeltaX = totalDeltaX / count;
-
-                            if (avgDeltaY !== 0) {
-                                closeAnyOpenMenusAndLabels();
-                                that.blocksContainer.y -= avgDeltaY;
-                            }
-
-                            if (that.scrollBlockContainer && avgDeltaX !== 0) {
-                                closeAnyOpenMenusAndLabels();
-                                that.blocksContainer.x -= avgDeltaX;
-                            }
-                        }
-
-                        that.refreshCanvas();
                     }
-                },
-                { passive: false }
-            );
+
+                    let totalDeltaY = 0;
+                    let totalDeltaX = 0;
+                    let count = 0;
+
+                    for (let i = 0; i < 2; i++) {
+                        const touchY = event.touches[i].clientY;
+                        const touchX = event.touches[i].clientX;
+
+                        if (initialTouches[i][0] !== null && initialTouches[i][1] !== null) {
+                            totalDeltaY += touchY - initialTouches[i][0];
+                            totalDeltaX += touchX - initialTouches[i][1];
+                            count++;
+                        }
+
+                        initialTouches[i][0] = touchY;
+                        initialTouches[i][1] = touchX;
+                    }
+
+                    if (count > 0) {
+                        const avgDeltaY = totalDeltaY / count;
+                        const avgDeltaX = totalDeltaX / count;
+
+                        if (avgDeltaY !== 0) {
+                            closeAnyOpenMenusAndLabels();
+                            that.blocksContainer.y -= avgDeltaY;
+                        }
+
+                        if (that.scrollBlockContainer && avgDeltaX !== 0) {
+                            closeAnyOpenMenusAndLabels();
+                            that.blocksContainer.x -= avgDeltaX;
+                        }
+                    }
+
+                    that.refreshCanvas();
+                }
+            };
+
+            // Remove previous touchmove event listener if it exists
+            if (this._touchMoveHandler) {
+                this.removeEventListener(myCanvas, "touchmove", this._touchMoveHandler, {
+                    passive: false
+                });
+            }
+
+            // Store the handler reference for future cleanup
+            this._touchMoveHandler = __touchMoveHandler;
+
+            this.addEventListener(myCanvas, "touchmove", __touchMoveHandler, { passive: false });
 
             /**
              * Handles touch end event on the canvas.
              */
-            myCanvas.addEventListener("touchend", () => {
+            const __touchHandler = () => {
                 for (let i = 0; i < 2; i++) {
                     initialTouches[i][0] = null;
                     initialTouches[i][1] = null;
                 }
                 initialPinchDistance = null;
-            });
+            };
+
+            // Remove previous touchend event listener if it exists
+            if (this._touchEndHandler) {
+                this.removeEventListener(myCanvas, "touchend", this._touchEndHandler);
+            }
+
+            // Store the handler reference for future cleanup
+            this._touchEndHandler = __touchHandler;
+
+            this.addEventListener(myCanvas, "touchend", __touchHandler);
 
             /**
              * Handles wheel event on the canvas.

--- a/js/activity.js
+++ b/js/activity.js
@@ -1303,7 +1303,7 @@ class Activity {
             /**
              * Handles touch end event on the canvas.
              */
-            const __touchHandler = () => {
+            const __touchEndHandler = () => {
                 for (let i = 0; i < 2; i++) {
                     initialTouches[i][0] = null;
                     initialTouches[i][1] = null;
@@ -1317,9 +1317,9 @@ class Activity {
             }
 
             // Store the handler reference for future cleanup
-            this._touchEndHandler = __touchHandler;
+            this._touchEndHandler = __touchEndHandler;
 
-            this.addEventListener(myCanvas, "touchend", __touchHandler);
+            this.addEventListener(myCanvas, "touchend", __touchEndHandler);
 
             /**
              * Handles wheel event on the canvas.


### PR DESCRIPTION
## Description

`_setupBlocksContainerEvents()` in `js/activity.js` attaches `touchstart`, `touchmove`, `touchend`, and `wheel` listeners to `myCanvas`. This function reruns every time the user toggles "Enable/Disable horizontal scrolling" in the Advanced mode toolbar (via `setScroller`, see `toolbar-ui.js:1373-1378`), not just once at startup.

The `wheel` listener already guards against this, it stores a handler reference and removes the old one before adding a new one on each rerun. The `touchstart`, `touchmove`, and `touchend` listeners didn't have that guard. They were attached with raw `myCanvas.addEventListener(...)` calls with no stored reference and no removal, so every toggle added a fresh set of touch handlers on top of the old ones. The old ones never got removed and kept firing alongside the new ones, each one holding the whole `Activity` instance alive through its closure.

This PR applies the same store-reference-and-remove-before-add pattern the `wheel` handler already uses to the three touch handlers, and routes all of them through the class's managed `this.addEventListener`/`this.removeEventListener` so they also get swept up automatically by `cleanupEventListeners()`.

## Related Issue

This PR fixes #7993 

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

-   Wrapped the `touchstart` handler in a named function (`__touchStartHandler`), stored on `this._touchStartHandler`, with a remove-before-add guard, matching the existing `wheel` handler pattern.
-   Did the same for `touchmove` (`__touchMoveHandler` / `this._touchMoveHandler`) and `touchend` (`__touchEndHandler` / `this._touchEndHandler`).
-   Switched all three from raw `myCanvas.addEventListener(...)` to the class's managed `this.addEventListener(...)`, so they're tracked in `this._listeners` and cleaned up by `cleanupEventListeners()` like the rest of the managed listeners.
-   No behavioral logic inside the handlers themselves was changed, pinch-zoom, two-finger scroll, and pinch-distance tracking work exactly as before.

## Testing Performed

-   Added a temporary `console.count("_setupBlocksContainerEvents")` at the top of the function and confirmed it climbs on each horizontal-scroll toggle, both before and after this fix (confirming the function itself is still expected to rerun, that part isn't the bug).
-   Before the fix: checked `getEventListeners(document.getElementById("myCanvas"))` in Chrome DevTools after several toggles and confirmed `touchstart`/`touchmove`/`touchend` entries grew by one per toggle while `wheel` stayed at one.
-   After the fix: repeated the same steps and confirmed all four (`touchstart`, `touchmove`, `touchend`, `wheel`) stay at exactly one listener entry regardless of how many times horizontal scrolling is toggled.
-   Manually tested pinch-zoom and two-finger scroll on a touch device after multiple toggles to confirm no duplicated/doubled behavior and no regressions.
-   Verified `node --check js/activity.js` passes.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

The fix mirrors the exact pattern already present in this same function for the `wheel` listener (see the lines right below the touch handlers), so it's intentionally not introducing a new convention, just applying the existing one consistently to the three handlers that were missing it. Happy to add a regression test around `_setupBlocksContainerEvents` if there's an existing pattern in the test suite for asserting listener counts on canvas elements, pointers welcome.