### PR TITLE
feat(utils): add shorthand 3-digit hex color support to hexToRGB

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -240,8 +240,16 @@ describe("Utility Logic Functions", () => {
             expect(hexToRGB("00ff00")).toEqual({ r: 0, g: 255, b: 0 });
         });
 
-        it("returns null for invalid hex", () => {
+        it("converts shorthand 3-digit hex to rgb object", () => {
+            expect(hexToRGB("#fff")).toEqual({ r: 255, g: 255, b: 255 });
+            expect(hexToRGB("f00")).toEqual({ r: 255, g: 0, b: 0 });
+            expect(hexToRGB("#0f0")).toEqual({ r: 0, g: 255, b: 0 });
+        });
+
+        it("returns null for invalid hex or non-string inputs", () => {
             expect(hexToRGB("#zzz")).toBeNull();
+            expect(hexToRGB(null)).toBeNull();
+            expect(hexToRGB(123)).toBeNull();
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -538,14 +538,25 @@ var rgbToHex = (r, g, b) => {
  * Converts a hexadecimal color code to RGB values.
  */
 var hexToRGB = hex => {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result
-        ? {
-              r: parseInt(result[1], 16),
-              g: parseInt(result[2], 16),
-              b: parseInt(result[3], 16)
-          }
-        : null;
+    if (typeof hex !== "string") return null;
+    const cleanHex = hex.trim();
+    const fullResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(cleanHex);
+    if (fullResult) {
+        return {
+            r: parseInt(fullResult[1], 16),
+            g: parseInt(fullResult[2], 16),
+            b: parseInt(fullResult[3], 16)
+        };
+    }
+    const shortResult = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(cleanHex);
+    if (shortResult) {
+        return {
+            r: parseInt(shortResult[1] + shortResult[1], 16),
+            g: parseInt(shortResult[2] + shortResult[2], 16),
+            b: parseInt(shortResult[3] + shortResult[3], 16)
+        };
+    }
+    return null;
 };
 
 /**


### PR DESCRIPTION
## Description

Enhances `hexToRGB()` in `js/utils/utils-logic.js` to support CSS shorthand 3-character hexadecimal color strings (such as `#fff`, `#f00`, `0f0`).

Previously, `hexToRGB()` used a regular expression that strictly matched 6-digit hex strings (`/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i`). Passing a valid CSS 3-digit shorthand hex code like `#fff` or `#f00` returned `null`. This change expands color parsing capability while preserving full backward compatibility.

## Related Issue

N/A

## PR Category

- [x] Feature — Adds new functionality
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/utils/utils-logic.js`**:
  - Updated `hexToRGB()` to parse both 6-character hex strings (`#ff0000`) and 3-character shorthand hex strings (`#f00` -> `{ r: 255, g: 0, b: 0 }`).
- **`js/utils/__tests__/utils-logic.test.js`**:
  - Added unit test cases verifying 3-character shorthand hex code expansion and non-string/invalid input fallback to `null`.

## Testing Performed

- Ran local Jest test suite: `npx jest js/utils/__tests__/utils-logic.test.js --coverage=false` (51/51 passed).
- Ran ESLint: `npx eslint js/utils/utils-logic.js js/utils/__tests__/utils-logic.test.js` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
