### PR TITLE
fix: add typeof guard for MusicBlocks in RhythmActions and PitchActions

### DIFF
--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -458,7 +458,7 @@ function setupPitchActions(activity) {
             const listenerName = "_accidental_" + turtle + "_" + blk;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -488,7 +488,7 @@ function setupPitchActions(activity) {
             const listenerName = "_scalar_transposition_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -519,7 +519,7 @@ function setupPitchActions(activity) {
             const listenerName = "_transposition_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -548,7 +548,7 @@ function setupPitchActions(activity) {
             const listenerName = "_transposition_ratio_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -608,7 +608,7 @@ function setupPitchActions(activity) {
             const listenerName = "_invert_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }

--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -132,7 +132,7 @@ function setupRhythmActions(activity) {
             const listenerName = "_playnote_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -249,7 +249,7 @@ function setupRhythmActions(activity) {
             const listenerName = "_dot_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -286,7 +286,7 @@ function setupRhythmActions(activity) {
             const listenerName = "_tie_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -398,7 +398,7 @@ function setupRhythmActions(activity) {
             const listenerName = "_multiplybeat_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }
@@ -434,7 +434,7 @@ function setupRhythmActions(activity) {
             const listenerName = "_swing_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
-            } else if (MusicBlocks.isRun) {
+            } else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
                 const mouse = Mouse.getMouseFromTurtle(tur);
                 if (mouse !== null) mouse.MB.listeners.push(listenerName);
             }


### PR DESCRIPTION
## Description

`RhythmActions.js` and `PitchActions.js` access `MusicBlocks.isRun` directly without first checking whether `MusicBlocks` is defined. In environments where the `js-export` module has not yet been loaded (e.g. during test setup or module initialization), this line:

```js
} else if (MusicBlocks.isRun) {
```

throws a `ReferenceError: MusicBlocks is not defined`, silently crashing the listener registration for those blocks.

Every other file in `js/turtleactions/` — `ToneActions.js`, `VolumeActions.js`, `MeterActions.js`, `OrnamentActions.js`, `IntervalsActions.js`, and `DrumActions.js` — already uses the correct defensive guard:

```js
} else if (typeof MusicBlocks !== "undefined" && MusicBlocks.isRun) {
```

`RhythmActions.js` and `PitchActions.js` were the only two files missing this guard. This PR fixes all 10 affected sites (5 per file) to be consistent with the rest of the codebase. There is no behavior change in normal runtime — the guard evaluates identically when `MusicBlocks` is loaded.


## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- `js/turtleactions/RhythmActions.js`:
  - Added `typeof MusicBlocks !== "undefined" &&` guard at 5 sites: `_playnote_`, `_dot_`, `_tie_`, `_multiplybeat_`, `_swing_`

- `js/turtleactions/PitchActions.js`:
  - Added `typeof MusicBlocks !== "undefined" &&` guard at 5 sites: `_accidental_`, `_scalar_transposition_`, `_transposition_`, `_transposition_ratio_`, `_invert_`

## Testing Performed

- Ran `npx jest js/turtleactions/__tests__/PitchActions.test.js js/turtleactions/__tests__/RhythmActions.test.js --no-coverage` → **91/91 tests passed**
- Ran `npx eslint js/turtleactions/PitchActions.js js/turtleactions/RhythmActions.js` → **0 errors, 0 warnings**
- Ran `npx prettier --check js/turtleactions/PitchActions.js js/turtleactions/RhythmActions.js` → **All matched files use Prettier code style**

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
