### PR TITLE
feat(utils): add safeNumber utility function to utils-logic

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -33,7 +33,8 @@ const {
     deepClone,
     isSafeUrl,
     isUnsafeObjectKey,
-    isValidHex
+    isValidHex,
+    safeNumber
 } = require("../utils-logic.js");
 
 describe("Utility Logic Functions", () => {
@@ -251,6 +252,30 @@ describe("Utility Logic Functions", () => {
             expect(clampNumber("invalid", 0, 10)).toBe(0);
             expect(clampNumber(NaN, 0, 10, 5)).toBe(5);
             expect(clampNumber(null, 0, 10)).toBe(0);
+        });
+    });
+
+    describe("safeNumber()", () => {
+        it("returns finite numbers as is", () => {
+            expect(safeNumber(42)).toBe(42);
+            expect(safeNumber(3.14)).toBe(3.14);
+            expect(safeNumber(0)).toBe(0);
+            expect(safeNumber(-10)).toBe(-10);
+        });
+
+        it("parses valid numeric strings", () => {
+            expect(safeNumber("42")).toBe(42);
+            expect(safeNumber("  100  ")).toBe(100);
+            expect(safeNumber("-15.5")).toBe(-15.5);
+        });
+
+        it("returns fallback for non-numeric, NaN, or non-finite inputs", () => {
+            expect(safeNumber("invalid", 10)).toBe(10);
+            expect(safeNumber(NaN, 5)).toBe(5);
+            expect(safeNumber(Infinity, 0)).toBe(0);
+            expect(safeNumber(null, 7)).toBe(7);
+            expect(safeNumber(undefined, 0)).toBe(0);
+            expect(safeNumber({}, 0)).toBe(0);
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -21,7 +21,7 @@
    deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, isUnsafeObjectKey, last,
    mixedNumber, nearestBeat, oneHundredToFraction, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, unescapeHTML, escapeHTML,
-   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex
+   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex, safeNumber
 */
 
 /**
@@ -558,6 +558,25 @@ var clampNumber = (val, min, max, fallback = min) => {
 };
 
 /**
+ * Safely parses a value into a finite number with a fallback value.
+ * @param {*} val - Value to parse into a number
+ * @param {number} [fallback=0] - Fallback numeric value if val is not finite or is NaN
+ * @returns {number} The parsed finite number or fallback value
+ */
+var safeNumber = (val, fallback = 0) => {
+    if (typeof val === "number" && Number.isFinite(val)) {
+        return val;
+    }
+    if (typeof val === "string" && val.trim() !== "") {
+        const parsed = Number(val);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+    return typeof fallback === "number" && Number.isFinite(fallback) ? fallback : 0;
+};
+
+/**
  * Converts RGB values to a hexadecimal color code.
  */
 var rgbToHex = (r, g, b) => {
@@ -677,7 +696,8 @@ var UtilsLogic = {
     hex2rgb,
     resolveObject,
     clampNumber,
-    isValidHex
+    isValidHex,
+    safeNumber
 };
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Description

Introduces a pure, dependency-free `safeNumber(val, fallback)` helper function to `js/utils/utils-logic.js`.

This utility safely parses string numbers (e.g. `"42"`, `"-15.5"`) into finite numbers and provides fallback handling for `NaN`, non-finite, or non-numeric inputs (`null`, `undefined`, objects):
- `safeNumber("42")` -> `42`
- `safeNumber(3.14)` -> `3.14`
- `safeNumber("invalid", 10)` -> `10`
- `safeNumber(NaN, 5)` -> `5`
- `safeNumber(null, 0)` -> `0`

1. **Widget Range Input Parsing (`js/widgets/pitchslider.js`)**:
   ```javascript
   // Current: Returns NaN if slider.value is empty or malformed
   const currentValue = parseFloat(slider.value);
   // Planned refactor with safeNumber: Safely defaults to fallback frequency (392 Hz)
   const currentValue = safeNumber(slider.value, 392);

## Related Issue

N/A

## PR Category

- [x] Enhancement / Feature — New features or improvements to existing functionality
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/utils/utils-logic.js`**:
  - Added `safeNumber(val, fallback)` parsing helper function.
  - Added `safeNumber` to export comment header and `UtilsLogic` export object.
- **`js/utils/__tests__/utils-logic.test.js`**:
  - Added unit test suite covering finite numbers, numeric strings, and non-numeric/NaN fallback inputs (64/64 passed).

## Testing Performed

- Ran local Jest test suite: `npx jest js/utils/__tests__/utils-logic.test.js` (64/64 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
