### PR TITLE
fix: add silence block when extracting last pitch

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -471,7 +471,12 @@ class Blocks {
             if (this.activeBlock !== null) {
                 /** Don't extract silence blocks. */
                 if (this.blockList[this.activeBlock].name !== "rest2") {
+                    const thisBlock = this.activeBlock;
+
+                    const parentExpandableBlk = this.insideExpandableBlock(thisBlock);
                     this._extractBlock(this.activeBlock, true);
+
+                    this.addDefaultBlock(parentExpandableBlk, thisBlock);
                 }
             }
         };


### PR DESCRIPTION
## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes a bug in the right-click piemenu **"Extract"** action where extracting the last pitch block from a note does not insert the default silence block.

When a pitch block is dragged out of a note, the normal removal path automatically adds a `rest2` silence block when no pitch blocks remain. However, the `Extract` action only disconnects the extracted block and does not perform the same default-block insertion, leaving the note without a silence block.

## How to reproduce

1. Load the default project
2. Create or open a note block containing a pitch block
3. Using the right-click piemenu, select **Extract** on the pitch block
4. Observe that the pitch block is extracted without a silence block being inserted into the note

## Fix
<img width="1071" height="816" alt="image" src="https://github.com/user-attachments/assets/8eabd4b2-009a-44d4-89a2-87be88ef02c6" />


Updated the **Extract** action in `js/blocks.js` to add the default block after extracting a pitch block from a note.

The parent expandable block is captured before extraction, and `addDefaultBlock()` is called after `_extractBlock()` so that when the last pitch block is removed, the note automatically receives the expected `rest2` silence block.

Fixes #8020