### PR TITLE
feat(utils): add toArray utility helper function to utils-logic

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -34,7 +34,8 @@ const {
     isSafeUrl,
     isUnsafeObjectKey,
     isValidHex,
-    safeNumber
+    safeNumber,
+    toArray
 } = require("../utils-logic.js");
 
 describe("Utility Logic Functions", () => {
@@ -276,6 +277,26 @@ describe("Utility Logic Functions", () => {
             expect(safeNumber(null, 7)).toBe(7);
             expect(safeNumber(undefined, 0)).toBe(0);
             expect(safeNumber({}, 0)).toBe(0);
+        });
+    });
+
+    describe("toArray()", () => {
+        it("returns the original array if input is already an array", () => {
+            const arr = [1, 2, 3];
+            expect(toArray(arr)).toBe(arr);
+            expect(toArray([])).toEqual([]);
+        });
+
+        it("wraps single non-array values in an array", () => {
+            expect(toArray(42)).toEqual([42]);
+            expect(toArray("hello")).toEqual(["hello"]);
+            expect(toArray(true)).toEqual([true]);
+            expect(toArray({ key: "val" })).toEqual([{ key: "val" }]);
+        });
+
+        it("returns an empty array for null or undefined", () => {
+            expect(toArray(null)).toEqual([]);
+            expect(toArray(undefined)).toEqual([]);
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -21,7 +21,7 @@
    deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, isUnsafeObjectKey, last,
    mixedNumber, nearestBeat, oneHundredToFraction, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, unescapeHTML, escapeHTML,
-   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex, safeNumber
+   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex, safeNumber, toArray
 */
 
 /**
@@ -577,6 +577,17 @@ var safeNumber = (val, fallback = 0) => {
 };
 
 /**
+ * Safely converts a single value, array, or nullish input into an array.
+ * @param {*} val - Value to convert
+ * @returns {Array} An array containing the value, the original array if already an array, or an empty array for null/undefined
+ */
+var toArray = val => {
+    if (val === null || val === undefined) return [];
+    if (Array.isArray(val)) return val;
+    return [val];
+};
+
+/**
  * Converts RGB values to a hexadecimal color code.
  */
 var rgbToHex = (r, g, b) => {
@@ -697,7 +708,8 @@ var UtilsLogic = {
     resolveObject,
     clampNumber,
     isValidHex,
-    safeNumber
+    safeNumber,
+    toArray
 };
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Description

Introduces a pure, dependency-free `toArray(val)` helper function to `js/utils/utils-logic.js`.

This helper safely converts single values, arrays, or nullish inputs into an array format:
- `toArray([1, 2, 3])` -> `[1, 2, 3]` (returns original array)
- `toArray(42)` -> `[42]` (wraps non-array value)
- `toArray(null)` -> `[]` (returns empty array for null/undefined)



## Related Issue

N/A

## PR Category

- [x] Enhancement / Feature — New features or improvements to existing functionality
- [x] Tests — Adds or updates test coverage

### Planned Usage Plan

In MusicBlocks, functions often receive data that could be a single item (e.g. `"tempo"`), a list of items (e.g. `["tempo", "volume"]`), or `null`. 

Instead of writing messy checks like `Array.isArray(x) ? x : (x ? [x] : [])` everywhere, `toArray(x)` will be used in future refactoring PRs to simplify:

1. **`js/activity.js`**: Loading module script paths cleanly.
2. **`js/blocks/WidgetBlocks.js`**: Safely reading widget plugin dependencies.
3. **`js/widgets/aidebugger.js`**: Parsing block connections without crashes.


## Changes Made

- **`js/utils/utils-logic.js`**:
  - Added `toArray(val)` conversion helper function.
  - Added `toArray` to export comment header and `UtilsLogic` export object.
- **`js/utils/__tests__/utils-logic.test.js`**:
  - Added unit test suite covering array inputs, single scalar inputs, and nullish inputs (64/64 passed).

## Testing Performed

- Ran local Jest test suite: `npx jest js/utils/__tests__/utils-logic.test.js` (64/64 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
