### PR TITLE
refactor: remove dead _enqueue param from playNote

### DIFF
--- a/js/__tests__/noteclamp-beat-doublequeue.test.js
+++ b/js/__tests__/noteclamp-beat-doublequeue.test.js
@@ -295,14 +295,8 @@ describe("note clamp + beat event double queue", () => {
         const newnote = makeFlowBlock(
             "newnote",
             [null, 1, 2, 4],
-            (args, l, t, blk, receivedArg) => {
-                const tur = l.turtles.ithTurtle(t);
-                const _callback = () => {
-                    const queueBlock = new Queue(args[1], 1, blk, receivedArg);
-                    tur.parentFlowQueue.push(blk);
-                    tur.queue.push(queueBlock);
-                };
-                Singer.RhythmActions.playNote(args[0], "newnote", t, blk, _callback);
+            (args, l, t, blk) => {
+                Singer.RhythmActions.playNote(args[0], "newnote", t, blk);
                 return [args[1], 1];
             },
             [null, "numberin", "in", "in"],

--- a/js/blocks/RhythmBlocks.js
+++ b/js/blocks/RhythmBlocks.js
@@ -13,7 +13,7 @@
    global
 
    _, FlowBlock, NOINPUTERRORMSG, Singer, ValueBlock, mixedNumber,
-   FlowClampBlock, DEFAULTDRUM, Queue, i18nSolfege
+   FlowClampBlock, DEFAULTDRUM, i18nSolfege
  */
 
 /* exported setupRhythmBlocks */
@@ -194,15 +194,7 @@ function setupRhythmBlocks(activity) {
             const value =
                 args[0] === null || typeof args[0] !== "number" ? 1 / 4 : Math.abs(args[0]);
 
-            const _callback = () => {
-                const tur = activity.turtles.ithTurtle(turtle);
-
-                const queueBlock = new Queue(args[1], 1, blk, receivedArg);
-                tur.parentFlowQueue.push(blk);
-                tur.queue.push(queueBlock);
-            };
-
-            Singer.RhythmActions.playNote(value, "osctime", turtle, blk, _callback);
+            Singer.RhythmActions.playNote(value, "osctime", turtle, blk);
 
             return [args[1], 1];
         }
@@ -1094,15 +1086,7 @@ function setupRhythmBlocks(activity) {
             const value =
                 args[0] === null || typeof args[0] !== "number" ? 1 / 4 : Math.abs(args[0]);
 
-            const _callback = () => {
-                const tur = activity.turtles.ithTurtle(turtle);
-
-                const queueBlock = new Queue(args[1], 1, blk, receivedArg);
-                tur.parentFlowQueue.push(blk);
-                tur.queue.push(queueBlock);
-            };
-
-            Singer.RhythmActions.playNote(value, "note", turtle, blk, _callback);
+            Singer.RhythmActions.playNote(value, "note", turtle, blk);
 
             return [args[1], 1];
         }
@@ -1174,14 +1158,6 @@ function setupRhythmBlocks(activity) {
             const value =
                 args[0] === null || typeof args[0] !== "number" ? 1 / 4 : Math.abs(args[0]);
 
-            const _callback = () => {
-                const tur = activity.turtles.ithTurtle(turtle);
-
-                const queueBlock = new Queue(args[1], 1, blk, receivedArg);
-                tur.parentFlowQueue.push(blk);
-                tur.queue.push(queueBlock);
-            };
-
             const tur = activity.turtles.ithTurtle(turtle);
             if (tur.singer.inNoteBlock.length > 0) {
                 tur.singer.delayedNotes.push([blk, value]);
@@ -1190,7 +1166,7 @@ function setupRhythmBlocks(activity) {
             if (logo.inMatrix && value > 0) {
                 logo.tupletRhythms.push(["individual", 1, 1 / value]);
             }
-            Singer.RhythmActions.playNote(value, "newnote", turtle, blk, _callback);
+            Singer.RhythmActions.playNote(value, "newnote", turtle, blk);
             return [args[1], 1];
         }
     }

--- a/js/blocks/__tests__/RhythmBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlocks.test.js
@@ -323,8 +323,7 @@ describe("RhythmBlocks", () => {
                 200,
                 "osctime",
                 0,
-                5,
-                expect.any(Function)
+                5
             );
         });
 
@@ -597,15 +596,14 @@ describe("RhythmBlocks", () => {
     });
 
     describe("OscTimeBlock", () => {
-        test("flow calls playNote with callback that queues block", () => {
+        test("flow calls playNote", () => {
             const block = getBlock("osctime");
             block.flow([0.25, 1], logo, 0, 5, null);
             expect(global.Singer.RhythmActions.playNote).toHaveBeenCalledWith(
                 0.25,
                 "osctime",
                 0,
-                5,
-                expect.any(Function)
+                5
             );
         });
 
@@ -616,8 +614,7 @@ describe("RhythmBlocks", () => {
                 0.25,
                 "osctime",
                 0,
-                5,
-                expect.any(Function)
+                5
             );
         });
     });
@@ -693,13 +690,7 @@ describe("RhythmBlocks", () => {
         test("flow calls playNote with correct value", () => {
             const block = getBlock("note");
             block.flow([0.5, 1], logo, 0, 5, null);
-            expect(global.Singer.RhythmActions.playNote).toHaveBeenCalledWith(
-                0.5,
-                "note",
-                0,
-                5,
-                expect.any(Function)
-            );
+            expect(global.Singer.RhythmActions.playNote).toHaveBeenCalledWith(0.5, "note", 0, 5);
         });
     });
 
@@ -735,29 +726,11 @@ describe("RhythmBlocks", () => {
             turtle.singer.inNoteBlock = [];
             const block = getBlock("newnote");
             block.flow([0.5, 1], logo, 0, 5, null);
-            expect(global.Singer.RhythmActions.playNote).toHaveBeenCalledWith(
-                0.5,
-                "newnote",
-                0,
-                5,
-                expect.any(Function)
-            );
+            expect(global.Singer.RhythmActions.playNote).toHaveBeenCalledWith(0.5, "newnote", 0, 5);
         });
     });
 
     describe("Callback and listener body coverage", () => {
-        test("OscTimeBlock callback pushes to queue", () => {
-            let capturedCallback;
-            global.Singer.RhythmActions.playNote.mockImplementation((v, t, turtle, blk, cb) => {
-                capturedCallback = cb;
-            });
-            const block = getBlock("osctime");
-            block.flow([0.25, 1], logo, 0, 5, null);
-            capturedCallback();
-            expect(turtle.parentFlowQueue).toContain(5);
-            expect(turtle.queue.length).toBe(1);
-        });
-
         test("NewSwingBlock listener fires and pops swing when not suppressed", () => {
             let capturedListener;
             logo.setTurtleListener.mockImplementation((t, name, fn) => {
@@ -796,31 +769,6 @@ describe("RhythmBlocks", () => {
             expect(turtle.singer.skipFactor).toBe(0);
         });
 
-        test("NoteBlock callback pushes to queue", () => {
-            let capturedCallback;
-            global.Singer.RhythmActions.playNote.mockImplementation((v, t, turtle, blk, cb) => {
-                capturedCallback = cb;
-            });
-            const block = getBlock("note");
-            block.flow([0.5, 1], logo, 0, 5, null);
-            capturedCallback();
-            expect(turtle.parentFlowQueue).toContain(5);
-            expect(turtle.queue.length).toBe(1);
-        });
-
-        test("NewNoteBlock callback pushes to queue", () => {
-            let capturedCallback;
-            global.Singer.RhythmActions.playNote.mockImplementation((v, t, turtle, blk, cb) => {
-                capturedCallback = cb;
-            });
-            turtle.singer.inNoteBlock = [];
-            const block = getBlock("newnote");
-            block.flow([0.5, 1], logo, 0, 5, null);
-            capturedCallback();
-            expect(turtle.parentFlowQueue).toContain(5);
-            expect(turtle.queue.length).toBe(1);
-        });
-
         test("RhythmicDotBlock flow and listener update beatFactor", () => {
             let capturedListener;
             logo.setTurtleListener.mockImplementation((t, name, fn) => {
@@ -840,25 +788,6 @@ describe("RhythmBlocks", () => {
             const block = getBlock("rhythmicdot");
             block.flow([null, 1], logo, 0, 5);
             expect(activity.errorMsg).toHaveBeenCalledWith(global.NOINPUTERRORMSG, 5);
-        });
-    });
-
-    // ── NoteBlock callback (lines 193-197) ──────────────────────────────
-    describe("NoteBlock callback queue path", () => {
-        test("callback pushes queue block to turtle", () => {
-            const block = getBlock("osctime");
-            let capturedCallback;
-            global.Singer.RhythmActions.playNote.mockImplementation(
-                (val, type, turtle, blk, cb) => {
-                    capturedCallback = cb;
-                }
-            );
-            block.flow([200, true], logo, 0, 5, "receivedArg");
-            expect(capturedCallback).toBeDefined();
-            capturedCallback();
-            expect(turtle.parentFlowQueue).toContain(5);
-            expect(turtle.queue.length).toBe(1);
-            expect(turtle.queue[0].child).toBe(true);
         });
     });
 

--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -47,12 +47,9 @@ function setupRhythmActions(activity) {
          * @param {String} blkName - note block type name
          * @param {Object} turtle - Turtle object
          * @param {Object} blk - corresponding Block object index in blocks.blockList or custom block number
-         * @param {Function} _enqueue - callback, no longer invoked by playNote. The note clamp's
-         *     child flow is queued by the interpreter from the flow block's `[childFlow, 1]` return
-         *     value (runFromBlockNow step 3); kept for signature compatibility.
          * @returns {void}
          */
-        static playNote(value, blkName, turtle, blk, _enqueue) {
+        static playNote(value, blkName, turtle, blk) {
             /**
              * The interpreter queues the child flow of the note clamp from the flow block's
              * `[childFlow, 1]` return value and, once all of the children are run, triggers a

--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -97,17 +97,13 @@ describe("setupRhythmActions", () => {
     });
 
     it("sets beat and measure to 0 when pickup not crossed", () => {
-        const enqueue = jest.fn();
-
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
         expect(targetTurtle.singer.currentBeat).toBe(0);
         expect(targetTurtle.singer.currentMeasure).toBe(0);
     });
 
     it("sets correct beat and measure when pickup is crossed", () => {
-        const enqueue = jest.fn();
-
         targetTurtle.singer.notesPlayed = [2, 1]; // pickup crossed
         targetTurtle.singer.pickup = 0;
         targetTurtle.singer.noteValuePerBeat = 1;
@@ -115,29 +111,24 @@ describe("setupRhythmActions", () => {
         targetTurtle.singer.beatList = [];
         targetTurtle.singer.factorList = [];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
         expect(targetTurtle.singer.currentBeat).toBe(3);
         expect(targetTurtle.singer.currentMeasure).toBe(1);
     });
 
     it("triggers everybeat event when beatList contains 'everybeat'", () => {
-        const enqueue = jest.fn();
-
         targetTurtle.singer.notesPlayed = [1, 1]; // pickup crossed
         targetTurtle.singer.pickup = 0;
         targetTurtle.singer.beatList = ["everybeat"];
         targetTurtle.singer.factorList = [];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
-        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__everybeat_0__");
     });
 
     it("triggers specific beat event when beatList contains current beat", () => {
-        const enqueue = jest.fn();
-
         // setup so beat = 2
         targetTurtle.singer.notesPlayed = [1, 1]; // 1 beat played
         targetTurtle.singer.pickup = 0;
@@ -147,16 +138,13 @@ describe("setupRhythmActions", () => {
         targetTurtle.singer.beatList = [2];
         targetTurtle.singer.factorList = [];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
         expect(targetTurtle.singer.currentBeat).toBe(2);
-        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_2_0__");
     });
 
     it("triggers offbeat event when beatList contains 'offbeat' and beat > 1", () => {
-        const enqueue = jest.fn();
-
         // make beat = 2
         targetTurtle.singer.notesPlayed = [1, 1]; // beat = 1 → beatValue = 2
         targetTurtle.singer.pickup = 0;
@@ -166,15 +154,12 @@ describe("setupRhythmActions", () => {
         targetTurtle.singer.beatList = ["offbeat"];
         targetTurtle.singer.factorList = [];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
         expect(targetTurtle.singer.currentBeat).toBe(2);
-        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__offbeat_0__");
     });
     it("triggers factorList beat event when beat matches factor", () => {
-        const enqueue = jest.fn();
-
         // beat = 2
         targetTurtle.singer.notesPlayed = [1, 1]; // beatValue = 2
         targetTurtle.singer.pickup = 0;
@@ -184,9 +169,8 @@ describe("setupRhythmActions", () => {
         targetTurtle.singer.beatList = [];
         targetTurtle.singer.factorList = [2];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
-        expect(enqueue).not.toHaveBeenCalled();
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_2_0__");
     });
     it("adds rest note when inside a note block", () => {
@@ -524,10 +508,9 @@ describe("setupRhythmActions", () => {
         expect(targetTurtle.singer.beatFactor).toBeGreaterThan(0);
     });
     it("treats osctime differently from note duration", () => {
-        const enqueue = jest.fn();
         Singer.processNote.mockClear();
 
-        Singer.RhythmActions.playNote(2, "note", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(2, "note", 0, 1);
         let listener = activity.logo.setTurtleListener.mock.calls[0][2];
         listener();
 
@@ -535,7 +518,7 @@ describe("setupRhythmActions", () => {
 
         Singer.processNote.mockClear();
 
-        Singer.RhythmActions.playNote(500, "osctime", 0, 1, enqueue);
+        Singer.RhythmActions.playNote(500, "osctime", 0, 1);
         listener = activity.logo.setTurtleListener.mock.calls[1][2];
         listener();
 
@@ -547,7 +530,7 @@ describe("setupRhythmActions", () => {
     it("activates multipleVoices for nested notes", () => {
         targetTurtle.singer.inNoteBlock = [10];
 
-        Singer.RhythmActions.playNote(1, "note", 0, 1, jest.fn());
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
 
         expect(targetTurtle.singer.multipleVoices).toBe(true);
     });


### PR DESCRIPTION
This PR removes the unused `_enqueue` parameter from `playNote()` and the redundant callback logic in rhythm blocks. This cleanup follows #7946, where child-flow queueing was moved to `runFromBlockNow()`. Updated the related tests and verified all affected tests, ESLint, and Prettier pass.
