### PR TITLE
ci: add DCO check for pull requests

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,62 @@
+name: DCO Check
+
+# Verifies every commit in a pull request carries a `Signed-off-by:` trailer,
+# per the Developer Certificate of Origin (https://developercertificate.org/).
+# No third-party Action: the check is a few lines of git log parsing, so
+# there's no reason to trust an external Action's supply chain for it.
+#
+# Uses `pull_request` (NOT pull_request_target): this only reads the PR's own
+# commit history, so it stays in the unprivileged, fork-safe context alongside
+# ci.yml and pr-title-check.yml.
+
+on:
+    pull_request:
+        branches: [master]
+        types: [opened, reopened, synchronize]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    dco-check:
+        name: Check DCO sign-off
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
+
+            - name: Check for Signed-off-by on every commit
+              run: |
+                  set -e
+                  base="${{ github.event.pull_request.base.sha }}"
+                  head="${{ github.event.pull_request.head.sha }}"
+                  missing=0
+
+                  for sha in $(git rev-list --no-merges "$base..$head"); do
+                    message=$(git log -1 --format=%B "$sha")
+                    if ! printf '%s\n' "$message" | grep -qE '^Signed-off-by: .+ <.+>$'; then
+                      echo "::error::Commit $sha is missing a Signed-off-by trailer."
+                      missing=1
+                    fi
+                  done
+
+                  if [ "$missing" -eq 1 ]; then
+                    echo ""
+                    echo "One or more commits are missing a DCO sign-off."
+                    echo "Fix it with:"
+                    echo "  git commit -s --amend            # last commit only"
+                    echo "  git rebase --signoff <base-branch>   # whole branch"
+                    echo "then force-push: git push --force-with-lease"
+                    echo "See: https://developercertificate.org/"
+                    exit 1
+                  fi
+
+                  echo "All commits are signed off."

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -41,7 +41,7 @@ jobs:
                   missing=0
 
                   for sha in $(git rev-list --no-merges "$base..$head"); do
-                    message=$(git log -1 --format=%B "$sha")
+                    message=$(git log -1 --format=%B "$sha" | tr -d '\r')
                     if ! printf '%s\n' "$message" | grep -qE '^Signed-off-by: .+ <.+>$'; then
                       echo "::error::Commit $sha is missing a Signed-off-by trailer."
                       missing=1
@@ -60,3 +60,4 @@ jobs:
                   fi
 
                   echo "All commits are signed off."
+                  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,28 @@ NOTE: Only run `prettier` on the files you have modified.
 
 If formatting fails, run `npx prettier --write .` to fix it.
 
+### Developer Certificate of Origin (DCO)
+
+Every commit must include a `Signed-off-by` trailer certifying you wrote the
+change or otherwise have the right to submit it under the project's license
+(see the [Developer Certificate of Origin](https://developercertificate.org/)
+for the full text). A CI check enforces this on every pull request.
+
+Add the trailer automatically with the `-s` flag:
+
+```bash
+git commit -s -m "docs: add AI contribution guidelines (Related to #XXXX)"
+```
+
+Forgot it on a commit that's already made? Fix it with:
+
+```bash
+git commit -s --amend                # amends only the last commit
+git rebase --signoff master          # adds it to every commit on the branch
+```
+
+Then force-push the branch: `git push --force-with-lease`.
+
 ### Creating Pull Requests
 
 Follow these steps when contributing:


### PR DESCRIPTION
## What this does

Adds a CI check that verifies every commit in a pull request includes a
`Signed-off-by` trailer, per the [Developer Certificate of Origin](https://developercertificate.org/).
Also updates `CONTRIBUTING.md` so contributors know about the requirement
and how to satisfy it.

## Why

Follow-up to [the discussion thread](https://github.com/sugarlabs/musicblocks/discussions/8090workflow) — raised as a
discussion topic in the dev room. This gives the project a lightweight,
widely-used way to track contribution provenance without requiring a CLA.

## Implementation notes

- No third-party Action — the check is a few lines of `git log` parsing in
  `.github/workflows/dco-check.yml`, so there's no external Action to trust
  or keep updated.
- Matches the conventions already used in `pr-title-check.yml`: `pull_request`
  (not `pull_request_target`, so fork PRs stay unprivileged), `contents: read`
  only, one run in flight per PR.
- Skips merge commits (`--no-merges`) so merging `master` into a branch
  doesn't trigger a false failure.
- `CONTRIBUTING.md` gets a new "Developer Certificate of Origin (DCO)"
  section, and the existing commit example in "Creating Pull Requests" now
  shows `-s` in use.

## Testing

Not yet verified against a live PR run — happy to hold this as a draft until
that's confirmed and the discussion has settled.

## PR Category

- [x] CI / CD
- [x] Documentation
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Chore