### PR TITLE
feat: announce previewed note to screen readers (#6608)

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -75,6 +75,7 @@ global.platformColor = {
     accidentalsWheelcolorspush: "#cccccc"
 };
 global._ = jest.fn(s => s);
+global.announceToScreenReader = jest.fn();
 global.Tone = {
     start: jest.fn().mockResolvedValue(),
     context: { state: "running" }
@@ -188,6 +189,42 @@ describe("piemenus behavioral tests", () => {
         // prevPitch+delta = 4+1 = 5. 5 > 4, so deltaOctave = -1.
         // Octave 4 -> 3.
         expect(mockBlock.blocks.setPitchOctave).toHaveBeenCalledWith("mock-id", 3);
+    });
+    test("announces the previewed note to screen readers on pitch navigation", async () => {
+        const noteLabels = ["C", "D", "E", "F", "G", "A", "B"];
+        const noteValues = ["C", "D", "E", "F", "G", "A", "B"];
+
+        mockBlock.blocks.blockList["mock-id"].name = "pitch";
+
+        piemenuPitches(mockBlock, noteLabels, noteValues, ["♯", "♭"], "B", "");
+
+        const navigateFunc = mockBlock._pitchWheel.navItems[0].navigateFunction;
+        mockBlock._pitchWheel.selectedNavItemIndex = 0;
+        mockBlock._pitchWheel.navItems[0].title = "C";
+
+        await navigateFunc();
+
+        expect(global.announceToScreenReader).toHaveBeenCalledWith(expect.stringContaining("C"));
+    });
+
+    test("does not announce when the trigger is locked (rapid navigation)", async () => {
+        const noteLabels = ["C", "D", "E", "F", "G", "A", "B"];
+        const noteValues = ["C", "D", "E", "F", "G", "A", "B"];
+
+        mockBlock.blocks.blockList["mock-id"].name = "pitch";
+
+        piemenuPitches(mockBlock, noteLabels, noteValues, ["♯", "♭"], "B", "");
+
+        const navigateFunc = mockBlock._pitchWheel.navItems[0].navigateFunction;
+        mockBlock._pitchWheel.selectedNavItemIndex = 0;
+        mockBlock._pitchWheel.navItems[0].title = "C";
+
+        mockBlock._triggerLock = true;
+        global.announceToScreenReader.mockClear();
+
+        await navigateFunc();
+
+        expect(global.announceToScreenReader).not.toHaveBeenCalled();
     });
 
     describe("Phrase Maker refresh on pitch change", () => {

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -22,7 +22,7 @@
    FIXEDSOLFEGE, NOTENAMES, numberToPitch,
     nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
     _THIS_IS_TURTLE_BLOCKS_,
-    CHORDNAMES, Synth, Tone, activity
+    CHORDNAMES, Synth, Tone, activity, announceToScreenReader
 */
 
 /*
@@ -36,7 +36,7 @@
         nthDegreeToPitch, SOLFEGENAMES, buildScale
 
      - js/utils/utils.js
-        _, last, docById
+        _, last, docById, announceToScreenReader
      - js/turtle-singer.js
         Singer
      - js/utils/munsell.js
@@ -813,6 +813,11 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
                         null,
                         false
                     );
+                    // Trigger note with proper error handling
+                    // Announce the previewed note to screen readers (screen
+                    // reader only, no visual message). Naturally throttled by
+                    // _triggerLock, so rapid wheel navigation doesn't spam.
+                    announceToScreenReader(_("played") + " " + obj[0] + obj[1]);
                 } catch (e) {
                     console.error("Synth trigger error:", e);
                 }


### PR DESCRIPTION
## Description

Adds a screen reader announcement when a note is previewed via the pitch
pie menu (e.g. navigating pitch options with the wheel in `js/piemenus.js`).
Currently, sighted users hear the preview tone play, but screen reader
users get no textual confirmation of which note was previewed.

Deliberately scoped to single-note, user-initiated preview (pie menu
navigation) rather than full program playback — announcing every note
during a running program would fire many times per second and become
an unusable stream of announcements. This reuses the existing
`_triggerLock` cooldown (125ms) that already guards the preview trigger,
so rapid wheel navigation doesn't produce overlapping announcements
either.

Uses the shared `announceToScreenReader()` helper (introduced in #7764).

## Related Issue

Part of #6608

## Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD

## Testing Performed

### How to test locally

1. Run `npm run serve` and open `http://localhost:3000`
2. Enable VoiceOver (Cmd+F5 on Mac) or NVDA on Windows
3. Drag a Pitch block onto the canvas, click it to open the pitch pie menu
4. Navigate through pitch options on the wheel
5. VoiceOver should announce e.g. "played C4" as each pitch is previewed

### Test cases

1. Announcement fires with the previewed note name/octave on wheel
   navigation
2. Announcement is correctly suppressed while `_triggerLock` is active
   (rapid navigation), preventing overlapping announcements
3. Existing `piemenuPitches` test suite (12 tests total) still passes
   unchanged
4. `npx eslint` and `npx prettier --check` clean on both changed files

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts