### PR TITLE
test: add coverage for CameraManager and announceToScreenReader utilities

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -47,9 +47,18 @@ global.document = {
     querySelector: jest.fn(() => ({
         getContext: jest.fn(() => ({ measureText: () => ({ width: 42 }) }))
     })),
-    body: { innerHTML: "" },
-    createElement: jest.fn(() => ({
-        getContext: jest.fn(() => ({ measureText: () => ({ width: 42 }) }))
+    body: {
+        innerHTML: "",
+        appendChild: jest.fn()
+    },
+    createElement: jest.fn(tagName => ({
+        getContext: jest.fn(() => ({ measureText: () => ({ width: 42 }) })),
+        setAttribute: jest.fn(),
+        getAttribute: jest.fn(),
+        style: {},
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        tagName: tagName ? tagName.toUpperCase() : ""
     }))
 };
 
@@ -125,7 +134,9 @@ const {
     processMacroData,
     hideDOMLabel,
     displayMsg,
-    _
+    _,
+    CameraManager,
+    announceToScreenReader
 } = require("../utils.js");
 
 describe("Utility Functions (logic-only)", () => {
@@ -1278,5 +1289,91 @@ describe("importMembers() additional branches", () => {
         const obj = new Lonely();
         expect(() => importMembers(obj)).not.toThrow();
         delete global.Lonely;
+    });
+});
+
+describe("announceToScreenReader()", () => {
+    let mockElement;
+    beforeEach(() => {
+        mockElement = { setAttribute: jest.fn(), style: {} };
+        document.getElementById = jest.fn(() => null);
+        document.createElement = jest.fn(() => mockElement);
+        document.body.appendChild = jest.fn();
+    });
+
+    it("creates a live region and sets textContent", () => {
+        announceToScreenReader("Test message 1");
+        expect(document.createElement).toHaveBeenCalledWith("div");
+        expect(mockElement.id).toBe("mbA11yLiveRegion");
+        expect(mockElement.textContent).toBe("Test message 1");
+        expect(mockElement.setAttribute).toHaveBeenCalledWith("aria-live", "polite");
+        expect(document.body.appendChild).toHaveBeenCalledWith(mockElement);
+    });
+
+    it("reuses the existing live region", () => {
+        document.getElementById = jest.fn(() => mockElement);
+        announceToScreenReader("Second message");
+        expect(document.createElement).not.toHaveBeenCalled();
+        expect(mockElement.textContent).toBe("Second message");
+    });
+});
+
+describe("CameraManager", () => {
+    beforeEach(() => {
+        CameraManager.reset();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        CameraManager.reset();
+        jest.useRealTimers();
+    });
+
+    it("starts and stops capture correctly", () => {
+        const drawFn = jest.fn();
+        const id = CameraManager.startCapture(drawFn, 100);
+        expect(id).not.toBeNull();
+        expect(CameraManager.intervalId).toBe(id);
+
+        jest.advanceTimersByTime(250);
+        expect(drawFn).toHaveBeenCalledTimes(2);
+
+        CameraManager.stopCapture();
+        expect(CameraManager.intervalId).toBeNull();
+
+        jest.advanceTimersByTime(200);
+        expect(drawFn).toHaveBeenCalledTimes(2); // Should not increase
+    });
+
+    it("startCapture is idempotent", () => {
+        const id1 = CameraManager.startCapture(jest.fn(), 100);
+        const id2 = CameraManager.startCapture(jest.fn(), 100);
+        expect(id1).toBe(id2);
+    });
+
+    it("sets and clears canplay listener", () => {
+        const video = {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        };
+        const handler = jest.fn();
+
+        CameraManager.setCanplayListener(video, handler);
+        expect(video.addEventListener).toHaveBeenCalledWith("canplay", handler, false);
+        expect(CameraManager.canPlayHandler).toBe(handler);
+        expect(CameraManager.listenerVideoElement).toBe(video);
+
+        CameraManager.clearCanplayListener();
+        expect(video.removeEventListener).toHaveBeenCalledWith("canplay", handler, false);
+        expect(CameraManager.canPlayHandler).toBeNull();
+        expect(CameraManager.listenerVideoElement).toBeNull();
+    });
+
+    it("reset clears interval and listener", () => {
+        CameraManager.intervalId = 123;
+        CameraManager.isSetup = true;
+        CameraManager.reset();
+        expect(CameraManager.intervalId).toBeNull();
+        expect(CameraManager.isSetup).toBe(false);
     });
 });


### PR DESCRIPTION
## Description

This PR adds missing unit tests to `js/utils/__tests__/utils.test.js` to cover pure logic utility functions from `js/utils/utils.js`. 


## PR Category

-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   Added `describe("CameraManager")` test suite checking idempotency (preventing interval leaks on rapid repeated calls), `setInterval`/`clearInterval` handling, and strict `canplay` event listener cleanup.
-   Added `describe("announceToScreenReader")` test suite verifying the `mbA11yLiveRegion` DOM element is properly created, correctly configured with ARIA attributes (`aria-live="polite"`), and effectively reused without duplication.
-   Updated the `document.createElement` global mock within `utils.test.js` to correctly support `setAttribute`, `getAttribute`, `addEventListener`, and `removeEventListener`.

## Testing Performed

-   Ran specific test suite locally: `npx jest js/utils/__tests__/utils.test.js --coverage --collectCoverageFrom=js/utils/utils.js` (All 151 tests in this suite pass).
-   Verified test coverage bump explicitly for the `utils.js` file.
-   Ran the full application test suite (`npm test`) locally to ensure the updated `createElement` mock caused no regressions.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
