### PR TITLE
fix(turtle-singer): detect empty weighted-partials clamp correctly

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -974,6 +974,24 @@ describe("processNote regression behavior", () => {
         Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
         expect(setTimeoutSpy).not.toHaveBeenCalled();
     });
+
+    test("shows an error when a weighted-partials clamp has no Partial blocks", () => {
+        activityMock.errorMsg = jest.fn();
+        singer.inHarmonic = ["mockBlk"];
+        singer.partials = [[]];
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+        expect(activityMock.errorMsg).toHaveBeenCalledWith(
+            "You must have at least one Partial block inside of a Weighted-partial block"
+        );
+    });
+
+    test("does not show the partials error when the clamp has Partial blocks", () => {
+        activityMock.errorMsg = jest.fn();
+        singer.inHarmonic = ["mockBlk"];
+        singer.partials = [[0, 1, 0]];
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+        expect(activityMock.errorMsg).not.toHaveBeenCalled();
+    });
 });
 
 describe("scalarDistance edge cases", () => {

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -1570,13 +1570,14 @@ class Singer {
 
         partials = [1];
         if (tur.singer.inHarmonic.length > 0) {
-            if (partials.length === 0) {
+            const activePartials = last(tur.singer.partials);
+            if (!activePartials || activePartials.length === 0) {
                 //.TRANS: partials are weighted components in a harmonic series
                 activity.errorMsg(
                     _("You must have at least one Partial block inside of a Weighted-partial block")
                 );
             } else {
-                partials = last(tur.singer.partials);
+                partials = activePartials;
             }
         }
 


### PR DESCRIPTION
## Description

In `Singer.processNote` (`js/turtle-singer.js`), the guard that is supposed to detect a **"weighted partials" clamp with no Partial blocks inside** could never fire:

-   `partials = [1];` is assigned on one line, and the very next line checks `if (partials.length === 0)` — a condition that is **impossible** for the freshly-assigned `[1]`. The intended check was clearly against the singer's partials stack (`last(tur.singer.partials)`).

`HarmonicBlock` ("weighted partials") pushes an **empty** array onto `tur.singer.partials` when its flow starts (`js/blocks/ToneBlocks.js`), and only nested `Partial` blocks fill it. So with no Partial blocks inside the clamp:

-   the empty array was taken as-is (`partials = last(tur.singer.partials)` in the `else` branch),
-   shipped to the synth as `paramsEffects.partials`,
-   and assigned to the Tone.js oscillator (`js/utils/synthutils.js`) — an empty partials array means **no harmonic content, i.e. total silence**.

**User-visible effect:** a child who drags a weighted-partials clamp around notes but hasn't added Partial blocks yet hears nothing at all, with no explanation. The purpose-built error message — "You must have at least one Partial block inside of a Weighted-partial block" — was unreachable dead code (translators have been maintaining a `.TRANS` string for a message that could never appear).

**Fix:** read `last(tur.singer.partials)` first; if it is missing or empty, show the existing translated error and keep the `[1]` default (audible fundamental), otherwise use the clamp's partials — the behavior the code always intended.

## Related Issue

No existing issue — found through code inspection while auditing `Singer.processNote` for unreachable branches.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/turtle-singer.js` — the empty-clamp guard now inspects `last(tur.singer.partials)` instead of the just-assigned local: shows the error and falls back to `[1]` when the clamp is empty, uses the clamp's partials otherwise. (Also covers the defensive `!activePartials` case where the stack itself is empty.)
-   `js/__tests__/turtle-singer.test.js` — two new tests in the `processNote` suite:
    -   a weighted-partials clamp with no Partial blocks (`inHarmonic` set, `partials = [[]]`) calls `activity.errorMsg` with the exact message;
    -   a clamp **with** Partial blocks (`partials = [[0, 1, 0]]`) does not trigger the error.

## Testing Performed

-   Followed TDD: the error-message test was written first and failed on the old code (the branch was dead — `errorMsg` was never called), then passed after the fix; the with-partials guard test passes in both states, protecting against the check over-firing.
-   `npx jest js/__tests__/turtle-singer.test.js js/blocks/__tests__/ToneBlocks.test.js` — 162/162 pass.
-   Full Jest suite: 7,303 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit independently of this change.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   The fix deliberately keeps the `[1]` fundamental as the fallback when the clamp is empty, so the child still hears their notes while the error message explains what is missing — silence plus a message would be the same dead end as before, just labeled.
-   No change to the case where the harmonic clamp has Partial blocks: the clamp's weights are used exactly as before.