### PR TITLE
fix: update guide URLs

### DIFF
--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -39,7 +39,7 @@ const VERSION = "3.7.1";
 let LOGODEFAULT;
 let LOGOJA1 = LOGODEFAULT;
 let LOGOJA = LOGODEFAULT;
-//.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+//.TRANS: put the URL to the guide here, e.g., Docs/guide/index.html
 let GUIDEURL = _("guide url");
 let NUMBERBLOCKDEFAULT;
 let DEFAULTPALETTE;
@@ -52,7 +52,8 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
     LOGOJA = LOGODEFAULT;
 
     if (GUIDEURL === "guide url" || GUIDEURL === "") {
-        GUIDEURL = "https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md";
+	// Fix me: Move turtle guide to MB repo.
+        GUIDEURL = "Docs/guide/README.md";
     }
 
     NUMBERBLOCKDEFAULT = 100;

--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -52,7 +52,7 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
     LOGOJA = LOGODEFAULT;
 
     if (GUIDEURL === "guide url" || GUIDEURL === "") {
-	// Fix me: Move turtle guide to MB repo.
+        // Fix me: Move turtle guide to MB repo.
         GUIDEURL = "Docs/guide/README.md";
     }
 

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -192,8 +192,8 @@
     "kana": "ミュージック・ブロックスはすでにこのテーマにせっていされています。"
   },
   "guide url": {
-    "kanji": "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf",
-    "kana": "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf"
+    "kanji": "Docs/guide-ja/music_blocks_operation_manual.pdf",
+    "kana": "Docs/guide-ja/music_blocks_operation_manual.pdf"
   },
   "Turtle Blocks": {
     "kanji": "タートル・ブロックス",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -47,7 +47,7 @@
   "Close": "Fechar",
   "Theme switched to %s mode.": "O tema mudou para o modo %s.",
   "Music Blocks is already set to this theme.": "O Music Blocks já está configurado para este tema.",
-  "guide url": "guia url",
+  "guide url": "Docs/guide-pt/index.html",
   "Turtle Blocks": "Blocos da Tartaruga",
   "search": "buscar",
   "rhythm": "Ritmo",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -47,7 +47,7 @@
   "Close": "关闭",
   "Theme switched to %s mode.": "主题切换到 %s 模式。",
   "Music Blocks is already set to this theme.": "Music Blocks 已经设置为此主题。",
-  "guide url": "指南网址",
+  "guide url": "Docs/guide-zhCN/MusicBlocks_Guide_ZH.pdf",
   "Turtle Blocks": "海龟图形块",
   "search": "搜索",
   "rhythm": "节奏",

--- a/po/MusicBlocks.pot
+++ b/po/MusicBlocks.pot
@@ -426,7 +426,7 @@ msgid "Music Blocks is already set to this theme."
 msgstr ""
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
 msgstr ""
 

--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -503,9 +503,9 @@ msgid "Music Blocks is already set to this theme."
 msgstr "ミュージック・ブロックスはすでにこのテーマにせっていされています。"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
-msgstr "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf"
+msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
 
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"

--- a/po/ja.po
+++ b/po/ja.po
@@ -557,9 +557,9 @@ msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocksはすでにこのテーマに設定されています。"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
-msgstr "https://github.com/sugarlabs/musicblocks/tree/master/guide-ja/music_blocks_operation_manual.pdf"
+msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
 
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"

--- a/po/pt.po
+++ b/po/pt.po
@@ -560,9 +560,9 @@ msgid "Music Blocks is already set to this theme."
 msgstr "O Music Blocks já está configurado para este tema."
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
-msgstr "guia url"
+msgstr "Docs/guide-pt/index.html"
 
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -951,9 +951,9 @@ msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocks 已经设置为此主题。"
 
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md
+#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
-msgstr "指南网址"
+msgstr "Docs/guide-zhCN/MusicBlocks_Guide_ZH.pdf"
 
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"


### PR DESCRIPTION
The guide is available in English, Spanish, Portuguese, Japanese, and Chinese, but the guide URLs were not set properly in the PO files. This PR puts the proper strings in those files.

## PR Category

- [x] Bug Fix

For example, 

<img width="558" height="466" alt="image" src="https://github.com/user-attachments/assets/689d9e72-1fbe-4698-b269-71507697846e" />
 
Opens:

<img width="988" height="583" alt="image" src="https://github.com/user-attachments/assets/572e6fea-07c8-4d2e-b6bb-c55ad6627132" />
