### PR TITLE
fix: correct CSS styling on PitchDrumMatrix play/stop icons

### DIFF
--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -625,8 +625,7 @@ class PitchDrumMatrix {
         img.alt = label;
         img.setAttribute("height", PitchDrumMatrix.ICONSIZE);
         img.setAttribute("width", PitchDrumMatrix.ICONSIZE);
-        img.setAttribute("vertical-align", "middle");
-        img.setAttribute("align-content", "center");
+        img.style.verticalAlign = "middle";
         icon.appendChild(img);
         icon.appendChild(document.createTextNode("\u00A0\u00A0"));
     }


### PR DESCRIPTION
### PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

### Changes
- Replaced `img.setAttribute("vertical-align", "middle")` with `img.style.verticalAlign = "middle"`.
- Removed invalid `img.setAttribute("align-content", "center")` call.

### Related Issue
Fixes #8057