### PR TITLE
fix(turtleactions): halt synth definitions in ToneActions on oscillator conflict

### DIFF
--- a/js/turtleactions/ToneActions.js
+++ b/js/turtleactions/ToneActions.js
@@ -379,6 +379,7 @@ function setupToneActions(activity) {
                 activity.logo.timbre.FMSynthParams = [];
                 if (activity.logo.timbre.osc.length !== 0) {
                     activity.errorMsg(_("Unable to use synth due to existing oscillator."));
+                    return;
                 }
             }
 
@@ -418,6 +419,7 @@ function setupToneActions(activity) {
                 activity.logo.timbre.AMSynthParams = [];
                 if (activity.logo.timbre.osc.length !== 0) {
                     activity.errorMsg(_("Unable to use synth due to existing oscillator."));
+                    return;
                 }
             }
 
@@ -457,6 +459,7 @@ function setupToneActions(activity) {
             if (activity.logo.inTimbre) {
                 if (activity.logo.timbre.osc.length !== 0) {
                     activity.errorMsg(_("Unable to use synth due to existing oscillator."));
+                    return;
                 }
                 activity.logo.timbre.duoSynthParams = [];
             }

--- a/js/turtleactions/__tests__/ToneActions.test.js
+++ b/js/turtleactions/__tests__/ToneActions.test.js
@@ -569,12 +569,13 @@ describe("setupToneActions", () => {
             expect(activity.logo.timbre.FMSynthParams).toContain(10);
         });
 
-        it("should show error when oscillators exist", () => {
+        it("should show error and halt when oscillators exist", () => {
             activity.logo.timbre.osc = [{}];
             Singer.ToneActions.defFMSynth(10, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith(
                 "Unable to use synth due to existing oscillator."
             );
+            expect(activity.logo.synth.createSynth).not.toHaveBeenCalled();
         });
 
         it("should not create parameters when not in timbre mode", () => {
@@ -614,12 +615,13 @@ describe("setupToneActions", () => {
             expect(activity.logo.timbre.AMSynthParams).toContain(5);
         });
 
-        it("should show error when oscillators exist", () => {
+        it("should show error and halt when oscillators exist", () => {
             activity.logo.timbre.osc = [{}];
             Singer.ToneActions.defAMSynth(5, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith(
                 "Unable to use synth due to existing oscillator."
             );
+            expect(activity.logo.synth.createSynth).not.toHaveBeenCalled();
         });
 
         it("should not create parameters when not in timbre mode", () => {
@@ -672,12 +674,13 @@ describe("setupToneActions", () => {
             expect(activity.logo.timbre.duoSynthParams).toContain(20);
         });
 
-        it("should show error when oscillators exist", () => {
+        it("should show error and halt when oscillators exist", () => {
             activity.logo.timbre.osc = [{}];
             Singer.ToneActions.defDuoSynth(10, 20, 0, 1);
             expect(activity.errorMsg).toHaveBeenCalledWith(
                 "Unable to use synth due to existing oscillator."
             );
+            expect(activity.logo.synth.createSynth).not.toHaveBeenCalled();
         });
 
         it("should not create parameters when not in timbre mode", () => {


### PR DESCRIPTION
## Description

Refactors `defFMSynth()`, `defAMSynth()`, and `defDuoSynth()` in `js/turtleactions/ToneActions.js` by adding early `return;` guards when an oscillator conflict is detected (`activity.logo.timbre.osc.length !== 0`).

Previously, when an oscillator already existed, these methods logged an error message (`"Unable to use synth due to existing oscillator."`), but did not return early. Execution continued, creating an invalid synth (`createSynth()`) and polluting parameter arrays despite the error.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- **`js/turtleactions/ToneActions.js`**:
  - Added early `return;` guards to `defFMSynth()`, `defAMSynth()`, and `defDuoSynth()` when `activity.logo.timbre.osc.length !== 0`.
- **`js/turtleactions/__tests__/ToneActions.test.js`**:
  - Updated test assertions for `defFMSynth`, `defAMSynth`, and `defDuoSynth` to verify that `createSynth()` is not called when an oscillator conflict occurs.

## Testing Performed

- Ran local Jest test suite: `npx jest js/turtleactions/__tests__/ToneActions.test.js --coverage=false` (61/61 passed).
- Ran ESLint: `npx eslint js/turtleactions/ToneActions.js js/turtleactions/__tests__/ToneActions.test.js` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
