### PR TITLE
refactor(controller): add widgetWindows null safety guards to KeyboardController

### DIFF
--- a/js/__tests__/keyboard-controller.test.js
+++ b/js/__tests__/keyboard-controller.test.js
@@ -532,4 +532,26 @@ describe("KeyboardController", () => {
             expect(activity.workspaceLayoutController._findBlocks).toHaveBeenCalled();
         });
     });
+
+    describe("widget Windows null safety", () => {
+        it("handles undefined window.widgetWindows without throwing", () => {
+            const activity = makeActivity();
+            delete global.window.widgetWindows;
+            const controller = createController(activity);
+
+            expect(() => {
+                controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            }).not.toThrow();
+        });
+
+        it("handles missing openWindows object gracefully", () => {
+            const activity = makeActivity();
+            global.window.widgetWindows = {};
+            const controller = createController(activity);
+
+            expect(() => {
+                controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            }).not.toThrow();
+        });
+    });
 });

--- a/js/keyboard-controller.js
+++ b/js/keyboard-controller.js
@@ -35,6 +35,33 @@ class KeyboardController {
         document.addEventListener("keydown", this._handleKeyDown);
     }
 
+    /**
+     * Checks if a specific widget window is open safely.
+     * @param {string} name
+     * @returns {boolean}
+     */
+    _isWidgetOpen(name) {
+        return !!(
+            typeof window !== "undefined" &&
+            window.widgetWindows &&
+            typeof window.widgetWindows.isOpen === "function" &&
+            window.widgetWindows.isOpen(name)
+        );
+    }
+
+    /**
+     * Checks if any widget window is open safely.
+     * @returns {boolean}
+     */
+    _hasOpenWidget() {
+        return !!(
+            typeof window !== "undefined" &&
+            window.widgetWindows &&
+            window.widgetWindows.openWindows &&
+            Object.values(window.widgetWindows.openWindows).some(w => w)
+        );
+    }
+
     /*
      * Handles keyboard shortcuts in MB
      */
@@ -42,7 +69,7 @@ class KeyboardController {
         const activity = this.activity;
 
         // First, check if the pitch slider is open
-        if (window.widgetWindows.isOpen("slider") === true) {
+        if (this._isWidgetOpen("slider")) {
             // If the event is an arrow key, let the PitchSlider handle it
             if (
                 event.keyCode === 37 ||
@@ -58,7 +85,7 @@ class KeyboardController {
             }
         }
 
-        if (window.widgetWindows.isOpen("JavaScript Editor") === true) return;
+        if (this._isWidgetOpen("JavaScript Editor")) return;
         if (!activity.keyboardEnableFlag) {
             return;
         }
@@ -194,9 +221,7 @@ class KeyboardController {
                     }
 
                     // Check if any widget window is open
-                    const hasOpenWidget = Object.values(window.widgetWindows.openWindows).some(
-                        w => w
-                    );
+                    const hasOpenWidget = this._hasOpenWidget();
                     if (activity.turtles.running()) {
                         activity._doHardStopButton();
                     } else if (!hasOpenWidget) {
@@ -270,7 +295,7 @@ class KeyboardController {
                 }
             } else if (event.keyCode === SPACE) {
                 // Check if any widget window is open
-                const hasOpenWidget = Object.values(window.widgetWindows.openWindows).some(w => w);
+                const hasOpenWidget = this._hasOpenWidget();
                 if (activity.turtles.running()) {
                     event.preventDefault();
                     activity._doHardStopButton();
@@ -407,9 +432,7 @@ class KeyboardController {
                         break;
                     case RETURN: {
                         // Check if any widget window is open
-                        const hasOpenWidget = Object.values(window.widgetWindows.openWindows).some(
-                            w => w
-                        );
+                        const hasOpenWidget = this._hasOpenWidget();
                         if (activity.turtles.running()) {
                             event.preventDefault();
                             activity._doHardStopButton();


### PR DESCRIPTION
## Description

Refactors `KeyboardController` in `js/keyboard-controller.js` by introducing helper methods `_isWidgetOpen()` and `_hasOpenWidget()` to add defensive null and property guards around `window.widgetWindows` and `window.widgetWindows.openWindows`.

Previously, `__keyPressed()` directly invoked `window.widgetWindows.isOpen("slider")` and `Object.values(window.widgetWindows.openWindows)`. If `window.widgetWindows` was `undefined` or null (such as before widget initialization or in headless/test environments), pressing any key threw an unhandled `TypeError: Cannot read properties of undefined (reading 'isOpen')`.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/keyboard-controller.js`**:
  - Added helper methods `_isWidgetOpen(name)` and `_hasOpenWidget()`.
  - Replaced direct `window.widgetWindows` calls to safely handle uninitialized or missing widget managers.
- **`js/__tests__/keyboard-controller.test.js`**:
  - Added `widget Windows null safety` test suite verifying that key events execute cleanly without throwing when `window.widgetWindows` or `openWindows` is `undefined`.

## Testing Performed

- Ran local Jest test suite: `npx jest js/__tests__/keyboard-controller.test.js --coverage=false` (29/29 passed).
- Ran ESLint: `npx eslint js/keyboard-controller.js js/__tests__/keyboard-controller.test.js` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
