### PR TITLE
feat(widget): pitchslider reset frequency button

### DIFF
--- a/Docs/guide/README.md
+++ b/Docs/guide/README.md
@@ -2187,7 +2187,7 @@ the clamp. Every column has a slider that can be used to move up or
 down in frequency, continuously or in intervals of 1/12th of the
 starting frequency. The mouse is used to move the frequency up and
 down continuously. Buttons are used for intervals. Arrow keys can also
-be used to move up and down, or between columns.
+be used to move up and down, or between columns. There is a save button to export a note block, and a reset button to restore the initial starting pitch.
 
 ![widget](./pitchslider0a.svg "Pitch Slider Block")
 

--- a/Docs/guide/pitchslider1.svg
+++ b/Docs/guide/pitchslider1.svg
@@ -1,64 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    width="160.86668mm"
    height="195.20389mm"
    viewBox="0 0 160.86669 195.20388"
    version="1.1"
-   id="svg8">
-  <defs
-     id="defs2">
-    <marker
+   id="svg8"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs2"><marker
        style="overflow:visible"
        id="marker1424"
        refX="0"
        refY="0"
-       orient="auto">
-      <path
+       orient="auto"><path
          transform="scale(-0.4)"
          style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt;stroke-opacity:1"
          d="M 5.77,0 -2.88,5 V -5 Z"
-         id="path1422" />
-    </marker>
-    <marker
+         id="path1422" /></marker><marker
        style="overflow:visible"
        id="TriangleInM"
        refX="0"
        refY="0"
-       orient="auto">
-      <path
+       orient="auto"><path
          transform="scale(-0.4)"
          style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt;stroke-opacity:1"
          d="M 5.77,0 -2.88,5 V -5 Z"
-         id="path1282" />
-    </marker>
-    <style
+         id="path1282" /></marker><style
        type="text/css"
-       id="style4474" />
-    <style
+       id="style4474" /><style
        id="style4474-3"
-       type="text/css" />
-    <style
+       type="text/css" /><style
        type="text/css"
-       id="style4474-1" />
-  </defs>
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <rect
+       id="style4474-1" /><marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="DotM"
+       style="overflow:visible"><path
+         id="path899"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.4) translate(7.4, 1)" /></marker><marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Mstart"
+       style="overflow:visible"><path
+         id="path859"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(0.6) translate(0,0)" /></marker><marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lstart"
+       style="overflow:visible"><path
+         id="path853"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) translate(1,0)" /></marker></defs><metadata
+     id="metadata5"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
      style="fill:#c0c0c0;fill-opacity:1;stroke:#646464;stroke-width:1.03052;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect881"
      width="159.83617"
@@ -66,59 +73,45 @@
      x="0.51525998"
      y="0.51525998"
      ry="4.3195853"
-     rx="2.8866458" />
-  <path
+     rx="2.8866458" /><path
      style="fill:none;stroke:#646464;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 0.66212402,10.610459 H 160.20463"
-     id="path883" />
-  <g
+     id="path883" /><g
      id="g911"
      style="stroke:#646464;stroke-width:0.661458;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     transform="translate(-25.063508,-99.341975)">
-    <path
+     transform="translate(-25.063508,-99.341975)"><path
        style="fill:none;stroke:#646464;stroke-width:0.661458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 95.10757,103.79287 H 115.8861"
-       id="path885" />
-    <path
+       id="path885" /><path
        style="fill:none;stroke:#646464;stroke-width:0.661458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 96.767342,105.18868 H 114.22633"
-       id="path885-3" />
-    <path
+       id="path885-3" /><path
        style="fill:none;stroke:#646464;stroke-width:0.661458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 95.107573,106.58448 H 115.8861"
-       id="path885-6" />
-  </g>
-  <rect
+       id="path885-6" /></g><rect
      style="fill:#646464;fill-opacity:1;stroke:none;stroke-width:0.79375;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect964"
      width="6.6145835"
      height="6.6145835"
      x="2.4612412"
-     y="2.663718" />
-  <g
+     y="2.663718" /><g
      id="g962"
-     transform="translate(-24.885611,-99.232433)">
-    <path
+     transform="translate(-24.885611,-99.232433)"><path
        style="fill:none;stroke:#ffffff;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 28.793962,103.37892 3.720378,3.64904"
-       id="path943" />
-    <path
+       id="path943" /><path
        style="fill:none;stroke:#ffffff;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 28.829631,107.06363 3.64904,-3.72038"
-       id="path943-7" />
-  </g>
-  <rect
+       id="path943-7" /></g><rect
      style="fill:#646464;fill-opacity:1;stroke:none;stroke-width:0.79375;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect964-3-1"
      width="6.6145835"
      height="6.6145835"
      x="10.821455"
-     y="2.663718" />
-  <path
+     y="2.663718" /><path
      style="fill:none;stroke:#ffffff;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 12.304234,5.9710095 h 3.64904"
-     id="path943-7-2-0" />
-  <text
+     id="path943-7-2-0" /><text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.9389px;line-height:7.14375px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      x="19.355642"
@@ -127,275 +120,214 @@
        id="tspan1562"
        x="19.355642"
        y="7.5566769"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';fill:#646464;fill-opacity:1;stroke-width:0.264583px">pitch slider</tspan></text>
-  <rect
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';fill:#646464;fill-opacity:1;stroke-width:0.264583px">pitch slider</tspan></text><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:1.17847;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1673"
      width="16.933332"
      height="88.209145"
      x="2.1488633"
-     y="12.861993" />
-  <path
+     y="12.861993" /><path
      id="path4138"
      d="m 2.1949841,-63.198489 -0.18578,0.185772 c -0.69937,-0.710304 -3.68265,-3.748223 -4.03234,-4.086984 -0.3934,-0.393399 -0.33876,-1.202054 -0.80866,-1.682875 -0.10927,-0.109278 -0.28412,-0.109278 -0.3934,0 l -0.43711,0.43711 -0.43711,0.437111 c -0.10927,0.109278 -0.10927,0.284122 0,0.393399 0.48082,0.480822 1.28948,0.415255 1.68288,0.808655 0.34969,0.349688 3.37667992,3.332968 4.08698,4.032345 l -0.18577,0.185772 c -0.3169,0.316905 -0.18577,0.699377 0.13113,1.016282 l 1.79216,1.792153 0.0983,-0.09835 -1.51896,-1.814008 c -0.17485,-0.229483 -0.20763,-0.371544 -0.14206,-0.469894 l 2.05442,1.890503 0.10927,-0.109278 -1.85772,-2.087203 0.0765,-0.07649 0.0765,-0.07649 2.09813,1.857719 0.10928,-0.109277 -1.8905,-2.065348 c 0.0983,-0.06557 0.24041,-0.03278 0.46989,0.142061 l 1.81401,1.51896 0.0983,-0.09835 -1.79215,-1.792154 c -0.31691,-0.316905 -0.69938,-0.448038 -1.01628,-0.131133 z m -5.89007,-4.327394 0.42618,-0.426183 0.42619,-0.426183 c 0.48082,0.480822 0.0437,0.896077 0.0437,0.896077 0,0 -0.42619,0.426183 -0.89608,-0.04371 z"
      display="none"
-     style="display:none;fill:#000000;stroke-width:0.218555" />
-  <path
+     style="display:none;fill:#000000;stroke-width:0.218555" /><path
      id="path4138-5"
      d="m 9.1740541,-27.427935 -0.13438,0.118157 c -0.50589,-0.451782 -2.66386,-2.384025 -2.91681,-2.59949 -0.28457,-0.250219 -0.24505,-0.764556 -0.58495,-1.070381 -0.079,-0.06951 -0.20552,-0.06951 -0.28457,0 l -0.31618,0.278022 -0.31619,0.27802 c -0.079,0.06951 -0.079,0.180715 0,0.25022 0.34781,0.305822 0.93275,0.264119 1.21732,0.514337 0.25295,0.222417 2.44254,2.119907 2.95634,2.56474 l -0.13438,0.118159 c -0.22923,0.201565 -0.13438,0.444832 0.0949,0.646397 l 1.2963599,1.139884 0.0711,-0.06255 -1.0987499,-1.153786 c -0.12647,-0.14596 -0.15018,-0.236317 -0.10276,-0.298872 l 1.4860799,1.202439 0.079,-0.06951 -1.3437999,-1.327549 0.0553,-0.04865 0.0553,-0.04866 1.5176899,1.181588 0.079,-0.0695 -1.3675099,-1.313648 c 0.0712,-0.04171 0.17391,-0.02085 0.33991,0.09035 l 1.3121699,0.966124 0.0711,-0.06256 -1.2963599,-1.139886 c -0.22924,-0.201565 -0.5059,-0.28497 -0.73514,-0.0834 z m -4.26061,-2.752404 0.30829,-0.27107 0.30828,-0.27107 c 0.3478,0.305822 0.0316,0.569942 0.0316,0.569942 0,0 -0.30829,0.27107 -0.64819,-0.0278 z"
      display="none"
-     style="display:none;fill:#000000;stroke-width:0.218555" />
-  <g
+     style="display:none;fill:#000000;stroke-width:0.218555" /><g
      transform="matrix(0.07904655,0,0,0.06950514,3.9253641,-31.563491)"
      id="g4140-2"
      display="none"
-     style="display:none">
-    <polygon
+     style="display:none"><polygon
        id="polygon4142-8"
        points="74.7,49.7 75.6,55.9 71.1,53.2 71.1,51.7 70.9,53.1 67.7,51.1 70.8,53.9 69.8,59.9 64,53.2 71.3,65.2 71.1,54.2 80,62.1 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <path
+       style="display:inline;fill:#000000" /><path
        id="path4144-4"
        d="m 87.7,69.9 5.9,1.2 -0.1,-1.1 c 0,-0.4 -0.7,-9.6 -7.3,-17.4 l 3,1 -0.7,-1.8 C 88.4,51.5 85.1,43.6 83.1,40.6 81.7,38.5 80.5,36.9 79.6,35.8 l 2.5,0.7 -1.5,-2.1 C 80,33.6 67.9,17.1 50.1,17.1 32.3,17.1 20.2,33.6 19.7,34.3 l -1.5,2.1 2.5,-0.7 c -0.9,1.1 -2.1,2.7 -3.5,4.8 -2,3 -5.3,10.8 -5.4,11.2 l -0.7,1.8 3,-1 c -6.6,7.9 -7.3,17 -7.3,17.4 l -0.1,1.2 5.9,-1.2 -1.4,1.8 12.2,0.8 -0.9,2.1 13.6,-0.9 -0.8,3 6.8,-3.1 13,2.1 3.1,-2.1 6.6,3 -0.8,-3 13.6,0.9 -0.9,-2.1 12.2,-0.8 z m -13.4,1 1.3,2.3 -13.8,-1.5 1.7,3 -5.2,-3 -3.1,3 -13.2,-2.9 -4.4,2.3 1.1,-2.4 -13.8,1.5 1.3,-2.3 -12.6,-0.1 3.4,-3.6 -8.1,1.7 c 0.5,-3.1 2.3,-11.4 9,-17.6 l 2.9,-2.8 -6.4,2.1 c 1.1,-2.5 3.1,-7 4.5,-9 3.4,-5 5.4,-6.8 5.4,-6.8 l 2.7,-2.5 -4,0.9 c 3.9,-4.5 14,-14.3 27.1,-14.3 13.1,0 23.2,9.9 27.1,14.3 l -3.8,-1.1 2.7,2.5 c 0,0 2,1.9 5.4,6.8 1.4,2 3.4,6.5 4.5,9 l -6.4,-2.1 2.9,2.8 c 6.7,6.3 8.5,14.6 9,17.6 l -8.1,-1.7 2.8,3.6 z"
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4146-6"
        points="35,33.9 29.1,38.2 29.4,34.5 26.6,42.5 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4148-4"
        points="66,32.3 61.1,25 61.6,28.5 54.1,26.7 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4150-2"
        points="53.6,44.3 49.8,41.6 50.5,40.5 49.7,41.5 48.3,40.5 49.4,41.7 45.5,46.3 43.4,40 43.6,51.7 49.6,41.9 55.4,48.6 55.4,40 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4152-5"
        points="30.8,60.2 30.8,52.8 27.8,65.3 39.6,54.3 "
        display="inline"
-       style="display:inline;fill:#000000" />
-  </g>
-  <g
+       style="display:inline;fill:#000000" /></g><g
      transform="matrix(0.07904655,0,0,0.06950514,3.9253641,-31.563491)"
      id="g4154-5"
      display="none"
-     style="display:none">
-    <polygon
+     style="display:none"><polygon
        id="polygon4156-8"
        points="67.8,51.1 71,53.8 71.3,54.2 80.3,62.1 75,49.6 75.9,55.9 71.3,53.1 71.1,53 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <path
+       style="display:inline;fill:#000000" /><path
        id="path4158-0"
        d="m 88,69.9 5.9,1.2 -0.1,-1.2 c 0,-0.4 -0.7,-9.6 -7.3,-17.5 l 3,1 -0.7,-1.8 C 88.7,51.3 85.4,43.4 83.4,40.4 82,38.3 80.8,36.7 79.8,35.6 l 2.5,0.7 -1.5,-2.1 C 80.3,33.5 68.2,16.9 50.3,16.9 c -17.9,0 -30,16.6 -30.5,17.3 l -1.5,2.1 2.5,-0.7 c -0.9,1.1 -2.1,2.7 -3.6,4.8 -2,3 -5.3,10.9 -5.4,11.2 l -0.7,1.8 3,-1 C 7.5,60.3 6.8,69.5 6.8,69.9 l -0.1,1.2 5.9,-1.2 -1.4,1.8 12.2,0.8 -0.9,2.1 13.7,-0.9 -0.8,3 6.8,-3.1 13.2,1.9 3,-1.8 6.6,3 -0.8,-3 13.8,0.9 -0.9,-2.1 12.2,-0.8 z m -13.5,1 1.3,2.3 -13.9,-1.5 1.7,3 -5.3,-3.1 -3.2,2.6 L 42,71.8 37.5,74.2 38.6,71.8 24.7,73.3 26,71 14,70.9 16.8,67.3 8.6,69 c 0.5,-3.1 2.3,-11.4 9,-17.7 l 2.9,-2.8 -6.5,2.1 c 1.1,-2.5 3.1,-7.1 4.5,-9.1 3.4,-5 5.4,-6.9 5.4,-6.9 l 2.8,-2.5 -3.7,1 c 3.9,-4.5 14.1,-14.4 27.2,-14.4 13.1,0 23.3,9.9 27.2,14.4 l -3.7,-1.1 2.7,2.5 c 0,0 2,1.9 5.4,6.9 1.4,2 3.4,6.5 4.5,9.1 l -6.5,-2.1 2.9,2.8 c 6.7,6.3 8.6,14.6 9,17.7 l -8.2,-1.7 2.8,3.6 z"
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4160-1"
        points="35.1,33.8 29.2,38 29.5,34.3 26.7,42.4 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4162-0"
        points="54.3,26.5 66.2,32.2 61.3,24.8 61.8,28.4 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4164-4"
        points="55.6,48.5 55.6,39.8 53.8,44.2 50,41.5 50.6,40.4 49.8,41.3 48.4,40.4 49.5,41.6 45.6,46.2 43.5,39.8 43.7,51.6 49.7,41.8 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4166-2"
        points="30.9,60.2 30.9,52.8 27.9,65.3 39.7,54.2 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4168-9"
        points="50.5,66.6 50.7,66.7 50.8,66.6 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <polygon
+       style="display:inline;fill:#000000" /><polygon
        id="polygon4170-1"
        points="54.2,68.8 54.2,68.9 54.4,69 54.4,68.8 "
        display="inline"
-       style="display:inline;fill:#000000" />
-    <path
+       style="display:inline;fill:#000000" /><path
        id="path4172-7"
        d="M 74.7,40 C 75,39.6 74.8,39 74.4,38.8 L 72.7,37.7 71,36.6 c -0.4,-0.3 -1,-0.1 -1.2,0.3 -1.2,1.9 -0.4,4.4 -1.4,5.9 -0.9,1.4 -8.1,13.1 -9.9,15.9 l -0.7,-0.5 c -1.2,-0.8 -2.4,-0.1 -3.1,1.2 L 54,60.6 v 1.3 l 0.5,-0.1 0.9,-1.2 c 0.6,-0.7 1,-0.9 1.4,-0.8 l -1,1.7 0.3,0.9 0.6,-0.1 1.3,-1.8 0.3,0.2 0.3,0.2 -1,1.8 0.4,1.6 1.8,-2.6 c 0.3,0.3 0.3,0.7 -0.1,1.6 l -0.1,0.2 h 1.3 v -0.1 c 0.8,-1.2 0.9,-2.6 -0.3,-3.3 L 59.9,59.6 C 61.7,56.9 69.1,45.2 70,43.8 71,42.3 73.6,41.9 74.7,40 Z m -4.6,-1.8 1.7,1 1.7,1 c -1.2,1.9 -2.8,0.8 -2.8,0.8 0,0 -1.7,-1 -0.6,-2.8 z"
        display="inline"
-       style="display:inline;fill:#000000" />
-  </g>
-  <g
+       style="display:inline;fill:#000000" /></g><g
      transform="matrix(0.07904655,0,0,0.06950514,3.9253641,-31.563491)"
      id="g4200-9"
      display="none"
-     style="display:none">
-    <path
+     style="display:none"><path
        id="path4202-2"
        d="m 51.2,45.1 c 0,-0.7 -3.3,-28.1 -4.3,-29.2 -1,-1.1 -7.1,-0.1 -8.5,0.4 -3.8,1.4 -7.3,4.3 -7.3,5.6 0,1.3 17.9,23.2 18.3,23.4 1.4,1.3 1.8,0.5 1.8,-0.2 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4204-2"
        d="M 48.8,46.4 C 48.4,46 29.4,24.4 28.1,23.8 c -1.3,-0.6 -3,0.6 -5.6,3.8 -2.5,3.1 -3.7,5.7 -3,7.2 0.7,1.5 27.5,12.3 28.1,12.6 0.7,0.3 1.6,-0.6 1.2,-1 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4206-3"
        d="M 46.9,48.4 C 46.2,48.2 18.3,38.2 18.3,38.2 c -1.7,0.4 -2.6,2.5 -3.1,7.4 -0.5,4.1 -0.2,6.4 0.8,6.7 1,0.3 29.6,-1.8 30.7,-2 1,-0.3 0.8,-1.7 0.2,-1.9 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4208-0"
        d="M 54,45 C 54.3,44.6 65.6,21.1 65.2,19.2 64.7,17.3 61.8,15.9 57.8,15 56.9,14.8 56,14.7 55,14.7 c -2.9,0 -3.9,-0.9 -4.6,0.6 -0.7,1.5 1.7,29.2 1.8,29.5 0.1,0.5 0.8,1.8 1.8,0.2 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4210-3"
        d="m 57.5,49.6 c 1.1,0.1 25.1,1.9 26.2,0.9 1.1,-1 1.7,-5.2 0.8,-9.2 C 83.6,37.4 81.8,34 80.3,34 78.7,34 57.8,46.9 57,47.7 c -0.9,0.8 -0.6,1.9 0.5,1.9 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4212-5"
        d="m 46.5,51.4 c -1,0.1 -28.3,3.3 -29.2,4.3 -0.9,1 -0.5,5.5 1.2,9.1 1.8,3.7 5.1,5.7 6.4,5.7 1.3,0 21.9,-16.7 22.6,-17.3 0.6,-0.5 0,-1.9 -1,-1.8 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4214-2"
        d="m 56.5,46.8 c 0,0 21.9,-12.9 22.7,-14.2 0.7,-1.3 -1.3,-5.3 -4.2,-8.2 -2.9,-2.8 -6,-4.5 -6.9,-4 C 67.2,20.7 56.8,41 55.3,45.7 55,47 56,46.9 56.5,46.8 Z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4216-8"
        d="m 48.2,54 c -0.6,0.5 -22.1,18 -22.1,19.4 0,1.4 1.9,3.8 5.3,5.9 3.2,2 3.6,3.5 6.7,2.6 3.1,-0.9 11.8,-26.5 12,-27.4 0.3,-0.8 -1.3,-1 -1.9,-0.5 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4218-4"
        d="m 58.7,50.8 c -3.8,-0.3 -2.6,2.4 -1.6,3.2 1,0.8 18.9,13.8 20.3,13.9 1.5,0.1 3.2,-0.2 4.7,-4 1.5,-3.9 2.8,-9.2 1.4,-10.2 -1.3,-1.1 -21,-2.6 -24.8,-2.9 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4220-0"
        d="M 50.2,5 C 25.6,5 5.5,25 5.5,49.7 c 0,24.6 20,44.7 44.7,44.7 24.6,0 44.7,-20 44.7,-44.7 C 94.9,25 74.8,5 50.2,5 Z m 0,87 C 29.7,92 8.9,73 8.9,49.7 8.9,26.3 27.8,8.4 51.2,8.4 74.6,8.4 92.5,26.3 92.5,49.7 92.5,73 70.7,92 50.2,92 Z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4222-1"
        d="m 54.1,55.4 c 0.3,1.4 5.5,25.1 6.8,26.1 1.3,1 4.8,-0.2 8,-2.2 3.5,-2.2 5.5,-4.2 5.5,-6.4 0,-2.2 -17.1,-17.5 -18.2,-18.4 -1,-1 -2.4,-0.4 -2.1,0.9 z"
        display="inline"
-       style="display:inline" />
-    <path
+       style="display:inline" /><path
        id="path4224-7"
        d="m 53.1,56 c -0.4,-1.5 -1.9,-1.5 -2.2,-0.7 -0.3,0.8 -7.8,24.4 -7.8,26.5 0,2.1 3,2.8 7,2.8 4.1,0 7.5,-1.8 7.5,-3.1 C 57.6,80.2 56,68.8 56,68.8 56,68.8 53.5,57.6 53.1,56 Z"
        display="inline"
-       style="display:inline" />
-  </g>
-  <rect
+       style="display:inline" /></g><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1673-4"
      width="16.933332"
      height="16.933332"
      x="2.1488633"
-     y="102.65864" />
-  <rect
+     y="102.65864" /><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1673-81"
      width="16.933332"
      height="16.933332"
      x="2.1488633"
-     y="120.98882" />
-  <path
+     y="120.98882" /><path
      d="m 6.6467741,125.48693 h 7.9374999 v 7.93755 H 6.6467741 Z"
      fill="none"
      id="path2499"
-     style="stroke-width:0.330729" />
-  <rect
+     style="stroke-width:0.330729" /><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1673-4-3"
      width="16.933332"
      height="16.933332"
      x="2.1488638"
-     y="138.98033" />
-  <rect
+     y="138.98033" /><rect
      style="fill:#646464;fill-opacity:1;stroke:none;stroke-width:0.79375;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect964-3"
      width="6.6145835"
      height="6.6145835"
      x="151.89902"
-     y="2.663718" />
-  <path
+     y="2.663718" /><path
      style="fill:none;stroke:#ffffff;stroke-width:0.794;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 153.34612,4.1464995 3.72038,3.64904"
-     id="path943-6" />
-  <path
+     id="path943-6" /><path
      style="fill:none;stroke:#ffffff;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 153.38179,7.8312095 3.64904,-3.72038"
-     id="path943-7-2" />
-  <g
+     id="path943-7-2" /><g
      id="g1463"
-     transform="translate(-58.068726,-110.91844)">
-    <path
+     transform="translate(-58.068726,-110.91844)"><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 211.41484,115.06494 v 1.18901"
-       id="path1444" />
-    <path
+       id="path1444" /><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 212.60385,115.06494 h -1.18901"
-       id="path1444-9" />
-  </g>
-  <g
+       id="path1444-9" /></g><g
      id="g1463-3"
-     transform="rotate(90,239.69989,32.395871)">
-    <path
+     transform="rotate(90,239.69989,32.395871)"><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 211.41484,115.06494 v 1.18901"
-       id="path1444-6" />
-    <path
+       id="path1444-6" /><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 212.60385,115.06494 h -1.18901"
-       id="path1444-9-0" />
-  </g>
-  <g
+       id="path1444-9-0" /></g><g
      id="g1463-6"
-     transform="rotate(-90,128.78144,90.464601)">
-    <path
+     transform="rotate(-90,128.78144,90.464601)"><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 211.41484,115.06494 v 1.18901"
-       id="path1444-2" />
-    <path
+       id="path1444-2" /><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 212.60385,115.06494 h -1.18901"
-       id="path1444-9-6" />
-  </g>
-  <g
+       id="path1444-9-6" /></g><g
      id="g1463-1"
-     transform="rotate(180,184.24066,61.43024)">
-    <path
+     transform="rotate(180,184.24066,61.43024)"><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 211.41484,115.06494 v 1.18901"
-       id="path1444-8" />
-    <path
+       id="path1444-8" /><path
        style="fill:none;stroke:#ffffff;stroke-width:0.529167;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 212.60385,115.06494 h -1.18901"
-       id="path1444-9-7" />
-  </g>
-  <rect
+       id="path1444-9-7" /></g><rect
      style="fill:#646464;fill-opacity:1;stroke:none;stroke-width:0.780756;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1506"
      width="1.5875"
      height="1.5875"
      x="104.73154"
      y="113.17583"
-     transform="rotate(-45)" />
-  <text
+     transform="rotate(-45)" /><text
      xml:space="preserve"
      style="font-size:6.35px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
      x="4.53373"
@@ -404,106 +336,79 @@
        id="tspan1067"
        x="4.53373"
        y="113.4368"
-       style="stroke-width:0.264583">220</tspan></text>
-  <rect
+       style="stroke-width:0.264583">220</tspan></text><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect1673-4-6"
      width="16.933332"
      height="16.933332"
      x="1.7317145"
-     y="157.04347" />
-  <g
+     y="157.04347" /><g
      id="g5171"
-     transform="matrix(0.21855528,0,0,0.21855528,4.6052594,159.47192)">
-    <path
+     transform="matrix(0.21855528,0,0,0.21855528,4.6052594,159.47192)"><path
        style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path2882"
-       d="M 1.2614679,17.408256 V 9.3348628 A 8.0733945,8.0733945 0 0 1 9.3348632,1.2614679 H 17.408256 V 5.298166 H 37.591743 V 1.2614679 h 8.073394 a 8.0733945,8.0733945 0 0 1 8.073395,8.0733949 v 8.0733932 8.073395 a 8.0733945,8.0733945 0 0 1 -8.073395,8.073395 h -8.073394 -2.018348 v 4.036697 H 19.426605 V 33.555046 H 17.408256 9.3348631 A 8.0733945,8.0733945 0 0 1 1.2614679,25.481651 Z" />
-    <path
+       d="M 1.2614679,17.408256 V 9.3348628 A 8.0733945,8.0733945 0 0 1 9.3348632,1.2614679 H 17.408256 V 5.298166 H 37.591743 V 1.2614679 h 8.073394 a 8.0733945,8.0733945 0 0 1 8.073395,8.0733949 v 8.0733932 8.073395 a 8.0733945,8.0733945 0 0 1 -8.073395,8.073395 h -8.073394 -2.018348 v 4.036697 H 19.426605 V 33.555046 H 17.408256 9.3348631 A 8.0733945,8.0733945 0 0 1 1.2614679,25.481651 Z" /><path
        style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.03909;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 47.541109,38.019545 v 10.185353 h 4.08222 L 45.5,53.637086 39.376671,48.204898 h 4.082218 V 38.019545 Z"
-       id="path4174" />
-    <g
+       id="path4174" /><g
        transform="translate(-3.146153)"
-       id="g5616">
-      <g
+       id="g5616"><g
          transform="matrix(1.1045431,0,0,0.73635024,-15.448443,-1.2713533)"
          id="g4166"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-        <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><path
            id="path4168"
            d="m 42.833345,41.891892 q 0,-2.342343 2.297297,-4.144145 2.297298,-1.846846 4.864865,-1.846846 1.486487,0 2.657658,0.765765 V 10 h 0.990991 v 29.144144 q 0,2.522522 -2.207208,4.189189 Q 49.229741,45 46.572084,45 45.085597,45 43.959471,44.144144 42.833345,43.243243 42.833345,41.891892 Z"
-           style="fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1" />
-      </g>
-      <g
+           style="fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1" /></g><g
          transform="matrix(1.1045431,0,0,0.73635024,-29.822809,-1.2713533)"
          id="g4166-1"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-        <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><path
            id="path4168-1"
            d="m 42.833345,41.891892 q 0,-2.342343 2.297297,-4.144145 2.297298,-1.846846 4.864865,-1.846846 1.486487,0 2.657658,0.765765 V 10 h 0.990991 v 29.144144 q 0,2.522522 -2.207208,4.189189 Q 49.229741,45 46.572084,45 45.085597,45 43.959471,44.144144 42.833345,43.243243 42.833345,41.891892 Z"
-           style="fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1" />
-      </g>
-      <path
+           style="fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1" /></g><path
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.72997px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 28.719977,6.7817002 14.210527,0.037758 0.113722,-0.037758"
-         id="path4379" />
-    </g>
-  </g>
-  <rect
+         id="path4379" /></g></g><rect
      style="fill:#666666;stroke:#808080;stroke-width:0.661458;stroke-linecap:round"
      id="rect1062"
      width="13.229167"
      height="3.96875"
      x="4.0009456"
-     y="89.801506" />
-  <g
+     y="89.801506" /><g
      id="g5-35-3-2"
-     transform="matrix(0,-0.26458333,0.26458333,0,3.339488,135.40861)">
-    <path
+     transform="matrix(0,-0.26458333,0.26458333,0,3.339488,135.40861)"><path
        d="M 22.561,50 C 34.954,50 45,39.924 45,27.498 45,15.076 34.954,5 22.561,5 H 0 v 45 z"
        id="path7-62-6-6"
-       style="fill:#ffffff" />
-    <g
-       id="g9-9-0-1">
-      <polygon
+       style="fill:#ffffff" /><g
+       id="g9-9-0-1"><polygon
          points="15.707,37.555 15.707,16.706 30.772,27.133 "
          id="polygon11-1-6-8"
-         style="fill:#4c4d4f" />
-    </g>
-  </g>
-  <g
+         style="fill:#4c4d4f" /></g></g><g
      id="g5-35-3-2-2"
-     transform="matrix(0,0.26458333,0.26458333,0,3.3394884,141.49387)">
-    <path
+     transform="matrix(0,0.26458333,0.26458333,0,3.3394884,141.49387)"><path
        d="M 22.561,50 C 34.954,50 45,39.924 45,27.498 45,15.076 34.954,5 22.561,5 H 0 v 45 z"
        id="path7-62-6-6-3"
-       style="fill:#ffffff" />
-    <g
-       id="g9-9-0-1-7">
-      <polygon
+       style="fill:#ffffff" /><g
+       id="g9-9-0-1-7"><polygon
          points="15.707,16.706 30.772,27.133 15.707,37.555 "
          id="polygon11-1-6-8-5"
-         style="fill:#4c4d4f" />
-    </g>
-  </g>
-  <rect
+         style="fill:#4c4d4f" /></g></g><rect
      style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect-reset-bg"
      width="16.933332"
      height="16.933332"
      x="1.7317145"
-     y="175.04347" />
-  <g
-     id="g5-35-3-2-reset"
-     transform="matrix(0.21855528,0,0,0.21855528,4.6052594,177.47192)">
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path2882-reset"
-       d="M 1.2614679,17.408256 V 9.3348628 A 8.0733945,8.0733945 0 0 1 9.3348632,1.2614679 H 17.408256 V 5.298166 H 37.591743 V 1.2614679 h 8.073394 a 8.0733945,8.0733945 0 0 1 8.073395,8.0733949 v 8.0733932 8.073395 a 8.0733945,8.0733945 0 0 1 -8.073395,8.073395 h -8.073394 -2.018348 v 4.036697 H 19.426605 V 33.555046 H 17.408256 9.3348631 A 8.0733945,8.0733945 0 0 1 1.2614679,25.481651 Z" />
-    <path
-       d="M 25,12 C 17.82,12 12,17.82 12,25 C 12,32.18 17.82,38 25,38 C 30.05,38 34.42,35.11 36.54,30.91 L 33.31,29.3 C 31.78,32.32 28.64,34.4 25,34.4 C 19.81,34.4 15.6,30.19 15.6,25 C 15.6,19.81 19.81,15.6 25,15.6 C 28.02,15.6 30.68,17.03 32.38,19.25 L 28,23.63 H 38 V 13.63 L 34.58,17.05 C 32.32,13.98 28.89,12 25,12 Z"
-       id="path-reset-symbol"
-       style="fill:#000000" />
-  </g>
-</svg>
+     y="175.04347" /><g
+     id="g1"
+     transform="matrix(0.71749515,0,0,0.71749515,5.395005,178.28961)"><path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.23481;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path833-3"
+       d="M 1.698239,7.1969863 A 5.7164413,5.7164413 0 0 1 6.1632342,1.6192104 5.7164413,5.7164413 0 0 1 12.583188,4.7548076" /><path
+       id="path1172"
+       d="M 0.62728029,6.3274826 1.6780237,7.7588429 2.8959814,6.3894573"
+       style="fill:none;stroke:#000000;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+       d="M 12.853844,7.3550974 A 5.7164413,5.7164413 0 0 1 8.3888487,12.932873 5.7164413,5.7164413 0 0 1 1.9688954,9.7972761"
+       id="path833-3-7"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.23481;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" /><path
+       style="fill:none;stroke:#000000;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13.924803,8.2246011 12.874059,6.7932408 11.656101,8.1626264"
+       id="path1172-5" /></g></svg>

--- a/Docs/guide/pitchslider1.svg
+++ b/Docs/guide/pitchslider1.svg
@@ -6,8 +6,8 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    width="160.86668mm"
-   height="176.20389mm"
-   viewBox="0 0 160.86669 176.20388"
+   height="195.20389mm"
+   viewBox="0 0 160.86669 195.20388"
    version="1.1"
    id="svg8">
   <defs
@@ -62,7 +62,7 @@
      style="fill:#c0c0c0;fill-opacity:1;stroke:#646464;stroke-width:1.03052;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect881"
      width="159.83617"
-     height="175.17337"
+     height="193.17337"
      x="0.51525998"
      y="0.51525998"
      ry="4.3195853"
@@ -486,5 +486,24 @@
          id="polygon11-1-6-8-5"
          style="fill:#4c4d4f" />
     </g>
+  </g>
+  <rect
+     style="fill:#93befe;fill-opacity:1;stroke:none;stroke-width:0.51634;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect-reset-bg"
+     width="16.933332"
+     height="16.933332"
+     x="1.7317145"
+     y="175.04347" />
+  <g
+     id="g5-35-3-2-reset"
+     transform="matrix(0.21855528,0,0,0.21855528,4.6052594,177.47192)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2882-reset"
+       d="M 1.2614679,17.408256 V 9.3348628 A 8.0733945,8.0733945 0 0 1 9.3348632,1.2614679 H 17.408256 V 5.298166 H 37.591743 V 1.2614679 h 8.073394 a 8.0733945,8.0733945 0 0 1 8.073395,8.0733949 v 8.0733932 8.073395 a 8.0733945,8.0733945 0 0 1 -8.073395,8.073395 h -8.073394 -2.018348 v 4.036697 H 19.426605 V 33.555046 H 17.408256 9.3348631 A 8.0733945,8.0733945 0 0 1 1.2614679,25.481651 Z" />
+    <path
+       d="M 25,12 C 17.82,12 12,17.82 12,25 C 12,32.18 17.82,38 25,38 C 30.05,38 34.42,35.11 36.54,30.91 L 33.31,29.3 C 31.78,32.32 28.64,34.4 25,34.4 C 19.81,34.4 15.6,30.19 15.6,25 C 15.6,19.81 19.81,15.6 25,15.6 C 28.02,15.6 30.68,17.03 32.38,19.25 L 28,23.63 H 38 V 13.63 L 34.58,17.05 C 32.32,13.98 28.89,12 25,12 Z"
+       id="path-reset-symbol"
+       style="fill:#000000" />
   </g>
 </svg>

--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -242,12 +242,12 @@ describe("PitchSlider Widget", () => {
             expect(slider.widgetWindow.addRangeSlider).toHaveBeenCalledTimes(2);
         });
 
-        test("creates up/down/save buttons for each frequency", () => {
+        test("creates up/down/save/reset buttons for each frequency", () => {
             slider.frequencies = [440, 880];
             slider.init(activityMock);
 
-            // 3 buttons per frequency = 6 buttons total
-            expect(slider.widgetWindow.addButton).toHaveBeenCalledTimes(6);
+            // 4 buttons per frequency = 8 buttons total
+            expect(slider.widgetWindow.addButton).toHaveBeenCalledTimes(8);
         });
 
         test("each slider has correct min/max range", () => {
@@ -513,6 +513,25 @@ describe("PitchSlider Widget", () => {
             saveBtn.onclick();
 
             expect(saveSpy).toHaveBeenCalledWith(500);
+        });
+
+        test("Reset frequency button restores initial frequency value and plays preview", () => {
+            slider.frequencies = [440];
+            slider.init(activityMock);
+
+            // Change frequency via slider to 600
+            const rangeSlider = slider.sliders[0];
+            rangeSlider.value = "600";
+            slider.frequencies[0] = 600;
+
+            const resetBtn = slider.widgetWindow
+                .getButtons()
+                .find(b => b.tip === "Reset frequency");
+            resetBtn.onclick();
+
+            expect(parseFloat(rangeSlider.value)).toBe(440);
+            expect(slider.frequencies[0]).toBe(440);
+            expect(mockOscillator.triggerAttackRelease).toHaveBeenCalledWith(440, "4n");
         });
 
         test("slider registers mousedown event listener", () => {

--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -524,9 +524,7 @@ describe("PitchSlider Widget", () => {
             rangeSlider.value = "600";
             slider.frequencies[0] = 600;
 
-            const resetBtn = slider.widgetWindow
-                .getButtons()
-                .find(b => b.tip === "Reset frequency");
+            const resetBtn = slider.widgetWindow.getButtons().find(b => b.tip === "Reset");
             resetBtn.onclick();
 
             expect(parseFloat(rangeSlider.value)).toBe(440);

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -48,6 +48,7 @@ class PitchSlider {
         const semitone = Math.pow(2, 1 / edo);
         if (window.widgetWindows.openWindows["slider"]) return;
         if (!this.frequencies || !this.frequencies.length) this.frequencies = [392];
+        this.initialFrequencies = [...this.frequencies];
 
         const oscillators = [];
         for (let i = 0; i < this.frequencies.length; i++) {
@@ -185,6 +186,21 @@ class PitchSlider {
                 toolBarDiv
             ).onclick = () => {
                 this._save(this.frequencies[id]);
+            };
+
+            this.widgetWindow.addButton(
+                "reload.svg",
+                PitchSlider.ICONSIZE,
+                _("Reset frequency"),
+                toolBarDiv
+            ).onclick = () => {
+                const initialFreq =
+                    this.initialFrequencies && this.initialFrequencies[id] !== undefined
+                        ? this.initialFrequencies[id]
+                        : 392;
+                slider.value = initialFreq;
+                changeFreq();
+                oscillators[id].triggerAttackRelease(this.frequencies[id], "4n");
             };
         };
 

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -191,7 +191,7 @@ class PitchSlider {
             this.widgetWindow.addButton(
                 "reload.svg",
                 PitchSlider.ICONSIZE,
-                _("Reset frequency"),
+                _("Reset"),
                 toolBarDiv
             ).onclick = () => {
                 const initialFreq =


### PR DESCRIPTION
## Description

Adds a **"Reset frequency"** toolbar button (`reload.svg`) and initial frequency memory to the `PitchSlider` interactive pitch widget (`js/widgets/pitchslider.js`).

Currently, when users adjust pitches using the `PitchSlider` slider or arrow buttons, there is no quick way to reset a slider back to its starting frequency without closing and reopening the widget.

This PR stores initial frequency values upon widget initialization (`this.initialFrequencies`) and adds a dedicated `reload.svg` button with tooltip `_("Reset frequency")` to instantly restore initial values.

## Related Issue

N/A

## PR Category

- [x] Enhancement / Feature — New features or improvements to existing functionality
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/widgets/pitchslider.js`**:
  - Saved `this.initialFrequencies = [...this.frequencies]` during `init()`.
  - Added `reload.svg` ("Reset frequency") button in `MakeToolbar()` that restores `slider.value` to initial frequency and plays note preview.
- **`js/widgets/__tests__/pitchslider.test.js`**:
  - Updated toolbar button count assertion (4 buttons per slider).
  - Added unit test case verifying `Reset frequency` button click handler functionality (61/61 passed).

## Testing Performed

- Ran local Jest test suite: `npx jest js/widgets/__tests__/pitchslider.test.js` (61/61 passed).
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

None.
