### PR TITLE
docs(deps): document electron rebuild version override

### DIFF
--- a/Docs/DEPENDENCY_OVERRIDES.md
+++ b/Docs/DEPENDENCY_OVERRIDES.md
@@ -1,0 +1,21 @@
+# Dependency Overrides
+
+This document records `npm` `overrides` in [`package.json`](../package.json)
+whose rationale isn't obvious from the version number alone, so future
+maintainers know why they exist and when they can be removed.
+
+## `@electron/rebuild` pinned to `3.7.2`
+
+- `@electron/rebuild` is a transitive dependency of `electron-builder`.
+- `@electron/rebuild` 4.x requires Node.js `>=22.12.0`.
+- Music Blocks currently supports Node.js 20 (see `engines` in `package.json`).
+- The override pins `@electron/rebuild` to `3.7.2`, the newest version still
+  compatible with Node 20, to avoid an `EBADENGINE` mismatch during install.
+- This is an **intentional compatibility constraint, not a permanent pin**.
+  It should not be removed just because a newer `@electron/rebuild` becomes
+  available.
+- **Revisit when:** Music Blocks officially raises its minimum supported
+  Node.js version to `>=22.12.0`. At that point, verify Node support and
+  Electron packaging compatibility before removing or changing the override.
+
+Added in [#7973](https://github.com/sugarlabs/musicblocks/pull/7973).

--- a/Docs/DEPENDENCY_OVERRIDES.md
+++ b/Docs/DEPENDENCY_OVERRIDES.md
@@ -6,11 +6,20 @@ maintainers know why they exist and when they can be removed.
 
 ## `@electron/rebuild` pinned to `3.7.2`
 
-- `@electron/rebuild` is a transitive dependency of `electron-builder`.
+- `@electron/rebuild` is not a direct Music Blocks dependency. It is pulled
+  in transitively via:
+
+    ```
+    Music Blocks -> electron-builder -> app-builder-lib -> @electron/rebuild
+    ```
+
 - `@electron/rebuild` 4.x requires Node.js `>=22.12.0`.
 - Music Blocks currently supports Node.js 20 (see `engines` in `package.json`).
-- The override pins `@electron/rebuild` to `3.7.2`, the newest version still
-  compatible with Node 20, to avoid an `EBADENGINE` mismatch during install.
+- Without the override, npm would resolve the transitive dependency to
+  `@electron/rebuild` 4.x, which is Node-22-only and produces an
+  `EBADENGINE` mismatch when installed under Node 20.
+- The override intentionally keeps this transitive dependency on
+  `3.7.2`, a Node 20-compatible version, so that mismatch doesn't occur.
 - This is an **intentional compatibility constraint, not a permanent pin**.
   It should not be removed just because a newer `@electron/rebuild` becomes
   available.


### PR DESCRIPTION
## Summary

Adds `Docs/DEPENDENCY_OVERRIDES.md` documenting why Music Blocks intentionally overrides `@electron/rebuild` to version `3.7.2`.

This is a follow-up to #7973 for a documented rationale so future maintainers understand why the dependency is pinned and when it can safely be revisited.

## Why

`@electron/rebuild` is pulled in transitively through `electron-builder`.The 4.x releases require Node.js `>=22.12.0`, while Music Blocks currently supports Node.js 20.

The override to `3.7.2` keeps the dependency compatible with the project's current Node.js support without requiring a change to the project's Node.js floor.

The override is intentional but not permanent. It should be revisited when Music Blocks intentionally raises its minimum supported Node.js version to `>=22.12.0`, with the Electron packaging workflow verified before removing or changing the override.

## Changes

- Added `Docs/DEPENDENCY_OVERRIDES.md`.
- Documented the `@electron/rebuild@3.7.2` override.
- Documented why the override exists.
- Documented when future maintainers should reconsider it.
- Linked the rationale to #7973.

No changes were made to:

- `package.json`
- `package-lock.json`
- `.nvmrc`
- CI Node.js versions
- the pinned `@electron/rebuild` version

## Testing

- `git diff --check` — passed
- Prettier check — passed
- `package.json` remains valid and unchanged
- Commitlint — 0 problems, 0 warnings