### PR TITLE
fix(synthutils): dispose distortion node after note cleanup

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1800,6 +1800,53 @@ describe("Utility Functions (logic-only)", () => {
             jest.useRealTimers();
         });
 
+        it("should dispose the distortion node during effects cleanup", async () => {
+            jest.useFakeTimers();
+
+            const distortionDispose = jest.fn();
+            const originalDistortion = global.Tone.Distortion;
+            global.Tone.Distortion = jest.fn().mockImplementation(() => ({
+                dispose: distortionDispose
+            }));
+
+            const mockSynth = {
+                toDestination: jest.fn().mockReturnThis(),
+                triggerAttackRelease: jest.fn(),
+                disconnect: jest.fn(),
+                connect: jest.fn(),
+                chain: jest.fn().mockReturnThis()
+            };
+            Synth.inTemperament = "equal";
+
+            const paramsEffects = {
+                doDistortion: true,
+                distortionAmount: 0.4
+            };
+
+            try {
+                await _performNotes.call(
+                    Synth,
+                    mockSynth,
+                    "C4",
+                    0.25,
+                    paramsEffects,
+                    null,
+                    false,
+                    0
+                );
+
+                expect(global.Tone.Distortion).toHaveBeenCalledWith(0.4);
+
+                // Fast-forward time to trigger the effects cleanup setTimeout
+                jest.advanceTimersByTime(2000);
+
+                expect(distortionDispose).toHaveBeenCalledTimes(1);
+            } finally {
+                global.Tone.Distortion = originalDistortion;
+                jest.useRealTimers();
+            }
+        });
+
         it("should catch errors when disconnect throws an error during effects cleanup", async () => {
             jest.useFakeTimers();
 

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -2014,6 +2014,7 @@ function Synth() {
                     if (paramsEffects.doDistortion) {
                         distortion = new Tone.Distortion(paramsEffects.distortionAmount);
                         chainNodes.push(distortion);
+                        effectsToDispose.push(distortion);
                     }
 
                     if (paramsEffects.doTremolo) {


### PR DESCRIPTION
## Description

In `Synth._performNotes` (`js/utils/synthutils.js`), every effect node created for a note is registered for cleanup by pushing it to `effectsToDispose` — vibrato, tremolo, phaser, chorus, and neighbor all follow this pattern — **except distortion**, which was pushed only to `chainNodes`:

-   The post-note cleanup (scheduled for `beatValue * 1000 + 500` ms after the note) disposes only `effectsToDispose` and `temp_filters`, then restores the synth's dry path.
-   The `Tone.Distortion` node — a native WaveShaper plus its curve buffer — was therefore **never disposed and never disconnected**, remaining attached in the WebAudio graph after every note.
-   This path runs **once per note** whenever a `dist` (distortion) block is active: `doDistortion` is part of the `_needsGraphRewire` condition, so every note inside a distortion clamp takes the full graph-rewire path and creates a fresh, never-freed node.

**User-visible effect:** any project playing notes inside a distortion block — especially repeat/forever loops — grows the audio graph without bound. Over a session this means steadily rising memory use and audio crackling/underruns, worst on the low-end hardware (Chromebooks, shared school machines) Music Blocks targets. Notably, the comment above the cleanup scheduler says this disposal scheme exists precisely to prevent "crackling artefacts in long sessions" — the missing push silently defeated that for distortion.

**Fix:** one line — `effectsToDispose.push(distortion);` right after `chainNodes.push(distortion)`, matching the pattern used by every sibling effect in the same function.

## Related Issue

No existing issue — found through code inspection while auditing the per-note effect lifecycle in `_performNotes` for leaks.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Feature — Adds new functionality
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/utils/synthutils.js` — added `effectsToDispose.push(distortion);` in the `doDistortion` branch of `_performNotes` (one line; no other logic touched).
-   `js/utils/__tests__/synthutils.test.js` — new regression test in the existing `_performNotes effects routing and cleanup` suite: triggers a note with `doDistortion: true`, advances fake timers past the cleanup timeout, and asserts the `Tone.Distortion` instance's `dispose()` was called exactly once (and that the node was constructed with the requested `distortionAmount`).

## Testing Performed

-   Followed TDD: the regression test was written first and failed on the old code (`dispose` received 0 calls — the cleanup ran but distortion was never in the disposal list), then passed after the one-line fix.
-   `npx jest js/utils/__tests__/synthutils.test.js` — 133/133 pass, including the pre-existing effects-routing, glide/portamento, guarded-timeout, and use-after-dispose suites around the same code.
-   Full Jest suite: 7,431 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit independently of this change.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   The disposal itself is already guarded (`typeof effect.dispose === "function"`) and wrapped in try/catch in the cleanup path, so this change introduces no new failure modes — it only makes distortion participate in the cleanup that vibrato/tremolo/phaser/chorus/neighbor already get.
-   The error-path cleanup (the `catch` block of `_performNotes`) also iterates `effectsToDispose`, so a failed note now frees its distortion node too.