### PR TITLE
fix: reattach pitch args after extraction

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -540,6 +540,9 @@ class Blocks {
                         this.adjustExpandableClampBlock();
                     }
                 }
+                if (adjustDock) {
+                    this.adjustDocks(blk, true);
+                }
             } else {
                 if (firstConnection !== null) {
                     connectionIdx = this.blockList[firstConnection].connections.indexOf(blk);


### PR DESCRIPTION
## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes a bug in `Blocks._extractBlock()` where extracting a pitch block via the
piemenu left its `name`/`octave` argument blocks visually detached from it,
even though the underlying connection data was correct (reloading the project
would show them properly attached). The function only called `adjustDocks()`
on `firstConnection`, never on the extracted block (`blk`) itself, so the
extracted block's own dock pixel positions were never refreshed.

## How to reproduce
1. Load the default project
2. Using the right-click piemenu, extract a pitch block from one of the note blocks
3. Observe that the pitch and octave args are not attached

## Fix
Added a call to `this.adjustDocks(blk, true)` after the existing
`adjustDocks(firstConnection, true)` call in `_extractBlock`, so the
extracted block's own connections are reconciled immediately instead of
requiring a reload.

Fixes #8018