### PR TITLE
refactor(widgets): add stepFrequency helper & clamping to pitchslider

### DIFF
--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -22,6 +22,7 @@
 
 global._ = msg => msg;
 global.getCurrentEDO = () => 12;
+global.clampNumber = require("../../utils/utils-logic.js").clampNumber;
 
 const mockOscillator = {
     toDestination: jest.fn().mockReturnThis(),
@@ -628,6 +629,35 @@ describe("PitchSlider Widget", () => {
             expect(stack[1][4]).toEqual([0]);
             // Hertz block: [0, freq, hidden] - connects to note, frequency, hidden
             expect(stack[2][4]).toEqual([0, 3, 4]);
+        });
+    });
+
+    describe("Frequency Stepping (_stepFrequency)", () => {
+        const semitone = Math.pow(2, 1 / 12);
+
+        test("steps up by semitone ratio", () => {
+            const result = slider._stepFrequency(440, "up", semitone, 220, 880);
+            expect(result).toBeCloseTo(440 * semitone, 2);
+        });
+
+        test("steps down by semitone ratio", () => {
+            const result = slider._stepFrequency(440, "down", semitone, 220, 880);
+            expect(result).toBeCloseTo(440 / semitone, 2);
+        });
+
+        test("clamps upper bound to max", () => {
+            const result = slider._stepFrequency(870, "up", semitone, 220, 880);
+            expect(result).toBe(880);
+        });
+
+        test("clamps lower bound to min", () => {
+            const result = slider._stepFrequency(225, "down", semitone, 220, 880);
+            expect(result).toBe(220);
+        });
+
+        test("parses numeric string inputs correctly", () => {
+            const result = slider._stepFrequency("440", "up", semitone, 220, 880);
+            expect(result).toBeCloseTo(440 * semitone, 2);
         });
     });
 });

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -13,7 +13,7 @@
 // from given frequency to nextoctave frequency(two times the given frequency)
 // in continuous manner.
 
-/* global _, Tone, getCurrentEDO */
+/* global _, Tone, getCurrentEDO, clampNumber */
 
 /*
    Global locations
@@ -92,10 +92,16 @@ class PitchSlider {
 
                     if (event.key === "ArrowUp" || event.key === "ArrowRight") {
                         // Move up by a semitone
-                        slider.value = Math.min(currentValue * semitone, max);
+                        slider.value = this._stepFrequency(currentValue, "up", semitone, min, max);
                     } else if (event.key === "ArrowDown" || event.key === "ArrowLeft") {
                         // Move down by a semitone
-                        slider.value = Math.max(currentValue / semitone, min);
+                        slider.value = this._stepFrequency(
+                            currentValue,
+                            "down",
+                            semitone,
+                            min,
+                            max
+                        );
                     }
 
                     const inputEvent = new Event("input", { bubbles: true });
@@ -162,7 +168,7 @@ class PitchSlider {
                 _("Move up"),
                 toolBarDiv
             ).onclick = () => {
-                slider.value = Math.min(parseFloat(slider.value) * semitone, max);
+                slider.value = this._stepFrequency(slider.value, "up", semitone, min, max);
                 changeFreq();
                 oscillators[id].triggerAttackRelease(this.frequencies[id], "4n");
             };
@@ -173,7 +179,7 @@ class PitchSlider {
                 _("Move down"),
                 toolBarDiv
             ).onclick = () => {
-                slider.value = Math.max(parseFloat(slider.value) / semitone, min);
+                slider.value = this._stepFrequency(slider.value, "down", semitone, min, max);
                 changeFreq();
                 oscillators[id].triggerAttackRelease(this.frequencies[id], "4n");
             };
@@ -195,6 +201,23 @@ class PitchSlider {
         activity.textMsg(_("Use the up/down buttons or arrow keys to change pitch."), 3000);
         activity.textMsg(_("Click on the slider to create a note block."), 3000);
         window.requestAnimationFrame(() => this.widgetWindow.sendToCenter());
+    }
+
+    /**
+     * Calculates semitone frequency step with bounds clamping.
+     *
+     * @private
+     * @param {number|string} currentValue
+     * @param {string} direction - "up" or "down"
+     * @param {number} semitone
+     * @param {number} min
+     * @param {number} max
+     * @returns {number} Clamped frequency value
+     */
+    _stepFrequency(currentValue, direction, semitone, min, max) {
+        const val = parseFloat(currentValue);
+        const target = direction === "up" ? val * semitone : val / semitone;
+        return clampNumber(target, min, max);
     }
 
     /**


### PR DESCRIPTION
## Description

Refactor and modernize the `PitchSlider` interactive pitch widget (`js/widgets/pitchslider.js`) by extracting modular frequency stepping helper logic (`_stepFrequency`) and enforcing safe numeric bounds clamping using `clampNumber()`.

Previously, frequency stepping calculations (`Math.min(currentValue * semitone, max)` and `Math.max(currentValue / semitone, min)`) were duplicated across keyboard event handlers (`ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`) and toolbar button click handlers (`Move up`, `Move down`). 

This PR extracts `_stepFrequency(currentValue, direction, semitone, min, max)` to centralize frequency scaling and enforce defensive numeric bounds clamping.

## Related Issue

N/A

## PR Category

- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/widgets/pitchslider.js`**:
  - Extracted `_stepFrequency(currentValue, direction, semitone, min, max)` helper method to encapsulate semitone calculation and clamp values safely using `clampNumber()`.
  - Refactored `keyHandler` and toolbar button click handlers (`Move up` / `Move down`) to utilize `_stepFrequency()`.
  - Added `clampNumber` to global comment header.
- **`js/widgets/__tests__/pitchslider.test.js`**:
  - Added `global.clampNumber` test setup.
  - Added unit test suite covering `_stepFrequency` semitone stepping, upper/lower bounds clamping, and numeric string parsing (65/65 passed).

## Testing Performed

- Ran local Jest test suite: `npx jest js/widgets/__tests__/pitchslider.test.js` (65/65 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
