### PR TITLE
feat(utils): add formatSeconds duration formatting utility function

### DIFF
--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -35,7 +35,8 @@ const {
     isUnsafeObjectKey,
     isValidHex,
     safeNumber,
-    toArray
+    toArray,
+    formatSeconds
 } = require("../utils-logic.js");
 
 describe("Utility Logic Functions", () => {
@@ -297,6 +298,33 @@ describe("Utility Logic Functions", () => {
         it("returns an empty array for null or undefined", () => {
             expect(toArray(null)).toEqual([]);
             expect(toArray(undefined)).toEqual([]);
+        });
+    });
+
+    describe("formatSeconds()", () => {
+        it("formats seconds into MM:SS format", () => {
+            expect(formatSeconds(0)).toBe("00:00");
+            expect(formatSeconds(5)).toBe("00:05");
+            expect(formatSeconds(65)).toBe("01:05");
+            expect(formatSeconds(125)).toBe("02:05");
+        });
+
+        it("formats large durations into HH:MM:SS format", () => {
+            expect(formatSeconds(3600)).toBe("01:00:00");
+            expect(formatSeconds(3665)).toBe("01:01:05");
+        });
+
+        it("handles numeric string inputs", () => {
+            expect(formatSeconds("125")).toBe("02:05");
+            expect(formatSeconds("65.8")).toBe("01:05");
+        });
+
+        it("returns fallback 00:00 for invalid or negative inputs", () => {
+            expect(formatSeconds(-10)).toBe("00:00");
+            expect(formatSeconds(NaN)).toBe("00:00");
+            expect(formatSeconds(null)).toBe("00:00");
+            expect(formatSeconds(undefined)).toBe("00:00");
+            expect(formatSeconds("invalid")).toBe("00:00");
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -21,7 +21,7 @@
    deepClone, fileBasename, fileExt, hex2rgb, hexToRGB, isSafeUrl, isUnsafeObjectKey, last,
    mixedNumber, nearestBeat, oneHundredToFraction, rationalSum, rgbToHex,
    safeSVG, safeJSONParse, toFixed2, toTitleCase, unescapeHTML, escapeHTML,
-   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex, safeNumber, toArray
+   rationalToFraction, GCD, LCD, resolveObject, clampNumber, isValidHex, safeNumber, toArray, formatSeconds
 */
 
 /**
@@ -588,6 +588,29 @@ var toArray = val => {
 };
 
 /**
+ * Formats a duration in seconds into a standardized digital time display string (MM:SS or HH:MM:SS).
+ * @param {number|string} seconds - Duration in seconds
+ * @returns {string} Formatted duration string e.g. "02:05" or "01:01:05", defaulting to "00:00" for invalid inputs
+ */
+var formatSeconds = seconds => {
+    if (seconds === null || seconds === undefined) return "00:00";
+    const num = Number(seconds);
+    if (!Number.isFinite(num) || num < 0) return "00:00";
+
+    const totalSecs = Math.floor(num);
+    const hours = Math.floor(totalSecs / 3600);
+    const mins = Math.floor((totalSecs % 3600) / 60);
+    const secs = totalSecs % 60;
+
+    const pad = n => String(n).padStart(2, "0");
+
+    if (hours > 0) {
+        return `${pad(hours)}:${pad(mins)}:${pad(secs)}`;
+    }
+    return `${pad(mins)}:${pad(secs)}`;
+};
+
+/**
  * Converts RGB values to a hexadecimal color code.
  */
 var rgbToHex = (r, g, b) => {
@@ -709,7 +732,8 @@ var UtilsLogic = {
     clampNumber,
     isValidHex,
     safeNumber,
-    toArray
+    toArray,
+    formatSeconds
 };
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Description

Introduces a pure, dependency-free `formatSeconds(seconds)` utility function to `js/utils/utils-logic.js`.

This helper formats durations in seconds into standardized digital time display strings (`MM:SS` or `HH:MM:SS`) with fallback handling for negative or non-numeric inputs:
- `formatSeconds(0)` -> `"00:00"`
- `formatSeconds(125)` -> `"02:05"`
- `formatSeconds(3665)` -> `"01:01:05"`
- `formatSeconds("125")` -> `"02:05"`
- `formatSeconds(null)` -> `"00:00"`

## Related Issue

N/A

## PR Category

- [x] Enhancement / Feature — New features or improvements to existing functionality
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/utils/utils-logic.js`**:
  - Added `formatSeconds(seconds)` duration formatting helper function.
  - Added `formatSeconds` to export comment header and `UtilsLogic` export object.
- **`js/utils/__tests__/utils-logic.test.js`**:
  - Added unit test suite covering `MM:SS` format, `HH:MM:SS` format, numeric string inputs, and negative/invalid fallbacks (65/65 passed).
    
## Testing Performed

- Ran local Jest test suite: `npx jest js/utils/__tests__/utils-logic.test.js` (65/65 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

t give me whole description
6:35 PM
markdown
## Description
Introduces a pure, dependency-free `formatSeconds(seconds)` utility function to `js/utils/utils-logic.js`.
This helper formats durations in seconds into standardized digital time display strings (`MM:SS` or `HH:MM:SS`) with fallback handling for negative or non-numeric inputs:
- `formatSeconds(0)` -> `"00:00"`
- `formatSeconds(125)` -> `"02:05"`
- `formatSeconds(3665)` -> `"01:01:05"`
- `formatSeconds("125")` -> `"02:05"`
- `formatSeconds(null)` -> `"00:00"`
## Planned Usage Examples
The `formatSeconds` helper standardizes digital time duration formatting across multiple components in MusicBlocks:
### 1. Screen & Canvas Recording Timer (`js/activity/recorder.js`)
Formatting live recording duration timers in the toolbar:
```javascript
// BEFORE:
const mins = Math.floor(elapsed / 60);
const secs = Math.floor(elapsed % 60);
const timeStr = `${mins < 10 ? "0" : ""}${mins}:${secs < 10 ? "0" : ""}${secs}`;
// AFTER:
const timeStr = formatSeconds(elapsed);
```
### 2. Project Statistics & Duration Analytics (js/widgets/statistics.js)
Formatting calculated total piece playback duration into human-readable minutes and seconds:
```javascript
// BEFORE:
const formattedTime = Math.floor(totalSeconds / 60) + ":" + (totalSeconds % 60);

// AFTER:
const formattedTime = formatSeconds(totalSeconds);
```
### 3. Rhythm & Playback Timeline Progress (js/widgets/rhythmruler.js)
Displaying elapsed track duration during piece playback:
```javascript
// BEFORE:
const displayTime = Math.floor(currentTime / 60) + ":" + Math.floor(currentTime % 60);

// AFTER:
const displayTime = formatSeconds(currentTime);
```


