### PR TITLE
refactor: migrate WIDENAMES to wideLabel capability

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -279,6 +279,29 @@ describe("Block Foundation", () => {
             expect(block.hasValueDrivenLabel()).toBe(false);
         });
 
+        it("hasWideLabel() should return true from capability metadata", () => {
+            mockProtoBlock.capabilities.wideLabel = true;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasWideLabel()).toBe(true);
+        });
+
+        it("hasWideLabel() should respect explicit false metadata", () => {
+            mockProtoBlock.name = "drumname";
+            mockProtoBlock.capabilities.wideLabel = false;
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasWideLabel()).toBe(false);
+        });
+
+        it("hasWideLabel() should return false for ordinary blocks", () => {
+            mockProtoBlock.name = "forward";
+            mockProtoBlock.capabilities = Object.create(null);
+
+            const block = new Block(mockProtoBlock, mockBlocks);
+            expect(block.hasWideLabel()).toBe(false);
+        });
+
         describe("isArgumentLikeBlock()", () => {
             it("should return true for a normal value block (style 'value' / isArgBlock())", () => {
                 mockProtoBlock.name = "number";

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -100,7 +100,6 @@ global.NUMBERBLOCKDEFAULT = 0;
 global.STRINGLEN = 30;
 global.TEXTWIDTH = 100;
 global.WESTERN2EISOLFEGENAMES = {};
-global.WIDENAMES = [];
 global.BACKWARDCOMPATIBILITYDICT = {};
 global.DEFAULTCHORD = [];
 
@@ -1202,6 +1201,50 @@ describe("Blocks Foundation", () => {
             blocks._deletePitchBlocks(1);
 
             expect(blocks._extractBlock).toHaveBeenCalledWith(1, false);
+        });
+    });
+
+    describe("wideLabel Capability Migration", () => {
+        let blocks;
+
+        beforeEach(() => {
+            blocks = new Blocks({});
+        });
+
+        it("updateBlockText skips truncation for wideLabel blocks", () => {
+            const longLabel = "x".repeat(40);
+            const wideBlock = {
+                name: "drumname",
+                value: longLabel,
+                hasWideLabel: () => true,
+                text: { text: "" },
+                container: {
+                    children: { length: 1 },
+                    setChildIndex: jest.fn(),
+                    updateCache: jest.fn()
+                },
+                loadComplete: true
+            };
+            const normalBlock = {
+                name: "text",
+                value: longLabel,
+                hasWideLabel: () => false,
+                text: { text: "" },
+                container: {
+                    children: { length: 1 },
+                    setChildIndex: jest.fn(),
+                    updateCache: jest.fn()
+                },
+                loadComplete: true
+            };
+
+            blocks.blockList = [wideBlock, normalBlock];
+            blocks.updateBlockText(0);
+            blocks.updateBlockText(1);
+
+            expect(wideBlock.text.text).toBe(longLabel);
+            expect(normalBlock.text.text.endsWith("...")).toBe(true);
+            expect(normalBlock.text.text.length).toBeLessThan(longLabel.length);
         });
     });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -94,29 +94,6 @@ const STRINGLEN = 9;
 const LONGPRESSTIME = 1500;
 
 /**
- * List of block types whose names should be widened.
- * @type {string[]}
- */
-const WIDENAMES = [
-    "intervalname",
-    "accidentalname",
-    "drumname",
-    "effectsname",
-    "voicename",
-    "modename",
-    "chordname",
-    "temperamentname",
-    "noisename",
-    "outputtools"
-];
-
-/**
- * List of additional block types whose names should be widened.
- * @type {string[]}
- */
-const EXTRAWIDENAMES = [];
-
-/**
  * Async function to create bitmap from SVG data.
  * @param {string} data - SVG data.
  * @param {Function} callback - Callback function.
@@ -1517,10 +1494,7 @@ class Block {
                 }
             }
 
-            if (
-                !WIDENAMES.includes(this.name) &&
-                getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH
-            ) {
+            if (!this.hasWideLabel() && getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {
                 label = label.substr(0, STRINGLEN) + "...";
             }
 
@@ -2076,6 +2050,14 @@ class Block {
      */
     hasValueDrivenLabel() {
         return this.hasCapability("valueDrivenLabel");
+    }
+
+    /**
+     * Checks if the block should keep a wide (untruncated) value label layout.
+     * @returns {boolean} - True if the block has wideLabel capability.
+     */
+    hasWideLabel() {
+        return this.hasCapability("wideLabel");
     }
 
     /**
@@ -2955,9 +2937,7 @@ class Block {
         if (this.hasValueDrivenLabel()) {
             this.text.textAlign = "center";
             this.text.x = Math.floor((VALUETEXTX * blockScale) / 2 + 10.0);
-            if (EXTRAWIDENAMES.includes(this.name)) {
-                this.text.x *= 3.0;
-            } else if (WIDENAMES.includes(this.name)) {
+            if (this.hasWideLabel()) {
                 this.text.x = Math.floor(this.text.x * 1.75 + 0.5);
             } else if (this.name === "text") {
                 this.text.x = Math.floor(this.width / 2 + 0.5);
@@ -4848,7 +4828,7 @@ class Block {
             label = _(this.value.toString());
         }
 
-        if (!WIDENAMES.includes(this.name) && getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {
+        if (!this.hasWideLabel() && getTextWidth(label, "bold 20pt Sans") > TEXTWIDTH) {
             let slen = label.length - 5;
             let nlabel = "" + label.substr(0, slen) + "...";
             while (getTextWidth(nlabel, "bold 20pt Sans") > TEXTWIDTH) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -18,7 +18,7 @@
     DEFAULTNOISE, DEFAULTOSCILLATORTYPE, DEFAULTTEMPERAMENT,
     DEFAULTVOICE, NATURAL, NUMBERBLOCKDEFAULT,
     STANDARDBLOCKHEIGHT, STRINGLEN, TEXTWIDTH,
-    WESTERN2EISOLFEGENAMES, WIDENAMES, addTemperamentToDictionary,
+    WESTERN2EISOLFEGENAMES, addTemperamentToDictionary,
    Block, closeBlkWidgets, ConnectionValidator, createjs, delayExecution, DEFAULTCHORD,
    deleteTemperamentFromList, getDrumSynthName, getNoiseName,
    getNoiseSynthName, getTemperamentsList, getTextWidth,
@@ -2072,7 +2072,7 @@ class Blocks {
                     break;
             }
 
-            if (!WIDENAMES.includes(myBlock.name) && label.length > maxLength) {
+            if (!myBlock.hasWideLabel() && label.length > maxLength) {
                 label = label.substr(0, maxLength - 1) + "...";
             }
 
@@ -2998,7 +2998,7 @@ class Blocks {
                             that.blockList[b].value = v;
                             let l = _(value.toString());
                             if (
-                                !WIDENAMES.includes(that.blockList[b].name) &&
+                                !that.blockList[b].hasWideLabel() &&
                                 getTextWidth(l, "bold 20pt Sans") > TEXTWIDTH
                             ) {
                                 l = l.substr(0, STRINGLEN) + "...";
@@ -3025,7 +3025,7 @@ class Blocks {
                         that.blockList[b].value = v;
                         let l = _(v.toString());
                         if (
-                            !WIDENAMES.includes(that.blockList[b].name) &&
+                            !that.blockList[b].hasWideLabel() &&
                             getTextWidth(l, "bold 20pt Sans") > TEXTWIDTH
                         ) {
                             l = l.substr(0, STRINGLEN) + "...";

--- a/js/blocks/DrumBlocks.js
+++ b/js/blocks/DrumBlocks.js
@@ -32,6 +32,7 @@ function setupDrumBlocks(activity) {
             super("noisename", _("noise name"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             /**
              * Sets the palette for the block.
@@ -77,6 +78,7 @@ function setupDrumBlocks(activity) {
             super("drumname", _("drum name"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             /**
              * Sets the palette for the block.
@@ -123,6 +125,7 @@ function setupDrumBlocks(activity) {
             super("effectsname", _("effects name"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             /**
              * Sets the palette for the block.

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -94,6 +94,7 @@ function setupIntervalsBlocks(activity) {
             super("temperamentname", _("temperament name"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             // Set the palette, activity, extra width, and form the block with specific parameters
             this.setPalette("tone", activity);
@@ -121,6 +122,7 @@ function setupIntervalsBlocks(activity) {
             super("modename");
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -144,6 +146,7 @@ function setupIntervalsBlocks(activity) {
             super("chordname");
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);
@@ -248,6 +251,7 @@ function setupIntervalsBlocks(activity) {
             super("intervalname");
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
 
             // Set the palette, activity, help string, extra width, and form the block with specific parameters
             this.setPalette("intervals", activity);

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -425,6 +425,7 @@ function setupPitchBlocks(activity) {
             super("outputtools", _("pitch converter"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
             this.setPalette("pitch", activity);
             this.beginnerBlock(true);
             this.extraWidth = 50;
@@ -883,6 +884,7 @@ function setupPitchBlocks(activity) {
             super("accidentalname", _("accidental selector"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
             this.setPalette("pitch", activity);
             this.setHelpString([
                 _(
@@ -2048,8 +2050,8 @@ function setupPitchBlocks(activity) {
                             ? 1
                             : 0
                         : semitones < ref
-                          ? 1
-                          : 0;
+                        ? 1
+                        : 0;
 
                     octave =
                         (isNegativeArg ? -1 : 1) * (deltaOctave + deltaSemi) +

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -2050,8 +2050,8 @@ function setupPitchBlocks(activity) {
                             ? 1
                             : 0
                         : semitones < ref
-                        ? 1
-                        : 0;
+                          ? 1
+                          : 0;
 
                     octave =
                         (isNegativeArg ? -1 : 1) * (deltaOctave + deltaSemi) +

--- a/js/blocks/ToneBlocks.js
+++ b/js/blocks/ToneBlocks.js
@@ -925,6 +925,7 @@ function setupToneBlocks(activity) {
             super("voicename", _("set instrument"));
             this.setCapability("valueDrivenLabel");
             this.setCapability("discreteChoice");
+            this.setCapability("wideLabel");
             this.setPalette("tone", activity);
             this.setHelpString([
                 _(

--- a/js/blocks/__tests__/DrumBlocks.test.js
+++ b/js/blocks/__tests__/DrumBlocks.test.js
@@ -591,6 +591,12 @@ describe("real DrumBlocks instances - direct method coverage", () => {
         global.ValueBlock = origValueBlock;
     });
 
+    test("name selector blocks declare the wideLabel capability", () => {
+        expect(instances["noisename"].getCapability("wideLabel")).toBe(true);
+        expect(instances["drumname"].getCapability("wideLabel")).toBe(true);
+        expect(instances["effectsname"].getCapability("wideLabel")).toBe(true);
+    });
+
     test("real PlayNoiseBlock flow() calls errorMsg for invalid args", () => {
         instances["playnoise"].flow([], {}, 0, "blk1");
         expect(activity.errorMsg).toHaveBeenCalledWith(global.NOINPUTERRORMSG, "blk1");

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -204,7 +204,7 @@ describe("setupIntervalsBlocks", () => {
         });
     });
 
-    describe("inlineCollapsible capability", () => {
+describe("inlineCollapsible capability", () => {
         it("interval declares collapsible and inlineCollapsible", () => {
             expect(createdBlocks.interval.getCapability("collapsible")).toBe(true);
             expect(createdBlocks.interval.getCapability("inlineCollapsible")).toBe(true);
@@ -215,6 +215,19 @@ describe("setupIntervalsBlocks", () => {
         it("definemode declares collapsible and inlineCollapsible", () => {
             expect(createdBlocks.definemode.getCapability("collapsible")).toBe(true);
             expect(createdBlocks.definemode.getCapability("inlineCollapsible")).toBe(true);
+        });
+    });
+
+    describe("wideLabel capability", () => {
+        it("marks temperament/mode/chord/interval name blocks as wideLabel", () => {
+            expect(createdBlocks["temperamentname"].getCapability("wideLabel")).toBe(true);
+            expect(createdBlocks["modename"].getCapability("wideLabel")).toBe(true);
+            expect(createdBlocks["chordname"].getCapability("wideLabel")).toBe(true);
+            expect(createdBlocks["intervalname"].getCapability("wideLabel")).toBe(true);
+        });
+
+        it("does not mark intervalnumber as wideLabel", () => {
+            expect(createdBlocks["intervalnumber"].getCapability("wideLabel")).toBeUndefined();
         });
     });
 

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -204,7 +204,7 @@ describe("setupIntervalsBlocks", () => {
         });
     });
 
-describe("inlineCollapsible capability", () => {
+    describe("inlineCollapsible capability", () => {
         it("interval declares collapsible and inlineCollapsible", () => {
             expect(createdBlocks.interval.getCapability("collapsible")).toBe(true);
             expect(createdBlocks.interval.getCapability("inlineCollapsible")).toBe(true);

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -854,6 +854,15 @@ describe("setupPitchBlocks", () => {
         it("does not mark pitchnumber as a value-driven label block", () => {
             expect(createdBlocks["pitchnumber"].getCapability("valueDrivenLabel")).toBeUndefined();
         });
+
+        it("marks accidentalname and outputtools as wideLabel", () => {
+            expect(createdBlocks["accidentalname"].getCapability("wideLabel")).toBe(true);
+            expect(createdBlocks["outputtools"].getCapability("wideLabel")).toBe(true);
+        });
+
+        it("does not mark solfege as wideLabel", () => {
+            expect(createdBlocks["solfege"].getCapability("wideLabel")).toBeUndefined();
+        });
     });
 
     describe("Comprehensive Block Coverage", () => {

--- a/js/blocks/__tests__/ToneBlocks.test.js
+++ b/js/blocks/__tests__/ToneBlocks.test.js
@@ -551,6 +551,10 @@ describe("setupToneBlocks", () => {
             voiceName.setup(activity);
             expect(voiceName.extraWidth).toEqual(50);
         });
+
+        it("declares the wideLabel capability", () => {
+            expect(getBlock("voicename").getCapability("wideLabel")).toBe(true);
+        });
     });
 
     describe("SetTimbreBlock", () => {


### PR DESCRIPTION
## Description

This PR replaces the remaining hardcoded `WIDENAMES` block classification with the existing capability-based approach.

The affected blocks now declare the `wideLabel` capability, and consumers use `Block.hasWideLabel()` instead of maintaining a separate list of block names.

## What changed

- Added `wideLabel` capability to the blocks previously listed in `WIDENAMES`.
- Added `Block.hasWideLabel()` helper.
- Replaced all `WIDENAMES` consumers with capability checks.
- Removed the obsolete `WIDENAMES` and empty `EXTRAWIDENAMES` lists.
- Added/updated tests for the new capability and affected block behavior.

## Behavior

This is a refactoring only. The existing wide-label behavior is preserved while removing the hardcoded block-name classification.

## Testing

- Prettier: passed locally
- ESLint: passed locally
- Tests: 298/298 passed locally

## PR Category

- [x] chore / refactor
- [x] tests