### PR TITLE
fix(bug): resolve piemenuNumber bounds and rotation bugs

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -9,14 +9,18 @@
  * (at your option) any later version.
  */
 
-const { piemenuPitches } = require("../piemenus");
+const { piemenuPitches, piemenuNumber } = require("../piemenus");
 
 // Mock Globals
 global.docById = jest.fn().mockReturnValue({
     style: { display: "", opacity: "" },
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    getBoundingClientRect: jest.fn().mockReturnValue({ x: 0, y: 0 })
+    getBoundingClientRect: jest.fn().mockReturnValue({ x: 0, y: 0 }),
+    replaceChildren: jest.fn(),
+    classList: { add: jest.fn(), remove: jest.fn() },
+    value: "",
+    focus: jest.fn()
 });
 global.document = {
     getElementById: global.docById,
@@ -117,7 +121,10 @@ describe("piemenus behavioral tests", () => {
             updateCache: jest.fn(),
             text: { text: "" },
             value: "",
-            name: "notename"
+            name: "notename",
+            _exitKeyPressed: jest.fn(),
+            _labelChanged: jest.fn(),
+            _usePieNumberC1: jest.fn().mockReturnValue(false)
         };
         jest.clearAllMocks();
     });
@@ -257,7 +264,12 @@ describe("piemenus behavioral tests", () => {
             }
             return {
                 style: { display: "" },
-                contains: jest.fn().mockReturnValue(false)
+                contains: jest.fn().mockReturnValue(false),
+                replaceChildren: jest.fn(),
+                classList: { add: jest.fn(), remove: jest.fn() },
+                value: "",
+                addEventListener: jest.fn(),
+                focus: jest.fn()
             };
         });
 
@@ -285,5 +297,57 @@ describe("piemenus behavioral tests", () => {
         expect(mockNavigate).toHaveBeenCalled();
 
         jest.useRealTimers();
+    });
+
+    describe("piemenuNumber behavioral tests", () => {
+        beforeEach(() => {
+            mockBlock.protoblock = { scale: 1 };
+        });
+
+        test("selects the closest valid value when selectedValue is outside wheelValues", () => {
+            const wheelValues = [1, 2, 3, 4, 5, 6, 7, 8];
+            piemenuNumber(mockBlock, wheelValues, 10);
+
+            expect(mockBlock._numberWheel.navigateWheel).toHaveBeenCalledWith(7);
+        });
+
+        test("selects the closest valid value for float selectedValue", () => {
+            const wheelValues = [1, 2, 3, 4, 5, 6, 7, 8];
+            piemenuNumber(mockBlock, wheelValues, 3.7);
+
+            expect(mockBlock._numberWheel.navigateWheel).toHaveBeenCalledWith(3);
+        });
+
+        test("decrements value and updates navigation on minus button click", () => {
+            const wheelValues = [1, 2, 3, 4, 5, 6, 7, 8];
+            piemenuNumber(mockBlock, wheelValues, 5); // Index 4
+
+            const minusNavigate = mockBlock._exitWheel.navItems[1].navigateFunction;
+
+            mockBlock.value = 5;
+            mockBlock._numberWheel.navItems[3].navigateFunction = jest.fn();
+
+            minusNavigate();
+
+            expect(mockBlock.value).toBe(4);
+            expect(mockBlock.label.value).toBe(4);
+            expect(mockBlock._numberWheel.navigateWheel).toHaveBeenCalledWith(3);
+        });
+
+        test("increments value and updates navigation on plus button click", () => {
+            const wheelValues = [1, 2, 3, 4, 5, 6, 7, 8];
+            piemenuNumber(mockBlock, wheelValues, 5); // Index 4
+
+            const plusNavigate = mockBlock._exitWheel.navItems[2].navigateFunction;
+
+            mockBlock.value = 5;
+            mockBlock._numberWheel.navItems[5].navigateFunction = jest.fn();
+
+            plusNavigate();
+
+            expect(mockBlock.value).toBe(6);
+            expect(mockBlock.label.value).toBe(6);
+            expect(mockBlock._numberWheel.navigateWheel).toHaveBeenCalledWith(5);
+        });
     });
 });

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -2214,13 +2214,18 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
         (Math.round(selectorWidth * block.blocks.blockScale) * block.protoblock.scale) / 2 + "px";
     // Navigate to a the current number value.
     let i = wheelValues.indexOf(selectedValue);
-    if (i === -1 || selectedValue < 1 || selectedValue > 8) {
-        selectedValue = Math.min(Math.max(selectedValue, 1), 8);
-        i = wheelValues.indexOf(selectedValue);
-    }
-    // In case of float value, navigate to the nearest integer within the range
-    if (selectedValue % 1 !== 0) {
-        selectedValue = Math.min(Math.max(Math.floor(selectedValue + 0.5), 1), 8);
+    if (i === -1) {
+        // Find the closest valid value from the wheelValues array
+        let closest = wheelValues[0];
+        let minDiff = Math.abs(selectedValue - closest);
+        for (let j = 1; j < wheelValues.length; j++) {
+            const diff = Math.abs(selectedValue - wheelValues[j]);
+            if (diff < minDiff) {
+                minDiff = diff;
+                closest = wheelValues[j];
+            }
+        }
+        selectedValue = closest;
         i = wheelValues.indexOf(selectedValue);
     }
     if (i !== -1) {
@@ -2262,6 +2267,12 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
         that.label.value = that.value;
+
+        const newIndex = wheelValues.indexOf(that.value);
+        const navFunc = that._numberWheel.navItems[newIndex].navigateFunction;
+        that._numberWheel.navItems[newIndex].navigateFunction = null;
+        that._numberWheel.navigateWheel(newIndex);
+        that._numberWheel.navItems[newIndex].navigateFunction = navFunc;
     };
 
     block._exitWheel.navItems[2].navigateFunction = () => {
@@ -2284,6 +2295,12 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
         that.container.setChildIndex(that.text, that.container.children.length - 1);
         that.updateCache();
         that.label.value = that.value;
+
+        const newIndex = wheelValues.indexOf(that.value);
+        const navFunc = that._numberWheel.navItems[newIndex].navigateFunction;
+        that._numberWheel.navItems[newIndex].navigateFunction = null;
+        that._numberWheel.navigateWheel(newIndex);
+        that._numberWheel.navItems[newIndex].navigateFunction = navFunc;
     };
 
     const __pitchPreviewForNum = () => {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4469,5 +4469,5 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches };
+    module.exports = { piemenuPitches, piemenuNumber };
 }


### PR DESCRIPTION
## Description

This PR fixes two significant bugs within the `piemenuNumber` function that affected all generic number-based pie menus (such as Volume, Panning, BPM, Pen Size, Angles, etc.):

1. **Initial Highlight Bounds Bug:** The pie menu used to check if `selectedValue < 1 || selectedValue > 8` and forcibly clamp values outside that range (like `80`) to `8`. Because `8` wouldn't exist in arrays like `[0, 10, ... 100]`, the menu would default to highlighting the `0`th slice upon opening. This PR removes those hardcoded octave checks and replaces them with a dynamic `closest-value` snapping algorithm that respects the actual numbers provided in `wheelValues`. As a bonus, this also fixes a secondary bug where valid decimal values (like `1.5` in ADSR envelopes) were forcibly rounded to integers.
2. **Unresponsive Rotation Bug:** When clicking the inner `+` or `-` buttons, the block's text would update, but the outer pie menu UI would fail to rotate. Adding a call to `navigateWheel()` fixed the rotation.


## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Removed hardcoded `1` and `8` boundary checks from `piemenuNumber` initialization.
- Replaced `Math.floor()` decimal stripping logic with a dynamic `closest valid value` fallback algorithm.
- Added a `newIndex` resolution block to `navItems[1]` (decrement) and `navItems[2]` (increment) button click handlers.
- Safely invoked `that._numberWheel.navigateWheel(newIndex)` to sync the UI rotation with the updated block state.

## Clip 
[Screencast from 2026-08-13 17-47-39.webm](https://github.com/user-attachments/assets/c9691ec0-a374-49da-9764-3d0c7f2627a0)


## Testing Performed

- Attached a `number` block set to "80" into the "set master volume" block. Verified that clicking the number block successfully opens the pie menu with the `80` slice highlighted (previously highlighted `0`).
- Clicked the `+` and `-` buttons in the center of the pie menu and verified that the outer ring smoothly rotates to match the newly incremented/decremented value without exiting the menu.
- Ran the full test suite (`npm test`) to ensure the closest-value logic did not introduce regressions to existing octave or time-signature behaviors.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [x] I have addressed the code review feedback from the previous submission, if applicable.
