### PR TITLE
perf(blocks): skip unchanged parameter block redraws

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -377,6 +377,34 @@ describe("Blocks Foundation", () => {
         });
     });
 
+    describe("Parameter Block Cache Updates", () => {
+        it("only rebuilds the cache when the displayed value changes", () => {
+            const blocks = new Blocks(mockActivity);
+            const updateParameter = jest.fn(() => 0);
+            const updateCache = jest.fn();
+            const parameterBlock = {
+                name: "heading",
+                protoblock: { parameter: true, updateParameter },
+                text: { text: "heading" },
+                container: { updateCache }
+            };
+            blocks.blockList = [parameterBlock];
+
+            expect(blocks.updateParameterBlock({}, 0, 0)).toBe(true);
+            expect(parameterBlock.text.text).toBe("0");
+            expect(updateCache).toHaveBeenCalledTimes(1);
+
+            expect(blocks.updateParameterBlock({}, 0, 0)).toBe(false);
+            expect(updateCache).toHaveBeenCalledTimes(1);
+
+            updateParameter.mockReturnValue(10);
+
+            expect(blocks.updateParameterBlock({}, 0, 0)).toBe(true);
+            expect(parameterBlock.text.text).toBe("10");
+            expect(updateCache).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe("Sparse Array Safety", () => {
         it("should not throw TypeError in findStacks when blockList is sparse", () => {
             const blocks = new Blocks(mockActivity);

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2023,6 +2023,30 @@ describe("Logo runFromBlockNow", () => {
         expect(logo.statusMatrix.updateAll).toHaveBeenCalled();
         expect(mockActivity.blocks.updateParameterBlock).toHaveBeenCalledWith(logo, 0, 10);
     });
+
+    test("refreshes slow execution only when a parameter display changes", () => {
+        timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(() => 32);
+        logo.blockList = [
+            {
+                ...makeFlowBlock("print"),
+                connections: [null, 1]
+            },
+            makeFlowBlock()
+        ];
+        turtle0.parameterQueue = [10];
+        logo.turtleDelay = 10;
+
+        mockActivity.blocks.updateParameterBlock.mockReturnValue(false);
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+        expect(mockActivity.refreshCanvas).not.toHaveBeenCalled();
+
+        mockActivity.blocks.updateParameterBlock.mockClear();
+        mockActivity.blocks.updateParameterBlock.mockReturnValue(true);
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(mockActivity.blocks.updateParameterBlock).toHaveBeenCalledWith(logo, 0, 10);
+        expect(mockActivity.refreshCanvas).toHaveBeenCalledTimes(1);
+    });
 });
 
 // ─── Logo clearTurtleRun ──────────────────────────────────────────────────────

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6788,12 +6788,14 @@ class Blocks {
          * @param logo
          * @param turtle
          * @param blk
-         * @returns {void}
+         * @returns {boolean} Whether the displayed parameter value changed.
          */
         this.updateParameterBlock = (logo, turtle, blk) => {
             const name = this.blockList[blk].name;
 
             if (this.blockList[blk].protoblock.parameter && this.blockList[blk].text !== null) {
+                const text = this.blockList[blk].text;
+                const previousText = text.text;
                 let value = 0;
 
                 if (typeof this.blockList[blk].protoblock.updateParameter === "function") {
@@ -6808,32 +6810,39 @@ class Blocks {
                             name
                         );
                     } else {
-                        return;
+                        return false;
                     }
                 }
 
                 // Comprehensive safety check for all value types
                 if (value === null || value === undefined) {
-                    this.blockList[blk].text.text = "";
+                    text.text = "";
                 } else if (typeof value === "string") {
                     if (value.length > 6) {
                         value = value.substr(0, 5) + "...";
                     }
-                    this.blockList[blk].text.text = value;
+                    text.text = value;
                 } else if (name === "divide") {
-                    this.blockList[blk].text.text = mixedNumber(value);
+                    text.text = mixedNumber(value);
                 } else {
                     // Safe toString conversion
                     try {
-                        this.blockList[blk].text.text = value.toString();
+                        text.text = value.toString();
                     } catch (error) {
                         console.warn("Error converting value to string:", value, error);
-                        this.blockList[blk].text.text = "";
+                        text.text = "";
                     }
                 }
 
+                if (text.text === previousText) {
+                    return false;
+                }
+
                 this.blockList[blk].container.updateCache();
+                return true;
             }
+
+            return false;
         };
 
         /**

--- a/js/logo.js
+++ b/js/logo.js
@@ -2203,8 +2203,9 @@ class Logo {
             if (logo.turtleDelay !== 0) {
                 let updatedParameterBlocks = false;
                 for (const pblk in tur.parameterQueue) {
-                    logo.blocks.updateParameterBlock(logo, turtle, tur.parameterQueue[pblk]);
-                    updatedParameterBlocks = true;
+                    if (logo.blocks.updateParameterBlock(logo, turtle, tur.parameterQueue[pblk])) {
+                        updatedParameterBlocks = true;
+                    }
                 }
 
                 if (updatedParameterBlocks) {


### PR DESCRIPTION
 ## Summary

  Avoids redundant canvas cache updates during slow and step-by-step execution when a parameter block’s displayed value has not changed.

  For example, a `heading` block can be evaluated repeatedly inside a loop while continuing to display `0`. Previously, every evaluation rebuilt its cache and refreshed the canvas.

  ## Problem

  - **Unchanged parameter blocks are redrawn repeatedly** — `updateParameterBlock()` always called `container.updateCache()`, even when the displayed text was unchanged.
  - **Canvas refresh occurs for every queued parameter update** — slow/step execution refreshed the canvas after processing the parameter queue, including when no visible block value changed.
  - This creates avoidable cache work and canvas redraws in loops containing constant parameter blocks.

  ## Changes

  ### `js/blocks.js`

  - Track a parameter block’s previous displayed text in `updateParameterBlock()`.
  - Rebuild the block cache only when the evaluated display value changes.
  - Return whether the parameter block’s displayed value changed.

### `js/logo.js`

- Track whether any queued parameter block changed during slow/step execution.
- Refresh the canvas only when at least one parameter block requires a visual update.

### Tests

- Added coverage that verifies:
  - the first value update rebuilds the cache;
  - repeated identical values do not rebuild it;
  - changed values still rebuild the cache;
  - slow execution refreshes the canvas only after a visible parameter change.

## Testing

### Automated

- ✅ `npm run lint`
- ✅ `npx prettier --check js/blocks.js js/logo.js js/__tests__/blocks.test.js js/__tests__/logo.test.js`
- ✅ `npm test -- --runInBand` — 209 suites, 7,464 tests passed

### Browser Testing

Use:

`start → repeat 20 → forward (heading)`
<img width="525" height="424" alt="image" src="https://github.com/user-attachments/assets/86ec3ab4-d89c-4637-a8da-68c8382bc011" />


Run it in slow/step mode.

- A constant `heading` value should no longer trigger repeated cache updates or unnecessary canvas refreshes.
- If the heading changes during execution, its displayed value and the canvas should still update normally.


- [x] Test 
- [x] Performance
