### PR TITLE
fix(activity): clean up helpful wheel listeners

### DIFF
--- a/js/__tests__/context-menu-controller.test.js
+++ b/js/__tests__/context-menu-controller.test.js
@@ -129,6 +129,12 @@ function makeActivity() {
         copyMultipleBlocks: jest.fn(),
         textMsg: jest.fn(),
         __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        }),
         _allClear: jest.fn(),
         turtles: {
             collapse: jest.fn(),
@@ -228,6 +234,7 @@ describe("ContextMenuController", () => {
                 "showHideAuxMenu",
                 "hideAuxMenu",
                 "deltaY",
+                "closeHelpfulWheel",
                 "setHelpfulSearchDiv",
                 "_displayHelpfulSearchDiv",
                 "_hideHelpfulSearchWidget"
@@ -395,6 +402,55 @@ describe("ContextMenuController", () => {
                 document,
                 "click",
                 expect.any(Function)
+            );
+        });
+
+        test("removes the tracked listener when an internal action closes the wheel", () => {
+            controller.displayHelpfulWheel(rightClick);
+            const closeListener = activity.addEventListener.mock.calls.find(
+                call => call[0] === document && call[1] === "click"
+            )[2];
+
+            controller.closeHelpfulWheel();
+
+            expect(activity.removeEventListener).toHaveBeenCalledWith(
+                document,
+                "click",
+                closeListener
+            );
+            expect(mockElement.style.display).toBe("none");
+        });
+
+        test("keeps one listener across repeated wheel openings", () => {
+            controller.displayHelpfulWheel(rightClick);
+            controller.displayHelpfulWheel(rightClick);
+
+            const clickListeners = activity.addEventListener.mock.calls.filter(
+                call => call[0] === document && call[1] === "click"
+            );
+            expect(clickListeners).toHaveLength(2);
+            expect(activity.removeEventListener).toHaveBeenCalledWith(
+                document,
+                "click",
+                clickListeners[0][2]
+            );
+        });
+
+        test("removes the listener when a wheel action closes through the activity API", () => {
+            const activityWithDelegation = makeActivity();
+            const delegatedController = setupContextMenuController(activityWithDelegation);
+            delegatedController.setupPaletteMenu();
+            delegatedController.displayHelpfulWheel(rightClick);
+            const closeListener = activityWithDelegation.addEventListener.mock.calls.find(
+                call => call[0] === document && call[1] === "click"
+            )[2];
+
+            delegatedController.changeBlockVisibility(activityWithDelegation);
+
+            expect(activityWithDelegation.removeEventListener).toHaveBeenCalledWith(
+                document,
+                "click",
+                closeListener
             );
         });
     });

--- a/js/__tests__/search-ui.test.js
+++ b/js/__tests__/search-ui.test.js
@@ -50,7 +50,13 @@ function makeActivity() {
         getStageScale: jest.fn(() => 1),
         addEventListener: jest.fn(),
         removeEventListener: jest.fn(),
-        __tick: jest.fn()
+        __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        })
     };
 }
 

--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -448,7 +448,12 @@ describe("Toolbar Class", () => {
                 { label: "Turtle Wrap Off", display: false },
                 { label: "Turtle Wrap On", display: true }
             ],
-            textMsg: jest.fn()
+            textMsg: jest.fn(),
+            closeHelpfulWheel: jest.fn(() => {
+                const wasOpen = helpfulWheelDiv.style.display !== "none";
+                if (wasOpen) helpfulWheelDiv.style.display = "none";
+                return wasOpen;
+            })
         };
 
         const wrapIcon = {

--- a/js/__tests__/trash-controller.test.js
+++ b/js/__tests__/trash-controller.test.js
@@ -74,7 +74,13 @@ function makeActivity() {
         refreshCanvas: jest.fn(),
         textMsg: jest.fn(),
         cellSize: 10,
-        __tick: jest.fn()
+        __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        })
     };
 
     return activity;

--- a/js/__tests__/turtles.test.js
+++ b/js/__tests__/turtles.test.js
@@ -91,6 +91,13 @@ function mixinPrototypes(turtles) {
     }
 }
 
+function closeHelpfulWheel() {
+    const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+    const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+    if (wasOpen) helpfulWheelDiv.style.display = "none";
+    return wasOpen;
+}
+
 describe("Turtles Class", () => {
     let activityMock;
     let turtles;
@@ -102,7 +109,8 @@ describe("Turtles Class", () => {
             turtleContainer: new createjs.Container(),
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -168,7 +176,8 @@ describe("markAllAsStopped", () => {
             turtleContainer: new createjs.Container(),
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -234,7 +243,8 @@ describe("Coordinate Conversion", () => {
             canvas: { width: 1200, height: 900, style: {} },
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -385,7 +395,8 @@ describe("setBackgroundColor", () => {
             canvas: { width: 1200, height: 900, style: {} },
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -449,7 +460,8 @@ describe("doScale", () => {
             canvas: { width: 1200, height: 900, style: {} },
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -500,7 +512,8 @@ describe("setStageScale", () => {
             canvas: { width: 1200, height: 900, style: {} },
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         turtles = new Turtles(activityMock);
@@ -578,7 +591,8 @@ describe("aux toolbar collapse and expand", () => {
                 { label: "Grid", display: true }
             ],
             __tick: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
 
         document.body.innerHTML = `
@@ -682,7 +696,8 @@ describe("TurtlesModel doGrid initialization order", () => {
             canvas: {},
             hideAuxMenu: jest.fn(),
             hideGrids: jest.fn(),
-            _doCartesianPolar: jest.fn()
+            _doCartesianPolar: jest.fn(),
+            closeHelpfulWheel
         };
     }
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -634,7 +634,8 @@ class Activity {
         // Context menu / helpful wheel / bottom toolbar functionality has been
         // extracted to ContextMenuController (js/context-menu-controller.js).
         // setupContextMenuController() installs the delegation stubs below:
-        // setHelpfulSearchDiv, _displayHelpfulSearchDiv, _hideHelpfulSearchWidget,
+        // closeHelpfulWheel, setHelpfulSearchDiv, _displayHelpfulSearchDiv,
+        // _hideHelpfulSearchWidget,
         // doContextMenus, displayHelpfulWheel, setupPaletteMenu, makeButton,
         // loadButtonDragHandler, openAuxMenu, _showHideAuxMenu, showHideAuxMenu,
         // hideAuxMenu, deltaY.
@@ -819,10 +820,7 @@ class Activity {
                     table.remove();
                 }
 
-                // Cache DOM element reference for performance
-                const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-                if (helpfulWheelDiv.style.display !== "none") {
-                    helpfulWheelDiv.style.display = "none";
+                if (this.closeHelpfulWheel()) {
                     this.__tick();
                 }
 
@@ -1020,11 +1018,7 @@ class Activity {
         const setScroller = activity => {
             activity._setScroller();
             activity._setupBlocksContainerEvents();
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
+            activity.closeHelpfulWheel();
         };
         // Exposed so ContextMenuController (activity/context-menu-controller.js) can
         // reference it from the helpfulWheelItems registry it builds.
@@ -2200,11 +2194,7 @@ class Activity {
          */
         const chooseKeyMenu = that => {
             piemenuKey(that);
-            // Cache DOM element reference for performance
-            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-            if (helpfulWheelDiv.style.display !== "none") {
-                helpfulWheelDiv.style.display = "none";
-            }
+            that.closeHelpfulWheel();
         };
         // Exposed so ContextMenuController (activity/context-menu-controller.js) can
         // reference it from the helpfulWheelItems registry it builds.

--- a/js/activity/__tests__/block-scale-controller.test.js
+++ b/js/activity/__tests__/block-scale-controller.test.js
@@ -61,7 +61,13 @@ function makeActivity(blockscale = DEFAULT_INDEX) {
         stageDirty: false,
         smallerContainer: { children: [{}] },
         largerContainer: { children: [{}] },
-        __tick: jest.fn()
+        __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        })
     };
 }
 

--- a/js/activity/__tests__/search-controller.test.js
+++ b/js/activity/__tests__/search-controller.test.js
@@ -86,6 +86,12 @@ function makeActivity(protoBlocks = {}) {
         removeEventListener: jest.fn(),
         errorMsg: jest.fn(),
         __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        }),
         update: false
     };
 }

--- a/js/activity/__tests__/selection-controller.test.js
+++ b/js/activity/__tests__/selection-controller.test.js
@@ -73,6 +73,12 @@ function makeActivity() {
         scrollBlockContainer: false,
         refreshCanvas: jest.fn(),
         textMsg: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        }),
         moving: true,
         addEventListener: jest.fn((target, event, handler) => {
             listeners[event] = listeners[event] || [];

--- a/js/activity/__tests__/workspace-layout-controller.test.js
+++ b/js/activity/__tests__/workspace-layout-controller.test.js
@@ -118,7 +118,13 @@ function makeActivity({ blockList = {}, turtleList = [] } = {}) {
         palettes: { updatePalettes: jest.fn() },
         homeButtonContainer: { children: [{}] },
         _changeBlockVisibility: jest.fn(),
-        __tick: jest.fn()
+        __tick: jest.fn(),
+        closeHelpfulWheel: jest.fn(() => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+            if (wasOpen) helpfulWheelDiv.style.display = "none";
+            return wasOpen;
+        })
     };
 }
 

--- a/js/activity/block-scale-controller.js
+++ b/js/activity/block-scale-controller.js
@@ -84,10 +84,7 @@ class BlockScaleController {
      */
     _hideHelpfulWheelIfVisible() {
         const activity = this.activity;
-        // Cache DOM element reference for performance
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
+        if (activity.closeHelpfulWheel()) {
             activity.__tick();
         }
     }

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -618,10 +618,7 @@ class SearchController {
      * Hides and removes the helpfulSearchDiv from the DOM.
      */
     _hideHelpfulSearchWidget() {
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
-        }
+        this.activity.closeHelpfulWheel();
         if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
             this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
         }
@@ -647,7 +644,7 @@ class SearchController {
         if (this.helpfulSearchDiv.style.display === "block") {
             activity.helpfulSearchWidget.value = null;
             activity.helpfulSearchWidget.style.visibility = "visible";
-            document.getElementById("helpfulWheelDiv").style.display = "none";
+            activity.closeHelpfulWheel();
             this.searchBlockPosition = [100, 100];
             this.prepSearchWidget();
             const that = this;

--- a/js/activity/selection-controller.js
+++ b/js/activity/selection-controller.js
@@ -313,8 +313,7 @@ class SelectionController {
             // set selection mode to false
             activity.blocks.setSelectionToActivity(false);
             activity.refreshCanvas();
-            // Cache DOM element reference for performance
-            document.getElementById("helpfulWheelDiv").style.display = "none";
+            activity.closeHelpfulWheel();
         }
     }
 
@@ -355,8 +354,7 @@ class SelectionController {
             this.unhighlightSelectedBlocks(false, false);
             activity.blocks.setSelectedBlocks(this.selectedBlocks);
             activity.refreshCanvas();
-            // Cache DOM element reference for performance
-            document.getElementById("helpfulWheelDiv").style.display = "none";
+            activity.closeHelpfulWheel();
         }
     }
 
@@ -367,7 +365,7 @@ class SelectionController {
         this.isSelecting
             ? activity.textMsg(_("Select is enabled."))
             : activity.textMsg(_("Select is disabled."));
-        document.getElementById("helpfulWheelDiv").style.display = "none";
+        activity.closeHelpfulWheel();
     }
 }
 

--- a/js/activity/workspace-layout-controller.js
+++ b/js/activity/workspace-layout-controller.js
@@ -35,10 +35,7 @@ class WorkspaceLayoutController {
     findBlocks() {
         const activity = this.activity;
         this._findBlocks();
-        // Lookup the element once before checking its visibility.
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
+        if (activity.closeHelpfulWheel()) {
             activity.__tick();
         }
     }

--- a/js/block.js
+++ b/js/block.js
@@ -3065,12 +3065,7 @@ class Block {
          * @param {Event} event - The click event.
          */
         this.container.on("click", event => {
-            if (
-                _getStatic("helpfulWheelDiv") &&
-                _getStatic("helpfulWheelDiv").style.display !== "none"
-            ) {
-                _getStatic("helpfulWheelDiv").style.display = "none";
-            }
+            that.activity.closeHelpfulWheel();
             // We might be able to check which button was clicked.
             if ("nativeEvent" in event) {
                 if ("button" in event.nativeEvent && event.nativeEvent.button === 2) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4564,7 +4564,7 @@ class Blocks {
                     this.selectedBlocksObj[0][3] =
                         helpfulWheelDiv.offsetTop + 130 - this.activity.blocksContainer.y;
 
-                    helpfulWheelDiv.style.display = "none";
+                    this.activity.closeHelpfulWheel();
                 } else {
                     this.selectedBlocksObj[0][2] =
                         175 - this.activity.blocksContainer.x + this.pasteDx;

--- a/js/context-menu-controller.js
+++ b/js/context-menu-controller.js
@@ -28,9 +28,7 @@
  * (not `controller.fn(activity)`), so anything they call must not depend on `this`.
  */
 const closeHelpfulWheelAndTick = activity => {
-    const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-    if (helpfulWheelDiv.style.display !== "none") {
-        helpfulWheelDiv.style.display = "none";
+    if (activity.closeHelpfulWheel()) {
         activity.__tick();
     }
 };
@@ -41,6 +39,34 @@ class ContextMenuController {
      */
     constructor(activity) {
         this.activity = activity;
+        this._helpfulWheelCloseListener = event => {
+            const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+            if (helpfulWheelDiv && !helpfulWheelDiv.contains(event.target)) {
+                this.closeHelpfulWheel();
+            }
+        };
+        this._helpfulWheelCloseListenerAttached = false;
+    }
+
+    /**
+     * Hides the helpful wheel and removes its document-level close listener.
+     *
+     * @returns {boolean} Whether the wheel was visible before it was closed.
+     */
+    closeHelpfulWheel() {
+        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
+        const wasOpen = Boolean(helpfulWheelDiv && helpfulWheelDiv.style.display !== "none");
+
+        if (this._helpfulWheelCloseListenerAttached) {
+            this.activity.removeEventListener(document, "click", this._helpfulWheelCloseListener);
+            this._helpfulWheelCloseListenerAttached = false;
+        }
+
+        if (helpfulWheelDiv && wasOpen) {
+            helpfulWheelDiv.style.display = "none";
+        }
+
+        return wasOpen;
     }
 
     /**
@@ -76,6 +102,7 @@ class ContextMenuController {
      */
     displayHelpfulWheel(event) {
         const activity = this.activity;
+        this.closeHelpfulWheel();
         // Cache DOM element reference for performance (7 lookups reduced to 1)
         const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
         helpfulWheelDiv.style.position = "absolute";
@@ -146,15 +173,8 @@ class ContextMenuController {
             wheel.navItems[i].setTooltip(_(ele.label));
             wheel.navItems[i].navigateFunction = () => ele.fn(activity);
         });
-        const closeHelpfulWheel = e => {
-            const isClickInside = helpfulWheelDiv.contains(e.target);
-            if (!isClickInside) {
-                helpfulWheelDiv.style.display = "none";
-                activity.removeEventListener(document, "click", closeHelpfulWheel);
-            }
-        };
-
-        activity.addEventListener(document, "click", closeHelpfulWheel);
+        activity.addEventListener(document, "click", this._helpfulWheelCloseListener);
+        this._helpfulWheelCloseListenerAttached = true;
     }
 
     /**
@@ -657,6 +677,7 @@ const setupContextMenuController = activity => {
     activity.contextMenuController = controller;
 
     activity.doContextMenus = (...args) => controller.doContextMenus(...args);
+    activity.closeHelpfulWheel = (...args) => controller.closeHelpfulWheel(...args);
     activity.displayHelpfulWheel = (...args) => controller.displayHelpfulWheel(...args);
     activity.setupPaletteMenu = (...args) => controller.setupPaletteMenu(...args);
     activity.makeButton = (...args) => controller.makeButton(...args);

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3990,9 +3990,7 @@ const piemenuGrid = activity => {
         hidePiemenu(activity);
     };
 
-    if (docById("helpfulWheelDiv").style.display !== "none") {
-        docById("helpfulWheelDiv").style.display = "none";
-    }
+    activity.closeHelpfulWheel();
 
     const hidePiemenu = activity => {
         docById("wheelDivptm").style.display = "none";

--- a/js/search-ui.js
+++ b/js/search-ui.js
@@ -274,7 +274,7 @@ class SearchUI {
         activity.helpfulSearchWidget.idInput_custom = "";
         activity.helpfulSearchWidget.value = null;
         activity.helpfulSearchWidget.style.visibility = "visible";
-        document.getElementById("helpfulWheelDiv").style.display = "none";
+        activity.closeHelpfulWheel();
     }
 
     /**
@@ -406,10 +406,7 @@ class SearchUI {
      * Hides the helpfulWheelDiv and removes helpfulSearchDiv from the DOM.
      */
     removeHelpfulSearchDiv() {
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
-        }
+        this.activity.closeHelpfulWheel();
         if (this.helpfulSearchDiv && this.helpfulSearchDiv.parentNode) {
             this.helpfulSearchDiv.parentNode.removeChild(this.helpfulSearchDiv);
             this.helpfulSearchDiv = null;

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -881,9 +881,7 @@ class ToolbarUI {
             delay: 100
         });
 
-        if (docById("helpfulWheelDiv").style.display !== "none") {
-            docById("helpfulWheelDiv").style.display = "none";
-        }
+        activity.closeHelpfulWheel();
     }
 
     /**

--- a/js/trash-controller.js
+++ b/js/trash-controller.js
@@ -58,10 +58,7 @@ class TrashController {
             return;
         }
 
-        // Cache DOM element reference for performance
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
+        if (activity.closeHelpfulWheel()) {
             activity.__tick();
         }
     }
@@ -78,10 +75,7 @@ class TrashController {
         this.restoreTrashById(activity.blocks.trashStacks[activity.blocks.trashStacks.length - 1]);
         activity.textMsg(_("Item restored from the trash."), 3000);
 
-        // Cache DOM element reference for performance
-        const helpfulWheelDiv = document.getElementById("helpfulWheelDiv");
-        if (helpfulWheelDiv && helpfulWheelDiv.style.display !== "none") {
-            helpfulWheelDiv.style.display = "none";
+        if (activity.closeHelpfulWheel()) {
             activity.__tick();
         }
     }

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1080,8 +1080,7 @@ Turtles.TurtlesView = class {
             });
             __collapse();
 
-            if (docById("helpfulWheelDiv").style.display !== "none") {
-                docById("helpfulWheelDiv").style.display = "none";
+            if (this.activity.closeHelpfulWheel()) {
                 this.activity.__tick();
             }
         };
@@ -1170,8 +1169,7 @@ Turtles.TurtlesView = class {
             this.masterStage.removeChild(turtlesStage);
             this.masterStage.addChildAt(turtlesStage, 0);
 
-            if (docById("helpfulWheelDiv").style.display !== "none") {
-                docById("helpfulWheelDiv").style.display = "none";
+            if (this.activity.closeHelpfulWheel()) {
                 this.activity.__tick();
             }
         };


### PR DESCRIPTION
## Summary

Fixes a document-level click listener leak in the helpful wheel described in #6756.

## Problem

When the helpful wheel opens, it registers a document click listener for outside-click closing. Several internal close paths only hid the wheel with `style.display = "none"` and did not remove the listener.

Repeated open → internal close cycles therefore accumulated stale listeners and caused repeated close-handler work on later clicks.

## Changes

- Added centralized `closeHelpfulWheel()` cleanup in `ContextMenuController`.
- Store and reuse one outside-click handler for the helpful wheel.
- Remove the document listener whenever the wheel closes.
- Remove any previous listener before reopening the wheel.
- Routed all current helpful-wheel close paths through the shared cleanup:
  - context-menu actions
  - search and selection controls
  - workspace, trash, and block scaling controls
  - toolbar, paste, turtle, and pi-menu actions
- Added regression coverage for internal closes and repeated wheel openings.

## Testing

### Automated

- ✅ `npm run lint`
- ✅ `npx prettier --check` on all modified files
- ✅ `npm test -- --runInBand`
- ✅ 210 test suites passed
- ✅ 7,508 tests passed

### Browser Testing

1. Run `npm run serve:dev`.
2. Open `http://127.0.0.1:3000`.
3. Switch to Advanced Mode.
4. Right-click an empty canvas area to open the helpful wheel.
5. Choose an internal action such as **Show/hide blocks**.
6. Repeat the open → internal close cycle several times.
7. Confirm document click listeners do not accumulate.

Fixes #6756

- [x] Bug fix
- [x] Test
- [x] Performance