### PR TITLE
fix(widget-windows): make toolbar buttons keyboard accessible

### DIFF
--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -142,6 +142,12 @@
   background-color: #7bb5ee;
 }
 
+.wfbtItem:focus-visible {
+  outline: 3px solid #005a9c;
+  outline-offset: -3px;
+  background-color: #7bb5ee;
+}
+
 .wfbtItem > input {
   border: none;
   width: 100%;

--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -312,6 +312,61 @@ describe("widgetWindows", () => {
 
             expect(win._buttons).toHaveLength(3);
         });
+
+        test("is keyboard-focusable with role and aria-label", () => {
+            const win = createTestWindow();
+            const btn = win.addButton("icon.svg", 24, "My Label");
+
+            expect(btn.getAttribute("role")).toBe("button");
+            expect(btn.getAttribute("tabindex")).toBe("0");
+            expect(btn.getAttribute("aria-label")).toBe("My Label");
+        });
+
+        test("Enter key activates the caller-assigned onclick", () => {
+            const win = createTestWindow();
+            const btn = win.addButton("icon.svg", 24, "Play");
+            btn.onclick = jest.fn();
+
+            btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+            expect(btn.onclick).toHaveBeenCalledTimes(1);
+        });
+
+        test("Space key activates onclick and prevents page scroll", () => {
+            const win = createTestWindow();
+            const btn = win.addButton("icon.svg", 24, "Play");
+            btn.onclick = jest.fn();
+
+            const event = new KeyboardEvent("keydown", {
+                key: " ",
+                bubbles: true,
+                cancelable: true
+            });
+            btn.dispatchEvent(event);
+
+            expect(btn.onclick).toHaveBeenCalledTimes(1);
+            expect(event.defaultPrevented).toBe(true);
+        });
+
+        test("other keys do not activate onclick", () => {
+            const win = createTestWindow();
+            const btn = win.addButton("icon.svg", 24, "Play");
+            btn.onclick = jest.fn();
+
+            btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+            expect(btn.onclick).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("modifyButton accessibility", () => {
+        test("updates the aria-label along with the icon", () => {
+            const win = createTestWindow();
+            win.addButton("old.svg", 24, "Old Label");
+            const btn = win.modifyButton(0, "new.svg", 24, "New Label");
+
+            expect(btn.getAttribute("aria-label")).toBe("New Label");
+        });
     });
 
     describe("addDivider", () => {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -490,6 +490,7 @@ class WidgetWindow {
         img.height = iconSize;
         img.width = iconSize;
         this._buttons[index].replaceChildren(img);
+        this._buttons[index].setAttribute("aria-label", label);
         return this._buttons[index];
     }
 
@@ -546,6 +547,15 @@ class WidgetWindow {
         img.height = iconSize;
         img.width = iconSize;
         el.replaceChildren(img);
+        el.tabIndex = 0;
+        el.setAttribute("role", "button");
+        el.setAttribute("aria-label", label);
+        el.addEventListener("keydown", event => {
+            if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                el.click();
+            }
+        });
         this._buttons.push(el);
         return el;
     }


### PR DESCRIPTION
## Description

Every widget's toolbar buttons — Play, Save, Clear, Export, and the rest — are created by the shared factory `WidgetWindow.addButton` (`js/widgets/widgetWindows.js`). The factory produced a bare `<div class="wfbtItem">` with an `<img>` (only `title`/`alt` set): **no `tabindex`, no `role`, no `aria-label`, and no keyboard handler**. Callers then assign `.onclick` directly.

A search across `js/widgets/` confirms no widget toolbar button anywhere sets these attributes itself — the only accessible controls in the widget layer are the window title-bar buttons and the Help widget's arrows (`js/widgets/help.js`), which already follow the `tabIndex = 0` + `role="button"` + `aria-label` pattern this PR adopts.

**User-visible effect:** keyboard-only and switch-access users — a real audience for a classroom tool — can open any widget (Phrase Maker, Music Keyboard, Rhythm Maker, Meter, Oscilloscope, ~20 in all) but cannot reach or press a single toolbar button in any of them. Screen readers also announce these controls as plain images, not buttons. There was also no visible focus style: `.wfbtItem` only had a `:hover` rule.

**Fix (one factory, all widgets):**

-   `addButton` now sets `tabIndex = 0`, `role="button"`, and `aria-label` (from the `label` argument the callers already pass), and attaches a `keydown` handler that maps Enter/Space to `el.click()` — with `preventDefault()` so Space doesn't scroll the page. The returned element and the caller-assigned `.onclick` API are unchanged, so **zero widget files needed edits**.
-   `modifyButton` now updates the `aria-label` along with the icon, so a re-labeled button (e.g. Play → Stop) doesn't keep announcing its old name.
-   `dist/css/windows.css` gains a `.wfbtItem:focus-visible` outline so keyboard focus is actually visible (mouse clicks are unaffected — `:focus-visible` doesn't trigger on pointer interaction).

## Related Issue

No existing issue — found through code inspection while auditing keyboard accessibility across `js/widgets/`.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Tests — Adds or updates test coverage
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/widgets/widgetWindows.js` — `addButton`: `tabIndex`/`role`/`aria-label` + Enter/Space keydown activation; `modifyButton`: keeps `aria-label` in sync with the new label.
-   `dist/css/windows.css` — `.wfbtItem:focus-visible` outline (the class previously had only a `:hover` rule).
-   `js/widgets/__tests__/widgetWindows.test.js` — five new tests: attributes present (`role`/`tabindex`/`aria-label`); Enter fires the caller-assigned `onclick`; Space fires `onclick` **and** `defaultPrevented` is true; other keys do not activate; `modifyButton` updates `aria-label`.

## Testing Performed

-   Followed TDD: the four behavioral tests were written first and failed on the old code (no attributes, no keyboard activation), then passed after the factory change; the negative guard (other keys don't activate) protects against over-broad key handling.
-   `npx jest js/widgets/__tests__/widgetWindows.test.js` — 85/85 pass.
-   All `js/widgets` suites — 1,514/1,515 pass; the single failure (`sampler.test.js` getUserMedia case) is pre-existing on `master`, verified independently of this change.
-   Full Jest suite: 7,527 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit.
-   `npx eslint` on both changed JS files — clean (pre-commit hooks ran eslint + prettier).

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   Because the fix lives in the shared factory and preserves the returned element + `.onclick` contract, all ~20 widgets inherit keyboard access with no per-widget changes — and any future widget using `addButton` gets it for free.
-   Natural follow-ups kept out of scope to stay atomic: the window title-bar controls (Close/Roll-up/Maximize) are focusable but have no Enter/Space activation, and `addInputButton`/`addRangeSlider` take no label argument to derive an `aria-label` from — both are candidates for a separate PR.
-   The `:focus-visible` outline color (`#005a9c`) was chosen for contrast against the `#8cc6ff` button background; happy to adjust if the design team prefers a token from `css/tokens.css`.