### PR TITLE
fix(meterwidget): restore master volume on close and prevent TypeError during beat playback

### DIFF
--- a/js/widgets/__tests__/meterwidget.test.js
+++ b/js/widgets/__tests__/meterwidget.test.js
@@ -52,7 +52,8 @@ global.docById = jest.fn().mockImplementation(id => {
 global.Singer = {
     setSynthVolume: jest.fn(),
     defaultBPMFactor: 60,
-    masterBPM: 60
+    masterBPM: 60,
+    masterVolume: [1]
 };
 
 // Mock slicePath (Wheelnav dependency)
@@ -421,5 +422,40 @@ describe("Meter Widget", () => {
             expect(() => widget.widgetWindow.onclose()).not.toThrow();
             expect(widget._playing).toBe(false);
         }
+    });
+
+    test("should restore master volume and stop playing when closed", () => {
+        const widgetWindow = window.widgetWindows.windowFor();
+        meterWidget._playing = true;
+
+        widgetWindow.onclose();
+
+        expect(meterWidget._playing).toBe(false);
+        expect(mockActivity.logo.synth.setMasterVolume).toHaveBeenCalledWith(1);
+        expect(widgetWindow.destroy).toHaveBeenCalled();
+    });
+
+    test("should stop scheduled beat playback safely when _playing is set to false", () => {
+        meterWidget._playing = false;
+
+        expect(() => {
+            meterWidget.__playOneBeat(0, 500);
+        }).not.toThrow();
+
+        expect(mockActivity.logo.synth.trigger).not.toHaveBeenCalled();
+    });
+
+    test("should not attempt to restore master volume when Singer.masterVolume is empty", () => {
+        const widgetWindow = window.widgetWindows.windowFor();
+        mockActivity.logo.synth.setMasterVolume.mockClear();
+        const originalMasterVolume = global.Singer.masterVolume;
+        global.Singer.masterVolume = [];
+
+        expect(() => {
+            widgetWindow.onclose();
+        }).not.toThrow();
+
+        expect(mockActivity.logo.synth.setMasterVolume).not.toHaveBeenCalled();
+        global.Singer.masterVolume = originalMasterVolume;
     });
 });

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -168,6 +168,9 @@ class MeterWidget {
          */
         widgetWindow.onclose = () => {
             this._playing = false;
+            if (Singer && Singer.masterVolume && Singer.masterVolume.length > 0) {
+                this.activity.logo.synth.setMasterVolume(last(Singer.masterVolume));
+            }
             this.activity.hideMsgs();
             widgetWindow.destroy();
         };
@@ -397,9 +400,17 @@ class MeterWidget {
      * @returns {void}
      */
     __playOneBeat(i, ms) {
+        if (!this._playing) {
+            return;
+        }
+
         if (this.__getPauseStatus()) {
-            for (let i = 0; i < this._strongBeats.length; i++) {
-                this._playWheel.navItems[i].navItem.hide();
+            if (this._playWheel && this._playWheel.navItems) {
+                for (let i = 0; i < this._strongBeats.length; i++) {
+                    if (this._playWheel.navItems[i] && this._playWheel.navItems[i].navItem) {
+                        this._playWheel.navItems[i].navItem.hide();
+                    }
+                }
             }
             return;
         }
@@ -409,8 +420,17 @@ class MeterWidget {
             j += this._strongBeats.length;
         }
 
-        this._playWheel.navItems[i].navItem.show();
-        this._playWheel.navItems[j].navItem.hide();
+        if (
+            this._playWheel &&
+            this._playWheel.navItems &&
+            this._playWheel.navItems[i] &&
+            this._playWheel.navItems[i].navItem &&
+            this._playWheel.navItems[j] &&
+            this._playWheel.navItems[j].navItem
+        ) {
+            this._playWheel.navItems[i].navItem.show();
+            this._playWheel.navItems[j].navItem.hide();
+        }
 
         if (this._strongBeats[i]) {
             this.__playDrum("snare drum");
@@ -419,7 +439,9 @@ class MeterWidget {
         }
 
         setTimeout(() => {
-            this.__playOneBeat((i + 1) % this._strongBeats.length, ms);
+            if (this._playing) {
+                this.__playOneBeat((i + 1) % this._strongBeats.length, ms);
+            }
         }, ms);
     }
 


### PR DESCRIPTION
## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Description

Fixes two cleanup issues in the Meter Widget (`js/widgets/meterwidget.js`):

1. **Master Volume Leak**: When `MeterWidget` initializes, it sets `setMasterVolume(PREVIEWVOLUME)`. On `onclose`, master volume was never restored back to `last(Singer.masterVolume)`, leaving the app's master volume permanently reduced.
2. **Playback Cleanup Crash**: Closing `MeterWidget` during beat playback left scheduled `setTimeout` ticks that attempted to call `.hide()` on destroyed Raphaël SVG wheel elements, throwing an unhandled `TypeError`.

## Related Issue

This PR fixes #8027 

## Changes Made

- Restored master volume in `widgetWindow.onclose` to `last(Singer.masterVolume)`
- Added defensive checks in `__playOneBeat` for `this._playing` and wheel/navItem existence
- Added unit tests in `meterwidget.test.js` verifying volume restoration and safe playback shutdown

## Testing Performed

- Ran widget unit test suite: `npx jest js/widgets/__tests__/meterwidget.test.js` (11/11 tests pass)
- Verified master volume is restored when closing Meter Widget
- Verified closing widget mid-beat no longer throws console errors

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.