### PR TITLE
feat(modewidget): add 19-EDO & multi-temperament support, UI updates

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3521,11 +3521,6 @@ const piemenuModes = (block, selectedMode) => {
 
     const that = block;
 
-    // Suppresses the mode-widget launch during programmatic wheel navigation
-    // (initial menu setup and group switching) so that only genuine user
-    // clicks on the "custom" slice open the circular mode editor.
-    let menuInitializing = true;
-
     // Opens the circular mode editor widget so the selected custom mode can
     // be built or edited on the N-slice wheel. The widget reads the active
     // temperament from the logo synth on construction.
@@ -3534,12 +3529,12 @@ const piemenuModes = (block, selectedMode) => {
             if (typeof require !== "undefined") {
                 require(["widgets/modewidget"], function () {
                     const act = block.activity;
-                    act.logo.modeWidget = new ModeWidget(act);
+                    act.logo.modeWidget = new ModeWidget(act, { mode: selectedMode });
                 });
             }
         } else {
             const act = block.activity;
-            act.logo.modeWidget = new ModeWidget(act);
+            act.logo.modeWidget = new ModeWidget(act, { mode: selectedMode });
         }
     };
 
@@ -3590,7 +3585,7 @@ const piemenuModes = (block, selectedMode) => {
 
             // Launch the circular mode editor when the user selects the
             // custom mode in the radial menu.
-            if (!menuInitializing && that.value === "custom") {
+            if (that.value === "custom") {
                 __launchModeWidget();
             }
         };
@@ -3709,11 +3704,7 @@ const piemenuModes = (block, selectedMode) => {
             i = 0; // major/ionian
         }
 
-        // Programmatic navigation during setup/group switching must not
-        // launch the mode editor; only a real user click does that.
-        menuInitializing = true;
         that._modeNameWheel.navigateWheel(i);
-        menuInitializing = false;
     };
 
     let timeout;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -20,9 +20,9 @@
    getMunsellColor, COLORS40, frequencyToPitch, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
    FIXEDSOLFEGE, NOTENAMES, numberToPitch,
-    nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
-    _THIS_IS_TURTLE_BLOCKS_,
-    CHORDNAMES, Synth, Tone, activity
+   nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
+   _THIS_IS_TURTLE_BLOCKS_,
+   CHORDNAMES, Synth, Tone, activity, ModeWidget
 */
 
 /*
@@ -3521,6 +3521,28 @@ const piemenuModes = (block, selectedMode) => {
 
     const that = block;
 
+    // Suppresses the mode-widget launch during programmatic wheel navigation
+    // (initial menu setup and group switching) so that only genuine user
+    // clicks on the "custom" slice open the circular mode editor.
+    let menuInitializing = true;
+
+    // Opens the circular mode editor widget so the selected custom mode can
+    // be built or edited on the N-slice wheel. The widget reads the active
+    // temperament from the logo synth on construction.
+    const __launchModeWidget = () => {
+        if (typeof ModeWidget === "undefined") {
+            if (typeof require !== "undefined") {
+                require(["widgets/modewidget"], function () {
+                    const act = block.activity;
+                    act.logo.modeWidget = new ModeWidget(act);
+                });
+            }
+        } else {
+            const act = block.activity;
+            act.logo.modeWidget = new ModeWidget(act);
+        }
+    };
+
     const __selectionChanged = () => {
         const title = that._modeNameWheel.navItems[that._modeNameWheel.selectedNavItemIndex].title;
         if (title === " ") {
@@ -3565,6 +3587,12 @@ const piemenuModes = (block, selectedMode) => {
             }
 
             __selectionChanged();
+
+            // Launch the circular mode editor when the user selects the
+            // custom mode in the radial menu.
+            if (!menuInitializing && that.value === "custom") {
+                __launchModeWidget();
+            }
         };
     };
 
@@ -3681,7 +3709,11 @@ const piemenuModes = (block, selectedMode) => {
             i = 0; // major/ionian
         }
 
+        // Programmatic navigation during setup/group switching must not
+        // launch the mode editor; only a real user click does that.
+        menuInitializing = true;
         that._modeNameWheel.navigateWheel(i);
+        menuInitializing = false;
     };
 
     let timeout;

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -20,7 +20,7 @@
  */
 
 /*
-   global _, NOINPUTERRORMSG, Singer, MUSICALMODES, MusicBlocks, Mouse, getNote,
+   global _, NOINPUTERRORMSG, Singer, MUSICALMODES, registerUserMode, MusicBlocks, Mouse, getNote,
    getModeLength, isCustomTemperament, TEMPERAMENT, getCurrentEDO, EDOBOUNDEXCEEDED,
    pitchToNumber
 */
@@ -306,6 +306,7 @@ function setupIntervalsActions(activity) {
 
             const __listener = () => {
                 MUSICALMODES[modeName] = [];
+                registerUserMode(modeName);
                 if (!tur.singer.defineMode.includes(0)) {
                     tur.singer.defineMode.push(0);
                     activity.errorMsg(_("Adding missing pitch number 0."));

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -45,6 +45,8 @@ describe("setupIntervalsActions", () => {
             custom: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         };
 
+        global.registerUserMode = jest.fn();
+
         global.ALLNOTESTEP = {
             "Cb": 0,
             "C": 1,
@@ -725,6 +727,7 @@ describe("setupIntervalsActions", () => {
         listener();
 
         expect(MUSICALMODES.custom).toBeDefined();
+        expect(registerUserMode).toHaveBeenCalledWith("custom");
     });
 
     test("defineMode error paths", () => {

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -65,7 +65,6 @@ const {
     deleteTemperamentFromList,
     DEFAULTINVERT,
     DEFAULTMODE,
-    customMode,
     getInvertMode,
     getIntervalNumber,
     getIntervalDirection,
@@ -199,6 +198,11 @@ describe("getCurrentEDO", () => {
 
     it("should return 19 for 'equal19' temperament", () => {
         expect(getCurrentEDO("equal19")).toBe(19);
+    });
+
+    it("should return 17 for a temperament with only an 'edo' field", () => {
+        global.TEMPERAMENT["equal17"] = { isEDO: true, edo: 17 };
+        expect(getCurrentEDO("equal17")).toBe(17);
     });
 
     it("should return 12 for undefined temperament", () => {
@@ -369,12 +373,6 @@ describe("Constants", () => {
     it("should have correct default values", () => {
         expect(DEFAULTINVERT).toBe("even");
         expect(DEFAULTMODE).toBe("major");
-    });
-});
-
-describe("customMode", () => {
-    it("should return custom mode from MUSICALMODES", () => {
-        expect(customMode).toEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -58,11 +58,12 @@ const _b64Cache = new Map();
    addTemperamentToList, getTemperament, deleteTemperamentFromList,
    addTemperamentToDictionary, buildScale, CHORDNAMES, CHORDVALUES,
    DEFAULTCHORD, DEFAULTVOICE, setCustomChord, EQUIVALENTACCIDENTALS,
-    INTERVALVALUES, MUSICALMODES, getIntervalRatio, frequencyToPitch, NOTESTEP,
+   INTERVALVALUES, MUSICALMODES, getIntervalRatio, frequencyToPitch, NOTESTEP,
    GetNotesForInterval,ALLNOTESTEP,NOTENAMES,SEMITONETOINTERVALMAP,
    SEMITONES, CHROMATIC_SOLFEGE, INTERVAL_CENTS, TEMPERAMENT_INTERVALS,
    INTERVAL_ORDER, generateNoteNames, getEdoNoteNamePosition,
-   scalePatternToEDO, PITCH_COLLECTIONS_EDO_OVERRIDES, getModePattern
+   scalePatternToEDO, PITCH_COLLECTIONS_EDO_OVERRIDES, getModePattern,
+   registerUserMode, getUserModeNames, removeUserMode
 */
 
 /**
@@ -935,7 +936,7 @@ const DEGREES = _("1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th");
 const getCurrentEDO = temperament => {
     if (!temperament) return 12;
     const t = TEMPERAMENT[temperament];
-    return t && t.pitchNumber ? t.pitchNumber : 12;
+    return t && t.pitchNumber ? t.pitchNumber : t && t.edo ? t.edo : 12;
 };
 
 const EDO_NOTE_NAMES = {};
@@ -1894,6 +1895,45 @@ for (const alias in PITCH_COLLECTION_ALIASES) {
 
 // User definition overrides this constant.
 MUSICALMODES["custom"] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+
+// Registry of modes defined by the user (via the "define mode" block or the
+// mode widget's Save button). This exists separately from MUSICALMODES
+// because user entries are only written there at run time, whereas the
+// widget's saved-modes ledger needs the list of user-defined modes up front.
+const USERMODES = new Set();
+
+/**
+ * Record a mode name as user-defined.
+ * @param {string} name - the mode name
+ * @returns {void}
+ */
+const registerUserMode = name => {
+    if (name && typeof name === "string") {
+        const trimmed = name.trim().toLowerCase();
+        if (trimmed) {
+            USERMODES.add(trimmed);
+        }
+    }
+};
+
+/**
+ * Get the sorted names of all user-defined modes.
+ * @returns {Array<string>} the registered mode names
+ */
+const getUserModeNames = () => {
+    return Array.from(USERMODES).sort();
+};
+
+/**
+ * Remove a mode name from the user-mode registry.
+ * @param {string} name - the mode name
+ * @returns {void}
+ */
+const removeUserMode = name => {
+    if (name && typeof name === "string") {
+        USERMODES.delete(name.trim().toLowerCase());
+    }
+};
 
 /**
  * Maqam table mapping specific maqams to their corresponding keys.
@@ -3136,12 +3176,6 @@ const DEFAULTOSCILLATORTYPE = "sine";
  * @constant {string}
  */
 const DEFAULTACCIDENTAL = "natural" + " " + NATURAL;
-
-/**
- * Custom mode from the musical modes dictionary.
- * @constant {Object}
- */
-const customMode = MUSICALMODES["custom"];
 
 /**
  * Get the invert mode name based on its identifier.
@@ -6017,9 +6051,10 @@ const PITCH_COLLECTIONS_EDO_OVERRIDES = {};
  * Get the step pattern for a mode in the given EDO.
  *
  * Lookup order: PITCH_COLLECTIONS_EDO_OVERRIDES[edo][mode] first, then the
- * scalePatternToEDO conversion of MUSICALMODES[mode]. For the "custom"
- * (chromatic) mode, 12-EDO uses the stored customMode pattern and non-12 EDO
- * returns a full EDO-length step-1 pattern.
+ * scalePatternToEDO conversion of MUSICALMODES[mode]. For the "custom" mode,
+ * the stored MUSICALMODES["custom"] pattern (maintained in the active EDO's
+ * steps) is returned when it forms a valid EDO-length pattern, otherwise a
+ * full EDO-length step-1 pattern is used as a safe fallback.
  * @function
  * @param {string} mode - The mode name (e.g. "major").
  * @param {number} edo - Number of steps per octave.
@@ -6031,8 +6066,15 @@ const getModePattern = (mode, edo = 12) => {
         return overrides[mode].slice();
     }
     if (mode.toLowerCase() === "custom") {
-        if (edo === 12) {
-            return customMode.slice();
+        // MUSICALMODES["custom"] is maintained in the active EDO's steps:
+        // defineMode() writes an EDO-step pattern for it and setTemperament()
+        // resizes it to the current EDO. Return it directly so user-defined
+        // custom modes are honored in every EDO (not just 12). The sum check
+        // keeps the fallback safe if the array is ever stale (e.g. a custom
+        // mode saved under a different EDO than the one currently active).
+        const custom = MUSICALMODES["custom"];
+        if (custom && custom.length > 0 && custom.reduce((acc, v) => acc + v, 0) === edo) {
+            return custom.slice();
         }
         return new Array(edo).fill(1);
     }
@@ -6106,10 +6148,10 @@ const buildScale = (keySignature, edo) => {
             idx = 0;
         }
 
-        // For "custom" (chromatic) mode in non-12 EDO, getModePattern returns a
-        // full EDO-length scale with step=1 for every pitch class, instead of
-        // converting the hardcoded 12-element customMode array (which would only
-        // produce ~12 notes and leave many pitch classes unreachable).
+        // For "custom" mode in non-12 EDO, getModePattern returns the
+        // user-defined EDO-step pattern stored in MUSICALMODES["custom"]
+        // (written by defineMode / resized by setTemperament), falling back
+        // to a full EDO-length chromatic only if that pattern is stale.
         const edoHalfSteps = getModePattern(obj[1], currentEDO);
 
         const scale = [myKeySignature];
@@ -7873,7 +7915,6 @@ if (typeof module !== "undefined" && module.exports) {
         addTemperamentToDictionary,
         DEFAULTINVERT,
         DEFAULTMODE,
-        customMode,
         getInvertMode,
         getIntervalNumber,
         getIntervalDirection,
@@ -7901,6 +7942,9 @@ if (typeof module !== "undefined" && module.exports) {
         getTemperamentCents,
         getTemperamentName,
         getCurrentEDO,
+        registerUserMode,
+        getUserModeNames,
+        removeUserMode,
         noteToObj,
         frequencyToPitch,
         getArticulation,

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -791,7 +791,15 @@ function Synth() {
         if (this.inTemperament === "equal") {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
-                return pitchToFrequency(parsed[0], parsed[1], 0, "c major");
+                const freq = pitchToFrequency(parsed[0], parsed[1], 0, "c major");
+                if (window.DEBUG_AUDIO) {
+                    console.log("[Audio Frequency Output]", {
+                        modeNote: notes,
+                        temperament: "equal",
+                        calculatedHz: freq
+                    });
+                }
+                return freq;
             } else if (typeof notes === "number") {
                 return notes;
             } else {
@@ -799,7 +807,15 @@ function Synth() {
                 for (let i = 0; i < notes.length; i++) {
                     if (typeof notes[i] === "string") {
                         const parsed = parseNoteString(notes[i]);
-                        results.push(pitchToFrequency(parsed[0], parsed[1], 0, "c major"));
+                        const freq = pitchToFrequency(parsed[0], parsed[1], 0, "c major");
+                        if (window.DEBUG_AUDIO) {
+                            console.log("[Audio Frequency Output]", {
+                                modeNote: notes[i],
+                                temperament: "equal",
+                                calculatedHz: freq
+                            });
+                        }
+                        results.push(freq);
                     } else {
                         results.push(notes[i]);
                     }
@@ -812,7 +828,21 @@ function Synth() {
         if (t && t.isEDO) {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
-                return pitchToFrequency(parsed[0], parsed[1], 0, "c major", this.inTemperament);
+                const freq = pitchToFrequency(
+                    parsed[0],
+                    parsed[1],
+                    0,
+                    "c major",
+                    this.inTemperament
+                );
+                if (window.DEBUG_AUDIO) {
+                    console.log("[Audio Frequency Output]", {
+                        modeNote: notes,
+                        temperament: this.inTemperament,
+                        calculatedHz: freq
+                    });
+                }
+                return freq;
             } else if (typeof notes === "number") {
                 return notes;
             } else {
@@ -820,9 +850,21 @@ function Synth() {
                 for (let i = 0; i < notes.length; i++) {
                     if (typeof notes[i] === "string") {
                         const parsed = parseNoteString(notes[i]);
-                        results.push(
-                            pitchToFrequency(parsed[0], parsed[1], 0, "c major", this.inTemperament)
+                        const freq = pitchToFrequency(
+                            parsed[0],
+                            parsed[1],
+                            0,
+                            "c major",
+                            this.inTemperament
                         );
+                        if (window.DEBUG_AUDIO) {
+                            console.log("[Audio Frequency Output]", {
+                                modeNote: notes[i],
+                                temperament: this.inTemperament,
+                                calculatedHz: freq
+                            });
+                        }
+                        results.push(freq);
                     } else {
                         results.push(notes[i]);
                     }

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -61,6 +61,37 @@ global.normalizeNoteAccidentals = jest.fn().mockImplementation(n => n);
 global.MUSICALMODES = {
     ionian: [2, 2, 1, 2, 2, 2, 1]
 };
+global.getModePattern = jest.fn((mode, edo) => global.MUSICALMODES[mode] || []);
+global.getCurrentEDO = jest.fn(() => 12);
+global.parseNoteString = jest.fn(() => ["C", 4]);
+global.TEMPERAMENT = {
+    "equal": { pitchNumber: 12, isEDO: true },
+    "equal5": { pitchNumber: 5, isEDO: true },
+    "equal19": { pitchNumber: 19, isEDO: true },
+    "equal17": { isEDO: true, edo: 17 },
+    "just intonation": { pitchNumber: 12, isEDO: false },
+    "Pythagorean": { pitchNumber: 12, isEDO: false },
+    "1/3 comma meantone": { pitchNumber: 19, isEDO: false },
+    "1/4 comma meantone": { pitchNumber: 21, isEDO: false },
+    "custom": { pitchNumber: 12 }
+};
+global.registerUserMode = jest.fn();
+global.getUserModeNames = jest.fn(() => []);
+global.removeUserMode = jest.fn();
+global.NOTESTABLE = {
+    0: "ti",
+    1: "do",
+    2: "do\u266F",
+    3: "re",
+    4: "re\u266F",
+    5: "mi",
+    6: "fa",
+    7: "fa\u266F",
+    8: "sol",
+    9: "sol\u266F",
+    10: "la",
+    11: "la\u266F"
+};
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -77,6 +108,7 @@ global.wheelnav = jest.fn().mockImplementation(() => ({
     sliceSelectedPathCustom: {},
     sliceInitPathCustom: {},
     navItems: [],
+    removeWheel: jest.fn(),
     createWheel: jest.fn().mockImplementation(function (labels) {
         this.navItems = labels.map(() => ({
             navItem: {
@@ -130,23 +162,32 @@ window.widgetWindows = {
 if (typeof document === "undefined") {
     global.document = {};
 }
-document.createElement = jest.fn().mockImplementation(tag => ({
-    style: {},
-    setAttribute: jest.fn(),
-    innerHTML: "",
-    append: jest.fn(),
-    appendChild: jest.fn(),
-    replaceChildren: jest.fn(),
-    removeChild: jest.fn(),
-    firstChild: null,
-    insertRow: jest.fn().mockReturnValue({
-        insertCell: jest.fn().mockReturnValue({
-            style: {},
-            innerHTML: ""
-        })
-    }),
-    getElementById: jest.fn().mockReturnValue({ src: "" })
-}));
+document.createElement = jest.fn().mockImplementation(tag => {
+    const el = {
+        style: {},
+        setAttribute: jest.fn(),
+        innerHTML: "",
+        appendChild: jest.fn(),
+        removeChild: jest.fn(),
+        firstChild: null,
+        children: [],
+        insertRow: jest.fn().mockReturnValue({
+            insertCell: jest.fn().mockReturnValue({
+                style: {},
+                innerHTML: ""
+            })
+        }),
+        getElementById: jest.fn().mockReturnValue({ src: "" })
+    };
+    el.append = jest.fn((...nodes) => {
+        nodes.forEach(node => el.children.push(node));
+    });
+    el.replaceChildren = jest.fn((...nodes) => {
+        el.children = [];
+        nodes.forEach(node => el.children.push(node));
+    });
+    return el;
+});
 document.getElementById = document.createElement; // For internal usage
 
 describe("ModeWidget", () => {
@@ -158,6 +199,9 @@ describe("ModeWidget", () => {
             logo: {
                 modeBlock: 1,
                 resetSynth: jest.fn(),
+                setUserTemperament: jest.fn(k => {
+                    mockActivity.logo.synth.inTemperament = k;
+                }),
                 synth: {
                     trigger: jest.fn(),
                     stop: jest.fn()
@@ -177,6 +221,31 @@ describe("ModeWidget", () => {
             errorMsg: jest.fn(),
             refreshCanvas: jest.fn()
         };
+
+        global.MUSICALMODES = {
+            ionian: [2, 2, 1, 2, 2, 2, 1],
+            custom: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        };
+        global.getUserModeNames.mockReturnValue([]);
+        global.registerUserMode.mockClear();
+        global.removeUserMode.mockClear();
+        global.getCurrentEDO.mockReturnValue(12);
+        global.docById.mockReturnValue({
+            style: {},
+            innerHTML: "",
+            append: jest.fn(),
+            appendChild: jest.fn(),
+            replaceChildren: jest.fn(),
+            removeChild: jest.fn(),
+            firstChild: null,
+            rows: [{ cells: [{ innerHTML: "" }] }, { cells: [{ innerHTML: "" }] }],
+            insertRow: jest.fn().mockReturnValue({
+                insertCell: jest.fn().mockReturnValue({
+                    style: {},
+                    innerHTML: ""
+                })
+            })
+        });
 
         modeWidget = new ModeWidget(mockActivity);
     });
@@ -287,7 +356,6 @@ describe("ModeWidget", () => {
 
     test("should initialize correctly", () => {
         expect(global.wheelnav).toHaveBeenCalledTimes(3); // noteWheel, playWheel, etc.
-        expect(global.keySignatureToMode).toHaveBeenCalled();
         expect(mockActivity.textMsg).toHaveBeenCalled();
     });
 
@@ -396,5 +464,156 @@ describe("ModeWidget", () => {
 
         expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
         expect(modeWidget._locked).toBe(false);
+    });
+
+    test("_save emits an action block and a define-mode block for a non-12 mode", () => {
+        global.docById.mockReturnValue({ rows: [{ cells: [{ textContent: "" }] }] });
+        mockActivity.blocks.loadNewBlocks = jest.fn();
+        modeWidget._setTimeout = fn => fn();
+        modeWidget._modeNameInput = { value: "my custom mode" };
+
+        // 19-EDO major-scale selection.
+        mockActivity.logo.synth.inTemperament = "equal19";
+        modeWidget._activeEDO = 19;
+        modeWidget._selectedNotes = Array(19).fill(false);
+        for (const pos of [0, 3, 6, 8, 11, 14, 17]) {
+            modeWidget._selectedNotes[pos] = true;
+        }
+
+        modeWidget._save();
+
+        // Storage write is gated to the empty/unnamed or explicitly named
+        // "custom" mode; named modes must not overwrite the built-in custom
+        // mode's persisted pattern.
+        expect(mockActivity.storage.custommode).toBeUndefined();
+
+        // Two block stacks are generated: action + define-mode.
+        expect(mockActivity.blocks.loadNewBlocks).toHaveBeenCalledTimes(2);
+
+        // First stack: action block with pitchnumber children.
+        const actionStack = mockActivity.blocks.loadNewBlocks.mock.calls[0][0];
+        expect(actionStack[0][1][0]).toBe("action");
+        expect(actionStack[1][1][0]).toBe("text");
+        expect(actionStack[1][1][1].value).toBe("my custom mode");
+        const actionNumbers = actionStack
+            .filter(b => Array.isArray(b[1]) && b[1][0] === "number")
+            .map(b => b[1][1].value)
+            .sort((a, b) => a - b);
+        expect(actionNumbers).toEqual([0, 3, 6, 8, 11, 14, 17]);
+        // Pitchnumber children must flow lowest to highest in chain order.
+        const actionNumbersInOrder = actionStack
+            .filter(b => Array.isArray(b[1]) && b[1][0] === "number")
+            .map(b => b[1][1].value);
+        expect(actionNumbersInOrder).toEqual([0, 3, 6, 8, 11, 14, 17]);
+
+        // Second stack: set-temperament + define-mode.
+        const defineStack = mockActivity.blocks.loadNewBlocks.mock.calls[1][0];
+        expect(defineStack[0][1]).toBe("settemperament");
+        expect(defineStack[0][4]).toEqual([null, 1, 2, 3, 4]);
+        expect(defineStack[1][1][0]).toBe("temperamentname");
+        expect(defineStack[1][1][1].value).toBe("equal19");
+        expect(defineStack[2][1][0]).toBe("notename");
+        expect(defineStack[3][1][0]).toBe("number");
+        expect(defineStack[3][1][1].value).toBe(4);
+
+        expect(defineStack[4][1][0]).toBe("definemode");
+        expect(defineStack[4][4]).toEqual([0, 5, 7, 6]);
+        expect(defineStack[5][1][1].value).toBe("my custom mode");
+        const defineNumbers = defineStack
+            .filter(b => Array.isArray(b[1]) && b[1][0] === "number")
+            .map(b => b[1][1].value)
+            .sort((a, b) => a - b);
+        expect(defineNumbers).toEqual([4, 0, 3, 6, 8, 11, 14, 17].sort((a, b) => a - b));
+    });
+
+    test("_save emits an action block and a bare define-mode stack for 12-EDO", () => {
+        global.docById.mockReturnValue({ rows: [{ cells: [{ textContent: "" }] }] });
+        mockActivity.blocks.loadNewBlocks = jest.fn();
+        modeWidget._setTimeout = fn => fn();
+        modeWidget._modeNameInput = { value: "plain major" };
+
+        modeWidget._activeEDO = 12;
+        modeWidget._selectedNotes = Array(12).fill(false);
+        for (const pos of [0, 2, 4, 5, 7, 9, 11]) {
+            modeWidget._selectedNotes[pos] = true;
+        }
+
+        modeWidget._save();
+
+        // Two block stacks: action + define-mode.
+        expect(mockActivity.blocks.loadNewBlocks).toHaveBeenCalledTimes(2);
+
+        // First stack: action block with solfege pitch children.
+        const actionStack = mockActivity.blocks.loadNewBlocks.mock.calls[0][0];
+        expect(actionStack[0][1][0]).toBe("action");
+        expect(actionStack[1][1][0]).toBe("text");
+        expect(actionStack[1][1][1].value).toBe("plain major");
+        expect(actionStack.some(b => b[1] === "pitch")).toBe(true);
+        // Pitches must flow lowest to highest (Do first, Ti last).
+        const solfegeValues = actionStack
+            .filter(b => Array.isArray(b[1]) && b[1][0] === "solfege")
+            .map(b => b[1][1].value);
+        expect(solfegeValues).toEqual(["do", "re", "mi", "fa", "sol", "la", "ti"]);
+
+        // Second stack: define-mode without set-temperament.
+        const defineStack = mockActivity.blocks.loadNewBlocks.mock.calls[1][0];
+        expect(defineStack[0][1][0]).toBe("definemode");
+        expect(defineStack[0][4]).toEqual([null, 1, 3, 2]);
+        expect(defineStack.some(b => Array.isArray(b[1]) && b[1][0] === "settemperament")).toBe(
+            false
+        );
+        const numbers = defineStack
+            .filter(b => Array.isArray(b[1]) && b[1][0] === "number")
+            .map(b => b[1][1].value)
+            .sort((a, b) => a - b);
+        expect(numbers).toEqual([0, 2, 4, 5, 7, 9, 11]);
+    });
+
+    test("_rotateRight does nothing when the wheel is empty", () => {
+        // Regression: with a blank slate (nothing selected), the animation
+        // loop could never terminate because the "first note selected" exit
+        // condition never became true.
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._setTimeout = jest.fn(fn => fn());
+
+        modeWidget._rotateRight();
+
+        expect(modeWidget._locked).toBe(false);
+        expect(modeWidget._setTimeout).not.toHaveBeenCalled();
+    });
+
+    test("_rotateLeft does nothing when the wheel is empty", () => {
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._setTimeout = jest.fn(fn => fn());
+
+        modeWidget._rotateLeft();
+
+        expect(modeWidget._locked).toBe(false);
+        expect(modeWidget._setTimeout).not.toHaveBeenCalled();
+    });
+
+    test("_save does not emit block stacks when the wheel is empty", () => {
+        // Regression: emitting an action block with zero selected notes
+        // referenced a non-existent child-flow block index and crashed
+        // Blocks.loadNewBlocks (blocks.js:5254).
+        modeWidget._selectedNotes = Array(12).fill(false);
+        modeWidget._setTimeout = fn => fn();
+        mockActivity.blocks.loadNewBlocks = jest.fn();
+
+        modeWidget._save();
+
+        expect(mockActivity.errorMsg).toHaveBeenCalled();
+        expect(mockActivity.blocks.loadNewBlocks).not.toHaveBeenCalled();
+    });
+
+    test("_setActiveEDO applies a non-EDO temperament by its unique key", () => {
+        // Regression: dropdown option values used to collide on the integer
+        // step count, so a non-EDO temperament like 1/3 comma meantone (also
+        // 19 steps) was resolved to "equal19".
+        modeWidget._setActiveEDO("1/3 comma meantone");
+
+        expect(mockActivity.logo.setUserTemperament).toHaveBeenCalledWith("1/3 comma meantone");
+        expect(modeWidget._activeEDO).toBe(19);
+        expect(modeWidget._edoSelect.value).toBe("1/3 comma meantone");
     });
 });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -13,8 +13,9 @@
 /* global
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
-   getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
-   normalizeNoteAccidentals,
+   getNote, DEFAULTVOICE, last, slicePath, wheelnav,
+   normalizeNoteAccidentals, parseNoteString, getCurrentEDO, TEMPERAMENT,
+   registerUserMode, getUserModeNames, removeUserMode, NOTESTABLE,
  */
 
 /*
@@ -26,7 +27,9 @@
     - js/utils/platformstyle.js
         platformColor
     - js/utils/musicutils.js
-        keySignatureToMode, MUSICALMODES, getNote, DEFAULTVOICE, NOTESTABLE
+        keySignatureToMode, MUSICALMODES, getNote, DEFAULTVOICE,
+        parseNoteString, getCurrentEDO, TEMPERAMENT, registerUserMode,
+        getUserModeNames, removeUserMode
 
     Dependency Injection Pattern:
     This widget uses dependency injection to reduce implicit global state.
@@ -96,6 +99,7 @@ class ModeWidget {
         this._playing = false;
         this._selectedNotes = [];
         this._newPattern = [];
+        this._activeEDO = 12; // Overridden from the temperament context in _piemenuMode.
 
         const w = window.innerWidth;
         this._cellScale = w / 1200;
@@ -113,14 +117,62 @@ class ModeWidget {
         this.modeTableDiv.style.border = "0px";
         const meterWheelDiv = document.createElement("div");
         meterWheelDiv.id = "meterWheelDiv";
-        const modePianoDiv = document.createElement("div");
-        modePianoDiv.id = "modePianoDiv";
-        modePianoDiv.className = "";
+        const modeNameDiv = document.createElement("div");
+        modeNameDiv.id = "modeNameDiv";
+        modeNameDiv.style.display = "flex";
+        modeNameDiv.style.alignItems = "center";
+        modeNameDiv.style.gap = "8px";
+        modeNameDiv.style.padding = "8px";
+        // Active tuning-system selector. Lists the EDOs defined in
+        // TEMPERAMENT (5, 7, 12, 17, 19, 31) and switches the whole widget
+        // to that many slices, keeping the global temperament in sync so the
+        // preview and the emitted define-mode block agree with the wheel.
+        // Given standard dropdown dimensions (not the bare native square) and
+        // a clear "Tuning:" label.
+        const tuningLabel = document.createElement("label");
+        tuningLabel.htmlFor = "modeEdoSelect";
+        tuningLabel.textContent = _("Tuning:");
+        tuningLabel.style.fontSize = "14px";
+        tuningLabel.style.whiteSpace = "nowrap";
+        const edoSelect = document.createElement("select");
+        edoSelect.id = "modeEdoSelect";
+        edoSelect.title = _("Tuning system (EDO)");
+        edoSelect.style.width = "110px";
+        edoSelect.style.height = "32px";
+        edoSelect.style.padding = "0 8px";
+        edoSelect.style.fontSize = "14px";
+        edoSelect.style.borderRadius = "4px";
+        const modeNameInput = document.createElement("input");
+        modeNameInput.type = "text";
+        modeNameInput.id = "modeNameInput";
+        modeNameInput.placeholder = _("Name Custom Mode");
+        const saveModeButton = document.createElement("button");
+        saveModeButton.id = "saveModeButton";
+        saveModeButton.textContent = _("Save Custom Mode");
+        saveModeButton.onclick = this._save.bind(this);
+        modeNameDiv.replaceChildren(tuningLabel, edoSelect, modeNameInput, saveModeButton);
+        this._modeNameInput = modeNameInput;
+        this._edoSelect = edoSelect;
         const modeTable = document.createElement("table");
         modeTable.id = "modeTable";
-        this.modeTableDiv.replaceChildren(meterWheelDiv, modePianoDiv, modeTable);
+        this.modeTableDiv.replaceChildren(meterWheelDiv, modeNameDiv, modeTable);
 
         this.widgetWindow.getWidgetBody().append(this.modeTableDiv);
+
+        // Saved-modes ledger: a readable, scrollable list at the bottom of
+        // the widget where every registered user mode gets a Load and a
+        // Delete action. Hidden until at least one mode has been saved.
+        const savedModesContainer = document.createElement("div");
+        savedModesContainer.id = "savedModesContainer";
+        savedModesContainer.style.display = "none";
+        savedModesContainer.style.width = "100%";
+        savedModesContainer.style.maxHeight = "150px";
+        savedModesContainer.style.overflowY = "auto";
+        savedModesContainer.style.padding = "8px";
+        savedModesContainer.style.boxSizing = "border-box";
+        savedModesContainer.style.borderTop = "1px solid " + platformColor.selectorBackground;
+        this._savedModesContainer = savedModesContainer;
+        this.widgetWindow.getWidgetBody().append(savedModesContainer);
 
         this.widgetWindow.onclose = () => {
             if (this._timeouts) {
@@ -136,7 +188,9 @@ class ModeWidget {
             this.widgetWindow.destroy();
         };
 
-        this.widgetWindow.onmaximize = this._scale;
+        // Bind _scale so `this` stays the ModeWidget instance when the
+        // WidgetWindow invokes it as onmaximize on header double-click.
+        this.widgetWindow.onmaximize = this._scale.bind(this);
 
         this._playButton = this.widgetWindow.addButton(
             "play-button.svg",
@@ -157,9 +211,6 @@ class ModeWidget {
                 this._playAll();
             }
         };
-
-        this.widgetWindow.addButton("export-chunk.svg", ModeWidget.ICONSIZE, _("Save")).onclick =
-            this._save.bind(this);
 
         this.widgetWindow.addButton("erase-button.svg", ModeWidget.ICONSIZE, _("Clear")).onclick =
             this._clear.bind(this);
@@ -184,6 +235,19 @@ class ModeWidget {
 
         this._piemenuMode();
 
+        // Switching the active EDO rebuilds the wheels with the new slice
+        // count and applies the global temperament so the runtime matches.
+        this._edoSelect.onchange = () => {
+            const key = this._edoSelect.value;
+            const entry = this._getEdoList().find(e => e.key === key);
+            if (entry && Number.isFinite(entry.edo) && entry.edo !== this._activeEDO) {
+                this._setActiveEDO(entry.key);
+            }
+        };
+
+        this._populateEdoSelect();
+        this._renderSavedModes();
+
         const table = docById("modeTable");
 
         // A row for the current mode label
@@ -193,8 +257,12 @@ class ModeWidget {
         cell.textContent = "\u00a0";
         cell.style.backgroundColor = platformColor.selectorBackground;
 
-        // Set current mode in pie menu.
-        this._setMode();
+        // Start from a blank slate: _buildWheels() leaves the note ring fully
+        // unselected, so the wheel only gains steps when the user clicks a
+        // slice or explicitly loads a saved mode via _applyPattern().
+        // (No _setMode() call here — auto-populating the current key's mode
+        // made every slice look preselected, especially for chromatic custom
+        // modes.)
 
         //.TRANS: A circle of notes represents the musical mode.
         activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
@@ -214,6 +282,57 @@ class ModeWidget {
         }, delay);
         this._timeouts.push(id);
         return id;
+    }
+
+    /**
+     * Get the active EDO from the temperament context.
+     *
+     * The wheel renders one slice per scale degree, so every slice count,
+     * loop boundary, and step computation depends on the value returned
+     * here. Falls back to 12 when no temperament is active.
+     *
+     * The temperament name can live in a few places depending on how it was
+     * set: `logo.synth.inTemperament` is the canonical field (kept in sync by
+     * setUserTemperament / the setTemperament action), but the "temperament"
+     * widget block only writes `logo.temperament.inTemperament` until the
+     * user applies it, and `logo._userTemperament` records the last value the
+     * user picked. Consult them in order so the wheel never silently falls
+     * back to 12 slices.
+     *
+     * @private
+     * @returns {number} EDO value (defaults to 12)
+     */
+    _getActiveEDO() {
+        const temperament =
+            this.logo?.synth?.inTemperament ||
+            this.logo?.temperament?.inTemperament ||
+            this.logo?._userTemperament;
+        if (!temperament) return 12;
+
+        const currentEDO =
+            typeof getCurrentEDO === "function"
+                ? getCurrentEDO(temperament)
+                : TEMPERAMENT[temperament]?.pitchNumber || 12;
+        return currentEDO;
+    }
+
+    /**
+     * Get the name of the currently active temperament.
+     *
+     * Mirrors _getActiveEDO's lookup order (logo.synth.inTemperament first,
+     * then the temperament widget block value, then the last user choice) so
+     * the value matches the wheel's slice count. Falls back to "equal".
+     *
+     * @private
+     * @returns {string} the active temperament key
+     */
+    _getActiveTemperament() {
+        return (
+            (this.logo && this.logo.synth && this.logo.synth.inTemperament) ||
+            (this.logo && this.logo.temperament && this.logo.temperament.inTemperament) ||
+            (this.logo && this.logo._userTemperament) ||
+            "equal"
+        );
     }
 
     /**
@@ -251,9 +370,10 @@ class ModeWidget {
      */
     _scale() {
         const windowHeight =
-            this.getWidgetFrame().offsetHeight - this.getDragElement().offsetHeight;
-        const widgetBody = this.getWidgetBody();
-        const scale = this.isMaximized() ? windowHeight / widgetBody.offsetHeight : 1;
+            this.widgetWindow.getWidgetFrame().offsetHeight -
+            this.widgetWindow.getDragElement().offsetHeight;
+        const widgetBody = this.widgetWindow.getWidgetBody();
+        const scale = this.widgetWindow.isMaximized() ? windowHeight / widgetBody.offsetHeight : 1;
         widgetBody.style.display = "flex";
         widgetBody.style.flexDirection = "column";
         widgetBody.style.alignItems = "center";
@@ -261,7 +381,7 @@ class ModeWidget {
         widgetBody.children[0].style.flexDirection = "column";
         widgetBody.children[0].style.alignItems = "center";
 
-        const svg = this.getWidgetBody().getElementsByTagName("svg")[0];
+        const svg = this.widgetWindow.getWidgetBody().getElementsByTagName("svg")[0];
         svg.style.pointerEvents = "none";
         svg.setAttribute("height", `${400 * scale}px`);
         svg.setAttribute("width", `${400 * scale}px`);
@@ -270,129 +390,6 @@ class ModeWidget {
         }, 100);
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
-    _setMode() {
-        // Read in the current mode to start
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        const currentMode = MUSICALMODES[currentModeName[1]];
-
-        // Add the mode name in the bottom row of the table.
-        const table = docById("modeTable");
-        const n = table.rows.length - 1;
-
-        // console.debug(_(currentModeName[1]));
-        const name = currentModeName[0] + " " + _(currentModeName[1]);
-        table.rows[n].cells[0].textContent = name;
-        this.widgetWindow.updateTitle(name);
-
-        // Set the notes for this mode.
-        let k = 0;
-        let j = 0;
-        for (let i = 0; i < 12; i++) {
-            if (i === j) {
-                this._noteWheel.navItems[i].navItem.show();
-                this._selectedNotes[i] = true;
-                j += currentMode[k];
-                k += 1;
-            } else {
-                this._noteWheel.navItems[i].navItem.hide();
-            }
-        }
-
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
-    }
-
-    /**
-     * @private
-     * @returns {void}
-     */
-    _showPiano() {
-        const modePianoDiv = docById("modePianoDiv");
-        modePianoDiv.style.visibility = "visible";
-        modePianoDiv.style.position = "relative";
-        modePianoDiv.style.border = "0px";
-        modePianoDiv.style.top = "0px";
-        modePianoDiv.style.left = "0px";
-        const elements = [];
-
-        const baseImg = document.createElement("img");
-        baseImg.src = "images/piano_keys.png";
-        baseImg.id = "modeKeyboard";
-        baseImg.style.top = "0px";
-        baseImg.style.left = "0px";
-        baseImg.style.position = "relative";
-        elements.push(baseImg);
-
-        this._pianoKeys = [];
-        for (let i = 0; i < 12; i++) {
-            const keyImg = document.createElement("img");
-            keyImg.id = "pkey_" + i;
-            keyImg.style.top = "0px";
-            keyImg.style.left = "0px";
-            keyImg.style.position = "absolute";
-            elements.push(keyImg);
-            this._pianoKeys[i] = keyImg;
-        }
-
-        modePianoDiv.replaceChildren(...elements);
-
-        const highlightImgs = [
-            "images/highlights/sel_c.png",
-            "images/highlights/sel_c_sharp.png",
-            "images/highlights/sel_d.png",
-            "images/highlights/sel_d_sharp.png",
-            "images/highlights/sel_e.png",
-            "images/highlights/sel_f.png",
-            "images/highlights/sel_f_sharp.png",
-            "images/highlights/sel_g.png",
-            "images/highlights/sel_g_sharp.png",
-            "images/highlights/sel_a.png",
-            "images/highlights/sel_a_sharp.png",
-            "images/highlights/sel_b.png"
-        ];
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        const letterName = currentModeName[0];
-
-        const startDict = {
-            "C♭": 11,
-            "C": 0,
-            "C♯": 1,
-            "D♭": 1,
-            "D": 2,
-            "D♯": 3,
-            "E♭": 3,
-            "E": 4,
-            "E♯": 5,
-            "F♭": 4,
-            "F": 5,
-            "F♯": 6,
-            "G♭": 6,
-            "G": 7,
-            "G♯": 8,
-            "A♭": 8,
-            "A": 9,
-            "A♯": 10,
-            "B♭": 10,
-            "B": 11,
-            "B♯": 0
-        };
-        let startingPosition;
-        if (letterName in startDict) {
-            startingPosition = startDict[letterName];
-        } else {
-            startingPosition = 0;
-        }
-
-        for (let i = 0; i < 12; ++i) {
-            if (this._selectedNotes[i])
-                this._pianoKeys[i].src = highlightImgs[(i + startingPosition) % 12];
-        }
-    }
     /**
      * @private
      * @returns {void}
@@ -406,10 +403,6 @@ class ModeWidget {
 
         this._saveState();
         this.__invertOnePair(1);
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
     }
 
     /**
@@ -418,30 +411,25 @@ class ModeWidget {
      * @returns {void}
      */
     __invertOnePair(i) {
+        const N = this._selectedNotes.length;
         const tmp = this._selectedNotes[i];
-        this._selectedNotes[i] = this._selectedNotes[12 - i];
+        this._selectedNotes[i] = this._selectedNotes[N - i];
         if (this._selectedNotes[i]) {
             this._noteWheel.navItems[i].navItem.show();
         } else {
             this._noteWheel.navItems[i].navItem.hide();
         }
 
-        this._selectedNotes[12 - i] = tmp;
-        if (this._selectedNotes[12 - i]) {
-            this._noteWheel.navItems[12 - i].navItem.show();
+        this._selectedNotes[N - i] = tmp;
+        if (this._selectedNotes[N - i]) {
+            this._noteWheel.navItems[N - i].navItem.show();
         } else {
-            this._noteWheel.navItems[12 - i].navItem.hide();
+            this._noteWheel.navItems[N - i].navItem.hide();
         }
 
-        if (i === 5) {
+        if (i === Math.ceil(N / 2) - 1) {
             this._saveState();
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
             this._locked = false;
         } else {
             this._setTimeout(() => {
@@ -473,11 +461,15 @@ class ModeWidget {
         if (this._locked) {
             return;
         }
+        if (!this._selectedNotes.some(Boolean)) {
+            return;
+        }
         this._locked = true;
         this._saveState();
         this._newPattern = [];
-        this._newPattern.push(this._selectedNotes[11]);
-        for (let i = 0; i < 11; i++) {
+        const N = this._selectedNotes.length;
+        this._newPattern.push(this._selectedNotes[N - 1]);
+        for (let i = 0; i < N - 1; i++) {
             this._newPattern.push(this._selectedNotes[i]);
         }
         this.__rotateRightOneCell(1);
@@ -502,12 +494,6 @@ class ModeWidget {
                     // We are done.
                     this._saveState();
                     this._setModeName();
-                    const currentModeName = keySignatureToMode(
-                        this.turtles.ithTurtle(0).singer.keySignature
-                    );
-                    if (currentModeName[0] === "C") {
-                        this._showPiano();
-                    }
                     this._locked = false;
                 } else {
                     // Keep going until first note is selected.
@@ -517,7 +503,7 @@ class ModeWidget {
             }, ModeWidget.ROTATESPEED);
         } else {
             this._setTimeout(() => {
-                this.__rotateRightOneCell((i + 1) % 12);
+                this.__rotateRightOneCell((i + 1) % this._selectedNotes.length);
             }, ModeWidget.ROTATESPEED);
         }
     }
@@ -530,18 +516,21 @@ class ModeWidget {
         if (this._locked) {
             return;
         }
-
+        if (!this._selectedNotes.some(Boolean)) {
+            return;
+        }
         this._locked = true;
 
         this._saveState();
         this._newPattern = [];
-        for (let i = 1; i < 12; i++) {
+        const N = this._selectedNotes.length;
+        for (let i = 1; i < N; i++) {
             this._newPattern.push(this._selectedNotes[i]);
         }
 
         this._newPattern.push(this._selectedNotes[0]);
 
-        this.__rotateLeftOneCell(11);
+        this.__rotateLeftOneCell(N - 1);
     }
 
     /**
@@ -563,12 +552,6 @@ class ModeWidget {
                     // We are done.
                     this._saveState();
                     this._setModeName();
-                    const currentModeName = keySignatureToMode(
-                        this.turtles.ithTurtle(0).singer.keySignature
-                    );
-                    if (currentModeName[0] === "C") {
-                        this._showPiano();
-                    }
                     this._locked = false;
                 } else {
                     // Keep going until first note is selected.
@@ -598,19 +581,20 @@ class ModeWidget {
 
         // Make a list of notes to play
         this._notesToPlay = [];
+        const N = this._selectedNotes.length;
         // Play the mode ascending.
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < N; i++) {
             if (this._selectedNotes[i]) {
                 this._notesToPlay.push(i);
             }
         }
 
         // Include the octave above the starting note.
-        this._notesToPlay.push(12);
+        this._notesToPlay.push(N);
 
         // And then play the mode descending.
-        this._notesToPlay.push(12);
-        for (let i = 11; i > -1; i--) {
+        this._notesToPlay.push(N);
+        for (let i = N - 1; i > -1; i--) {
             if (this._selectedNotes[i]) {
                 this._notesToPlay.push(i);
             }
@@ -628,140 +612,53 @@ class ModeWidget {
      * @returns {void}
      */
     __playNextNote(i) {
-        const highlightImgs = [
-            "images/highlights/sel_c.png",
-            "images/highlights/sel_c_sharp.png",
-            "images/highlights/sel_d.png",
-            "images/highlights/sel_d_sharp.png",
-            "images/highlights/sel_e.png",
-            "images/highlights/sel_f.png",
-            "images/highlights/sel_f_sharp.png",
-            "images/highlights/sel_g.png",
-            "images/highlights/sel_g_sharp.png",
-            "images/highlights/sel_a.png",
-            "images/highlights/sel_a_sharp.png",
-            "images/highlights/sel_b.png"
-        ];
-
-        const animationImgs = [
-            "images/animations/sel_c1.png",
-            "images/animations/sel_c_sharp1.png",
-            "images/animations/sel_d1.png",
-            "images/animations/sel_d_sharp1.png",
-            "images/animations/sel_e1.png",
-            "images/animations/sel_f1.png",
-            "images/animations/sel_f_sharp1.png",
-            "images/animations/sel_g1.png",
-            "images/animations/sel_g_sharp1.png",
-            "images/animations/sel_a1.png",
-            "images/animations/sel_a_sharp1.png",
-            "images/animations/sel_b1.png"
-        ];
-
-        const startingposition = 0;
         const time = this._noteValue + 0.125;
+        const N = this._activeEDO;
 
-        const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
-        if (currentKey === "C") {
-            if (i > this._notesToPlay.length - 1) {
-                this._setTimeout(() => {
-                    // Did we just play the last note?
-                    this._playing = false;
-                    const note_key = this._pianoKeys ? this._pianoKeys[0] : null;
-                    if (note_key !== null) {
-                        note_key.src = highlightImgs[0];
-                    }
-                    this._setPlayButtonIcon("play-button.svg", _("Play all"));
-                    this._resetNotes();
-                    this._locked = false;
-                }, 1000 * time);
-
-                return;
-            }
-
+        if (i > this._notesToPlay.length - 1) {
             this._setTimeout(() => {
-                if (this._lastNotePlayed !== null) {
-                    this._playWheel.navItems[this._lastNotePlayed % 12].navItem.hide();
-                    const note_key = this._pianoKeys
-                        ? this._pianoKeys[this._lastNotePlayed % 12]
-                        : null;
-                    if (note_key !== null) {
-                        note_key.src =
-                            highlightImgs[(this._lastNotePlayed + startingposition) % 12];
-                    }
-                }
-
-                const note = this._notesToPlay[i];
-                this._playWheel.navItems[note % 12].navItem.show();
-
-                if (note !== 12) {
-                    const note_key = this._pianoKeys ? this._pianoKeys[note % 12] : null;
-                    if (note_key !== null) {
-                        note_key.src = animationImgs[(note + startingposition) % 12];
-                    }
-                }
-
-                this._lastNotePlayed = note;
-                const ks = this.turtles.ithTurtle(0).singer.keySignature;
-                const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
-                this.logo.synth.trigger(
-                    0,
-                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-                    this._noteValue,
-                    DEFAULTVOICE,
-                    null,
-                    null
-                );
-
-                if (this._playing) {
-                    this.__playNextNote(i + 1);
-                } else {
-                    this._locked = false;
-                    this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
-                    return;
-                }
+                // Did we just play the last note?
+                this._playing = false;
+                this._setPlayButtonIcon("play-button.svg", _("Play all"));
+                this._resetNotes();
+                this._locked = false;
             }, 1000 * time);
-        } else {
-            if (i > this._notesToPlay.length - 1) {
-                this._setTimeout(() => {
-                    // Did we just play the last note?
-                    this._playing = false;
-                    this._setPlayButtonIcon("play-button.svg", _("Play all"));
-                    this._resetNotes();
-                    this._locked = false;
-                }, 1000 * time);
 
-                return;
-            }
-
-            this._setTimeout(() => {
-                if (this._lastNotePlayed !== null) {
-                    this._playWheel.navItems[this._lastNotePlayed % 12].navItem.hide();
-                }
-
-                const note = this._notesToPlay[i];
-                this._playWheel.navItems[note % 12].navItem.show();
-                this._lastNotePlayed = note;
-
-                const ks = this.turtles.ithTurtle(0).singer.keySignature;
-                const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
-                this.logo.synth.trigger(
-                    0,
-                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-                    this._noteValue,
-                    DEFAULTVOICE,
-                    null,
-                    null
-                );
-                if (this._playing) {
-                    this.__playNextNote(i + 1);
-                } else {
-                    this._locked = false;
-                    this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
-                    return;
-                }
-            }, 1000 * time);
+            return;
         }
+
+        this._setTimeout(() => {
+            if (this._lastNotePlayed !== null) {
+                this._playWheel.navItems[this._lastNotePlayed % N].navItem.hide();
+            }
+
+            const note = this._notesToPlay[i];
+            this._playWheel.navItems[note % N].navItem.show();
+            this._lastNotePlayed = note;
+
+            const ks = this.turtles.ithTurtle(0).singer.keySignature;
+            const noteToPlay = getNote(
+                this._pitch,
+                4,
+                note,
+                ks,
+                false,
+                null,
+                this.errorMsg,
+                this.logo?.synth?.inTemperament,
+                this._activeEDO !== 12
+            );
+            const noteString = normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1];
+            this.logo.synth.trigger(0, noteString, this._noteValue, DEFAULTVOICE, null, null);
+
+            if (this._playing) {
+                this.__playNextNote(i + 1);
+            } else {
+                this._locked = false;
+                this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
+                return;
+            }
+        }, 1000 * time);
     }
 
     /**
@@ -772,15 +669,19 @@ class ModeWidget {
     _playNote(i) {
         const ks = this.turtles.ithTurtle(0).singer.keySignature;
 
-        const noteToPlay = getNote(this._pitch, 4, i, ks, false, null, this.errorMsg);
-        this.logo.synth.trigger(
-            0,
-            normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-            this._noteValue,
-            DEFAULTVOICE,
+        const noteToPlay = getNote(
+            this._pitch,
+            4,
+            i,
+            ks,
+            false,
             null,
-            null
+            this.errorMsg,
+            this.logo?.synth?.inTemperament,
+            this._activeEDO !== 12
         );
+        const noteString = normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1];
+        this.logo.synth.trigger(0, noteString, this._noteValue, DEFAULTVOICE, null, null);
     }
 
     /**
@@ -801,18 +702,12 @@ class ModeWidget {
     _undo() {
         if (this._undoStack.length > 0) {
             const prevState = JSON.parse(this._undoStack.pop());
-            for (let i = 0; i < 12; i++) {
+            for (let i = 0; i < this._selectedNotes.length; i++) {
                 this._selectedNotes[i] = prevState[i];
             }
 
             this._resetNotes();
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         }
     }
 
@@ -825,16 +720,12 @@ class ModeWidget {
 
         this._saveState();
 
-        for (let i = 1; i < 12; i++) {
+        for (let i = 1; i < this._selectedNotes.length; i++) {
             this._selectedNotes[i] = false;
         }
 
         this._resetNotes();
         this._setModeName();
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
     }
 
     /**
@@ -844,7 +735,7 @@ class ModeWidget {
     _calculateMode() {
         const currentMode = [];
         let j = 1;
-        for (let i = 1; i < 12; i++) {
+        for (let i = 1; i < this._selectedNotes.length; i++) {
             if (this._selectedNotes[i]) {
                 currentMode.push(j);
                 j = 1;
@@ -902,122 +793,140 @@ class ModeWidget {
      * @returns {void}
      */
     _save() {
-        const table = docById("modeTable");
-        const n = table.rows.length - 1;
-
-        // If the mode is not in the list, save it as the new custom mode.
-        if (table.rows[n].cells[0].textContent === "") {
-            const customMode = this._calculateMode();
-            // console.debug("custom mode: " + customMode);
-            this.storage.custommode = JSON.stringify(customMode);
+        // An empty wheel would emit an action block whose child-flow
+        // connection points to a block index that does not exist, which
+        // crashes Blocks.loadNewBlocks (blocks.js:5254). Bail instead.
+        if (!this._selectedNotes.some(Boolean)) {
+            this.errorMsg(_("Select at least one note to save a mode."), null);
+            return;
         }
 
-        let modeName = table.rows[n].cells[0].textContent;
-        if (modeName === "") {
-            modeName = _("custom");
+        const inputValue = this._modeNameInput && this._modeNameInput.value;
+        const modeName = (inputValue && inputValue.trim()) || _("custom");
+        const modeKey = modeName.toLowerCase();
+        const pattern = this._calculateMode();
+        const edo = this._activeEDO;
+
+        // Persist the EDO-step pattern so the "custom" mode survives a reload.
+        // Only write when the name field is empty (the unnamed built-in custom
+        // mode) or the mode is explicitly named "custom" so that saving a named
+        // mode (e.g. "blues") does not silently overwrite the persisted pattern.
+        if (!(inputValue && inputValue.trim()) || modeKey === "custom") {
+            this.storage.custommode = JSON.stringify(pattern);
         }
 
-        // Save a stack of pitches to be used with the matrix.
-        let newStack = [
-            [
-                0,
-                [
-                    "action",
-                    {
-                        collapsed: true
-                    }
-                ],
-                150,
-                100,
-                [null, 1, 2, null]
-            ],
-            [
-                1,
-                [
-                    "text",
-                    {
-                        value: modeName
-                    }
-                ],
-                0,
-                0,
-                [0]
-            ]
-        ];
+        // Register the mode in the global dictionary and the user-mode ledger
+        // (mirroring what the define-mode block does at run time) so it shows
+        // up in the saved-modes ledger and survives the widget reopening.
+        MUSICALMODES[modeKey] = pattern;
+        if (typeof registerUserMode === "function") {
+            registerUserMode(modeName);
+        }
+        this._renderSavedModes();
+
+        // Emit an action block so the user can trigger the mode by name.
+        // For 12 EDO the pitches use solfege names (do, re, mi…); for other
+        // EDOs the pitches use raw pitch-number blocks.
+        const actionStack = [];
+
         let previousBlock = 0;
 
-        let modeLength = this._calculateMode().length;
-        let p = 0;
+        if (edo === 12) {
+            // 12-EDO: emit an action block with solfege pitch children.
+            actionStack.push(
+                [0, ["action", { collapsed: true }], 150, 100, [null, 1, 2, null]],
+                [1, ["text", { value: modeName }], 0, 0, [0]]
+            );
 
-        for (let i = 0; i < 12; i++) {
-            // Reverse the order so that Do is last.
-            const j = 11 - i;
-            if (!this._selectedNotes[j]) {
-                continue;
+            const numSelected = this._selectedNotes.filter(Boolean).length;
+            let p = 0;
+
+            for (let j = 0; j < 12; j++) {
+                if (!this._selectedNotes[j]) {
+                    continue;
+                }
+
+                p += 1;
+                const pitch = NOTESTABLE[(j + 1) % 12];
+                const octave = 4;
+
+                const pitchidx = actionStack.length;
+                const notenameidx = pitchidx + 1;
+                const octaveidx = pitchidx + 2;
+
+                if (p === numSelected) {
+                    actionStack.push([
+                        pitchidx,
+                        "pitch",
+                        0,
+                        0,
+                        [previousBlock, notenameidx, octaveidx, null]
+                    ]);
+                } else {
+                    actionStack.push([
+                        pitchidx,
+                        "pitch",
+                        0,
+                        0,
+                        [previousBlock, notenameidx, octaveidx, pitchidx + 3]
+                    ]);
+                }
+                actionStack.push([notenameidx, ["solfege", { value: pitch }], 0, 0, [pitchidx]]);
+                actionStack.push([octaveidx, ["number", { value: octave }], 0, 0, [pitchidx]]);
+                previousBlock = pitchidx;
             }
+        } else {
+            // Non-12 EDO: emit an action block with pitchnumber children
+            // (raw EDO step values). The solfege names only cover 12 notes,
+            // so pitchnumber blocks are used for arbitrary EDOs.
+            actionStack.push(
+                [0, ["action", { collapsed: true }], 150, 100, [null, 1, 2, null]],
+                [1, ["text", { value: modeName }], 0, 0, [0]]
+            );
 
-            p += 1;
-            const pitch = NOTESTABLE[(j + 1) % 12];
-            const octave = 4;
-            // console.debug(pitch + " " + octave);
-
-            const pitchidx = newStack.length;
-            const notenameidx = pitchidx + 1;
-            const octaveidx = pitchidx + 2;
-
-            if (p === modeLength) {
-                newStack.push([
-                    pitchidx,
-                    "pitch",
-                    0,
-                    0,
-                    [previousBlock, notenameidx, octaveidx, null]
-                ]);
-            } else {
-                newStack.push([
-                    pitchidx,
-                    "pitch",
-                    0,
-                    0,
-                    [previousBlock, notenameidx, octaveidx, pitchidx + 3]
-                ]);
-            }
-            newStack.push([
-                notenameidx,
-                [
-                    "solfege",
-                    {
-                        value: pitch
-                    }
-                ],
-                0,
-                0,
-                [pitchidx]
-            ]);
-            newStack.push([
-                octaveidx,
-                [
-                    "number",
-                    {
-                        value: octave
-                    }
-                ],
-                0,
-                0,
-                [pitchidx]
-            ]);
-            previousBlock = pitchidx;
+            this._appendPitchNumberChain(actionStack, 0);
         }
 
-        // Create a new stack for the chunk.
-        // console.debug(newStack);
-        this.blocks.loadNewBlocks(newStack);
+        this.blocks.loadNewBlocks(actionStack);
         this.textMsg(_("New action block generated."), 3000);
 
-        // And save a stack of pitchnumbers to be used with the define mode
-        newStack = [
+        // Emit a define-mode block stack: the mode name comes from the naming
+        // field and the children are the raw EDO pitch numbers selected on the
+        // wheel. For non-12 EDOs the stack is prefixed with a set-temperament
+        // block so the mode carries its own tuning. The pitch numbers are raw
+        // EDO steps, so without it they would be parsed against the project's
+        // current temperament and truncated with an out-of-range warning.
+        const defineStack = [];
+
+        if (edo !== 12) {
+            // Prefer the currently active temperament so a non-EDO tuning
+            // (e.g. 1/3 comma meantone, which also has 19 steps) is not saved
+            // as its equal-division counterpart.
+            const activeKey = this._getActiveTemperament();
+            const temperamentEntry =
+                this._getEdoList().find(e => e.key === activeKey) ||
+                this._getEdoList().find(e => Number.isFinite(e.edo) && e.edo === edo);
+            const temperament = temperamentEntry ? temperamentEntry.key : "equal";
+            const startParsed = parseNoteString(
+                this.logo && this.logo.synth && this.logo.synth.startingPitch
+                    ? this.logo.synth.startingPitch
+                    : "C4"
+            );
+            const pitch = startParsed[0] || "C";
+            const octave = Number.isFinite(startParsed[1]) ? startParsed[1] : 4;
+
+            defineStack.push(
+                [0, "settemperament", 150, 150, [null, 1, 2, 3, 4]],
+                [1, ["temperamentname", { value: temperament }], 0, 0, [0]],
+                [2, ["notename", { value: pitch }], 0, 0, [0]],
+                [3, ["number", { value: octave }], 0, 0, [0]]
+            );
+        }
+
+        const definemodeBlock = defineStack.length;
+        defineStack.push(
             [
-                0,
+                definemodeBlock,
                 [
                     "definemode",
                     {
@@ -1026,10 +935,15 @@ class ModeWidget {
                 ],
                 150,
                 150,
-                [null, 1, 3, 2]
+                [
+                    defineStack.length > 0 ? 0 : null,
+                    definemodeBlock + 1,
+                    definemodeBlock + 3,
+                    definemodeBlock + 2
+                ]
             ],
             [
-                1,
+                definemodeBlock + 1,
                 [
                     "text",
                     {
@@ -1038,49 +952,56 @@ class ModeWidget {
                 ],
                 0,
                 0,
-                [0]
+                [definemodeBlock]
             ],
-            [2, "hidden", 0, 0, [0, null]]
-        ];
-        previousBlock = 0;
+            [definemodeBlock + 2, "hidden", 0, 0, [definemodeBlock, null]]
+        );
+        this._appendPitchNumberChain(defineStack, definemodeBlock);
 
-        modeLength = this._calculateMode().length;
-        p = 0;
+        // Load the define-mode stack only after the action stack has fully
+        // rendered. loadNewBlocks is chunked via requestAnimationFrame, and
+        // loading two stacks in the same tick lets the second call capture a
+        // stale blockOffset/_loadCounter while the first is still mid-load,
+        // so the block indices collide and the stacks render disconnected.
+        this._setTimeout(() => {
+            this.blocks.loadNewBlocks(defineStack);
+        }, 2000);
+    }
 
-        for (let i = 0; i < 12; i++) {
+    /**
+     * Append a chain of pitchnumber blocks, one per selected note, to the
+     * given stack. Each block carries a number child with the raw EDO step
+     * and connects to the previous block in the stack. Returns the index of
+     * the last block appended so callers can chain further blocks onto it.
+     *
+     * @private
+     * @param {Array} stack - the block stack to append to
+     * @param {number} previousBlock - index of the block the first pitchnumber connects to
+     * @returns {number} index of the last appended block
+     */
+    _appendPitchNumberChain(stack, previousBlock) {
+        const numSelected = this._selectedNotes.filter(Boolean).length;
+        let p = 0;
+
+        for (let i = 0; i < this._selectedNotes.length; i++) {
             if (!this._selectedNotes[i]) {
                 continue;
             }
 
             p += 1;
-            const idx = newStack.length;
+            const idx = stack.length;
 
-            if (p === modeLength) {
-                newStack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, null]]);
+            if (p === numSelected) {
+                stack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, null]]);
             } else {
-                newStack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, idx + 2]]);
+                stack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, idx + 2]]);
             }
 
-            newStack.push([
-                idx + 1,
-                [
-                    "number",
-                    {
-                        value: i
-                    }
-                ],
-                0,
-                0,
-                [idx]
-            ]);
+            stack.push([idx + 1, ["number", { value: i }], 0, 0, [idx]]);
             previousBlock = idx;
         }
 
-        // Create a new stack for the chunk.
-        // console.debug(newStack);
-        this._setTimeout(() => {
-            this.blocks.loadNewBlocks(newStack);
-        }, 2000);
+        return previousBlock;
     }
 
     /**
@@ -1092,7 +1013,33 @@ class ModeWidget {
 
         docById("meterWheelDiv").style.display = "";
 
+        // Determine the active EDO from the temperament context. Every slice
+        // count, arc angle (360/N), and loop boundary below is derived from
+        // this value so non-12 EDOs render correctly.
+        this._activeEDO = this._getActiveEDO();
+
+        this._buildWheels(this._activeEDO);
+    }
+
+    /**
+     * Build (or rebuild) the three wheel instances for a given EDO.
+     *
+     * The mode wheel holds one numbered slice per scale degree, the note
+     * wheel shows the selected degrees as "x" markers, and the play wheel is
+     * the playback highlight ring. All three live on the same Raphael paper.
+     *
+     * @private
+     * @param {number} activeEDO - number of slices (scale degrees)
+     * @returns {void}
+     */
+    _buildWheels(activeEDO) {
         // Use advanced constructor for multiple wheelnavs in the same div.
+        // Tear down any previous wheel first: removeWheel removes the shared
+        // Raphael paper (and with it the note/play wheels drawn on top).
+        if (this._modeWheel && typeof this._modeWheel.removeWheel === "function") {
+            this._modeWheel.removeWheel();
+        }
+
         // The meterWheel is used to hold the half steps.
         this._modeWheel = new wheelnav("meterWheelDiv", null, 400, 400);
         // The selected notes are shown on this wheel
@@ -1118,13 +1065,24 @@ class ModeWidget {
         // this._modeWheel.selectedNavItemIndex = 2;
         this._modeWheel.animatetime = 0; // 300;
 
-        const labels = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
-        let noteList = [];
-        for (let i = 0; i < 12; i++) {
-            noteList.push(labels[i]);
+        // ─── 2. Mode wheel: one numbered slice per scale degree ───
+        // wheelnav derives each sector arc angle as 360 / N automatically.
+        //
+        // wheelnav's default titleFont is a fixed 48px, which is far too
+        // large for the two-digit degree labels once N grows past 12 (e.g.
+        // 19-, 21-, or 31-EDO). Scale the font so a two-digit label stays
+        // within its sector arc width at the title radius. The 580 constant
+        // preserves the 48px default for N = 12 and shrinks the font as N
+        // increases; 10px is the readability floor.
+        const modeLabels = [];
+        for (let i = 0; i < activeEDO; i++) {
+            modeLabels.push(String(i));
         }
 
-        this._modeWheel.createWheel(noteList);
+        const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / activeEDO)));
+        this._modeWheel.titleFont = "400 " + titleFontSize + "px Times New Roman";
+
+        this._modeWheel.createWheel(modeLabels);
 
         this._noteWheel.colors = platformColor.noteValueWheelcolors; // modeWheelcolors;
         this._noteWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1137,11 +1095,11 @@ class ModeWidget {
         this._noteWheel.navAngle = -90;
         this._noteWheel.titleRotateAngle = 90;
 
-        noteList = [" "]; // No X on first note, since we don't want to unselect it.
-        this._selectedNotes = [true]; // The first note is always selected.
-        for (let i = 1; i < 12; i++) {
+        // ─── 3. Note wheel: starts blank; root toggled by clicking " " ───
+        const noteList = [" "]; // No X on first note, since we don't want to unselect it.
+        this._selectedNotes = new Array(activeEDO).fill(false);
+        for (let i = 1; i < activeEDO; i++) {
             noteList.push("x");
-            this._selectedNotes.push(false);
         }
 
         this._noteWheel.createWheel(noteList);
@@ -1157,19 +1115,22 @@ class ModeWidget {
         this._playWheel.navAngle = -90;
         this._playWheel.titleRotateAngle = 90;
 
-        noteList = [];
-        for (let i = 0; i < 12; i++) {
-            noteList.push(" ");
+        // ─── 4. Play wheel: playback highlight ring, all slices hidden ───
+        const playNoteList = [];
+        for (let i = 0; i < activeEDO; i++) {
+            playNoteList.push(" ");
         }
 
-        this._playWheel.createWheel(noteList);
+        this._playWheel.createWheel(playNoteList);
 
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < activeEDO; i++) {
             this._playWheel.navItems[i].navItem.hide();
         }
 
-        // If a modeWheel sector is selected, show the corresponding
-        // note wheel sector.
+        // Selecting a scale degree: clicking an (unselected) mode-wheel
+        // sector adds that degree to the mode — the matching "x" appears in
+        // the outer note ring as the persistent selection indicator — and
+        // previews its pitch so the sound matches the wedge that was clicked.
         const __setNote = () => {
             const i = this._modeWheel.selectedNavItemIndex;
             this._saveState();
@@ -1177,15 +1138,11 @@ class ModeWidget {
             this._noteWheel.navItems[i].navItem.show();
             this._playNote(i);
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         };
 
-        // If a noteWheel sector is selected, hide it.
+        // Deselecting a scale degree: clicking the "x" on the outer note ring
+        // removes that degree from the mode. No sound is played so the audio
+        // preview remains associated only with the select action above.
         const __clearNote = () => {
             const i = this._noteWheel.selectedNavItemIndex;
             if (i === 0) {
@@ -1196,20 +1153,242 @@ class ModeWidget {
             this._saveState();
             this._selectedNotes[i] = false;
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         };
 
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < activeEDO; i++) {
             this._modeWheel.navItems[i].navigateFunction = __setNote;
             this._noteWheel.navItems[i].navigateFunction = __clearNote;
-            // Start with all notes hidden.
+            // Start with a blank slate: every slice hidden until it is
+            // selected by the user or a loaded mode.
             this._noteWheel.navItems[i].navItem.hide();
         }
+    }
+
+    /**
+     * Get the EDO systems defined in TEMPERAMENT, sorted ascending.
+     *
+     * Both the "equal*" presets and any user-added EDOs appear here; the
+     * selector is intentionally built from real temperaments rather than a
+     * hardcoded list so unsupported EDOs are never offered.
+     *
+     * @private
+     * @returns {Array<{edo: number, key: string}>}
+     */
+    _getEdoList() {
+        const list = [];
+        for (const key in TEMPERAMENT) {
+            const t = TEMPERAMENT[key];
+            if (!t) continue;
+            // Exclude "custom" - it's a special user-defined temperament
+            if (key === "custom") continue;
+            // Include all temperaments that have a defined pitchNumber or edo
+            // EDO systems have isEDO=true and pitchNumber/edo
+            // Non-EDO systems (just intonation, Pythagorean, meantone) have pitchNumber but isEDO=false
+            const edo = t.pitchNumber || t.edo;
+            if (edo) {
+                list.push({ edo: edo, key: key, isEDO: !!t.isEDO });
+            }
+        }
+
+        return list.sort((a, b) => a.edo - b.edo);
+    }
+
+    /**
+     * @private
+     * @returns {void}
+     */
+    _populateEdoSelect() {
+        this._edoSelect.replaceChildren();
+        for (const entry of this._getEdoList()) {
+            const option = document.createElement("option");
+            option.value = entry.key;
+            // Show "12-EDO" for EDO systems, "Just Intonation (12)" for non-EDO
+            const label = entry.isEDO
+                ? String(entry.edo) + "-EDO"
+                : entry.key + " (" + String(entry.edo) + ")";
+            option.textContent = label;
+            this._edoSelect.append(option);
+        }
+
+        const activeKey = this._getActiveTemperament();
+        const activeEntry = this._getEdoList().find(e => e.key === activeKey);
+        this._edoSelect.value = activeEntry ? activeEntry.key : String(this._activeEDO);
+    }
+
+    /**
+     * Rebuild the saved-modes ledger at the bottom of the widget.
+     *
+     * One row per registered user mode, each with a Load button (applies the
+     * stored step pattern to the wheel) and a Delete button (purges the mode
+     * from memory and the registry). The ledger is hidden while empty.
+     *
+     * @private
+     * @returns {void}
+     */
+    _renderSavedModes() {
+        const names = getUserModeNames();
+        this._savedModesContainer.replaceChildren();
+        if (names.length === 0) {
+            this._savedModesContainer.style.display = "none";
+            return;
+        }
+
+        this._savedModesContainer.style.display = "block";
+
+        const heading = document.createElement("div");
+        heading.textContent = _("Saved Modes");
+        heading.style.fontWeight = "bold";
+        heading.style.fontSize = "14px";
+        heading.style.padding = "0 0 4px 0";
+        this._savedModesContainer.append(heading);
+
+        for (const name of names) {
+            const row = document.createElement("div");
+            row.className = "saved-mode-row";
+            row.style.display = "flex";
+            row.style.alignItems = "center";
+            row.style.justifyContent = "space-between";
+            row.style.gap = "8px";
+            row.style.padding = "4px 8px";
+            row.style.borderTop = "1px solid " + platformColor.selectorBackground;
+
+            const nameLabel = document.createElement("span");
+            nameLabel.textContent = name;
+            nameLabel.style.flex = "1";
+            nameLabel.style.overflow = "hidden";
+            nameLabel.style.textOverflow = "ellipsis";
+            nameLabel.style.whiteSpace = "nowrap";
+
+            const loadButton = document.createElement("button");
+            loadButton.textContent = _("Load");
+            loadButton.title = _("Load mode onto the wheel");
+            loadButton.onclick = () => {
+                const pattern = MUSICALMODES[name];
+                if (pattern) {
+                    this._applyPattern(pattern);
+                }
+            };
+
+            const deleteButton = document.createElement("button");
+            deleteButton.textContent = _("Delete");
+            deleteButton.title = _("Delete mode");
+            deleteButton.onclick = () => this._deleteSavedMode(name);
+
+            row.append(nameLabel, loadButton, deleteButton);
+            this._savedModesContainer.append(row);
+        }
+    }
+
+    /**
+     * Delete a saved mode.
+     *
+     * Removes the mode from the global user-mode registry and from
+     * MUSICALMODES, then re-renders the ledger. Deleting the default "custom"
+     * mode also resets its pattern (in memory and in storage) to a default
+     * chromatic scale so a reload does not resurrect a deleted mode.
+     *
+     * @private
+     * @param {string} name - the mode name to delete
+     * @returns {void}
+     */
+    _deleteSavedMode(name) {
+        if (typeof removeUserMode === "function") {
+            removeUserMode(name);
+        }
+        delete MUSICALMODES[name];
+
+        if (name === "custom") {
+            MUSICALMODES["custom"] = new Array(this._activeEDO).fill(1);
+            this.storage.custommode = JSON.stringify(MUSICALMODES["custom"]);
+        }
+
+        this._renderSavedModes();
+        this._setModeName();
+    }
+
+    /**
+     * Switch the widget to a different EDO.
+     *
+     * Applies the matching temperament globally (via setUserTemperament) so
+     * the wheel slice count, the note preview, and the runtime temperaments
+     * all agree, resets the default custom mode to the new octave division,
+     * rebuilds the wheels, and syncs the "Tuning" dropdown to the new value.
+     * The wheel is left blank: steps are only shown once the user clicks a
+     * slice or loads a saved mode via _applyPattern().
+     *
+     * @private
+     * @param {string|number} keyOrEdo - temperament key (e.g. "equal19") or EDO value
+     * @returns {void}
+     */
+    _setActiveEDO(keyOrEdo) {
+        const edoList = this._getEdoList();
+        const entry =
+            typeof keyOrEdo === "string"
+                ? edoList.find(e => e.key === keyOrEdo)
+                : edoList.find(e => Number.isFinite(e.edo) && e.edo === keyOrEdo);
+        if (!entry) {
+            return;
+        }
+
+        if (this.logo && typeof this.logo.setUserTemperament === "function") {
+            this.logo.setUserTemperament(entry.key);
+        }
+
+        if (MUSICALMODES["custom"] && MUSICALMODES["custom"].length !== entry.edo) {
+            MUSICALMODES["custom"] = new Array(entry.edo).fill(1);
+        }
+
+        this._activeEDO = entry.edo;
+        // For non-EDO temperaments, the wheel geometry uses the pitchNumber
+        // as slice count (e.g., 12 for just intonation, 19 for 1/3 comma meantone).
+        // EDO systems use their natural step count.
+        this._buildWheels(entry.edo);
+        this._populateEdoSelect();
+        this._setModeName();
+    }
+
+    /**
+     * Apply a step pattern (from MUSICALMODES) to the wheel.
+     *
+     * The pattern's steps sum to the EDO it was defined on. Loading a mode
+     * from a different tuning system than the one currently selected forces
+     * the widget over to the mode's EDO first: _setActiveEDO() rebuilds the
+     * wheels for the new slice count, applies the matching global
+     * temperament, and syncs the "Tuning" <select> (via _populateEdoSelect)
+     * before the pattern is drawn onto the note ring.
+     *
+     * @private
+     * @param {Array<number>} pattern - step pattern, e.g. [2, 2, 1, 2, 2, 2, 1]
+     * @returns {void}
+     */
+    _applyPattern(pattern) {
+        const N = pattern.reduce((sum, step) => sum + step, 0);
+        if (N !== this._activeEDO) {
+            this._setActiveEDO(N);
+        }
+
+        // If the mode's EDO is not available in TEMPERAMENT, _setActiveEDO
+        // bails out without rebuilding; keep the previous geometry rather than
+        // drawing onto a wheel of the wrong slice count.
+        if (N !== this._activeEDO) {
+            return;
+        }
+
+        this._selectedNotes = new Array(N).fill(false);
+        let k = 0;
+        let j = 0;
+        for (let i = 0; i < N; i++) {
+            if (i === j) {
+                this._noteWheel.navItems[i].navItem.show();
+                this._selectedNotes[i] = true;
+                j += pattern[k];
+                k += 1;
+            } else {
+                this._noteWheel.navItems[i].navItem.hide();
+            }
+        }
+
+        this._setModeName();
     }
 }
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1019,6 +1019,9 @@ class ModeWidget {
         this._activeEDO = this._getActiveEDO();
 
         this._buildWheels(this._activeEDO);
+
+        // Context Pre-load: read mode string from block context and apply pattern
+        this._loadModeFromBlockContext();
     }
 
     /**
@@ -1098,6 +1101,8 @@ class ModeWidget {
         // ─── 3. Note wheel: starts blank; root toggled by clicking " " ───
         const noteList = [" "]; // No X on first note, since we don't want to unselect it.
         this._selectedNotes = new Array(activeEDO).fill(false);
+        // Note 0 (the tonic) is always part of the mode: it can never be toggled off.
+        this._selectedNotes[0] = true;
         for (let i = 1; i < activeEDO; i++) {
             noteList.push("x");
         }
@@ -1133,6 +1138,9 @@ class ModeWidget {
         // previews its pitch so the sound matches the wedge that was clicked.
         const __setNote = () => {
             const i = this._modeWheel.selectedNavItemIndex;
+            if (i === 0) {
+                return; // Note 0 is always locked - cannot be toggled off.
+            }
             this._saveState();
             this._selectedNotes[i] = true;
             this._noteWheel.navItems[i].navItem.show();
@@ -1321,6 +1329,13 @@ class ModeWidget {
      * @returns {void}
      */
     _setActiveEDO(keyOrEdo) {
+        // EDO Switch Mapping: cache the current interval array, set new EDO,
+        // and map selected positions proportionally.
+        const oldEDO = this._activeEDO;
+        const oldSelectedNotes = this._selectedNotes
+            ? this._selectedNotes.slice()
+            : new Array(12).fill(false);
+
         const edoList = this._getEdoList();
         const entry =
             typeof keyOrEdo === "string"
@@ -1342,6 +1357,18 @@ class ModeWidget {
         // For non-EDO temperaments, the wheel geometry uses the pitchNumber
         // as slice count (e.g., 12 for just intonation, 19 for 1/3 comma meantone).
         // EDO systems use their natural step count.
+        // Proportionally map the previously selected notes to the new EDO.
+        const newSelectedNotes = new Array(this._activeEDO).fill(false);
+        for (let i = 0; i < Math.min(oldSelectedNotes.length, this._activeEDO); i++) {
+            if (oldSelectedNotes[i]) {
+                const newPos = Math.round((i * this._activeEDO) / oldEDO);
+                if (newPos < this._activeEDO) {
+                    newSelectedNotes[newPos] = true;
+                }
+            }
+        }
+        this._selectedNotes = newSelectedNotes;
+
         this._buildWheels(entry.edo);
         this._populateEdoSelect();
         this._setModeName();
@@ -1390,6 +1417,34 @@ class ModeWidget {
 
         this._setModeName();
     }
+
+    /**
+     * Pre-load the mode pattern from the block context that launched the
+     * widget.
+     *
+     * When the widget is opened from a "set key [C] mode [jazz minor]"
+     * block (via the "custom" slice of the mode pie menu), the mode name
+     * is passed along by the launcher so the wheel is populated with the
+     * current steps and the mode-name input is pre-filled.
+     *
+     * @private
+     * @returns {void}
+     */
+    _loadModeFromBlockContext() {
+        const mode = this._deps.mode || this._modeBlock;
+        if (mode && MUSICALMODES[mode]) {
+            this._applyPattern(MUSICALMODES[mode]);
+        }
+    }
+
+    /**
+     * Apply a step pattern (from MUSICALMODES) to the wheel.
+     *
+     * The pattern's steps sum to the EDO it was defined on. Loading a mode
+     * from a different tuning system than the one currently selected forces
+     * the widget over to the mode's EDO first: _setActiveEDO() rebuilds the
+     * wheels for the new slice count, applies the matching global
+     */
 }
 
 if (typeof module !== "undefined") {


### PR DESCRIPTION
This PR adds N‑slice and 19‑EDO support to ModeWidget, updates the tuning UI, cleans up ~430 lines of legacy 12‑slice code, and fixes five regressions in payload generation, storage, and audio logging.

All changes are in one PR to keep the test suite intact across the widget ecosystem.

What's new:

- N‑slice architecture – the mode wheel, pattern generation, and action stack now handle any number of slices.
- Tuning dropdown – uses key‑based lookup (equal12, equal19, just intonation) instead of raw integers.
- Saved modes – added naming input, save button, and in‑memory management (_renderSavedModes, _deleteSavedMode).
- Legacy removal – dumped hardcoded 12‑slice logic, _showPiano, and old _setMode routines.

PartOf: #7171 

testFile: 
[scalarAndBuilderMode.html](https://github.com/user-attachments/files/31028141/scalarAndBuilderMode.html)

PR Category
 
- [x] Feature
- [ ] Tests
- [ ] Bug Fix
- [ ] Performance
- [ ] Documentation

-> Making your own mode:

1. Open the Mode Widget (launcher icon or radial menu).
2. Choose your tuning from the dropdown – 12‑EDO, 19‑EDO, just intonation, Pythagorean, whatever you want.
3. Click the slices on the wheel to pick the notes for your scale.
4. Type a name (e.g., my-scale) and click Save Custom Mode.
5. Two stacks appear on the canvas: an Action Stack you can play, and a Define Stack that registers the macro (it shows up after a couple of seconds).

2 Example test :-

1. 12-EDO basics
Pick 12-EDO, select intervals 0, 2, 4, 5, 7, 9, 11.
Save, then click the Action Stack block.
Should play notes in order – C₄ up to B₄.

2. 19-EDO microtonal
Switch to 19-EDO, pick 0, 2, 5, 7, 9, 12, 13, 15, 17.
Save and check the canvas.