### PR TITLE
test(turtleactions): add input validation guards and tests for OrnamentActions

### DIFF
--- a/js/turtleactions/OrnamentActions.js
+++ b/js/turtleactions/OrnamentActions.js
@@ -45,7 +45,7 @@ function setupOrnamentActions(activity) {
         static setStaccato(value, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
 
-            if (value === 0) {
+            if (typeof value !== "number" || isNaN(value) || value === 0) {
                 activity.errorMsg(_("Staccato value must be non-zero."), blk);
                 return;
             }
@@ -75,7 +75,7 @@ function setupOrnamentActions(activity) {
         static setSlur(value, turtle, blk) {
             const tur = activity.turtles.ithTurtle(turtle);
 
-            if (value === 0) {
+            if (typeof value !== "number" || isNaN(value) || value === 0) {
                 activity.errorMsg(_("Slur value must be non-zero."), blk);
                 return;
             }

--- a/js/turtleactions/__tests__/OrnamentActions.test.js
+++ b/js/turtleactions/__tests__/OrnamentActions.test.js
@@ -27,7 +27,8 @@ describe("OrnamentActions", () => {
         beginSlurCalls,
         endSlurCalls,
         mouseMB,
-        listenerFunctions;
+        listenerFunctions,
+        errorMsgCalls;
 
     beforeEach(() => {
         dispatchCalls = [];
@@ -46,9 +47,12 @@ describe("OrnamentActions", () => {
                 neighborNoteValue: []
             }
         };
+        global._ = msg => msg;
+        errorMsgCalls = [];
         activity = {
             turtles: { ithTurtle: () => turtle },
             blocks: { blockList: { 1: {}, 2: {} } },
+            errorMsg: (msg, blk) => errorMsgCalls.push({ msg, blk }),
             logo: {
                 setDispatchBlock: (blk, idx, name) =>
                     dispatchCalls.push({ blk, turtleIndex: idx, listenerName: name }),
@@ -120,6 +124,15 @@ describe("OrnamentActions", () => {
                 });
             }
         );
+
+        test("dispatches errorMsg when staccato value is zero or invalid", () => {
+            [0, null, undefined, NaN, "invalid"].forEach(val => {
+                const initialStaccato = [...turtle.singer.staccato];
+                Singer.OrnamentActions.setStaccato(val, 0, 1);
+                expect(errorMsgCalls.length).toBeGreaterThan(0);
+                expect(turtle.singer.staccato).toEqual(initialStaccato);
+            });
+        });
     });
 
     describe("setSlur", () => {
@@ -205,6 +218,15 @@ describe("OrnamentActions", () => {
                 });
             }
         );
+
+        test("dispatches errorMsg when slur value is zero or invalid", () => {
+            [0, null, undefined, NaN, "invalid"].forEach(val => {
+                const initialStaccato = [...turtle.singer.staccato];
+                Singer.OrnamentActions.setSlur(val, 0, 1);
+                expect(errorMsgCalls.length).toBeGreaterThan(0);
+                expect(turtle.singer.staccato).toEqual(initialStaccato);
+            });
+        });
     });
 
     describe("doNeighbor", () => {


### PR DESCRIPTION
## Description

Refactors `setStaccato()` and `setSlur()` in `js/turtleactions/OrnamentActions.js` to add type, `NaN`, and zero-value validation guards, preventing division by invalid values (`1 / value`) from pushing `Infinity` or `NaN` into the turtle singer's staccato rhythm array. Also expands test coverage in `js/turtleactions/__tests__/OrnamentActions.test.js`.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/turtleactions/OrnamentActions.js`**:
  - Added numeric, `NaN`, and zero validation guards to `setStaccato()` and `setSlur()`.
- **`js/turtleactions/__tests__/OrnamentActions.test.js`**:
  - Added unit test cases verifying error message dispatch and state preservation when `value` is `0`, `null`, `undefined`, `NaN`, or a non-numeric string.

## Testing Performed

- Ran local Jest test suite: `npx jest js/turtleactions/__tests__/OrnamentActions.test.js --coverage=false` (15/15 passed).
- Ran ESLint: `npx eslint js/turtleactions/OrnamentActions.js js/turtleactions/__tests__/OrnamentActions.test.js` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
