### PR TITLE
perf: replace array for...in loops with for...of loops

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -9,7 +9,7 @@
  * (at your option) any later version.
  */
 
-const { piemenuPitches } = require("../piemenus");
+const { piemenuPitches, piemenuKey } = require("../piemenus");
 
 // Mock Globals
 global.docById = jest.fn().mockReturnValue({
@@ -30,7 +30,8 @@ global.window = {
 };
 global.wheelnav = jest.fn().mockImplementation(function (div) {
     const mockWheel = this;
-    this.navItems = Array.from({ length: 20 }, () => ({
+    this.id = div;
+    this.navItems = Array.from({ length: 30 }, () => ({
         title: "",
         enabled: true,
         navItem: { hide: jest.fn(), show: jest.fn() },
@@ -91,6 +92,11 @@ global.DEFAULTVOICE = "sine";
 global.PREVIEWVOLUME = 0.5;
 global.getNote = jest.fn().mockReturnValue(["C", 4]);
 global.buildScale = jest.fn(() => [["C", "D", "E", "F", "G", "A", "B", "C"], []]);
+
+global.DEFAULTVOLUME = 0.5;
+global.Singer = { setSynthVolume: jest.fn() };
+global.SHARP = "♯";
+global.FLAT = "♭";
 
 describe("piemenus behavioral tests", () => {
     let mockBlock;
@@ -285,5 +291,56 @@ describe("piemenus behavioral tests", () => {
         expect(mockNavigate).toHaveBeenCalled();
 
         jest.useRealTimers();
+    });
+});
+
+describe("piemenuKey behavioral tests", () => {
+    let mockActivity;
+
+    beforeEach(() => {
+        mockActivity = {
+            blocks: {
+                blockList: { length: 2 },
+                findStacks: jest.fn(),
+                stackList: [],
+                _makeNewBlockWithConnections: jest.fn(),
+                adjustExpandableClampBlock: jest.fn()
+            },
+            logo: {
+                blocks: {
+                    blockList: { length: 2 }
+                },
+                synth: new global.Synth()
+            },
+            KeySignatureEnv: ["C", "major", false],
+            storage: {},
+            textMsg: jest.fn(),
+            turtles: { ithTurtle: jest.fn().mockReturnValue({ singer: { instrumentNames: [] } }) }
+        };
+        global.event = { clientX: 100, clientY: 100 };
+        jest.clearAllMocks();
+    });
+
+    test("generates setkey blocks correctly when exiting and no setkey exists", () => {
+        // Prepare blockList to trigger the for...of loops
+        mockActivity.blocks.blockList = {
+            0: { name: "start", connections: [null, 1] },
+            1: { name: "action", connections: [0] },
+            length: 2
+        };
+        // The start block is at index 0
+        mockActivity.blocks.stackList = [0];
+
+        piemenuKey(mockActivity);
+
+        // Find the exitWheel instance created in piemenuKey
+        const exitWheel = global.wheelnav.mock.instances.find(w => w.id === "exitWheel");
+        expect(exitWheel).toBeDefined();
+
+        // Trigger __exitMenu which calls __generateSetKeyBlocks
+        exitWheel.navItems[0].navigateFunction();
+
+        // Verify that blocks were created
+        expect(mockActivity.blocks._makeNewBlockWithConnections).toHaveBeenCalled();
     });
 });

--- a/js/palette.js
+++ b/js/palette.js
@@ -1946,12 +1946,8 @@ class Palette {
         const __myCallback = newBlock => {
             // Move the drag group under the cursor.
             this.activity.blocks.findDragGroup(newBlock);
-            for (const i in this.activity.blocks.dragGroup) {
-                this.activity.blocks.moveBlockRelative(
-                    this.activity.blocks.dragGroup[i],
-                    saveX,
-                    saveY
-                );
+            for (const blockId of this.activity.blocks.dragGroup) {
+                this.activity.blocks.moveBlockRelative(blockId, saveX, saveY);
             }
             // Dock with other blocks if needed
             this.activity.blocks.blockMoved(newBlock);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -4082,14 +4082,14 @@ const piemenuKey = activity => {
             stacks.sort();
             let connectionsSetKey;
             let movable;
-            for (const i in stacks) {
-                if (activity.blocks.blockList[stacks[i]].name === "start") {
-                    const bottomBlock = activity.blocks.blockList[stacks[i]].connections[1];
+            for (const stackId of stacks) {
+                if (activity.blocks.blockList[stackId].name === "start") {
+                    const bottomBlock = activity.blocks.blockList[stackId].connections[1];
                     if (activity.KeySignatureEnv[2]) {
                         activity.blocks._makeNewBlockWithConnections(
                             "movable",
                             0,
-                            [stacks[i], null, null],
+                            [stackId, null, null],
                             null,
                             null
                         );
@@ -4105,7 +4105,7 @@ const piemenuKey = activity => {
                             activity.blocks.blockList.length - 1;
                         connectionsSetKey = [movable, null, null, bottomBlock];
                     } else {
-                        connectionsSetKey = [stacks[i], null, null, bottomBlock];
+                        connectionsSetKey = [stackId, null, null, bottomBlock];
                     }
 
                     activity.blocks._makeNewBlockWithConnections(
@@ -4120,10 +4120,10 @@ const piemenuKey = activity => {
                     activity.blocks.blockList[bottomBlock].connections[0] = setKey;
 
                     if (activity.KeySignatureEnv[2]) {
-                        activity.blocks.blockList[stacks[i]].connections[1] = movable;
+                        activity.blocks.blockList[stackId].connections[1] = movable;
                         activity.blocks.blockList[movable].connections[2] = setKey;
                     } else {
-                        activity.blocks.blockList[stacks[i]].connections[1] = setKey;
+                        activity.blocks.blockList[stackId].connections[1] = setKey;
                     }
 
                     activity.blocks.adjustExpandableClampBlock();

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -2245,7 +2245,6 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
     block._exitWheel.navItems[1].navigateFunction = () => {
         const index = wheelValues.indexOf(that.value);
         if (index === -1) return;
-
         const isAscending = wheelValues[0] < wheelValues[wheelValues.length - 1];
 
         if (isAscending) {
@@ -4452,5 +4451,5 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches };
+    module.exports = { piemenuPitches, piemenuKey };
 }


### PR DESCRIPTION
## Description

This PR replaces inefficient `for...in` loops iterating over arrays with modern `for...of` loops in `js/palette.js` and `js/piemenus.js`. This resolves one of the current performance bottlenecks by avoiding enumeration of the entire prototype chain and prevents potential prototype pollution issues.

## Related Issue

N/A

## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Replaced `for (const i in this.activity.blocks.dragGroup)` with `for (const blockId of this.activity.blocks.dragGroup)` in `js/palette.js`.
-   Replaced `for (const i in stacks)` with `for (const stackId of stacks)` in `js/piemenus.js`.

## Testing Performed

-   Ran `npm run lint` successfully with no errors.
-   Ran unit tests successfully (`npm test`).
---

