### PR TITLE
test(stryker): add mutation testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Docs/architecture/dev_architecture.html
 
 # Lighthouse CI
 .lighthouseci/
+
+# Stryker mutation testing
+.stryker-tmp/
+reports/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4349,6 +4349,23 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@stryker-mutator/core/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@stryker-mutator/core/node_modules/chalk": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -4445,6 +4462,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
             "version": "6.0.0",
@@ -12498,6 +12522,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/minimist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
                 "@babel/preset-env": "^7.29.5",
                 "@commitlint/cli": "^19.0.0",
                 "@commitlint/config-conventional": "^19.0.0",
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/core": "9.6.1",
+                "@stryker-mutator/instrumenter": "9.6.1",
+                "@stryker-mutator/jest-runner": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
                 "cross-env": "^7.0.3",
                 "cypress": "^15.15.0",
                 "electron": "40.8.5",
@@ -499,6 +504,24 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/@babel/plugin-proposal-decorators": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+            "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-syntax-decorators": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-proposal-private-property-in-object": {
             "version": "7.21.0-placeholder-for-preset-env.2",
             "dev": true,
@@ -549,6 +572,22 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-decorators": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+            "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1439,6 +1478,26 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-transform-typescript": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+            "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-syntax-typescript": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
             "version": "7.29.7",
             "dev": true,
@@ -1593,6 +1652,26 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/@babel/preset-typescript": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+            "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+                "@babel/plugin-transform-typescript": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/runtime": {
@@ -2774,6 +2853,380 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@inquirer/ansi": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+            "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            }
+        },
+        "node_modules/@inquirer/checkbox": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+            "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+            "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+            "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7",
+                "cli-width": "^4.1.0",
+                "fast-wrap-ansi": "^0.2.0",
+                "mute-stream": "^3.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/editor": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+            "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/external-editor": "^3.0.3",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/expand": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+            "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/external-editor": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.2"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@inquirer/figures": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+            "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+            "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/number": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+            "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/password": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+            "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/prompts": {
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+            "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/checkbox": "^5.2.1",
+                "@inquirer/confirm": "^6.1.1",
+                "@inquirer/editor": "^5.2.2",
+                "@inquirer/expand": "^5.1.1",
+                "@inquirer/input": "^5.1.2",
+                "@inquirer/number": "^4.1.1",
+                "@inquirer/password": "^5.1.1",
+                "@inquirer/rawlist": "^5.3.1",
+                "@inquirer/search": "^4.2.1",
+                "@inquirer/select": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/rawlist": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+            "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/search": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+            "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+            "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.7",
+                "@inquirer/core": "^11.2.1",
+                "@inquirer/figures": "^2.0.7",
+                "@inquirer/type": "^4.0.7"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+            "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@isaacs/fs-minipass": {
             "version": "4.0.1",
             "dev": true,
@@ -3780,6 +4233,13 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.10",
             "dev": true,
@@ -3794,6 +4254,19 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -3811,6 +4284,356 @@
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
+        },
+        "node_modules/@stryker-mutator/api": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+            "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "mutation-testing-metrics": "3.7.3",
+                "mutation-testing-report-schema": "3.7.3",
+                "tslib": "~2.8.0",
+                "typed-inject": "~5.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@stryker-mutator/api/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@stryker-mutator/core": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+            "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@inquirer/prompts": "^8.0.0",
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/instrumenter": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
+                "ajv": "~8.18.0",
+                "chalk": "~5.6.0",
+                "commander": "~14.0.0",
+                "diff-match-patch": "1.0.5",
+                "emoji-regex": "~10.6.0",
+                "execa": "~9.6.0",
+                "json-rpc-2.0": "^1.7.0",
+                "lodash.groupby": "~4.6.0",
+                "minimatch": "~10.2.4",
+                "mutation-server-protocol": "~0.4.0",
+                "mutation-testing-elements": "3.7.3",
+                "mutation-testing-metrics": "3.7.3",
+                "mutation-testing-report-schema": "3.7.3",
+                "npm-run-path": "~6.0.0",
+                "progress": "~2.0.3",
+                "rxjs": "~7.8.1",
+                "semver": "^7.6.3",
+                "source-map": "~0.7.4",
+                "tree-kill": "~1.2.2",
+                "tslib": "2.8.1",
+                "typed-inject": "~5.0.0",
+                "typed-rest-client": "~2.3.0"
+            },
+            "bin": {
+                "stryker": "bin/stryker.js"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@stryker-mutator/core/node_modules/execa": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+            "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.1",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.2.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/human-signals": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+            "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/core/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@stryker-mutator/core/node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@stryker-mutator/instrumenter": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+            "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/core": "~7.29.0",
+                "@babel/generator": "~7.29.0",
+                "@babel/parser": "~7.29.0",
+                "@babel/plugin-proposal-decorators": "~7.29.0",
+                "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+                "@babel/preset-typescript": "~7.28.0",
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
+                "angular-html-parser": "~10.4.0",
+                "semver": "~7.7.0",
+                "tslib": "2.8.1",
+                "weapon-regex": "~1.3.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@stryker-mutator/instrumenter/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@stryker-mutator/jest-runner": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.1.tgz",
+            "integrity": "sha512-nIrIndfWwdweYkIcxJmyBTpl84nrXs9AE6A8vzEwwzUGvDb9kVvwBPfpEajtdAkjwPceH0pPuVrPkotvqcgYqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
+                "semver": "~7.7.0",
+                "tslib": "~2.8.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@stryker-mutator/core": "9.6.1"
+            }
+        },
+        "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@stryker-mutator/jest-runner/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@stryker-mutator/util": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+            "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",
@@ -4202,6 +5025,16 @@
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/angular-html-parser": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
+            "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ansi-colors": {
@@ -5485,6 +6318,13 @@
                 "node": ">=10"
             }
         },
+        "node_modules/chardet": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+            "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "dev": true,
@@ -5629,6 +6469,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/cliui": {
@@ -6514,6 +7364,17 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/des.js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
         "node_modules/detect-file": {
             "version": "1.0.0",
             "dev": true,
@@ -6542,6 +7403,13 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -7539,6 +8407,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-truncated-width": "^3.0.2"
+            }
+        },
         "node_modules/fast-uri": {
             "version": "3.1.2",
             "dev": true,
@@ -7553,6 +8438,16 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-wrap-ansi": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+            "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-width": "^3.0.2"
+            }
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -7584,6 +8479,35 @@
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/figures/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/file-entry-cache": {
@@ -9268,6 +10192,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-plain-object": {
             "version": "5.0.0",
             "dev": true,
@@ -10298,6 +11235,13 @@
             "version": "1.12.1",
             "license": "MIT"
         },
+        "node_modules/js-md4": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+            "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "dev": true,
@@ -10397,6 +11341,13 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-rpc-2.0": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+            "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11023,6 +11974,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.groupby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+            "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "dev": true,
@@ -11521,6 +12479,13 @@
                 "node": ">=4"
             }
         },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/minimatch": {
             "version": "10.2.5",
             "dev": true,
@@ -11762,12 +12727,59 @@
             "version": "2.1.3",
             "license": "MIT"
         },
+        "node_modules/mutation-server-protocol": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+            "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "zod": "^4.1.12"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mutation-testing-elements": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+            "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/mutation-testing-metrics": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+            "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "mutation-testing-report-schema": "3.7.3"
+            }
+        },
+        "node_modules/mutation-testing-report-schema": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+            "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/mute-stdout": {
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/mute-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+            "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/nanoid": {
@@ -12284,6 +13296,19 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-ms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -13030,6 +14055,22 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/pretty-ms": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "dev": true,
@@ -13611,6 +14652,23 @@
             "version": "0.8.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/rxjs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -14703,6 +15761,16 @@
             "dev": true,
             "license": "0BSD"
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "dev": true,
@@ -14791,6 +15859,33 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/typed-inject": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+            "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/typed-rest-client": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+            "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "des.js": "^1.1.0",
+                "js-md4": "^0.3.2",
+                "qs": "6.15.1",
+                "tunnel": "0.0.6",
+                "underscore": "^1.13.8"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            }
+        },
         "node_modules/uglify-js": {
             "version": "3.19.3",
             "dev": true,
@@ -14812,6 +15907,13 @@
         },
         "node_modules/undefsafe": {
             "version": "2.0.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/underscore": {
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -15239,6 +16341,13 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/weapon-regex": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+            "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
             "dev": true,
@@ -15512,6 +16621,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "prod": "cross-env NODE_ENV=production node index.js",
         "test": "jest",
         "test:coverage": "jest --coverage",
+        "test:mutation": "stryker run",
         "cypress:run": "cypress run",
         "electron": "electron .",
         "dist": "electron-builder"
@@ -35,6 +36,11 @@
         "@babel/preset-env": "^7.29.5",
         "@commitlint/cli": "^19.0.0",
         "@commitlint/config-conventional": "^19.0.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/core": "9.6.1",
+        "@stryker-mutator/instrumenter": "9.6.1",
+        "@stryker-mutator/jest-runner": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
         "cross-env": "^7.0.3",
         "cypress": "^15.15.0",
         "electron": "40.8.5",
@@ -98,6 +104,9 @@
         "flatted": "3.4.2",
         "lodash": "4.18.1",
         "brace-expansion": "2.0.3",
+        "minimatch@^10.0.0": {
+            "brace-expansion": "^5.0.5"
+        },
         "tar": "^7.5.10",
         "path-to-regexp": "^8.4.0",
         "picomatch": "^4.0.4",
@@ -108,6 +117,9 @@
         "ajv": "^6.14.0",
         "@commitlint/config-validator": {
             "ajv": "^8.0.0"
+        },
+        "@stryker-mutator/core": {
+            "ajv": "~8.18.0"
         },
         "@isaacs/brace-expansion": "^5.0.1",
         "immutable": "5.1.9",

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -1,0 +1,30 @@
+/**
+ * Stryker Mutator configuration.
+ *
+ * This is an initial, deliberately conservative setup. The mutation scope is
+ * limited to modules that already have strong Jest coverage (turtleactions/,
+ * musicutils.js, piemenu-block-context.js) so that mutation results carry
+ * real signal instead of producing thousands of low-value "no coverage"
+ * mutants. Expand `mutate` incrementally as more of the codebase gains
+ * dedicated unit tests.
+ *
+ * Run with: npm run test:mutation
+ */
+module.exports = {
+    $schema: "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+    testRunner: "jest",
+    jest: {
+        projectType: "custom",
+        configFile: "jest.config.js",
+        enableFindRelatedTests: true
+    },
+    mutate: [
+        "js/turtleactions/*.js",
+        "js/utils/musicutils.js",
+        "js/piemenu-block-context.js",
+        "!js/turtleactions/**/__tests__/**",
+        "!js/utils/**/__tests__/**"
+    ],
+    coverageAnalysis: "perTest",
+    reporters: ["clear-text", "progress"]
+};


### PR DESCRIPTION
## Summary

Add Stryker Mutator 9.6.1 as declared development dependencies, a tracked `stryker.config.js`, and a standard `test:mutation` npm script.

Previously, the Stryker packages were present in `node_modules` but were extraneous and not declared in the repository. This change makes the mutation-testing setup reproducible from a fresh installation.

## Dependency Resolution

Two narrowly scoped dependency overrides were required for Stryker to run with the repository's existing dependency overrides:

- `@stryker-mutator/core` pulls in `minimatch@10.x`, whose `brace-expansion` dependency was being forced to the repository-wide `brace-expansion@2.0.3` override. This caused an ESM loader failure due to a missing named export. The override is scoped to `minimatch@^10.0.0`, leaving the existing global pin unchanged.
- `@stryker-mutator/core` requires `ajv` 8.x, while the repository-wide override pins `ajv` to 6.x for older electron-builder/eslint dependencies. The Stryker override is scoped to `@stryker-mutator/core`, following the same pattern as the existing `@commitlint/config-validator` override.

Neither change modifies the existing global overrides or changes the resolution of unrelated dependencies. This was verified with `npm ls`.

## Stryker Configuration

The initial mutation scope is deliberately conservative:

- `js/turtleactions/*.js`
- `js/utils/musicutils.js`
- `js/piemenu-block-context.js`

These modules were selected because they already have meaningful Jest coverage, allowing mutation results to provide useful signal.

The configuration:

- reuses the existing `jest.config.js`
- enables Jest related-test discovery
- uses `coverageAnalysis: "perTest"`
- excludes test files from mutation
- does not use `--testFiles` based scoping

No changes were made to `jest.config.js`.

## Verification

The setup was verified locally:

- `npm ls` confirms all five Stryker packages are declared and no longer extraneous.
- `npx stryker --version` reports `9.6.1`.
- Jest: **209 suites / 7392 tests passing**.
- Stryker dry run:
  - 11 files
  - 10,036 mutants instrumented
  - initial test run succeeded
  - 1,108 related Jest tests discovered
  - `perTest` coverage analysis working successfully
- Real mutation test against `js/turtleactions/DictActions.js`:
  - 175 mutants
  - 167 killed
  - 8 survived
  - 0 timeout
  - 0 no-coverage
  - 0 errors
  - **95.43% mutation score**
  - ~14 seconds

Per-test attribution was also verified for the mutants, confirming that Stryker is executing the related Jest tests correctly.

## Full-Scope Validation

The complete configured scope was also investigated.

The full run contains approximately 10,000 mutants. During validation, Stryker reported that 2,428 static mutants accounted for a disproportionate amount of the estimated runtime. After approximately 29 minutes, the estimated completion time had exceeded 25 hours and was continuing to increase. Three child test-runner processes also terminated with SIGSEGV.

The full run was therefore stopped rather than allowing an impractical multi-hour run to continue.

This does not prevent the infrastructure from working: the dry run succeeds and the independently verified `DictActions.js` mutation run completed successfully with real test attribution.

## Current Limitation

The main scalability issue is concentrated in `js/utils/musicutils.js`, which contains a large amount of module-level music-theory data. This produces a disproportionately large number of static mutants that are expensive for Stryker to execute.

`ignoreStatic` was deliberately not enabled globally because doing so would remove mutation-testing signal from this code rather than solve the underlying performance problem.

The appropriate mutation scope/runtime strategy for `musicutils.js` will be investigated separately.

## Scope

This PR only establishes the Stryker mutation-testing infrastructure.

It does not:

- modify Jest coverage thresholds
- modify `jest.config.js`
- add Track B tests
- add AI-generated tests
- add AST-based test generation
- add a mutation-testing GitHub Actions workflow
- refactor application code
- attempt to solve the `musicutils.js` scalability issue

## Follow-up

The verified Stryker infrastructure will be used as the foundation for the remaining Track work.

The next steps are to determine an appropriate mutation strategy for the large `musicutils.js` scope, and then build the automated test-generation workflow around the verified mutation-testing infrastructure.