### PR TITLE
fix: use last() to read neighborNoteValue stack in playNote listener

### DIFF
--- a/js/turtleactions/RhythmActions.js
+++ b/js/turtleactions/RhythmActions.js
@@ -145,10 +145,10 @@ function setupRhythmActions(activity) {
                 if (tur.singer.inNoteBlock.length > 0) {
                     if (tur.singer.inNeighbor.length > 0) {
                         tur.singer.neighborArgBeat.push(
-                            tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
+                            tur.singer.beatFactor * (1 / last(tur.singer.neighborNoteValue))
                         );
 
-                        const nextBeat = 1 / noteBeatValue - 2 * tur.singer.neighborNoteValue;
+                        const nextBeat = 1 / noteBeatValue - 2 * last(tur.singer.neighborNoteValue);
                         if (nextBeat <= 0 || !isFinite(nextBeat)) {
                             activity.errorMsg(
                                 _(


### PR DESCRIPTION
### Description

In `RhythmActions.js`, the `tur.singer.neighborNoteValue` variable is actually a list (an array) of numbers, not a single number. 

However, inside the `playNote` listener, the code was trying to do math (division and multiplication) directly on this list:
```javascript
tur.singer.beatFactor * (1 / tur.singer.neighborNoteValue)
```

In JavaScript, trying to do math on a full list gives a result of `NaN` (Not a Number). Because of this, the code would always think the note value was too large and throw an error. This made the Neighbor ornament block completely broken—it would never play.

To fix this, I added the `last()` function to correctly read just the top number from the list, exactly like the rest of the code does for other blocks:
```javascript
tur.singer.beatFactor * (1 / last(tur.singer.neighborNoteValue))
```

This simple change fixes the math, stops the error, and makes the Neighbor block work perfectly again.

### PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

### Changes Made

- `js/turtleactions/RhythmActions.js`:
  - Added `last()` in two places inside the `playNote` listener to correctly get the top number from the `neighborNoteValue` array instead of doing math on the array itself.

### Testing Performed

- Ran `npm test -- --testPathPattern=RhythmActions` → **28/28 tests passed**
- Ran `npm run lint` → **0 errors, 0 warnings**
- Ran `npx prettier --check js/turtleactions/RhythmActions.js` → **All matched files use Prettier code style**

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" *(required for auto-rebase; this only affects the PR branch, not your fork)*.
