### PR TITLE
refactor(piemenus): extract piemenuBlockContext into its own module

### DIFF
--- a/js/__tests__/piemenu-block-context.test.js
+++ b/js/__tests__/piemenu-block-context.test.js
@@ -1,0 +1,346 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const { piemenuBlockContext } = require("../piemenu-block-context");
+
+// ---------------------------------------------------------------------------
+// Mock Globals
+// ---------------------------------------------------------------------------
+
+const domElements = {};
+function getDomElement(id) {
+    if (!domElements[id]) {
+        domElements[id] = { style: {} };
+    }
+    return domElements[id];
+}
+
+global.docById = jest.fn(getDomElement);
+
+// jest-environment-jsdom keeps `document`/`window` as live bindings to the
+// real jsdom objects: wholesale reassignment (`global.document = {...}`) is
+// silently ignored. Mock behavior by overwriting properties on the real
+// objects instead (done fresh in beforeEach below).
+let bodyClickHandler = null;
+let computedDisplay = "none";
+
+function makeWheelNavItem() {
+    return { setTooltip: jest.fn(), navigateFunction: undefined, selected: true };
+}
+
+global.wheelnav = jest.fn().mockImplementation(function () {
+    this.navItems = Array.from({ length: 6 }, makeWheelNavItem);
+    this.initWheel = jest.fn();
+    this.createWheel = jest.fn();
+});
+
+global.slicePath = jest.fn().mockReturnValue({
+    DonutSlice: jest.fn(),
+    DonutSliceCustomization: jest.fn().mockReturnValue({ minRadiusPercent: 0, maxRadiusPercent: 0 })
+});
+
+global.platformColor = { wheelcolors: ["#fff", "#000"] };
+global._ = jest.fn(s => s);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBlock(overrides = {}) {
+    const blockBlockId = "active-id";
+    const topBlockId = "top-id";
+
+    const blockList = {
+        [blockBlockId]: {
+            name: "notename",
+            container: { x: 10, y: 20 },
+            protoblock: { helpString: "" }
+        },
+        [topBlockId]: { name: "notename" }
+    };
+
+    const block = {
+        blockIndex: blockBlockId,
+        name: "notename",
+        blocks: {
+            activeBlock: blockBlockId,
+            blockList,
+            findTopBlock: jest.fn(() => topBlockId),
+            prepareStackForCopy: jest.fn(),
+            pasteStack: jest.fn(),
+            extract: jest.fn(),
+            sendStackToTrash: jest.fn(),
+            saveStack: jest.fn(),
+            pasteDx: 0,
+            pasteDy: 0,
+            stageClick: true
+        },
+        activity: {
+            canvas: { offsetLeft: 0, offsetTop: 0 },
+            blocksContainer: { x: 0, y: 0 },
+            getStageScale: jest.fn(() => 1),
+            helpfulWheelItems: [],
+            errorMsg: jest.fn(),
+            textMsg: jest.fn()
+        }
+    };
+
+    return { ...block, ...overrides, blocks: { ...block.blocks, ...(overrides.blocks || {}) } };
+}
+
+let originalHelpWidget;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    computedDisplay = "none";
+    bodyClickHandler = null;
+    window._contextWheelClickHandler = undefined;
+    for (const key of Object.keys(domElements)) delete domElements[key];
+    originalHelpWidget = global.HelpWidget;
+    delete global.HelpWidget;
+
+    document.getElementById = jest.fn(getDomElement);
+    document.body.addEventListener = jest.fn((event, handler) => {
+        if (event === "click") bodyClickHandler = handler;
+    });
+    document.body.removeEventListener = jest.fn((event, handler) => {
+        if (event === "click" && bodyClickHandler === handler) bodyClickHandler = null;
+    });
+    window.getComputedStyle = jest.fn(() => ({ display: computedDisplay }));
+});
+
+afterEach(() => {
+    if (originalHelpWidget === undefined) delete global.HelpWidget;
+    else global.HelpWidget = originalHelpWidget;
+});
+
+describe("piemenuBlockContext", () => {
+    test("does nothing when there is no active block", () => {
+        const block = makeBlock({ blocks: { activeBlock: null } });
+
+        piemenuBlockContext(block);
+
+        expect(global.wheelnav).not.toHaveBeenCalled();
+    });
+
+    test("positions and displays the context wheel over the active block, with base menu items", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+
+        const wheelDiv = getDomElement("contextWheelDiv");
+        expect(wheelDiv.style.position).toBe("absolute");
+        expect(wheelDiv.style.display).toBe("");
+        expect(typeof wheelDiv.style.left).toBe("string");
+        expect(typeof wheelDiv.style.top).toBe("string");
+
+        expect(global.wheelnav).toHaveBeenCalledWith("contextWheelDiv", null, 250, 250);
+
+        const wheel = global.wheelnav.mock.instances[0];
+        expect(wheel.initWheel).toHaveBeenCalledWith([
+            "imgsrc:header-icons/copy-button.svg",
+            "imgsrc:header-icons/extract-button.svg",
+            "imgsrc:header-icons/empty-trash-button.svg",
+            "imgsrc:header-icons/cancel-button.svg"
+        ]);
+        expect(wheel.navItems[0].setTooltip).toHaveBeenCalledWith("Duplicate");
+        expect(wheel.navItems[1].setTooltip).toHaveBeenCalledWith("Extract");
+        expect(wheel.navItems[2].setTooltip).toHaveBeenCalledWith("Move to trash");
+        expect(wheel.navItems[3].setTooltip).toHaveBeenCalledWith("Close");
+        expect(wheel.navItems[4].setTooltip).not.toHaveBeenCalled();
+        expect(wheel.navItems[0].selected).toBe(false);
+    });
+
+    test("adds a save-stack menu item only for save-eligible block types", () => {
+        const block = makeBlock();
+        block.name = "action";
+        block.blocks.blockList["top-id"].name = "action";
+
+        piemenuBlockContext(block);
+
+        const wheel = global.wheelnav.mock.instances[0];
+        expect(wheel.initWheel).toHaveBeenCalledWith(
+            expect.arrayContaining(["imgsrc:header-icons/save-blocks-button.svg"])
+        );
+        expect(wheel.navItems[4].setTooltip).toHaveBeenCalledWith("Save stack");
+
+        wheel.navItems[4].navigateFunction();
+
+        expect(block.blocks.activeBlock).toBe(block.blockIndex);
+        expect(block.blocks.prepareStackForCopy).toHaveBeenCalled();
+        expect(block.blocks.saveStack).toHaveBeenCalled();
+    });
+
+    test("does not add a save-stack menu item for ordinary block types", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+
+        const wheel = global.wheelnav.mock.instances[0];
+        expect(wheel.initWheel).toHaveBeenCalledWith(
+            expect.not.arrayContaining(["imgsrc:header-icons/save-blocks-button.svg"])
+        );
+    });
+
+    test("adds a help menu item that opens HelpWidget directly when already loaded", () => {
+        const block = makeBlock();
+        block.blocks.blockList["active-id"].protoblock.helpString = "Some help text";
+        global.HelpWidget = jest.fn();
+
+        piemenuBlockContext(block);
+
+        const wheel = global.wheelnav.mock.instances[0];
+        expect(wheel.navItems[4].setTooltip).toHaveBeenCalledWith("Help");
+
+        wheel.navItems[4].navigateFunction();
+
+        expect(global.HelpWidget).toHaveBeenCalledWith(block, true);
+        expect(getDomElement("contextWheelDiv").style.display).toBe("none");
+    });
+
+    // Note: the `typeof HelpWidget === "undefined"` branch falls through to a
+    // bare `require(["widgets/help"], cb)` call — RequireJS's AMD signature.
+    // In Jest/Node, `require` is a per-module CommonJS function (not a
+    // globally-overridable binding), and Node's `require` does not accept an
+    // array as its first argument, so this branch cannot be exercised via a
+    // real invocation in this test environment. The rest of the codebase's
+    // equivalent AMD-lazy-require call sites (e.g. project-manager.js) are
+    // not directly invoked in their tests either, for the same reason.
+
+    test("duplicate pastes the stack and increments the paste offset on repeated use", () => {
+        const block = makeBlock();
+        const dxHistory = [];
+        block.blocks.pasteStack = jest.fn(() => dxHistory.push(block.blocks.pasteDx));
+
+        piemenuBlockContext(block);
+        const wheel = global.wheelnav.mock.instances[0];
+
+        wheel.navItems[0].navigateFunction();
+        wheel.navItems[0].navigateFunction();
+
+        expect(block.blocks.prepareStackForCopy).toHaveBeenCalledTimes(2);
+        expect(dxHistory).toEqual([0, 21]);
+    });
+
+    test("duplicate shows an error instead of pasting when the stack is a customsample", () => {
+        const block = makeBlock();
+        block.blocks.blockList["top-id"].name = "customsample";
+
+        piemenuBlockContext(block);
+        const wheel = global.wheelnav.mock.instances[0];
+
+        wheel.navItems[0].navigateFunction();
+
+        expect(block.activity.errorMsg).toHaveBeenCalled();
+        expect(block.blocks.pasteStack).not.toHaveBeenCalled();
+    });
+
+    test("extract sets the active block, extracts it, and hides the wheel", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+        const wheel = global.wheelnav.mock.instances[0];
+
+        wheel.navItems[1].navigateFunction();
+
+        expect(block.blocks.activeBlock).toBe(block.blockIndex);
+        expect(block.blocks.extract).toHaveBeenCalled();
+        expect(getDomElement("contextWheelDiv").style.display).toBe("none");
+    });
+
+    test("trash extracts and sends the stack to trash, hides the wheel, and notifies the user", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+        const wheel = global.wheelnav.mock.instances[0];
+
+        wheel.navItems[2].navigateFunction();
+
+        expect(block.blocks.activeBlock).toBe(block.blockIndex);
+        expect(block.blocks.extract).toHaveBeenCalled();
+        expect(block.blocks.sendStackToTrash).toHaveBeenCalled();
+        expect(getDomElement("contextWheelDiv").style.display).toBe("none");
+        expect(block.activity.textMsg).toHaveBeenCalled();
+    });
+
+    test("close hides the wheel", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+        const wheel = global.wheelnav.mock.instances[0];
+
+        wheel.navItems[3].navigateFunction();
+
+        expect(getDomElement("contextWheelDiv").style.display).toBe("none");
+    });
+
+    test("registers an outside-click handler that hides the wheel while it is displayed", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+
+        expect(global.document.body.addEventListener).toHaveBeenCalledWith(
+            "click",
+            expect.any(Function)
+        );
+        expect(bodyClickHandler).toBeInstanceOf(Function);
+
+        computedDisplay = "block";
+        bodyClickHandler({});
+
+        expect(getDomElement("contextWheelDiv").style.display).toBe("none");
+        expect(global.document.body.removeEventListener).toHaveBeenCalledWith(
+            "click",
+            expect.any(Function)
+        );
+    });
+
+    test("does not hide the wheel on an outside click when it is not displayed", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+        getDomElement("contextWheelDiv").style.display = "unrelated";
+        computedDisplay = "none";
+
+        bodyClickHandler({});
+
+        expect(getDomElement("contextWheelDiv").style.display).toBe("unrelated");
+    });
+
+    test("replaces the previous outside-click handler instead of accumulating listeners", () => {
+        const block = makeBlock();
+
+        piemenuBlockContext(block);
+        const firstHandler = bodyClickHandler;
+
+        piemenuBlockContext(block);
+
+        expect(global.document.body.removeEventListener).toHaveBeenCalledWith(
+            "click",
+            firstHandler
+        );
+        expect(bodyClickHandler).not.toBe(firstHandler);
+    });
+
+    test("clears stageClick after the cleanup timeout", () => {
+        jest.useFakeTimers();
+        const block = makeBlock();
+        block.blocks.stageClick = true;
+
+        piemenuBlockContext(block);
+        expect(block.blocks.stageClick).toBe(true);
+
+        jest.advanceTimersByTime(500);
+
+        expect(block.blocks.stageClick).toBe(false);
+        jest.useRealTimers();
+    });
+});

--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -9,13 +9,7 @@
  * (at your option) any later version.
  */
 
-const fs = require("fs");
-const path = require("path");
-
 const { piemenuPitches } = require("../piemenus");
-
-const piemenusPath = path.join(__dirname, "..", "piemenus.js");
-let piemenusContent;
 
 // Mock Globals
 global.docById = jest.fn().mockReturnValue({
@@ -100,10 +94,6 @@ global.buildScale = jest.fn(() => [["C", "D", "E", "F", "G", "A", "B", "C"], []]
 
 describe("piemenus behavioral tests", () => {
     let mockBlock;
-
-    beforeAll(() => {
-        piemenusContent = fs.readFileSync(piemenusPath, "utf8");
-    });
 
     beforeEach(() => {
         mockBlock = {
@@ -243,14 +233,6 @@ describe("piemenus behavioral tests", () => {
             mockBlock._exitWheel.navItems[0].navigateFunction();
 
             expect(refreshRowForBlock).not.toHaveBeenCalled();
-        });
-    });
-
-    describe("Block Help Menu", () => {
-        it("should load help before opening the aux pie menu help widget", () => {
-            expect(piemenusContent).toMatch(
-                /if \(typeof HelpWidget === "undefined"\)\s*\{\s*if \(typeof require !== "undefined"\)\s*\{\s*require\(\["widgets\/help"\], function \(\) \{\s*new HelpWidget\(that, true\);/
-            );
         });
     });
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -128,6 +128,7 @@ let MYDEFINES = [
     "activity/basicblocks",
     "activity/blockfactory",
     "activity/piemenus",
+    "activity/piemenu-block-context",
     "activity/planetInterface",
     "activity/rubrics",
     "activity/macros",

--- a/js/block.js
+++ b/js/block.js
@@ -64,7 +64,8 @@
    - js/logo.js
    - js/piemenus.js
         piemenuNumber, piemenuColor, piemenuNoteValue, piemenuBasic, piemenuBoolean, piemenuVoices,
-        piemenuIntervals, piemenuAccidentals, piemenuModes, piemenuPitches, piemenuCustomNotes,
+        piemenuIntervals, piemenuAccidentals, piemenuModes, piemenuPitches, piemenuCustomNotes
+   - js/piemenu-block-context.js
         piemenuBlockContext
    - js/utils/platformstyle.js
         platformColor

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -45,7 +45,7 @@
         setupBlockDragController
    - js/connection-validator.js
         ConnectionValidator
-   - js/piemenus.js
+   - js/piemenu-block-context.js
         piemenuBlockContext
    - js/protoblocks.js
         ProtoBlock

--- a/js/piemenu-block-context.js
+++ b/js/piemenu-block-context.js
@@ -1,0 +1,230 @@
+// Copyright (c) 2014-23 Walter Bender
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+/*
+   global
+
+   platformColor, docById, slicePath, wheelnav, HelpWidget, _
+*/
+
+/* exported piemenuBlockContext */
+
+/**
+ * Creates the per-block right-click/long-press context wheel (duplicate,
+ * extract, trash, close, and, conditionally, save-stack and help).
+ *
+ * @param {object} block - The Block instance the context wheel is opened for.
+ * @returns {void}
+ */
+const piemenuBlockContext = block => {
+    if (block.blocks.activeBlock === null) {
+        return;
+    }
+
+    let pasteDx = 0;
+    let pasteDy = 0;
+
+    const that = block;
+    const blockBlock = block.blockIndex;
+
+    // Position the widget centered over the active block.
+    docById("contextWheelDiv").style.position = "absolute";
+
+    const x = block.blocks.blockList[blockBlock].container.x;
+    const y = block.blocks.blockList[blockBlock].container.y;
+
+    const canvasLeft = block.activity.canvas.offsetLeft + 28 * block.activity.getStageScale();
+    const canvasTop = block.activity.canvas.offsetTop + 6 * block.activity.getStageScale();
+
+    docById("contextWheelDiv").style.left =
+        Math.round(
+            (x + block.activity.blocksContainer.x) * block.activity.getStageScale() + canvasLeft
+        ) -
+        150 +
+        "px";
+    docById("contextWheelDiv").style.top =
+        Math.round(
+            (y + block.activity.blocksContainer.y) * block.activity.getStageScale() + canvasTop
+        ) -
+        150 +
+        "px";
+
+    docById("contextWheelDiv").style.display = "";
+
+    const labels = [
+        "imgsrc:header-icons/copy-button.svg",
+        "imgsrc:header-icons/extract-button.svg",
+        "imgsrc:header-icons/empty-trash-button.svg",
+        "imgsrc:header-icons/cancel-button.svg"
+    ];
+
+    const topBlock = block.blocks.findTopBlock(blockBlock);
+    if (
+        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
+            block.name
+        )
+    ) {
+        labels.push("imgsrc:header-icons/save-blocks-button.svg");
+    }
+
+    const message = block.blocks.blockList[block.blocks.activeBlock].protoblock.helpString;
+
+    let helpButton;
+    if (message) {
+        labels.push("imgsrc:header-icons/help-button.svg");
+        helpButton = labels.length - 1;
+    } else {
+        helpButton = null;
+    }
+
+    const wheel = new wheelnav("contextWheelDiv", null, 250, 250);
+    wheel.colors = platformColor.wheelcolors;
+    wheel.slicePathFunction = slicePath().DonutSlice;
+    wheel.slicePathCustom = slicePath().DonutSliceCustomization();
+    wheel.slicePathCustom.minRadiusPercent = 0.2;
+    wheel.slicePathCustom.maxRadiusPercent = 0.6;
+    wheel.sliceSelectedPathCustom = wheel.slicePathCustom;
+    wheel.sliceInitPathCustom = wheel.slicePathCustom;
+    wheel.clickModeRotate = false;
+    wheel.initWheel(labels);
+    wheel.createWheel();
+
+    wheel.navItems[0].setTooltip(_("Duplicate"));
+    wheel.navItems[1].setTooltip(_("Extract"));
+    wheel.navItems[2].setTooltip(_("Move to trash"));
+    wheel.navItems[3].setTooltip(_("Close"));
+    if (
+        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
+            block.blocks.blockList[topBlock].name
+        )
+    ) {
+        wheel.navItems[4].setTooltip(_("Save stack"));
+    }
+
+    if (helpButton !== null) {
+        wheel.navItems[helpButton].setTooltip(_("Help"));
+    }
+
+    wheel.navItems[0].selected = false;
+
+    const stackPasting = function () {
+        that.blocks.activeBlock = blockBlock;
+        that.blocks.prepareStackForCopy();
+        that.blocks.pasteDx = pasteDx;
+        that.blocks.pasteDy = pasteDy;
+        that.blocks.pasteStack();
+        pasteDx += 21;
+        pasteDy += 21;
+
+        that.activity.helpfulWheelItems.forEach(ele => {
+            if (ele.label === "Paste previous stack") {
+                ele.display = true;
+                ele.fn = stackPasting.bind(that);
+            }
+        });
+    };
+
+    wheel.navItems[0].navigateFunction = () => {
+        if ("customsample" === block.blocks.blockList[topBlock].name) {
+            that.activity.errorMsg(
+                _(
+                    "In order to copy a sample, you must reload the widget, import the sample again, and export it."
+                )
+            );
+        } else {
+            stackPasting();
+        }
+    };
+
+    wheel.navItems[1].navigateFunction = () => {
+        that.blocks.activeBlock = blockBlock;
+        that.blocks.extract();
+        docById("contextWheelDiv").style.display = "none";
+    };
+
+    wheel.navItems[2].navigateFunction = () => {
+        that.blocks.activeBlock = blockBlock;
+        that.blocks.extract();
+        that.blocks.sendStackToTrash(that.blocks.blockList[blockBlock]);
+        docById("contextWheelDiv").style.display = "none";
+        // prompting a notification on deleting any block
+        that.activity.textMsg(
+            _("You can restore deleted blocks from the trash with the Restore From Trash button."),
+            3000
+        );
+    };
+
+    wheel.navItems[3].navigateFunction = () => {
+        docById("contextWheelDiv").style.display = "none";
+    };
+
+    // Use a named handler stored globally so we can remove the previous one
+    // before adding a new one, preventing accumulation of click listeners.
+    if (window._contextWheelClickHandler) {
+        document.body.removeEventListener("click", window._contextWheelClickHandler);
+    }
+
+    window._contextWheelClickHandler = event => {
+        const wheelElement = document.getElementById("contextWheelDiv");
+        const displayStyle = window.getComputedStyle(wheelElement).display;
+        if (displayStyle === "block") {
+            wheelElement.style.display = "none";
+            document.body.removeEventListener("click", window._contextWheelClickHandler);
+        }
+    };
+
+    document.body.addEventListener("click", window._contextWheelClickHandler);
+
+    if (
+        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
+            block.name
+        )
+    ) {
+        wheel.navItems[4].navigateFunction = () => {
+            that.blocks.activeBlock = blockBlock;
+            that.blocks.prepareStackForCopy();
+            that.blocks.saveStack();
+        };
+    }
+
+    if (helpButton !== null) {
+        wheel.navItems[helpButton].navigateFunction = () => {
+            that.blocks.activeBlock = blockBlock;
+            if (typeof HelpWidget === "undefined") {
+                if (typeof require !== "undefined") {
+                    require(["widgets/help"], function () {
+                        new HelpWidget(that, true);
+                    });
+                }
+            } else {
+                new HelpWidget(that, true);
+            }
+            docById("contextWheelDiv").style.display = "none";
+        };
+    }
+
+    setTimeout(() => {
+        that.blocks.stageClick = false;
+    }, 500);
+};
+
+// All browser execution goes through RequireJS (AMD). The module.exports branch
+// is present solely for Jest/Node test environments and is never exercised at
+// runtime in the browser.
+if (typeof define === "function" && define.amd) {
+    define(function () {
+        window.piemenuBlockContext = piemenuBlockContext;
+        return { piemenuBlockContext };
+    });
+} else if (typeof module !== "undefined" && module.exports) {
+    // Jest / Node environment
+    module.exports = { piemenuBlockContext };
+}

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -15,7 +15,7 @@
 
    platformColor, docById, Singer, slicePath, wheelnav,
    DEFAULTVOICE, getDrumName, getNote, MUSICALMODES last, SHARP, FLAT,
-   PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS, HelpWidget,
+   PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS,
    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
    getMunsellColor, COLORS40, frequencyToPitch, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
@@ -41,8 +41,6 @@
         Singer
      - js/utils/munsell.js
         getMunsellColor, COLORS40
-     - js/widgets/help.js
-        HelpWidget
      - js/utils/platformstyle.js
         platformColorcl
      - js/utils/synthutils.js
@@ -55,7 +53,7 @@
    exported
 
    piemenuModes, piemenuPitches, piemenuCustomNotes, piemenuGrid,
-   piemenuBlockContext, piemenuIntervals, piemenuVoices, piemenuBoolean,
+   piemenuIntervals, piemenuVoices, piemenuBoolean,
    piemenuBasic, piemenuColor, piemenuNumber, piemenuNthModalPitch,
    piemenuNoteValue, piemenuAccidentals, piemenuKey, piemenuChords,
    piemenuDissectNumber
@@ -3836,201 +3834,6 @@ const piemenuModes = (block, selectedMode) => {
 
     block._exitWheel.navItems[0].navigateFunction = __exitMenu;
     block._exitWheel.navItems[1].navigateFunction = __prepScale;
-};
-
-/*
- * Sets up context menu for each block
- */
-const piemenuBlockContext = block => {
-    if (block.blocks.activeBlock === null) {
-        return;
-    }
-
-    let pasteDx = 0;
-    let pasteDy = 0;
-
-    const that = block;
-    const blockBlock = block.blockIndex;
-
-    // Position the widget centered over the active block.
-    docById("contextWheelDiv").style.position = "absolute";
-
-    const x = block.blocks.blockList[blockBlock].container.x;
-    const y = block.blocks.blockList[blockBlock].container.y;
-
-    const canvasLeft = block.activity.canvas.offsetLeft + 28 * block.activity.getStageScale();
-    const canvasTop = block.activity.canvas.offsetTop + 6 * block.activity.getStageScale();
-
-    docById("contextWheelDiv").style.left =
-        Math.round(
-            (x + block.activity.blocksContainer.x) * block.activity.getStageScale() + canvasLeft
-        ) -
-        150 +
-        "px";
-    docById("contextWheelDiv").style.top =
-        Math.round(
-            (y + block.activity.blocksContainer.y) * block.activity.getStageScale() + canvasTop
-        ) -
-        150 +
-        "px";
-
-    docById("contextWheelDiv").style.display = "";
-
-    const labels = [
-        "imgsrc:header-icons/copy-button.svg",
-        "imgsrc:header-icons/extract-button.svg",
-        "imgsrc:header-icons/empty-trash-button.svg",
-        "imgsrc:header-icons/cancel-button.svg"
-    ];
-
-    const topBlock = block.blocks.findTopBlock(blockBlock);
-    if (
-        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
-            block.name
-        )
-    ) {
-        labels.push("imgsrc:header-icons/save-blocks-button.svg");
-    }
-
-    const message = block.blocks.blockList[block.blocks.activeBlock].protoblock.helpString;
-
-    let helpButton;
-    if (message) {
-        labels.push("imgsrc:header-icons/help-button.svg");
-        helpButton = labels.length - 1;
-    } else {
-        helpButton = null;
-    }
-
-    const wheel = new wheelnav("contextWheelDiv", null, 250, 250);
-    wheel.colors = platformColor.wheelcolors;
-    wheel.slicePathFunction = slicePath().DonutSlice;
-    wheel.slicePathCustom = slicePath().DonutSliceCustomization();
-    wheel.slicePathCustom.minRadiusPercent = 0.2;
-    wheel.slicePathCustom.maxRadiusPercent = 0.6;
-    wheel.sliceSelectedPathCustom = wheel.slicePathCustom;
-    wheel.sliceInitPathCustom = wheel.slicePathCustom;
-    wheel.clickModeRotate = false;
-    wheel.initWheel(labels);
-    wheel.createWheel();
-
-    wheel.navItems[0].setTooltip(_("Duplicate"));
-    wheel.navItems[1].setTooltip(_("Extract"));
-    wheel.navItems[2].setTooltip(_("Move to trash"));
-    wheel.navItems[3].setTooltip(_("Close"));
-    if (
-        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
-            block.blocks.blockList[topBlock].name
-        )
-    ) {
-        wheel.navItems[4].setTooltip(_("Save stack"));
-    }
-
-    if (helpButton !== null) {
-        wheel.navItems[helpButton].setTooltip(_("Help"));
-    }
-
-    wheel.navItems[0].selected = false;
-
-    const stackPasting = function () {
-        that.blocks.activeBlock = blockBlock;
-        that.blocks.prepareStackForCopy();
-        that.blocks.pasteDx = pasteDx;
-        that.blocks.pasteDy = pasteDy;
-        that.blocks.pasteStack();
-        pasteDx += 21;
-        pasteDy += 21;
-
-        that.activity.helpfulWheelItems.forEach(ele => {
-            if (ele.label === "Paste previous stack") {
-                ele.display = true;
-                ele.fn = stackPasting.bind(that);
-            }
-        });
-    };
-
-    wheel.navItems[0].navigateFunction = () => {
-        if ("customsample" === block.blocks.blockList[topBlock].name) {
-            that.activity.errorMsg(
-                _(
-                    "In order to copy a sample, you must reload the widget, import the sample again, and export it."
-                )
-            );
-        } else {
-            stackPasting();
-        }
-    };
-
-    wheel.navItems[1].navigateFunction = () => {
-        that.blocks.activeBlock = blockBlock;
-        that.blocks.extract();
-        docById("contextWheelDiv").style.display = "none";
-    };
-
-    wheel.navItems[2].navigateFunction = () => {
-        that.blocks.activeBlock = blockBlock;
-        that.blocks.extract();
-        that.blocks.sendStackToTrash(that.blocks.blockList[blockBlock]);
-        docById("contextWheelDiv").style.display = "none";
-        // prompting a notification on deleting any block
-        that.activity.textMsg(
-            _("You can restore deleted blocks from the trash with the Restore From Trash button."),
-            3000
-        );
-    };
-
-    wheel.navItems[3].navigateFunction = () => {
-        docById("contextWheelDiv").style.display = "none";
-    };
-
-    // Use a named handler stored globally so we can remove the previous one
-    // before adding a new one, preventing accumulation of click listeners.
-    if (window._contextWheelClickHandler) {
-        document.body.removeEventListener("click", window._contextWheelClickHandler);
-    }
-
-    window._contextWheelClickHandler = event => {
-        const wheelElement = document.getElementById("contextWheelDiv");
-        const displayStyle = window.getComputedStyle(wheelElement).display;
-        if (displayStyle === "block") {
-            wheelElement.style.display = "none";
-            document.body.removeEventListener("click", window._contextWheelClickHandler);
-        }
-    };
-
-    document.body.addEventListener("click", window._contextWheelClickHandler);
-
-    if (
-        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
-            block.name
-        )
-    ) {
-        wheel.navItems[4].navigateFunction = () => {
-            that.blocks.activeBlock = blockBlock;
-            that.blocks.prepareStackForCopy();
-            that.blocks.saveStack();
-        };
-    }
-
-    if (helpButton !== null) {
-        wheel.navItems[helpButton].navigateFunction = () => {
-            that.blocks.activeBlock = blockBlock;
-            if (typeof HelpWidget === "undefined") {
-                if (typeof require !== "undefined") {
-                    require(["widgets/help"], function () {
-                        new HelpWidget(that, true);
-                    });
-                }
-            } else {
-                new HelpWidget(that, true);
-            }
-            docById("contextWheelDiv").style.display = "none";
-        };
-    }
-
-    setTimeout(() => {
-        that.blocks.stageClick = false;
-    }, 500);
 };
 
 /**


### PR DESCRIPTION
## Summary

Extract `piemenuBlockContext` from `js/piemenus.js` into a dedicated `js/piemenu-block-context.js` module to improve maintainability, separation of concerns, and testability.

## Changes

* Added `js/piemenu-block-context.js` following the existing module/controller pattern.
* Added AMD/CommonJS exports and the `window.piemenuBlockContext` browser global.
* Registered the new module in `js/activity.js`.
* Removed `piemenuBlockContext` from `js/piemenus.js`.
* Updated related documentation comments in `js/block.js` and `js/blocks.js`.
* Replaced the source-text/regex test in `piemenus.test.js` with behavioral tests in `piemenu-block-context.test.js`.

## Tests Added

Behavioral tests cover:

* Wheel positioning and creation
* Context-menu items
* Duplicate/paste
* Extract
* Trash
* Close
* Save-stack and help actions
* Outside-click cleanup
* `stageClick` timeout

## Testing

* Targeted Jest: **111/111 tests passed**
* Full Jest suite: **208/208 suites, 7354/7354 tests passed**
* ESLint: **clean**
* Prettier: **clean**
* Stryker initial test run: **passed**

## Scope

No intentional behavior changes were introduced. The extraction is behavior-preserving and focuses on making `piemenuBlockContext` independently maintainable and testable.

Increasing mutation coverage for the other pie-menu functions is outside the scope of this PR.
