### PR TITLE
fix: cancel scheduled rhythm notes when stopping

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -34,6 +34,7 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
 function setupRhythmBlockPaletteBlocks(activity) {
     /**
      * Schedules a note to be played after a timeout.
+     * @param {object} logo - The Logo execution engine.
      * @param {object} activity - The activity object.
      * @param {number} beat - The beat value.
      * @param {string} blk - The block ID.

--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -41,8 +41,14 @@ function setupRhythmBlockPaletteBlocks(activity) {
      * @param {function} callback - The callback function.
      * @param {number} timeout - The timeout in milliseconds.
      */
-    const scheduleNote = (activity, beat, blk, turtle, callback, timeout) => {
-        setTimeout(() => Singer.processNote(activity, beat, false, blk, turtle, callback), timeout);
+    const scheduleNote = (logo, activity, beat, blk, turtle, callback, timeout) => {
+        const processNote = () => Singer.processNote(activity, beat, false, blk, turtle, callback);
+
+        if (logo._timerManager && typeof logo._timerManager.setGuardedTimeout === "function") {
+            logo._timerManager.setGuardedTimeout(processNote, timeout, () => logo.stopTurtle);
+        } else {
+            setTimeout(processNote, timeout);
+        }
     };
 
     /**
@@ -203,6 +209,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                     }
 
                     scheduleNote(
+                        logo,
                         activity,
                         noteBeatValue,
                         blk,
@@ -766,7 +773,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                             __callback = null;
                         }
 
-                        scheduleNote(activity, thisBeat, blk, turtle, __callback, timeout);
+                        scheduleNote(logo, activity, thisBeat, blk, turtle, __callback, timeout);
 
                         timeout += beatValue * 1000;
                         totalBeats += beatValue;
@@ -974,13 +981,6 @@ function setupRhythmBlockPaletteBlocks(activity) {
 
                 const beatValue = bpmFactor / noteBeatValue / arg0;
 
-                const __rhythmPlayNote = (thisBeat, blk, turtle, callback, timeout) => {
-                    setTimeout(
-                        () => Singer.processNote(activity, thisBeat, false, blk, turtle, callback),
-                        timeout
-                    );
-                };
-
                 let __callback = null;
                 for (let i = 0; i < arg0; i++) {
                     if (i === arg0 - 1) {
@@ -992,7 +992,9 @@ function setupRhythmBlockPaletteBlocks(activity) {
                         __callback = null;
                     }
 
-                    __rhythmPlayNote(
+                    scheduleNote(
+                        logo,
+                        activity,
                         noteBeatValue * arg0,
                         blk,
                         turtle,

--- a/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
@@ -25,6 +25,7 @@ global._THIS_IS_TURTLE_BLOCKS_ = false;
 global.DEFAULTDRUM = "drum";
 
 const { setupRhythmBlockPaletteBlocks } = require("../RhythmBlockPaletteBlocks");
+const ManagedTimer = require("../../utils/ManagedTimer");
 
 class DummyFlowBlock {
     constructor(name, displayName) {
@@ -140,6 +141,7 @@ describe("setupRhythmBlockPaletteBlocks", () => {
         DummyFlowBlock.createdBlocks = {};
         dummyActivity.errorMsg.mockClear();
         dummyActivity.textMsg.mockClear();
+        Singer.processNote.mockClear();
         dummyActivity.blocks.blockList = {};
         dummyActivity.turtles.turtleObjs = {};
         activity = dummyActivity;
@@ -164,6 +166,25 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             rhythmBlock.flow([4, 0.25], logo, turtleIndex, "blkRhythm");
             expect(logo.phraseMaker.addColBlock).toHaveBeenCalledWith("blkRhythm", 4);
             expect(Singer.processNote).toHaveBeenCalledTimes(4);
+        });
+
+        it("cancels scheduled notes when Logo stops", () => {
+            jest.useFakeTimers();
+
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            logo._timerManager = new ManagedTimer();
+            logo.stopTurtle = false;
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            rhythmBlock.flow([4, 0.25], logo, turtleIndex, "blkRhythm");
+            expect(logo._timerManager.activeTimeoutCount).toBe(4);
+
+            logo.stopTurtle = true;
+            logo._timerManager.clearAll();
+            jest.runAllTimers();
+
+            expect(Singer.processNote).not.toHaveBeenCalled();
+            jest.useRealTimers();
         });
     });
 


### PR DESCRIPTION
## Summary

Extends the managed-timer cleanup from #5799 to rhythm block playback.

<img width="525" height="424" alt="image" src="https://github.com/user-attachments/assets/a0bba798-4f2d-4163-8b9c-07cc7be5a994" />

Rhythm and tuplet blocks scheduled one native timeout per note outside `Logo`.
After pressing Stop, those callbacks could still call `Singer.processNote()` and
continue playback.

This change routes all rhythm-note scheduling paths through Logo’s
`ManagedTimer`, so `doStopTurtles()` cancels pending notes immediately, as user clicks stop.


## Changes

- Use `logo._timerManager.setGuardedTimeout()` for rhythm note scheduling
- Cover Rhythm, Tuplet, and Simple Tuplet paths through the shared scheduler
- Add a regression test confirming pending rhythm notes do not fire after Stop

## Testing

- `npx prettier --check js/blocks/RhythmBlockPaletteBlocks.js js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js`
- `npm run lint`
- `npm test -- --runInBand`

Related to #5799

- [x] Bug fix 
- [x] Test
- [x] Performance  
