### PR TITLE
fix(utils): guard updatePluginObj loops against missing plugin sections

### DIFF
--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -260,4 +260,37 @@ describe("updatePluginObj - prototype pollution guard", () => {
             ).toBe(false);
         }
     });
+
+    it("does not throw when a plugin is missing optional sections", () => {
+        const activity = {
+            pluginObjs: {
+                PALETTEPLUGINS: {},
+                PALETTEFILLCOLORS: {},
+                PALETTESTROKECOLORS: {},
+                PALETTEHIGHLIGHTCOLORS: {},
+                FLOWPLUGINS: {},
+                ARGPLUGINS: {},
+                BLOCKPLUGINS: {},
+                MACROPLUGINS: {},
+                ONLOAD: {},
+                ONSTART: {},
+                ONSTOP: {}
+            }
+        };
+
+        // Shape of plugins/maths.json: no FLOWPLUGINS, ONLOAD, ONSTART, ONSTOP.
+        const mathsLike = JSON.parse(
+            '{"PALETTEPLUGINS":{"maths":{"name":"maths"}},"ARGPLUGINS":{"a":"code"},"BLOCKPLUGINS":{"b":"code"}}'
+        );
+        expect(() => updatePluginObj(activity, mathsLike)).not.toThrow();
+
+        // Shape of plugins/accelerometer.json: no PALETTEPLUGINS at all.
+        const accelerometerLike = JSON.parse(
+            '{"GLOBALS":"var x=1;","ARGPLUGINS":{"a":"code"},"BLOCKPLUGINS":{"b":"code"}}'
+        );
+        expect(() => updatePluginObj(activity, accelerometerLike)).not.toThrow();
+
+        expect(activity.pluginObjs["PALETTEPLUGINS"]["maths"]).toEqual({ name: "maths" });
+        expect(activity.pluginObjs["ARGPLUGINS"]["a"]).toBe("code");
+    });
 });

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -834,39 +834,54 @@ const updatePluginObj = (activity, obj) => {
         return;
     }
 
-    for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["PALETTEPLUGINS"][name] = obj["PALETTEPLUGINS"][name];
+    if ("PALETTEPLUGINS" in obj) {
+        for (const name of Object.keys(obj["PALETTEPLUGINS"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["PALETTEPLUGINS"][name] = obj["PALETTEPLUGINS"][name];
+        }
     }
 
-    for (const name of Object.keys(obj["PALETTEFILLCOLORS"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["PALETTEFILLCOLORS"][name] = obj["PALETTEFILLCOLORS"][name];
+    if ("PALETTEFILLCOLORS" in obj) {
+        for (const name of Object.keys(obj["PALETTEFILLCOLORS"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["PALETTEFILLCOLORS"][name] = obj["PALETTEFILLCOLORS"][name];
+        }
     }
 
-    for (const name of Object.keys(obj["PALETTESTROKECOLORS"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["PALETTESTROKECOLORS"][name] = obj["PALETTESTROKECOLORS"][name];
+    if ("PALETTESTROKECOLORS" in obj) {
+        for (const name of Object.keys(obj["PALETTESTROKECOLORS"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["PALETTESTROKECOLORS"][name] = obj["PALETTESTROKECOLORS"][name];
+        }
     }
 
-    for (const name of Object.keys(obj["PALETTEHIGHLIGHTCOLORS"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["PALETTEHIGHLIGHTCOLORS"][name] = obj["PALETTEHIGHLIGHTCOLORS"][name];
+    if ("PALETTEHIGHLIGHTCOLORS" in obj) {
+        for (const name of Object.keys(obj["PALETTEHIGHLIGHTCOLORS"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["PALETTEHIGHLIGHTCOLORS"][name] =
+                obj["PALETTEHIGHLIGHTCOLORS"][name];
+        }
     }
 
-    for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
-        if (isUnsafeObjectKey(flow)) continue;
-        activity.pluginObjs["FLOWPLUGINS"][flow] = obj["FLOWPLUGINS"][flow];
+    if ("FLOWPLUGINS" in obj) {
+        for (const flow of Object.keys(obj["FLOWPLUGINS"])) {
+            if (isUnsafeObjectKey(flow)) continue;
+            activity.pluginObjs["FLOWPLUGINS"][flow] = obj["FLOWPLUGINS"][flow];
+        }
     }
 
-    for (const arg of Object.keys(obj["ARGPLUGINS"])) {
-        if (isUnsafeObjectKey(arg)) continue;
-        activity.pluginObjs["ARGPLUGINS"][arg] = obj["ARGPLUGINS"][arg];
+    if ("ARGPLUGINS" in obj) {
+        for (const arg of Object.keys(obj["ARGPLUGINS"])) {
+            if (isUnsafeObjectKey(arg)) continue;
+            activity.pluginObjs["ARGPLUGINS"][arg] = obj["ARGPLUGINS"][arg];
+        }
     }
 
-    for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
-        if (isUnsafeObjectKey(block)) continue;
-        activity.pluginObjs["BLOCKPLUGINS"][block] = obj["BLOCKPLUGINS"][block];
+    if ("BLOCKPLUGINS" in obj) {
+        for (const block of Object.keys(obj["BLOCKPLUGINS"])) {
+            if (isUnsafeObjectKey(block)) continue;
+            activity.pluginObjs["BLOCKPLUGINS"][block] = obj["BLOCKPLUGINS"][block];
+        }
     }
 
     if ("MACROPLUGINS" in obj) {
@@ -887,19 +902,25 @@ const updatePluginObj = (activity, obj) => {
         activity.pluginObjs["IMAGES"] = obj["IMAGES"];
     }
 
-    for (const name of Object.keys(obj["ONLOAD"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["ONLOAD"][name] = obj["ONLOAD"][name];
+    if ("ONLOAD" in obj) {
+        for (const name of Object.keys(obj["ONLOAD"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["ONLOAD"][name] = obj["ONLOAD"][name];
+        }
     }
 
-    for (const name of Object.keys(obj["ONSTART"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["ONSTART"][name] = obj["ONSTART"][name];
+    if ("ONSTART" in obj) {
+        for (const name of Object.keys(obj["ONSTART"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["ONSTART"][name] = obj["ONSTART"][name];
+        }
     }
 
-    for (const name of Object.keys(obj["ONSTOP"])) {
-        if (isUnsafeObjectKey(name)) continue;
-        activity.pluginObjs["ONSTOP"][name] = obj["ONSTOP"][name];
+    if ("ONSTOP" in obj) {
+        for (const name of Object.keys(obj["ONSTOP"])) {
+            if (isUnsafeObjectKey(name)) continue;
+            activity.pluginObjs["ONSTOP"][name] = obj["ONSTOP"][name];
+        }
     }
 };
 


### PR DESCRIPTION
PR #7952 replaced for...in loops with Object.keys(), but plugin JSON files don't always contain every section.

When a section such as FLOWPLUGINS is missing, Object.keys(undefined) throws a TypeError, causing built-in plugins like maths.json to fail during loading.

This fix adds an if ("SECTION" in obj) guard before each Object.keys() loop, matching the existing MACROPLUGINS pattern.

## Before
<img width="982" height="220" alt="image" src="https://github.com/user-attachments/assets/45e05dff-8f37-4b21-9523-5c832f001f34" />



## After

<img width="507" height="253" alt="image" src="https://github.com/user-attachments/assets/7b065ad9-4af5-476a-8ff6-9108b200f2fe" />


## PR Category
- [X] Bug Fix