### PR TITLE
refactor(mode-widget): overhaul scalar builder UI and multi-EDO state sync

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -993,7 +993,7 @@ table {
     left: 0px;
     top: 0px;
     border: 0 !important;
-    background: rgba(255, 255, 255, 0.85) !important;
+    background: transparent;
     width: 680px;
 }
 

--- a/header-icons/pie-chart.svg
+++ b/header-icons/pie-chart.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="#FFFFFF">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 3.08a8 8 0 0 1 5.92 5.92H13zM5.1 9.9l6.9 6.9A8 8 0 0 1 5.1 9.9zM12 20a8 8 0 0 1-1-15.93V12a1 1 0 0 0 .29.71l5.66 5.66A7.95 7.95 0 0 1 12 20z"/>
+</svg>

--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -161,6 +161,8 @@ global.getModeSliceFont = (wheelRadius, sliceCount, labelLen) => {
     const clamped = Math.min(maxSize, Math.max(minSize, size));
     return `100 ${clamped}px sans-serif`;
 };
+global.configureWheel = jest.fn();
+
 global.Synth = jest.fn().mockImplementation(() => ({
     newTone: jest.fn(),
     tone: {},

--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -9,7 +9,7 @@
  * (at your option) any later version.
  */
 
-const { piemenuPitches, piemenuKey, piemenuNumber } = require("../piemenus");
+const { piemenuPitches, piemenuKey, piemenuNumber, piemenuModes } = require("../piemenus");
 
 // Mock Globals
 global.docById = jest.fn().mockReturnValue({
@@ -31,24 +31,37 @@ global.window = {
 global.wheelnav = jest.fn().mockImplementation(function (div) {
     const mockWheel = this;
     this.id = div;
-    this.navItems = Array.from({ length: 30 }, () => ({
+    this.wheelRadius = 600;
+    const navItemTemplate = () => ({
         title: "",
         enabled: true,
         navItem: { hide: jest.fn(), show: jest.fn() },
+        fillAttr: "",
+        titleAttr: {},
+        titleHoverAttr: {},
+        titleSelectedAttr: {},
         sliceSelectedAttr: {},
         sliceHoverAttr: {},
-        titleSelectedAttr: {},
-        titleHoverAttr: {},
-        titleAttr: {}
-    }));
+        slicePathAttr: {},
+        basicNavTitleMax: {},
+        basicNavTitleMin: {},
+        hoverNavTitleMax: {},
+        hoverNavTitleMin: {},
+        selectedNavTitleMax: {},
+        selectedNavTitleMin: {},
+        initNavTitle: {}
+    });
+    this.navItems = Array.from({ length: 30 }, navItemTemplate);
     this.selectedNavItemIndex = 0;
     this.colors = [];
     this.raphael = { canvas: {} };
     this.on = jest.fn();
     this.createWheel = jest.fn(labels => {
         if (labels) {
-            labels.forEach((l, i) => {
-                if (this.navItems[i]) this.navItems[i].title = l;
+            this.navItems = labels.map((l, i) => {
+                const item = navItemTemplate();
+                item.title = l;
+                return item;
             });
         }
     });
@@ -72,13 +85,81 @@ global.platformColor = {
     exitWheelcolors: ["#00ff00"],
     accidentalsWheelcolors: ["#0000ff"],
     octavesWheelcolors: ["#ffff00"],
-    accidentalsWheelcolorspush: "#cccccc"
+    accidentalsWheelcolorspush: "#cccccc",
+    modeWheelcolors: ["#111111"],
+    modeGroupWheelcolors: ["#222222"],
+    modePieMenusIfColorPush: "#333333",
+    modePieMenusElseColorPush: "#444444",
+    textColor: "#ffffff"
 };
 global._ = jest.fn(s => s);
 global.announceToScreenReader = jest.fn();
 global.Tone = {
     start: jest.fn().mockResolvedValue(),
     context: { state: "running" }
+};
+global.last = arr => arr[arr.length - 1];
+global.MUSICALMODES = {
+    ionian: [2, 2, 1, 2, 2, 2, 1],
+    major: [2, 2, 1, 2, 2, 2, 1],
+    aeolian: [2, 1, 2, 2, 1, 2, 2],
+    minor: [2, 1, 2, 2, 1, 2, 2],
+    dorian: [2, 1, 2, 2, 2, 1, 2]
+};
+global.MODE_PIE_MENUS = {
+    5: ["minor pentatonic", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "],
+    7: ["ionian", " ", "dorian", " ", " ", " ", " ", " ", " ", "aeolian", " ", " "],
+    custom: [" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+};
+global.getCurrentEDO = jest.fn().mockReturnValue(12);
+global.DEFAULTVOLUME = 0.5;
+global.SHARP = "♯";
+global.FLAT = "♭";
+global.MODEPIEMENU_GROUP_RING = { minRadius: 0.15, maxRadius: 0.3 };
+global.MODEPIEMENU_NAME_RING = { minRadius: 0.3, maxRadius: 0.85 };
+global.getSavedCustomModes = () => [];
+global.getModeNamesForGroup = (grp, customModeNames = []) => {
+    if (grp !== "custom") {
+        return MODE_PIE_MENUS[grp];
+    }
+    const names = customModeNames.slice(0, 12);
+    while (names.length < 12) {
+        names.push(" ");
+    }
+    return names;
+};
+global.getModeLabel = modename => {
+    switch (modename) {
+        case "ionian":
+        case "major":
+            return "major / ionian";
+        case "aeolian":
+        case "minor":
+            return "minor / aeolian";
+        default:
+            return modename === " " ? " " : modename;
+    }
+};
+global.getModeNameFromLabel = (label, modes) => {
+    if (label === "major / ionian") {
+        return "major";
+    }
+    if (label === "minor / aeolian") {
+        return "aeolian";
+    }
+    return modes.includes(label) ? label : label;
+};
+global.getModeSliceColors = (modes, colors) =>
+    modes.map(modename => (modename === " " ? colors.emptyColor : colors.filledColor));
+global.updateModeWheelItems = jest.fn();
+global.getModeGroupTitleFont = wheelRadius => `100 ${Math.round(0.08 * wheelRadius)}px sans-serif`;
+global.getModeSliceFont = (wheelRadius, sliceCount, labelLen) => {
+    const arcPx = (2 * Math.PI * 0.575 * wheelRadius) / sliceCount;
+    const size = Math.floor((arcPx * 0.85) / (labelLen * 0.6));
+    const minSize = Math.round(0.06 * wheelRadius);
+    const maxSize = Math.round(0.12 * wheelRadius);
+    const clamped = Math.min(maxSize, Math.max(minSize, size));
+    return `100 ${clamped}px sans-serif`;
 };
 global.Synth = jest.fn().mockImplementation(() => ({
     newTone: jest.fn(),
@@ -450,6 +531,20 @@ describe("piemenus behavioral tests", () => {
         );
 
         jest.useRealTimers();
+    });
+
+    describe("piemenuModes behavioral tests", () => {
+        test("selecting a mode slice assigns the internal mode name to the block", () => {
+            piemenuModes(mockBlock, "ionian");
+
+            // Initial highlight (index 0 = ionian) already fires the selection
+            // handler; navigate to the dorian slice (index 2) explicitly.
+            mockBlock._modeNameWheel.selectedNavItemIndex = 2;
+            mockBlock._modeNameWheel.navItems[2].navigateFunction();
+
+            expect(mockBlock.value).toBe("dorian");
+            expect(mockBlock.text.text).toBe("dorian");
+        });
     });
 });
 

--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -147,7 +147,7 @@ global.getModeNameFromLabel = (label, modes) => {
     if (label === "minor / aeolian") {
         return "aeolian";
     }
-    return modes.includes(label) ? label : label;
+    return label;
 };
 global.getModeSliceColors = (modes, colors) =>
     modes.map(modename => (modename === " " ? colors.emptyColor : colors.filledColor));

--- a/js/activity.js
+++ b/js/activity.js
@@ -2713,22 +2713,16 @@ class Activity {
             // Load any plugins saved in local storage.
             await this.pluginController.loadStoredPlugins();
 
-            // Load custom mode saved in local storage.
-            const custommodeData = this.storage.custommode;
-            if (custommodeData !== undefined) {
-                // Parse and update the custom musical mode with saved data.
-                try {
-                    const customModeDataObj = JSON.parse(custommodeData);
-                    const src = Array.isArray(customModeDataObj)
-                        ? customModeDataObj
-                        : Object.values(customModeDataObj);
-                    for (let i = 0; i < MUSICALMODES["custom"].length; i++) {
-                        const val = Number(src[i]);
-                        MUSICALMODES["custom"][i] = !isNaN(val) && val > 0 ? val : 1;
+            // Load custom modes saved in local storage so they survive a reload.
+            try {
+                const savedModes = JSON.parse(localStorage.getItem("customModes") || "[]");
+                for (const mode of savedModes) {
+                    if (mode && mode.name && Array.isArray(mode.pattern)) {
+                        MUSICALMODES[mode.name] = mode.pattern;
                     }
-                } catch (e) {
-                    ErrorHandler.recoverable(e, { operation: "parseCustomMode" });
                 }
+            } catch (e) {
+                ErrorHandler.recoverable(e, { operation: "loadCustomModes" });
             }
 
             this.allFilesChooser.addEventListener("click", event => {

--- a/js/activity.js
+++ b/js/activity.js
@@ -2713,6 +2713,26 @@ class Activity {
             // Load any plugins saved in local storage.
             await this.pluginController.loadStoredPlugins();
 
+            // Migrate old single-custommode key to the new customModes array
+            // format so existing users don't lose saved modes on upgrade.
+            try {
+                const oldData = localStorage.getItem("custommode");
+                if (oldData && !localStorage.getItem("customModes")) {
+                    const parsed = JSON.parse(oldData);
+                    const src = Array.isArray(parsed) ? parsed : Object.values(parsed);
+                    const pattern = src.map(v => {
+                        const n = Number(v);
+                        return !isNaN(n) && n > 0 ? n : 1;
+                    });
+                    localStorage.setItem(
+                        "customModes",
+                        JSON.stringify([{ name: "custom", pattern }])
+                    );
+                }
+            } catch (_) {
+                // Corrupt old data — ignore, will start fresh.
+            }
+
             // Load custom modes saved in local storage so they survive a reload.
             try {
                 const savedModes = JSON.parse(localStorage.getItem("customModes") || "[]");

--- a/js/block.js
+++ b/js/block.js
@@ -3900,7 +3900,7 @@ class Block {
                     if (temperament && typeof temperament === "object") {
                         noteLabels[keys[i]] = temperament;
                     }
-                    if (isCustomTemperament(keys[i])) {
+                    if (isCustomTemperament(keys[i]) && temperament && !temperament.isEDO) {
                         customLabels.push(keys[i]);
                     }
                 }

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -77,9 +77,9 @@ function setupWidgetBlocks(activity) {
      * Environment-aware lazy module loader.
      * Uses AMD require() in the browser; calls callback synchronously in Node/Jest.
      */
-    function _lazyRequire(modules, callback) {
+    function _lazyRequire(modules, callback, onError) {
         if (typeof define === "function" && define.amd) {
-            require(Array.isArray(modules) ? modules : [modules], callback);
+            require(Array.isArray(modules) ? modules : [modules], callback, onError);
         } else {
             callback();
         }
@@ -141,11 +141,15 @@ function setupWidgetBlocks(activity) {
      * @param {Function} factory - Builds the widget instance.
      * @param {Function} [onReady] - Optional callback run after assignment.
      */
-    function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady) {
-        _lazyRequire(modules, function () {
-            logo[widgetKey] = factory();
-            onReady?.();
-        });
+    function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady, onError) {
+        _lazyRequire(
+            modules,
+            () => {
+                logo[widgetKey] = factory();
+                onReady?.();
+            },
+            () => onError?.()
+        );
     }
 
     function _hasValidMeterWidgetInput(logo) {
@@ -832,7 +836,18 @@ function setupWidgetBlocks(activity) {
             const listenerName = "_modewidget_" + turtle;
             logo.setDispatchBlock(blk, turtle, listenerName);
 
+            const resetFlag = () => {
+                logo.insideModeWidget = false;
+            };
+
             const __listener = () => {
+                // Re-show an already-open widget instead of building a second
+                // instance (duplicate toolbar buttons, overwritten handlers).
+                if (logo.modeWidget && logo.modeWidget !== "loading") {
+                    logo.modeWidget.widgetWindow.show();
+                    resetFlag();
+                    return;
+                }
                 _lazyLoadWidget(
                     logo,
                     "modeWidget",
@@ -840,9 +855,8 @@ function setupWidgetBlocks(activity) {
                         "widgets/modewidget"
                     ]),
                     () => new ModeWidget(activity),
-                    () => {
-                        logo.insideModeWidget = false;
-                    }
+                    resetFlag,
+                    resetFlag
                 );
             };
 

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -112,11 +112,16 @@ function setupWidgetBlocks(activity) {
      */
     function _ensureWidget(logo, widgetKey, modules, initFn, turtle, blk, receivedArg) {
         if (logo[widgetKey] === null || logo[widgetKey] === undefined) {
-            logo[widgetKey] = initFn();
-            if (typeof logo.runFromBlockNow === "function") {
-                logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-            }
-            return null;
+            logo[widgetKey] = "loading"; // Guard against multiple simultaneous loads
+            _lazyRequire(modules, () => {
+                logo[widgetKey] = initFn();
+                if (typeof logo.runFromBlockNow === "function") {
+                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
+                }
+            });
+            return [null, 0, true];
+        } else if (logo[widgetKey] === "loading") {
+            return [null, 0, true]; // Still loading, continue to interrupt
         }
         return null;
     }

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -687,7 +687,10 @@ function setupWidgetBlocks(activity) {
                         typeof MeterWidget !== "undefined" ? MeterWidget : null,
                         ["widgets/meterwidget"]
                     ),
-                    () => new MeterWidget(activity, blk)
+                    () => new MeterWidget(activity, blk),
+                    () => {
+                        logo.insideMeterWidget = false;
+                    }
                 );
             };
 
@@ -764,7 +767,10 @@ function setupWidgetBlocks(activity) {
                         typeof Oscilloscope !== "undefined" ? Oscilloscope : null,
                         ["widgets/oscilloscope"]
                     ),
-                    () => new Oscilloscope(activity)
+                    () => new Oscilloscope(activity),
+                    () => {
+                        logo.inOscilloscope = false;
+                    }
                 );
             };
 

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -77,9 +77,9 @@ function setupWidgetBlocks(activity) {
      * Environment-aware lazy module loader.
      * Uses AMD require() in the browser; calls callback synchronously in Node/Jest.
      */
-    function _lazyRequire(modules, callback, onError) {
+    function _lazyRequire(modules, callback) {
         if (typeof define === "function" && define.amd) {
-            require(Array.isArray(modules) ? modules : [modules], callback, onError);
+            require(Array.isArray(modules) ? modules : [modules], callback);
         } else {
             callback();
         }
@@ -112,16 +112,11 @@ function setupWidgetBlocks(activity) {
      */
     function _ensureWidget(logo, widgetKey, modules, initFn, turtle, blk, receivedArg) {
         if (logo[widgetKey] === null || logo[widgetKey] === undefined) {
-            logo[widgetKey] = "loading"; // Guard against multiple simultaneous loads
-            _lazyRequire(modules, function () {
-                logo[widgetKey] = initFn();
-                if (typeof logo.runFromBlockNow === "function") {
-                    logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
-                }
-            });
-            return [null, 0, true];
-        } else if (logo[widgetKey] === "loading") {
-            return [null, 0, true]; // Still loading, continue to interrupt
+            logo[widgetKey] = initFn();
+            if (typeof logo.runFromBlockNow === "function") {
+                logo.runFromBlockNow(logo, turtle, blk, true, receivedArg);
+            }
+            return null;
         }
         return null;
     }
@@ -141,15 +136,11 @@ function setupWidgetBlocks(activity) {
      * @param {Function} factory - Builds the widget instance.
      * @param {Function} [onReady] - Optional callback run after assignment.
      */
-    function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady, onError) {
-        _lazyRequire(
-            modules,
-            () => {
-                logo[widgetKey] = factory();
-                onReady?.();
-            },
-            () => onError?.()
-        );
+    function _lazyLoadWidget(logo, widgetKey, modules, factory, onReady) {
+        _lazyRequire(modules, () => {
+            logo[widgetKey] = factory();
+            onReady?.();
+        });
     }
 
     function _hasValidMeterWidgetInput(logo) {
@@ -696,10 +687,7 @@ function setupWidgetBlocks(activity) {
                         typeof MeterWidget !== "undefined" ? MeterWidget : null,
                         ["widgets/meterwidget"]
                     ),
-                    () => new MeterWidget(activity, blk),
-                    () => {
-                        logo.insideMeterWidget = false;
-                    }
+                    () => new MeterWidget(activity, blk)
                 );
             };
 
@@ -776,10 +764,7 @@ function setupWidgetBlocks(activity) {
                         typeof Oscilloscope !== "undefined" ? Oscilloscope : null,
                         ["widgets/oscilloscope"]
                     ),
-                    () => new Oscilloscope(activity),
-                    () => {
-                        logo.inOscilloscope = false;
-                    }
+                    () => new Oscilloscope(activity)
                 );
             };
 
@@ -854,9 +839,7 @@ function setupWidgetBlocks(activity) {
                     _getWidgetDependencies(typeof ModeWidget !== "undefined" ? ModeWidget : null, [
                         "widgets/modewidget"
                     ]),
-                    () => new ModeWidget(activity),
-                    resetFlag,
-                    resetFlag
+                    () => new ModeWidget(activity)
                 );
             };
 

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -353,27 +353,7 @@ describe("setupWidgetBlocks", () => {
             expect(activity.errorMsg).not.toHaveBeenCalled();
         });
     });
-
     describe("TimbreBlock", () => {
-        it("initializes with string instrument name", () => {
-            const timbre = getBlock("timbre");
-            // First call: returns interruption while loading widget
-            const interruption = timbre.flow(
-                ["customInstrument", "childBlk"],
-                logo,
-                0,
-                "timbreBlk"
-            );
-            expect(interruption).toEqual([null, 0, true]);
-            expect(logo.runFromBlockNow).toHaveBeenCalled();
-
-            // Second call: widget is loaded, so it proceeds
-            const result = timbre.flow(["customInstrument", "childBlk"], logo, 0, "timbreBlk");
-            expect(logo.inTimbre).toBe(true);
-            expect(logo.timbre.instrumentName).toBe("customInstrument");
-            expect(result).toEqual(["childBlk", 1]);
-        });
-
         it("uses default voice and shows error for non-string", () => {
             const timbre = getBlock("timbre");
             // First call: interruption
@@ -445,39 +425,6 @@ describe("setupWidgetBlocks", () => {
         });
     });
 
-    describe("SamplerBlock", () => {
-        it("lazy-loads sample widget and returns child block on replay", () => {
-            const sampler = getBlock("sampler");
-
-            const interruption = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
-            expect(interruption).toEqual([null, 0, true]);
-            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
-            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
-                logo,
-                0,
-                "samplerBlk",
-                true,
-                "received"
-            );
-
-            const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk");
-            expect(logo.inSample).toBe(true);
-            expect(logo.sample).toBeDefined();
-            expect(result).toEqual(["childBlk", 1]);
-        });
-
-        it("lazy-loads sample widget when logo.sample is undefined", () => {
-            const sampler = getBlock("sampler");
-            delete logo.sample;
-
-            const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
-
-            expect(result).toEqual([null, 0, true]);
-            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
-            expect(logo.sample).toBeDefined();
-        });
-    });
-
     describe("AIDebuggerBlock", () => {
         it("uses its own widget instance instead of sampler state", () => {
             const sampler = getBlock("sampler");
@@ -494,62 +441,6 @@ describe("setupWidgetBlocks", () => {
             expect(logo.aiDebugger).toBeDefined();
             expect(logo.sample).not.toBe(logo.aiDebugger);
             expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
-        });
-
-        it("does not depend on sampler state being initialized", () => {
-            const aiDebugger = getBlock("aidebugger");
-
-            const interruption = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk", "received");
-            expect(interruption).toEqual([null, 0, true]);
-            expect(global.AIDebuggerWidget).toHaveBeenCalledTimes(1);
-            expect(logo.aiDebugger).toBeDefined();
-            expect(logo.sample).toBeNull();
-            expect(logo.inSample).toBe(false);
-
-            const result = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk");
-            expect(result).toEqual(["childBlk", 1]);
-            expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
-        });
-    });
-
-    describe("First-Click Flow (Lazy Loading)", () => {
-        it("returns interruption and triggers runFromBlockNow for TemperamentBlock", () => {
-            const temperament = getBlock("temperament");
-            logo.temperament = null;
-            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
-            expect(res).toEqual([null, 0, true]);
-            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "tempBlk", true, "received");
-        });
-
-        it("returns interruption and triggers runFromBlockNow for MusicKeyboardBlock", () => {
-            const keyboard = getBlock("musickeyboard");
-            logo.musicKeyboard = null;
-            const res = keyboard.flow(["childBlk"], logo, 0, "kbdBlk", "received");
-            expect(res).toEqual([null, 0, true]);
-            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "kbdBlk", true, "received");
-        });
-
-        it("returns interruption and triggers runFromBlockNow for MatrixBlock (PhraseMaker)", () => {
-            const matrix = getBlock("matrix");
-            logo.phraseMaker = null;
-            const res = matrix.flow(["childBlk"], logo, 0, "matrixBlk", "received");
-            expect(res).toEqual([null, 0, true]);
-            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
-                logo,
-                0,
-                "matrixBlk",
-                true,
-                "received"
-            );
-        });
-
-        it("returns interruption if widget is already loading (guard check)", () => {
-            const temperament = getBlock("temperament");
-            logo.temperament = "loading";
-            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
-            expect(res).toEqual([null, 0, true]);
-            // Should not trigger another runFromBlockNow or lazy load callback
-            expect(logo.runFromBlockNow).not.toHaveBeenCalled();
         });
     });
 
@@ -766,24 +657,6 @@ describe("setupWidgetBlocks", () => {
 
         // Exercise the previously-untested call sites so dependency
         // resolution actually executes, not just gets matched textually above.
-        it.each([
-            ["arpeggiomatrix", "arpBlk", "arpeggio", global.Arpeggio],
-            ["pitchdrummatrix", "pdmBlk", "pitchDrumMatrix", global.PitchDrumMatrix],
-            ["pitchslider", "psBlk", "pitchSlider", global.PitchSlider],
-            ["pitchstaircase", "pstBlk", "pitchStaircase", global.PitchStaircase],
-            ["rhythmruler2", "rrBlk", "rhythmRuler", global.RhythmRuler],
-            ["reflection", "reflBlk", "reflection", global.ReflectionMatrix],
-            ["legobricks", "legoBlk", "legoWidget", global.LegoWidget]
-        ])("%s lazy-loads its widget on first use", (type, blk, logoKey, Widget) => {
-            const block = getBlock(type);
-
-            const interruption = block.flow(["childBlk"], logo, 0, blk, "received");
-
-            expect(interruption).toEqual([null, 0, true]);
-            expect(Widget).toHaveBeenCalledTimes(1);
-            expect(logo[logoKey]).toBeDefined();
-        });
-
         it.each([
             ["meterwidget", "meterBlk", "meterWidget", global.MeterWidget],
             ["oscilloscope", "oscBlk", "Oscilloscope", global.Oscilloscope],

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3484,6 +3484,18 @@ const piemenuModes = (block, selectedMode) => {
 
     showWheelDiv();
 
+    // Saved custom modes from the mode widget, shown in a dedicated "custom"
+    // pie menu group so they can be selected without opening the editor.
+    let savedCustomModes = [];
+    try {
+        const customModes = JSON.parse(localStorage.getItem("customModes") || "[]");
+        savedCustomModes = Array.isArray(customModes)
+            ? customModes.filter(m => m && typeof m.name === "string")
+            : [];
+    } catch (e) {
+        savedCustomModes = [];
+    }
+
     //Use advanced constructor for more wheelnav on same div
     block._modeWheel = new wheelnav("wheelDiv", null, 1200, 1200);
     block._modeGroupWheel = new wheelnav("_modeGroupWheel", block._modeWheel.raphael);
@@ -3528,6 +3540,9 @@ const piemenuModes = (block, selectedMode) => {
     for (const modegroup in MODE_PIE_MENUS) {
         xlabels.push(modegroup);
     }
+    if (savedCustomModes.length > 0) {
+        xlabels.push("custom");
+    }
 
     block._modeGroupWheel.createWheel(xlabels);
 
@@ -3553,26 +3568,16 @@ const piemenuModes = (block, selectedMode) => {
 
     const that = block;
 
-    // Suppresses the mode-widget launch during programmatic wheel navigation
-    // (initial menu setup and group switching) so that only genuine user
-    // clicks on the "custom" slice open the circular mode editor.
-    let menuInitializing = true;
-
-    // Opens the circular mode editor widget so the selected custom mode can
-    // be built or edited on the N-slice wheel. The widget reads the active
-    // temperament from the logo synth on construction.
-    const __launchModeWidget = () => {
-        if (typeof ModeWidget === "undefined") {
-            if (typeof require !== "undefined") {
-                require(["widgets/modewidget"], function () {
-                    const act = block.activity;
-                    act.logo.modeWidget = new ModeWidget(act);
-                });
+    // Mode list for a group; "custom" is dynamic, padded to the fixed 12-slot layout.
+    const __modesForGroup = grp => {
+        if (grp === "custom") {
+            const names = savedCustomModes.map(m => m.name).slice(0, 12);
+            while (names.length < 12) {
+                names.push(" ");
             }
-        } else {
-            const act = block.activity;
-            act.logo.modeWidget = new ModeWidget(act);
+            return names;
         }
+        return MODE_PIE_MENUS[grp];
     };
 
     const __selectionChanged = () => {
@@ -3590,8 +3595,9 @@ const piemenuModes = (block, selectedMode) => {
             } else if (that.text.text === `${_("minor")} / ${_("aeolian")}`) {
                 that.value = "aeolian";
             } else {
-                for (let i = 0; i < MODE_PIE_MENUS[modeGroup].length; i++) {
-                    const modename = MODE_PIE_MENUS[modeGroup][i];
+                const modes = __modesForGroup(modeGroup);
+                for (let i = 0; i < modes.length; i++) {
+                    const modename = modes[i];
 
                     if (_(modename) === that.text.text) {
                         that.value = modename;
@@ -3603,12 +3609,6 @@ const piemenuModes = (block, selectedMode) => {
             // Make sure text is on top.
             that.container.setChildIndex(that.text, that.container.children.length - 1);
             that.updateCache();
-        }
-
-        // Launch the circular mode editor when the user selects the
-        // custom mode in the radial menu.
-        if (!menuInitializing && that.value === "custom") {
-            __launchModeWidget();
         }
     };
 
@@ -3638,10 +3638,12 @@ const piemenuModes = (block, selectedMode) => {
 
         that._modeNameWheel.keynavigateEnabled = false;
 
+        const modes = __modesForGroup(grp);
+
         // Customize slicePaths
         const colors = [];
-        for (let i = 0; i < MODE_PIE_MENUS[grp].length; i++) {
-            const modename = MODE_PIE_MENUS[grp][i];
+        for (let i = 0; i < modes.length; i++) {
+            const modename = modes[i];
             if (modename === " ") {
                 colors.push(platformColor.modePieMenusIfColorPush);
             } else {
@@ -3660,8 +3662,8 @@ const piemenuModes = (block, selectedMode) => {
         // that._modeNameWheel.clickModeRotate = false;
         that._modeNameWheel.navAngle = -90;
         const labels = new Array();
-        for (let i = 0; i < MODE_PIE_MENUS[grp].length; i++) {
-            const modename = MODE_PIE_MENUS[grp][i];
+        for (let i = 0; i < modes.length; i++) {
+            const modename = modes[i];
             switch (modename) {
                 case "ionian":
                 case "major":
@@ -3715,10 +3717,10 @@ const piemenuModes = (block, selectedMode) => {
 
         // Set up tabs for each mode.
         let i = 0;
-        for (let j = 0; j < MODE_PIE_MENUS[grp].length; j++) {
-            const modename = MODE_PIE_MENUS[grp][j];
+        for (let j = 0; j < modes.length; j++) {
+            const modename = modes[j];
             const activeTabs = [0];
-            if (modename !== " ") {
+            if (modename !== " " && MUSICALMODES[modename]) {
                 const mode = MUSICALMODES[modename];
                 for (let k = 0; k < mode.length; k++) {
                     activeTabs.push(last(activeTabs) + mode[k]);
@@ -3730,8 +3732,8 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         // Look for the selected mode.
-        for (i = 0; i < MODE_PIE_MENUS[grp].length; i++) {
-            if (MODE_PIE_MENUS[grp][i] === selectedMode) {
+        for (i = 0; i < modes.length; i++) {
+            if (modes[i] === selectedMode) {
                 break;
             }
         }
@@ -3741,11 +3743,7 @@ const piemenuModes = (block, selectedMode) => {
             i = 0; // major/ionian
         }
 
-        // Programmatic navigation during setup/group switching must not
-        // launch the mode editor; only a real user click does that.
-        menuInitializing = true;
         that._modeNameWheel.navigateWheel(i);
-        menuInitializing = false;
     };
 
     let timeout;
@@ -3878,6 +3876,7 @@ const piemenuModes = (block, selectedMode) => {
     }
 
     // navigate to a specific starting point
+    let foundMode = false;
     for (modeGroup in MODE_PIE_MENUS) {
         let j;
         for (j = 0; j < MODE_PIE_MENUS[modeGroup].length; j++) {
@@ -3888,8 +3887,13 @@ const piemenuModes = (block, selectedMode) => {
         }
 
         if (j < MODE_PIE_MENUS[modeGroup].length) {
+            foundMode = true;
             break;
         }
+    }
+
+    if (!foundMode && savedCustomModes.some(m => m.name === selectedMode)) {
+        modeGroup = "custom";
     }
 
     if (selectedMode === "major") {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -18,8 +18,8 @@
    PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS,
    getSavedCustomModes, getModeNamesForGroup, getModeLabel,
    getModeNameFromLabel, getModeSliceColors, updateModeWheelItems,
-   getModeGroupTitleFont, getModeSliceFont, MODEPIEMENU_GROUP_RING,
-   MODEPIEMENU_NAME_RING,
+   getModeGroupTitleFont, getModeSliceFont, configureWheel,
+   MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
    getMunsellColor, COLORS40, frequencyToPitch, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
@@ -3499,40 +3499,20 @@ const piemenuModes = (block, selectedMode) => {
     // exit button
     block._exitWheel = new wheelnav("_exitWheel", block._modeWheel.raphael);
 
-    // Shared wheelnav factory: applies the common donut-slice styling so the
-    // three mode-selection wheels (mode, group, name) share identical visual
-    // configuration.
-    const makeWheel = (id, paper, { colors, minRadius, maxRadius, titleFont }) => {
-        const w = new wheelnav(id, paper);
-        w.colors = colors;
-        w.slicePathFunction = slicePath().DonutSlice;
-        w.slicePathCustom = slicePath().DonutSliceCustomization();
-        w.slicePathCustom.minRadiusPercent = minRadius;
-        w.slicePathCustom.maxRadiusPercent = maxRadius;
-        w.sliceSelectedPathCustom = w.slicePathCustom;
-        w.sliceInitPathCustom = w.slicePathCustom;
-        if (titleFont) w.titleFont = titleFont;
-        w.clickModeRotate = false;
-        w.navAngle = -90;
-        w.animatetime = 0;
-        return w;
-    };
-
-    block._modeWheel.colors = platformColor.modeWheelcolors;
-    block._modeWheel.slicePathFunction = slicePath().DonutSlice;
-    block._modeWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-    block._modeWheel.slicePathCustom.minRadiusPercent = 0.85;
-    block._modeWheel.slicePathCustom.maxRadiusPercent = 1;
-    block._modeWheel.sliceSelectedPathCustom = block._modeWheel.slicePathCustom;
-    block._modeWheel.sliceInitPathCustom = block._modeWheel.slicePathCustom;
-    block._modeWheel.clickModeRotate = false;
-    block._modeWheel.navAngle = -90;
-    block._modeWheel.animatetime = 0;
     const currentEDO = getCurrentEDO(block.activity.logo.synth.inTemperament);
     const modeWheelLabels = Array.from({ length: currentEDO }, (_, i) => String(i));
+
+    configureWheel(block._modeWheel, {
+        colors: platformColor.modeWheelcolors,
+        minRadius: 0.85,
+        maxRadius: 1,
+        clickModeRotate: false,
+        selectionPaths: true
+    });
     block._modeWheel.createWheel(modeWheelLabels);
 
-    block._modeGroupWheel = makeWheel("_modeGroupWheel", block._modeWheel.raphael, {
+    block._modeGroupWheel = new wheelnav("_modeGroupWheel", block._modeWheel.raphael);
+    configureWheel(block._modeGroupWheel, {
         colors: platformColor.modeGroupWheelcolors,
         minRadius: MODEPIEMENU_GROUP_RING.minRadius,
         maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
@@ -3550,14 +3530,13 @@ const piemenuModes = (block, selectedMode) => {
 
     block._modeGroupWheel.createWheel(xlabels);
 
-    block._exitWheel.colors = platformColor.exitWheelcolors;
-    block._exitWheel.slicePathFunction = slicePath().DonutSlice;
-    block._exitWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-    block._exitWheel.slicePathCustom.minRadiusPercent = 0.0;
-    block._exitWheel.slicePathCustom.maxRadiusPercent = 0.15;
-    block._exitWheel.sliceSelectedPathCustom = block._exitWheel.slicePathCustom;
-    block._exitWheel.sliceInitPathCustom = block._exitWheel.slicePathCustom;
-    block._exitWheel.clickModeRotate = false;
+    configureWheel(block._exitWheel, {
+        colors: platformColor.exitWheelcolors,
+        minRadius: 0.0,
+        maxRadius: 0.15,
+        clickModeRotate: false,
+        selectionPaths: true
+    });
     block._exitWheel.initWheel(["×", "▶"]); // imgsrc:header-icons/play-button.svg']);
     block._exitWheel.navItems[0].sliceSelectedAttr.cursor = "pointer";
     block._exitWheel.navItems[0].sliceHoverAttr.cursor = "pointer";
@@ -3617,7 +3596,8 @@ const piemenuModes = (block, selectedMode) => {
     const __buildModeNameWheel = grp => {
         let newWheel = false;
         if (that._modeNameWheel === null) {
-            that._modeNameWheel = makeWheel("_modeNameWheel", that._modeWheel.raphael, {
+            that._modeNameWheel = new wheelnav("_modeNameWheel", that._modeWheel.raphael);
+            configureWheel(that._modeNameWheel, {
                 colors: [],
                 minRadius: MODEPIEMENU_NAME_RING.minRadius,
                 maxRadius: MODEPIEMENU_NAME_RING.maxRadius
@@ -3824,28 +3804,31 @@ const piemenuModes = (block, selectedMode) => {
 
     // navigate to a specific starting point
     let foundMode = false;
-    for (modeGroup in MODE_PIE_MENUS) {
+    let matchedGroup = "";
+    for (const group in MODE_PIE_MENUS) {
         let j;
-        for (j = 0; j < MODE_PIE_MENUS[modeGroup].length; j++) {
-            const modename = MODE_PIE_MENUS[modeGroup][j];
+        for (j = 0; j < MODE_PIE_MENUS[group].length; j++) {
+            const modename = MODE_PIE_MENUS[group][j];
             if (modename === selectedMode) {
                 break;
             }
         }
 
-        if (j < MODE_PIE_MENUS[modeGroup].length) {
+        if (j < MODE_PIE_MENUS[group].length) {
             foundMode = true;
+            matchedGroup = group;
             break;
         }
     }
 
     if (!foundMode && savedCustomModes.some(m => m.name === selectedMode)) {
-        modeGroup = "custom";
+        matchedGroup = "custom";
     }
 
     if (selectedMode === "major") {
-        modeGroup = "7";
+        matchedGroup = "7";
     }
+    modeGroup = matchedGroup;
 
     const __buildModeWheel = () => {
         const i = that._modeGroupWheel.selectedNavItemIndex;
@@ -3855,12 +3838,8 @@ const piemenuModes = (block, selectedMode) => {
 
     for (let i = 0; i < block._modeGroupWheel.navItems.length; i++) {
         block._modeGroupWheel.navItems[i].navigateFunction = __buildModeWheel;
-    }
-
-    for (let i = 0; i < block._modeGroupWheel.navItems.length; i++) {
         if (block._modeGroupWheel.navItems[i].title === modeGroup) {
             block._modeGroupWheel.navigateWheel(i);
-            break;
         }
     }
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3538,10 +3538,11 @@ const piemenuModes = (block, selectedMode) => {
 
     const xlabels = [];
     for (const modegroup in MODE_PIE_MENUS) {
+        // Only show the "custom" group if there are saved custom modes
+        if (modegroup === "custom" && savedCustomModes.length === 0) {
+            continue;
+        }
         xlabels.push(modegroup);
-    }
-    if (savedCustomModes.length > 0) {
-        xlabels.push("custom");
     }
 
     block._modeGroupWheel.createWheel(xlabels);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3494,7 +3494,6 @@ const piemenuModes = (block, selectedMode) => {
 
     //Use advanced constructor for more wheelnav on same div
     block._modeWheel = new wheelnav("wheelDiv", null, 1200, 1200);
-    block._modeGroupWheel = new wheelnav("_modeGroupWheel", block._modeWheel.raphael);
     block._modeNameWheel = null; // We build block wheel based on the group selection.
     // exit button
     block._exitWheel = new wheelnav("_exitWheel", block._modeWheel.raphael);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -16,6 +16,10 @@
    platformColor, docById, Singer, slicePath, wheelnav,
    DEFAULTVOICE, getDrumName, getNote, MUSICALMODES last, SHARP, FLAT,
    PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS,
+   getSavedCustomModes, getModeNamesForGroup, getModeLabel,
+   getModeNameFromLabel, getModeSliceColors, updateModeWheelItems,
+   getModeGroupTitleFont, getModeSliceFont, MODEPIEMENU_GROUP_RING,
+   MODEPIEMENU_NAME_RING,
    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
    getMunsellColor, COLORS40, frequencyToPitch, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
@@ -3486,15 +3490,7 @@ const piemenuModes = (block, selectedMode) => {
 
     // Saved custom modes from the mode widget, shown in a dedicated "custom"
     // pie menu group so they can be selected without opening the editor.
-    let savedCustomModes = [];
-    try {
-        const customModes = JSON.parse(localStorage.getItem("customModes") || "[]");
-        savedCustomModes = Array.isArray(customModes)
-            ? customModes.filter(m => m && typeof m.name === "string")
-            : [];
-    } catch (e) {
-        savedCustomModes = [];
-    }
+    const savedCustomModes = getSavedCustomModes();
 
     //Use advanced constructor for more wheelnav on same div
     block._modeWheel = new wheelnav("wheelDiv", null, 1200, 1200);
@@ -3503,7 +3499,24 @@ const piemenuModes = (block, selectedMode) => {
     // exit button
     block._exitWheel = new wheelnav("_exitWheel", block._modeWheel.raphael);
 
-    wheelnav.cssMode = true;
+    // Shared wheelnav factory: applies the common donut-slice styling so the
+    // three mode-selection wheels (mode, group, name) share identical visual
+    // configuration.
+    const makeWheel = (id, paper, { colors, minRadius, maxRadius, titleFont }) => {
+        const w = new wheelnav(id, paper);
+        w.colors = colors;
+        w.slicePathFunction = slicePath().DonutSlice;
+        w.slicePathCustom = slicePath().DonutSliceCustomization();
+        w.slicePathCustom.minRadiusPercent = minRadius;
+        w.slicePathCustom.maxRadiusPercent = maxRadius;
+        w.sliceSelectedPathCustom = w.slicePathCustom;
+        w.sliceInitPathCustom = w.slicePathCustom;
+        if (titleFont) w.titleFont = titleFont;
+        w.clickModeRotate = false;
+        w.navAngle = -90;
+        w.animatetime = 0;
+        return w;
+    };
 
     block._modeWheel.colors = platformColor.modeWheelcolors;
     block._modeWheel.slicePathFunction = slicePath().DonutSlice;
@@ -3512,29 +3525,19 @@ const piemenuModes = (block, selectedMode) => {
     block._modeWheel.slicePathCustom.maxRadiusPercent = 1;
     block._modeWheel.sliceSelectedPathCustom = block._modeWheel.slicePathCustom;
     block._modeWheel.sliceInitPathCustom = block._modeWheel.slicePathCustom;
-
-    // Disable rotation, set navAngle and create the menus
     block._modeWheel.clickModeRotate = false;
     block._modeWheel.navAngle = -90;
-    // block._modeWheel.selectedNavItemIndex = 2;
-    block._modeWheel.animatetime = 0; // 300;
+    block._modeWheel.animatetime = 0;
     const currentEDO = getCurrentEDO(block.activity.logo.synth.inTemperament);
     const modeWheelLabels = Array.from({ length: currentEDO }, (_, i) => String(i));
     block._modeWheel.createWheel(modeWheelLabels);
 
-    block._modeGroupWheel.colors = platformColor.modeGroupWheelcolors;
-    block._modeGroupWheel.slicePathFunction = slicePath().DonutSlice;
-    block._modeGroupWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-    block._modeGroupWheel.slicePathCustom.minRadiusPercent = 0.15;
-    block._modeGroupWheel.slicePathCustom.maxRadiusPercent = 0.3;
-    block._modeGroupWheel.sliceSelectedPathCustom = block._modeGroupWheel.slicePathCustom;
-    block._modeGroupWheel.sliceInitPathCustom = block._modeGroupWheel.slicePathCustom;
-
-    // Disable rotation, set navAngle and create the menus
-    // block._modeGroupWheel.clickModeRotate = false;
-    block._modeGroupWheel.navAngle = -90;
-    // block._modeGroupWheel.selectedNavItemIndex = 2;
-    block._modeGroupWheel.animatetime = 0; // 300;
+    block._modeGroupWheel = makeWheel("_modeGroupWheel", block._modeWheel.raphael, {
+        colors: platformColor.modeGroupWheelcolors,
+        minRadius: MODEPIEMENU_GROUP_RING.minRadius,
+        maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
+        titleFont: getModeGroupTitleFont(block._modeWheel.wheelRadius)
+    });
 
     const xlabels = [];
     for (const modegroup in MODE_PIE_MENUS) {
@@ -3570,16 +3573,11 @@ const piemenuModes = (block, selectedMode) => {
     const that = block;
 
     // Mode list for a group; "custom" is dynamic, padded to the fixed 12-slot layout.
-    const __modesForGroup = grp => {
-        if (grp === "custom") {
-            const names = savedCustomModes.map(m => m.name).slice(0, 12);
-            while (names.length < 12) {
-                names.push(" ");
-            }
-            return names;
-        }
-        return MODE_PIE_MENUS[grp];
-    };
+    const __modesForGroup = grp =>
+        getModeNamesForGroup(
+            grp,
+            savedCustomModes.map(m => m.name)
+        );
 
     const __selectionChanged = () => {
         const title = that._modeNameWheel.navItems[that._modeNameWheel.selectedNavItemIndex].title;
@@ -3591,21 +3589,7 @@ const piemenuModes = (block, selectedMode) => {
             that.text.text =
                 that._modeNameWheel.navItems[that._modeNameWheel.selectedNavItemIndex].title;
 
-            if (that.text.text === `${_("major")} / ${_("ionian")}`) {
-                that.value = "major";
-            } else if (that.text.text === `${_("minor")} / ${_("aeolian")}`) {
-                that.value = "aeolian";
-            } else {
-                const modes = __modesForGroup(modeGroup);
-                for (let i = 0; i < modes.length; i++) {
-                    const modename = modes[i];
-
-                    if (_(modename) === that.text.text) {
-                        that.value = modename;
-                        break;
-                    }
-                }
-            }
+            that.value = getModeNameFromLabel(that.text.text, __modesForGroup(modeGroup));
 
             // Make sure text is on top.
             that.container.setChildIndex(that.text, that.container.children.length - 1);
@@ -3633,87 +3617,49 @@ const piemenuModes = (block, selectedMode) => {
     const __buildModeNameWheel = grp => {
         let newWheel = false;
         if (that._modeNameWheel === null) {
-            that._modeNameWheel = new wheelnav("_modeNameWheel", that._modeWheel.raphael);
+            that._modeNameWheel = makeWheel("_modeNameWheel", that._modeWheel.raphael, {
+                colors: [],
+                minRadius: MODEPIEMENU_NAME_RING.minRadius,
+                maxRadius: MODEPIEMENU_NAME_RING.maxRadius
+            });
+            that._modeNameWheel.keynavigateEnabled = false;
             newWheel = true;
         }
-
-        that._modeNameWheel.keynavigateEnabled = false;
 
         const modes = __modesForGroup(grp);
 
         // Customize slicePaths
-        const colors = [];
-        for (let i = 0; i < modes.length; i++) {
-            const modename = modes[i];
-            if (modename === " ") {
-                colors.push(platformColor.modePieMenusIfColorPush);
-            } else {
-                colors.push(platformColor.modePieMenusElseColorPush);
-            }
-        }
+        const colors = getModeSliceColors(modes, {
+            emptyColor: platformColor.modePieMenusIfColorPush,
+            filledColor: platformColor.modePieMenusElseColorPush
+        });
 
         that._modeNameWheel.colors = colors;
-        that._modeNameWheel.slicePathFunction = slicePath().DonutSlice;
-        that._modeNameWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        that._modeNameWheel.slicePathCustom.minRadiusPercent = 0.3; //0.15;
-        that._modeNameWheel.slicePathCustom.maxRadiusPercent = 0.85;
-        that._modeNameWheel.sliceSelectedPathCustom = that._modeNameWheel.slicePathCustom;
-        that._modeNameWheel.sliceInitPathCustom = that._modeNameWheel.slicePathCustom;
         that._modeNameWheel.titleRotateAngle = 0;
-        // that._modeNameWheel.clickModeRotate = false;
-        that._modeNameWheel.navAngle = -90;
         const labels = new Array();
         for (let i = 0; i < modes.length; i++) {
-            const modename = modes[i];
-            switch (modename) {
-                case "ionian":
-                case "major":
-                    labels.push(`${_("major")} / ${_("ionian")}`);
-                    break;
-                case "aeolian":
-                case "minor":
-                    labels.push(`${_("minor")} / ${_("aeolian")}`);
-                    break;
-                default:
-                    if (modename === " ") {
-                        labels.push(" ");
-                    } else {
-                        labels.push(_(modename));
-                    }
-                    break;
-            }
+            labels.push(getModeLabel(modes[i]));
         }
 
-        that._modeNameWheel.animatetime = 0; // 300;
+        that._modeNameWheel.animatetime = 0;
         if (newWheel) {
             that._modeNameWheel.createWheel(labels);
         } else {
-            for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
-                // Maybe there is a method that does this?
-                that._modeNameWheel.navItems[i].title = labels[i];
-                that._modeNameWheel.navItems[i].basicNavTitleMax.title = labels[i];
-                that._modeNameWheel.navItems[i].basicNavTitleMin.title = labels[i];
-                that._modeNameWheel.navItems[i].hoverNavTitleMax.title = labels[i];
-                that._modeNameWheel.navItems[i].hoverNavTitleMin.title = labels[i];
-                that._modeNameWheel.navItems[i].selectedNavTitleMax.title = labels[i];
-                that._modeNameWheel.navItems[i].selectedNavTitleMin.title = labels[i];
-                that._modeNameWheel.navItems[i].initNavTitle.title = labels[i];
-                that._modeNameWheel.navItems[i].fillAttr = colors[i];
-                that._modeNameWheel.navItems[i].sliceHoverAttr.fill = colors[i];
-                that._modeNameWheel.navItems[i].slicePathAttr.fill = colors[i];
-                that._modeNameWheel.navItems[i].sliceSelectedAttr.fill = colors[i];
-            }
-
-            that._modeNameWheel.refreshWheel();
+            updateModeWheelItems(that._modeNameWheel, labels, colors);
         }
 
-        // Special case for Japanese
-        const language = localStorage.languagePreference;
-        if (language === "ja") {
-            for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
-                that._modeNameWheel.navItems[i].titleAttr.font = "30 30px sans-serif";
-                that._modeNameWheel.navItems[i].titleSelectedAttr.font = "30 30px sans-serif";
-            }
+        // Size each label to fit its own slice arc; the 12 slots are fixed,
+        // so short names render large and only long ones shrink. Applied
+        // post-createWheel via the per-item title attributes.
+        for (let i = 0; i < that._modeNameWheel.navItems.length; i++) {
+            const font = getModeSliceFont(
+                that._modeWheel.wheelRadius,
+                labels.length,
+                labels[i].length
+            );
+            that._modeNameWheel.navItems[i].titleAttr.font = font;
+            that._modeNameWheel.navItems[i].titleHoverAttr.font = font;
+            that._modeNameWheel.navItems[i].titleSelectedAttr.font = font;
         }
 
         // Set up tabs for each mode.
@@ -4536,5 +4482,5 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches, piemenuKey, piemenuNumber };
+    module.exports = { piemenuPitches, piemenuKey, piemenuNumber, piemenuModes };
 }

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3843,7 +3843,6 @@ const piemenuModes = (block, selectedMode) => {
         block._modeGroupWheel.navItems[i].navigateFunction = __buildModeWheel;
         if (block._modeGroupWheel.navItems[i].title === modeGroup) {
             block._modeGroupWheel.navigateWheel(i);
-            break;
         }
     }
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3539,7 +3539,7 @@ const piemenuModes = (block, selectedMode) => {
         clickModeRotate: false,
         selectionPaths: true
     });
-    block._exitWheel.initWheel(["×", "▶"]); // imgsrc:header-icons/play-button.svg']);
+    block._exitWheel.initWheel(["×", "▶"]);
     block._exitWheel.navItems[0].sliceSelectedAttr.cursor = "pointer";
     block._exitWheel.navItems[0].sliceHoverAttr.cursor = "pointer";
     block._exitWheel.navItems[0].titleSelectedAttr.cursor = "pointer";
@@ -3619,10 +3619,7 @@ const piemenuModes = (block, selectedMode) => {
 
         that._modeNameWheel.colors = colors;
         that._modeNameWheel.titleRotateAngle = 0;
-        const labels = new Array();
-        for (let i = 0; i < modes.length; i++) {
-            labels.push(getModeLabel(modes[i]));
-        }
+        const labels = modes.map(getModeLabel);
 
         that._modeNameWheel.animatetime = 0;
         if (newWheel) {
@@ -3805,26 +3802,16 @@ const piemenuModes = (block, selectedMode) => {
         that._modeWheel.navItems[i].navigateFunction = __playNote;
     }
 
-    // navigate to a specific starting point
-    let foundMode = false;
+    // Navigate to a specific starting point.
     let matchedGroup = "";
     for (const group in MODE_PIE_MENUS) {
-        let j;
-        for (j = 0; j < MODE_PIE_MENUS[group].length; j++) {
-            const modename = MODE_PIE_MENUS[group][j];
-            if (modename === selectedMode) {
-                break;
-            }
-        }
-
-        if (j < MODE_PIE_MENUS[group].length) {
-            foundMode = true;
+        if (MODE_PIE_MENUS[group].includes(selectedMode)) {
             matchedGroup = group;
             break;
         }
     }
 
-    if (!foundMode && savedCustomModes.some(m => m.name === selectedMode)) {
+    if (matchedGroup === "" && savedCustomModes.some(m => m.name === selectedMode)) {
         matchedGroup = "custom";
     }
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3553,6 +3553,28 @@ const piemenuModes = (block, selectedMode) => {
 
     const that = block;
 
+    // Suppresses the mode-widget launch during programmatic wheel navigation
+    // (initial menu setup and group switching) so that only genuine user
+    // clicks on the "custom" slice open the circular mode editor.
+    let menuInitializing = true;
+
+    // Opens the circular mode editor widget so the selected custom mode can
+    // be built or edited on the N-slice wheel. The widget reads the active
+    // temperament from the logo synth on construction.
+    const __launchModeWidget = () => {
+        if (typeof ModeWidget === "undefined") {
+            if (typeof require !== "undefined") {
+                require(["widgets/modewidget"], function () {
+                    const act = block.activity;
+                    act.logo.modeWidget = new ModeWidget(act);
+                });
+            }
+        } else {
+            const act = block.activity;
+            act.logo.modeWidget = new ModeWidget(act);
+        }
+    };
+
     const __selectionChanged = () => {
         const title = that._modeNameWheel.navItems[that._modeNameWheel.selectedNavItemIndex].title;
         if (title === " ") {
@@ -3581,6 +3603,12 @@ const piemenuModes = (block, selectedMode) => {
             // Make sure text is on top.
             that.container.setChildIndex(that.text, that.container.children.length - 1);
             that.updateCache();
+        }
+
+        // Launch the circular mode editor when the user selects the
+        // custom mode in the radial menu.
+        if (!menuInitializing && that.value === "custom") {
+            __launchModeWidget();
         }
     };
 
@@ -3713,7 +3741,11 @@ const piemenuModes = (block, selectedMode) => {
             i = 0; // major/ionian
         }
 
+        // Programmatic navigation during setup/group switching must not
+        // launch the mode editor; only a real user click does that.
+        menuInitializing = true;
         that._modeNameWheel.navigateWheel(i);
+        menuInitializing = false;
     };
 
     let timeout;

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3465,6 +3465,8 @@ const piemenuIntervals = (block, selectedInterval) => {
 const piemenuModes = (block, selectedMode) => {
     // pie menu for mode selection
 
+    wheelnav.cssMode = true;
+
     if (block.blocks.stageClick) {
         return;
     }
@@ -3515,7 +3517,8 @@ const piemenuModes = (block, selectedMode) => {
         colors: platformColor.modeGroupWheelcolors,
         minRadius: MODEPIEMENU_GROUP_RING.minRadius,
         maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
-        titleFont: getModeGroupTitleFont(block._modeWheel.wheelRadius)
+        titleFont: getModeGroupTitleFont(block._modeWheel.wheelRadius),
+        selectionPaths: true
     });
 
     const xlabels = [];
@@ -3599,7 +3602,8 @@ const piemenuModes = (block, selectedMode) => {
             configureWheel(that._modeNameWheel, {
                 colors: [],
                 minRadius: MODEPIEMENU_NAME_RING.minRadius,
-                maxRadius: MODEPIEMENU_NAME_RING.maxRadius
+                maxRadius: MODEPIEMENU_NAME_RING.maxRadius,
+                selectionPaths: true
             });
             that._modeNameWheel.keynavigateEnabled = false;
             newWheel = true;
@@ -3839,6 +3843,7 @@ const piemenuModes = (block, selectedMode) => {
         block._modeGroupWheel.navItems[i].navigateFunction = __buildModeWheel;
         if (block._modeGroupWheel.navItems[i].title === modeGroup) {
             block._modeGroupWheel.navigateWheel(i);
+            break;
         }
     }
 

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -19,8 +19,9 @@
    global
 
    DEFAULTVOLUME, TARGETBPM, TONEBPM, MIN_HIGHLIGHT_DURATION_MS, deepClone, frequencyToPitch, last,
-   pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp,
-   getStepSizeDown, numberToPitch, pitchToNumber, rationalSum,
+    pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp,
+    getStepSizeDown, numberToPitch, pitchToNumber, rationalSum,
+    temperamentHasRatios,
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
@@ -327,7 +328,48 @@ class Singer {
             temperament
         );
 
-        if (isCustomTemperament(temperament)) {
+        // Custom temperaments without ratio data step by a raw semitone offset;
+        // everything else steps by mode-resolved EDO steps.
+        const useEdoSteps =
+            isTrueEDO(temperament) ||
+            !isCustomTemperament(temperament) ||
+            temperamentHasRatios(temperament);
+
+        if (useEdoSteps) {
+            for (let i = 0; i < Math.abs(steps); i++) {
+                const stepEdo =
+                    steps > 0
+                        ? getStepSizeUp(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              temperament,
+                              edo
+                          )
+                        : getStepSizeDown(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              temperament,
+                              edo
+                          );
+                noteObj = getNote(
+                    noteObj[0],
+                    noteObj[1],
+                    stepEdo,
+                    tur.singer.keySignature,
+                    tur.singer.movable,
+                    null,
+                    activity.errorMsg,
+                    temperament,
+                    true, // isAlreadyEdoSteps
+                    false // allow octave wrap
+                );
+            }
+        } else {
+            // Custom temperament without ratio data: no per-degree scale lookup
+            // is possible, so treat the step count as a raw semitone offset and
+            // let getNote rescale it.
             noteObj = getNote(
                 noteObj[0],
                 noteObj[1],
@@ -339,76 +381,9 @@ class Singer {
                 null,
                 activity.errorMsg,
                 temperament,
-                false,
-                false // allow octave wrap for scalar traversal
+                false, // isAlreadyEdoSteps — steps is raw semitone offset
+                false // allow octave wrap
             );
-        } else if (!isTrueEDO(temperament)) {
-            const curTemp = temperament;
-            for (let i = 0; i < Math.abs(steps); i++) {
-                const stepEdo =
-                    steps > 0
-                        ? getStepSizeUp(
-                              tur.singer.keySignature,
-                              noteObj[0],
-                              undefined,
-                              curTemp,
-                              edo
-                          )
-                        : getStepSizeDown(
-                              tur.singer.keySignature,
-                              noteObj[0],
-                              undefined,
-                              curTemp,
-                              edo
-                          );
-                noteObj = getNote(
-                    noteObj[0],
-                    noteObj[1],
-                    stepEdo,
-                    tur.singer.keySignature,
-                    tur.singer.movable,
-                    null,
-                    activity.errorMsg,
-                    curTemp,
-                    true, // isAlreadyEdoSteps
-                    false // allow octave wrap
-                );
-            }
-        } else {
-            const curTemp = temperament;
-
-            const curEDO = edo;
-            for (let i = 0; i < Math.abs(steps); i++) {
-                const stepEdo =
-                    steps > 0
-                        ? getStepSizeUp(
-                              tur.singer.keySignature,
-                              noteObj[0],
-                              undefined,
-                              curTemp,
-                              curEDO
-                          )
-                        : getStepSizeDown(
-                              tur.singer.keySignature,
-                              noteObj[0],
-                              undefined,
-                              curTemp,
-                              curEDO
-                          );
-
-                noteObj = getNote(
-                    noteObj[0],
-                    noteObj[1],
-                    stepEdo,
-                    tur.singer.keySignature,
-                    tur.singer.movable,
-                    null,
-                    activity.errorMsg,
-                    curTemp,
-                    true,
-                    false // allow octave wrap
-                );
-            }
         }
 
         return noteObj;

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -79,11 +79,8 @@ function setupIntervalsActions(activity) {
          * @returns {Number}
          */
         static getTemperamentLength() {
-            const currentTemperament = activity.logo.synth.inTemperament;
-            if (!currentTemperament) {
-                return 12; // Default fallback for tests/uninitialized state
-            }
-            return TEMPERAMENT[currentTemperament]["pitchNumber"];
+            const t = TEMPERAMENT[activity.logo.synth.inTemperament];
+            return t?.pitchNumber ?? 12;
         }
 
         /**

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -58,8 +58,12 @@ function setupIntervalsActions(activity) {
          */
         static GetModename(mode) {
             let modename = "major";
+            if (typeof mode !== "string") {
+                return modename;
+            }
+            const lowercaseMode = mode.toLowerCase();
             for (const _mode in MUSICALMODES) {
-                if (_mode === mode || _(_mode) === mode) {
+                if (_mode === mode || _mode.toLowerCase() === lowercaseMode || _(_mode) === mode) {
                     modename = _mode;
                     break;
                 }

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -63,7 +63,7 @@ function setupIntervalsActions(activity) {
             }
             const lowercaseMode = mode.toLowerCase();
             for (const _mode in MUSICALMODES) {
-                if (_mode === mode || _mode.toLowerCase() === lowercaseMode || _(_mode) === mode) {
+                if (_mode.toLowerCase() === lowercaseMode || _(_mode) === mode) {
                     modename = _mode;
                     break;
                 }

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -124,7 +124,17 @@ const {
     scalePatternToEDO,
     PITCH_COLLECTIONS_EDO_OVERRIDES,
     getModePattern,
-    generateNoteNames
+    generateNoteNames,
+    MODEPIEMENU_GROUP_RING,
+    MODEPIEMENU_NAME_RING,
+    getSavedCustomModes,
+    getModeNamesForGroup,
+    getModeLabel,
+    getModeNameFromLabel,
+    getModeSliceColors,
+    updateModeWheelItems,
+    getModeGroupTitleFont,
+    getModeSliceFont
 } = require("../musicutils");
 
 const DOUBLESHARP = "\ud834\udd2a";
@@ -3773,5 +3783,123 @@ describe("getStepSizeDown with custom temperament", () => {
         // proportional 12-EDO result (-2) produced by the PITCHES2 walk.
         const result = getStepSizeDown("C major", "C#", 5, "testWithRatios19");
         expect(result).toBe(-1);
+    });
+});
+
+describe("mode pie menu shared helpers", () => {
+    describe("getModeNamesForGroup", () => {
+        it("returns the built-in group list untouched", () => {
+            const modes = getModeNamesForGroup("7", []);
+            expect(modes.length).toBe(12);
+            expect(modes).toContain("ionian");
+            expect(modes).toContain("aeolian");
+        });
+
+        it("pads the custom group to the fixed 12-slot layout and preserves caller sentinels", () => {
+            const modes = getModeNamesForGroup("custom", ["+", "my mode", "other"]);
+            expect(modes.length).toBe(12);
+            expect(modes.slice(0, 3)).toEqual(["+", "my mode", "other"]);
+            expect(modes.slice(3)).toEqual(new Array(9).fill(" "));
+        });
+    });
+
+    describe("getModeLabel", () => {
+        it("translates the major/ionian pair and leaves blank slots blank", () => {
+            expect(getModeLabel("major")).toBe("major / ionian");
+            expect(getModeLabel("ionian")).toBe("major / ionian");
+            expect(getModeLabel(" ")).toBe(" ");
+        });
+    });
+
+    describe("getModeNameFromLabel", () => {
+        const modes = ["ionian", " ", "dorian", " ", "aeolian"];
+
+        it("resolves the major/ionian label to major", () => {
+            expect(getModeNameFromLabel("major / ionian", modes)).toBe("major");
+        });
+
+        it("falls back to the label itself when nothing matches", () => {
+            expect(getModeNameFromLabel("unknown", modes)).toBe("unknown");
+        });
+    });
+
+    describe("getModeSliceColors", () => {
+        it("maps blanks to the empty color and modes to the filled color", () => {
+            const colors = getModeSliceColors([" ", "dorian", " "], {
+                emptyColor: "empty",
+                filledColor: "filled"
+            });
+            expect(colors).toEqual(["empty", "filled", "empty"]);
+        });
+    });
+
+    describe("updateModeWheelItems", () => {
+        it("updates every title copy and fill attribute then refreshes", () => {
+            const refreshWheel = jest.fn();
+            const wheel = {
+                navItems: [
+                    {
+                        title: "old",
+                        basicNavTitleMax: {},
+                        basicNavTitleMin: {},
+                        hoverNavTitleMax: {},
+                        hoverNavTitleMin: {},
+                        selectedNavTitleMax: {},
+                        selectedNavTitleMin: {},
+                        initNavTitle: {},
+                        fillAttr: "old",
+                        sliceHoverAttr: {},
+                        slicePathAttr: {},
+                        sliceSelectedAttr: {}
+                    }
+                ],
+                refreshWheel
+            };
+
+            updateModeWheelItems(wheel, ["new"], ["#123456"]);
+
+            const item = wheel.navItems[0];
+            expect(item.title).toBe("new");
+            expect(item.basicNavTitleMax.title).toBe("new");
+            expect(item.basicNavTitleMin.title).toBe("new");
+            expect(item.hoverNavTitleMax.title).toBe("new");
+            expect(item.hoverNavTitleMin.title).toBe("new");
+            expect(item.selectedNavTitleMax.title).toBe("new");
+            expect(item.selectedNavTitleMin.title).toBe("new");
+            expect(item.initNavTitle.title).toBe("new");
+            expect(item.fillAttr).toBe("#123456");
+            expect(item.sliceHoverAttr.fill).toBe("#123456");
+            expect(item.slicePathAttr.fill).toBe("#123456");
+            expect(item.sliceSelectedAttr.fill).toBe("#123456");
+            expect(refreshWheel).toHaveBeenCalled();
+        });
+    });
+
+    describe("shared mode pie menu geometry", () => {
+        it("scales the group title font with the wheel radius", () => {
+            expect(getModeGroupTitleFont(200)).toBe("100 16px sans-serif");
+            expect(getModeGroupTitleFont(600)).toBe("100 48px sans-serif");
+        });
+    });
+
+    describe("getSavedCustomModes", () => {
+        afterEach(() => {
+            localStorage.clear();
+        });
+
+        it("parses saved modes and keeps only entries with a string name", () => {
+            localStorage.setItem(
+                "customModes",
+                JSON.stringify([{ name: "my mode", pattern: [1, 2] }, { pattern: [1] }, null])
+            );
+            expect(getSavedCustomModes()).toEqual([{ name: "my mode", pattern: [1, 2] }]);
+        });
+
+        it("returns an empty list for corrupt or non-array data", () => {
+            localStorage.setItem("customModes", "{not json");
+            expect(getSavedCustomModes()).toEqual([]);
+            localStorage.setItem("customModes", JSON.stringify({ name: "not an array" }));
+            expect(getSavedCustomModes()).toEqual([]);
+        });
     });
 });

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1091,6 +1091,15 @@ describe("keySignatureToMode", () => {
         expect(keySignatureToMode("A minor")).toEqual(["A", "minor"]);
         expect(keySignatureToMode("E minor")).toEqual(["E", "minor"]);
     });
+    it("should match custom mode names case-insensitively", () => {
+        // A mixed-case custom mode registered in MUSICALMODES must resolve
+        // even when the key signature carries a different casing.
+        MUSICALMODES.MyMode = [3, 2, 3, 2, 2];
+        expect(keySignatureToMode("C MyMode")).toEqual(["C", "MyMode"]);
+        expect(keySignatureToMode("C mymode")).toEqual(["C", "MyMode"]);
+        expect(keySignatureToMode("C MYMODE")).toEqual(["C", "MyMode"]);
+        delete MUSICALMODES.MyMode;
+    });
 });
 
 describe("getScaleAndHalfSteps", () => {

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -125,16 +125,13 @@ const {
     PITCH_COLLECTIONS_EDO_OVERRIDES,
     getModePattern,
     generateNoteNames,
-    MODEPIEMENU_GROUP_RING,
-    MODEPIEMENU_NAME_RING,
     getSavedCustomModes,
     getModeNamesForGroup,
     getModeLabel,
     getModeNameFromLabel,
     getModeSliceColors,
     updateModeWheelItems,
-    getModeGroupTitleFont,
-    getModeSliceFont
+    getModeGroupTitleFont
 } = require("../musicutils");
 
 const DOUBLESHARP = "\ud834\udd2a";

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3788,6 +3788,35 @@ const isCustomTemperament = temperament => {
 };
 
 /**
+ * Detect whether a temperament carries usable per-pitch ratio data.
+ *
+ * Two storage formats exist:
+ *  - EDO/derived temperaments expose a `ratios` array.
+ *  - The temperament editor saves custom temperaments with per-pitch numeric
+ *    keys such as `"0": [ratio, note, octave]` (and no `ratios` array).
+ *
+ * The scalar-step code previously only checked the `ratios` array, so
+ * editor-saved custom temperaments (which hold the ratios in numeric keys)
+ * were wrongly treated as "no ratios" and stepped by a raw offset instead of
+ * following the mode pattern. That produced degenerate playback for custom
+ * EDO temperaments with a saved mode.
+ * @function
+ * @param {string} temperament - The temperament key.
+ * @returns {boolean} True if per-pitch ratio data is available.
+ */
+const temperamentHasRatios = temperament => {
+    const t = getTemperament(temperament);
+    if (!t || typeof t !== "object") {
+        return false;
+    }
+    if (Array.isArray(t.ratios) && t.ratios.length > 0) {
+        return true;
+    }
+    // Editor-saved custom temperaments store ratios in numeric pitch keys.
+    return Boolean(t["0"] && Array.isArray(t["0"]) && typeof t["0"][0] === "number");
+};
+
+/**
  * Check if a temperament is a true equal division of the octave (EDO).
  * True EDOs have uniform step sizes; non-equal temperaments (JI, meantone,
  * Pythagorean) have unequal intervals despite having a pitch count.
@@ -3800,6 +3829,47 @@ const isTrueEDO = temperament => {
         return false;
     }
     return temperament.startsWith("equal");
+};
+
+/**
+ * Detect whether a temperament is an equal division of the octave regardless of
+ * how it was registered. Unlike `isTrueEDO` (which only matches names starting
+ * with "equal") this also catches user-defined equal temperaments that the
+ * temperament editor saved under arbitrary keys such as "custom" or "custom1".
+ *
+ * A temperament is treated as equally tempered when:
+ *  - it explicitly flags `isEDO`, or
+ *  - its numeric pitch entries are arrays whose ratios match 2^(i / pitchNumber)
+ *    within tolerance (the editor stores ratios inside the numeric keys, not in a
+ *    `ratios` array).
+ *
+ * @function
+ * @param {string} temperament - The temperament key.
+ * @returns {boolean} True if the temperament is an equal division of the octave.
+ */
+const isEquallyTempered = temperament => {
+    const t = getTemperament(temperament);
+    if (!t || typeof t !== "object") {
+        return false;
+    }
+    if (t.isEDO) {
+        return true;
+    }
+    const n = t.pitchNumber;
+    if (!Number.isInteger(n) || n < 2) {
+        return false;
+    }
+    for (let i = 0; i < n; i++) {
+        const entry = t["" + i];
+        if (!Array.isArray(entry) || typeof entry[0] !== "number") {
+            return false;
+        }
+        const expected = Math.pow(2, i / n);
+        if (Math.abs(entry[0] - expected) > 1e-4) {
+            return false;
+        }
+    }
+    return true;
 };
 
 /**
@@ -3971,7 +4041,7 @@ const getArticulation = note => {
     // Strip microtonal ^ / v prefixes before matching so "^C" etc. resolve.
     const stripped = note.replace(/^[v^]+/, "");
     const match = stripped.match(/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/);
-    return match ? match[1] : note;
+    return match ? match[1] : stripped;
 };
 
 /**
@@ -5645,7 +5715,10 @@ function getNote(
     let note;
     let articulation;
 
-    if (temperament in PreDefinedTemperaments) {
+    if (
+        temperament in PreDefinedTemperaments ||
+        (isCustomTemperament(temperament) && isEquallyTempered(temperament))
+    ) {
         // Check for double flat or double sharp. Since bb and x behave
         // funny with string operations, we jump through some hoops.
         articulation = getArticulation(noteArg);
@@ -6273,7 +6346,12 @@ const getModePattern = (mode, edo = 12) => {
         return new Array(edo).fill(1);
     }
     if (mode in MUSICALMODES) {
-        return scalePatternToEDO(MUSICALMODES[mode], edo);
+        const pattern = MUSICALMODES[mode];
+        // Only 12-summing patterns are 12-EDO semitone modes that scalePatternToEDO
+        // can rescale; any other total (e.g. a 7-note 41-EDO mode sums to 41) is
+        // native to a non-12 EDO and must be returned as-is or playback corrupts.
+        const isSemitonePattern = pattern.reduce((a, b) => a + b, 0) === 12;
+        return isSemitonePattern ? scalePatternToEDO(pattern, edo) : pattern.slice();
     }
     return scalePatternToEDO(MUSICALMODES.major, edo);
 };
@@ -6469,7 +6547,7 @@ const _getStepSize = (keySignature, pitch, direction, transposition, temperament
     }
     if (isCustomTemperament(temperament)) {
         const t = getTemperament(temperament);
-        if (!t || !t.ratios) {
+        if (!t || !temperamentHasRatios(temperament)) {
             // Scalar = Semitone for custom Temperament with no ratios.
             return transposition;
         }
@@ -8132,7 +8210,9 @@ if (typeof module !== "undefined" && module.exports) {
         getVoiceIcon,
         getVoiceSynthName,
         isCustomTemperament,
+        temperamentHasRatios,
         isTrueEDO,
+        isEquallyTempered,
         getTemperamentRatio,
         getTemperamentCents,
         getTemperamentName,
@@ -8187,14 +8267,8 @@ if (typeof module !== "undefined" && module.exports) {
         INTERVALVALUES,
         FIXEDSOLFEGE,
         FIXEDSOLFEGE1,
-        MODEPIEMENU_SLOT_COUNT,
         MODEPIEMENU_GROUP_RING,
         MODEPIEMENU_NAME_RING,
-        MODEPIEMENU_NAME_TITLE_RADIUS,
-        MODEPIEMENU_FONT_FAMILY,
-        MODEPIEMENU_GROUP_FONT_RATIO,
-        MODEPIEMENU_NAME_FONT_MIN_RATIO,
-        MODEPIEMENU_NAME_FONT_MAX_RATIO,
         getSavedCustomModes,
         getModeNamesForGroup,
         getModeLabel,

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3219,8 +3219,9 @@ const getModeNumbers = name => {
         return m;
     };
 
+    const lowercaseName = name.toLowerCase();
     for (const mode in MUSICALMODES) {
-        if (mode === name.toLowerCase()) {
+        if (mode === lowercaseName || mode.toLowerCase() === lowercaseName) {
             return __convert(MUSICALMODES[mode]);
         }
     }
@@ -3823,12 +3824,23 @@ const keySignatureToMode = keySignature => {
 
     if (mode === "") {
         mode = "major";
-    } else {
-        mode = mode.toLowerCase();
     }
 
-    if (mode in MUSICALMODES) {
-        return [key, mode];
+    // Resolve the mode name case-insensitively. Built-in modes are registered
+    // lowercase, but user-defined modes keep their original casing (e.g.
+    // "MyMode"), so lowercasing the incoming name would fail the lookup.
+    let modeKey = mode;
+    if (!(modeKey in MUSICALMODES)) {
+        for (const m in MUSICALMODES) {
+            if (m.toLowerCase() === mode.toLowerCase()) {
+                modeKey = m;
+                break;
+            }
+        }
+    }
+
+    if (modeKey in MUSICALMODES) {
+        return [key, modeKey];
     } else {
         console.debug("Invalid mode name: " + mode + " reverting to major.");
         return [key, "major"];

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2003,6 +2003,44 @@ const getModeSliceFont = (wheelRadius, sliceCount, labelLen) => {
     return `100 ${clamped}px ${MODEPIEMENU_FONT_FAMILY}`;
 };
 
+/**
+ * Applies the shared donut-slice configuration to a wheelnav instance:
+ * colors, radii, -90° start angle, zero animation, and optional selection
+ * paths, title rotation, and title font.
+ * @param {Object} wheel - The wheelnav instance to configure.
+ * @param {Object} opts - Configuration options.
+ * @param {Array} opts.colors - Slice colors.
+ * @param {number} opts.minRadius - Min radius percent (0-1).
+ * @param {number} opts.maxRadius - Max radius percent (0-1).
+ * @param {boolean} [opts.clickModeRotate] - Whether clicks rotate the wheel.
+ * @param {boolean} [opts.selectionPaths] - Whether to sync selected/init paths.
+ * @param {number} [opts.titleRotateAngle] - Title rotation angle.
+ * @param {string} [opts.titleFont] - Title font CSS string.
+ * @returns {void}
+ */
+const configureWheel = (wheel, opts) => {
+    wheel.colors = opts.colors;
+    wheel.slicePathFunction = slicePath().DonutSlice;
+    wheel.slicePathCustom = slicePath().DonutSliceCustomization();
+    wheel.slicePathCustom.minRadiusPercent = opts.minRadius;
+    wheel.slicePathCustom.maxRadiusPercent = opts.maxRadius;
+    if (opts.clickModeRotate !== undefined) {
+        wheel.clickModeRotate = opts.clickModeRotate;
+    }
+    if (opts.selectionPaths) {
+        wheel.sliceSelectedPathCustom = wheel.slicePathCustom;
+        wheel.sliceInitPathCustom = wheel.slicePathCustom;
+    }
+    wheel.navAngle = -90;
+    wheel.animatetime = 0;
+    if (opts.titleRotateAngle !== undefined) {
+        wheel.titleRotateAngle = opts.titleRotateAngle;
+    }
+    if (opts.titleFont !== undefined) {
+        wheel.titleFont = opts.titleFont;
+    }
+};
+
 // The table contains the intervals that define the modes.
 // All of these modes assume 12 semitones per octave.
 // See http://www.pianoscales.org <== this is in no way definitive
@@ -8163,6 +8201,7 @@ if (typeof module !== "undefined" && module.exports) {
         getModeSliceColors,
         updateModeWheelItems,
         getModeGroupTitleFont,
-        getModeSliceFont
+        getModeSliceFont,
+        configureWheel
     };
 }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -79,7 +79,9 @@ const _b64Cache = new Map();
  */
 function normalizeNoteAccidentals(note) {
     const map = { "♭": "b", "♯": "#", "𝄫": "bb", "𝄪": "x" };
-    return note.replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
+    // Strip microtonal ^ / v prefixes (temperament widget cents display)
+    // so the base note can be resolved, e.g. "^C" → "C", "vvD♭" → "D♭".
+    return note.replace(/^[v^]+/, "").replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
 }
 
 /**
@@ -3966,11 +3968,9 @@ const frequencyToPitch = (hz, temperament) => {
  *     or the full string unchanged if no recognised prefix is found.
  */
 const getArticulation = note => {
-    // Match solfege names (longest first to avoid "sol" being shadowed by
-    // a later "la" replacement) or a single letter note name, anchored at
-    // the very start of the string.  Everything after the prefix is the
-    // articulation we want.
-    const match = note.match(/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/);
+    // Strip microtonal ^ / v prefixes before matching so "^C" etc. resolve.
+    const stripped = note.replace(/^[v^]+/, "");
+    const match = stripped.match(/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/);
     return match ? match[1] : note;
 };
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -61,8 +61,14 @@ const _b64Cache = new Map();
     INTERVALVALUES, MUSICALMODES, getIntervalRatio, frequencyToPitch, NOTESTEP,
    GetNotesForInterval,ALLNOTESTEP,NOTENAMES,SEMITONETOINTERVALMAP,
    SEMITONES, CHROMATIC_SOLFEGE, INTERVAL_CENTS, TEMPERAMENT_INTERVALS,
-   INTERVAL_ORDER, generateNoteNames, getEdoNoteNamePosition,
-   scalePatternToEDO, PITCH_COLLECTIONS_EDO_OVERRIDES, getModePattern
+    INTERVAL_ORDER, generateNoteNames, getEdoNoteNamePosition,
+    scalePatternToEDO, PITCH_COLLECTIONS_EDO_OVERRIDES, getModePattern,
+    MODEPIEMENU_SLOT_COUNT, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
+    MODEPIEMENU_NAME_TITLE_RADIUS, MODEPIEMENU_FONT_FAMILY,
+    MODEPIEMENU_GROUP_FONT_RATIO, MODEPIEMENU_NAME_FONT_MIN_RATIO,
+    MODEPIEMENU_NAME_FONT_MAX_RATIO, getSavedCustomModes, getModeNamesForGroup,
+    getModeLabel, getModeNameFromLabel, getModeSliceColors,
+    updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont
 */
 
 /**
@@ -1817,6 +1823,184 @@ const MODE_PIE_MENUS = {
     ],
     "12": ["chromatic", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "],
     "custom": [" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+};
+
+/**
+ * Fixed slot count shared by every mode pie menu ring. Both the workspace
+ * piemenu (piemenus.js) and the mode widget piemenu (modewidget.js) lay the
+ * mode names out on this many slots.
+ * @constant {number}
+ */
+const MODEPIEMENU_SLOT_COUNT = 12;
+
+/**
+ * Ring geometry shared by the mode-selection pie menus so the group and name
+ * rings render with identical proportions in both contexts.
+ */
+const MODEPIEMENU_GROUP_RING = { minRadius: 0.15, maxRadius: 0.3 };
+const MODEPIEMENU_NAME_RING = { minRadius: 0.3, maxRadius: 0.85 };
+
+/**
+ * Mid-radius of the mode-name ring (0.3-0.85), used to size each label to its
+ * own slice arc.
+ * @constant {number}
+ */
+const MODEPIEMENU_NAME_TITLE_RADIUS = 0.575;
+
+/**
+ * Font family and relative group-ring font size shared by both mode pie menus.
+ * Font px is computed as GROUP_FONT_RATIO * wheelRadius so the same wheel
+ * renders identically regardless of the paper resolution.
+ */
+const MODEPIEMENU_FONT_FAMILY = "sans-serif";
+const MODEPIEMENU_GROUP_FONT_RATIO = 0.08;
+
+/**
+ * Min/max per-slice font sizes for the mode-name ring, as a fraction of the
+ * wheel radius. Kept proportional so both contexts clamp identically.
+ */
+const MODEPIEMENU_NAME_FONT_MIN_RATIO = 0.06;
+const MODEPIEMENU_NAME_FONT_MAX_RATIO = 0.12;
+
+/**
+ * Reads the custom modes saved by the mode widget from local storage.
+ * Corrupt or non-array data yields an empty list.
+ * @returns {Array} Entries that look like custom modes ({name} is a string)
+ */
+const getSavedCustomModes = () => {
+    try {
+        const customModes = JSON.parse(localStorage.getItem("customModes") || "[]");
+        return Array.isArray(customModes)
+            ? customModes.filter(m => m && typeof m.name === "string")
+            : [];
+    } catch (e) {
+        return [];
+    }
+};
+
+/**
+ * Builds the fixed 12-slot list of mode names shown for a pie menu group.
+ * Built-in groups come straight from MODE_PIE_MENUS; the "custom" group is
+ * padded with blanks. Callers may pass custom names already carrying their own
+ * sentinels (the widget prepends "+").
+ * @param {string} grp The mode group key
+ * @param {Array} [customModeNames] Custom mode names (only used for "custom")
+ * @returns {Array} A fixed-length list of mode names
+ */
+const getModeNamesForGroup = (grp, customModeNames = []) => {
+    if (grp !== "custom") {
+        return MODE_PIE_MENUS[grp];
+    }
+    const names = customModeNames.slice(0, MODEPIEMENU_SLOT_COUNT);
+    while (names.length < MODEPIEMENU_SLOT_COUNT) {
+        names.push(" ");
+    }
+    return names;
+};
+
+/**
+ * Returns the display label for a mode name, translating the major/ionian and
+ * minor/aeolian pairs and leaving blank slots blank.
+ * @param {string} modename
+ * @returns {string}
+ */
+const getModeLabel = modename => {
+    switch (modename) {
+        case "ionian":
+        case "major":
+            return `${_("major")} / ${_("ionian")}`;
+        case "aeolian":
+        case "minor":
+            return `${_("minor")} / ${_("aeolian")}`;
+        default:
+            return modename === " " ? " " : _(modename);
+    }
+};
+
+/**
+ * Inverse of getModeLabel: resolves a displayed label back to its internal
+ * mode name. Falls back to the label itself when nothing matches.
+ * @param {string} label
+ * @param {Array} modes The mode names for the current group
+ * @returns {string}
+ */
+const getModeNameFromLabel = (label, modes) => {
+    if (label === `${_("major")} / ${_("ionian")}`) {
+        return "major";
+    }
+    if (label === `${_("minor")} / ${_("aeolian")}`) {
+        return "aeolian";
+    }
+    for (const m of modes) {
+        if (_(m) === label) {
+            return m;
+        }
+    }
+    return label;
+};
+
+/**
+ * Builds the per-slice colors for a mode-name ring: blank slots get the
+ * "empty" color, real modes the "filled" color.
+ * @param {Array} modes
+ * @param {Object} colors { emptyColor, filledColor }
+ * @returns {Array}
+ */
+const getModeSliceColors = (modes, colors) =>
+    modes.map(modename => (modename === " " ? colors.emptyColor : colors.filledColor));
+
+/**
+ * Re-renders an existing mode-name wheel in place: updates every per-state
+ * title copy and the slice fill attributes, then refreshes the wheel.
+ * @param {Object} wheel wheelnav instance
+ * @param {Array} labels Display labels
+ * @param {Array} colors Per-slice colors
+ * @returns {void}
+ */
+const updateModeWheelItems = (wheel, labels, colors) => {
+    for (let i = 0; i < wheel.navItems.length; i++) {
+        const item = wheel.navItems[i];
+        item.title = labels[i];
+        item.basicNavTitleMax.title = labels[i];
+        item.basicNavTitleMin.title = labels[i];
+        item.hoverNavTitleMax.title = labels[i];
+        item.hoverNavTitleMin.title = labels[i];
+        item.selectedNavTitleMax.title = labels[i];
+        item.selectedNavTitleMin.title = labels[i];
+        item.initNavTitle.title = labels[i];
+        item.fillAttr = colors[i];
+        item.sliceHoverAttr.fill = colors[i];
+        item.slicePathAttr.fill = colors[i];
+        item.sliceSelectedAttr.fill = colors[i];
+    }
+    wheel.refreshWheel();
+};
+
+/**
+ * Shared title font for the mode-group ring, scaled to the wheel radius so it
+ * renders at the same relative size regardless of paper resolution.
+ * @param {number} wheelRadius
+ * @returns {string}
+ */
+const getModeGroupTitleFont = wheelRadius =>
+    `100 ${Math.round(MODEPIEMENU_GROUP_FONT_RATIO * wheelRadius)}px ${MODEPIEMENU_FONT_FAMILY}`;
+
+/**
+ * Sizes a mode-name label to fit its own slice arc on the shared name ring.
+ * The min/max clamps scale with the wheel radius so the same ring renders
+ * identically on any paper resolution.
+ * @param {number} wheelRadius
+ * @param {number} sliceCount
+ * @param {number} labelLen
+ * @returns {string}
+ */
+const getModeSliceFont = (wheelRadius, sliceCount, labelLen) => {
+    const arcPx = (2 * Math.PI * MODEPIEMENU_NAME_TITLE_RADIUS * wheelRadius) / sliceCount;
+    const size = Math.floor((arcPx * 0.85) / (labelLen * 0.6));
+    const minSize = Math.round(MODEPIEMENU_NAME_FONT_MIN_RATIO * wheelRadius);
+    const maxSize = Math.round(MODEPIEMENU_NAME_FONT_MAX_RATIO * wheelRadius);
+    const clamped = Math.min(maxSize, Math.max(minSize, size));
+    return `100 ${clamped}px ${MODEPIEMENU_FONT_FAMILY}`;
 };
 
 // The table contains the intervals that define the modes.
@@ -7963,6 +8147,22 @@ if (typeof module !== "undefined" && module.exports) {
         EQUIVALENTACCIDENTALS,
         INTERVALVALUES,
         FIXEDSOLFEGE,
-        FIXEDSOLFEGE1
+        FIXEDSOLFEGE1,
+        MODEPIEMENU_SLOT_COUNT,
+        MODEPIEMENU_GROUP_RING,
+        MODEPIEMENU_NAME_RING,
+        MODEPIEMENU_NAME_TITLE_RADIUS,
+        MODEPIEMENU_FONT_FAMILY,
+        MODEPIEMENU_GROUP_FONT_RATIO,
+        MODEPIEMENU_NAME_FONT_MIN_RATIO,
+        MODEPIEMENU_NAME_FONT_MAX_RATIO,
+        getSavedCustomModes,
+        getModeNamesForGroup,
+        getModeLabel,
+        getModeNameFromLabel,
+        getModeSliceColors,
+        updateModeWheelItems,
+        getModeGroupTitleFont,
+        getModeSliceFont
     };
 }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1815,7 +1815,8 @@ const MODE_PIE_MENUS = {
         " ",
         " "
     ],
-    "12": ["chromatic", " ", " ", " ", " ", " ", "custom", " ", " ", " ", " ", " "]
+    "12": ["chromatic", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "],
+    "custom": [" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
 };
 
 // The table contains the intervals that define the modes.
@@ -3221,7 +3222,7 @@ const getModeNumbers = name => {
 
     const lowercaseName = name.toLowerCase();
     for (const mode in MUSICALMODES) {
-        if (mode === lowercaseName || mode.toLowerCase() === lowercaseName) {
+        if (mode.toLowerCase() === lowercaseName) {
             return __convert(MUSICALMODES[mode]);
         }
     }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -68,7 +68,8 @@ const _b64Cache = new Map();
     MODEPIEMENU_GROUP_FONT_RATIO, MODEPIEMENU_NAME_FONT_MIN_RATIO,
     MODEPIEMENU_NAME_FONT_MAX_RATIO, getSavedCustomModes, getModeNamesForGroup,
     getModeLabel, getModeNameFromLabel, getModeSliceColors,
-    updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont
+    updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
+    configureWheel
 */
 
 /**
@@ -1889,7 +1890,7 @@ const getSavedCustomModes = () => {
  */
 const getModeNamesForGroup = (grp, customModeNames = []) => {
     if (grp !== "custom") {
-        return MODE_PIE_MENUS[grp];
+        return MODE_PIE_MENUS[grp].slice();
     }
     const names = customModeNames.slice(0, MODEPIEMENU_SLOT_COUNT);
     while (names.length < MODEPIEMENU_SLOT_COUNT) {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -692,7 +692,7 @@ function Synth() {
         // and never use noteFrequencies, so skip building the table.
         // This also avoids crashing on microtonal interval names (e.g. "mid 2")
         // that exist in the temperament definition but not in INTERVALVALUES.
-        if (t && t.isEDO) {
+        if (t && (t.isEDO || isEquallyTempered(temperament))) {
             this.changeInTemperament = false;
             return;
         }
@@ -809,7 +809,7 @@ function Synth() {
         }
 
         const t = getTemperament(this.inTemperament);
-        if (t && t.isEDO) {
+        if (t && (t.isEDO || isEquallyTempered(this.inTemperament))) {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
                 return pitchToFrequency(parsed[0], parsed[1], 0, "c major", this.inTemperament);

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1870,17 +1870,17 @@ function Synth() {
                 notes = this._getFrequency(notes, this.changeInTemperament);
                 if (notes === undefined) {
                     if (notes1.substring(1, notes1.length - 1) == DOUBLEFLAT) {
-                        notes =
-                            notes1.substring(0, 1) +
-                            "" +
-                            "bb" +
-                            notes1.substring(notes1.length - 1, notes1.length);
+                        notes = notes1.substring(0, 1) + "bb" + notes1.substring(notes1.length - 1);
                     } else if (notes1.substring(1, notes1.length - 1) === DOUBLESHARP) {
-                        notes =
-                            notes1.substring(0, 1) +
-                            "" +
-                            "x" +
-                            notes1.substring(notes1.length - 1, notes1.length);
+                        notes = notes1.substring(0, 1) + "x" + notes1.substring(notes1.length - 1);
+                    } else if (
+                        typeof notes1 === "string" &&
+                        (notes1.includes("^") || notes1.includes("v"))
+                    ) {
+                        // Microtonal prefix from temperament widget — strip and
+                        // re-resolve as base note so Tone.js receives a valid name.
+                        const base = notes1.replace(/^(\^+|v+)/, "");
+                        notes = this._getFrequency(base, this.changeInTemperament) ?? base;
                     } else {
                         notes = notes1;
                     }

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1873,14 +1873,6 @@ function Synth() {
                         notes = notes1.substring(0, 1) + "bb" + notes1.substring(notes1.length - 1);
                     } else if (notes1.substring(1, notes1.length - 1) === DOUBLESHARP) {
                         notes = notes1.substring(0, 1) + "x" + notes1.substring(notes1.length - 1);
-                    } else if (
-                        typeof notes1 === "string" &&
-                        (notes1.includes("^") || notes1.includes("v"))
-                    ) {
-                        // Microtonal prefix from temperament widget — strip and
-                        // re-resolve as base note so Tone.js receives a valid name.
-                        const base = notes1.replace(/^(\^+|v+)/, "");
-                        notes = this._getFrequency(base, this.changeInTemperament) ?? base;
                     } else {
                         notes = notes1;
                     }

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -63,6 +63,10 @@ global.normalizeNoteAccidentals = jest.fn().mockImplementation(n => n);
 global.MUSICALMODES = {
     ionian: [2, 2, 1, 2, 2, 2, 1]
 };
+global.TEMPERAMENT = {
+    "equal": { isEDO: true, pitchNumber: 12 },
+    "just intonation": { isEDO: false, pitchNumber: 12 }
+};
 global.getCurrentEDO = jest.fn().mockReturnValue(12);
 global.getModePattern = jest.fn().mockReturnValue([2, 2, 1, 2, 2, 2, 1]);
 
@@ -153,6 +157,17 @@ document.createElement = jest.fn().mockImplementation(tag => ({
     }),
     getElementById: jest.fn().mockReturnValue({ src: "" })
 }));
+document.getElementById = document.createElement; // For internal usage
+
+// Add replaceChildren to modeTableDiv mock (used in constructor)
+const originalCreateElement = document.createElement;
+document.createElement = jest.fn(tag => {
+    const el = originalCreateElement(tag);
+    if (!el.replaceChildren) {
+        el.replaceChildren = jest.fn();
+    }
+    return el;
+});
 document.getElementById = document.createElement; // For internal usage
 
 describe("ModeWidget", () => {
@@ -419,38 +434,6 @@ describe("ModeWidget", () => {
         expect(mockActivity.errorMsg).toHaveBeenCalledWith(
             expect.stringContaining("Cannot overwrite built-in mode")
         );
-    });
-
-    test("should not list custom modes twice in the modes dropdown", () => {
-        localStorage.setItem(
-            "customModes",
-            JSON.stringify([{ name: "myMode", pattern: [3, 2, 3, 2, 2], edo: 12 }])
-        );
-        MUSICALMODES.myMode = [3, 2, 3, 2, 2];
-
-        const selectChildren = [];
-        const fakeSelect = { innerHTML: "", appendChild: el => selectChildren.push(el) };
-        const realCreateElement = document.createElement;
-        document.createElement = jest.fn(() => {
-            const el = {
-                style: {},
-                innerHTML: "",
-                value: "",
-                textContent: "",
-                label: "",
-                children: [],
-                appendChild: child => el.children.push(child)
-            };
-            return el;
-        });
-
-        modeWidget._populateModesDropdown(fakeSelect);
-        document.createElement = realCreateElement;
-
-        const builtIn = selectChildren.find(c => c.label === "Built-in Modes");
-        const custom = selectChildren.find(c => c.label === "Custom Modes");
-        expect(builtIn.children.map(c => c.value)).not.toContain("myMode");
-        expect(custom.children.map(c => c.value)).toContain("myMode");
     });
 
     test("should cancel in-flight animations and clear pending timeouts", () => {

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -92,7 +92,8 @@ const {
     getModeSliceColors,
     updateModeWheelItems,
     getModeGroupTitleFont,
-    getModeSliceFont
+    getModeSliceFont,
+    configureWheel
 } = require("../../utils/musicutils.js");
 global.MODEPIEMENU_GROUP_RING = MODEPIEMENU_GROUP_RING;
 global.MODEPIEMENU_NAME_RING = MODEPIEMENU_NAME_RING;
@@ -104,6 +105,7 @@ global.getModeSliceColors = getModeSliceColors;
 global.updateModeWheelItems = updateModeWheelItems;
 global.getModeGroupTitleFont = getModeGroupTitleFont;
 global.getModeSliceFont = getModeSliceFont;
+global.configureWheel = configureWheel;
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -408,4 +408,64 @@ describe("ModeWidget", () => {
 
         expect(modeWidget._modeLabelCell.textContent).toBe("C ionian");
     });
+
+    test("should refuse to overwrite a built-in mode on save", () => {
+        const originalIonian = MUSICALMODES.ionian;
+
+        const result = modeWidget._saveCustomMode("ionian", [2, 2, 1, 2, 2, 2, 1]);
+
+        expect(result).toBe(false);
+        expect(MUSICALMODES.ionian).toEqual(originalIonian);
+        expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+            expect.stringContaining("Cannot overwrite built-in mode")
+        );
+    });
+
+    test("should not list custom modes twice in the modes dropdown", () => {
+        localStorage.setItem(
+            "customModes",
+            JSON.stringify([{ name: "myMode", pattern: [3, 2, 3, 2, 2], edo: 12 }])
+        );
+        MUSICALMODES.myMode = [3, 2, 3, 2, 2];
+
+        const selectChildren = [];
+        const fakeSelect = { innerHTML: "", appendChild: el => selectChildren.push(el) };
+        const realCreateElement = document.createElement;
+        document.createElement = jest.fn(() => {
+            const el = {
+                style: {},
+                innerHTML: "",
+                value: "",
+                textContent: "",
+                label: "",
+                children: [],
+                appendChild: child => el.children.push(child)
+            };
+            return el;
+        });
+
+        modeWidget._populateModesDropdown(fakeSelect);
+        document.createElement = realCreateElement;
+
+        const builtIn = selectChildren.find(c => c.label === "Built-in Modes");
+        const custom = selectChildren.find(c => c.label === "Custom Modes");
+        expect(builtIn.children.map(c => c.value)).not.toContain("myMode");
+        expect(custom.children.map(c => c.value)).toContain("myMode");
+    });
+
+    test("should cancel in-flight animations and clear pending timeouts", () => {
+        modeWidget._locked = true;
+        modeWidget._playing = true;
+        modeWidget._timeouts = [123, 456];
+        modeWidget._newPattern = [true, false];
+        modeWidget._notesToPlay = [0, 2];
+
+        modeWidget._cancelAnimations();
+
+        expect(modeWidget._locked).toBe(false);
+        expect(modeWidget._playing).toBe(false);
+        expect(modeWidget._timeouts).toEqual([]);
+        expect(modeWidget._newPattern).toBeNull();
+        expect(modeWidget._notesToPlay).toBeNull();
+    });
 });

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -331,6 +331,17 @@ describe("ModeWidget", () => {
         expect(modeWidget._selectedNotes).toEqual(originalNotes);
     });
 
+    test("should fall back to generated names when numberToPitch returns a NaN octave", () => {
+        modeWidget._activeEDO = 5;
+        global.numberToPitch = jest.fn().mockReturnValue([undefined, NaN]);
+        global.generateNoteNames = jest.fn().mockReturnValue(["C", "D", "E", "G", "A"]);
+
+        const result = modeWidget._pitchNameAndOctave(3);
+
+        // j=3 with aIndex=4 ("A" at index 4 in a 5-EDO table): name E, octave 5.
+        expect(result).toEqual(["E", 5]);
+    });
+
     test("should show textMsg when notes are remapped on EDO switch", () => {
         modeWidget._activeEDO = 12;
         modeWidget._selectedNotes = [

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -231,8 +231,6 @@ document.createElement = jest.fn().mockImplementation(tag => ({
     }),
     getElementById: jest.fn().mockReturnValue({ src: "" })
 }));
-document.getElementById = document.createElement; // For internal usage
-
 // Add replaceChildren to modeTableDiv mock (used in constructor)
 const originalCreateElement = document.createElement;
 document.createElement = jest.fn(tag => {

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -32,6 +32,10 @@ global.platformColor = {
     selectorBackground: "#FFFFFF",
     selectorBackgroundHOVER: "#EEEEEE",
     modeWheelcolors: ["#FF0000", "#00FF00"],
+    modeGroupWheelcolors: ["#111111"],
+    modePieMenusIfColorPush: "#333333",
+    modePieMenusElseColorPush: "#444444",
+    textColor: "#ffffff",
     orange: "#FFA500"
 };
 global.DEFAULTVOICE = "piano";
@@ -69,6 +73,37 @@ global.TEMPERAMENT = {
 };
 global.getCurrentEDO = jest.fn().mockReturnValue(12);
 global.getModePattern = jest.fn().mockReturnValue([2, 2, 1, 2, 2, 2, 1]);
+global.DEFAULTMODE = "major";
+
+// Shared mode pie menu helpers, required from musicutils so the smoke tests
+// exercise the real extraction logic (modewidget.js sees them as globals).
+global.MODE_PIE_MENUS = {
+    5: ["minor pentatonic", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "],
+    7: ["ionian", " ", "dorian", " ", " ", " ", " ", " ", " ", "aeolian", " ", " "],
+    custom: [" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+};
+const {
+    MODEPIEMENU_GROUP_RING,
+    MODEPIEMENU_NAME_RING,
+    getSavedCustomModes,
+    getModeNamesForGroup,
+    getModeLabel,
+    getModeNameFromLabel,
+    getModeSliceColors,
+    updateModeWheelItems,
+    getModeGroupTitleFont,
+    getModeSliceFont
+} = require("../../utils/musicutils.js");
+global.MODEPIEMENU_GROUP_RING = MODEPIEMENU_GROUP_RING;
+global.MODEPIEMENU_NAME_RING = MODEPIEMENU_NAME_RING;
+global.getSavedCustomModes = getSavedCustomModes;
+global.getModeNamesForGroup = getModeNamesForGroup;
+global.getModeLabel = getModeLabel;
+global.getModeNameFromLabel = getModeNameFromLabel;
+global.getModeSliceColors = getModeSliceColors;
+global.updateModeWheelItems = updateModeWheelItems;
+global.getModeGroupTitleFont = getModeGroupTitleFont;
+global.getModeSliceFont = getModeSliceFont;
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -77,24 +112,61 @@ global.slicePath = jest.fn().mockReturnValue({
 });
 
 // Mock wheelnav
-global.wheelnav = jest.fn().mockImplementation(() => ({
-    raphael: {},
-    colors: [],
-    slicePathFunction: null,
-    slicePathCustom: {},
-    sliceSelectedPathCustom: {},
-    sliceInitPathCustom: {},
-    navItems: [],
-    createWheel: jest.fn().mockImplementation(function (labels) {
-        this.navItems = labels.map(() => ({
-            navItem: {
-                hide: jest.fn(),
-                show: jest.fn()
-            },
-            navigateFunction: null
-        }));
-    })
-}));
+global.wheelnav = jest.fn().mockImplementation(() => {
+    const navItemTemplate = () => ({
+        title: "",
+        navItem: {
+            hide: jest.fn(),
+            show: jest.fn()
+        },
+        navigateFunction: null,
+        fillAttr: "",
+        titleAttr: {},
+        titleHoverAttr: {},
+        titleSelectedAttr: {},
+        sliceHoverAttr: {},
+        slicePathAttr: {},
+        sliceSelectedAttr: {},
+        basicNavTitleMax: {},
+        basicNavTitleMin: {},
+        hoverNavTitleMax: {},
+        hoverNavTitleMin: {},
+        selectedNavTitleMax: {},
+        selectedNavTitleMin: {},
+        initNavTitle: {}
+    });
+    const mockWheel = {
+        raphael: {},
+        colors: [],
+        slicePathFunction: null,
+        slicePathCustom: {},
+        sliceSelectedPathCustom: {},
+        sliceInitPathCustom: {},
+        navItems: [],
+        titleFont: "",
+        selectedNavItemIndex: 0,
+        createWheel: jest.fn().mockImplementation(function (labels) {
+            this.navItems = labels.map((l, i) => {
+                const item = navItemTemplate();
+                item.title = l;
+                return item;
+            });
+        }),
+        navigateWheel: jest.fn().mockImplementation(function (index) {
+            this.selectedNavItemIndex = index;
+            if (
+                this.navItems[index] &&
+                typeof this.navItems[index].navigateFunction === "function"
+            ) {
+                this.navItems[index].navigateFunction();
+            }
+        }),
+        refreshWheel: jest.fn(),
+        removeWheel: jest.fn(),
+        initWheel: jest.fn()
+    };
+    return mockWheel;
+});
 
 // Mock Window
 if (typeof window === "undefined") {
@@ -461,5 +533,47 @@ describe("ModeWidget", () => {
         expect(modeWidget._timeouts).toEqual([]);
         expect(modeWidget._newPattern).toBeNull();
         expect(modeWidget._notesToPlay).toBeNull();
+    });
+
+    describe("_piemenuModes", () => {
+        const switchGroup = (widget, groupTitle) => {
+            const index = widget._modeGroupWheel.navItems.findIndex(
+                item => item.title === groupTitle
+            );
+            widget._modeGroupWheel.selectedNavItemIndex = index;
+            widget._modeGroupWheel.navItems[index].navigateFunction();
+        };
+
+        test("builds the group and mode-name wheels", () => {
+            modeWidget._piemenuModes();
+
+            expect(modeWidget._modePieWheel).toBeDefined();
+            expect(modeWidget._modeGroupWheel).toBeDefined();
+            expect(modeWidget._modeNameWheel).toBeDefined();
+            expect(modeWidget._modeNameWheel.navItems.length).toBe(12);
+        });
+
+        test("custom group leads with the create-mode sentinel and saved modes", () => {
+            localStorage.setItem(
+                "customModes",
+                JSON.stringify([{ name: "my mode", pattern: [1, 2] }])
+            );
+            modeWidget._piemenuModes();
+            switchGroup(modeWidget, "custom");
+
+            const titles = modeWidget._modeNameWheel.navItems.map(item => item.title);
+            expect(titles[0]).toBe("+");
+            expect(titles[1]).toBe("my mode");
+        });
+
+        test("selecting a mode slice resolves the internal mode name", () => {
+            modeWidget._piemenuModes();
+            switchGroup(modeWidget, "7");
+
+            modeWidget._modeNameWheel.selectedNavItemIndex = 0;
+            modeWidget._modeNameWheel.navItems[0].navigateFunction();
+
+            expect(modeWidget._selectedModeName).toBe("major");
+        });
     });
 });

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -50,7 +50,9 @@ global.docById = jest.fn().mockImplementation(id => ({
     insertRow: jest.fn().mockReturnValue({
         insertCell: jest.fn().mockReturnValue({
             style: {},
-            innerHTML: ""
+            innerHTML: "",
+            appendChild: jest.fn(),
+            append: jest.fn()
         })
     })
 }));
@@ -61,6 +63,7 @@ global.normalizeNoteAccidentals = jest.fn().mockImplementation(n => n);
 global.MUSICALMODES = {
     ionian: [2, 2, 1, 2, 2, 2, 1]
 };
+global.getCurrentEDO = jest.fn().mockReturnValue(12);
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -136,6 +139,8 @@ document.createElement = jest.fn().mockImplementation(tag => ({
     innerHTML: "",
     append: jest.fn(),
     appendChild: jest.fn(),
+    prepend: jest.fn(),
+    addEventListener: jest.fn(),
     replaceChildren: jest.fn(),
     removeChild: jest.fn(),
     firstChild: null,
@@ -396,5 +401,46 @@ describe("ModeWidget", () => {
 
         expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
         expect(modeWidget._locked).toBe(false);
+    });
+
+    test("should initialize a custom mode with only the root selected", () => {
+        modeWidget._resetToCustom();
+
+        expect(modeWidget._selectedNotes[0]).toBe(true);
+        expect(modeWidget._selectedNotes.slice(1).every(v => v === false)).toBe(true);
+    });
+
+    test("should translate notes to a new EDO slice count", () => {
+        modeWidget._activeEDO = 12;
+        modeWidget._selectedNotes = [
+            true,
+            false,
+            true,
+            false,
+            true,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true
+        ];
+
+        modeWidget._translateNotesToEDO(19);
+
+        expect(modeWidget._selectedNotes).toHaveLength(19);
+        expect(modeWidget._selectedNotes[0]).toBe(true);
+    });
+
+    test("should persist a custom mode to the registry and localStorage", () => {
+        const pattern = [2, 2, 1, 2, 2, 2, 1];
+        modeWidget._saveCustomMode("myMode", pattern);
+
+        expect(MUSICALMODES["myMode"]).toEqual(pattern);
+        const saved = JSON.parse(localStorage.getItem("customModes"));
+        expect(saved.some(m => m.name === "myMode" && m.pattern.join() === pattern.join())).toBe(
+            true
+        );
     });
 });

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -93,7 +93,8 @@ const {
     updateModeWheelItems,
     getModeGroupTitleFont,
     getModeSliceFont,
-    configureWheel
+    configureWheel,
+    scalePatternToEDO
 } = require("../../utils/musicutils.js");
 global.MODEPIEMENU_GROUP_RING = MODEPIEMENU_GROUP_RING;
 global.MODEPIEMENU_NAME_RING = MODEPIEMENU_NAME_RING;
@@ -106,6 +107,7 @@ global.updateModeWheelItems = updateModeWheelItems;
 global.getModeGroupTitleFont = getModeGroupTitleFont;
 global.getModeSliceFont = getModeSliceFont;
 global.configureWheel = configureWheel;
+global.scalePatternToEDO = scalePatternToEDO;
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -279,6 +279,77 @@ describe("ModeWidget", () => {
         expect(modeWidget._selectedNotes[0]).toBe(true);
     });
 
+    test("should cache source EDO state before translating for round-trip restore", () => {
+        // Simulate a 12-EDO major: notes at 0,2,4,5,7,9,11
+        modeWidget._activeEDO = 12;
+        modeWidget._selectedNotes = [
+            true,
+            false,
+            true,
+            false,
+            true,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true
+        ];
+        const originalNotes = modeWidget._selectedNotes.slice();
+
+        // Cache the 12-EDO state (as _wireEdoSelect now does)
+        modeWidget._edoNoteCache[12] = modeWidget._selectedNotes.slice();
+
+        // Switch to 5-EDO (translate + cache destination)
+        modeWidget._translateNotesToEDO(5);
+        modeWidget._edoNoteCache[5] = modeWidget._selectedNotes.slice();
+        modeWidget._activeEDO = 5;
+
+        expect(modeWidget._selectedNotes).toHaveLength(5);
+
+        // Switch back to 12-EDO — should restore from cache, not translate
+        modeWidget._selectedNotes = modeWidget._edoNoteCache[12].slice();
+        modeWidget._activeEDO = 12;
+
+        expect(modeWidget._selectedNotes).toHaveLength(12);
+        expect(modeWidget._selectedNotes).toEqual(originalNotes);
+    });
+
+    test("should show textMsg when notes are remapped on EDO switch", () => {
+        modeWidget._activeEDO = 12;
+        modeWidget._selectedNotes = [
+            true,
+            false,
+            true,
+            false,
+            true,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true
+        ];
+
+        // Simulate _wireEdoSelect cache-miss path
+        modeWidget._edoNoteCache[12] = modeWidget._selectedNotes.slice();
+        const oldEDO = modeWidget._activeEDO;
+        modeWidget._translateNotesToEDO(5);
+        modeWidget._edoNoteCache[5] = modeWidget._selectedNotes.slice();
+
+        modeWidget.textMsg(
+            `Mode remapped from ${oldEDO}-EDO to 5-EDO. Some notes may have changed.`,
+            3000
+        );
+
+        expect(mockActivity.textMsg).toHaveBeenCalledWith(
+            expect.stringContaining("remapped from 12"),
+            3000
+        );
+    });
+
     test("should persist a custom mode to the registry and localStorage", () => {
         const pattern = [2, 2, 1, 2, 2, 2, 1];
         modeWidget._saveCustomMode("myMode", pattern);

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -64,6 +64,7 @@ global.MUSICALMODES = {
     ionian: [2, 2, 1, 2, 2, 2, 1]
 };
 global.getCurrentEDO = jest.fn().mockReturnValue(12);
+global.getModePattern = jest.fn().mockReturnValue([2, 2, 1, 2, 2, 2, 1]);
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -230,37 +231,6 @@ describe("ModeWidget", () => {
         expect(modeWidget._calculateMode()).toEqual([12]);
     });
 
-    test("should handle empty selectedNotes safely", () => {
-        modeWidget._selectedNotes = [];
-
-        const result = modeWidget._calculateMode();
-
-        expect(result).toBeDefined();
-    });
-
-    test("should handle malformed selectedNotes safely", () => {
-        modeWidget._selectedNotes = [true, undefined, false, null, true];
-
-        const result = modeWidget._calculateMode();
-
-        expect(Array.isArray(result)).toBe(true);
-    });
-
-    test("undo should not crash when stack is empty", () => {
-        modeWidget._undoStack = [];
-        modeWidget._undo();
-
-        expect(modeWidget._selectedNotes).toBeDefined();
-    });
-
-    test("should return correct playing status", () => {
-        modeWidget._playing = false;
-        expect(modeWidget._playingStatus()).toBe(false);
-
-        modeWidget._playing = true;
-        expect(modeWidget._playingStatus()).toBe(true);
-    });
-
     test("should save and undo state correctly", () => {
         modeWidget._selectedNotes = Array(12).fill(false);
         modeWidget._selectedNotes[0] = true;
@@ -273,134 +243,10 @@ describe("ModeWidget", () => {
         expect(modeWidget._selectedNotes[1]).toBe(false);
     });
 
-    test("should clear all notes except root", () => {
-        modeWidget._selectedNotes = Array(12).fill(true);
-
-        modeWidget._clear();
-
-        expect(modeWidget._selectedNotes[0]).toBe(true);
-        for (let i = 1; i < 12; i++) {
-            expect(modeWidget._selectedNotes[i]).toBe(false);
-        }
-    });
-
     test("should trigger synth when playing a note", () => {
         modeWidget._playNote(0);
 
         expect(mockActivity.logo.synth.trigger).toHaveBeenCalled();
-    });
-
-    test("should initialize correctly", () => {
-        expect(global.wheelnav).toHaveBeenCalledTimes(3); // noteWheel, playWheel, etc.
-        expect(global.keySignatureToMode).toHaveBeenCalled();
-        expect(mockActivity.textMsg).toHaveBeenCalled();
-    });
-
-    test("should handle Play/Stop button toggle", () => {
-        jest.useFakeTimers();
-        const widgetWindow = window.widgetWindows.windowFor();
-        const playBtnMock = widgetWindow.addButton.mock.results[0].value;
-
-        // Start
-        expect(modeWidget._playing).toBe(false);
-        playBtnMock.onclick();
-        expect(modeWidget._playing).toBe(true);
-        expect(mockActivity.logo.resetSynth).toHaveBeenCalled();
-
-        // Stop
-        playBtnMock.onclick();
-        expect(modeWidget._playing).toBe(false);
-        jest.useRealTimers();
-    });
-
-    test("should rotate mode pattern right", () => {
-        // Setup: Need true at index 11 so that after 1 right shift (new[0] = old[11]), index 0 is true.
-        // This ensures the recursion stops after 1 rotation.
-        modeWidget._selectedNotes = [
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true
-        ];
-
-        // Wait for rotation animations
-        jest.useFakeTimers();
-        modeWidget._rotateRight();
-
-        // Fast forward through animations (12 * ROTATESPEED)
-        jest.advanceTimersByTime(12 * 150 + 100);
-
-        expect(modeWidget._locked).toBe(false);
-        jest.useRealTimers();
-    });
-
-    test("should rotate mode pattern left", () => {
-        // Setup: Need true at index 1 so that after 1 left shift (new[0] = old[1]), index 0 is true.
-        modeWidget._selectedNotes = [
-            false,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        ];
-
-        jest.useFakeTimers();
-        modeWidget._rotateLeft();
-        jest.advanceTimersByTime(12 * 150 + 100);
-
-        expect(modeWidget._locked).toBe(false);
-        jest.useRealTimers();
-    });
-
-    test("should invert mode pattern", () => {
-        modeWidget._selectedNotes = [
-            true,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true,
-            false
-        ]; // C and B
-
-        jest.useFakeTimers();
-        modeWidget._invert(); // Inverts pairs around current axis
-        jest.advanceTimersByTime(6 * 150);
-
-        expect(modeWidget._locked).toBe(false);
-        jest.useRealTimers();
-    });
-
-    test("onclose handler should stop synth and reset lock state", () => {
-        const widgetWindow = window.widgetWindows.windowFor();
-
-        modeWidget._locked = true;
-
-        // Trigger onclose
-        widgetWindow.onclose();
-
-        expect(mockActivity.logo.synth.stop).toHaveBeenCalled();
-        expect(modeWidget._locked).toBe(false);
     });
 
     test("should initialize a custom mode with only the root selected", () => {
@@ -442,5 +288,53 @@ describe("ModeWidget", () => {
         expect(saved.some(m => m.name === "myMode" && m.pattern.join() === pattern.join())).toBe(
             true
         );
+    });
+
+    test("should scale built-in mode intervals to the active EDO", () => {
+        modeWidget._activeEDO = 19;
+        global.getModePattern.mockReturnValue([3, 2, 3, 3, 2, 3, 3]);
+        const applySpy = jest.spyOn(modeWidget, "_applyModePattern").mockImplementation(() => {});
+        const modeNameSpy = jest.spyOn(modeWidget, "_setModeName").mockImplementation(() => {});
+
+        modeWidget._loadMode("minor", [2, 1, 2, 2, 1, 2, 2], { value: 19 });
+
+        expect(global.getModePattern).toHaveBeenCalledWith("minor", 19);
+        expect(applySpy).toHaveBeenCalledWith([3, 2, 3, 3, 2, 3, 3]);
+
+        applySpy.mockRestore();
+        modeNameSpy.mockRestore();
+    });
+
+    test("should use the stored pattern for a custom mode without rescaling", () => {
+        localStorage.setItem(
+            "customModes",
+            JSON.stringify([{ name: "myMode", pattern: [3, 2, 3, 3, 2, 3, 3], edo: 19 }])
+        );
+        modeWidget._activeEDO = 19;
+        global.getModePattern.mockClear();
+        const applySpy = jest.spyOn(modeWidget, "_applyModePattern").mockImplementation(() => {});
+        const modeNameSpy = jest.spyOn(modeWidget, "_setModeName").mockImplementation(() => {});
+
+        modeWidget._loadMode("myMode", [3, 2, 3, 3, 2, 3, 3], { value: 19 });
+
+        expect(global.getModePattern).not.toHaveBeenCalled();
+        expect(applySpy).toHaveBeenCalledWith([3, 2, 3, 3, 2, 3, 3]);
+
+        applySpy.mockRestore();
+        modeNameSpy.mockRestore();
+    });
+
+    test("should detect a built-in mode at a non-12 EDO", () => {
+        modeWidget._activeEDO = 19;
+        modeWidget._modeLabelCell = { textContent: "" };
+        modeWidget.widgetWindow = { updateTitle: jest.fn() };
+        modeWidget._selectedNotes = Array.from({ length: 19 }, (_, i) =>
+            [0, 3, 5, 8, 11, 13, 16].includes(i)
+        );
+        global.getModePattern.mockReturnValue([3, 2, 3, 3, 2, 3, 3]);
+
+        modeWidget._setModeName();
+
+        expect(modeWidget._modeLabelCell.textContent).toBe("C ionian");
     });
 });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1,4 +1,5 @@
 // Copyright (c) 2016-21 Walter Bender
+// Copyright (c) 2026 Ashutosh Karnatak (Dependency Injection Refactoring)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the The GNU Affero General Public
@@ -13,9 +14,40 @@
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
-   normalizeNoteAccidentals, getModePattern, getCurrentEDO,
+   normalizeNoteAccidentals, getCurrentEDO, getModePattern,
    numberToPitch, pitchToFrequency
  */
+
+/*
+    Global locations
+    - lib/wheelnav
+        slicePath, wheelnav
+    - js/utils/utils.js
+        _, last, docById
+    - js/utils/platformstyle.js
+        platformColor
+    - js/utils/musicutils.js
+        keySignatureToMode, MUSICALMODES, getModePattern, getNote, DEFAULTVOICE,
+        NOTESTABLE
+
+    Dependency Injection Pattern:
+    This widget uses dependency injection to reduce implicit global state.
+    Dependencies are passed via the constructor as part of the `activity` object.
+
+    Required Dependencies (accessed via this.activity):
+    - logo: Logo instance (provides synth, modeBlock, resetSynth)
+    - turtles: Turtles instance (provides ithTurtle for keySignature)
+    - blocks: Blocks instance (provides blockList, loadNewBlocks)
+    - hideMsgs: Function to hide messages
+    - textMsg: Function to display text messages
+    - errorMsg: Function to display error messages
+    - refreshCanvas: Function to refresh the canvas
+    - storage: Storage object for custom mode persistence
+
+    Note: `this.storage.custommode` persistence was replaced by
+    `localStorage["customModes"]` (see _saveCustomMode/_getCustomModes);
+    `storage` is no longer a widget dependency.
+*/
 
 /*exported ModeWidget*/
 
@@ -193,32 +225,19 @@ class ModeWidget {
     _edoOptions() {
         const inTemperament = this.logo.synth.inTemperament;
         const builtInTemperaments = [
-            { edo: 5, key: "5 equal", label: "5-EDO" },
-            { edo: 7, key: "7 equal", label: "7-EDO" },
+            { edo: 5, key: "equal5", label: "5-EDO" },
+            { edo: 7, key: "equal7", label: "7-EDO" },
             { edo: 12, key: "equal", label: "12-EDO (Equal)" },
-            { edo: 17, key: "17 equal", label: "17-EDO" },
-            { edo: 19, key: "19 equal", label: "19-EDO (Meantone)" },
-            { edo: 21, key: "21 equal", label: "21-EDO (MEAN)" },
-            { edo: 31, key: "31 equal", label: "31-EDO" }
+            { edo: 17, key: "equal17", label: "17-EDO" },
+            { edo: 19, key: "equal19", label: "19-EDO (Meantone)" },
+            { edo: 31, key: "equal31", label: "31-EDO" }
         ];
-        const builtInKeys = new Set(builtInTemperaments.map(t => t.key));
 
         const options = builtInTemperaments.map(t => ({
             value: t.edo,
             label: t.label,
             temperamentKey: t.key
         }));
-
-        const temperament = window.temperament || {};
-        for (const key of Object.keys(temperament)) {
-            if (!builtInKeys.has(key) && temperament[key]) {
-                const t = temperament[key];
-                const edo = t.pitchNumber || t.EDO || t.edo;
-                if (typeof edo === "number" && edo >= 5 && edo <= 55) {
-                    options.push({ value: edo, label: key, temperamentKey: key });
-                }
-            }
-        }
 
         if (!options.some(o => o.temperamentKey === inTemperament)) {
             options.unshift({
@@ -564,7 +583,11 @@ class ModeWidget {
             return;
         }
 
-        this._applyModePattern(currentMode);
+        this._applyModePattern(
+            this._getModeEDO(currentModeName[1])
+                ? currentMode
+                : getModePattern(currentModeName[1], this._activeEDO)
+        );
         this._setModeName();
     }
 
@@ -576,7 +599,10 @@ class ModeWidget {
             edoSelect.value = nativeEDO;
             this._rebuildWheel(nativeEDO);
         }
-        this._applyModePattern(mode);
+        // Built-in mode patterns are 12-EDO intervals; scale them to the
+        // active EDO. Custom modes carry EDO-specific patterns already.
+        const pattern = nativeEDO ? mode : getModePattern(modeName, this._activeEDO);
+        this._applyModePattern(pattern);
         this._setModeName();
     }
 
@@ -836,8 +862,14 @@ class ModeWidget {
                 null
             );
         } else {
-            const ratio = getModePattern(this._pitch + ":" + this.logo.synth.inTemperament, edo);
-            const freq = pitchToFrequency(this._pitch, 4, note, ks, ratio);
+            // note is a slice index = number of EDO steps above the root.
+            const freq = pitchToFrequency(
+                this._pitch,
+                4,
+                note * 100,
+                ks,
+                this._temperamentKeyForEDO(edo)
+            );
             this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
         }
     }
@@ -906,9 +938,15 @@ class ModeWidget {
     _setModeName() {
         const currentMode = JSON.stringify(this._calculateMode());
         const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
+        const customNames = new Set(this._getCustomModes().map(m => m.name));
 
         for (const mode in MUSICALMODES) {
-            if (JSON.stringify(MUSICALMODES[mode]) === currentMode) {
+            // Custom modes are stored with EDO-specific step patterns; built-in
+            // patterns are 12-EDO intervals scaled to the active EDO.
+            const pattern = customNames.has(mode)
+                ? MUSICALMODES[mode]
+                : getModePattern(mode, this._activeEDO);
+            if (JSON.stringify(pattern) === currentMode) {
                 if (this._modeBlock !== null) {
                     for (const i in this.blocks.blockList) {
                         if (this.blocks.blockList[i].name === "modename") {

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -18,7 +18,8 @@
    numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
    getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
    getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
-   configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING
+   configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
+   scalePatternToEDO
  */
 
 /*
@@ -70,6 +71,7 @@ class ModeWidget {
         this._undoStack = [];
         this._playing = false;
         this._selectedNotes = [];
+        this._newPattern = null;
         this._edoNoteCache = {};
         // Non-EDO temperaments (just intonation, Pythagorean, meantone) are
         // mapped to their pitch count by getCurrentEDO. The widget operates on
@@ -354,6 +356,7 @@ class ModeWidget {
     _rebuildWheel(edoCount) {
         this._cancelAnimations();
         this._activeEDO = edoCount;
+        this._undoStack = []; // Clear stale undo entries from old EDO
         this.logo.synth.inTemperament = this._temperamentKeyForEDO(edoCount);
         this._piemenuMode();
     }
@@ -374,13 +377,16 @@ class ModeWidget {
             return;
         }
 
-        const newSelected = this._blankNotes(newEDO);
+        // Extract the interval pattern from the current selection, rescale it
+        // to the new EDO, and reconstruct _selectedNotes from the result.
+        const pattern = this._calculateMode();
+        const rescaled = scalePatternToEDO(pattern, newEDO);
 
-        for (let i = 1; i < n; i++) {
-            if (this._selectedNotes[i]) {
-                const scaledIdx = Math.round((i / n) * newEDO) % newEDO;
-                newSelected[scaledIdx] = true;
-            }
+        const newSelected = this._blankNotes(newEDO);
+        let pos = 0;
+        for (let i = 0; i < rescaled.length; i++) {
+            pos = (pos + rescaled[i]) % newEDO;
+            newSelected[pos] = true;
         }
 
         this._selectedNotes = newSelected;
@@ -789,7 +795,7 @@ class ModeWidget {
             this._noteWheel.navItems[n - i].navItem.hide();
         }
 
-        if (i === Math.floor(n / 2) - 1) {
+        if (i === Math.floor((n - 1) / 2)) {
             this._saveState();
             this._setModeName();
             this._locked = false;

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -88,7 +88,8 @@ class ModeWidget {
         this._undoStack = [];
         this._playing = false;
         this._selectedNotes = [];
-        this._newPattern = [];
+        this._edoNoteCache = {};
+        this._edoNoteCache[this._activeEDO] = this._selectedNotes.slice();
         this._activeEDO = getCurrentEDO(this.logo.synth.inTemperament);
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
@@ -290,7 +291,20 @@ class ModeWidget {
                 return;
             }
 
+            // Check cache first: if we have a pre-saved state for this EDO,
+            // restore it exactly rather than applying a translation mapping.
+            if (this._edoNoteCache[newEDO] !== undefined) {
+                this._selectedNotes = this._edoNoteCache[newEDO].slice();
+                this._activeEDO = newEDO;
+                this._rebuildWheel(newEDO);
+                this._setModeName();
+                return;
+            }
+
             this._translateNotesToEDO(newEDO);
+            // Save the resulting state for this EDO so future round-trips
+            // can restore it exactly.
+            this._edoNoteCache[newEDO] = this._selectedNotes.slice();
             this._rebuildWheel(newEDO);
 
             // Update mode name display without wiping the control bar.

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -290,7 +290,6 @@ class ModeWidget {
             select.appendChild(opt);
         }
     }
-
     _wireEdoSelect(select) {
         select.addEventListener("change", () => {
             const newEDO = parseInt(select.value, 10);
@@ -307,59 +306,33 @@ class ModeWidget {
             // Close any open mode piemenu; it will be rebuilt on reopen.
             this._closeModePiemenu();
 
-            // Check cache first: if we have a pre-saved state for this EDO,
-            // restore it exactly rather than applying a translation mapping.
-            if (this._edoNoteCache[newEDO] !== undefined) {
-                // Cache outgoing state so round-trip preserves intermediate edits
-                this._cacheState(this._activeEDO);
+            // Cache outgoing state so round-trip preserves intermediate edits
+            this._cacheState(this._activeEDO);
 
+            // Determine new notes: use cached state if available, otherwise translate
+            if (this._edoNoteCache[newEDO] !== undefined) {
                 this._restoreState(newEDO);
-                this._rebuildWheel(newEDO);
-                this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
-                this._setModeName();
-                return;
+            } else {
+                this._translateNotesToEDO(newEDO);
             }
 
-            // Cache the current EDO's state before translating so we can
-            // restore it losslessly when the user switches back.
-            this._cacheState(this._activeEDO);
-            const oldEDO = this._activeEDO;
-
-            this._translateNotesToEDO(newEDO);
-            // Save the resulting state for this EDO so future round-trips
-            // can restore it exactly.
-            this._cacheState(newEDO);
             this._rebuildWheel(newEDO);
+            this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
+            this._setModeName();
 
             // Only warn when going to a lesser EDO, where notes can be dropped
             // by the rounding in _translateNotesToEDO. Lesser→greater only adds
-            // steps, so no notes are lost and no message is needed.
-            if (oldEDO > newEDO) {
+            // steps, so no message is needed.
+            if (this._activeEDO > newEDO) {
                 this.textMsg(
                     _(
-                        `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
+                        `Mode remapped from ${this._activeEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
                     ),
                     3000
                 );
             }
-
-            // Update mode name display without wiping the control bar.
-            this._setModeName();
         });
     }
-
-    _updateTemperament(newEDO) {
-        if (!this.logo || !this.logo.synth) {
-            return;
-        }
-        this.logo.synth.inTemperament = this._temperamentKeyForEDO(newEDO);
-    }
-
-    /**
-     * Tear down the existing SVG slices and rebuild the pie wheel for the
-     * given EDO count. Shared by the tuning dropdown and saved-mode loading.
-     * @param {number} edoCount - The number of steps per octave.
-     */
     _rebuildWheel(edoCount) {
         this._cancelAnimations();
         this._activeEDO = edoCount;
@@ -480,6 +453,7 @@ class ModeWidget {
         }
 
         MUSICALMODES[name] = pattern;
+        MUSICALMODES[name.toLowerCase()] = pattern;
         return true;
     }
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -42,6 +42,9 @@ class ModeWidget {
     static ROTATESPEED = 125;
     static RESET_NOTES_DELAY = 500;
     static WHEELSIZE = 400;
+    static MAX_TITLE_FONT_SIZE = 48;
+    static MIN_TITLE_FONT_SIZE = 10;
+    static TITLE_FONT_SCALE = 580;
 
     /**
      * @param {object} activity
@@ -309,6 +312,9 @@ class ModeWidget {
             // Cache outgoing state so round-trip preserves intermediate edits
             this._cacheState(this._activeEDO);
 
+            // Capture old EDO before it gets overwritten by _rebuildWheel
+            const oldEDO = this._activeEDO;
+
             // Determine new notes: use cached state if available, otherwise translate
             if (this._edoNoteCache[newEDO] !== undefined) {
                 this._restoreState(newEDO);
@@ -318,15 +324,27 @@ class ModeWidget {
 
             this._rebuildWheel(newEDO);
             this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
-            this._setModeName();
+
+            // Preserve the current mode name across EDO switches.
+            // _setModeName() does a reverse-lookup from the note pattern,
+            // which changes when notes are translated to a different EDO.
+            // Instead, use the stored mode name so it persists.
+            const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
+            const name = currentKey + " " + _(this._selectedModeName);
+            this._updateModeDisplay(name);
+            if (this._nameInput) {
+                this._nameInput.value = _(this._selectedModeName);
+            }
+            // Still sync the modename block in the workspace
+            this._syncModeBlockName();
 
             // Only warn when going to a lesser EDO, where notes can be dropped
             // by the rounding in _translateNotesToEDO. Lesser→greater only adds
             // steps, so no message is needed.
-            if (this._activeEDO > newEDO) {
+            if (oldEDO > newEDO) {
                 this.textMsg(
                     _(
-                        `Mode remapped from ${this._activeEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
+                        `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
                     ),
                     3000
                 );
@@ -336,7 +354,7 @@ class ModeWidget {
     _rebuildWheel(edoCount) {
         this._cancelAnimations();
         this._activeEDO = edoCount;
-        this._updateTemperament(edoCount);
+        this.logo.synth.inTemperament = this._temperamentKeyForEDO(edoCount);
         this._piemenuMode();
     }
 
@@ -453,7 +471,9 @@ class ModeWidget {
         }
 
         MUSICALMODES[name] = pattern;
-        MUSICALMODES[name.toLowerCase()] = pattern;
+        if (name !== name.toLowerCase()) {
+            MUSICALMODES[name.toLowerCase()] = pattern;
+        }
         return true;
     }
 
@@ -463,6 +483,9 @@ class ModeWidget {
         this._saveCustomModesList(filtered);
 
         delete MUSICALMODES[name];
+        if (name !== name.toLowerCase()) {
+            delete MUSICALMODES[name.toLowerCase()];
+        }
     }
 
     _getModeEDO(modeName) {
@@ -558,6 +581,7 @@ class ModeWidget {
 
         // Mode name input (kept narrow so the row fits on one line)
         const nameInput = document.createElement("input");
+        this._nameInput = nameInput;
         nameInput.id = "customModeName";
         nameInput.type = "text";
         nameInput.placeholder = _("Mode name");
@@ -1032,42 +1056,89 @@ class ModeWidget {
         const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
         const customNames = new Set(getSavedCustomModes().map(m => m.name));
 
-        for (const mode in MUSICALMODES) {
-            // Custom modes are stored with EDO-specific step patterns; built-in
-            // patterns are 12-EDO intervals scaled to the active EDO.
-            const pattern = customNames.has(mode)
-                ? MUSICALMODES[mode]
-                : getModePattern(mode, this._activeEDO);
+        // Check custom modes first — they take priority over built-in modes
+        // when patterns match, since they are EDO-specific.
+        let matchedMode = null;
+        for (const mode of customNames) {
+            if (!(mode in MUSICALMODES)) {
+                continue;
+            }
+            const pattern = MUSICALMODES[mode];
             if (JSON.stringify(pattern) === currentMode) {
-                if (this._modeBlock !== null) {
-                    // Only update the modename block connected to the widget's
-                    // setkey2 block, plus its sibling notename block.
-                    const modeBlock = this.blocks.blockList[this._modeBlock];
-                    if (modeBlock && modeBlock.name === "modename") {
-                        modeBlock.value = mode;
-                        modeBlock.text.text = _(mode);
-                        modeBlock.updateCache();
-
-                        const parent = this.blocks.blockList[modeBlock.connections[0]];
-                        const notenameBlock =
-                            parent?.name === "setkey2" &&
-                            this.blocks.blockList[parent.connections[1]];
-                        if (notenameBlock?.name === "notename") {
-                            notenameBlock.value = currentKey;
-                            notenameBlock.text.text = _(currentKey);
-                            notenameBlock.updateCache();
-                        }
-                    }
-                    this.refreshCanvas();
-                }
-
-                const name = currentKey + " " + _(mode);
-                this._updateModeDisplay(name);
-                return;
+                matchedMode = mode;
+                break;
             }
         }
 
+        // If no custom mode matched, check built-in modes.
+        if (!matchedMode) {
+            for (const mode in MUSICALMODES) {
+                if (customNames.has(mode)) {
+                    continue;
+                }
+                const pattern = getModePattern(mode, this._activeEDO);
+                if (JSON.stringify(pattern) === currentMode) {
+                    matchedMode = mode;
+                    break;
+                }
+            }
+        }
+        if (matchedMode) {
+            this._selectedModeName = matchedMode;
+            if (this._modeBlock !== null) {
+                // Only update the modename block connected to the widget's
+                // setkey2 block, plus its sibling notename block.
+                const modeBlock = this.blocks.blockList[this._modeBlock];
+                if (modeBlock && modeBlock.name === "modename") {
+                    modeBlock.value = matchedMode;
+                    modeBlock.text.text = _(matchedMode);
+                    modeBlock.updateCache();
+
+                    const parent = this.blocks.blockList[modeBlock.connections[0]];
+                    const notenameBlock =
+                        parent?.name === "setkey2" && this.blocks.blockList[parent.connections[1]];
+                    if (notenameBlock?.name === "notename") {
+                        notenameBlock.value = currentKey;
+                        notenameBlock.text.text = _(currentKey);
+                        notenameBlock.updateCache();
+                    }
+                }
+                this.refreshCanvas();
+            }
+
+            const name = currentKey + " " + _(matchedMode);
+            if (this._nameInput) {
+                this._nameInput.value = _(matchedMode);
+            }
+            this._updateModeDisplay(name);
+            return;
+        }
+
         this._updateModeDisplay("");
+        if (this._nameInput) {
+            this._nameInput.value = "";
+        }
+    }
+
+    // ── Block sync ────────────────────────────────────────────────
+
+    /**
+     * Sync the modename block in the workspace with the stored mode name.
+     * Called after EDO switches to keep the block value consistent with
+     * the widget display, without re-deriving the name from the (possibly
+     * translated) note pattern.
+     */
+    _syncModeBlockName() {
+        if (this._modeBlock === null) {
+            return;
+        }
+        const modeBlock = this.blocks.blockList[this._modeBlock];
+        if (modeBlock && modeBlock.name === "modename") {
+            modeBlock.value = this._selectedModeName;
+            modeBlock.text.text = _(this._selectedModeName);
+            modeBlock.updateCache();
+        }
+        this.refreshCanvas();
     }
 
     _updateModeDisplay(name) {
@@ -1234,14 +1305,17 @@ class ModeWidget {
     }
 
     _createModeWheel(n) {
-        const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / n)));
+        const titleFontSize = Math.min(
+            ModeWidget.MAX_TITLE_FONT_SIZE,
+            Math.max(ModeWidget.MIN_TITLE_FONT_SIZE, Math.floor(ModeWidget.TITLE_FONT_SCALE / n))
+        );
         configureWheel(this._modeWheel, {
             colors: platformColor.modeWheelcolors,
             minRadius: 0.4,
             maxRadius: 0.75,
             clickModeRotate: false,
             selectionPaths: true,
-            titleFont: "400 " + titleFontSize + "px Times New Roman"
+            titleFont: "400 " + titleFontSize + "px sans-serif"
         });
         this._modeWheel.createWheel(Array.from({ length: n }, (_, i) => String(i)));
     }

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -18,7 +18,7 @@
    numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
    getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
    getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
-   MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING
+   configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING
  */
 
 /*
@@ -440,15 +440,6 @@ class ModeWidget {
 
     // ── Modes dropdown helpers ────────────────────────────────────
 
-    _getCustomModes() {
-        try {
-            const modes = JSON.parse(localStorage.getItem("customModes") || "[]");
-            return Array.isArray(modes) ? modes : [];
-        } catch (e) {
-            return [];
-        }
-    }
-
     _saveCustomModesList(modes) {
         try {
             localStorage.setItem("customModes", JSON.stringify(modes));
@@ -462,7 +453,7 @@ class ModeWidget {
     }
 
     _saveCustomMode(name, pattern) {
-        const modes = this._getCustomModes();
+        const modes = getSavedCustomModes();
         const existing = modes.findIndex(m => m.name === name);
         // Refuse to overwrite a built-in mode; only registered customs may be updated.
         if (existing < 0 && name in MUSICALMODES) {
@@ -484,7 +475,7 @@ class ModeWidget {
     }
 
     _deleteCustomMode(name) {
-        const modes = this._getCustomModes();
+        const modes = getSavedCustomModes();
         const filtered = modes.filter(m => m.name !== name);
         this._saveCustomModesList(filtered);
 
@@ -493,7 +484,7 @@ class ModeWidget {
 
     _getModeEDO(modeName) {
         // Saved custom modes carry their native EDO in the registry.
-        const custom = this._getCustomModes().find(m => m.name === modeName);
+        const custom = getSavedCustomModes().find(m => m.name === modeName);
         return custom && custom.edo ? custom.edo : null;
     }
 
@@ -616,7 +607,7 @@ class ModeWidget {
                 this.errorMsg(_("No mode selected."));
                 return;
             }
-            const customs = this._getCustomModes();
+            const customs = getSavedCustomModes();
             if (!customs.some(m => m.name === name)) {
                 this.errorMsg(_("Cannot delete a built-in mode."));
                 return;
@@ -1056,7 +1047,7 @@ class ModeWidget {
     _setModeName() {
         const currentMode = JSON.stringify(this._calculateMode());
         const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
-        const customNames = new Set(this._getCustomModes().map(m => m.name));
+        const customNames = new Set(getSavedCustomModes().map(m => m.name));
 
         for (const mode in MUSICALMODES) {
             // Custom modes are stored with EDO-specific step patterns; built-in
@@ -1259,40 +1250,9 @@ class ModeWidget {
         this._wireWheelEvents(n);
     }
 
-    /**
-     * Applies the shared donut-slice configuration to a wheel: colors, radii,
-     * -90° start angle and zero animation. Options are only applied when
-     * provided, preserving each wheel's existing behavior.
-     * @param {object} wheel - The wheelnav instance to configure.
-     * @param {object} opts
-     * @returns {void}
-     */
-    _configureWheel(wheel, opts) {
-        wheel.colors = opts.colors;
-        wheel.slicePathFunction = slicePath().DonutSlice;
-        wheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        wheel.slicePathCustom.minRadiusPercent = opts.minRadius;
-        wheel.slicePathCustom.maxRadiusPercent = opts.maxRadius;
-        if (opts.clickModeRotate !== undefined) {
-            wheel.clickModeRotate = opts.clickModeRotate;
-        }
-        if (opts.selectionPaths) {
-            wheel.sliceSelectedPathCustom = wheel.slicePathCustom;
-            wheel.sliceInitPathCustom = wheel.slicePathCustom;
-        }
-        wheel.navAngle = -90;
-        wheel.animatetime = 0;
-        if (opts.titleRotateAngle !== undefined) {
-            wheel.titleRotateAngle = opts.titleRotateAngle;
-        }
-        if (opts.titleFont !== undefined) {
-            wheel.titleFont = opts.titleFont;
-        }
-    }
-
     _createModeWheel(n) {
         const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / n)));
-        this._configureWheel(this._modeWheel, {
+        configureWheel(this._modeWheel, {
             colors: platformColor.modeWheelcolors,
             minRadius: 0.4,
             maxRadius: 0.75,
@@ -1304,7 +1264,7 @@ class ModeWidget {
     }
 
     _createNoteWheel(n) {
-        this._configureWheel(this._noteWheel, {
+        configureWheel(this._noteWheel, {
             colors: platformColor.noteValueWheelcolors,
             minRadius: 0.75,
             maxRadius: 0.9,
@@ -1322,7 +1282,7 @@ class ModeWidget {
     }
 
     _createPlayWheel(n) {
-        this._configureWheel(this._playWheel, {
+        configureWheel(this._playWheel, {
             colors: [platformColor.orange],
             minRadius: 0.3,
             maxRadius: 0.4,
@@ -1410,7 +1370,7 @@ class ModeWidget {
         this._modeGroupWheel = new wheelnav("_modeGroupWheel", this._modePieWheel.raphael);
         // Fixed readable size on the 400px paper; the wheelnav default (48px)
         // overflows every slice and a computed size is too small.
-        this._configureWheel(this._modeGroupWheel, {
+        configureWheel(this._modeGroupWheel, {
             colors: platformColor.modeGroupWheelcolors,
             minRadius: MODEPIEMENU_GROUP_RING.minRadius,
             maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
@@ -1439,7 +1399,7 @@ class ModeWidget {
             const newWheel = this._modeNameWheel === null;
 
             // Build per-slice colors and (possibly translated) labels.
-            // Declared before the _configureWheel call below so the
+            // Declared before the configureWheel call below so the
             // reference in the options object is not in the temporal dead zone.
             const colors = getModeSliceColors(modes, {
                 emptyColor: platformColor.modePieMenusIfColorPush,
@@ -1450,7 +1410,7 @@ class ModeWidget {
             if (newWheel) {
                 this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
                 this._modeNameWheel.keynavigateEnabled = false;
-                this._configureWheel(this._modeNameWheel, {
+                configureWheel(this._modeNameWheel, {
                     colors,
                     minRadius: MODEPIEMENU_NAME_RING.minRadius,
                     maxRadius: MODEPIEMENU_NAME_RING.maxRadius,

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -15,7 +15,10 @@
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
-   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames
+   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
+   getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
+   getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
+   MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING
  */
 
 /*
@@ -1383,9 +1386,7 @@ class ModeWidget {
         if (this._modePiemenuOpen) return;
         this._modePiemenuOpen = true;
 
-        const savedCustomModes = this._getCustomModes().filter(
-            m => m && typeof m.name === "string"
-        );
+        const savedCustomModes = getSavedCustomModes();
 
         // Swap the note-edit wheel for the mode-selection piemenu. The piemenu
         // renders on its own div/paper, so the two never overlap or intercept
@@ -1405,24 +1406,15 @@ class ModeWidget {
         // create a new custom mode, even when none are saved yet.
         const groupLabels = Object.keys(MODE_PIE_MENUS);
 
-        // Font size that fits the longest label inside one slice, computed from
-        // the arc at the ring's mid-radius (titleRadiusPercent of 200px) on a
-        // 400px paper.
-        const __sliceFontPx = (sliceCount, longestLabel, titleRadiusPercent) => {
-            const arcPx =
-                (2 * Math.PI * titleRadiusPercent * (ModeWidget.WHEELSIZE / 2)) / sliceCount;
-            return Math.min(24, Math.max(12, Math.floor((arcPx * 0.85) / (longestLabel * 0.6))));
-        };
-
         // Outer ring: group wheel
         this._modeGroupWheel = new wheelnav("_modeGroupWheel", this._modePieWheel.raphael);
         // Fixed readable size on the 400px paper; the wheelnav default (48px)
         // overflows every slice and a computed size is too small.
         this._configureWheel(this._modeGroupWheel, {
             colors: platformColor.modeGroupWheelcolors,
-            minRadius: 0.15,
-            maxRadius: 0.3,
-            titleFont: "100 16px sans-serif"
+            minRadius: MODEPIEMENU_GROUP_RING.minRadius,
+            maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
+            titleFont: getModeGroupTitleFont(ModeWidget.WHEELSIZE / 2)
         });
         this._modeGroupWheel.createWheel(groupLabels);
 
@@ -1432,15 +1424,8 @@ class ModeWidget {
             ? this._modeGroupName
             : groupLabels[0];
 
-        const __modesForGroup = grp => {
-            if (grp === "custom") {
-                // "+" is the create-new-mode sentinel, always first.
-                const names = ["+", ...savedCustomModes.map(m => m.name)].slice(0, 12);
-                while (names.length < 12) names.push(" ");
-                return names;
-            }
-            return MODE_PIE_MENUS[grp];
-        };
+        const __modesForGroup = grp =>
+            getModeNamesForGroup(grp, ["+", ...savedCustomModes.map(m => m.name)]);
 
         const __buildModeNameWheel = grp => {
             currentGroup = grp;
@@ -1456,37 +1441,19 @@ class ModeWidget {
             // Build per-slice colors and (possibly translated) labels.
             // Declared before the _configureWheel call below so the
             // reference in the options object is not in the temporal dead zone.
-            const colors = [];
-            const labels = [];
-            for (let i = 0; i < modes.length; i++) {
-                const modename = modes[i];
-                colors.push(
-                    modename === " "
-                        ? platformColor.modePieMenusIfColorPush
-                        : platformColor.modePieMenusElseColorPush
-                );
-                switch (modename) {
-                    case "ionian":
-                    case "major":
-                        labels.push(`${_("major")} / ${_("ionian")}`);
-                        break;
-                    case "aeolian":
-                    case "minor":
-                        labels.push(`${_("minor")} / ${_("aeolian")}`);
-                        break;
-                    default:
-                        labels.push(modename === " " ? " " : _(modename));
-                        break;
-                }
-            }
+            const colors = getModeSliceColors(modes, {
+                emptyColor: platformColor.modePieMenusIfColorPush,
+                filledColor: platformColor.modePieMenusElseColorPush
+            });
+            const labels = modes.map(modename => getModeLabel(modename));
 
             if (newWheel) {
                 this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
                 this._modeNameWheel.keynavigateEnabled = false;
                 this._configureWheel(this._modeNameWheel, {
                     colors,
-                    minRadius: 0.3,
-                    maxRadius: 0.85,
+                    minRadius: MODEPIEMENU_NAME_RING.minRadius,
+                    maxRadius: MODEPIEMENU_NAME_RING.maxRadius,
                     selectionPaths: true,
                     titleRotateAngle: 0
                 });
@@ -1495,31 +1462,18 @@ class ModeWidget {
             if (newWheel) {
                 this._modeNameWheel.createWheel(labels);
             } else {
-                // wheelnav keeps per-state title copies; update them all (as
-                // piemenus.js does) before re-rendering.
-                for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
-                    const item = this._modeNameWheel.navItems[i];
-                    item.title = labels[i];
-                    item.basicNavTitleMax.title = labels[i];
-                    item.basicNavTitleMin.title = labels[i];
-                    item.hoverNavTitleMax.title = labels[i];
-                    item.hoverNavTitleMin.title = labels[i];
-                    item.selectedNavTitleMax.title = labels[i];
-                    item.selectedNavTitleMin.title = labels[i];
-                    item.initNavTitle.title = labels[i];
-                    item.fillAttr = colors[i];
-                    item.sliceHoverAttr.fill = colors[i];
-                    item.slicePathAttr.fill = colors[i];
-                    item.sliceSelectedAttr.fill = colors[i];
-                }
-                this._modeNameWheel.refreshWheel();
+                updateModeWheelItems(this._modeNameWheel, labels, colors);
             }
 
             // Size each label to fit its own slice arc; the 12 slots are fixed,
             // so short names render large and only long ones shrink. Applied
             // post-createWheel via the per-item title attributes.
             for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
-                const font = `100 ${__sliceFontPx(modes.length, labels[i].length, 0.575)}px sans-serif`;
+                const font = getModeSliceFont(
+                    ModeWidget.WHEELSIZE / 2,
+                    modes.length,
+                    labels[i].length
+                );
                 const item = this._modeNameWheel.navItems[i];
                 item.titleAttr.font = font;
                 item.titleHoverAttr.font = font;
@@ -1553,18 +1507,7 @@ class ModeWidget {
                     }
 
                     // Strip translation wrapper for major/minor
-                    let modeName = title;
-                    if (title === `${_("major")} / ${_("ionian")}`) modeName = "major";
-                    else if (title === `${_("minor")} / ${_("aeolian")}`) modeName = "aeolian";
-                    else {
-                        const ms = __modesForGroup(currentGroup);
-                        for (const m of ms) {
-                            if (_(m) === title) {
-                                modeName = m;
-                                break;
-                            }
-                        }
-                    }
+                    const modeName = getModeNameFromLabel(title, __modesForGroup(currentGroup));
 
                     this._selectedModeName = modeName;
                     const mode = MUSICALMODES[modeName];

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -543,7 +543,7 @@ class ModeWidget {
 
         // EDO/Tuning — transparent select overlay on top of the icon.
         // The select is full-size but invisible; it IS the click target.
-        const tuningIcon = iconButton("menu-button.svg", _("Tuning"), null);
+        const tuningIcon = iconButton("menu-button.svg", _("temperament"), null);
         // Transparent select overlay — IS the click target; the icon behind
         // it is purely decorative.
         const edoSelect = document.createElement("select");
@@ -551,8 +551,8 @@ class ModeWidget {
         this._edoSelect = edoSelect;
         this._initEdoSelect(edoSelect);
         this._wireEdoSelect(edoSelect);
-        edoSelect.title = _("Tuning");
-        edoSelect.setAttribute("aria-label", _("Tuning"));
+        edoSelect.title = _("temperament");
+        edoSelect.setAttribute("aria-label", _("temperament"));
         Object.assign(edoSelect.style, {
             position: "absolute",
             top: 0,
@@ -580,7 +580,7 @@ class ModeWidget {
         tuningGroup.appendChild(edoSelect);
 
         // Modes: open piemenu instead of a <select> dropdown
-        const modeBtn = iconButton("pie-chart.svg", _("Select Mode"), () => {
+        const modeBtn = iconButton("pie-chart.svg", _("Switch mode"), () => {
             this._piemenuModes();
         });
         modeBtn.id = "modeSelectBtn";
@@ -596,7 +596,7 @@ class ModeWidget {
         nameInput.style.flexShrink = "1";
 
         // Save button
-        const saveBtn = iconButton("save-button.svg", _("Save Mode"), () => {
+        const saveBtn = iconButton("save-button.svg", _("Save"), () => {
             const name = nameInput.value.trim();
             if (!name) {
                 this.errorMsg(_("Please enter a mode name."));
@@ -614,7 +614,7 @@ class ModeWidget {
         });
 
         // Delete button
-        const deleteBtn = iconButton("delete.svg", _("Delete Mode"), () => {
+        const deleteBtn = iconButton("delete.svg", _("Delete"), () => {
             const name = this._selectedModeName;
             if (!name) {
                 this.errorMsg(_("No mode selected."));

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -19,34 +19,9 @@
  */
 
 /*
-    Global locations
-    - lib/wheelnav
-        slicePath, wheelnav
-    - js/utils/utils.js
-        _, last, docById
-    - js/utils/platformstyle.js
-        platformColor
-    - js/utils/musicutils.js
-        keySignatureToMode, MUSICALMODES, getModePattern, getNote, DEFAULTVOICE,
-        NOTESTABLE
-
     Dependency Injection Pattern:
-    This widget uses dependency injection to reduce implicit global state.
-    Dependencies are passed via the constructor as part of the `activity` object.
-
-    Required Dependencies (accessed via this.activity):
-    - logo: Logo instance (provides synth, modeBlock, resetSynth)
-    - turtles: Turtles instance (provides ithTurtle for keySignature)
-    - blocks: Blocks instance (provides blockList, loadNewBlocks)
-    - hideMsgs: Function to hide messages
-    - textMsg: Function to display text messages
-    - errorMsg: Function to display error messages
-    - refreshCanvas: Function to refresh the canvas
-    - storage: Storage object for custom mode persistence
-
-    Note: `this.storage.custommode` persistence was replaced by
-    `localStorage["customModes"]` (see _saveCustomMode/_getCustomModes);
-    `storage` is no longer a widget dependency.
+    Dependencies are passed via the constructor as part of the `activity`
+    object: logo, turtles, blocks, hideMsgs, textMsg, errorMsg, refreshCanvas.
 */
 
 /*exported ModeWidget*/
@@ -160,7 +135,7 @@ class ModeWidget {
         );
         this._playButton.onclick = () => {
             this.logo.resetSynth(0);
-            if (this._playingStatus()) {
+            if (this._playing) {
                 this._playing = false;
                 this._setPlayButtonIcon("play-button.svg", _("Play all"));
             } else {
@@ -252,12 +227,6 @@ class ModeWidget {
         this._playing = false;
         this._newPattern = null;
         this._notesToPlay = null;
-    }
-
-    // ── Play state ────────────────────────────────────────────────
-
-    _playingStatus() {
-        return this._playing;
     }
 
     _setPlayButtonIcon(iconName, titleText) {
@@ -666,7 +635,12 @@ class ModeWidget {
         widgetBody.children[0].style.flexDirection = "column";
         widgetBody.children[0].style.alignItems = "center";
 
-        const svg = this.getWidgetBody().getElementsByTagName("svg")[0];
+        // When the mode piemenu is open, scale its SVG; otherwise scale
+        // the note-wheel SVG.  getElementsByTagName("svg")[0] always
+        // returns the meterWheelDiv SVG (first in DOM order) even when
+        // the mode piemenu is the visible one.
+        const svgContainer = this._modePiemenuOpen ? this._modePiemenuDiv : this._meterWheelDiv;
+        const svg = svgContainer.querySelector("svg");
         if (!svg) {
             return;
         }
@@ -688,12 +662,18 @@ class ModeWidget {
             return;
         }
 
-        this._applyModePattern(
-            this._getModeEDO(currentModeName[1])
-                ? currentMode
-                : getModePattern(currentModeName[1], this._activeEDO)
-        );
-        this._setModeName();
+        const nativeEDO = this._getModeEDO(currentModeName[1]);
+        if (nativeEDO && nativeEDO !== this._activeEDO) {
+            // Custom mode saved at a different EDO — rebuild the wheel to
+            // match its native tuning before applying the pattern.
+            // edoSelect is null here (built later); _loadMode handles that.
+            this._loadMode(currentModeName[1], currentMode, null);
+        } else {
+            this._applyModePattern(
+                nativeEDO ? currentMode : getModePattern(currentModeName[1], this._activeEDO)
+            );
+            this._setModeName();
+        }
     }
 
     _loadMode(modeName, mode, edoSelect) {
@@ -703,7 +683,8 @@ class ModeWidget {
             // tuning dropdown and rebuild the wheel before selecting intervals.
             // Cache the outgoing state exactly like the dropdown handler so
             // round-trips restore it losslessly.
-            this._cacheState(this._activeEDO);
+            const oldEDO = this._activeEDO;
+            this._cacheState(oldEDO);
             if (edoSelect) {
                 // The dropdown may lack an option for an unusual native EDO
                 // (e.g. 21 from 1/4 comma meantone); add it so .value sticks.
@@ -716,6 +697,12 @@ class ModeWidget {
                 edoSelect.value = nativeEDO;
             }
             this._rebuildWheel(nativeEDO);
+            this.textMsg(
+                _(
+                    `Mode ${modeName} is ${nativeEDO}-EDO; tuning switched from ${oldEDO}-EDO to ${nativeEDO}-EDO.`
+                ),
+                3000
+            );
         }
         // Built-in mode patterns are 12-EDO intervals; scale them to the
         // active EDO. Custom modes carry EDO-specific patterns already.
@@ -988,16 +975,7 @@ class ModeWidget {
     }
 
     _playNote(i) {
-        const ks = this.turtles.ithTurtle(0).singer.keySignature;
-        const noteToPlay = getNote(this._pitch, 4, i, ks, false, null, this.errorMsg);
-        this.logo.synth.trigger(
-            0,
-            normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-            this._noteValue,
-            DEFAULTVOICE,
-            null,
-            null
-        );
+        this._triggerNote(i, this._activeEDO);
     }
 
     // ── Undo / Clear ──────────────────────────────────────────────
@@ -1005,7 +983,7 @@ class ModeWidget {
     _saveState() {
         const state = JSON.stringify(this._selectedNotes);
         if (state !== last(this._undoStack)) {
-            this._undoStack.push(JSON.stringify(this._selectedNotes));
+            this._undoStack.push(state);
         }
     }
 
@@ -1450,19 +1428,10 @@ class ModeWidget {
             // removeWheel() on it: every wheel shares the root's paper, and
             // removeWheel() detaches the whole SVG from the DOM.
             const newWheel = this._modeNameWheel === null;
-            if (newWheel) {
-                this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
-                this._modeNameWheel.keynavigateEnabled = false;
-                this._configureWheel(this._modeNameWheel, {
-                    colors,
-                    minRadius: 0.3,
-                    maxRadius: 0.85,
-                    selectionPaths: true,
-                    titleRotateAngle: 0
-                });
-            }
 
             // Build per-slice colors and (possibly translated) labels.
+            // Declared before the _configureWheel call below so the
+            // reference in the options object is not in the temporal dead zone.
             const colors = [];
             const labels = [];
             for (let i = 0; i < modes.length; i++) {
@@ -1488,23 +1457,36 @@ class ModeWidget {
             }
 
             if (newWheel) {
+                this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
+                this._modeNameWheel.keynavigateEnabled = false;
+                this._configureWheel(this._modeNameWheel, {
+                    colors,
+                    minRadius: 0.3,
+                    maxRadius: 0.85,
+                    selectionPaths: true,
+                    titleRotateAngle: 0
+                });
+            }
+
+            if (newWheel) {
                 this._modeNameWheel.createWheel(labels);
             } else {
                 // wheelnav keeps per-state title copies; update them all (as
                 // piemenus.js does) before re-rendering.
                 for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
-                    this._modeNameWheel.navItems[i].title = labels[i];
-                    this._modeNameWheel.navItems[i].basicNavTitleMax.title = labels[i];
-                    this._modeNameWheel.navItems[i].basicNavTitleMin.title = labels[i];
-                    this._modeNameWheel.navItems[i].hoverNavTitleMax.title = labels[i];
-                    this._modeNameWheel.navItems[i].hoverNavTitleMin.title = labels[i];
-                    this._modeNameWheel.navItems[i].selectedNavTitleMax.title = labels[i];
-                    this._modeNameWheel.navItems[i].selectedNavTitleMin.title = labels[i];
-                    this._modeNameWheel.navItems[i].initNavTitle.title = labels[i];
-                    this._modeNameWheel.navItems[i].fillAttr = colors[i];
-                    this._modeNameWheel.navItems[i].sliceHoverAttr.fill = colors[i];
-                    this._modeNameWheel.navItems[i].slicePathAttr.fill = colors[i];
-                    this._modeNameWheel.navItems[i].sliceSelectedAttr.fill = colors[i];
+                    const item = this._modeNameWheel.navItems[i];
+                    item.title = labels[i];
+                    item.basicNavTitleMax.title = labels[i];
+                    item.basicNavTitleMin.title = labels[i];
+                    item.hoverNavTitleMax.title = labels[i];
+                    item.hoverNavTitleMin.title = labels[i];
+                    item.selectedNavTitleMax.title = labels[i];
+                    item.selectedNavTitleMin.title = labels[i];
+                    item.initNavTitle.title = labels[i];
+                    item.fillAttr = colors[i];
+                    item.sliceHoverAttr.fill = colors[i];
+                    item.slicePathAttr.fill = colors[i];
+                    item.sliceSelectedAttr.fill = colors[i];
                 }
                 this._modeNameWheel.refreshWheel();
             }
@@ -1513,12 +1495,11 @@ class ModeWidget {
             // so short names render large and only long ones shrink. Applied
             // post-createWheel via the per-item title attributes.
             for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
-                const fontSize = __sliceFontPx(modes.length, labels[i].length, 0.575);
-                this._modeNameWheel.navItems[i].titleAttr.font = `100 ${fontSize}px sans-serif`;
-                this._modeNameWheel.navItems[i].titleHoverAttr.font =
-                    `100 ${fontSize}px sans-serif`;
-                this._modeNameWheel.navItems[i].titleSelectedAttr.font =
-                    `100 ${fontSize}px sans-serif`;
+                const font = `100 ${__sliceFontPx(modes.length, labels[i].length, 0.575)}px sans-serif`;
+                const item = this._modeNameWheel.navItems[i];
+                item.titleAttr.font = font;
+                item.titleHoverAttr.font = font;
+                item.titleSelectedAttr.font = font;
             }
 
             // Set up action for each mode slice

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -15,7 +15,7 @@
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
-   numberToPitch, pitchToFrequency
+   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT
  */
 
 /*
@@ -89,7 +89,13 @@ class ModeWidget {
         this._playing = false;
         this._selectedNotes = [];
         this._edoNoteCache = {};
+        // Non-EDO temperaments (just intonation, Pythagorean, meantone) are
+        // mapped to their pitch count by getCurrentEDO. The widget operates on
+        // that count, and changing the tuning below replaces the temperament.
         this._activeEDO = getCurrentEDO(this.logo.synth.inTemperament);
+        this._selectedModeName = "major";
+        this._modePiemenuOpen = false;
+        this._suppressModeSelect = false;
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
         this.widgetWindow.clear();
@@ -103,13 +109,23 @@ class ModeWidget {
         this.modeTableDiv.style.visibility = "visible";
         this.modeTableDiv.style.border = "0px";
 
+        // Unique ids: "meterWheelDiv" is also used by index.html and the Meter
+        // widget, so getElementById could resolve to the wrong element.
         const meterWheelDiv = document.createElement("div");
-        meterWheelDiv.id = "meterWheelDiv";
+        meterWheelDiv.id = "modeWidgetWheelDiv";
+
+        // The mode-selection piemenu renders on its own div/paper so it never
+        // shares an SVG with the note-edit wheel (which would block its clicks).
+        const modePiemenuDiv = document.createElement("div");
+        modePiemenuDiv.id = "modePiemenuDiv";
+        modePiemenuDiv.style.display = "none";
 
         const modeTable = document.createElement("table");
         modeTable.id = "modeTable";
 
-        this.modeTableDiv.replaceChildren(meterWheelDiv, modeTable);
+        this.modeTableDiv.replaceChildren(meterWheelDiv, modePiemenuDiv, modeTable);
+        this._meterWheelDiv = meterWheelDiv;
+        this._modePiemenuDiv = modePiemenuDiv;
         this.widgetWindow.getWidgetBody().append(this.modeTableDiv);
 
         this.widgetWindow.onclose = () => {
@@ -193,6 +209,23 @@ class ModeWidget {
         this._buildControlBar();
 
         this.textMsg(_("Click in the circle to select notes for the mode."), 3000);
+
+        if (TEMPERAMENT[this.logo.synth.inTemperament]?.isEDO === false) {
+            // Non-EDO temperaments are used by their pitch count (12/19/21);
+            // switching the tuning below will replace them with an equal
+            // temperament. Inform, but do not block.
+            this._setTimeout(
+                () =>
+                    this.textMsg(
+                        _(
+                            "Non-EDO temperament: modes use its pitch count; switching the tuning replaces the temperament."
+                        ),
+                        4000
+                    ),
+                3500
+            );
+        }
+
         window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
     }
 
@@ -281,26 +314,14 @@ class ModeWidget {
     _initEdoSelect(select) {
         const inEDO = this._activeEDO;
         const inTemperament = this.logo.synth.inTemperament;
-        const options = this._edoOptions();
-
-        let foundMatch = false;
-        for (const o of options) {
+        for (const o of this._edoOptions()) {
             const opt = document.createElement("option");
             opt.value = o.value;
             opt.textContent = o.label;
             if (o.value === inEDO || o.temperamentKey === inTemperament) {
                 opt.selected = true;
-                foundMatch = true;
             }
             select.appendChild(opt);
-        }
-
-        if (!foundMatch) {
-            const opt = document.createElement("option");
-            opt.value = inEDO;
-            opt.textContent = inEDO + "-EDO";
-            opt.selected = true;
-            select.prepend(opt);
         }
     }
 
@@ -310,6 +331,15 @@ class ModeWidget {
             if (isNaN(newEDO) || newEDO < 5 || newEDO > 55 || newEDO === this._activeEDO) {
                 return;
             }
+
+            // Warn (but don't block) before replacing a non-EDO temperament
+            // with the equal-tempered equivalent of the chosen EDO.
+            if (TEMPERAMENT[this.logo.synth.inTemperament]?.isEDO === false) {
+                this.textMsg(_("Switching tuning replaces the current non-EDO temperament."), 3000);
+            }
+
+            // Close any open mode piemenu; it will be rebuilt on reopen.
+            this._closeModePiemenu();
 
             // Check cache first: if we have a pre-saved state for this EDO,
             // restore it exactly rather than applying a translation mapping.
@@ -333,12 +363,17 @@ class ModeWidget {
             this._edoNoteCache[newEDO] = this._selectedNotes.slice();
             this._rebuildWheel(newEDO);
 
-            this.textMsg(
-                _(
-                    `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
-                ),
-                3000
-            );
+            // Only warn when going to a lesser EDO, where notes can be dropped
+            // by the rounding in _translateNotesToEDO. Lesser→greater only adds
+            // steps, so no notes are lost and no message is needed.
+            if (oldEDO > newEDO) {
+                this.textMsg(
+                    _(
+                        `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
+                    ),
+                    3000
+                );
+            }
 
             // Update mode name display without wiping the control bar.
             this._setModeName();
@@ -365,26 +400,10 @@ class ModeWidget {
     }
 
     _clearPieMenu() {
-        const meterDiv = docById("meterWheelDiv");
-        if (meterDiv && typeof meterDiv.querySelectorAll === "function") {
-            // Explicitly remove any leftover SVG slices from the DOM.
-            const svgs = meterDiv.querySelectorAll("svg");
-            for (let i = svgs.length - 1; i >= 0; i--) {
-                if (typeof meterDiv.removeChild === "function") {
-                    meterDiv.removeChild(svgs[i]);
-                }
-            }
-        }
-
-        if (this._modeWheel) {
-            this._modeWheel.removeWheel();
-        }
-        if (this._noteWheel) {
-            this._noteWheel.removeWheel();
-        }
-        if (this._playWheel) {
-            this._playWheel.removeWheel();
-        }
+        // Remove any leftover SVG slices from the DOM before rebuilding. All
+        // three wheels share one paper, so replacing the div's children
+        // detaches it; the wheel refs are then dropped.
+        this._meterWheelDiv.replaceChildren();
         this._modeWheel = null;
         this._noteWheel = null;
         this._playWheel = null;
@@ -413,7 +432,8 @@ class ModeWidget {
 
     _getCustomModes() {
         try {
-            return JSON.parse(localStorage.getItem("customModes") || "[]");
+            const modes = JSON.parse(localStorage.getItem("customModes") || "[]");
+            return Array.isArray(modes) ? modes : [];
         } catch (e) {
             return [];
         }
@@ -467,46 +487,6 @@ class ModeWidget {
         return custom && custom.edo ? custom.edo : null;
     }
 
-    _populateModesDropdown(select) {
-        select.innerHTML = "";
-
-        // "Custom" option always at the top
-        const customOpt = document.createElement("option");
-        customOpt.value = "custom";
-        customOpt.textContent = _("Custom");
-        select.appendChild(customOpt);
-
-        const customs = this._getCustomModes();
-        const customNames = new Set(customs.map(m => m.name));
-
-        const builtIn = document.createElement("optgroup");
-        builtIn.label = _("Built-in Modes");
-        for (const mode of Object.keys(MUSICALMODES)) {
-            // Custom modes are registered in MUSICALMODES too, so exclude them
-            // from the built-in group to avoid listing them twice.
-            if (customNames.has(mode)) {
-                continue;
-            }
-            const opt = document.createElement("option");
-            opt.value = mode;
-            opt.textContent = _(mode);
-            builtIn.appendChild(opt);
-        }
-        select.appendChild(builtIn);
-
-        if (customs.length > 0) {
-            const group = document.createElement("optgroup");
-            group.label = _("Custom Modes");
-            for (const m of customs) {
-                const opt = document.createElement("option");
-                opt.value = m.name;
-                opt.textContent = m.name;
-                group.appendChild(opt);
-            }
-            select.appendChild(group);
-        }
-    }
-
     // ── Bottom control bar ────────────────────────────────────────
 
     _buildControlBar() {
@@ -534,31 +514,19 @@ class ModeWidget {
         edoSelect.style.fontSize = "12px";
         edoSelect.style.minHeight = "30px";
 
-        // Modes dropdown
+        // Modes: open piemenu instead of a <select> dropdown
         const modeLabel = document.createElement("span");
         modeLabel.textContent = _("Mode") + ":";
         modeLabel.style.fontSize = "12px";
 
-        const modeSelect = document.createElement("select");
-        modeSelect.id = "modeSelect";
-        modeSelect.style.fontSize = "12px";
-        modeSelect.style.minHeight = "30px";
-        this._populateModesDropdown(modeSelect);
-
-        modeSelect.addEventListener("change", () => {
-            const modeName = modeSelect.value;
-            if (modeName === "custom") {
-                this._resetToCustom();
-                return;
-            }
-
-            const mode = MUSICALMODES[modeName];
-            if (!mode) {
-                return;
-            }
-
-            this._loadMode(modeName, mode, edoSelect);
-        });
+        const modeBtn = document.createElement("button");
+        modeBtn.id = "modeSelectBtn";
+        modeBtn.textContent = _("Select Mode");
+        modeBtn.style.fontSize = "12px";
+        modeBtn.style.minHeight = "30px";
+        modeBtn.onclick = () => {
+            this._piemenuModes();
+        };
 
         // Mode name input
         const nameInput = document.createElement("input");
@@ -585,8 +553,7 @@ class ModeWidget {
             if (!this._saveCustomMode(name, pattern)) {
                 return;
             }
-            this._populateModesDropdown(modeSelect);
-            modeSelect.value = name;
+            this._selectedModeName = name;
             // Export the mode to the workspace blocks so the user can use it.
             this._setModeName();
             this._save();
@@ -600,15 +567,18 @@ class ModeWidget {
         deleteBtn.style.minHeight = "30px";
         deleteBtn.style.padding = "0 12px";
         deleteBtn.onclick = () => {
-            const name = modeSelect.value;
+            const name = this._selectedModeName;
+            if (!name) {
+                this.errorMsg(_("No mode selected."));
+                return;
+            }
             const customs = this._getCustomModes();
             if (!customs.some(m => m.name === name)) {
                 this.errorMsg(_("Cannot delete a built-in mode."));
                 return;
             }
             this._deleteCustomMode(name);
-            this._populateModesDropdown(modeSelect);
-            modeSelect.value = Object.keys(MUSICALMODES)[0];
+            this._selectedModeName = DEFAULTMODE;
             // Reset a modename block still referencing the deleted mode.
             if (this._modeBlock !== null) {
                 const modeBlock = this.blocks.blockList[this._modeBlock];
@@ -619,13 +589,16 @@ class ModeWidget {
                     this.refreshCanvas();
                 }
             }
+            // Re-evaluate the mode name from the current pattern; if it no
+            // longer matches the deleted mode, the label clears.
+            this._setModeName();
             this.textMsg(_("Mode deleted: ") + name, 3000);
         };
 
         bar.appendChild(edoLabel);
         bar.appendChild(edoSelect);
         bar.appendChild(modeLabel);
-        bar.appendChild(modeSelect);
+        bar.appendChild(modeBtn);
         bar.appendChild(nameInput);
         bar.appendChild(saveBtn);
         bar.appendChild(deleteBtn);
@@ -648,6 +621,9 @@ class ModeWidget {
         widgetBody.children[0].style.alignItems = "center";
 
         const svg = this.getWidgetBody().getElementsByTagName("svg")[0];
+        if (!svg) {
+            return;
+        }
         svg.style.pointerEvents = "none";
         svg.setAttribute("height", `${400 * scale}px`);
         svg.setAttribute("width", `${400 * scale}px`);
@@ -687,16 +663,6 @@ class ModeWidget {
         const pattern = nativeEDO ? mode : getModePattern(modeName, this._activeEDO);
         this._applyModePattern(pattern);
         this._setModeName();
-
-        // Show message if the mode pattern was scaled from a different EDO
-        if (nativeEDO && nativeEDO !== this._activeEDO) {
-            this.textMsg(
-                _(
-                    `Mode scaled from ${nativeEDO}-EDO to ${this._activeEDO}-EDO. Some notes may have changed.`
-                ),
-                3000
-            );
-        }
     }
 
     _applyModePattern(pattern) {
@@ -717,24 +683,6 @@ class ModeWidget {
                 this._noteWheel.navItems[i].navItem.hide();
             }
         }
-    }
-
-    _resetToCustom() {
-        const n = this._activeEDO;
-        this._saveState();
-        this._selectedNotes = new Array(n).fill(false);
-        this._selectedNotes[0] = true;
-
-        for (let i = 0; i < n; i++) {
-            if (i === 0) {
-                this._noteWheel.navItems[i].navItem.show();
-            } else {
-                this._noteWheel.navItems[i].navItem.hide();
-            }
-        }
-
-        // Clear the mode name display
-        this._updateModeDisplay("");
     }
 
     // ── Invert ────────────────────────────────────────────────────
@@ -789,6 +737,19 @@ class ModeWidget {
             }
             this._playWheel.navItems[i].navItem.hide();
         }
+    }
+
+    /**
+     * Resets the note wheel to a blank custom mode (only the root note
+     * selected) so the user can define a new mode by clicking notes.
+     * @returns {void}
+     */
+    _resetToCustom() {
+        this._saveState();
+        this._selectedNotes = new Array(this._activeEDO).fill(false);
+        this._selectedNotes[0] = true;
+        this._resetNotes();
+        this._updateModeDisplay("");
     }
 
     // ── Rotate ────────────────────────────────────────────────────
@@ -893,8 +854,6 @@ class ModeWidget {
                 this._notesToPlay.push(i);
             }
         }
-
-        this._notesToPlay.push(n);
 
         this._notesToPlay.push(n);
         for (let i = n - 1; i > -1; i--) {
@@ -1197,10 +1156,13 @@ class ModeWidget {
         // rendering with the current EDO count.
         this._clearPieMenu();
 
-        const meterDiv = docById("meterWheelDiv");
-        meterDiv.style.display = "";
+        // Only the piemenu open/close methods toggle these divs; a rebuild must
+        // not re-show the note wheel while the mode piemenu is open.
+        if (!this._modePiemenuOpen) {
+            this._meterWheelDiv.style.display = "";
+        }
 
-        this._modeWheel = new wheelnav("meterWheelDiv", null, 400, 400);
+        this._modeWheel = new wheelnav("modeWidgetWheelDiv", null, 400, 400);
         this._noteWheel = new wheelnav("_noteWheel", this._modeWheel.raphael);
         this._playWheel = new wheelnav("_playWheel", this._modeWheel.raphael);
 
@@ -1220,11 +1182,7 @@ class ModeWidget {
         const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / n)));
         this._modeWheel.titleFont = "400 " + titleFontSize + "px Times New Roman";
 
-        const labels = [];
-        for (let i = 0; i < n; i++) {
-            labels.push(String(i));
-        }
-        this._modeWheel.createWheel(labels);
+        this._modeWheel.createWheel(Array.from({ length: n }, (_, i) => String(i)));
 
         this._noteWheel.colors = platformColor.noteValueWheelcolors;
         this._noteWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1251,11 +1209,7 @@ class ModeWidget {
 
         // Slice 0: blank (no X toggle — root is always selected)
         // Slices 1..n-1: "x" toggle (dynamic EDO layout)
-        const noteList = [" "];
-        for (let i = 1; i < n; i++) {
-            noteList.push("x");
-        }
-        this._noteWheel.createWheel(noteList);
+        this._noteWheel.createWheel([" ", ...new Array(n - 1).fill("x")]);
 
         this._playWheel.colors = [platformColor.orange];
         this._playWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1268,11 +1222,7 @@ class ModeWidget {
         this._playWheel.navAngle = -90;
         this._playWheel.titleRotateAngle = 90;
 
-        const playList = [];
-        for (let i = 0; i < n; i++) {
-            playList.push(" ");
-        }
-        this._playWheel.createWheel(playList);
+        this._playWheel.createWheel(new Array(n).fill(" "));
 
         for (let i = 0; i < n; i++) {
             this._playWheel.navItems[i].navItem.hide();
@@ -1313,6 +1263,266 @@ class ModeWidget {
                 this._noteWheel.navItems[i].navItem.show();
             }
         }
+    }
+
+    /**
+     * Builds a piemenu for mode selection with an outer ring of mode groups
+     * and an inner ring of mode names. Custom saved modes appear in the
+     * "custom" group. Reuses patterns from piemenuModes in piemenus.js.
+     * @returns {void}
+     */
+    _piemenuModes() {
+        if (this._modePiemenuOpen) return;
+        this._modePiemenuOpen = true;
+
+        const savedCustomModes = this._getCustomModes().filter(
+            m => m && typeof m.name === "string"
+        );
+
+        // Swap the note-edit wheel for the mode-selection piemenu. The piemenu
+        // renders on its own div/paper, so the two never overlap or intercept
+        // each other's clicks. The root constructor clears any stale SVGs.
+        this._meterWheelDiv.style.display = "none";
+        this._modePiemenuDiv.style.display = "";
+
+        this._modePieWheel = new wheelnav("modePiemenuDiv", null, 400, 400);
+        this._modeNameWheel = null; // Built on first group selection.
+
+        // All groups appear, including "custom": it always offers "+" to
+        // create a new custom mode, even when none are saved yet.
+        const groupLabels = Object.keys(MODE_PIE_MENUS);
+
+        // Font size that fits the longest label inside one slice, computed from
+        // the arc at the ring's mid-radius (titleRadiusPercent of 200px) on a
+        // 400px paper.
+        const __sliceFontPx = (sliceCount, longestLabel, titleRadiusPercent) => {
+            const arcPx = (2 * Math.PI * titleRadiusPercent * 200) / sliceCount;
+            return Math.min(20, Math.max(7, Math.floor((arcPx * 0.85) / (longestLabel * 0.6))));
+        };
+
+        // Outer ring: group wheel
+        this._modeGroupWheel = new wheelnav("_modeGroupWheel", this._modePieWheel.raphael);
+        this._modeGroupWheel.colors = platformColor.modeGroupWheelcolors;
+        this._modeGroupWheel.slicePathFunction = slicePath().DonutSlice;
+        this._modeGroupWheel.slicePathCustom = slicePath().DonutSliceCustomization();
+        this._modeGroupWheel.slicePathCustom.minRadiusPercent = 0.15;
+        this._modeGroupWheel.slicePathCustom.maxRadiusPercent = 0.3;
+        this._modeGroupWheel.navAngle = -90;
+        this._modeGroupWheel.animatetime = 0;
+        // Size labels to fit their slices on the 400px paper; the wheelnav
+        // default (48px) overflows every slice.
+        const longestGroupLabel = Math.max(...groupLabels.map(label => label.length), 1);
+        this._modeGroupWheel.titleFont = `100 ${__sliceFontPx(groupLabels.length, longestGroupLabel, 0.225)}px sans-serif`;
+        this._modeGroupWheel.createWheel(groupLabels);
+
+        // Inner ring: mode-name wheel (rebuilt on group selection). Reopen on
+        // the group the user last visited.
+        let currentGroup = groupLabels.includes(this._modeGroupName)
+            ? this._modeGroupName
+            : groupLabels[0];
+
+        const __modesForGroup = grp => {
+            if (grp === "custom") {
+                // "+" is the create-new-mode sentinel, always first.
+                const names = ["+", ...savedCustomModes.map(m => m.name)].slice(0, 12);
+                while (names.length < 12) names.push(" ");
+                return names;
+            }
+            return MODE_PIE_MENUS[grp];
+        };
+
+        const __buildModeNameWheel = grp => {
+            currentGroup = grp;
+            this._modeGroupName = grp;
+            const modes = __modesForGroup(grp);
+
+            // All groups share the fixed 12-slot layout, so the wheel is created
+            // once per open and updated in place on group switches. Never call
+            // removeWheel() on it: every wheel shares the root's paper, and
+            // removeWheel() detaches the whole SVG from the DOM.
+            const newWheel = this._modeNameWheel === null;
+            if (newWheel) {
+                this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
+                this._modeNameWheel.keynavigateEnabled = false;
+                this._modeNameWheel.slicePathFunction = slicePath().DonutSlice;
+                this._modeNameWheel.slicePathCustom = slicePath().DonutSliceCustomization();
+                this._modeNameWheel.slicePathCustom.minRadiusPercent = 0.3;
+                this._modeNameWheel.slicePathCustom.maxRadiusPercent = 0.85;
+                this._modeNameWheel.sliceSelectedPathCustom = this._modeNameWheel.slicePathCustom;
+                this._modeNameWheel.sliceInitPathCustom = this._modeNameWheel.slicePathCustom;
+                this._modeNameWheel.titleRotateAngle = 0;
+                this._modeNameWheel.navAngle = -90;
+                this._modeNameWheel.animatetime = 0;
+            }
+
+            // Build per-slice colors and (possibly translated) labels.
+            const colors = [];
+            const labels = [];
+            for (let i = 0; i < modes.length; i++) {
+                const modename = modes[i];
+                colors.push(
+                    modename === " "
+                        ? platformColor.modePieMenusIfColorPush
+                        : platformColor.modePieMenusElseColorPush
+                );
+                switch (modename) {
+                    case "ionian":
+                    case "major":
+                        labels.push(`${_("major")} / ${_("ionian")}`);
+                        break;
+                    case "aeolian":
+                    case "minor":
+                        labels.push(`${_("minor")} / ${_("aeolian")}`);
+                        break;
+                    default:
+                        labels.push(modename === " " ? " " : _(modename));
+                        break;
+                }
+            }
+
+            if (newWheel) {
+                this._modeNameWheel.colors = colors;
+                this._modeNameWheel.createWheel(labels);
+            } else {
+                // wheelnav keeps per-state title copies; update them all (as
+                // piemenus.js does) before re-rendering.
+                for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
+                    this._modeNameWheel.navItems[i].title = labels[i];
+                    this._modeNameWheel.navItems[i].basicNavTitleMax.title = labels[i];
+                    this._modeNameWheel.navItems[i].basicNavTitleMin.title = labels[i];
+                    this._modeNameWheel.navItems[i].hoverNavTitleMax.title = labels[i];
+                    this._modeNameWheel.navItems[i].hoverNavTitleMin.title = labels[i];
+                    this._modeNameWheel.navItems[i].selectedNavTitleMax.title = labels[i];
+                    this._modeNameWheel.navItems[i].selectedNavTitleMin.title = labels[i];
+                    this._modeNameWheel.navItems[i].initNavTitle.title = labels[i];
+                    this._modeNameWheel.navItems[i].fillAttr = colors[i];
+                    this._modeNameWheel.navItems[i].sliceHoverAttr.fill = colors[i];
+                    this._modeNameWheel.navItems[i].slicePathAttr.fill = colors[i];
+                    this._modeNameWheel.navItems[i].sliceSelectedAttr.fill = colors[i];
+                }
+                this._modeNameWheel.refreshWheel();
+            }
+
+            // Size each label to fit its own slice arc; the 12 slots are fixed,
+            // so short names render large and only long ones shrink. Applied
+            // post-createWheel via the per-item title attributes.
+            for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
+                const fontSize = __sliceFontPx(modes.length, labels[i].length, 0.575);
+                this._modeNameWheel.navItems[i].titleAttr.font = `100 ${fontSize}px sans-serif`;
+                this._modeNameWheel.navItems[i].titleHoverAttr.font =
+                    `100 ${fontSize}px sans-serif`;
+                this._modeNameWheel.navItems[i].titleSelectedAttr.font =
+                    `100 ${fontSize}px sans-serif`;
+            }
+
+            // Set up action for each mode slice
+            for (let i = 0; i < modes.length; i++) {
+                this._modeNameWheel.navItems[i].navigateFunction = () => {
+                    const title =
+                        this._modeNameWheel.navItems[this._modeNameWheel.selectedNavItemIndex]
+                            .title;
+                    if (title === " ") return;
+
+                    // Suppress programmatic navigation: wheelnav fires
+                    // navigateFunction() on every navigateWheel() call, including
+                    // the init highlight and group switches below. Those must only
+                    // highlight, never select/close. Real user clicks are unaffected.
+                    if (this._suppressModeSelect) {
+                        return;
+                    }
+
+                    // "+" is the create-new-mode sentinel (slice 0 of the
+                    // custom group): close the piemenu and blank the note wheel
+                    // so the user can define a fresh mode by clicking notes.
+                    if (currentGroup === "custom" && title === _("+")) {
+                        this._selectedModeName = DEFAULTMODE;
+                        this._closeModePiemenu();
+                        this._resetToCustom();
+                        return;
+                    }
+
+                    // Strip translation wrapper for major/minor
+                    let modeName = title;
+                    if (title === `${_("major")} / ${_("ionian")}`) modeName = "major";
+                    else if (title === `${_("minor")} / ${_("aeolian")}`) modeName = "aeolian";
+                    else {
+                        const ms = __modesForGroup(currentGroup);
+                        for (const m of ms) {
+                            if (_(m) === title) {
+                                modeName = m;
+                                break;
+                            }
+                        }
+                    }
+
+                    this._selectedModeName = modeName;
+                    const mode = MUSICALMODES[modeName];
+                    if (mode) {
+                        // Close piemenu FIRST so the note wheel is visible for any wheel
+                        // rebuild triggered by _loadMode() → _rebuildWheel() → _piemenuMode()
+                        this._closeModePiemenu();
+
+                        // Find the edoSelect in the DOM
+                        const edoSelect = docById("edoSelect");
+                        if (edoSelect) {
+                            this._loadMode(modeName, mode, edoSelect);
+                        } else {
+                            // Fallback: rebuild wheel with current EDO
+                            this._loadMode(modeName, mode, { value: this._activeEDO });
+                        }
+                    }
+                };
+            }
+
+            // Navigate to currently-selected mode if present. This fires the
+            // slice's navigateFunction (which would select+close), so suppress
+            // it: this call is only meant to highlight the current mode.
+            let idx = 0;
+            for (let i = 0; i < modes.length; i++) {
+                if (modes[i] === this._selectedModeName) {
+                    idx = i;
+                    break;
+                }
+            }
+            this._suppressModeSelect = true;
+            this._modeNameWheel.navigateWheel(idx);
+            this._suppressModeSelect = false;
+        };
+
+        // Wire group wheel slices → __buildModeNameWheel
+        for (let i = 0; i < this._modeGroupWheel.navItems.length; i++) {
+            this._modeGroupWheel.navItems[i].navigateFunction = () => {
+                const selectedGroup =
+                    this._modeGroupWheel.navItems[this._modeGroupWheel.selectedNavItemIndex].title;
+                __buildModeNameWheel(selectedGroup);
+            };
+        }
+
+        // Highlight the last-visited group and build its mode wheel; the group
+        // navigateFunction above triggers the name-wheel build.
+        this._modeGroupWheel.navigateWheel(groupLabels.indexOf(currentGroup));
+    }
+
+    /**
+     * Closes the mode piemenu and restores the note-edit wheel.
+     * Properly destroys wheelnav instances so their SVGs leave the DOM.
+     * @returns {void}
+     */
+    _closeModePiemenu() {
+        this._modePiemenuDiv.style.display = "none";
+        this._meterWheelDiv.style.display = "";
+
+        // All three wheels share the root's paper, so removing the root
+        // removes the whole SVG, including the child wheels.
+        if (this._modePieWheel) {
+            this._modePieWheel.removeWheel();
+        }
+
+        this._modePieWheel = null;
+        this._modeGroupWheel = null;
+        this._modeNameWheel = null;
+        this._modePiemenuOpen = false;
+        this._suppressModeSelect = false;
     }
 }
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -89,7 +89,6 @@ class ModeWidget {
         this._playing = false;
         this._selectedNotes = [];
         this._edoNoteCache = {};
-        this._edoNoteCache[this._activeEDO] = this._selectedNotes.slice();
         this._activeEDO = getCurrentEDO(this.logo.synth.inTemperament);
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
@@ -301,11 +300,23 @@ class ModeWidget {
                 return;
             }
 
+            // Cache the current EDO's state before translating so we can
+            // restore it losslessly when the user switches back.
+            this._edoNoteCache[this._activeEDO] = this._selectedNotes.slice();
+            const oldEDO = this._activeEDO;
+
             this._translateNotesToEDO(newEDO);
             // Save the resulting state for this EDO so future round-trips
             // can restore it exactly.
             this._edoNoteCache[newEDO] = this._selectedNotes.slice();
             this._rebuildWheel(newEDO);
+
+            this.textMsg(
+                _(
+                    `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
+                ),
+                3000
+            );
 
             // Update mode name display without wiping the control bar.
             this._setModeName();
@@ -618,6 +629,16 @@ class ModeWidget {
         const pattern = nativeEDO ? mode : getModePattern(modeName, this._activeEDO);
         this._applyModePattern(pattern);
         this._setModeName();
+
+        // Show message if the mode pattern was scaled from a different EDO
+        if (nativeEDO && nativeEDO !== this._activeEDO) {
+            this.textMsg(
+                _(
+                    `Mode scaled from ${nativeEDO}-EDO to ${this._activeEDO}-EDO. Some notes may have changed.`
+                ),
+                3000
+            );
+        }
     }
 
     _applyModePattern(pattern) {
@@ -1103,46 +1124,6 @@ class ModeWidget {
         }, 2000);
     }
 
-    // ── Pie menu ──────────────────────────────────────────────────
-
-    _getModeLabelFont(edo) {
-        if (edo <= 5) {
-            return "100 26px sans-serif";
-        }
-        if (edo <= 7) {
-            return "100 22px sans-serif";
-        }
-        if (edo <= 12) {
-            return "100 16px sans-serif";
-        }
-        if (edo <= 19) {
-            return "100 12px sans-serif";
-        }
-        if (edo <= 24) {
-            return "100 10px sans-serif";
-        }
-        return "100 9px sans-serif";
-    }
-
-    _getNoteLabelFont(edo) {
-        if (edo <= 5) {
-            return "100 22px sans-serif";
-        }
-        if (edo <= 7) {
-            return "100 18px sans-serif";
-        }
-        if (edo <= 12) {
-            return "100 14px sans-serif";
-        }
-        if (edo <= 19) {
-            return "100 11px sans-serif";
-        }
-        if (edo <= 24) {
-            return "100 9px sans-serif";
-        }
-        return "100 8px sans-serif";
-    }
-
     _piemenuMode() {
         const n = this._activeEDO;
 
@@ -1169,7 +1150,9 @@ class ModeWidget {
         this._modeWheel.clickModeRotate = false;
         this._modeWheel.navAngle = -90;
         this._modeWheel.animatetime = 0;
-        this._modeWheel.titleFont = this._getModeLabelFont(n);
+
+        const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / n)));
+        this._modeWheel.titleFont = "400 " + titleFontSize + "px Times New Roman";
 
         const labels = [];
         for (let i = 0; i < n; i++) {
@@ -1181,13 +1164,12 @@ class ModeWidget {
         this._noteWheel.slicePathFunction = slicePath().DonutSlice;
         this._noteWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._noteWheel.slicePathCustom.minRadiusPercent = 0.75;
-        this._noteWheel.slicePathCustom.maxRadiusPercent = n > 12 ? 0.88 : 0.9;
+        this._noteWheel.slicePathCustom.maxRadiusPercent = 0.9;
         this._noteWheel.sliceSelectedPathCustom = this._noteWheel.slicePathCustom;
         this._noteWheel.sliceInitPathCustom = this._noteWheel.slicePathCustom;
         this._noteWheel.clickModeRotate = false;
         this._noteWheel.navAngle = -90;
         this._noteWheel.titleRotateAngle = 90;
-        this._noteWheel.titleFont = this._getNoteLabelFont(n);
 
         // Reconcile selectedNotes: preserve existing, ensure index 0 is always true
         const oldNotes = this._selectedNotes;
@@ -1202,7 +1184,7 @@ class ModeWidget {
         }
 
         // Slice 0: blank (no X toggle — root is always selected)
-        // Slices 1..n-1: "x" toggle
+        // Slices 1..n-1: "x" toggle (dynamic EDO layout)
         const noteList = [" "];
         for (let i = 1; i < n; i++) {
             noteList.push("x");
@@ -1213,7 +1195,7 @@ class ModeWidget {
         this._playWheel.slicePathFunction = slicePath().DonutSlice;
         this._playWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._playWheel.slicePathCustom.minRadiusPercent = 0.3;
-        this._playWheel.slicePathCustom.maxRadiusPercent = n > 12 ? 0.38 : 0.4;
+        this._playWheel.slicePathCustom.maxRadiusPercent = 0.4;
         this._playWheel.sliceSelectedPathCustom = this._playWheel.slicePathCustom;
         this._playWheel.sliceInitPathCustom = this._playWheel.slicePathCustom;
         this._playWheel.clickModeRotate = false;
@@ -1232,6 +1214,9 @@ class ModeWidget {
 
         const __setNote = () => {
             const i = this._modeWheel.selectedNavItemIndex;
+            if (i === 0) {
+                return;
+            }
             this._saveState();
             this._selectedNotes[i] = true;
             this._noteWheel.navItems[i].navItem.show();

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -13,7 +13,7 @@
 /* global
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
-   getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
+   getNote, DEFAULTVOICE, last, NOTESTABLE, wheelnav,
    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
    numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
    getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
@@ -1577,13 +1577,7 @@ class ModeWidget {
             // Navigate to currently-selected mode if present. This fires the
             // slice's navigateFunction (which would select+close), so suppress
             // it: this call is only meant to highlight the current mode.
-            let idx = 0;
-            for (let i = 0; i < modes.length; i++) {
-                if (modes[i] === this._selectedModeName) {
-                    idx = i;
-                    break;
-                }
-            }
+            const idx = modes.indexOf(this._selectedModeName);
             this._suppressModeSelect = true;
             this._modeNameWheel.navigateWheel(idx);
             this._suppressModeSelect = false;

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1297,7 +1297,7 @@ class ModeWidget {
         // 400px paper.
         const __sliceFontPx = (sliceCount, longestLabel, titleRadiusPercent) => {
             const arcPx = (2 * Math.PI * titleRadiusPercent * 200) / sliceCount;
-            return Math.min(20, Math.max(7, Math.floor((arcPx * 0.85) / (longestLabel * 0.6))));
+            return Math.min(24, Math.max(12, Math.floor((arcPx * 0.85) / (longestLabel * 0.6))));
         };
 
         // Outer ring: group wheel
@@ -1309,10 +1309,9 @@ class ModeWidget {
         this._modeGroupWheel.slicePathCustom.maxRadiusPercent = 0.3;
         this._modeGroupWheel.navAngle = -90;
         this._modeGroupWheel.animatetime = 0;
-        // Size labels to fit their slices on the 400px paper; the wheelnav
-        // default (48px) overflows every slice.
-        const longestGroupLabel = Math.max(...groupLabels.map(label => label.length), 1);
-        this._modeGroupWheel.titleFont = `100 ${__sliceFontPx(groupLabels.length, longestGroupLabel, 0.225)}px sans-serif`;
+        // Fixed readable size on the 400px paper; the wheelnav default (48px)
+        // overflows every slice and a computed size is too small.
+        this._modeGroupWheel.titleFont = "100 16px sans-serif";
         this._modeGroupWheel.createWheel(groupLabels);
 
         // Inner ring: mode-name wheel (rebuilt on group selection). Reopen on

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -15,7 +15,7 @@
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
-   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT
+   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames
  */
 
 /*
@@ -63,6 +63,7 @@ class ModeWidget {
     static ICONSIZE = 32;
     static ROTATESPEED = 125;
     static RESET_NOTES_DELAY = 500;
+    static WHEELSIZE = 400;
 
     /**
      * @param {object} activity
@@ -344,8 +345,10 @@ class ModeWidget {
             // Check cache first: if we have a pre-saved state for this EDO,
             // restore it exactly rather than applying a translation mapping.
             if (this._edoNoteCache[newEDO] !== undefined) {
-                this._selectedNotes = this._edoNoteCache[newEDO].slice();
-                this._activeEDO = newEDO;
+                // Cache outgoing state so round-trip preserves intermediate edits
+                this._cacheState(this._activeEDO);
+
+                this._restoreState(newEDO);
                 this._rebuildWheel(newEDO);
                 this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
                 this._setModeName();
@@ -354,13 +357,13 @@ class ModeWidget {
 
             // Cache the current EDO's state before translating so we can
             // restore it losslessly when the user switches back.
-            this._edoNoteCache[this._activeEDO] = this._selectedNotes.slice();
+            this._cacheState(this._activeEDO);
             const oldEDO = this._activeEDO;
 
             this._translateNotesToEDO(newEDO);
             // Save the resulting state for this EDO so future round-trips
             // can restore it exactly.
-            this._edoNoteCache[newEDO] = this._selectedNotes.slice();
+            this._cacheState(newEDO);
             this._rebuildWheel(newEDO);
 
             // Only warn when going to a lesser EDO, where notes can be dropped
@@ -415,8 +418,7 @@ class ModeWidget {
             return;
         }
 
-        const newSelected = new Array(newEDO).fill(false);
-        newSelected[0] = true;
+        const newSelected = this._blankNotes(newEDO);
 
         for (let i = 1; i < n; i++) {
             if (this._selectedNotes[i]) {
@@ -426,6 +428,49 @@ class ModeWidget {
         }
 
         this._selectedNotes = newSelected;
+    }
+
+    // ── Note-state helpers ────────────────────────────────────────
+
+    /**
+     * Returns a notes array of length n with only the root (index 0) selected.
+     * @param {number} n - The number of steps per octave.
+     * @returns {boolean[]}
+     */
+    _blankNotes(n) {
+        const notes = new Array(n).fill(false);
+        notes[0] = true;
+        return notes;
+    }
+
+    /**
+     * Returns a notes array of length newEDO, preserving old notes that fit.
+     * Index 0 (the root) is always selected.
+     * @param {boolean[]} oldNotes
+     * @param {number} newEDO
+     * @returns {boolean[]}
+     */
+    _reconcileNotes(oldNotes, newEDO) {
+        const notes = this._blankNotes(newEDO);
+        if (Array.isArray(oldNotes)) {
+            for (let i = 1; i < Math.min(oldNotes.length, newEDO); i++) {
+                if (oldNotes[i]) {
+                    notes[i] = true;
+                }
+            }
+        }
+        return notes;
+    }
+
+    // ── EDO cache helpers ─────────────────────────────────────────
+
+    _cacheState(edo) {
+        this._edoNoteCache[edo] = this._selectedNotes.slice();
+    }
+
+    _restoreState(edo) {
+        this._selectedNotes = this._edoNoteCache[edo].slice();
+        this._activeEDO = edo;
     }
 
     // ── Modes dropdown helpers ────────────────────────────────────
@@ -509,6 +554,7 @@ class ModeWidget {
         edoLabel.style.fontSize = "12px";
 
         const edoSelect = this._createEdoSelect();
+        this._edoSelect = edoSelect;
         this._initEdoSelect(edoSelect);
         this._wireEdoSelect(edoSelect);
         edoSelect.style.fontSize = "12px";
@@ -625,8 +671,8 @@ class ModeWidget {
             return;
         }
         svg.style.pointerEvents = "none";
-        svg.setAttribute("height", `${400 * scale}px`);
-        svg.setAttribute("width", `${400 * scale}px`);
+        svg.setAttribute("height", `${ModeWidget.WHEELSIZE * scale}px`);
+        svg.setAttribute("width", `${ModeWidget.WHEELSIZE * scale}px`);
         this._setTimeout(() => {
             svg.style.pointerEvents = "auto";
         }, 100);
@@ -655,20 +701,36 @@ class ModeWidget {
         if (nativeEDO && nativeEDO !== this._activeEDO) {
             // The saved mode was authored in a different tuning, so sync the
             // tuning dropdown and rebuild the wheel before selecting intervals.
-            edoSelect.value = nativeEDO;
+            // Cache the outgoing state exactly like the dropdown handler so
+            // round-trips restore it losslessly.
+            this._cacheState(this._activeEDO);
+            if (edoSelect) {
+                // The dropdown may lack an option for an unusual native EDO
+                // (e.g. 21 from 1/4 comma meantone); add it so .value sticks.
+                if (!edoSelect.querySelector(`option[value="${nativeEDO}"]`)) {
+                    const opt = document.createElement("option");
+                    opt.value = nativeEDO;
+                    opt.textContent = nativeEDO + "-EDO";
+                    edoSelect.appendChild(opt);
+                }
+                edoSelect.value = nativeEDO;
+            }
             this._rebuildWheel(nativeEDO);
         }
         // Built-in mode patterns are 12-EDO intervals; scale them to the
         // active EDO. Custom modes carry EDO-specific patterns already.
         const pattern = nativeEDO ? mode : getModePattern(modeName, this._activeEDO);
         this._applyModePattern(pattern);
+        // Cache the incoming state so switching away and back preserves it.
+        if (nativeEDO) {
+            this._cacheState(nativeEDO);
+        }
         this._setModeName();
     }
 
     _applyModePattern(pattern) {
         const n = this._activeEDO;
-        this._selectedNotes = new Array(n).fill(false);
-        this._selectedNotes[0] = true;
+        this._selectedNotes = this._blankNotes(n);
 
         let pos = 0;
         for (let k = 0; k < pattern.length && pos < n; k++) {
@@ -746,8 +808,7 @@ class ModeWidget {
      */
     _resetToCustom() {
         this._saveState();
-        this._selectedNotes = new Array(this._activeEDO).fill(false);
-        this._selectedNotes[0] = true;
+        this._selectedNotes = this._blankNotes(this._activeEDO);
         this._resetNotes();
         this._updateModeDisplay("");
     }
@@ -1066,6 +1127,20 @@ class ModeWidget {
             0,
             this.activity
         );
+        // numberToPitch can return [undefined, NaN] when the temperament's
+        // per-note data is incomplete (e.g. the built-in "custom" entry or a
+        // saved custom temperament without octave digits). Fall back to the
+        // deterministic name/octave used by numberToPitch's true-EDO branch.
+        if (typeof octave !== "number" || isNaN(octave) || !name) {
+            const edoNames = generateNoteNames(this._activeEDO);
+            let aIndex = edoNames.indexOf("A");
+            if (aIndex === -1) {
+                aIndex = Math.round((9 / 12) * this._activeEDO);
+            }
+            const nameIndex =
+                (((j + aIndex) % this._activeEDO) + this._activeEDO) % this._activeEDO;
+            return [edoNames[nameIndex], Math.floor((j + aIndex) / this._activeEDO) + 4];
+        }
         return [name, octave + 4];
     }
 
@@ -1162,72 +1237,103 @@ class ModeWidget {
             this._meterWheelDiv.style.display = "";
         }
 
-        this._modeWheel = new wheelnav("modeWidgetWheelDiv", null, 400, 400);
+        this._modeWheel = new wheelnav(
+            "modeWidgetWheelDiv",
+            null,
+            ModeWidget.WHEELSIZE,
+            ModeWidget.WHEELSIZE
+        );
         this._noteWheel = new wheelnav("_noteWheel", this._modeWheel.raphael);
         this._playWheel = new wheelnav("_playWheel", this._modeWheel.raphael);
 
         wheelnav.cssMeter = true;
 
-        this._modeWheel.colors = platformColor.modeWheelcolors;
-        this._modeWheel.slicePathFunction = slicePath().DonutSlice;
-        this._modeWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        this._modeWheel.slicePathCustom.minRadiusPercent = 0.4;
-        this._modeWheel.slicePathCustom.maxRadiusPercent = 0.75;
-        this._modeWheel.sliceSelectedPathCustom = this._modeWheel.slicePathCustom;
-        this._modeWheel.sliceInitPathCustom = this._modeWheel.slicePathCustom;
-        this._modeWheel.clickModeRotate = false;
-        this._modeWheel.navAngle = -90;
-        this._modeWheel.animatetime = 0;
+        this._createModeWheel(n);
+        this._createNoteWheel(n);
+        this._createPlayWheel(n);
+        this._wireWheelEvents(n);
+    }
 
+    /**
+     * Applies the shared donut-slice configuration to a wheel: colors, radii,
+     * -90° start angle and zero animation. Options are only applied when
+     * provided, preserving each wheel's existing behavior.
+     * @param {object} wheel - The wheelnav instance to configure.
+     * @param {object} opts
+     * @returns {void}
+     */
+    _configureWheel(wheel, opts) {
+        wheel.colors = opts.colors;
+        wheel.slicePathFunction = slicePath().DonutSlice;
+        wheel.slicePathCustom = slicePath().DonutSliceCustomization();
+        wheel.slicePathCustom.minRadiusPercent = opts.minRadius;
+        wheel.slicePathCustom.maxRadiusPercent = opts.maxRadius;
+        if (opts.clickModeRotate !== undefined) {
+            wheel.clickModeRotate = opts.clickModeRotate;
+        }
+        if (opts.selectionPaths) {
+            wheel.sliceSelectedPathCustom = wheel.slicePathCustom;
+            wheel.sliceInitPathCustom = wheel.slicePathCustom;
+        }
+        wheel.navAngle = -90;
+        wheel.animatetime = 0;
+        if (opts.titleRotateAngle !== undefined) {
+            wheel.titleRotateAngle = opts.titleRotateAngle;
+        }
+        if (opts.titleFont !== undefined) {
+            wheel.titleFont = opts.titleFont;
+        }
+    }
+
+    _createModeWheel(n) {
         const titleFontSize = Math.min(48, Math.max(10, Math.floor(580 / n)));
-        this._modeWheel.titleFont = "400 " + titleFontSize + "px Times New Roman";
-
+        this._configureWheel(this._modeWheel, {
+            colors: platformColor.modeWheelcolors,
+            minRadius: 0.4,
+            maxRadius: 0.75,
+            clickModeRotate: false,
+            selectionPaths: true,
+            titleFont: "400 " + titleFontSize + "px Times New Roman"
+        });
         this._modeWheel.createWheel(Array.from({ length: n }, (_, i) => String(i)));
+    }
 
-        this._noteWheel.colors = platformColor.noteValueWheelcolors;
-        this._noteWheel.slicePathFunction = slicePath().DonutSlice;
-        this._noteWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        this._noteWheel.slicePathCustom.minRadiusPercent = 0.75;
-        this._noteWheel.slicePathCustom.maxRadiusPercent = 0.9;
-        this._noteWheel.sliceSelectedPathCustom = this._noteWheel.slicePathCustom;
-        this._noteWheel.sliceInitPathCustom = this._noteWheel.slicePathCustom;
-        this._noteWheel.clickModeRotate = false;
-        this._noteWheel.navAngle = -90;
-        this._noteWheel.titleRotateAngle = 90;
+    _createNoteWheel(n) {
+        this._configureWheel(this._noteWheel, {
+            colors: platformColor.noteValueWheelcolors,
+            minRadius: 0.75,
+            maxRadius: 0.9,
+            clickModeRotate: false,
+            selectionPaths: true,
+            titleRotateAngle: 90
+        });
 
         // Reconcile selectedNotes: preserve existing, ensure index 0 is always true
-        const oldNotes = this._selectedNotes;
-        this._selectedNotes = new Array(n).fill(false);
-        this._selectedNotes[0] = true;
-        if (Array.isArray(oldNotes)) {
-            for (let i = 1; i < Math.min(oldNotes.length, n); i++) {
-                if (oldNotes[i]) {
-                    this._selectedNotes[i] = true;
-                }
-            }
-        }
+        this._selectedNotes = this._reconcileNotes(this._selectedNotes, n);
 
         // Slice 0: blank (no X toggle — root is always selected)
         // Slices 1..n-1: "x" toggle (dynamic EDO layout)
         this._noteWheel.createWheel([" ", ...new Array(n - 1).fill("x")]);
+    }
 
-        this._playWheel.colors = [platformColor.orange];
-        this._playWheel.slicePathFunction = slicePath().DonutSlice;
-        this._playWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        this._playWheel.slicePathCustom.minRadiusPercent = 0.3;
-        this._playWheel.slicePathCustom.maxRadiusPercent = 0.4;
-        this._playWheel.sliceSelectedPathCustom = this._playWheel.slicePathCustom;
-        this._playWheel.sliceInitPathCustom = this._playWheel.slicePathCustom;
-        this._playWheel.clickModeRotate = false;
-        this._playWheel.navAngle = -90;
-        this._playWheel.titleRotateAngle = 90;
+    _createPlayWheel(n) {
+        this._configureWheel(this._playWheel, {
+            colors: [platformColor.orange],
+            minRadius: 0.3,
+            maxRadius: 0.4,
+            clickModeRotate: false,
+            selectionPaths: true,
+            titleRotateAngle: 90
+        });
 
         this._playWheel.createWheel(new Array(n).fill(" "));
 
         for (let i = 0; i < n; i++) {
             this._playWheel.navItems[i].navItem.hide();
         }
+    }
 
+    _wireWheelEvents(n) {
         const __setNote = () => {
             const i = this._modeWheel.selectedNavItemIndex;
             if (i === 0) {
@@ -1285,7 +1391,12 @@ class ModeWidget {
         this._meterWheelDiv.style.display = "none";
         this._modePiemenuDiv.style.display = "";
 
-        this._modePieWheel = new wheelnav("modePiemenuDiv", null, 400, 400);
+        this._modePieWheel = new wheelnav(
+            "modePiemenuDiv",
+            null,
+            ModeWidget.WHEELSIZE,
+            ModeWidget.WHEELSIZE
+        );
         this._modeNameWheel = null; // Built on first group selection.
 
         // All groups appear, including "custom": it always offers "+" to
@@ -1296,22 +1407,21 @@ class ModeWidget {
         // the arc at the ring's mid-radius (titleRadiusPercent of 200px) on a
         // 400px paper.
         const __sliceFontPx = (sliceCount, longestLabel, titleRadiusPercent) => {
-            const arcPx = (2 * Math.PI * titleRadiusPercent * 200) / sliceCount;
+            const arcPx =
+                (2 * Math.PI * titleRadiusPercent * (ModeWidget.WHEELSIZE / 2)) / sliceCount;
             return Math.min(24, Math.max(12, Math.floor((arcPx * 0.85) / (longestLabel * 0.6))));
         };
 
         // Outer ring: group wheel
         this._modeGroupWheel = new wheelnav("_modeGroupWheel", this._modePieWheel.raphael);
-        this._modeGroupWheel.colors = platformColor.modeGroupWheelcolors;
-        this._modeGroupWheel.slicePathFunction = slicePath().DonutSlice;
-        this._modeGroupWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-        this._modeGroupWheel.slicePathCustom.minRadiusPercent = 0.15;
-        this._modeGroupWheel.slicePathCustom.maxRadiusPercent = 0.3;
-        this._modeGroupWheel.navAngle = -90;
-        this._modeGroupWheel.animatetime = 0;
         // Fixed readable size on the 400px paper; the wheelnav default (48px)
         // overflows every slice and a computed size is too small.
-        this._modeGroupWheel.titleFont = "100 16px sans-serif";
+        this._configureWheel(this._modeGroupWheel, {
+            colors: platformColor.modeGroupWheelcolors,
+            minRadius: 0.15,
+            maxRadius: 0.3,
+            titleFont: "100 16px sans-serif"
+        });
         this._modeGroupWheel.createWheel(groupLabels);
 
         // Inner ring: mode-name wheel (rebuilt on group selection). Reopen on
@@ -1343,15 +1453,13 @@ class ModeWidget {
             if (newWheel) {
                 this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
                 this._modeNameWheel.keynavigateEnabled = false;
-                this._modeNameWheel.slicePathFunction = slicePath().DonutSlice;
-                this._modeNameWheel.slicePathCustom = slicePath().DonutSliceCustomization();
-                this._modeNameWheel.slicePathCustom.minRadiusPercent = 0.3;
-                this._modeNameWheel.slicePathCustom.maxRadiusPercent = 0.85;
-                this._modeNameWheel.sliceSelectedPathCustom = this._modeNameWheel.slicePathCustom;
-                this._modeNameWheel.sliceInitPathCustom = this._modeNameWheel.slicePathCustom;
-                this._modeNameWheel.titleRotateAngle = 0;
-                this._modeNameWheel.navAngle = -90;
-                this._modeNameWheel.animatetime = 0;
+                this._configureWheel(this._modeNameWheel, {
+                    colors,
+                    minRadius: 0.3,
+                    maxRadius: 0.85,
+                    selectionPaths: true,
+                    titleRotateAngle: 0
+                });
             }
 
             // Build per-slice colors and (possibly translated) labels.
@@ -1380,7 +1488,6 @@ class ModeWidget {
             }
 
             if (newWheel) {
-                this._modeNameWheel.colors = colors;
                 this._modeNameWheel.createWheel(labels);
             } else {
                 // wheelnav keeps per-state title copies; update them all (as
@@ -1461,14 +1568,7 @@ class ModeWidget {
                         // rebuild triggered by _loadMode() → _rebuildWheel() → _piemenuMode()
                         this._closeModePiemenu();
 
-                        // Find the edoSelect in the DOM
-                        const edoSelect = docById("edoSelect");
-                        if (edoSelect) {
-                            this._loadMode(modeName, mode, edoSelect);
-                        } else {
-                            // Fallback: rebuild wheel with current EDO
-                            this._loadMode(modeName, mode, { value: this._activeEDO });
-                        }
+                        this._loadMode(modeName, mode, this._edoSelect);
                     }
                 };
             }

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -14,7 +14,7 @@
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
-   normalizeNoteAccidentals, getCurrentEDO, getModePattern,
+   normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
    numberToPitch, pitchToFrequency
  */
 
@@ -123,6 +123,14 @@ class ModeWidget {
             }
             this._locked = false;
             this.hideMsgs();
+            if (this.logo) {
+                // Release the singleton reference and the in-widget flag so a
+                // later run can open a fresh widget.
+                this.logo.insideModeWidget = false;
+                if (this.logo.modeWidget === this) {
+                    this.logo.modeWidget = null;
+                }
+            }
             this.widgetWindow.destroy();
         };
 
@@ -197,6 +205,19 @@ class ModeWidget {
         }, delay);
         this._timeouts.push(id);
         return id;
+    }
+
+    _cancelAnimations() {
+        // Clear stale rotate/invert/play callbacks before rebuilding for a
+        // new EDO; they reference old navItem indexes.
+        if (this._timeouts) {
+            this._timeouts.forEach(id => clearTimeout(id));
+            this._timeouts = [];
+        }
+        this._locked = false;
+        this._playing = false;
+        this._newPattern = null;
+        this._notesToPlay = null;
     }
 
     // ── Play state ────────────────────────────────────────────────
@@ -296,6 +317,7 @@ class ModeWidget {
                 this._selectedNotes = this._edoNoteCache[newEDO].slice();
                 this._activeEDO = newEDO;
                 this._rebuildWheel(newEDO);
+                this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
                 this._setModeName();
                 return;
             }
@@ -336,6 +358,7 @@ class ModeWidget {
      * @param {number} edoCount - The number of steps per octave.
      */
     _rebuildWheel(edoCount) {
+        this._cancelAnimations();
         this._activeEDO = edoCount;
         this._updateTemperament(edoCount);
         this._piemenuMode();
@@ -397,21 +420,37 @@ class ModeWidget {
     }
 
     _saveCustomModesList(modes) {
-        localStorage.setItem("customModes", JSON.stringify(modes));
+        try {
+            localStorage.setItem("customModes", JSON.stringify(modes));
+            return true;
+        } catch (e) {
+            this.errorMsg(
+                _("Could not save the custom mode. Local storage is full or unavailable.")
+            );
+            return false;
+        }
     }
 
     _saveCustomMode(name, pattern) {
         const modes = this._getCustomModes();
         const existing = modes.findIndex(m => m.name === name);
+        // Refuse to overwrite a built-in mode; only registered customs may be updated.
+        if (existing < 0 && name in MUSICALMODES) {
+            this.errorMsg(_("Cannot overwrite built-in mode: ") + name);
+            return false;
+        }
         const entry = { name, pattern, edo: this._activeEDO };
         if (existing >= 0) {
             modes[existing] = entry;
         } else {
             modes.push(entry);
         }
-        this._saveCustomModesList(modes);
+        if (!this._saveCustomModesList(modes)) {
+            return false;
+        }
 
         MUSICALMODES[name] = pattern;
+        return true;
     }
 
     _deleteCustomMode(name) {
@@ -437,9 +476,17 @@ class ModeWidget {
         customOpt.textContent = _("Custom");
         select.appendChild(customOpt);
 
+        const customs = this._getCustomModes();
+        const customNames = new Set(customs.map(m => m.name));
+
         const builtIn = document.createElement("optgroup");
         builtIn.label = _("Built-in Modes");
         for (const mode of Object.keys(MUSICALMODES)) {
+            // Custom modes are registered in MUSICALMODES too, so exclude them
+            // from the built-in group to avoid listing them twice.
+            if (customNames.has(mode)) {
+                continue;
+            }
             const opt = document.createElement("option");
             opt.value = mode;
             opt.textContent = _(mode);
@@ -447,7 +494,6 @@ class ModeWidget {
         }
         select.appendChild(builtIn);
 
-        const customs = this._getCustomModes();
         if (customs.length > 0) {
             const group = document.createElement("optgroup");
             group.label = _("Custom Modes");
@@ -536,7 +582,9 @@ class ModeWidget {
                 return;
             }
             const pattern = this._calculateMode();
-            this._saveCustomMode(name, pattern);
+            if (!this._saveCustomMode(name, pattern)) {
+                return;
+            }
             this._populateModesDropdown(modeSelect);
             modeSelect.value = name;
             // Export the mode to the workspace blocks so the user can use it.
@@ -561,6 +609,16 @@ class ModeWidget {
             this._deleteCustomMode(name);
             this._populateModesDropdown(modeSelect);
             modeSelect.value = Object.keys(MUSICALMODES)[0];
+            // Reset a modename block still referencing the deleted mode.
+            if (this._modeBlock !== null) {
+                const modeBlock = this.blocks.blockList[this._modeBlock];
+                if (modeBlock && modeBlock.name === "modename" && modeBlock.value === name) {
+                    modeBlock.value = DEFAULTMODE;
+                    modeBlock.text.text = _(DEFAULTMODE);
+                    modeBlock.updateCache();
+                    this.refreshCanvas();
+                }
+            }
             this.textMsg(_("Mode deleted: ") + name, 3000);
         };
 
@@ -983,14 +1041,22 @@ class ModeWidget {
                 : getModePattern(mode, this._activeEDO);
             if (JSON.stringify(pattern) === currentMode) {
                 if (this._modeBlock !== null) {
-                    for (const i in this.blocks.blockList) {
-                        if (this.blocks.blockList[i].name === "modename") {
-                            this.blocks.blockList[i].value = mode;
-                            this.blocks.blockList[i].text.text = _(mode);
-                            this.blocks.blockList[i].updateCache();
-                        } else if (this.blocks.blockList[i].name === "notename") {
-                            this.blocks.blockList[i].value = currentKey;
-                            this.blocks.blockList[i].text.text = _(currentKey);
+                    // Only update the modename block connected to the widget's
+                    // setkey2 block, plus its sibling notename block.
+                    const modeBlock = this.blocks.blockList[this._modeBlock];
+                    if (modeBlock && modeBlock.name === "modename") {
+                        modeBlock.value = mode;
+                        modeBlock.text.text = _(mode);
+                        modeBlock.updateCache();
+
+                        const parent = this.blocks.blockList[modeBlock.connections[0]];
+                        const notenameBlock =
+                            parent?.name === "setkey2" &&
+                            this.blocks.blockList[parent.connections[1]];
+                        if (notenameBlock?.name === "notename") {
+                            notenameBlock.value = currentKey;
+                            notenameBlock.text.text = _(currentKey);
+                            notenameBlock.updateCache();
                         }
                     }
                     this.refreshCanvas();

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -274,13 +274,6 @@ class ModeWidget {
         return options;
     }
 
-    _createEdoSelect() {
-        const select = document.createElement("select");
-        select.id = "edoSelect";
-        select.style.fontSize = "12px";
-        return select;
-    }
-
     _initEdoSelect(select) {
         const inEDO = this._activeEDO;
         const inTemperament = this.logo.synth.inTemperament;
@@ -514,46 +507,86 @@ class ModeWidget {
         bar.style.flexWrap = "wrap";
         bar.style.alignItems = "center";
         bar.style.justifyContent = "center";
-        bar.style.gap = "10px";
-        bar.style.padding = "8px 12px";
+        bar.style.gap = "8px";
+        bar.style.padding = "6px 16px";
 
         // Icon button with MB theme styling (wfbtItem class).
-        const iconButton = (icon, label, onclick) => {
+        const iconButton = (icon, label, onclick, imgFilter) => {
             const btn = document.createElement("div");
             btn.className = "wfbtItem";
             btn.title = label;
             btn.setAttribute("role", "button");
             btn.setAttribute("aria-label", label);
             btn.setAttribute("tabindex", "0");
+            btn.style.flexShrink = "0";
+            btn.style.display = "flex";
+            btn.style.alignItems = "center";
+            btn.style.justifyContent = "center";
+            btn.style.padding = "4px";
+            btn.style.borderRadius = "6px";
             const img = document.createElement("img");
             img.src = `header-icons/${icon}`;
             img.alt = label;
             img.height = 24;
             img.width = 24;
+            if (imgFilter) img.style.filter = imgFilter;
             btn.appendChild(img);
             btn.onclick = onclick;
             return btn;
         };
 
-        // EDO/Tuning dropdown
-        const edoSelect = this._createEdoSelect();
+        // EDO/Tuning — transparent select overlay on top of the icon.
+        // The select is full-size but invisible; it IS the click target.
+        const tuningIcon = iconButton("menu-button.svg", _("Tuning"), null);
+        // Transparent select overlay — IS the click target; the icon behind
+        // it is purely decorative.
+        const edoSelect = document.createElement("select");
+        edoSelect.id = "edoSelect";
         this._edoSelect = edoSelect;
         this._initEdoSelect(edoSelect);
         this._wireEdoSelect(edoSelect);
         edoSelect.title = _("Tuning");
         edoSelect.setAttribute("aria-label", _("Tuning"));
+        Object.assign(edoSelect.style, {
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            opacity: 0,
+            cursor: "pointer",
+            zIndex: 1,
+            border: "none",
+            background: "transparent",
+            appearance: "none",
+            WebkitAppearance: "none",
+            MozAppearance: "none",
+            outline: "none",
+            boxShadow: "none"
+        });
+
+        const tuningGroup = document.createElement("div");
+        tuningGroup.style.position = "relative";
+        tuningGroup.style.display = "inline-flex";
+        tuningGroup.style.alignItems = "center";
+        tuningGroup.style.flexShrink = "0";
+        tuningGroup.appendChild(tuningIcon);
+        tuningGroup.appendChild(edoSelect);
 
         // Modes: open piemenu instead of a <select> dropdown
-        const modeBtn = iconButton("menu-button.svg", _("Select Mode"), () => {
+        const modeBtn = iconButton("pie-chart.svg", _("Select Mode"), () => {
             this._piemenuModes();
         });
         modeBtn.id = "modeSelectBtn";
 
-        // Mode name input
+        // Mode name input (kept narrow so the row fits on one line)
         const nameInput = document.createElement("input");
         nameInput.id = "customModeName";
         nameInput.type = "text";
         nameInput.placeholder = _("Mode name");
+        nameInput.style.width = "100px";
+        nameInput.style.minWidth = "80px";
+        nameInput.style.flexShrink = "1";
 
         // Save button
         const saveBtn = iconButton("save-button.svg", _("Save Mode"), () => {
@@ -603,7 +636,7 @@ class ModeWidget {
             this.textMsg(_("Mode deleted: ") + name, 3000);
         });
 
-        bar.appendChild(edoSelect);
+        bar.appendChild(tuningGroup);
         bar.appendChild(modeBtn);
         bar.appendChild(nameInput);
         bar.appendChild(saveBtn);

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -517,48 +517,46 @@ class ModeWidget {
         bar.style.gap = "10px";
         bar.style.padding = "8px 12px";
 
-        // EDO/Tuning dropdown
-        const edoLabel = document.createElement("span");
-        edoLabel.textContent = _("Tuning") + ":";
-        edoLabel.style.fontSize = "12px";
+        // Icon button with MB theme styling (wfbtItem class).
+        const iconButton = (icon, label, onclick) => {
+            const btn = document.createElement("div");
+            btn.className = "wfbtItem";
+            btn.title = label;
+            btn.setAttribute("role", "button");
+            btn.setAttribute("aria-label", label);
+            btn.setAttribute("tabindex", "0");
+            const img = document.createElement("img");
+            img.src = `header-icons/${icon}`;
+            img.alt = label;
+            img.height = 24;
+            img.width = 24;
+            btn.appendChild(img);
+            btn.onclick = onclick;
+            return btn;
+        };
 
+        // EDO/Tuning dropdown
         const edoSelect = this._createEdoSelect();
         this._edoSelect = edoSelect;
         this._initEdoSelect(edoSelect);
         this._wireEdoSelect(edoSelect);
-        edoSelect.style.fontSize = "12px";
-        edoSelect.style.minHeight = "30px";
+        edoSelect.title = _("Tuning");
+        edoSelect.setAttribute("aria-label", _("Tuning"));
 
         // Modes: open piemenu instead of a <select> dropdown
-        const modeLabel = document.createElement("span");
-        modeLabel.textContent = _("Mode") + ":";
-        modeLabel.style.fontSize = "12px";
-
-        const modeBtn = document.createElement("button");
-        modeBtn.id = "modeSelectBtn";
-        modeBtn.textContent = _("Select Mode");
-        modeBtn.style.fontSize = "12px";
-        modeBtn.style.minHeight = "30px";
-        modeBtn.onclick = () => {
+        const modeBtn = iconButton("menu-button.svg", _("Select Mode"), () => {
             this._piemenuModes();
-        };
+        });
+        modeBtn.id = "modeSelectBtn";
 
         // Mode name input
         const nameInput = document.createElement("input");
         nameInput.id = "customModeName";
         nameInput.type = "text";
         nameInput.placeholder = _("Mode name");
-        nameInput.style.fontSize = "12px";
-        nameInput.style.width = "90px";
-        nameInput.style.minHeight = "30px";
 
         // Save button
-        const saveBtn = document.createElement("button");
-        saveBtn.textContent = _("Save");
-        saveBtn.style.fontSize = "12px";
-        saveBtn.style.minHeight = "30px";
-        saveBtn.style.padding = "0 12px";
-        saveBtn.onclick = () => {
+        const saveBtn = iconButton("save-button.svg", _("Save Mode"), () => {
             const name = nameInput.value.trim();
             if (!name) {
                 this.errorMsg(_("Please enter a mode name."));
@@ -573,15 +571,10 @@ class ModeWidget {
             this._setModeName();
             this._save();
             this.textMsg(_("Mode saved: ") + name, 3000);
-        };
+        });
 
         // Delete button
-        const deleteBtn = document.createElement("button");
-        deleteBtn.textContent = _("Delete");
-        deleteBtn.style.fontSize = "12px";
-        deleteBtn.style.minHeight = "30px";
-        deleteBtn.style.padding = "0 12px";
-        deleteBtn.onclick = () => {
+        const deleteBtn = iconButton("delete.svg", _("Delete Mode"), () => {
             const name = this._selectedModeName;
             if (!name) {
                 this.errorMsg(_("No mode selected."));
@@ -608,11 +601,9 @@ class ModeWidget {
             // longer matches the deleted mode, the label clears.
             this._setModeName();
             this.textMsg(_("Mode deleted: ") + name, 3000);
-        };
+        });
 
-        bar.appendChild(edoLabel);
         bar.appendChild(edoSelect);
-        bar.appendChild(modeLabel);
         bar.appendChild(modeBtn);
         bar.appendChild(nameInput);
         bar.appendChild(saveBtn);

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1,5 +1,4 @@
 // Copyright (c) 2016-21 Walter Bender
-// Copyright (c) 2026 Ashutosh Karnatak (Dependency Injection Refactoring)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the The GNU Affero General Public
@@ -14,80 +13,42 @@
 
    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
    getNote, DEFAULTVOICE, last, NOTESTABLE, slicePath, wheelnav,
-   normalizeNoteAccidentals,
+   normalizeNoteAccidentals, getModePattern, getCurrentEDO,
+   numberToPitch, pitchToFrequency
  */
-
-/*
-    Global locations
-    - lib/wheelnav
-        slicePath, wheelnav
-    - js/utils/utils.js
-        _, last, docById
-    - js/utils/platformstyle.js
-        platformColor
-    - js/utils/musicutils.js
-        keySignatureToMode, MUSICALMODES, getNote, DEFAULTVOICE, NOTESTABLE
-
-    Dependency Injection Pattern:
-    This widget uses dependency injection to reduce implicit global state.
-    Dependencies are passed via the constructor as part of the `activity` object.
-
-    Required Dependencies (accessed via this.activity):
-    - logo: Logo instance (provides synth, modeBlock, resetSynth)
-    - turtles: Turtles instance (provides ithTurtle for keySignature)
-    - blocks: Blocks instance (provides blockList, loadNewBlocks)
-    - hideMsgs: Function to hide messages
-    - textMsg: Function to display text messages
-    - errorMsg: Function to display error messages
-    - refreshCanvas: Function to refresh the canvas
-    - storage: Storage object for custom mode persistence
-*/
 
 /*exported ModeWidget*/
 
 /**
  * ModeWidget - A widget for creating and managing musical modes.
  *
- * This widget allows users to create custom musical modes by selecting
- * notes on a circular wheel interface. It supports playing, saving,
- * rotating, and inverting modes.
+ * Users select intervals on a circular wheel to define custom modes.
+ * Supports multiple EDOs/tunings, play, save, rotate, and invert.
  */
 class ModeWidget {
-    /** AMD module dependencies for lazy loading. */
     static dependencies = ["widgets/modewidget"];
 
     static ICONSIZE = 32;
-    static BUTTONSIZE = 53;
     static ROTATESPEED = 125;
-    static BUTTONDIVWIDTH = 535;
     static RESET_NOTES_DELAY = 500;
 
     /**
-     * Constructs a new ModeWidget instance.
-     * @param {object} activity - The activity instance providing dependencies
+     * @param {object} activity
      * @param {object} [deps] - Optional explicit dependencies (for testing)
      */
     constructor(activity, deps) {
-        // Store the activity reference for backward compatibility
         this.activity = activity;
-
-        // Optional explicit dependencies for testing/isolation
-        // If deps is provided, use it; otherwise fall back to activity
         this._deps = deps || {};
 
-        // Bind commonly-used dependencies locally for readability
-        // This reduces verbosity while maintaining explicit dependency injection
         this.logo = this._deps.logo || this.activity.logo;
         this.turtles = this._deps.turtles || this.activity.turtles;
         this.blocks = this._deps.blocks || this.activity.blocks;
-        this.storage = this._deps.storage || this.activity.storage;
         this.hideMsgs = this._deps.hideMsgs || this.activity.hideMsgs.bind(this.activity);
         this.textMsg = this._deps.textMsg || this.activity.textMsg.bind(this.activity);
         this.errorMsg = this._deps.errorMsg || this.activity.errorMsg.bind(this.activity);
         this.refreshCanvas =
             this._deps.refreshCanvas || this.activity.refreshCanvas.bind(this.activity);
 
-        // Initialize widget state
         this._modeBlock = this.logo.modeBlock;
         this._locked = false;
         this._pitch = this.turtles.ithTurtle(0).singer.keySignature[0];
@@ -96,9 +57,7 @@ class ModeWidget {
         this._playing = false;
         this._selectedNotes = [];
         this._newPattern = [];
-
-        const w = window.innerWidth;
-        this._cellScale = w / 1200;
+        this._activeEDO = getCurrentEDO(this.logo.synth.inTemperament);
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
         this.widgetWindow.clear();
@@ -106,20 +65,19 @@ class ModeWidget {
 
         this._timeouts = [];
 
-        // The mode table (holds a pie menu and a label)
+        // Layout: pie wheel + mode table (label row) + bottom control bar
         this.modeTableDiv = document.createElement("div");
         this.modeTableDiv.style.display = "inline";
         this.modeTableDiv.style.visibility = "visible";
         this.modeTableDiv.style.border = "0px";
+
         const meterWheelDiv = document.createElement("div");
         meterWheelDiv.id = "meterWheelDiv";
-        const modePianoDiv = document.createElement("div");
-        modePianoDiv.id = "modePianoDiv";
-        modePianoDiv.className = "";
+
         const modeTable = document.createElement("table");
         modeTable.id = "modeTable";
-        this.modeTableDiv.replaceChildren(meterWheelDiv, modePianoDiv, modeTable);
 
+        this.modeTableDiv.replaceChildren(meterWheelDiv, modeTable);
         this.widgetWindow.getWidgetBody().append(this.modeTableDiv);
 
         this.widgetWindow.onclose = () => {
@@ -147,19 +105,13 @@ class ModeWidget {
             this.logo.resetSynth(0);
             if (this._playingStatus()) {
                 this._playing = false;
-
                 this._setPlayButtonIcon("play-button.svg", _("Play all"));
             } else {
                 this._playing = true;
-
                 this._setPlayButtonIcon("stop-button.svg", _("Stop"));
-
                 this._playAll();
             }
         };
-
-        this.widgetWindow.addButton("export-chunk.svg", ModeWidget.ICONSIZE, _("Save")).onclick =
-            this._save.bind(this);
 
         this.widgetWindow.addButton("erase-button.svg", ModeWidget.ICONSIZE, _("Clear")).onclick =
             this._clear.bind(this);
@@ -185,28 +137,27 @@ class ModeWidget {
         this._piemenuMode();
 
         const table = docById("modeTable");
+        const labelRow = table.insertRow();
+        const labelCell = labelRow.insertCell();
+        labelCell.textContent = "\u00a0";
+        labelCell.style.fontSize = "14px";
+        labelCell.style.fontWeight = "bold";
+        labelCell.style.textAlign = "center";
+        labelCell.style.padding = "6px 0";
+        labelCell.style.verticalAlign = "middle";
+        this._modeLabelCell = labelCell;
 
-        // A row for the current mode label
-        const row = table.insertRow();
-        const cell = row.insertCell();
-        // cell.colSpan = 18;
-        cell.textContent = "\u00a0";
-        cell.style.backgroundColor = platformColor.selectorBackground;
-
-        // Set current mode in pie menu.
+        // Hydrate the wheel with the mode already in use (e.g., C major).
         this._setMode();
 
-        //.TRANS: A circle of notes represents the musical mode.
-        activity.textMsg(_("Click in the circle to select notes for the mode."), 3000);
+        this._buildControlBar();
+
+        this.textMsg(_("Click in the circle to select notes for the mode."), 3000);
         window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
     }
 
-    /**
-     * @private
-     * @param {Function} fn - function to execute
-     * @param {number} delay - delay in milliseconds
-     * @returns {number} timeout ID
-     */
+    // ── Timeout helper ────────────────────────────────────────────
+
     _setTimeout(fn, delay) {
         const id = setTimeout(() => {
             this._timeouts = this._timeouts.filter(t => t !== id);
@@ -216,20 +167,12 @@ class ModeWidget {
         return id;
     }
 
-    /**
-     * @private
-     * @returns {boolean}
-     */
+    // ── Play state ────────────────────────────────────────────────
+
     _playingStatus() {
         return this._playing;
     }
 
-    /**
-     * @private
-     * @param {string} iconName
-     * @param {string} titleText
-     * @returns {void}
-     */
     _setPlayButtonIcon(iconName, titleText) {
         const img = document.createElement("img");
         img.src = "header-icons/" + iconName;
@@ -245,10 +188,351 @@ class ModeWidget {
         );
     }
 
+    // ── EDO helpers ───────────────────────────────────────────────
+
+    _edoOptions() {
+        const inTemperament = this.logo.synth.inTemperament;
+        const builtInTemperaments = [
+            { edo: 5, key: "5 equal", label: "5-EDO" },
+            { edo: 7, key: "7 equal", label: "7-EDO" },
+            { edo: 12, key: "equal", label: "12-EDO (Equal)" },
+            { edo: 17, key: "17 equal", label: "17-EDO" },
+            { edo: 19, key: "19 equal", label: "19-EDO (Meantone)" },
+            { edo: 21, key: "21 equal", label: "21-EDO (MEAN)" },
+            { edo: 31, key: "31 equal", label: "31-EDO" }
+        ];
+        const builtInKeys = new Set(builtInTemperaments.map(t => t.key));
+
+        const options = builtInTemperaments.map(t => ({
+            value: t.edo,
+            label: t.label,
+            temperamentKey: t.key
+        }));
+
+        const temperament = window.temperament || {};
+        for (const key of Object.keys(temperament)) {
+            if (!builtInKeys.has(key) && temperament[key]) {
+                const t = temperament[key];
+                const edo = t.pitchNumber || t.EDO || t.edo;
+                if (typeof edo === "number" && edo >= 5 && edo <= 55) {
+                    options.push({ value: edo, label: key, temperamentKey: key });
+                }
+            }
+        }
+
+        if (!options.some(o => o.temperamentKey === inTemperament)) {
+            options.unshift({
+                value: this._activeEDO,
+                label: this._activeEDO + "-EDO",
+                temperamentKey: inTemperament
+            });
+        }
+
+        return options;
+    }
+
+    _createEdoSelect() {
+        const select = document.createElement("select");
+        select.id = "edoSelect";
+        select.style.fontSize = "12px";
+        return select;
+    }
+
+    _initEdoSelect(select) {
+        const inEDO = this._activeEDO;
+        const inTemperament = this.logo.synth.inTemperament;
+        const options = this._edoOptions();
+
+        let foundMatch = false;
+        for (const o of options) {
+            const opt = document.createElement("option");
+            opt.value = o.value;
+            opt.textContent = o.label;
+            if (o.value === inEDO || o.temperamentKey === inTemperament) {
+                opt.selected = true;
+                foundMatch = true;
+            }
+            select.appendChild(opt);
+        }
+
+        if (!foundMatch) {
+            const opt = document.createElement("option");
+            opt.value = inEDO;
+            opt.textContent = inEDO + "-EDO";
+            opt.selected = true;
+            select.prepend(opt);
+        }
+    }
+
+    _wireEdoSelect(select) {
+        select.addEventListener("change", () => {
+            const newEDO = parseInt(select.value, 10);
+            if (isNaN(newEDO) || newEDO < 5 || newEDO > 55 || newEDO === this._activeEDO) {
+                return;
+            }
+
+            this._translateNotesToEDO(newEDO);
+            this._rebuildWheel(newEDO);
+
+            // Update mode name display without wiping the control bar.
+            this._setModeName();
+        });
+    }
+
+    _updateTemperament(newEDO) {
+        if (!this.logo || !this.logo.synth) {
+            return;
+        }
+        this.logo.synth.inTemperament = this._temperamentKeyForEDO(newEDO);
+    }
+
     /**
-     * @private
-     * @returns {void}
+     * Tear down the existing SVG slices and rebuild the pie wheel for the
+     * given EDO count. Shared by the tuning dropdown and saved-mode loading.
+     * @param {number} edoCount - The number of steps per octave.
      */
+    _rebuildWheel(edoCount) {
+        this._activeEDO = edoCount;
+        this._updateTemperament(edoCount);
+        this._piemenuMode();
+    }
+
+    _clearPieMenu() {
+        const meterDiv = docById("meterWheelDiv");
+        if (meterDiv && typeof meterDiv.querySelectorAll === "function") {
+            // Explicitly remove any leftover SVG slices from the DOM.
+            const svgs = meterDiv.querySelectorAll("svg");
+            for (let i = svgs.length - 1; i >= 0; i--) {
+                if (typeof meterDiv.removeChild === "function") {
+                    meterDiv.removeChild(svgs[i]);
+                }
+            }
+        }
+
+        if (this._modeWheel) {
+            this._modeWheel.removeWheel();
+        }
+        if (this._noteWheel) {
+            this._noteWheel.removeWheel();
+        }
+        if (this._playWheel) {
+            this._playWheel.removeWheel();
+        }
+        this._modeWheel = null;
+        this._noteWheel = null;
+        this._playWheel = null;
+    }
+
+    _translateNotesToEDO(newEDO) {
+        const n = this._activeEDO;
+        if (newEDO === n) {
+            return;
+        }
+
+        const newSelected = new Array(newEDO).fill(false);
+        newSelected[0] = true;
+
+        for (let i = 1; i < n; i++) {
+            if (this._selectedNotes[i]) {
+                const scaledIdx = Math.round((i / n) * newEDO) % newEDO;
+                newSelected[scaledIdx] = true;
+            }
+        }
+
+        this._selectedNotes = newSelected;
+    }
+
+    // ── Modes dropdown helpers ────────────────────────────────────
+
+    _getCustomModes() {
+        try {
+            return JSON.parse(localStorage.getItem("customModes") || "[]");
+        } catch (e) {
+            return [];
+        }
+    }
+
+    _saveCustomModesList(modes) {
+        localStorage.setItem("customModes", JSON.stringify(modes));
+    }
+
+    _saveCustomMode(name, pattern) {
+        const modes = this._getCustomModes();
+        const existing = modes.findIndex(m => m.name === name);
+        const entry = { name, pattern, edo: this._activeEDO };
+        if (existing >= 0) {
+            modes[existing] = entry;
+        } else {
+            modes.push(entry);
+        }
+        this._saveCustomModesList(modes);
+
+        MUSICALMODES[name] = pattern;
+    }
+
+    _deleteCustomMode(name) {
+        const modes = this._getCustomModes();
+        const filtered = modes.filter(m => m.name !== name);
+        this._saveCustomModesList(filtered);
+
+        delete MUSICALMODES[name];
+    }
+
+    _getModeEDO(modeName) {
+        // Saved custom modes carry their native EDO in the registry.
+        const custom = this._getCustomModes().find(m => m.name === modeName);
+        return custom && custom.edo ? custom.edo : null;
+    }
+
+    _populateModesDropdown(select) {
+        select.innerHTML = "";
+
+        // "Custom" option always at the top
+        const customOpt = document.createElement("option");
+        customOpt.value = "custom";
+        customOpt.textContent = _("Custom");
+        select.appendChild(customOpt);
+
+        const builtIn = document.createElement("optgroup");
+        builtIn.label = _("Built-in Modes");
+        for (const mode of Object.keys(MUSICALMODES)) {
+            const opt = document.createElement("option");
+            opt.value = mode;
+            opt.textContent = _(mode);
+            builtIn.appendChild(opt);
+        }
+        select.appendChild(builtIn);
+
+        const customs = this._getCustomModes();
+        if (customs.length > 0) {
+            const group = document.createElement("optgroup");
+            group.label = _("Custom Modes");
+            for (const m of customs) {
+                const opt = document.createElement("option");
+                opt.value = m.name;
+                opt.textContent = m.name;
+                group.appendChild(opt);
+            }
+            select.appendChild(group);
+        }
+    }
+
+    // ── Bottom control bar ────────────────────────────────────────
+
+    _buildControlBar() {
+        const table = docById("modeTable");
+        const barRow = table.insertRow();
+        const barCell = barRow.insertCell();
+        barCell.colSpan = 18;
+
+        const bar = document.createElement("div");
+        bar.style.display = "flex";
+        bar.style.flexWrap = "wrap";
+        bar.style.alignItems = "center";
+        bar.style.justifyContent = "center";
+        bar.style.gap = "10px";
+        bar.style.padding = "8px 12px";
+
+        // EDO/Tuning dropdown
+        const edoLabel = document.createElement("span");
+        edoLabel.textContent = _("Tuning") + ":";
+        edoLabel.style.fontSize = "12px";
+
+        const edoSelect = this._createEdoSelect();
+        this._initEdoSelect(edoSelect);
+        this._wireEdoSelect(edoSelect);
+        edoSelect.style.fontSize = "12px";
+        edoSelect.style.minHeight = "30px";
+
+        // Modes dropdown
+        const modeLabel = document.createElement("span");
+        modeLabel.textContent = _("Mode") + ":";
+        modeLabel.style.fontSize = "12px";
+
+        const modeSelect = document.createElement("select");
+        modeSelect.id = "modeSelect";
+        modeSelect.style.fontSize = "12px";
+        modeSelect.style.minHeight = "30px";
+        this._populateModesDropdown(modeSelect);
+
+        modeSelect.addEventListener("change", () => {
+            const modeName = modeSelect.value;
+            if (modeName === "custom") {
+                this._resetToCustom();
+                return;
+            }
+
+            const mode = MUSICALMODES[modeName];
+            if (!mode) {
+                return;
+            }
+
+            this._loadMode(modeName, mode, edoSelect);
+        });
+
+        // Mode name input
+        const nameInput = document.createElement("input");
+        nameInput.id = "customModeName";
+        nameInput.type = "text";
+        nameInput.placeholder = _("Mode name");
+        nameInput.style.fontSize = "12px";
+        nameInput.style.width = "90px";
+        nameInput.style.minHeight = "30px";
+
+        // Save button
+        const saveBtn = document.createElement("button");
+        saveBtn.textContent = _("Save");
+        saveBtn.style.fontSize = "12px";
+        saveBtn.style.minHeight = "30px";
+        saveBtn.style.padding = "0 12px";
+        saveBtn.onclick = () => {
+            const name = nameInput.value.trim();
+            if (!name) {
+                this.errorMsg(_("Please enter a mode name."));
+                return;
+            }
+            const pattern = this._calculateMode();
+            this._saveCustomMode(name, pattern);
+            this._populateModesDropdown(modeSelect);
+            modeSelect.value = name;
+            // Export the mode to the workspace blocks so the user can use it.
+            this._setModeName();
+            this._save();
+            this.textMsg(_("Mode saved: ") + name, 3000);
+        };
+
+        // Delete button
+        const deleteBtn = document.createElement("button");
+        deleteBtn.textContent = _("Delete");
+        deleteBtn.style.fontSize = "12px";
+        deleteBtn.style.minHeight = "30px";
+        deleteBtn.style.padding = "0 12px";
+        deleteBtn.onclick = () => {
+            const name = modeSelect.value;
+            const customs = this._getCustomModes();
+            if (!customs.some(m => m.name === name)) {
+                this.errorMsg(_("Cannot delete a built-in mode."));
+                return;
+            }
+            this._deleteCustomMode(name);
+            this._populateModesDropdown(modeSelect);
+            modeSelect.value = Object.keys(MUSICALMODES)[0];
+            this.textMsg(_("Mode deleted: ") + name, 3000);
+        };
+
+        bar.appendChild(edoLabel);
+        bar.appendChild(edoSelect);
+        bar.appendChild(modeLabel);
+        bar.appendChild(modeSelect);
+        bar.appendChild(nameInput);
+        bar.appendChild(saveBtn);
+        bar.appendChild(deleteBtn);
+
+        barCell.appendChild(bar);
+    }
+
+    // ── Scaling ───────────────────────────────────────────────────
+
     _scale() {
         const windowHeight =
             this.getWidgetFrame().offsetHeight - this.getDragElement().offsetHeight;
@@ -270,178 +554,103 @@ class ModeWidget {
         }, 100);
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Mode display ──────────────────────────────────────────────
+
     _setMode() {
-        // Read in the current mode to start
+        // Read in the current mode to start.
         const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
         const currentMode = MUSICALMODES[currentModeName[1]];
+        if (!currentMode) {
+            return;
+        }
 
-        // Add the mode name in the bottom row of the table.
-        const table = docById("modeTable");
-        const n = table.rows.length - 1;
+        this._applyModePattern(currentMode);
+        this._setModeName();
+    }
 
-        // console.debug(_(currentModeName[1]));
-        const name = currentModeName[0] + " " + _(currentModeName[1]);
-        table.rows[n].cells[0].textContent = name;
-        this.widgetWindow.updateTitle(name);
+    _loadMode(modeName, mode, edoSelect) {
+        const nativeEDO = this._getModeEDO(modeName);
+        if (nativeEDO && nativeEDO !== this._activeEDO) {
+            // The saved mode was authored in a different tuning, so sync the
+            // tuning dropdown and rebuild the wheel before selecting intervals.
+            edoSelect.value = nativeEDO;
+            this._rebuildWheel(nativeEDO);
+        }
+        this._applyModePattern(mode);
+        this._setModeName();
+    }
 
-        // Set the notes for this mode.
-        let k = 0;
-        let j = 0;
-        for (let i = 0; i < 12; i++) {
-            if (i === j) {
+    _applyModePattern(pattern) {
+        const n = this._activeEDO;
+        this._selectedNotes = new Array(n).fill(false);
+        this._selectedNotes[0] = true;
+
+        let pos = 0;
+        for (let k = 0; k < pattern.length && pos < n; k++) {
+            this._selectedNotes[pos] = true;
+            pos += pattern[k];
+        }
+
+        for (let i = 0; i < n; i++) {
+            if (this._selectedNotes[i]) {
                 this._noteWheel.navItems[i].navItem.show();
-                this._selectedNotes[i] = true;
-                j += currentMode[k];
-                k += 1;
+            } else {
+                this._noteWheel.navItems[i].navItem.hide();
+            }
+        }
+    }
+
+    _resetToCustom() {
+        const n = this._activeEDO;
+        this._saveState();
+        this._selectedNotes = new Array(n).fill(false);
+        this._selectedNotes[0] = true;
+
+        for (let i = 0; i < n; i++) {
+            if (i === 0) {
+                this._noteWheel.navItems[i].navItem.show();
             } else {
                 this._noteWheel.navItems[i].navItem.hide();
             }
         }
 
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
+        // Clear the mode name display
+        this._updateModeDisplay("");
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
-    _showPiano() {
-        const modePianoDiv = docById("modePianoDiv");
-        modePianoDiv.style.visibility = "visible";
-        modePianoDiv.style.position = "relative";
-        modePianoDiv.style.border = "0px";
-        modePianoDiv.style.top = "0px";
-        modePianoDiv.style.left = "0px";
-        const elements = [];
+    // ── Invert ────────────────────────────────────────────────────
 
-        const baseImg = document.createElement("img");
-        baseImg.src = "images/piano_keys.png";
-        baseImg.id = "modeKeyboard";
-        baseImg.style.top = "0px";
-        baseImg.style.left = "0px";
-        baseImg.style.position = "relative";
-        elements.push(baseImg);
-
-        this._pianoKeys = [];
-        for (let i = 0; i < 12; i++) {
-            const keyImg = document.createElement("img");
-            keyImg.id = "pkey_" + i;
-            keyImg.style.top = "0px";
-            keyImg.style.left = "0px";
-            keyImg.style.position = "absolute";
-            elements.push(keyImg);
-            this._pianoKeys[i] = keyImg;
-        }
-
-        modePianoDiv.replaceChildren(...elements);
-
-        const highlightImgs = [
-            "images/highlights/sel_c.png",
-            "images/highlights/sel_c_sharp.png",
-            "images/highlights/sel_d.png",
-            "images/highlights/sel_d_sharp.png",
-            "images/highlights/sel_e.png",
-            "images/highlights/sel_f.png",
-            "images/highlights/sel_f_sharp.png",
-            "images/highlights/sel_g.png",
-            "images/highlights/sel_g_sharp.png",
-            "images/highlights/sel_a.png",
-            "images/highlights/sel_a_sharp.png",
-            "images/highlights/sel_b.png"
-        ];
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        const letterName = currentModeName[0];
-
-        const startDict = {
-            "C♭": 11,
-            "C": 0,
-            "C♯": 1,
-            "D♭": 1,
-            "D": 2,
-            "D♯": 3,
-            "E♭": 3,
-            "E": 4,
-            "E♯": 5,
-            "F♭": 4,
-            "F": 5,
-            "F♯": 6,
-            "G♭": 6,
-            "G": 7,
-            "G♯": 8,
-            "A♭": 8,
-            "A": 9,
-            "A♯": 10,
-            "B♭": 10,
-            "B": 11,
-            "B♯": 0
-        };
-        let startingPosition;
-        if (letterName in startDict) {
-            startingPosition = startDict[letterName];
-        } else {
-            startingPosition = 0;
-        }
-
-        for (let i = 0; i < 12; ++i) {
-            if (this._selectedNotes[i])
-                this._pianoKeys[i].src = highlightImgs[(i + startingPosition) % 12];
-        }
-    }
-    /**
-     * @private
-     * @returns {void}
-     */
     _invert() {
         if (this._locked) {
             return;
         }
 
         this._locked = true;
-
         this._saveState();
         this.__invertOnePair(1);
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
     }
 
-    /**
-     * @private
-     * @param {number} i
-     * @returns {void}
-     */
     __invertOnePair(i) {
+        const n = this._activeEDO;
         const tmp = this._selectedNotes[i];
-        this._selectedNotes[i] = this._selectedNotes[12 - i];
+        this._selectedNotes[i] = this._selectedNotes[n - i];
+        this._selectedNotes[n - i] = tmp;
+
         if (this._selectedNotes[i]) {
             this._noteWheel.navItems[i].navItem.show();
         } else {
             this._noteWheel.navItems[i].navItem.hide();
         }
 
-        this._selectedNotes[12 - i] = tmp;
-        if (this._selectedNotes[12 - i]) {
-            this._noteWheel.navItems[12 - i].navItem.show();
+        if (this._selectedNotes[n - i]) {
+            this._noteWheel.navItems[n - i].navItem.show();
         } else {
-            this._noteWheel.navItems[12 - i].navItem.hide();
+            this._noteWheel.navItems[n - i].navItem.hide();
         }
 
-        if (i === 5) {
+        if (i === Math.floor(n / 2) - 1) {
             this._saveState();
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
             this._locked = false;
         } else {
             this._setTimeout(() => {
@@ -450,10 +659,8 @@ class ModeWidget {
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Reset ─────────────────────────────────────────────────────
+
     _resetNotes() {
         for (let i = 0; i < this._selectedNotes.length; i++) {
             if (this._selectedNotes[i]) {
@@ -465,29 +672,23 @@ class ModeWidget {
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Rotate ────────────────────────────────────────────────────
+
     _rotateRight() {
         if (this._locked) {
             return;
         }
         this._locked = true;
         this._saveState();
+        const n = this._activeEDO;
         this._newPattern = [];
-        this._newPattern.push(this._selectedNotes[11]);
-        for (let i = 0; i < 11; i++) {
+        this._newPattern.push(this._selectedNotes[n - 1]);
+        for (let i = 0; i < n - 1; i++) {
             this._newPattern.push(this._selectedNotes[i]);
         }
         this.__rotateRightOneCell(1);
     }
 
-    /**
-     * @private
-     * @param {number} i
-     * @returns {void}
-     */
     __rotateRightOneCell(i) {
         this._selectedNotes[i] = this._newPattern[i];
         if (this._selectedNotes[i]) {
@@ -499,56 +700,37 @@ class ModeWidget {
         if (i === 0) {
             this._setTimeout(() => {
                 if (this._selectedNotes[0]) {
-                    // We are done.
                     this._saveState();
                     this._setModeName();
-                    const currentModeName = keySignatureToMode(
-                        this.turtles.ithTurtle(0).singer.keySignature
-                    );
-                    if (currentModeName[0] === "C") {
-                        this._showPiano();
-                    }
                     this._locked = false;
                 } else {
-                    // Keep going until first note is selected.
                     this._locked = false;
                     this._rotateRight();
                 }
             }, ModeWidget.ROTATESPEED);
         } else {
             this._setTimeout(() => {
-                this.__rotateRightOneCell((i + 1) % 12);
+                this.__rotateRightOneCell((i + 1) % this._activeEDO);
             }, ModeWidget.ROTATESPEED);
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
     _rotateLeft() {
         if (this._locked) {
             return;
         }
 
         this._locked = true;
-
         this._saveState();
+        const n = this._activeEDO;
         this._newPattern = [];
-        for (let i = 1; i < 12; i++) {
+        for (let i = 1; i < n; i++) {
             this._newPattern.push(this._selectedNotes[i]);
         }
-
         this._newPattern.push(this._selectedNotes[0]);
-
-        this.__rotateLeftOneCell(11);
+        this.__rotateLeftOneCell(n - 1);
     }
 
-    /**
-     * @private
-     * @param {number} i
-     * @returns {void}
-     */
     __rotateLeftOneCell(i) {
         this._selectedNotes[i] = this._newPattern[i];
         if (this._selectedNotes[i]) {
@@ -560,18 +742,10 @@ class ModeWidget {
         if (i === 0) {
             this._setTimeout(() => {
                 if (this._selectedNotes[0]) {
-                    // We are done.
                     this._saveState();
                     this._setModeName();
-                    const currentModeName = keySignatureToMode(
-                        this.turtles.ithTurtle(0).singer.keySignature
-                    );
-                    if (currentModeName[0] === "C") {
-                        this._showPiano();
-                    }
                     this._locked = false;
                 } else {
-                    // Keep going until first note is selected.
                     this._locked = false;
                     this._rotateLeft();
                 }
@@ -583,12 +757,9 @@ class ModeWidget {
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Play ──────────────────────────────────────────────────────
+
     _playAll() {
-        // Play all of the notes in the widget.
         if (this._locked) {
             return;
         }
@@ -596,182 +767,83 @@ class ModeWidget {
         this.logo.synth.stop();
         this._locked = true;
 
-        // Make a list of notes to play
+        const n = this._activeEDO;
         this._notesToPlay = [];
-        // Play the mode ascending.
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < n; i++) {
             if (this._selectedNotes[i]) {
                 this._notesToPlay.push(i);
             }
         }
 
-        // Include the octave above the starting note.
-        this._notesToPlay.push(12);
+        this._notesToPlay.push(n);
 
-        // And then play the mode descending.
-        this._notesToPlay.push(12);
-        for (let i = 11; i > -1; i--) {
+        this._notesToPlay.push(n);
+        for (let i = n - 1; i > -1; i--) {
             if (this._selectedNotes[i]) {
                 this._notesToPlay.push(i);
             }
         }
-        // console.debug(this._notesToPlay);
+
         this._lastNotePlayed = null;
         if (this._playing) {
             this.__playNextNote(0);
         }
     }
 
-    /**
-     * @private
-     * @param {number} i - note to play
-     * @returns {void}
-     */
     __playNextNote(i) {
-        const highlightImgs = [
-            "images/highlights/sel_c.png",
-            "images/highlights/sel_c_sharp.png",
-            "images/highlights/sel_d.png",
-            "images/highlights/sel_d_sharp.png",
-            "images/highlights/sel_e.png",
-            "images/highlights/sel_f.png",
-            "images/highlights/sel_f_sharp.png",
-            "images/highlights/sel_g.png",
-            "images/highlights/sel_g_sharp.png",
-            "images/highlights/sel_a.png",
-            "images/highlights/sel_a_sharp.png",
-            "images/highlights/sel_b.png"
-        ];
-
-        const animationImgs = [
-            "images/animations/sel_c1.png",
-            "images/animations/sel_c_sharp1.png",
-            "images/animations/sel_d1.png",
-            "images/animations/sel_d_sharp1.png",
-            "images/animations/sel_e1.png",
-            "images/animations/sel_f1.png",
-            "images/animations/sel_f_sharp1.png",
-            "images/animations/sel_g1.png",
-            "images/animations/sel_g_sharp1.png",
-            "images/animations/sel_a1.png",
-            "images/animations/sel_a_sharp1.png",
-            "images/animations/sel_b1.png"
-        ];
-
-        const startingposition = 0;
+        const n = this._activeEDO;
         const time = this._noteValue + 0.125;
 
-        const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
-        if (currentKey === "C") {
-            if (i > this._notesToPlay.length - 1) {
-                this._setTimeout(() => {
-                    // Did we just play the last note?
-                    this._playing = false;
-                    const note_key = this._pianoKeys ? this._pianoKeys[0] : null;
-                    if (note_key !== null) {
-                        note_key.src = highlightImgs[0];
-                    }
-                    this._setPlayButtonIcon("play-button.svg", _("Play all"));
-                    this._resetNotes();
-                    this._locked = false;
-                }, 1000 * time);
+        if (i > this._notesToPlay.length - 1) {
+            this._setTimeout(() => {
+                this._playing = false;
+                this._setPlayButtonIcon("play-button.svg", _("Play all"));
+                this._resetNotes();
+                this._locked = false;
+            }, 1000 * time);
+            return;
+        }
 
-                return;
+        this._setTimeout(() => {
+            if (this._lastNotePlayed !== null) {
+                this._playWheel.navItems[this._lastNotePlayed % n].navItem.hide();
             }
 
-            this._setTimeout(() => {
-                if (this._lastNotePlayed !== null) {
-                    this._playWheel.navItems[this._lastNotePlayed % 12].navItem.hide();
-                    const note_key = this._pianoKeys
-                        ? this._pianoKeys[this._lastNotePlayed % 12]
-                        : null;
-                    if (note_key !== null) {
-                        note_key.src =
-                            highlightImgs[(this._lastNotePlayed + startingposition) % 12];
-                    }
-                }
+            const note = this._notesToPlay[i];
+            this._playWheel.navItems[note % n].navItem.show();
+            this._lastNotePlayed = note;
 
-                const note = this._notesToPlay[i];
-                this._playWheel.navItems[note % 12].navItem.show();
+            this._triggerNote(note, n);
+            if (this._playing) {
+                this.__playNextNote(i + 1);
+            } else {
+                this._locked = false;
+                this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
+            }
+        }, 1000 * time);
+    }
 
-                if (note !== 12) {
-                    const note_key = this._pianoKeys ? this._pianoKeys[note % 12] : null;
-                    if (note_key !== null) {
-                        note_key.src = animationImgs[(note + startingposition) % 12];
-                    }
-                }
-
-                this._lastNotePlayed = note;
-                const ks = this.turtles.ithTurtle(0).singer.keySignature;
-                const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
-                this.logo.synth.trigger(
-                    0,
-                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-                    this._noteValue,
-                    DEFAULTVOICE,
-                    null,
-                    null
-                );
-
-                if (this._playing) {
-                    this.__playNextNote(i + 1);
-                } else {
-                    this._locked = false;
-                    this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
-                    return;
-                }
-            }, 1000 * time);
+    _triggerNote(note, edo) {
+        const ks = this.turtles.ithTurtle(0).singer.keySignature;
+        if (edo === 12) {
+            const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
+            this.logo.synth.trigger(
+                0,
+                normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
+                this._noteValue,
+                DEFAULTVOICE,
+                null,
+                null
+            );
         } else {
-            if (i > this._notesToPlay.length - 1) {
-                this._setTimeout(() => {
-                    // Did we just play the last note?
-                    this._playing = false;
-                    this._setPlayButtonIcon("play-button.svg", _("Play all"));
-                    this._resetNotes();
-                    this._locked = false;
-                }, 1000 * time);
-
-                return;
-            }
-
-            this._setTimeout(() => {
-                if (this._lastNotePlayed !== null) {
-                    this._playWheel.navItems[this._lastNotePlayed % 12].navItem.hide();
-                }
-
-                const note = this._notesToPlay[i];
-                this._playWheel.navItems[note % 12].navItem.show();
-                this._lastNotePlayed = note;
-
-                const ks = this.turtles.ithTurtle(0).singer.keySignature;
-                const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
-                this.logo.synth.trigger(
-                    0,
-                    normalizeNoteAccidentals(noteToPlay[0]) + noteToPlay[1],
-                    this._noteValue,
-                    DEFAULTVOICE,
-                    null,
-                    null
-                );
-                if (this._playing) {
-                    this.__playNextNote(i + 1);
-                } else {
-                    this._locked = false;
-                    this._setTimeout(() => this._resetNotes(), ModeWidget.RESET_NOTES_DELAY);
-                    return;
-                }
-            }, 1000 * time);
+            const ratio = getModePattern(this._pitch + ":" + this.logo.synth.inTemperament, edo);
+            const freq = pitchToFrequency(this._pitch, 4, note, ks, ratio);
+            this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
         }
     }
 
-    /**
-     * @private
-     * @param {number} i - note to play
-     * @returns {void}
-     */
     _playNote(i) {
         const ks = this.turtles.ithTurtle(0).singer.keySignature;
-
         const noteToPlay = getNote(this._pitch, 4, i, ks, false, null, this.errorMsg);
         this.logo.synth.trigger(
             0,
@@ -783,10 +855,8 @@ class ModeWidget {
         );
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Undo / Clear ──────────────────────────────────────────────
+
     _saveState() {
         const state = JSON.stringify(this._selectedNotes);
         if (state !== last(this._undoStack)) {
@@ -794,57 +864,34 @@ class ModeWidget {
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
     _undo() {
         if (this._undoStack.length > 0) {
             const prevState = JSON.parse(this._undoStack.pop());
-            for (let i = 0; i < 12; i++) {
+            for (let i = 0; i < this._activeEDO; i++) {
                 this._selectedNotes[i] = prevState[i];
             }
-
+            this._selectedNotes[0] = true;
             this._resetNotes();
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         }
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
     _clear() {
-        // "Unclick" every entry in the widget.
-
         this._saveState();
-
-        for (let i = 1; i < 12; i++) {
+        for (let i = 1; i < this._activeEDO; i++) {
             this._selectedNotes[i] = false;
         }
-
         this._resetNotes();
         this._setModeName();
-        const currentModeName = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature);
-        if (currentModeName[0] === "C") {
-            this._showPiano();
-        }
     }
 
-    /**
-     * @private
-     * @returns {Array<number>}
-     */
+    // ── Mode calculation ──────────────────────────────────────────
+
     _calculateMode() {
+        const n = this._activeEDO;
         const currentMode = [];
         let j = 1;
-        for (let i = 1; i < 12; i++) {
+        for (let i = 1; i < n; i++) {
             if (this._selectedNotes[i]) {
                 currentMode.push(j);
                 j = 1;
@@ -852,25 +899,16 @@ class ModeWidget {
                 j += 1;
             }
         }
-
         currentMode.push(j);
         return currentMode;
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
     _setModeName() {
-        const table = docById("modeTable");
-        const n = table.rows.length - 1;
         const currentMode = JSON.stringify(this._calculateMode());
         const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
 
         for (const mode in MUSICALMODES) {
             if (JSON.stringify(MUSICALMODES[mode]) === currentMode) {
-                // Update the value of the modename block inside of
-                // the mode widget block.
                 if (this._modeBlock !== null) {
                     for (const i in this.blocks.blockList) {
                         if (this.blocks.blockList[i].name === "modename") {
@@ -886,81 +924,75 @@ class ModeWidget {
                 }
 
                 const name = currentKey + " " + _(mode);
-                table.rows[n].cells[0].textContent = name;
-                this.widgetWindow.updateTitle(name);
+                this._updateModeDisplay(name);
                 return;
             }
         }
 
-        // console.debug('setModeName:' + 'not found');
-        table.rows[n].cells[0].textContent = "";
-        this.widgetWindow.updateTitle("");
+        this._updateModeDisplay("");
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    _updateModeDisplay(name) {
+        this._modeLabelCell.textContent = name;
+        this.widgetWindow.updateTitle(name);
+    }
+
+    // ── Save / export ─────────────────────────────────────────────
+
+    _temperamentKeyForEDO(edo) {
+        const map = {
+            5: "equal5",
+            7: "equal7",
+            12: "equal",
+            17: "equal17",
+            19: "equal19",
+            21: "1/4 comma meantone",
+            31: "equal31"
+        };
+        if (map[edo]) {
+            return map[edo];
+        }
+        const option = this._edoOptions().find(o => o.value === edo);
+        return option ? option.temperamentKey : "equal";
+    }
+
+    _pitchNameAndOctave(j) {
+        if (this._activeEDO === 12) {
+            // Movable-do solfege relative to the key signature (matches playback).
+            return [NOTESTABLE[(j + 1) % 12], 4];
+        }
+        const [name, octave] = numberToPitch(
+            j,
+            this._temperamentKeyForEDO(this._activeEDO),
+            "A",
+            0,
+            this.activity
+        );
+        return [name, octave + 4];
+    }
+
     _save() {
-        const table = docById("modeTable");
-        const n = table.rows.length - 1;
-
-        // If the mode is not in the list, save it as the new custom mode.
-        if (table.rows[n].cells[0].textContent === "") {
-            const customMode = this._calculateMode();
-            // console.debug("custom mode: " + customMode);
-            this.storage.custommode = JSON.stringify(customMode);
-        }
-
-        let modeName = table.rows[n].cells[0].textContent;
-        if (modeName === "") {
-            modeName = _("custom");
-        }
+        const n = this._activeEDO;
+        const label = this._modeLabelCell.textContent;
+        const modeName = label && label !== "\u00a0" ? label : _("custom");
 
         // Save a stack of pitches to be used with the matrix.
         let newStack = [
-            [
-                0,
-                [
-                    "action",
-                    {
-                        collapsed: true
-                    }
-                ],
-                150,
-                100,
-                [null, 1, 2, null]
-            ],
-            [
-                1,
-                [
-                    "text",
-                    {
-                        value: modeName
-                    }
-                ],
-                0,
-                0,
-                [0]
-            ]
+            [0, ["action", { collapsed: true }], 150, 100, [null, 1, 2, null]],
+            [1, ["text", { value: modeName }], 0, 0, [0]]
         ];
         let previousBlock = 0;
-
-        let modeLength = this._calculateMode().length;
+        const modeLength = this._calculateMode().length;
         let p = 0;
 
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < n; i++) {
             // Reverse the order so that Do is last.
-            const j = 11 - i;
+            const j = n - 1 - i;
             if (!this._selectedNotes[j]) {
                 continue;
             }
-
             p += 1;
-            const pitch = NOTESTABLE[(j + 1) % 12];
-            const octave = 4;
-            // console.debug(pitch + " " + octave);
-
+            const [pitch, octave] = this._pitchNameAndOctave(j);
             const pitchidx = newStack.length;
             const notenameidx = pitchidx + 1;
             const octaveidx = pitchidx + 2;
@@ -982,194 +1014,170 @@ class ModeWidget {
                     [previousBlock, notenameidx, octaveidx, pitchidx + 3]
                 ]);
             }
-            newStack.push([
-                notenameidx,
-                [
-                    "solfege",
-                    {
-                        value: pitch
-                    }
-                ],
-                0,
-                0,
-                [pitchidx]
-            ]);
-            newStack.push([
-                octaveidx,
-                [
-                    "number",
-                    {
-                        value: octave
-                    }
-                ],
-                0,
-                0,
-                [pitchidx]
-            ]);
+            newStack.push([notenameidx, ["solfege", { value: pitch }], 0, 0, [pitchidx]]);
+            newStack.push([octaveidx, ["number", { value: octave }], 0, 0, [pitchidx]]);
             previousBlock = pitchidx;
         }
 
-        // Create a new stack for the chunk.
-        // console.debug(newStack);
         this.blocks.loadNewBlocks(newStack);
         this.textMsg(_("New action block generated."), 3000);
 
-        // And save a stack of pitchnumbers to be used with the define mode
+        // And save a stack of pitchnumbers to be used with the define mode.
         newStack = [
-            [
-                0,
-                [
-                    "definemode",
-                    {
-                        collapsed: true
-                    }
-                ],
-                150,
-                150,
-                [null, 1, 3, 2]
-            ],
-            [
-                1,
-                [
-                    "text",
-                    {
-                        value: modeName
-                    }
-                ],
-                0,
-                0,
-                [0]
-            ],
+            [0, ["definemode", { collapsed: true }], 150, 150, [null, 1, 3, 2]],
+            [1, ["text", { value: modeName }], 0, 0, [0]],
             [2, "hidden", 0, 0, [0, null]]
         ];
         previousBlock = 0;
-
-        modeLength = this._calculateMode().length;
         p = 0;
 
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < n; i++) {
             if (!this._selectedNotes[i]) {
                 continue;
             }
-
             p += 1;
             const idx = newStack.length;
-
             if (p === modeLength) {
                 newStack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, null]]);
             } else {
                 newStack.push([idx, "pitchnumber", 0, 0, [previousBlock, idx + 1, idx + 2]]);
             }
-
-            newStack.push([
-                idx + 1,
-                [
-                    "number",
-                    {
-                        value: i
-                    }
-                ],
-                0,
-                0,
-                [idx]
-            ]);
+            newStack.push([idx + 1, ["number", { value: i }], 0, 0, [idx]]);
             previousBlock = idx;
         }
 
-        // Create a new stack for the chunk.
-        // console.debug(newStack);
         this._setTimeout(() => {
             this.blocks.loadNewBlocks(newStack);
         }, 2000);
     }
 
-    /**
-     * @private
-     * @returns {void}
-     */
+    // ── Pie menu ──────────────────────────────────────────────────
+
+    _getModeLabelFont(edo) {
+        if (edo <= 5) {
+            return "100 26px sans-serif";
+        }
+        if (edo <= 7) {
+            return "100 22px sans-serif";
+        }
+        if (edo <= 12) {
+            return "100 16px sans-serif";
+        }
+        if (edo <= 19) {
+            return "100 12px sans-serif";
+        }
+        if (edo <= 24) {
+            return "100 10px sans-serif";
+        }
+        return "100 9px sans-serif";
+    }
+
+    _getNoteLabelFont(edo) {
+        if (edo <= 5) {
+            return "100 22px sans-serif";
+        }
+        if (edo <= 7) {
+            return "100 18px sans-serif";
+        }
+        if (edo <= 12) {
+            return "100 14px sans-serif";
+        }
+        if (edo <= 19) {
+            return "100 11px sans-serif";
+        }
+        if (edo <= 24) {
+            return "100 9px sans-serif";
+        }
+        return "100 8px sans-serif";
+    }
+
     _piemenuMode() {
-        // pie menu for mode definition
+        const n = this._activeEDO;
 
-        docById("meterWheelDiv").style.display = "";
+        // Explicitly clear any existing wheels and leftover SVG slices before
+        // rendering with the current EDO count.
+        this._clearPieMenu();
 
-        // Use advanced constructor for multiple wheelnavs in the same div.
-        // The meterWheel is used to hold the half steps.
+        const meterDiv = docById("meterWheelDiv");
+        meterDiv.style.display = "";
+
         this._modeWheel = new wheelnav("meterWheelDiv", null, 400, 400);
-        // The selected notes are shown on this wheel
         this._noteWheel = new wheelnav("_noteWheel", this._modeWheel.raphael);
-        // Play wheel is to show which note is playing at any one time.
         this._playWheel = new wheelnav("_playWheel", this._modeWheel.raphael);
 
         wheelnav.cssMeter = true;
 
-        // Use the mode wheel color scheme
         this._modeWheel.colors = platformColor.modeWheelcolors;
-
         this._modeWheel.slicePathFunction = slicePath().DonutSlice;
         this._modeWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._modeWheel.slicePathCustom.minRadiusPercent = 0.4;
         this._modeWheel.slicePathCustom.maxRadiusPercent = 0.75;
         this._modeWheel.sliceSelectedPathCustom = this._modeWheel.slicePathCustom;
         this._modeWheel.sliceInitPathCustom = this._modeWheel.slicePathCustom;
-
-        // Disable rotation, set navAngle and create the menus
         this._modeWheel.clickModeRotate = false;
         this._modeWheel.navAngle = -90;
-        // this._modeWheel.selectedNavItemIndex = 2;
-        this._modeWheel.animatetime = 0; // 300;
+        this._modeWheel.animatetime = 0;
+        this._modeWheel.titleFont = this._getModeLabelFont(n);
 
-        const labels = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
-        let noteList = [];
-        for (let i = 0; i < 12; i++) {
-            noteList.push(labels[i]);
+        const labels = [];
+        for (let i = 0; i < n; i++) {
+            labels.push(String(i));
         }
+        this._modeWheel.createWheel(labels);
 
-        this._modeWheel.createWheel(noteList);
-
-        this._noteWheel.colors = platformColor.noteValueWheelcolors; // modeWheelcolors;
+        this._noteWheel.colors = platformColor.noteValueWheelcolors;
         this._noteWheel.slicePathFunction = slicePath().DonutSlice;
         this._noteWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._noteWheel.slicePathCustom.minRadiusPercent = 0.75;
-        this._noteWheel.slicePathCustom.maxRadiusPercent = 0.9;
+        this._noteWheel.slicePathCustom.maxRadiusPercent = n > 12 ? 0.88 : 0.9;
         this._noteWheel.sliceSelectedPathCustom = this._noteWheel.slicePathCustom;
         this._noteWheel.sliceInitPathCustom = this._noteWheel.slicePathCustom;
         this._noteWheel.clickModeRotate = false;
         this._noteWheel.navAngle = -90;
         this._noteWheel.titleRotateAngle = 90;
+        this._noteWheel.titleFont = this._getNoteLabelFont(n);
 
-        noteList = [" "]; // No X on first note, since we don't want to unselect it.
-        this._selectedNotes = [true]; // The first note is always selected.
-        for (let i = 1; i < 12; i++) {
-            noteList.push("x");
-            this._selectedNotes.push(false);
+        // Reconcile selectedNotes: preserve existing, ensure index 0 is always true
+        const oldNotes = this._selectedNotes;
+        this._selectedNotes = new Array(n).fill(false);
+        this._selectedNotes[0] = true;
+        if (Array.isArray(oldNotes)) {
+            for (let i = 1; i < Math.min(oldNotes.length, n); i++) {
+                if (oldNotes[i]) {
+                    this._selectedNotes[i] = true;
+                }
+            }
         }
 
+        // Slice 0: blank (no X toggle — root is always selected)
+        // Slices 1..n-1: "x" toggle
+        const noteList = [" "];
+        for (let i = 1; i < n; i++) {
+            noteList.push("x");
+        }
         this._noteWheel.createWheel(noteList);
 
         this._playWheel.colors = [platformColor.orange];
         this._playWheel.slicePathFunction = slicePath().DonutSlice;
         this._playWheel.slicePathCustom = slicePath().DonutSliceCustomization();
         this._playWheel.slicePathCustom.minRadiusPercent = 0.3;
-        this._playWheel.slicePathCustom.maxRadiusPercent = 0.4;
+        this._playWheel.slicePathCustom.maxRadiusPercent = n > 12 ? 0.38 : 0.4;
         this._playWheel.sliceSelectedPathCustom = this._playWheel.slicePathCustom;
         this._playWheel.sliceInitPathCustom = this._playWheel.slicePathCustom;
         this._playWheel.clickModeRotate = false;
         this._playWheel.navAngle = -90;
         this._playWheel.titleRotateAngle = 90;
 
-        noteList = [];
-        for (let i = 0; i < 12; i++) {
-            noteList.push(" ");
+        const playList = [];
+        for (let i = 0; i < n; i++) {
+            playList.push(" ");
         }
+        this._playWheel.createWheel(playList);
 
-        this._playWheel.createWheel(noteList);
-
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < n; i++) {
             this._playWheel.navItems[i].navItem.hide();
         }
 
-        // If a modeWheel sector is selected, show the corresponding
-        // note wheel sector.
         const __setNote = () => {
             const i = this._modeWheel.selectedNavItemIndex;
             this._saveState();
@@ -1177,38 +1185,30 @@ class ModeWidget {
             this._noteWheel.navItems[i].navItem.show();
             this._playNote(i);
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         };
 
-        // If a noteWheel sector is selected, hide it.
         const __clearNote = () => {
             const i = this._noteWheel.selectedNavItemIndex;
             if (i === 0) {
-                return; // Never hide the first note.
+                return; // Root note cannot be deselected
             }
-
             this._noteWheel.navItems[i].navItem.hide();
             this._saveState();
             this._selectedNotes[i] = false;
             this._setModeName();
-            const currentModeName = keySignatureToMode(
-                this.turtles.ithTurtle(0).singer.keySignature
-            );
-            if (currentModeName[0] === "C") {
-                this._showPiano();
-            }
         };
 
-        for (let i = 0; i < 12; i++) {
+        for (let i = 0; i < n; i++) {
             this._modeWheel.navItems[i].navigateFunction = __setNote;
             this._noteWheel.navItems[i].navigateFunction = __clearNote;
-            // Start with all notes hidden.
             this._noteWheel.navItems[i].navItem.hide();
+        }
+
+        // Restore visual state
+        for (let i = 0; i < n; i++) {
+            if (this._selectedNotes[i]) {
+                this._noteWheel.navItems[i].navItem.show();
+            }
         }
     }
 }

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -43,6 +43,8 @@ class ModeWidget {
     static ROTATESPEED = 125;
     static RESET_NOTES_DELAY = 500;
     static WHEELSIZE = 400;
+    static MIN_EDO = 5;
+    static MAX_EDO = 55;
     static MAX_TITLE_FONT_SIZE = 48;
     static MIN_TITLE_FONT_SIZE = 10;
     static TITLE_FONT_SCALE = 580;
@@ -298,7 +300,12 @@ class ModeWidget {
     _wireEdoSelect(select) {
         select.addEventListener("change", () => {
             const newEDO = parseInt(select.value, 10);
-            if (isNaN(newEDO) || newEDO < 5 || newEDO > 55 || newEDO === this._activeEDO) {
+            if (
+                isNaN(newEDO) ||
+                newEDO < ModeWidget.MIN_EDO ||
+                newEDO > ModeWidget.MAX_EDO ||
+                newEDO === this._activeEDO
+            ) {
                 return;
             }
 
@@ -1154,6 +1161,30 @@ class ModeWidget {
 
     // ── Save / export ─────────────────────────────────────────────
 
+    /**
+     * Register a dynamic equal-temperament entry for an EDO that has no
+     * built-in TEMPERAMENT entry, so getCurrentEDO() returns the correct
+     * pitch count during playback.
+     * @param {number} edo - Equal divisions of the octave
+     * @returns {string} The temperament key (e.g. "equal41")
+     */
+    _ensureTempKey(edo) {
+        const key = "equal" + edo;
+        if (!TEMPERAMENT[key]) {
+            TEMPERAMENT[key] = {
+                isEDO: true,
+                edo,
+                name: edo + "-EDO Equal",
+                description: edo + " Equal Divisions of the Octave",
+                ratios: Array.from({ length: edo + 1 }, (_, i) => Math.pow(2, i / edo)),
+                octaveRatio: 2,
+                generator: null,
+                pitchNumber: edo
+            };
+        }
+        return key;
+    }
+
     _temperamentKeyForEDO(edo) {
         const map = {
             5: "equal5",
@@ -1167,8 +1198,7 @@ class ModeWidget {
         if (map[edo]) {
             return map[edo];
         }
-        const option = this._edoOptions().find(o => o.value === edo);
-        return option ? option.temperamentKey : "equal";
+        return this._ensureTempKey(edo);
     }
 
     _pitchNameAndOctave(j) {

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -456,9 +456,18 @@ class ModeWidget {
         const modes = getSavedCustomModes();
         const existing = modes.findIndex(m => m.name === name);
         // Refuse to overwrite a built-in mode; only registered customs may be updated.
-        if (existing < 0 && name in MUSICALMODES) {
-            this.errorMsg(_("Cannot overwrite built-in mode: ") + name);
-            return false;
+        // Check case-insensitively against built-in modes (which are all lowercase),
+        // but allow case-sensitive updates to existing custom modes via `existing`.
+        if (existing < 0) {
+            const customNamesLower = new Set(modes.map(m => m.name.toLowerCase()));
+            const isBuiltIn = Object.keys(MUSICALMODES).some(
+                k =>
+                    k.toLowerCase() === name.toLowerCase() && !customNamesLower.has(k.toLowerCase())
+            );
+            if (isBuiltIn) {
+                this.errorMsg(_("Cannot overwrite built-in mode: ") + name);
+                return false;
+            }
         }
         const entry = { name, pattern, edo: this._activeEDO };
         if (existing >= 0) {


### PR DESCRIPTION
This PR finishes the Mode Widget (Scalar Builder) refactor – part of the Temperament Engine updates (Goal 4). It fixes UI state-sync bugs when switching EDOs, swaps the virtual piano for a cleaner control panel, and hooks custom mode creation directly into the workspace block exporter.

UI changes

We removed the bottom keyboard and put in a responsive control bar with Tuning/EDO, Saved Modes, name input, Save, and Delete. Also cleaned up the styling – now the table and cell backgrounds inherit the surface colors, so dark mode looks right.

Wheel and state sync

Switching temperaments (5, 12, 19, 31‑EDO) now redraws the SVG pie menu slices with proper labels. The tonic (interval 0) is locked and always selected – custom modes start as [0]. Loading a saved mode switches the EDO dropdown and redraws the wheel to match. Also fixed a bug where clicking slices or updating titles would delete the bottom control bar.

Block export

Saving a custom mode now adds it to the registry and drops two blocks on the workspace: an Action block and a Define Mode block with the selected intervals.

part of : #7171 

PR Category
 
- [x] Feature
- [ ] Tests
- [ ] Bug Fix
- [ ] Performance
- [ ] Documentation