### PR TITLE
fix(sampler): dispose Tone.Analyser nodes and detach file input listener on close

### DIFF
--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -29,7 +29,8 @@ global.cancelAnimationFrame = jest.fn();
 global.setTimeout = setTimeout;
 global.Tone = {
     Analyser: jest.fn(() => ({
-        connect: jest.fn()
+        connect: jest.fn(),
+        dispose: jest.fn()
     }))
 };
 global.requestAnimationFrame = jest.fn(() => 1);
@@ -771,6 +772,57 @@ describe("Sampler Widget", () => {
 
             await widget._tunerBtn.onclick();
             expect(mockActivity.logo.synth.startTuner).toHaveBeenCalledTimes(2);
+        });
+
+        test("onclose disposes the pitch analysers and disconnects the synths", () => {
+            widget.init(mockActivity, 1);
+            widget.originalSampleName = "test";
+            global.instruments[0] = {
+                "electronic synth": { connect: jest.fn(), disconnect: jest.fn() },
+                "customsample_test": { connect: jest.fn(), disconnect: jest.fn() }
+            };
+
+            widget.reconnectSynthsToAnalyser();
+            const analysers = Object.values(widget.pitchAnalysers);
+            expect(analysers).toHaveLength(2);
+
+            widgetWindow.onclose();
+
+            for (const analyser of analysers) {
+                expect(analyser.dispose).toHaveBeenCalled();
+                expect(global.instruments[0]["electronic synth"].disconnect).toHaveBeenCalledWith(
+                    analyser
+                );
+                expect(global.instruments[0].customsample_test.disconnect).toHaveBeenCalledWith(
+                    analyser
+                );
+            }
+            expect(widget.pitchAnalysers).toEqual({});
+        });
+
+        test("upload button does not stack change listeners when the picker is cancelled", () => {
+            widget.init(mockActivity, 1);
+            const uploadButton = widgetWindow._buttons.find(btn => btn.tip === "Upload sample");
+            const fileChooser = docById("myOpenAll");
+            Object.defineProperty(fileChooser, "files", {
+                value: [{ name: "sample.wav" }]
+            });
+            fileChooser.focus = jest.fn();
+            fileChooser.click = jest.fn();
+            window.scroll = jest.fn();
+            widget.handleFiles = jest.fn();
+
+            // Two clicks with a cancel in between must leave only one listener.
+            uploadButton.onclick();
+            uploadButton.onclick();
+            fileChooser.dispatchEvent(new Event("change"));
+            expect(widget.handleFiles).toHaveBeenCalledTimes(1);
+
+            // A listener left pending at close time is detached.
+            uploadButton.onclick();
+            widgetWindow.onclose();
+            fileChooser.dispatchEvent(new Event("change"));
+            expect(widget.handleFiles).toHaveBeenCalledTimes(1);
         });
 
         test("onclose does not call stopRecording/stopTuner when neither is active", () => {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -434,6 +434,19 @@ function SampleWidget() {
     };
 
     /**
+     * Detaches the pending change listener from the shared file chooser, if any.
+     * @private
+     * @returns {void}
+     */
+    this._removeFileChooserListener = () => {
+        if (this._fileChooser && this._fileChooserAction) {
+            this._fileChooser.removeEventListener("change", this._fileChooserAction);
+        }
+        this._fileChooser = null;
+        this._fileChooserAction = null;
+    };
+
+    /**
      * Initializes the sampler widget.
      * @param {Activity} activity - The activity instance.
      * @param {number} timbreBlock - The timbre block number.
@@ -544,7 +557,18 @@ function SampleWidget() {
             if (this._octavesWheel !== undefined) {
                 this._octavesWheel.removeWheel();
             }
+            for (const id in this.pitchAnalysers) {
+                const analyser = this.pitchAnalysers[id];
+                if (analyser) {
+                    for (const synth in instruments[0]) {
+                        instruments[0][synth].disconnect(analyser);
+                    }
+                    analyser.dispose();
+                }
+            }
             this.pitchAnalysers = {};
+
+            this._removeFileChooserListener();
 
             if (this._dropZone) {
                 this._dropZone.removeEventListener("dragover", this._dragOverHandler);
@@ -588,13 +612,20 @@ function SampleWidget() {
                 stopTuner();
                 const fileChooser = docById("myOpenAll");
 
-                const __readerAction = function (event) {
+                // The file chooser is shared and its change event never fires when
+                // the user cancels, so drop any listener left over from a previous
+                // click before adding a new one.
+                that._removeFileChooserListener();
+
+                const __readerAction = function () {
                     window.scroll(0, 0);
                     const sampleFile = fileChooser.files[0];
                     that.handleFiles(sampleFile);
-                    fileChooser.removeEventListener("change", __readerAction);
+                    that._removeFileChooserListener();
                 };
 
+                that._fileChooser = fileChooser;
+                that._fileChooserAction = __readerAction;
                 fileChooser.addEventListener("change", __readerAction, false);
                 fileChooser.focus();
                 fileChooser.click();


### PR DESCRIPTION
Fixes #7976

## What

Two cleanup leaks in the Sampler widget (`js/widgets/sampler.js`):

1. **`Tone.Analyser` nodes were never disposed.** `reconnectSynthsToAnalyser()` creates two `Tone.Analyser` instances (one for the reference tone, one for the custom sample) and connects instruments to them. The `onclose` handler only did `this.pitchAnalysers = {}`, which drops the JS reference but leaves the underlying Web Audio `AnalyserNode`s alive and still wired into the audio graph. Opening and closing the Sampler repeatedly piled up orphaned nodes.

2. **The file chooser `change` listener stacked up on cancel.** The "Upload sample" button attached a `change` listener to the shared `#myOpenAll` file input, and that listener only removed itself from inside its own callback. If the user opened the picker and cancelled, no `change` fired, so the listener stayed attached. The next click added another on top, and eventually picking a file invoked `handleFiles()` several times. The listener also outlived the widget entirely, since it was never removed on close.

## How

- `onclose` now disconnects every synth in `instruments[0]` from each analyser and calls `analyser.dispose()` before clearing `pitchAnalysers`. This mirrors the cleanup the AI widget already performs (`js/widgets/aiwidget.js:754-763`).
- The pending file-chooser listener is tracked on the widget (`_fileChooser` / `_fileChooserAction`) and removed by a small `_removeFileChooserListener()` helper. It is called in three places: before attaching a new listener (so a cancelled pick can't stack), from inside the callback after a successful pick, and from `onclose`.

## Testing

- Added `onclose disposes the pitch analysers and disconnects the synths` — runs `reconnectSynthsToAnalyser()`, closes the widget, and asserts `dispose()` was called on each analyser and each synth was disconnected from it.
- Added `upload button does not stack change listeners when the picker is cancelled` — clicks Upload twice with no `change` in between, then dispatches one `change`, asserting `handleFiles` fires exactly once; then clicks Upload again, closes the widget, and asserts a later `change` does nothing.
- The `Tone.Analyser` jest mock gained a `dispose` stub.

Both new tests fail against the unmodified `sampler.js` and pass with the fix. Full suite: 205 suites / 7306 tests passing. `npm run lint` and `prettier --check` are clean.

---

*Prepared with AI assistance. All changes were reviewed and verified locally before submitting: `npm run lint` clean, `npx prettier --check` clean on both modified files, and `npm test` passing at 205 suites / 7306 tests. Both new tests were confirmed to fail against the unmodified `sampler.js`.*