### PR TITLE
perf(startup): lazy-load optional widget modules

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -196,6 +196,8 @@ let MYDEFINES = [
     "widgets/widgetWindows"
 ];
 
+// Optional widget implementations are loaded by WidgetBlocks on first use.
+
 /**
  * Dynamically load one or more RequireJS modules on demand.
  * Returns a Promise that resolves once all modules are loaded.
@@ -216,35 +218,6 @@ function lazyLoad(modulePaths) {
             resolve();
         });
     });
-}
-
-if (_THIS_IS_MUSIC_BLOCKS_) {
-    const MUSICBLOCKS_EXTRAS = [
-        "widgets/modewidget",
-        "widgets/meterwidget",
-        "widgets/PhraseMakerUtils",
-        "widgets/PhraseMakerGrid",
-        "widgets/PhraseMakerUI",
-        "widgets/PhraseMakerAudio",
-        "widgets/phrasemaker",
-        "widgets/arpeggio",
-        "widgets/aiwidget",
-        "widgets/aidebugger",
-        "widgets/pitchdrummatrix",
-        "widgets/rhythmruler",
-        "widgets/pitchstaircase",
-        "widgets/temperament",
-        "widgets/tempo",
-        "widgets/pitchslider",
-        "widgets/musickeyboard",
-        "widgets/timbre",
-        "widgets/oscilloscope",
-        "widgets/tuner",
-        "widgets/sampler",
-        "widgets/reflection",
-        "widgets/legobricks"
-    ];
-    MYDEFINES = MYDEFINES.concat(MUSICBLOCKS_EXTRAS);
 }
 
 // Module-scoped singleton reference to the active Activity instance.

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -86,6 +86,18 @@ function setupWidgetBlocks(activity) {
     }
 
     /**
+     * Use a widget's declared dependencies when its constructor is already
+     * available, otherwise fall back to the module ids needed to load it.
+     *
+     * @param {Function|null} widget - The loaded widget constructor, if any.
+     * @param {string[]} fallback - AMD module ids for the widget.
+     * @returns {string[]} Module ids to pass to the lazy loader.
+     */
+    function _getWidgetDependencies(widget, fallback) {
+        return widget && Array.isArray(widget.dependencies) ? widget.dependencies : fallback;
+    }
+
+    /**
      * Ensures that a widget is loaded and initialized before executing block logic.
      * If the widget is missing, it initiates a lazy load and returns an interruption signal.
      *
@@ -371,7 +383,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "temperament",
-                TemperamentWidget.dependencies,
+                _getWidgetDependencies(
+                    typeof TemperamentWidget !== "undefined" ? TemperamentWidget : null,
+                    ["widgets/temperament"]
+                ),
                 () => new TemperamentWidget(),
                 turtle,
                 blk,
@@ -459,7 +474,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "sample",
-                SampleWidget.dependencies,
+                _getWidgetDependencies(typeof SampleWidget !== "undefined" ? SampleWidget : null, [
+                    "widgets/tuner",
+                    "widgets/sampler"
+                ]),
                 () => new SampleWidget(),
                 turtle,
                 blk,
@@ -550,7 +568,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "timbre",
-                TimbreWidget.dependencies,
+                _getWidgetDependencies(typeof TimbreWidget !== "undefined" ? TimbreWidget : null, [
+                    "widgets/timbre"
+                ]),
                 () => new TimbreWidget(),
                 turtle,
                 blk,
@@ -668,7 +688,10 @@ function setupWidgetBlocks(activity) {
                 _lazyLoadWidget(
                     logo,
                     "meterWidget",
-                    MeterWidget.dependencies,
+                    _getWidgetDependencies(
+                        typeof MeterWidget !== "undefined" ? MeterWidget : null,
+                        ["widgets/meterwidget"]
+                    ),
                     () => new MeterWidget(activity, blk),
                     () => {
                         logo.insideMeterWidget = false;
@@ -745,7 +768,10 @@ function setupWidgetBlocks(activity) {
                 _lazyLoadWidget(
                     logo,
                     "Oscilloscope",
-                    Oscilloscope.dependencies,
+                    _getWidgetDependencies(
+                        typeof Oscilloscope !== "undefined" ? Oscilloscope : null,
+                        ["widgets/oscilloscope"]
+                    ),
                     () => new Oscilloscope(activity),
                     () => {
                         logo.inOscilloscope = false;
@@ -810,7 +836,9 @@ function setupWidgetBlocks(activity) {
                 _lazyLoadWidget(
                     logo,
                     "modeWidget",
-                    ModeWidget.dependencies,
+                    _getWidgetDependencies(typeof ModeWidget !== "undefined" ? ModeWidget : null, [
+                        "widgets/modewidget"
+                    ]),
                     () => new ModeWidget(activity),
                     () => {
                         logo.insideModeWidget = false;
@@ -872,7 +900,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "tempo",
-                Tempo.dependencies,
+                _getWidgetDependencies(typeof Tempo !== "undefined" ? Tempo : null, [
+                    "widgets/tempo"
+                ]),
                 () => new Tempo(),
                 turtle,
                 blk,
@@ -949,7 +979,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "arpeggio",
-                Arpeggio.dependencies,
+                _getWidgetDependencies(typeof Arpeggio !== "undefined" ? Arpeggio : null, [
+                    "widgets/arpeggio"
+                ]),
                 () => new Arpeggio(),
                 turtle,
                 blk,
@@ -1032,7 +1064,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "pitchDrumMatrix",
-                PitchDrumMatrix.dependencies,
+                _getWidgetDependencies(
+                    typeof PitchDrumMatrix !== "undefined" ? PitchDrumMatrix : null,
+                    ["widgets/pitchdrummatrix"]
+                ),
                 () => new PitchDrumMatrix(),
                 turtle,
                 blk,
@@ -1114,7 +1149,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "pitchSlider",
-                PitchSlider.dependencies,
+                _getWidgetDependencies(typeof PitchSlider !== "undefined" ? PitchSlider : null, [
+                    "widgets/pitchslider"
+                ]),
                 () => new PitchSlider(),
                 turtle,
                 blk,
@@ -1274,7 +1311,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "musicKeyboard",
-                MusicKeyboard.dependencies,
+                _getWidgetDependencies(
+                    typeof MusicKeyboard !== "undefined" ? MusicKeyboard : null,
+                    ["widgets/musickeyboard"]
+                ),
                 () => new MusicKeyboard(activity),
                 turtle,
                 blk,
@@ -1347,7 +1387,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "pitchStaircase",
-                PitchStaircase.dependencies,
+                _getWidgetDependencies(
+                    typeof PitchStaircase !== "undefined" ? PitchStaircase : null,
+                    ["widgets/pitchstaircase"]
+                ),
                 () => new PitchStaircase(),
                 turtle,
                 blk,
@@ -1463,7 +1506,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "rhythmRuler",
-                RhythmRuler.dependencies,
+                _getWidgetDependencies(typeof RhythmRuler !== "undefined" ? RhythmRuler : null, [
+                    "widgets/rhythmruler"
+                ]),
                 () => new RhythmRuler(),
                 turtle,
                 blk,
@@ -1672,7 +1717,13 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "phraseMaker",
-                PhraseMaker.dependencies,
+                _getWidgetDependencies(typeof PhraseMaker !== "undefined" ? PhraseMaker : null, [
+                    "widgets/PhraseMakerUtils",
+                    "widgets/PhraseMakerGrid",
+                    "widgets/PhraseMakerUI",
+                    "widgets/PhraseMakerAudio",
+                    "widgets/phrasemaker"
+                ]),
                 () => {
                     // Create explicit dependency object for PhraseMaker
                     const phraseMakerDeps = {
@@ -1991,7 +2042,9 @@ function setupWidgetBlocks(activity) {
                 const interruption = _ensureWidget(
                     logo,
                     "aiMusic",
-                    AIWidget.dependencies,
+                    _getWidgetDependencies(typeof AIWidget !== "undefined" ? AIWidget : null, [
+                        "widgets/aiwidget"
+                    ]),
                     () => new AIWidget(),
                     turtle,
                     blk,
@@ -2042,7 +2095,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "reflection",
-                ReflectionMatrix.dependencies,
+                _getWidgetDependencies(
+                    typeof ReflectionMatrix !== "undefined" ? ReflectionMatrix : null,
+                    ["widgets/reflection"]
+                ),
                 () => new ReflectionMatrix(),
                 turtle,
                 blk,
@@ -2126,7 +2182,9 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "legoWidget",
-                LegoWidget.dependencies,
+                _getWidgetDependencies(typeof LegoWidget !== "undefined" ? LegoWidget : null, [
+                    "widgets/legobricks"
+                ]),
                 () => new LegoWidget(),
                 turtle,
                 blk,
@@ -2196,7 +2254,10 @@ function setupWidgetBlocks(activity) {
             const interruption = _ensureWidget(
                 logo,
                 "aiDebugger",
-                AIDebuggerWidget.dependencies,
+                _getWidgetDependencies(
+                    typeof AIDebuggerWidget !== "undefined" ? AIDebuggerWidget : null,
+                    ["widgets/aidebugger"]
+                ),
                 () => new AIDebuggerWidget(),
                 turtle,
                 blk,

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -135,7 +135,7 @@ global.TimbreWidget = jest.fn(() => ({
 }));
 global.TimbreWidget.dependencies = ["widgets/timbre"];
 global.SampleWidget = jest.fn(() => ({ init: jest.fn() }));
-global.SampleWidget.dependencies = ["widgets/sampler"];
+global.SampleWidget.dependencies = ["widgets/tuner", "widgets/sampler"];
 global.AIDebuggerWidget = jest.fn(() => ({ init: jest.fn() }));
 global.AIDebuggerWidget.dependencies = ["widgets/aidebugger"];
 global.TemperamentWidget = jest.fn(() => ({
@@ -702,26 +702,18 @@ describe("setupWidgetBlocks", () => {
         });
     });
 
-    describe("Widget dependency metadata wiring", () => {
+    describe("Widget dependency resolution", () => {
         // _ensureWidget()/_lazyLoadWidget() are local closures inside
         // setupWidgetBlocks() and aren't exported, so their `modules`
         // argument can't be intercepted at runtime without changing the
         // loader itself, and in this non-AMD test environment `_lazyRequire`
         // (which both of them delegate to) ignores `modules` entirely, so no
         // behavioural test can observe it either. As a last resort, a single
-        // source-text check confirms every call site reads modules from the
-        // widget's own static `dependencies` rather than a hardcoded
-        // literal; kept to one test (not one per widget) since it's the
-        // wiring itself being checked, not per-widget behaviour -- the
-        // behavioural tests below cover that.
-        //
-        // Caveat: this relies on source-text matching, which can become
-        // brittle during future refactors (e.g. reformatting the
-        // _ensureWidget/_lazyLoadWidget calls). If dependency resolution is
-        // ever exposed through a helper or otherwise made observable
-        // behaviourally, prefer replacing these regex assertions with
-        // behavioural tests.
-        it("every _ensureWidget/_lazyLoadWidget call site reads modules from its widget's dependencies", () => {
+        // source-text check confirms every call site resolves dependencies
+        // from the widget metadata when available and supplies a fallback
+        // module id when the widget is not part of the startup dependency
+        // graph. The behavioural tests below cover the loading paths.
+        it("resolves widget dependencies with startup-safe fallbacks", () => {
             const widgetBlocksSource = require("fs").readFileSync(
                 require("path").join(__dirname, "..", "WidgetBlocks.js"),
                 "utf8"
@@ -752,21 +744,19 @@ describe("setupWidgetBlocks", () => {
             const notWired = [];
             for (const [widgetKey, className] of ensureWidgetSites) {
                 const callSite = new RegExp(
-                    `_ensureWidget\\(\\s*logo,\\s*"${widgetKey}",\\s*${className}\\.dependencies,`
+                    `_ensureWidget\\(\\s*logo,\\s*"${widgetKey}",\\s*_getWidgetDependencies\\(\\s*typeof ${className} !== "undefined" \\? ${className} : null,`
                 );
                 if (!callSite.test(widgetBlocksSource)) {
-                    notWired.push(
-                        `_ensureWidget("${widgetKey}") should read ${className}.dependencies`
-                    );
+                    notWired.push(`_ensureWidget("${widgetKey}") is missing a dependency fallback`);
                 }
             }
             for (const [widgetKey, className] of lazyLoadWidgetSites) {
                 const callSite = new RegExp(
-                    `_lazyLoadWidget\\(\\s*logo,\\s*"${widgetKey}",\\s*${className}\\.dependencies,`
+                    `_lazyLoadWidget\\(\\s*logo,\\s*"${widgetKey}",\\s*_getWidgetDependencies\\(\\s*typeof ${className} !== "undefined" \\? ${className} : null,`
                 );
                 if (!callSite.test(widgetBlocksSource)) {
                     notWired.push(
-                        `_lazyLoadWidget("${widgetKey}") should read ${className}.dependencies`
+                        `_lazyLoadWidget("${widgetKey}") is missing a dependency fallback`
                     );
                 }
             }
@@ -774,9 +764,8 @@ describe("setupWidgetBlocks", () => {
             expect(notWired).toEqual([]);
         });
 
-        // Exercise the previously-untested call sites so the metadata read
-        // (Widget.dependencies) actually executes, not just gets matched
-        // textually above.
+        // Exercise the previously-untested call sites so dependency
+        // resolution actually executes, not just gets matched textually above.
         it.each([
             ["arpeggiomatrix", "arpBlk", "arpeggio", global.Arpeggio],
             ["pitchdrummatrix", "pdmBlk", "pitchDrumMatrix", global.PitchDrumMatrix],

--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -79,6 +79,12 @@ global.TunerDisplay = class {
 
 const { SampleWidget, PitchSmoother } = require("../sampler.js");
 
+describe("SampleWidget.dependencies", () => {
+    test("includes the tuner module used by the sampler", () => {
+        expect(SampleWidget.dependencies).toEqual(["widgets/tuner", "widgets/sampler"]);
+    });
+});
+
 describe("Sampler Widget", () => {
     beforeAll(() => {
         if (!HTMLCanvasElement.prototype.getContext) {

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -15,12 +15,12 @@
 
    _, docById, DOUBLEFLAT, FLAT, NATURAL, SHARP, DOUBLESHARP,
    CUSTOMSAMPLES, wheelnav, getVoiceSynthName, Singer, DRUMS, Tone,
-   instruments, slicePath, platformColor
+   instruments, slicePath, platformColor, TunerDisplay, TunerUtils
 */
 
 /* exported SampleWidget */
 /** AMD module dependencies for lazy loading. */
-SampleWidget.dependencies = ["widgets/sampler"];
+SampleWidget.dependencies = ["widgets/tuner", "widgets/sampler"];
 
 /**
  * Represents a Sample Widget.


### PR DESCRIPTION
## Summary

Follow-up to #8073. Defer optional widget modules until they are first used, reducing unnecessary work during Music Blocks startup.

## Motivation

While investigating the slow-network startup failure, I found that 23 optional widget modules were included in the initial RequireJS dependency list. This meant users downloaded and evaluated widget code even when they never used those widgets.

## Changes

- Removed optional widget modules from the eager startup dependency list.
- Load widget implementations from `WidgetBlocks` when their blocks are first used.
- Preserve declared widget dependency metadata with safe fallback module paths.
- Include the tuner dependency when loading the Sampler widget.
- Added and updated regression tests for lazy dependency resolution.

## Expected impact

- 23 optional widget modules are deferred from startup.
- The initial application load performs less downloading, parsing, and evaluation.
- The first use of a widget will trigger one additional request of that widget .
- Later uses are served from RequireJS's module cache.


## Testing

### Automated

- `npm run lint`
- `npx prettier --check` on modified files
- `npm test -- --runInBand`

### Browser

- Confirmed optional widget files are absent during initial startup.
- Confirmed `tempo.js` loads when a Tempo block is first used.
- Confirmed `sampler.js` and `tuner.js` load when Sampler is first used.
- Confirmed subsequent uses do not issue duplicate module requests.

Related to #8070

- [x] Performance
- [x] Tests
