### PR TITLE
feat(blocks): make the Speak block work again, with an optional neural voice

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,13 +108,10 @@
 
         <!-- <script src="sounds/samples/manifest.js"></script> -->
 
-        <!-- <script src="lib/mespeak.js"></script> -->
-
         <!-- Release config: resolves Turtle/Music mode from URL/hostname and seeds
      window._THIS_IS_*_ globals. Must load first, synchronously, before
      loader.js and activity.js read those globals. -->
         <script src="js/releaseconfig.js"></script>
-
 
         <script src="dist/vendor.min.js"></script>
         <link

--- a/js/__tests__/kokoro-speech.test.js
+++ b/js/__tests__/kokoro-speech.test.js
@@ -1,0 +1,234 @@
+/**
+ * Tests for the Speak block's Kokoro engine.
+ *
+ * The model itself is never loaded here: _ensureEngine is stubbed, so these
+ * cover the parts that are ours, namely the phrase queue, cancellation, and
+ * what happens when the model can't be fetched at all.
+ */
+
+const { KokoroSpeech } = require("../kokoro-speech");
+
+// A fake Web Audio graph. Sources record when they start and let the test decide
+// when playback "finishes".
+function installAudio() {
+    const started = [];
+    const pending = [];
+
+    global.window.AudioContext = function () {
+        this.state = "running";
+        this.resume = jest.fn();
+        this.destination = {};
+        this.createBuffer = (channels, length, rate) => ({
+            length,
+            sampleRate: rate,
+            getChannelData: () => new Float32Array(length)
+        });
+        this.createBufferSource = () => {
+            const source = {
+                buffer: null,
+                onended: null,
+                connect: jest.fn(),
+                stop: jest.fn(() => {
+                    if (source.onended) source.onended();
+                }),
+                start: jest.fn(() => {
+                    started.push(source);
+                    pending.push(source);
+                })
+            };
+            return source;
+        };
+    };
+
+    return {
+        started,
+        // Let the phrase that is currently playing run to its end.
+        finishOne() {
+            const source = pending.shift();
+            if (source && source.onended) source.onended();
+        }
+    };
+}
+
+function fakeAudio() {
+    return { audio: new Float32Array(8), sampling_rate: 24000 };
+}
+
+// Lets the queue pump run between assertions.
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe("KokoroSpeech", () => {
+    let audio;
+
+    beforeEach(() => {
+        audio = installAudio();
+    });
+
+    afterEach(() => {
+        delete global.window.AudioContext;
+        jest.restoreAllMocks();
+    });
+
+    test("speaks a phrase through the engine and plays the result", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("hello there");
+        await settle();
+
+        expect(generate).toHaveBeenCalledWith("hello there", { voice: "af_heart" });
+        expect(audio.started).toHaveLength(1);
+    });
+
+    test("plays consecutive phrases one after another, not on top of each other", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("first");
+        speech.speak("second");
+        await settle();
+
+        // Only one phrase is ever audible at a time.
+        expect(audio.started).toHaveLength(1);
+
+        audio.finishOne();
+        await settle();
+
+        expect(audio.started).toHaveLength(2);
+        expect(generate.mock.calls.map(c => c[0])).toEqual(["first", "second"]);
+    });
+
+    test("renders the next phrase while the current one is still playing", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("first");
+        speech.speak("second");
+        await settle();
+
+        // "second" is already being synthesised even though "first" has not
+        // finished, which is what keeps the gap between blocks short.
+        expect(audio.started).toHaveLength(1);
+        expect(generate).toHaveBeenCalledTimes(2);
+    });
+
+    test("imports the model once no matter how many phrases are spoken", async () => {
+        const speech = new KokoroSpeech();
+        const load = jest.fn(async () => ({ generate: async () => fakeAudio() }));
+        // Stand in for the dynamic import plus from_pretrained, so we can count
+        // how often the 92 MB download would actually have been triggered.
+        speech._enginePromise = null;
+        jest.spyOn(speech, "_ensureEngine").mockImplementation(function () {
+            if (this._enginePromise === null) {
+                this._enginePromise = load();
+            }
+            return this._enginePromise;
+        });
+
+        speech.speak("one");
+        speech.speak("two");
+        await settle();
+        audio.finishOne();
+        await settle();
+
+        expect(load).toHaveBeenCalledTimes(1);
+        expect(audio.started).toHaveLength(2);
+    });
+
+    test("cancel drops everything still queued", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("first");
+        speech.speak("second");
+        speech.speak("third");
+        await settle();
+
+        speech.cancel();
+        await settle();
+
+        expect(speech._queue).toHaveLength(0);
+        // "first" is playing and "second" was rendered ahead of it, but nothing
+        // past the cancel point is touched.
+        expect(generate).not.toHaveBeenCalledWith("third", expect.anything());
+        expect(audio.started).toHaveLength(1);
+    });
+
+    test("cancel stops the phrase that is currently playing", async () => {
+        const speech = new KokoroSpeech();
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({
+            generate: async () => fakeAudio()
+        });
+
+        speech.speak("a long sentence");
+        await settle();
+        const source = audio.started[0];
+
+        speech.cancel();
+        expect(source.stop).toHaveBeenCalled();
+    });
+
+    test("cancel is safe when nothing has been spoken", () => {
+        const speech = new KokoroSpeech();
+        expect(() => speech.cancel()).not.toThrow();
+    });
+
+    test("ignores empty and whitespace-only phrases", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("");
+        speech.speak("   ");
+        speech.speak(null);
+        speech.speak(undefined);
+        await settle();
+
+        expect(generate).not.toHaveBeenCalled();
+    });
+
+    test("coerces non-string input", async () => {
+        const speech = new KokoroSpeech();
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak(42);
+        await settle();
+
+        expect(generate).toHaveBeenCalledWith("42", { voice: "af_heart" });
+    });
+
+    test("gives up quietly and stays quiet when the model cannot be loaded", async () => {
+        const speech = new KokoroSpeech();
+        const ensure = jest.spyOn(speech, "_ensureEngine").mockRejectedValue(new Error("offline"));
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+        speech.speak("first");
+        speech.speak("second");
+        await settle();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(audio.started).toHaveLength(0);
+
+        // A later block shouldn't retry the failed download.
+        ensure.mockClear();
+        speech.speak("third");
+        await settle();
+        expect(ensure).not.toHaveBeenCalled();
+    });
+
+    test("honours a voice chosen by the user", async () => {
+        const speech = new KokoroSpeech({ voice: "bm_george" });
+        const generate = jest.fn(async () => fakeAudio());
+        jest.spyOn(speech, "_ensureEngine").mockResolvedValue({ generate });
+
+        speech.speak("good afternoon");
+        await settle();
+
+        expect(generate).toHaveBeenCalledWith("good afternoon", { voice: "bm_george" });
+    });
+});

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -307,7 +307,6 @@ function createMockActivity(turtle) {
         showBlocksAfterRun: false,
         onStopTurtle: jest.fn(),
         onRunTurtle: jest.fn(),
-        meSpeak: { speak: jest.fn() },
         save: {
             afterSaveLilypond: jest.fn(),
             afterSaveAbc: jest.fn(),
@@ -516,7 +515,6 @@ describe("Logo constructor", () => {
             storage: { saveLocally: jest.fn() },
             config: { showBlocksAfterRun: false },
             callbacks: { onStopTurtle: jest.fn(), onRunTurtle: jest.fn() },
-            meSpeak: { speak: jest.fn() },
             classes: {
                 Notation: jest.fn(() => ({})),
                 Synth: jest.fn(() => ({}))
@@ -2671,5 +2669,201 @@ describe("Logo processShow", () => {
 
         global.CAMERAVALUE = originalCameraValue;
         global.VIDEOVALUE = originalVideoValue;
+    });
+});
+describe("Logo.processSpeak", () => {
+    let logo;
+    let speakMock;
+    let cancelMock;
+    let utterances;
+
+    // A tiny stand-in for the Web Speech API. We capture the utterances that
+    // get spoken so the assertions can look at what the browser would have said.
+    function installSpeechSynthesis(voices = []) {
+        utterances = [];
+        speakMock = jest.fn(u => utterances.push(u));
+        cancelMock = jest.fn();
+
+        global.window.speechSynthesis = {
+            speak: speakMock,
+            cancel: cancelMock,
+            getVoices: () => voices
+        };
+
+        // jsdom doesn't provide SpeechSynthesisUtterance, so give it a plain
+        // constructor that just records the text.
+        global.SpeechSynthesisUtterance = function (text) {
+            this.text = text;
+            this.lang = "";
+            this.voice = null;
+            this.rate = null;
+            this.pitch = null;
+            this.volume = null;
+            this.onerror = null;
+        };
+    }
+
+    // jsdom's navigator.language is read-only, so reassigning global.navigator
+    // does nothing. Redefine the property instead.
+    function setLanguage(lang) {
+        Object.defineProperty(global.navigator, "language", {
+            value: lang,
+            configurable: true
+        });
+    }
+
+    // Switch the neural voice on and hand back the fake engine it will use.
+    function enableKokoro() {
+        const engine = { speak: jest.fn(), cancel: jest.fn() };
+        global.window.KokoroSpeech = function () {
+            return engine;
+        };
+        window.localStorage.setItem("kokoroSpeech", "on");
+        return engine;
+    }
+
+    beforeEach(() => {
+        setupLogoEnv();
+        logo = new Logo(createMockActivity());
+        setLanguage("en-US");
+    });
+
+    afterEach(() => {
+        window.localStorage.removeItem("kokoroSpeech");
+        delete global.window.KokoroSpeech;
+        delete global.window.speechSynthesis;
+        delete global.SpeechSynthesisUtterance;
+        jest.restoreAllMocks();
+    });
+
+    describe("with the built-in browser voice, the default", () => {
+        test("speaks the given text through the synthesizer", () => {
+            installSpeechSynthesis();
+            logo.processSpeak("hello world");
+            expect(speakMock).toHaveBeenCalledTimes(1);
+            expect(utterances[0].text).toBe("hello world");
+        });
+
+        test("queues consecutive phrases instead of cutting the first one off", () => {
+            installSpeechSynthesis();
+            logo.processSpeak("first");
+            logo.processSpeak("second");
+            // Two Speak blocks in a row should both be heard, in order, so
+            // nothing is cancelled between them.
+            expect(cancelMock).not.toHaveBeenCalled();
+            expect(speakMock).toHaveBeenCalledTimes(2);
+            expect(utterances.map(u => u.text)).toEqual(["first", "second"]);
+        });
+
+        test("clears queued speech when a run starts or Stop is pressed", () => {
+            installSpeechSynthesis();
+            logo.processSpeak("left over from the last run");
+            expect(cancelMock).not.toHaveBeenCalled();
+
+            logo._cancelSpeech();
+            expect(cancelMock).toHaveBeenCalledTimes(1);
+        });
+
+        test("cancelling speech is safe when the API is unavailable", () => {
+            expect(() => logo._cancelSpeech()).not.toThrow();
+        });
+
+        test("ignores empty or whitespace-only text", () => {
+            installSpeechSynthesis();
+            logo.processSpeak("");
+            logo.processSpeak("   ");
+            expect(speakMock).not.toHaveBeenCalled();
+        });
+
+        test("coerces non-string input to a string", () => {
+            installSpeechSynthesis();
+            logo.processSpeak(42);
+            expect(utterances[0].text).toBe("42");
+        });
+
+        test("does nothing and does not throw when the API is unavailable", () => {
+            // No speechSynthesis on window at all.
+            expect(() => logo.processSpeak("hello")).not.toThrow();
+        });
+
+        test("prefers a voice matching the current locale", () => {
+            installSpeechSynthesis([
+                { lang: "en-US", name: "US English" },
+                { lang: "hi-IN", name: "Hindi India" }
+            ]);
+            setLanguage("hi-IN");
+            logo.processSpeak("नमस्ते");
+            expect(utterances[0].voice.name).toBe("Hindi India");
+            expect(utterances[0].lang).toBe("hi-IN");
+        });
+
+        test("falls back to a same-language voice when the region differs", () => {
+            installSpeechSynthesis([
+                { lang: "en-US", name: "US English" },
+                { lang: "es-MX", name: "Spanish Mexico" }
+            ]);
+            setLanguage("es-ES");
+            logo.processSpeak("hola");
+            expect(utterances[0].voice.name).toBe("Spanish Mexico");
+        });
+
+        test("lets the browser choose when no voices are loaded yet", () => {
+            installSpeechSynthesis([]); // empty, as on Chrome's first call
+            logo.processSpeak("hello");
+            expect(utterances[0].voice).toBeNull();
+            expect(utterances[0].lang).toBe("en-US");
+        });
+    });
+
+    describe("with the neural voice switched on", () => {
+        test("sends the phrase to Kokoro instead of the browser", () => {
+            installSpeechSynthesis();
+            const engine = enableKokoro();
+
+            logo.processSpeak("hello world");
+
+            expect(engine.speak).toHaveBeenCalledWith("hello world");
+            expect(speakMock).not.toHaveBeenCalled();
+        });
+
+        test("is off unless it has been explicitly switched on", () => {
+            installSpeechSynthesis();
+            const engine = { speak: jest.fn(), cancel: jest.fn() };
+            global.window.KokoroSpeech = function () {
+                return engine;
+            };
+            // No "kokoroSpeech" entry in localStorage: nothing should be
+            // downloaded, so the browser voice does the talking.
+            logo.processSpeak("hello world");
+
+            expect(engine.speak).not.toHaveBeenCalled();
+            expect(speakMock).toHaveBeenCalledTimes(1);
+        });
+
+        test("builds the engine once and reuses it", () => {
+            const engine = enableKokoro();
+            logo.processSpeak("first");
+            logo.processSpeak("second");
+            expect(engine.speak.mock.calls.map(c => c[0])).toEqual(["first", "second"]);
+        });
+
+        test("falls back to the browser voice if the engine isn't loaded", () => {
+            installSpeechSynthesis();
+            window.localStorage.setItem("kokoroSpeech", "on");
+            // Switched on, but js/kokoro-speech.js never loaded.
+            logo.processSpeak("hello world");
+            expect(speakMock).toHaveBeenCalledTimes(1);
+        });
+
+        test("cancelling stops both engines", () => {
+            installSpeechSynthesis();
+            const engine = enableKokoro();
+            logo.processSpeak("something");
+
+            logo._cancelSpeech();
+
+            expect(engine.cancel).toHaveBeenCalledTimes(1);
+            expect(cancelMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/js/blocks/MediaBlocks.js
+++ b/js/blocks/MediaBlocks.js
@@ -562,7 +562,6 @@ function setupMediaBlocks(activity) {
      * @extends FlowBlock
      */
     class SpeakBlock extends FlowBlock {
-        // Eliminating until we find a better option.
         /**
          * Constructs a SpeakBlock instance.
          * @constructor
@@ -576,7 +575,7 @@ function setupMediaBlocks(activity) {
 
             // Set help string for the block
             this.setHelpString([
-                _("The Speak block outputs to the text-to-speech synthesizer"),
+                _("The Speak block reads its text aloud using the built-in speech synthesizer."),
                 "documentation",
                 ""
             ]);
@@ -587,9 +586,6 @@ function setupMediaBlocks(activity) {
                 defaults: ["hello"],
                 argTypes: ["textin"]
             });
-
-            // Set the block as hidden
-            this.hidden = true;
         }
 
         /**
@@ -600,18 +596,20 @@ function setupMediaBlocks(activity) {
          * @param {string} blk - The block identifier.
          */
         flow(args, logo, turtle, blk) {
+            if (args.length !== 1) {
+                return;
+            }
+
             const tur = activity.turtles.ithTurtle(turtle);
 
-            if (args.length === 1) {
-                if (logo.meSpeak !== null) {
-                    if (tur.singer.inNoteBlock.length > 0) {
-                        tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
-                    } else {
-                        if (!tur.singer.suppressOutput) {
-                            logo.processSpeak(args[0]);
-                        }
-                    }
-                }
+            // Inside a note block, hand the block off to the embedded-graphics
+            // scheduler so the speech lines up with the note's timing instead
+            // of firing the instant the block is reached. Outside a note, and
+            // as long as we're not silently pre-running the project, speak now.
+            if (tur.singer.inNoteBlock.length > 0) {
+                tur.singer.embeddedGraphics[last(tur.singer.inNoteBlock)].push(blk);
+            } else if (!tur.singer.suppressOutput) {
+                logo.processSpeak(args[0]);
             }
         }
     }

--- a/js/blocks/__tests__/MediaBlocks.test.js
+++ b/js/blocks/__tests__/MediaBlocks.test.js
@@ -184,7 +184,6 @@ const dummyLogo = {
     parseArg: jest.fn((logo, turtle, cblk, blk, receivedArg) => receivedArg),
     processShow: jest.fn(),
     processSpeak: jest.fn(),
-    meSpeak: {},
     setDispatchBlock: jest.fn(),
     setTurtleListener: jest.fn(),
     cameraID: null
@@ -351,10 +350,12 @@ describe("setupMediaBlocks", () => {
     });
 
     describe("SpeakBlock", () => {
-        it("should call processSpeak if meSpeak is not null and no note block is active", () => {
+        it("should not be hidden, so it shows up in the palette", () => {
+            expect(createdBlocks["speak"].hidden).toBeFalsy();
+        });
+        it("should call processSpeak when no note block is active", () => {
             const turtle = activity.turtles.ithTurtle(turtleIndex);
             turtle.singer.inNoteBlock = [];
-            logo.meSpeak = {};
             logo.processSpeak = jest.fn();
             const speakBlock = createdBlocks["speak"];
             speakBlock.flow(["Hello world"], logo, turtleIndex, 400);
@@ -367,6 +368,22 @@ describe("setupMediaBlocks", () => {
             const speakBlock = createdBlocks["speak"];
             speakBlock.flow(["Hello world"], logo, turtleIndex, 400);
             expect(turtle.singer.embeddedGraphics[999]).toContain(400);
+        });
+        it("should stay silent while output is suppressed", () => {
+            const turtle = activity.turtles.ithTurtle(turtleIndex);
+            turtle.singer.inNoteBlock = [];
+            turtle.singer.suppressOutput = true;
+            logo.processSpeak = jest.fn();
+            const speakBlock = createdBlocks["speak"];
+            speakBlock.flow(["Hello world"], logo, turtleIndex, 400);
+            expect(logo.processSpeak).not.toHaveBeenCalled();
+            turtle.singer.suppressOutput = false;
+        });
+        it("should do nothing when no text is connected", () => {
+            logo.processSpeak = jest.fn();
+            const speakBlock = createdBlocks["speak"];
+            speakBlock.flow([], logo, turtleIndex, 400);
+            expect(logo.processSpeak).not.toHaveBeenCalled();
         });
     });
 

--- a/js/kokoro-speech.js
+++ b/js/kokoro-speech.js
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 Walter Bender
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/*
+   exported
+
+   KokoroSpeech
+ */
+
+/**
+ * Speech for the Speak block, using Kokoro, an 82M-parameter neural
+ * text-to-speech model that runs entirely in the browser.
+ *
+ * Nothing here is bundled. kokoro-js is pulled in with a dynamic import the
+ * first time a project actually speaks, and the weights are fetched straight
+ * from Hugging Face, so dist/ and the service-worker precache are untouched and
+ * a child who never uses the Speak block never downloads any of it. The q8
+ * build is about 92 MB; Transformers.js parks it in the Cache Storage API, so
+ * it is a one-time cost per browser rather than per run.
+ *
+ * Phrases are queued rather than overlapped: synthesis is slow enough that two
+ * Speak blocks in a row would otherwise start talking on top of each other.
+ */
+class KokoroSpeech {
+    /** npm package that wraps the model. Pinned so a bad release can't land silently. */
+    static get CDN() {
+        return "https://cdn.jsdelivr.net/npm/kokoro-js@1.2.1/+esm";
+    }
+
+    /** The published ONNX conversion of Kokoro v1.0. */
+    static get MODEL_ID() {
+        return "onnx-community/Kokoro-82M-v1.0-ONNX";
+    }
+
+    /**
+     * Weight precision. "q8" is the smallest build kokoro-js exposes, roughly
+     * 92 MB against 326 MB for fp32, and the quality difference is very hard to
+     * hear on short phrases.
+     */
+    static get DTYPE() {
+        return "q8";
+    }
+
+    /** Kokoro's default American English voice. */
+    static get DEFAULT_VOICE() {
+        return "af_heart";
+    }
+
+    /**
+     * @param {object} [options]
+     * @param {string} [options.voice] - a Kokoro voice id, e.g. "af_heart"
+     */
+    constructor(options = {}) {
+        this._voice = options.voice || KokoroSpeech._storedVoice() || KokoroSpeech.DEFAULT_VOICE;
+        this._enginePromise = null;
+        this._engine = null;
+        this._unavailable = false;
+
+        this._queue = [];
+        this._pumping = false;
+        // Bumped by cancel(). Work started under an older token is discarded,
+        // which is how an in-flight synthesis gets abandoned mid-way.
+        this._token = 0;
+
+        this._audioCtx = null;
+        this._source = null;
+    }
+
+    /**
+     * A voice id set by the user, if any.
+     * @returns {string|null}
+     */
+    static _storedVoice() {
+        try {
+            return typeof localStorage === "undefined" ? null : localStorage.getItem("kokoroVoice");
+        } catch (e) {
+            // Storage can be blocked outright in a locked-down profile.
+            return null;
+        }
+    }
+
+    /**
+     * Loads kokoro-js and the model weights, once. Later calls get the same
+     * promise, so ten Speak blocks in a project still only trigger one download.
+     *
+     * @returns {Promise<object>} the KokoroTTS instance
+     */
+    _ensureEngine() {
+        if (this._enginePromise === null) {
+            this._enginePromise = (async () => {
+                // Written this way so bundlers and the AMD loader leave it
+                // alone and the browser resolves the URL at runtime.
+                const { KokoroTTS } = await import(/* webpackIgnore: true */ KokoroSpeech.CDN);
+                return KokoroTTS.from_pretrained(KokoroSpeech.MODEL_ID, {
+                    dtype: KokoroSpeech.DTYPE,
+                    device: "wasm"
+                });
+            })();
+        }
+        return this._enginePromise;
+    }
+
+    /**
+     * Queues a phrase to be spoken.
+     *
+     * Returns immediately; the actual synthesis happens in the background. The
+     * first call also kicks off the model download, so there is a noticeable
+     * pause before anything is heard on a cold cache.
+     *
+     * @param {string} text
+     * @returns {void}
+     */
+    speak(text) {
+        const phrase = text === null || text === undefined ? "" : String(text);
+        if (phrase.trim() === "" || this._unavailable) {
+            return;
+        }
+
+        this._queue.push({ phrase, token: this._token });
+        if (!this._pumping) {
+            this._pump();
+        }
+    }
+
+    /**
+     * Stops whatever is being said and throws away anything still queued.
+     *
+     * @returns {void}
+     */
+    cancel() {
+        this._token += 1;
+        this._queue.length = 0;
+
+        if (this._source !== null) {
+            try {
+                this._source.stop();
+            } catch (e) {
+                // Already finished; nothing to stop.
+            }
+            this._source = null;
+        }
+    }
+
+    /**
+     * Works through the queue, playing one phrase at a time.
+     *
+     * Synthesis runs a phrase ahead of playback. Rendering a short line takes a
+     * few seconds on WebAssembly, so doing it only after the previous line had
+     * finished left an audible gap between two Speak blocks. Starting the next
+     * render while the current one is still playing hides most of that.
+     *
+     * @returns {Promise<void>}
+     */
+    async _pump() {
+        this._pumping = true;
+        try {
+            let current = this._takeNext();
+            let rendering = current === null ? null : this._render(current.phrase);
+
+            while (rendering !== null) {
+                const audio = await rendering;
+                const item = current;
+
+                // Get the following phrase under way before playing this one.
+                current = this._takeNext();
+                rendering = current === null ? null : this._render(current.phrase);
+
+                // A null render means the model is gone; _render has already
+                // explained why and emptied the queue.
+                if (audio !== null && item.token === this._token) {
+                    await this._play(audio, item.token);
+                }
+            }
+        } finally {
+            this._pumping = false;
+            // Something may have been queued as the loop was winding down.
+            if (this._queue.length > 0 && !this._unavailable) {
+                this._pump();
+            }
+        }
+    }
+
+    /**
+     * The next phrase still worth speaking, skipping anything a cancel() dropped.
+     *
+     * @returns {{phrase: string, token: number}|null}
+     */
+    _takeNext() {
+        while (this._queue.length > 0) {
+            const next = this._queue.shift();
+            if (next.token === this._token) {
+                return next;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Renders one phrase to audio.
+     *
+     * @param {string} phrase
+     * @returns {Promise<object|null>} null if the model could not be used
+     */
+    async _render(phrase) {
+        try {
+            const engine = await this._ensureEngine();
+            return await engine.generate(phrase, { voice: this._voice });
+        } catch (e) {
+            // A blocked CDN, an offline first run, or a browser without
+            // WebAssembly all land here. Say so once and then stay quiet rather
+            // than retrying on every block.
+            this._unavailable = true;
+            this._queue.length = 0;
+            console.warn(`Speak block: could not load the Kokoro voice (${e.message}).`);
+            return null;
+        }
+    }
+
+    /**
+     * Plays one rendered phrase and resolves when it finishes.
+     *
+     * Kokoro hands back raw mono samples, so they go straight into an
+     * AudioBuffer. There is no container to decode.
+     *
+     * @param {object} audio - kokoro-js result, with `audio` and `sampling_rate`
+     * @param {number} token - the cancel token this phrase belongs to
+     * @returns {Promise<void>}
+     */
+    _play(audio, token) {
+        const samples = audio.audio;
+        const rate = audio.sampling_rate;
+        if (!samples || !samples.length) {
+            return Promise.resolve();
+        }
+
+        if (this._audioCtx === null) {
+            const Ctx = window.AudioContext || window.webkitAudioContext;
+            if (!Ctx) {
+                this._unavailable = true;
+                return Promise.resolve();
+            }
+            this._audioCtx = new Ctx();
+        }
+        const ctx = this._audioCtx;
+
+        // Autoplay policy parks the context until a gesture; pressing Run is
+        // one, so this resolves in practice.
+        if (ctx.state === "suspended" && typeof ctx.resume === "function") {
+            ctx.resume();
+        }
+
+        const buffer = ctx.createBuffer(1, samples.length, rate);
+        buffer.getChannelData(0).set(samples);
+
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(ctx.destination);
+        this._source = source;
+
+        return new Promise(resolve => {
+            source.onended = () => {
+                if (this._source === source) {
+                    this._source = null;
+                }
+                resolve();
+            };
+            if (token !== this._token) {
+                resolve();
+                return;
+            }
+            source.start();
+        });
+    }
+}
+
+if (typeof define === "function" && define.amd) {
+    define([], function () {
+        return KokoroSpeech;
+    });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { KokoroSpeech };
+}
+
+if (typeof window !== "undefined") {
+    window.KokoroSpeech = KokoroSpeech;
+}

--- a/js/loader.js
+++ b/js/loader.js
@@ -134,6 +134,9 @@ requirejs.config({
         "activity/embedded-graphics-scheduler": {
             exports: "EmbeddedGraphicsScheduler"
         },
+        "activity/kokoro-speech": {
+            exports: "KokoroSpeech"
+        },
         "activity/LogoDependencies": {
             exports: "LogoDependencies"
         },
@@ -145,6 +148,7 @@ requirejs.config({
                 "activity/logoconstants",
                 "utils/ManagedTimer",
                 "activity/embedded-graphics-scheduler",
+                "activity/kokoro-speech",
                 "activity/LogoDependencies"
             ],
             exports: "Logo"

--- a/js/logo.js
+++ b/js/logo.js
@@ -27,7 +27,7 @@
    EMPTYHEAPERRORMSG, INVALIDPITCH, POSNUMBER, NOTATIONNOTE, NOTATIONDURATION,
    NOTATIONDOTCOUNT, NOTATIONTUPLETVALUE, NOTATIONROUNDDOWN,
    NOTATIONINSIDECHORD, NOTATIONSTACCATO, ManagedTimer,
-   EmbeddedGraphicsScheduler
+   EmbeddedGraphicsScheduler, KokoroSpeech
  */
 
 /*
@@ -627,13 +627,173 @@ class Logo {
     }
 
     /**
-     * Speaks all characters in the range of comma, full stop, space, A to Z, a to z in the input text.
+     * Speaks the given text aloud.
+     *
+     * Two engines are available. The Web Speech API is the default because it
+     * costs nothing: it is already in the browser, it works offline, and it
+     * starts talking immediately. Kokoro is a neural voice that sounds much
+     * more human, but it has to fetch about 92 MB of weights the first time it
+     * runs, so it is opt-in rather than the default. See js/kokoro-speech.js.
      *
      * @param {string} text
      * @returns {void}
      */
     processSpeak(text) {
-        // meSpeak was removed from the codebase.
+        // The Speak block used to run on meSpeak, a JavaScript port of espeak
+        // that was bundled with the app. It was heavy, it sounded robotic, and
+        // it was eventually dropped, which left the block doing nothing at all.
+
+        const phrase = text === null || text === undefined ? "" : String(text);
+        if (phrase.trim() === "") {
+            return;
+        }
+
+        const kokoro = this._kokoroIfEnabled();
+        if (kokoro !== null) {
+            kokoro.speak(phrase);
+            return;
+        }
+
+        this._speakWithWebSpeech(phrase);
+    }
+
+    /**
+     * Silences anything the Speak block still has queued, whichever engine is
+     * doing the talking.
+     *
+     * Called when a run starts and when Stop is pressed, so speech left over
+     * from a previous run never bleeds into the next one.
+     *
+     * @returns {void}
+     */
+    _cancelSpeech() {
+        if (this._kokoroSpeech) {
+            this._kokoroSpeech.cancel();
+        }
+        if (typeof window !== "undefined" && window.speechSynthesis) {
+            window.speechSynthesis.cancel();
+        }
+    }
+
+    /**
+     * The Kokoro engine, but only if the user has asked for it.
+     *
+     * Turned on by setting "kokoroSpeech" to "on" in localStorage. Building the
+     * engine is cheap and downloads nothing; the weights are only fetched once
+     * something is actually spoken.
+     *
+     * @returns {KokoroSpeech|null} null when it is switched off or unavailable
+     */
+    _kokoroIfEnabled() {
+        let enabled = false;
+        try {
+            enabled =
+                typeof localStorage !== "undefined" &&
+                localStorage.getItem("kokoroSpeech") === "on";
+        } catch (e) {
+            // Storage can be blocked outright in a locked-down profile.
+            return null;
+        }
+        if (!enabled) {
+            return null;
+        }
+
+        if (!this._kokoroSpeech) {
+            const Speech =
+                typeof KokoroSpeech !== "undefined"
+                    ? KokoroSpeech
+                    : typeof window !== "undefined" && window.KokoroSpeech;
+            if (!Speech) {
+                return null;
+            }
+            this._kokoroSpeech = new Speech();
+        }
+        return this._kokoroSpeech;
+    }
+
+    /**
+     * Speaks a phrase with the browser's built-in synthesizer.
+     *
+     * @param {string} phrase
+     * @returns {void}
+     */
+    _speakWithWebSpeech(phrase) {
+        // Bail quietly if we're somewhere without the API (an older browser, a
+        // test runner, a server-side render). Speaking is a nice-to-have, so a
+        // missing synthesizer should never throw and take a running project down.
+        if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+            return;
+        }
+
+        const synth = window.speechSynthesis;
+
+        // Nothing is cancelled here on purpose. The synthesizer keeps its own
+        // queue, so two Speak blocks one after another are read one after the
+        // other instead of the second cutting the first off mid-word. Leftover
+        // speech from an earlier run is cleared by _cancelSpeech() when the next
+        // run starts or when Stop is pressed.
+        const utterance = new SpeechSynthesisUtterance(phrase);
+
+        // Try to pronounce the words in the child's own language rather than
+        // reading them as if they were English. We look for a voice that
+        // matches the current locale and quietly fall back to the browser
+        // default if there isn't one.
+        const preferredLang = navigator.language || "en-US";
+        const voice = this._pickSpeechVoice(synth, preferredLang);
+        if (voice) {
+            utterance.voice = voice;
+            utterance.lang = voice.lang;
+        } else {
+            utterance.lang = preferredLang;
+        }
+
+        // Calm, clear defaults that read well for kids: normal speed, natural
+        // pitch, full volume.
+        utterance.rate = 1.0;
+        utterance.pitch = 1.0;
+        utterance.volume = 1.0;
+
+        utterance.onerror = event => {
+            // "interrupted" and "canceled" are what a Stop or a fresh Run looks
+            // like from in here, so they aren't worth surfacing.
+            if (event.error === "interrupted" || event.error === "canceled") {
+                return;
+            }
+            console.warn(`Speak block: speech synthesis failed (${event.error}).`);
+        };
+
+        synth.speak(utterance);
+    }
+
+    /**
+     * Picks the best available speech-synthesis voice for a language.
+     *
+     * @param {SpeechSynthesis} synth - the window.speechSynthesis instance
+     * @param {string} preferredLang - a BCP-47 tag like "hi-IN" or "es"
+     * @returns {SpeechSynthesisVoice|null} the best match, or null to let the
+     *     browser choose its own default
+     */
+    _pickSpeechVoice(synth, preferredLang) {
+        // getVoices() is famously empty on the very first call in some browsers:
+        // Chrome loads the list asynchronously and fires 'voiceschanged' a beat
+        // later. By the time a child actually presses Run the list has almost
+        // always populated. If it hasn't yet, returning null just lets the
+        // browser pick its own default, which is still perfectly fine.
+        const voices = synth.getVoices();
+        if (!voices || voices.length === 0) {
+            return null;
+        }
+
+        const wanted = preferredLang.toLowerCase();
+        const base = wanted.split("-")[0];
+
+        // Prefer an exact locale match ("hi-IN"), then any voice for the same
+        // language ("hi-*"), and otherwise let the browser decide.
+        return (
+            voices.find(v => v.lang && v.lang.toLowerCase() === wanted) ||
+            voices.find(v => v.lang && v.lang.toLowerCase().split("-")[0] === base) ||
+            null
+        );
     }
 
     /**
@@ -1246,6 +1406,7 @@ class Logo {
     doStopTurtles() {
         this.stopTurtle = true;
         this.turtles.markAllAsStopped();
+        this._cancelSpeech();
 
         // Cancel all pending timers to prevent zombie graphics and sounds.
         const cancelledTimers = this._timerManager.clearAll();
@@ -1392,6 +1553,10 @@ class Logo {
         // Reset run-state flags for the new execution.
         this._alreadyRunning = false;
         this._prematureRestart = false;
+
+        // Drop any speech the previous run left queued, so pressing Run twice
+        // doesn't leave the old phrases talking over the new ones.
+        this._cancelSpeech();
 
         // eslint-disable-next-line eqeqeq
         if (this._lastNoteTimeout != null) {


### PR DESCRIPTION
## PR Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [x] Feature — Adds new functionality
- [x] Tests — Adds or updates test coverage

## The problem

The Speak block has been dead for a while. When meSpeak was pulled out of the codebase:

- `Logo.processSpeak()` was left as an empty method with a `// meSpeak was removed from the codebase.` comment
- the block set `this.hidden = true`, so it stopped appearing in the **Media** palette
- `SpeakBlock.flow()` still guarded on `logo.meSpeak !== null`, which nothing sets anymore

So a child cannot find the block at all, and if they do get one onto the canvas from an older project file, it silently does nothing.

## What I went with, and why

**The default is the Web Speech API.** It is already in every browser we target, it adds nothing to the bundle, it starts talking immediately, and it works offline. For a tool that children open on school hardware and sometimes without a connection, that felt like the right thing to have on by default.

**I also wired up Kokoro**, an 82M-parameter neural voice that runs in the browser, because it sounds dramatically more human than anything the OS ships. It is **opt-in and off by default**, and I want to be upfront about why: it is heavy.

Here is what it actually costs on first use, measured rather than estimated:

| Asset | Size |
| --- | --- |
| Model weights, `q8` build | 92.4 MB |
| Voice embedding | 0.5 MB |
| onnxruntime-web wasm | 4.1 MB |
| kokoro-js | 0.7 MB |
| **Total, first phrase only** | **97.7 MB** |
| **Added to the shipped bundle** | **0 bytes** |

That is a lot to ask of a child on a slow connection, which is exactly why it is not the default. Turning it on is a `kokoroSpeech` entry set to `on` in localStorage for now.

**The shipped bundle genuinely does not change.** `dist/` is byte-for-byte the same, the service-worker precache list is untouched, and no dependency is added to `package.json`. Music Blocks has no module bundler, so `js/kokoro-speech.js` reaches kokoro-js through a native dynamic `import()` of a pinned CDN URL, evaluated only when someone has switched the neural voice on **and** a phrase is actually spoken. Transformers.js keeps the weights in the Cache Storage API, so it is one download per browser rather than per run, and it works offline afterwards.

## There are other options here, and I would welcome direction

I do not think the split above is the only reasonable answer, and I would rather agree on the direction with maintainers than assume. The realistic alternatives, with sizes:

- **Web Speech only.** Zero cost, works everywhere, but the voice quality is whatever the operating system provides, and on some Linux setups that is still fairly robotic.
- **Kokoro on by default.** Best quality, but every user pays 97.7 MB before hearing anything, and a first run that is offline stays silent. I did not think that was a fair default for this audience.
- **A smaller neural model.** [KittenTTS nano](https://huggingface.co/KittenML/kitten-tts-nano-0.2) is **23.8 MB**, roughly a quarter of Kokoro, and is ONNX and CPU friendly. [Piper](https://huggingface.co/rhasspy/piper-voices) `en_US-amy-low` is **63.1 MB**. Either would be a meaningful step up from the OS voices at a fraction of Kokoro's download. The engine sits behind a small interface, so swapping it is a contained change and I am happy to do it.
- **Self-hosting the weights** instead of reaching Hugging Face and jsDelivr at runtime, which removes the third-party dependency at the cost of hosting the files.

Happy to go whichever way the team prefers.

## What changed

- **`Logo.processSpeak()`** validates the text and routes it to the active engine. Empty and whitespace-only text is ignored, and non-string values are coerced.
- **Web Speech path** picks a voice matching the current locale, falls back to any voice for the same language, and otherwise lets the browser choose. Chrome returns an empty `getVoices()` on the first call, which is treated as "browser decides" rather than a failure.
- **New `js/kokoro-speech.js`** for the neural path. It lazily imports kokoro-js, memoises the model load so ten Speak blocks trigger one download, queues phrases, plays the raw samples through a single `AudioContext`, and gives up quietly with a console warning if the weights cannot be fetched.
- **Synthesis is pipelined**: the next phrase starts rendering as soon as the current one begins playing, rather than only after it finishes. Rendering takes a few seconds on WebAssembly, so without this two Speak blocks in a row left a noticeable gap between them.
- **Consecutive Speak blocks now queue** instead of cutting each other off, on both engines. Added `Logo._cancelSpeech()`, called from `runLogoCommands()` and `doStopTurtles()`, so speech from an old run never talks over a new one and **Stop** actually stops the talking.
- Registered `activity/kokoro-speech` in `js/loader.js` and added it to the `activity/logo` dependency list.
- **Unhid the block** and updated its help string.
- Simplified `SpeakBlock.flow()`: dropped the dead `logo.meSpeak` guard and flattened the nesting. Behaviour inside a note block is unchanged, it still hands off to the embedded-graphics scheduler so the speech lands on the note's timing.
- Removed the commented-out `lib/mespeak.js` script tag from `index.html` and the stale `meSpeak` entries in the test mocks. That file has not existed for some time.

## Tests

`js/__tests__/logo.test.js` covers **both engines**: the happy path, empty and whitespace input, non-string coercion, a missing API, exact-locale and same-language voice selection, the empty `getVoices()` case, queueing, cancellation, that the neural voice stays off unless explicitly switched on, and that it falls back cleanly if switched on without the module present.

`js/__tests__/kokoro-speech.test.js` covers the engine itself: the phrase queue, cancelling mid-phrase, one-time model loading, a custom voice, and the path where the weights cannot be fetched. The model is never downloaded in tests; the engine boundary is stubbed.

All suites pass locally. The one unrelated failure on this branch is `RhythmBlocks.test.js` (`setupBlockDragController is not defined`), which fails the same way on `master`.

## Demo

Two videos attached, **sound on**. `speak-block-demo.mp4` shows the default browser voice, since that is what ships enabled. `speak-block-demo-kokoro.mp4` shows the same flow with the neural voice switched on, recorded against a warm cache so it reflects synthesis speed rather than the one-time download. In both, the Speak block is picked out of the Media palette, dropped under **Start**, given a phrase, and run; the second half adds a second Speak block and runs both, so you can hear the two phrases read in order rather than the first getting cut off.