### PR TITLE
fix: validate Logo dependencies before initialization

### DIFF
--- a/js/LogoDependencies.js
+++ b/js/LogoDependencies.js
@@ -77,44 +77,34 @@ class LogoDependencies {
      * @param {Object} [deps.statsWindow] - Stats display handler
      * @param {Function} [deps.statsWindow.displayInfo]
      */
-    constructor({
-        blocks,
-        turtles,
-        stage,
-        errorHandler,
-        messageHandler,
-        storage,
-        config,
-        callbacks,
+    constructor(deps = {}) {
+        LogoDependencies.validate(deps);
 
-        refreshCanvas = null,
-        textMsg = null,
-        markStageDirty = null,
-        save = null,
-        statsWindow = null,
+        const {
+            blocks,
+            turtles,
+            stage,
+            errorHandler,
+            messageHandler,
+            storage,
+            config,
+            callbacks,
 
-        instruments = null,
-        instrumentsFilters = null,
-        instrumentsEffects = null,
-        widgetWindows = null,
-        utils = null,
-        Singer = null,
-        Tone = null,
-        classes = null
-    }) {
-        // Validate required dependencies
-        if (!blocks) {
-            throw new Error("LogoDependencies: 'blocks' is required");
-        }
-        if (!turtles) {
-            throw new Error("LogoDependencies: 'turtles' is required");
-        }
-        if (!stage) {
-            throw new Error("LogoDependencies: 'stage' is required");
-        }
-        if (!errorHandler) {
-            throw new Error("LogoDependencies: 'errorHandler' is required");
-        }
+            refreshCanvas = null,
+            textMsg = null,
+            markStageDirty = null,
+            save = null,
+            statsWindow = null,
+
+            instruments = null,
+            instrumentsFilters = null,
+            instrumentsEffects = null,
+            widgetWindows = null,
+            utils = null,
+            Singer = null,
+            Tone = null,
+            classes = null
+        } = deps;
 
         /**
          * Blocks subsystem - manages program structure and visual feedback
@@ -333,6 +323,55 @@ class LogoDependencies {
      */
     static isLogoDependencies(obj) {
         return obj instanceof LogoDependencies;
+    }
+
+    /**
+     * Validate the dependencies required by the Logo execution engine.
+     *
+     * This is intentionally shared by the constructor and Logo's explicit
+     * dependency path so plain objects receive the same validation as class
+     * instances.
+     *
+     * @param {*} deps - Dependency object to validate
+     * @throws {Error} When a required dependency is missing or malformed
+     */
+    static validate(deps) {
+        if (deps === null || typeof deps !== "object" || Array.isArray(deps)) {
+            throw new Error("LogoDependencies: dependencies must be an object");
+        }
+
+        const required = ["blocks", "turtles", "stage", "errorHandler"];
+        for (const key of required) {
+            if (deps[key] === null || deps[key] === undefined) {
+                throw new Error(`LogoDependencies: '${key}' is required`);
+            }
+        }
+
+        if (typeof deps.blocks !== "object" || Array.isArray(deps.blocks)) {
+            throw new Error("LogoDependencies: 'blocks' must be an object");
+        }
+        if (!Array.isArray(deps.blocks.blockList)) {
+            throw new Error("LogoDependencies: 'blocks.blockList' must be an array");
+        }
+
+        if (typeof deps.turtles !== "object" || Array.isArray(deps.turtles)) {
+            throw new Error("LogoDependencies: 'turtles' must be an object");
+        }
+        if (!Array.isArray(deps.turtles.turtleList)) {
+            throw new Error("LogoDependencies: 'turtles.turtleList' must be an array");
+        }
+
+        if (
+            typeof deps.stage !== "object" ||
+            Array.isArray(deps.stage) ||
+            typeof deps.stage.addEventListener !== "function"
+        ) {
+            throw new Error("LogoDependencies: 'stage.addEventListener' must be a function");
+        }
+
+        if (typeof deps.errorHandler !== "function") {
+            throw new Error("LogoDependencies: 'errorHandler' must be a function");
+        }
     }
 }
 

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -449,6 +449,11 @@ describe("Logo constructor", () => {
         expect(freshLogo.activity).toBe(mockActivity);
     });
 
+    test("supports Activity initialization before saveLocally is available", () => {
+        mockActivity.saveLocally = null;
+        expect(() => new Logo(mockActivity)).not.toThrow();
+    });
+
     test("initializes default volume-related properties", () => {
         expect(logo.stopTurtle).toBe(false);
         expect(logo.time).toBe(0);
@@ -528,6 +533,39 @@ describe("Logo constructor", () => {
         expect(depLogo.activity.blocks).toBe(mockActivity.blocks);
         expect(depLogo.activity.turtles).toBe(mockActivity.turtles);
         expect(depLogo.activity.stage).toBe(mockActivity.stage);
+    });
+
+    test("rejects incomplete explicit dependencies before initialization", () => {
+        expect(() => new Logo({ blocks: {}, turtles: {} })).toThrow(
+            "LogoDependencies: 'stage' is required"
+        );
+    });
+
+    test("rejects malformed explicit dependencies before initialization", () => {
+        expect(
+            () =>
+                new Logo({
+                    blocks: {},
+                    turtles: {},
+                    stage: { addEventListener: jest.fn() },
+                    errorHandler: jest.fn()
+                })
+        ).toThrow("LogoDependencies: 'blocks.blockList' must be an array");
+    });
+
+    test("rejects missing error handlers instead of treating deps as Activity", () => {
+        expect(
+            () =>
+                new Logo({
+                    blocks: { blockList: [] },
+                    turtles: { turtleList: [] },
+                    stage: { addEventListener: jest.fn() }
+                })
+        ).toThrow("LogoDependencies: 'errorHandler' is required");
+    });
+
+    test("rejects null constructor input with a dependency error", () => {
+        expect(() => new Logo(null)).toThrow("LogoDependencies: dependencies must be an object");
     });
 });
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -87,24 +87,26 @@ class Logo {
      * const logo = new Logo(deps);
      */
     constructor(activityOrDeps) {
-        // `errorHandler` is the single property that distinguishes a
-        // LogoDependencies container from a legacy Activity object (which uses
-        // `errorMsg` instead). instanceof is checked first as the strongest
-        // signal; the typeof clause is a fallback for plain objects that satisfy
-        // the shape but are not formal instances (e.g. after jest.resetModules()
-        // clears module identity). When the project migrates to ES modules the
-        // require fallback and typeof clause can be removed.
+        // These methods identify the legacy Activity shape. An object without
+        // the Activity adapter is treated as explicit dependencies so malformed
+        // dependency objects fail validation instead of being adapted as an
+        // Activity and failing later during execution.
         const LD =
             typeof LogoDependencies !== "undefined"
                 ? LogoDependencies
                 : require("./LogoDependencies");
-        const isExplicitDeps =
-            activityOrDeps instanceof LD ||
-            (activityOrDeps !== null &&
-                activityOrDeps !== undefined &&
-                typeof activityOrDeps.errorHandler === "function");
+        const isLegacyActivity =
+            activityOrDeps !== null &&
+            activityOrDeps !== undefined &&
+            typeof activityOrDeps === "object" &&
+            typeof activityOrDeps.errorMsg === "function" &&
+            typeof activityOrDeps.hideMsgs === "function" &&
+            typeof activityOrDeps.errorHandler !== "function";
+        const isExplicitDeps = !isLegacyActivity;
 
         if (isExplicitDeps) {
+            LD.validate(activityOrDeps);
+
             // Explicit dependency container: use directly and build a
             // compatibility facade so callers that expect an activity object
             // still work (Notation constructor, plugins, getStatsFromNotation).


### PR DESCRIPTION
## Summary

Fixes #6914 by validating Logo dependencies before initialization and preventing malformed dependency objects from being treated as legacy Activity objects.

## Changes

- Added shared dependency validation for required Logo dependencies.
- Validate `blocks.blockList`, `turtles.turtleList`, stage event handling, and `errorHandler`.
- Fail fast with clear errors for missing, null, or malformed dependencies.
- Preserved legacy `new Logo(activity)` initialization.
- Covered the startup state where `activity.saveLocally` is temporarily unavailable.
- Added regression tests for incomplete and malformed dependency objects.

## Testing

- `npm run lint`
- Prettier check passed
- `git diff --check`
- Jest: 210 suites, 7,515 tests passed

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Performance
- [ ] Documentation

Fixes #6914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Logo dependencies, including required objects, arrays, and functions.
  * Invalid or incomplete dependency configurations now produce clear errors during construction.
  * Improved detection of legacy Activity inputs to prevent malformed configurations from failing later.
  * Logo construction now supports activities with no local save handler.
  * Plain dependency configurations now receive appropriate default optional handlers and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->