### PR TITLE
refactor: use inlineCollapsible capability for block checks

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -919,6 +919,41 @@ describe("Blocks Foundation", () => {
         let mockActivity;
         let blocks;
 
+        /**
+         * Build a block stand-in whose isCollapsible / isInlineCollapsible
+         * derive from a capabilities map (same contract as Block / ProtoBlock),
+         * rather than hard-coding isInlineCollapsible: () => true.
+         */
+        const makeCapabilityBlock = ({ name, capabilities = [], ...rest }) => {
+            const caps = Object.create(null);
+            for (const capability of capabilities) {
+                caps[capability] = true;
+            }
+
+            return {
+                name,
+                trash: false,
+                collapsed: false,
+                capabilities: caps,
+                hasCapability(capability) {
+                    return Object.prototype.hasOwnProperty.call(this.capabilities, capability)
+                        ? this.capabilities[capability]
+                        : false;
+                },
+                isCollapsible() {
+                    return this.hasCapability("collapsible");
+                },
+                isInlineCollapsible() {
+                    return this.hasCapability("inlineCollapsible");
+                },
+                isClampBlock() {
+                    return false;
+                },
+                connections: [null],
+                ...rest
+            };
+        };
+
         beforeEach(() => {
             mockActivity = {
                 storage: {},
@@ -941,124 +976,128 @@ describe("Blocks Foundation", () => {
         });
 
         it("toggleCollapsibles toggles standard collapsible blocks but excludes inlineCollapsible ones", () => {
-            const mockStartBlock = {
+            const startBlock = makeCapabilityBlock({
                 name: "start",
-                trash: false,
-                collapsed: false,
-                isCollapsible: () => true,
-                isInlineCollapsible: () => false,
+                capabilities: ["collapsible"],
                 collapseToggle: jest.fn(function () {
                     this.collapsed = !this.collapsed;
                 })
-            };
+            });
 
-            const mockDefinemodeBlock = {
-                name: "definemode",
-                trash: false,
-                collapsed: false,
-                isCollapsible: () => true,
-                isInlineCollapsible: () => true,
-                collapseToggle: jest.fn(function () {
-                    this.collapsed = !this.collapsed;
+            // newnote / interval / osctime: same exclude behavior as the old name list.
+            // definemode: intentionally excluded too — it declares inlineCollapsible and
+            // was part of historical INLINECOLLAPSIBLES; completing the capability migration.
+            const inlineBlocks = ["newnote", "interval", "osctime", "definemode"].map(name =>
+                makeCapabilityBlock({
+                    name,
+                    capabilities: ["collapsible", "inlineCollapsible"],
+                    collapseToggle: jest.fn(function () {
+                        this.collapsed = !this.collapsed;
+                    })
                 })
-            };
+            );
 
-            const mockNewNoteBlock = {
-                name: "newnote",
-                trash: false,
-                collapsed: false,
-                isCollapsible: () => true,
-                isInlineCollapsible: () => true,
-                collapseToggle: jest.fn(function () {
-                    this.collapsed = !this.collapsed;
-                })
-            };
+            blocks.blockList = [startBlock, ...inlineBlocks];
 
-            const mockIntervalBlock = {
-                name: "interval",
-                trash: false,
-                collapsed: false,
-                isCollapsible: () => true,
-                isInlineCollapsible: () => true,
-                collapseToggle: jest.fn(function () {
-                    this.collapsed = !this.collapsed;
-                })
-            };
-
-            blocks.blockList = [
-                mockStartBlock,
-                mockDefinemodeBlock,
-                mockNewNoteBlock,
-                mockIntervalBlock
-            ];
-
-            // All currently uncollapsed: collapse standard collapsibles, skip inline ones
             blocks.toggleCollapsibles();
 
-            expect(mockStartBlock.collapseToggle).toHaveBeenCalled();
-            expect(mockDefinemodeBlock.collapseToggle).not.toHaveBeenCalled();
-            expect(mockNewNoteBlock.collapseToggle).not.toHaveBeenCalled();
-            expect(mockIntervalBlock.collapseToggle).not.toHaveBeenCalled();
+            expect(startBlock.collapseToggle).toHaveBeenCalled();
+            for (const inlineBlock of inlineBlocks) {
+                expect(inlineBlock.collapseToggle).not.toHaveBeenCalled();
+            }
         });
 
         it("_getBlockSize spoofs size 1 for collapsed inlineCollapsible blocks including definemode", () => {
             blocks.blockList = [
-                {
+                makeCapabilityBlock({
                     name: "newnote",
                     size: 4,
                     collapsed: true,
-                    isInlineCollapsible: () => true
-                },
-                {
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
+                    name: "interval",
+                    size: 4,
+                    collapsed: true,
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
+                    name: "osctime",
+                    size: 4,
+                    collapsed: true,
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                // Intentional: definemode joins compact-size path via inlineCollapsible.
+                makeCapabilityBlock({
                     name: "definemode",
                     size: 5,
                     collapsed: true,
-                    isInlineCollapsible: () => true
-                },
-                {
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
                     name: "start",
                     size: 3,
                     collapsed: true,
-                    isInlineCollapsible: () => false
-                },
-                {
+                    capabilities: ["collapsible"]
+                }),
+                makeCapabilityBlock({
                     name: "newnote",
                     size: 4,
                     collapsed: false,
-                    isInlineCollapsible: () => true
-                }
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                })
             ];
 
             expect(blocks._getBlockSize(0)).toBe(1);
             expect(blocks._getBlockSize(1)).toBe(1);
-            expect(blocks._getBlockSize(2)).toBe(3);
-            expect(blocks._getBlockSize(3)).toBe(4);
+            expect(blocks._getBlockSize(2)).toBe(1);
+            expect(blocks._getBlockSize(3)).toBe(1);
+            expect(blocks._getBlockSize(4)).toBe(3);
+            expect(blocks._getBlockSize(5)).toBe(4);
         });
 
         it("_getStackSize spoofs size 1 for collapsed inlineCollapsible blocks including definemode", () => {
             blocks.blocksToCollapse = [];
             blocks._sizeCounter = 0;
             blocks.blockList = [
-                {
-                    name: "definemode",
-                    size: 5,
-                    collapsed: true,
-                    isClampBlock: () => false,
-                    isInlineCollapsible: () => true,
-                    connections: [null]
-                },
-                {
+                makeCapabilityBlock({
                     name: "newnote",
                     size: 4,
                     collapsed: true,
-                    isClampBlock: () => false,
-                    isInlineCollapsible: () => true,
-                    connections: [null]
-                }
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
+                    name: "interval",
+                    size: 4,
+                    collapsed: true,
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
+                    name: "osctime",
+                    size: 4,
+                    collapsed: true,
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                // Intentional: definemode stack size spoofs like other inline collapsibles.
+                makeCapabilityBlock({
+                    name: "definemode",
+                    size: 5,
+                    collapsed: true,
+                    capabilities: ["collapsible", "inlineCollapsible"]
+                }),
+                makeCapabilityBlock({
+                    name: "start",
+                    size: 3,
+                    collapsed: true,
+                    capabilities: ["collapsible"]
+                })
             ];
 
             expect(blocks._getStackSize(0)).toBe(1);
             expect(blocks._getStackSize(1)).toBe(1);
+            expect(blocks._getStackSize(2)).toBe(1);
+            expect(blocks._getStackSize(3)).toBe(1);
+            expect(blocks._getStackSize(4)).toBe(3);
         });
 
         it("_processOneBlock correctly uses ProtoBlock capability metadata to initialize collapsed state on load", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -940,7 +940,7 @@ describe("Blocks Foundation", () => {
             blocks = new Blocks(mockActivity);
         });
 
-        it("toggleCollapsibles toggles standard collapsible blocks and definemode, but excludes newnote", () => {
+        it("toggleCollapsibles toggles standard collapsible blocks but excludes inlineCollapsible ones", () => {
             const mockStartBlock = {
                 name: "start",
                 trash: false,
@@ -974,14 +974,91 @@ describe("Blocks Foundation", () => {
                 })
             };
 
-            blocks.blockList = [mockStartBlock, mockDefinemodeBlock, mockNewNoteBlock];
+            const mockIntervalBlock = {
+                name: "interval",
+                trash: false,
+                collapsed: false,
+                isCollapsible: () => true,
+                isInlineCollapsible: () => true,
+                collapseToggle: jest.fn(function () {
+                    this.collapsed = !this.collapsed;
+                })
+            };
 
-            // Trigger toggleCollapsibles (all are currently uncollapsed, so it should collapse start and definemode, but skip newnote)
+            blocks.blockList = [
+                mockStartBlock,
+                mockDefinemodeBlock,
+                mockNewNoteBlock,
+                mockIntervalBlock
+            ];
+
+            // All currently uncollapsed: collapse standard collapsibles, skip inline ones
             blocks.toggleCollapsibles();
 
             expect(mockStartBlock.collapseToggle).toHaveBeenCalled();
-            expect(mockDefinemodeBlock.collapseToggle).toHaveBeenCalled();
+            expect(mockDefinemodeBlock.collapseToggle).not.toHaveBeenCalled();
             expect(mockNewNoteBlock.collapseToggle).not.toHaveBeenCalled();
+            expect(mockIntervalBlock.collapseToggle).not.toHaveBeenCalled();
+        });
+
+        it("_getBlockSize spoofs size 1 for collapsed inlineCollapsible blocks including definemode", () => {
+            blocks.blockList = [
+                {
+                    name: "newnote",
+                    size: 4,
+                    collapsed: true,
+                    isInlineCollapsible: () => true
+                },
+                {
+                    name: "definemode",
+                    size: 5,
+                    collapsed: true,
+                    isInlineCollapsible: () => true
+                },
+                {
+                    name: "start",
+                    size: 3,
+                    collapsed: true,
+                    isInlineCollapsible: () => false
+                },
+                {
+                    name: "newnote",
+                    size: 4,
+                    collapsed: false,
+                    isInlineCollapsible: () => true
+                }
+            ];
+
+            expect(blocks._getBlockSize(0)).toBe(1);
+            expect(blocks._getBlockSize(1)).toBe(1);
+            expect(blocks._getBlockSize(2)).toBe(3);
+            expect(blocks._getBlockSize(3)).toBe(4);
+        });
+
+        it("_getStackSize spoofs size 1 for collapsed inlineCollapsible blocks including definemode", () => {
+            blocks.blocksToCollapse = [];
+            blocks._sizeCounter = 0;
+            blocks.blockList = [
+                {
+                    name: "definemode",
+                    size: 5,
+                    collapsed: true,
+                    isClampBlock: () => false,
+                    isInlineCollapsible: () => true,
+                    connections: [null]
+                },
+                {
+                    name: "newnote",
+                    size: 4,
+                    collapsed: true,
+                    isClampBlock: () => false,
+                    isInlineCollapsible: () => true,
+                    connections: [null]
+                }
+            ];
+
+            expect(blocks._getStackSize(0)).toBe(1);
+            expect(blocks._getStackSize(1)).toBe(1);
         });
 
         it("_processOneBlock correctly uses ProtoBlock capability metadata to initialize collapsed state on load", () => {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -568,8 +568,9 @@ class Blocks {
         };
 
         /**
-         * Toggle state of collapsible blocks, except for note blocks,
-         * which are handled separately.
+         * Toggle state of collapsible blocks, except for inline-collapsible
+         * blocks (e.g. note, interval, osctime, definemode), which are
+         * handled separately.
          * @public
          * @returns {void}
          */
@@ -577,7 +578,7 @@ class Blocks {
             let allCollapsed = true;
             let someCollapsed = false;
             for (const myBlock of this.blockList) {
-                if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                if (!myBlock || myBlock.isInlineCollapsible()) {
                     continue;
                 }
 
@@ -596,7 +597,7 @@ class Blocks {
                  * If any blocks are collapsed, collapse them all.
                  */
                 for (const myBlock of this.blockList) {
-                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (!myBlock || myBlock.isInlineCollapsible()) {
                         continue;
                     }
 
@@ -607,7 +608,7 @@ class Blocks {
             } else {
                 /** If no blocks are collapsed, collapse them all. */
                 for (const myBlock of this.blockList) {
-                    if (!myBlock || ["newnote", "interval", "osctime"].includes(myBlock.name)) {
+                    if (!myBlock || myBlock.isInlineCollapsible()) {
                         continue;
                     }
 
@@ -755,8 +756,8 @@ class Blocks {
         this._getBlockSize = blk => {
             const myBlock = this.blockList[blk];
             if (myBlock === undefined) return 0;
-            /** Special case for collapsed note blocks. */
-            if (["newnote", "interval", "osctime"].includes(myBlock.name) && myBlock.collapsed) {
+            /** Special case for collapsed inline-collapsible blocks. */
+            if (myBlock.isInlineCollapsible() && myBlock.collapsed) {
                 return 1;
             }
 
@@ -1020,13 +1021,10 @@ class Blocks {
                 size = myBlock.size;
             }
 
-            /** If the note value block is collapsed, spoof size. */
+            /** If the inline-collapsible block is collapsed, spoof size. */
             if (this.blocksToCollapse.indexOf(blk) !== -1) {
                 size = 1;
-            } else if (
-                ["newnote", "interval", "osctime"].includes(myBlock.name) &&
-                myBlock.collapsed
-            ) {
+            } else if (myBlock.isInlineCollapsible() && myBlock.collapsed) {
                 size = 1;
             }
 

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -204,6 +204,20 @@ describe("setupIntervalsBlocks", () => {
         });
     });
 
+    describe("inlineCollapsible capability", () => {
+        it("interval declares collapsible and inlineCollapsible", () => {
+            expect(createdBlocks.interval.getCapability("collapsible")).toBe(true);
+            expect(createdBlocks.interval.getCapability("inlineCollapsible")).toBe(true);
+        });
+
+        // definemode was historically in INLINECOLLAPSIBLES and already declares
+        // inlineCollapsible; size/toggle paths must treat it like other inline blocks.
+        it("definemode declares collapsible and inlineCollapsible", () => {
+            expect(createdBlocks.definemode.getCapability("collapsible")).toBe(true);
+            expect(createdBlocks.definemode.getCapability("inlineCollapsible")).toBe(true);
+        });
+    });
+
     describe("Setup", () => {
         it("registers interval blocks", () => {
             expect(Object.keys(createdBlocks).length).toBeGreaterThan(0);

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -937,6 +937,18 @@ describe("RhythmBlocks", () => {
         });
     });
 
+    describe("inlineCollapsible capability", () => {
+        test("newnote declares collapsible and inlineCollapsible", () => {
+            expect(getBlock("newnote").getCapability("collapsible")).toBe(true);
+            expect(getBlock("newnote").getCapability("inlineCollapsible")).toBe(true);
+        });
+
+        test("osctime declares collapsible and inlineCollapsible", () => {
+            expect(getBlock("osctime").getCapability("collapsible")).toBe(true);
+            expect(getBlock("osctime").getCapability("inlineCollapsible")).toBe(true);
+        });
+    });
+
     describe("Blocks note-container migration", () => {
         test("addDefaultBlock() adds vspace and rest2 inside a note container", () => {
             const blocks = createBlocksHarness();


### PR DESCRIPTION
## Description

This PR replaces the remaining hardcoded inline-collapsible block name checks with the existing `isInlineCollapsible()` capability.

This completes the remaining migration from #7950 and ensures blocks such as `definemode`, which already declare the `inlineCollapsible` capability, are handled consistently.

## Changes

- Replaced the remaining hardcoded `newnote`, `interval`, and `osctime` checks in `js/blocks.js`.
- Updated the relevant block tests to verify capability-based behavior.
- Added coverage for collapsed `definemode` handling.

No unrelated behavior or APIs were changed.

## Testing

- `js/__tests__/blocks.test.js`
- `js/blocks/__tests__/RhythmBlocks.test.js`
- `js/blocks/__tests__/IntervalsBlocks.test.js`
- Prettier applied to changed files

## PR category
- [x] chore / refactor
- [x]  tests