### PR TITLE
chore: remove dead idle watcher code

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -1526,19 +1526,9 @@ class Activity {
                 });
             }
 
-            if (this._idleWatcherIntervalId) {
-                clearInterval(this._idleWatcherIntervalId);
-                this._idleWatcherIntervalId = null;
-            }
-
             let lastActivity = Date.now();
             let lastIdleReset = lastActivity;
             this.isAppIdle = false;
-
-            // Prevent duplicate intervals
-            if (this._idleWatcherIntervalId) {
-                clearInterval(this._idleWatcherIntervalId);
-            }
 
             // Wake up function - restores full framerate
             // Stored as instance property for cleanup


### PR DESCRIPTION
## Description

Removes redundant cleanup code referencing `_idleWatcherIntervalId` from the idle watcher setup.

The actual interval handle is stored in `_idleWatcherInterval`, which is already managed by `_stopIdleWatcher()`. Since `_idleWatcherIntervalId` is never assigned an interval handle, the existing checks for it are dead code and have no effect.

## Related Issue

Fixes #8022 

## PR Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **Idle watcher setup**:
  - Removed redundant cleanup blocks referencing `_idleWatcherIntervalId`.
  - Kept the existing `_idleWatcherInterval` cleanup handled by `_stopIdleWatcher()`.
  - No functional behavior is changed.

## Testing Performed

- Ran ESLint on the modified file.
- Ran Prettier check on the modified file.
- Verified that the actual idle watcher interval continues to use `_idleWatcherInterval`.

## Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** *(required for auto-rebase; this only affects the PR branch, not your fork)*.