### PR TITLE
fix(loader): prevent timeout on slow startup (#8070)

### DIFF
--- a/js/__tests__/loader.test.js
+++ b/js/__tests__/loader.test.js
@@ -96,6 +96,7 @@ describe("loader.js coverage", () => {
         expect(mockRequireJSConfig).toHaveBeenCalledWith(
             expect.objectContaining({
                 baseUrl: "./",
+                waitSeconds: 0,
                 paths: expect.any(Object),
                 shim: expect.objectContaining({
                     "tweenjs.min": expect.objectContaining({

--- a/js/loader.js
+++ b/js/loader.js
@@ -19,7 +19,9 @@ const ASSET_VERSION = window.location.protocol === "file:" ? "" : "v=999999_fix7
 requirejs.config({
     baseUrl: "./",
     urlArgs: ASSET_VERSION,
-    waitSeconds: 60,
+    // Keep the bootstrap alive while modules download or evaluate on slow
+    // connections. The loading splash remains visible until initialization completes.
+    waitSeconds: 0,
     shim: {
         "easeljs.min": {
             exports: "createjs"


### PR DESCRIPTION
## Summary

- Prevent RequireJS from aborting startup after 60 seconds on slow connections.
- Keep the loading screen active until all startup modules finish loading.
- Add a regression assertion for the loader configuration.

## Root cause

RequireJS used `waitSeconds: 60`. On slow or heavily throttled connections, module loading exceeded this limit and triggered a fatal “Please refresh” alert.

## Fix

Set `waitSeconds` to `0`, allowing modules to finish downloading and evaluating without an artificial timeout.

## Testing

- `npm run lint`
- `npx prettier --check js/loader.js js/__tests__/loader.test.js`
- `npm test -- --runInBand`
-  Manual testing with Chrome DevTools network throttling to 3g and disabled network cache .

Closes #8070

- [x] Bug fix