### PR TITLE
fix: keep play-only widgets above toolbar

### DIFF
--- a/css/play-only-mode.css
+++ b/css/play-only-mode.css
@@ -69,7 +69,7 @@
     bottom: 0 !important;
     left: 0 !important;
     width: 100% !important;
-    z-index: 1001 !important;
+    z-index: 1002 !important;
     pointer-events: none !important;
 }
 

--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -20,6 +20,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const fs = require("fs");
+const path = require("path");
+
 // Set up globals required by widgetWindows.js before importing
 global._ = str => str;
 global.docById = jest.fn(id => document.getElementById(id));
@@ -752,6 +755,29 @@ describe("widgetWindows", () => {
     });
 
     describe("widgetWindows global functions", () => {
+        test("keeps floating windows above the toolbar in play-only mode", () => {
+            const style = document.createElement("style");
+            style.textContent = fs.readFileSync(
+                path.resolve(__dirname, "../../../css/play-only-mode.css"),
+                "utf8"
+            );
+            document.head.appendChild(style);
+            document.documentElement.classList.add("play-only");
+            nav.id = "toolbars";
+            nav.style.zIndex = "1001";
+
+            try {
+                expect(Number(getComputedStyle(floatingWindows).zIndex)).toBeGreaterThan(
+                    Number(getComputedStyle(nav).zIndex)
+                );
+            } finally {
+                style.remove();
+                document.documentElement.classList.remove("play-only");
+                nav.removeAttribute("id");
+                nav.style.removeProperty("z-index");
+            }
+        });
+
         test("windowFor creates and returns a window", () => {
             const widget = { blockNo: 900 };
             const win = windowFor(widget, "Global Test");

--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -764,6 +764,7 @@ describe("widgetWindows", () => {
             document.head.appendChild(style);
             document.documentElement.classList.add("play-only");
             nav.id = "toolbars";
+            nav.style.position = "fixed";
             nav.style.zIndex = "1001";
 
             try {
@@ -774,6 +775,7 @@ describe("widgetWindows", () => {
                 style.remove();
                 document.documentElement.classList.remove("play-only");
                 nav.removeAttribute("id");
+                nav.style.removeProperty("position");
                 nav.style.removeProperty("z-index");
             }
         });


### PR DESCRIPTION
## What

Keeps floating widget windows above the fixed toolbar in play-only mode. This restores the welcome tour title and close control on mobile viewports.

## Why

The toolbar and `#floatingWindows` used the same z-index. Since the toolbar appears later in the DOM, it covered the floating window header.

## How

  - Raises the play-only floating window z-index above the toolbar.
  - Adds a regression test using the production stylesheet.

## PR Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

## Tests

  - `npx jest js/widgets/__tests__/widgetWindows.test.js --runInBand --coverage=false`
  - `npm run lint -- --max-warnings=0`
  - `npm test -- --runInBand`

Closes #8001