### PR TITLE
fix(turtleactions): add defensive BPM tempo bounds clamping in MeterActions

### DIFF
--- a/js/turtleactions/MeterActions.js
+++ b/js/turtleactions/MeterActions.js
@@ -109,7 +109,7 @@ function setupMeterActions(activity) {
         static setBPM(bpm, beatValue, turtle, blk) {
             let _bpm = (bpm * beatValue) / 0.25;
             let obj, target;
-            if (_bpm < 30) {
+            if (Number.isNaN(_bpm) || !Number.isFinite(_bpm) || _bpm < 30) {
                 obj = rationalToFraction(beatValue);
                 target = (30 * 0.25) / beatValue;
                 activity.errorMsg(
@@ -133,7 +133,7 @@ function setupMeterActions(activity) {
         static setMasterBPM(bpm, beatValue, blk) {
             const _bpm = (bpm * beatValue) / 0.25;
             let obj, target;
-            if (_bpm < 30) {
+            if (Number.isNaN(_bpm) || !Number.isFinite(_bpm) || _bpm < 30) {
                 obj = rationalToFraction(beatValue);
                 target = (30 * 0.25) / beatValue;
                 activity.errorMsg(

--- a/js/turtleactions/__tests__/MeterActions.test.js
+++ b/js/turtleactions/__tests__/MeterActions.test.js
@@ -135,8 +135,10 @@ describe("setupMeterActions", () => {
         test.each([
             [120, 0.25, [], 120, undefined],
             [10, 0.25, ["1/4 beats per minute must be greater than 30"], 30, 1],
-            [5000, 0.25, ["maximum 1/4 beats per minute is 1000"], 1000, 1]
-        ])("setBPM(%i) should handle %s range", (bpm, factor, errors, expected, errBlk) => {
+            [5000, 0.25, ["maximum 1/4 beats per minute is 1000"], 1000, 1],
+            [NaN, 0.25, ["1/4 beats per minute must be greater than 30"], 30, 1],
+            ["invalid", 0.25, ["1/4 beats per minute must be greater than 30"], 30, 1]
+        ])("setBPM(%s) should handle %s range", (bpm, factor, errors, expected, errBlk) => {
             activity.errorMsg.mockClear();
             Singer.MeterActions.setBPM(bpm, factor, 0, errBlk);
             if (errors.length) {
@@ -151,8 +153,10 @@ describe("setupMeterActions", () => {
             [100, [], 100],
             [500, [], 500],
             [10, ["1/4 beats per minute must be greater than 30"], 30],
-            [5000, ["maximum 1/4 beats per minute is 1000"], 1000]
-        ])("setMasterBPM(%i) should result in masterBPM %i", (bpm, errors, expected) => {
+            [5000, ["maximum 1/4 beats per minute is 1000"], 1000],
+            [NaN, ["1/4 beats per minute must be greater than 30"], 30],
+            ["invalid", ["1/4 beats per minute must be greater than 30"], 30]
+        ])("setMasterBPM(%s) should result in masterBPM %i", (bpm, errors, expected) => {
             activity.errorMsg.mockClear();
             Singer.MeterActions.setMasterBPM(bpm, 0.25, 1);
             if (errors.length) {


### PR DESCRIPTION
## Description

Fixes a potential `NaN` state pollution bug in `js/turtleactions/MeterActions.js` (`setBPM()` and `setMasterBPM()`).

Currently, passing `NaN`, non-numeric strings, or `null` into `setBPM()` or `setMasterBPM()` causes `_bpm` calculation (`(bpm * beatValue) / 0.25`) to evaluate to `NaN`. Because `NaN < 30` and `NaN > 1000` both evaluate to `false`, `_bpm` is not clamped, resulting in `Singer.masterBPM` becoming `NaN` and `Singer.defaultBPMFactor = TONEBPM / NaN` becoming `NaN`, which freezes audio playback note durations.

This PR adds `Number.isNaN(_bpm) || !Number.isFinite(_bpm)` checks to safely catch invalid inputs and apply the default minimum BPM bound error handling.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Non-breaking change which fixes an issue
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/turtleactions/MeterActions.js`**:
  - Added `Number.isNaN(_bpm) || !Number.isFinite(_bpm)` bounds guards in `setBPM()` and `setMasterBPM()`.
- **`js/turtleactions/__tests__/MeterActions.test.js`**:
  - Added unit test cases verifying `NaN` and non-numeric input bounds handling in `setBPM()` and `setMasterBPM()` (53/53 passed).

## Testing Performed

- Ran local Jest test suite: `npx jest js/turtleactions/__tests__/MeterActions.test.js` (53/53 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
