### PR TITLE
Fix crash when loading a text block valued __proto__ in Blocks.loadNewBlocks

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -629,6 +629,25 @@ describe("Blocks Foundation", () => {
             expect(flagDuringLoad).toBe(true);
         });
 
+        it("loads a text block valued '__proto__' without throwing", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.protoBlockDict = {
+                text: { style: "value", hasCapability: () => false }
+            };
+            blocks.newStorein2Block = jest.fn();
+            blocks.newNamedboxBlock = jest.fn();
+            blocks.setActionProtoVisibility = jest.fn();
+            blocks._processOneBlock = jest.fn();
+            blocks.customTemperamentDefined = true;
+
+            // Legacy (pre-value-object) text block shape, still accepted for
+            // backward compatibility and reachable via pasted project JSON.
+            const blockObjs = [[0, ["text", "__proto__"], 0, 0, [null]]];
+
+            expect(() => blocks.loadNewBlocks(blockObjs)).not.toThrow();
+        });
+
         it("resets _suppressRefresh on circular connection early return", () => {
             const blocks = new Blocks(mockActivity);
             blocks.blockList = [];

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4846,7 +4846,7 @@ class Blocks {
 
                 /** Don't make duplicate action names. */
                 /** Add a palette entry for any new storein blocks. */
-                const stringValues = {}; /** label: [blocks with that label] */
+                const stringValues = Object.create(null); /** label: [blocks with that label] */
                 const actionNames = {}; /** action block: label block */
                 const storeinNames = {}; /** storein block: label block */
                 const doNames = {}; /** do block: label block, nameddo block value */


### PR DESCRIPTION
## Description

`loadNewBlocks()` in `js/blocks.js` builds a lookup, `stringValues`, to track which blocks share a given text label while scanning pasted or loaded block data. It's a plain object (`{}`) keyed directly by the label content, with no sanitization. A text block valued exactly `__proto__` resolves `stringValues[key]` to `Object.prototype` instead of `undefined`, so the code proceeds to call `.push()` on `Object.prototype`, which throws.

This is reachable through the paste-blocks feature (`Activity.pasted()` parses clipboard JSON with no shape validation and passes it straight to `loadNewBlocks()`), and through legacy-format project files, which the codebase still accepts for backward compatibility alongside the modern text block shape. It is not reachable through normal in-app text block editing, since the live UI always saves the modern `{ value: "..." }` shape.

This PR switches `stringValues` to `Object.create(null)`, so it has no prototype chain and `__proto__` becomes an ordinary key like any other.

## Related Issue

This PR fixes #8039 

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior

## Changes Made

-   Changed `const stringValues = {}` to `const stringValues = Object.create(null)` in `loadNewBlocks()` (`js/blocks.js`).
-   Checked the three sibling lookup objects declared on the same lines, `actionNames`, `storeinNames`, `doNames`, they're keyed by loop index and valued by numeric connection indices, not by label strings, so they don't share this risk and were left untouched.
-   Added a regression test in `js/__tests__/blocks.test.js`, in the existing `_suppressRefresh during loading` describe block, asserting that a text block valued `__proto__` loads without throwing.

## Testing Performed

-   Reproduced the crash live in the browser via the paste-blocks feature before fixing, confirmed the console error matched the one described in the linked issue exactly.
-   Wrote a regression test against the real `loadNewBlocks()` and confirmed it fails with the exact same `TypeError: stringValues[key].push is not a function` on the unfixed source.
-   Applied the fix, reran the same test, confirms it passes.
-   Ran the full `_suppressRefresh during loading` describe block (6 tests) to confirm nothing else in that block broke.
-   Verified `node --check js/blocks.js` passes.
-   Ran `npx eslint` and `npx prettier --check` on both changed files, clean.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

`stringValues` is write-only within `loadNewBlocks`, it's populated but never read back later in the function, so this fix only needed to stop the crash, not preserve any downstream read behavior. Happy to also harden the other three lookup objects as defense-in-depth if reviewers would rather have all four use `Object.create(null)` for consistency, even though only `stringValues` is currently reachable with an attacker-controlled key.