### PR TITLE
test(turtleactions): improve RhythmActions mutation coverage

### DIFF
--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -96,13 +96,6 @@ describe("setupRhythmActions", () => {
         setupRhythmActions(activity);
     });
 
-    afterEach(() => {
-        // Reset globals mutated by dispatch/mouse-listener tests so later tests
-        // in the file don't observe a leaked MusicBlocks.isRun or mock mouse.
-        global.MusicBlocks.isRun = false;
-        global.Mouse.getMouseFromTurtle = jest.fn(() => ({ MB: { listeners: [] } }));
-    });
-
     it("sets beat and measure to 0 when pickup not crossed", () => {
         Singer.RhythmActions.playNote(1, "note", 0, 1);
 
@@ -352,6 +345,24 @@ describe("setupRhythmActions", () => {
         // same "dispatch via blockList, else register with the running mouse"
         // setup that doTie's own describe block already exercises. These mirror
         // that pattern for the remaining four block methods.
+
+        // Snapshot/restore, mirroring doTie's own beforeEach/afterEach below, so
+        // MusicBlocks.isRun and Mouse.getMouseFromTurtle don't leak into tests
+        // outside this describe block. Scoped here rather than at the top level
+        // since no other tests in this file touch these two globals.
+        let originalGetMouseFromTurtle;
+        let originalIsRun;
+
+        beforeEach(() => {
+            originalGetMouseFromTurtle = global.Mouse.getMouseFromTurtle;
+            originalIsRun = global.MusicBlocks.isRun;
+        });
+
+        afterEach(() => {
+            global.MusicBlocks.isRun = originalIsRun;
+            global.Mouse.getMouseFromTurtle = originalGetMouseFromTurtle;
+        });
+
         it("playNote dispatches block listener when blk is present in blockList", () => {
             activity.blocks.blockList = { 5: {} };
 

--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -96,6 +96,13 @@ describe("setupRhythmActions", () => {
         setupRhythmActions(activity);
     });
 
+    afterEach(() => {
+        // Reset globals mutated by dispatch/mouse-listener tests so later tests
+        // in the file don't observe a leaked MusicBlocks.isRun or mock mouse.
+        global.MusicBlocks.isRun = false;
+        global.Mouse.getMouseFromTurtle = jest.fn(() => ({ MB: { listeners: [] } }));
+    });
+
     it("sets beat and measure to 0 when pickup not crossed", () => {
         Singer.RhythmActions.playNote(1, "note", 0, 1);
 
@@ -192,6 +199,19 @@ describe("setupRhythmActions", () => {
         expect(targetTurtle.singer.noteHertz[1]).toContain(0);
         expect(targetTurtle.singer.noteBeatValues[1]).toContain(1);
         expect(targetTurtle.singer.pushedNote).toBe(true);
+    });
+    it("does nothing when inNoteBlock is empty", () => {
+        targetTurtle.singer.inNoteBlock = [];
+
+        expect(() => Singer.RhythmActions.playRest(0)).not.toThrow();
+        expect(targetTurtle.singer.pushedNote).toBeUndefined();
+    });
+    it("does not push a rest when the active note has no pitches array yet", () => {
+        targetTurtle.singer.inNoteBlock = [7];
+        targetTurtle.singer.notePitches = {};
+
+        expect(() => Singer.RhythmActions.playRest(0)).not.toThrow();
+        expect(targetTurtle.singer.pushedNote).toBeUndefined();
     });
     it("updates dotCount and beatFactor for valid dot value", () => {
         targetTurtle.singer.dotCount = 0;
@@ -303,6 +323,144 @@ describe("setupRhythmActions", () => {
         const value = Singer.RhythmActions.getNoteValue(0);
 
         expect(value).toBe(0.25); // 1 / 4
+    });
+    it("falls back past noteValue when it is explicitly null", () => {
+        // clearNoteParams() in logo.js sets noteValue[blk] = null before a note
+        // is assigned a real value, so null is a realistic, not artificial, input.
+        targetTurtle.singer.inNoteBlock = [3];
+        targetTurtle.singer.noteValue = { 3: null };
+        targetTurtle.singer.lastNotePlayed = [null, 8];
+
+        const value = Singer.RhythmActions.getNoteValue(0);
+
+        expect(value).toBe(0.125); // falls through to lastNotePlayed, same as null noteValue never happened
+    });
+    it("does not fall back to noteBeat when notePitches is an empty array", () => {
+        targetTurtle.singer.inNoteBlock = [6];
+        targetTurtle.singer.noteValue = {};
+        targetTurtle.singer.lastNotePlayed = null;
+        targetTurtle.singer.notePitches = { 6: [] };
+        targetTurtle.singer.noteBeat = { 6: 4 };
+
+        const value = Singer.RhythmActions.getNoteValue(0);
+
+        expect(value).toBe(0);
+    });
+
+    describe("dispatch-block and mouse-listener registration", () => {
+        // playNote, doRhythmicDot, multiplyNoteValue, and addSwing all share the
+        // same "dispatch via blockList, else register with the running mouse"
+        // setup that doTie's own describe block already exercises. These mirror
+        // that pattern for the remaining four block methods.
+        it("playNote dispatches block listener when blk is present in blockList", () => {
+            activity.blocks.blockList = { 5: {} };
+
+            Singer.RhythmActions.playNote(1, "note", 0, 5);
+
+            expect(activity.logo.setDispatchBlock).toHaveBeenCalledWith(5, 0, "_playnote_0");
+        });
+        it("playNote does not dispatch or register a mouse listener when blk is absent from blockList and MusicBlocks is not running", () => {
+            activity.blocks.blockList = {};
+            global.MusicBlocks.isRun = false;
+
+            Singer.RhythmActions.playNote(1, "note", 0, 99);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(global.Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
+        });
+        it("playNote registers listener with mouse when MusicBlocks.isRun and blk is undefined", () => {
+            const mockMouse = { MB: { listeners: [] } };
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => mockMouse);
+
+            Singer.RhythmActions.playNote(1, "note", 0, undefined);
+
+            expect(mockMouse.MB.listeners).toContain("_playnote_0");
+        });
+
+        it("doRhythmicDot dispatches block listener when blk is present in blockList", () => {
+            activity.blocks.blockList = { 5: {} };
+
+            Singer.RhythmActions.doRhythmicDot(1, 0, 5);
+
+            expect(activity.logo.setDispatchBlock).toHaveBeenCalledWith(5, 0, "_dot_0");
+        });
+        it("doRhythmicDot does not dispatch or register a mouse listener when blk is absent from blockList and MusicBlocks is not running", () => {
+            activity.blocks.blockList = {};
+            global.MusicBlocks.isRun = false;
+
+            Singer.RhythmActions.doRhythmicDot(1, 0, 99);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(global.Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
+        });
+        it("doRhythmicDot registers listener with mouse when MusicBlocks.isRun and blk is undefined", () => {
+            const mockMouse = { MB: { listeners: [] } };
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => mockMouse);
+
+            Singer.RhythmActions.doRhythmicDot(1, 0, undefined);
+
+            expect(mockMouse.MB.listeners).toContain("_dot_0");
+        });
+
+        it("multiplyNoteValue dispatches block listener when blk is present in blockList", () => {
+            activity.blocks.blockList = { 5: {} };
+
+            Singer.RhythmActions.multiplyNoteValue(2, 0, 5);
+
+            expect(activity.logo.setDispatchBlock).toHaveBeenCalledWith(5, 0, "_multiplybeat_0");
+        });
+        it("multiplyNoteValue does not dispatch or register a mouse listener when blk is absent from blockList and MusicBlocks is not running", () => {
+            activity.blocks.blockList = {};
+            global.MusicBlocks.isRun = false;
+
+            Singer.RhythmActions.multiplyNoteValue(2, 0, 99);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(global.Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
+        });
+        it("multiplyNoteValue registers listener with mouse when MusicBlocks.isRun and blk is undefined", () => {
+            const mockMouse = { MB: { listeners: [] } };
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => mockMouse);
+
+            Singer.RhythmActions.multiplyNoteValue(2, 0, undefined);
+
+            expect(mockMouse.MB.listeners).toContain("_multiplybeat_0");
+        });
+
+        it("addSwing dispatches block listener when blk is present in blockList", () => {
+            targetTurtle.singer.swing = [];
+            targetTurtle.singer.swingTarget = [];
+            activity.blocks.blockList = { 5: {} };
+
+            Singer.RhythmActions.addSwing(2, 4, 0, 5);
+
+            expect(activity.logo.setDispatchBlock).toHaveBeenCalledWith(5, 0, "_swing_0");
+        });
+        it("addSwing does not dispatch or register a mouse listener when blk is absent from blockList and MusicBlocks is not running", () => {
+            targetTurtle.singer.swing = [];
+            targetTurtle.singer.swingTarget = [];
+            activity.blocks.blockList = {};
+            global.MusicBlocks.isRun = false;
+
+            Singer.RhythmActions.addSwing(2, 4, 0, 99);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(global.Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
+        });
+        it("addSwing registers listener with mouse when MusicBlocks.isRun and blk is undefined", () => {
+            targetTurtle.singer.swing = [];
+            targetTurtle.singer.swingTarget = [];
+            const mockMouse = { MB: { listeners: [] } };
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => mockMouse);
+
+            Singer.RhythmActions.addSwing(2, 4, 0, undefined);
+
+            expect(mockMouse.MB.listeners).toContain("_swing_0");
+        });
     });
 
     describe("doTie", () => {
@@ -472,6 +630,15 @@ describe("setupRhythmActions", () => {
                 "_tie_0", // listener name
                 expect.any(Function) // callback
             );
+        });
+
+        it("does not dispatch when blk is defined but absent from blockList", () => {
+            activity.blocks.blockList = {};
+
+            Singer.RhythmActions.doTie(0, 99);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(global.Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Description

Adds targeted Jest tests to improve mutation coverage for `js/turtleactions/RhythmActions.js`.

Mutation testing identified **124 surviving mutants out of 357**, with the majority concentrated around the repeated dispatch-block and mouse-listener registration logic used by `playNote`, `doRhythmicDot`, `doTie`, `multiplyNoteValue`, and `addSwing`.

This PR adds focused tests for the identified surviving mutations without modifying production code.

## Changes

* Adds dispatch/listener tests for `playNote`, `doRhythmicDot`, `multiplyNoteValue`, and `addSwing`.
* Covers cases where:

  * `blk` exists in `blockList` and the dispatch listener is registered.
  * `blk` is defined but absent from `blockList` and `MusicBlocks.isRun` is `false`.
  * `blk` is undefined while `MusicBlocks.isRun` is `true` and the listener is registered with the mouse.
* Adds the missing `doTie` case where a defined `blk` is absent from `blockList`.
* Adds boundary tests for `getNoteValue` when `noteValue` is explicitly `null`.
* Adds a boundary test for an empty `notePitches` array to ensure stale `noteBeat` data is not used.
* Adds a `playRest` guard test for an empty `inNoteBlock`.
* Adds cleanup for mocked `MusicBlocks` and `Mouse` globals to prevent state leaking between tests.

The tests are focused on observable behavior and specifically target known surviving mutations rather than increasing coverage for its own sake.

## Testing

* Focused `RhythmActions.test.js` Jest tests pass.
* Full Jest suite passes.
* Stryker mutation testing was used to verify the targeted mutations.
* `git diff --check` passes.
* Prettier check passes.

No production code or test configuration is changed.

## Scope

Only the following file is modified:

```text
js/turtleactions/__tests__/RhythmActions.test.js
```

## Follow-up Work

Remaining listener-closure, arithmetic, and assertion-strengthening survivors are intentionally deferred to a separate mutation-coverage PR to keep this change focused and reviewable.
