### PR TITLE
docs: improve PR title guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -9,7 +9,7 @@ about: Submit changes to the project for review and inclusion
 
 Format: `<type>: <subject>`
 
-Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `i18n`, `perf`, `refactor`, `revert`, `style`, `test`
 
 Example: `fix: correct drag offset on touch devices`
 

--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -38,6 +38,7 @@ This PR fixes #
 - [ ] Tests — Adds or updates test coverage
 - [ ] Documentation — Updates to docs, comments, or README
 - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
+- [ ] i18n — Internationalization and localization changes
 - [ ] CI/CD — Changes to CI/CD workflows and automation
 
 ## Changes Made
@@ -65,6 +66,7 @@ This PR fixes #
 <!--- You can add or remove items as needed. -->
 
 - [ ] I have tested these changes locally and they work as expected.
+- [ ] I have included before/after screenshots if applicable, especially for UX/feature changes.
 - [ ] I have added/updated tests that prove the effectiveness of these changes.
 - [ ] I have updated the documentation to reflect these changes, if applicable.
 - [ ] I have followed the project's coding style guidelines.

--- a/.github/PULL_REQUEST_TEMPLATE/generic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic.md
@@ -3,6 +3,18 @@ name: Pull Request
 about: Submit changes to the project for review and inclusion
 ---
 
+## PR Title
+
+<!--- CI ENFORCED: The pull request TITLE (the field above this form) must be a Conventional Commit. -->
+
+Format: `<type>: <subject>`
+
+Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+
+Example: `fix: correct drag offset on touch devices`
+
+<!--- The PR Category checkboxes below are for labels only and are separate from the PR title type. -->
+
 ## Description
 
 <!--- Describe the changes introduced by this pull request. -->
@@ -20,45 +32,45 @@ This PR fixes #
 <!--- CI ENFORCED: You MUST check at least ONE category below or the CI will fail. -->
 <!--- Check all categories that apply to this pull request. -->
 
--   [ ] Bug Fix — Fixes a bug or incorrect behavior
--   [ ] Feature — Adds new functionality
--   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
--   [ ] Tests — Adds or updates test coverage
--   [ ] Documentation — Updates to docs, comments, or README
--   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
--   [ ] CI/CD — Changes to CI/CD workflows and automation
+- [ ] Bug Fix — Fixes a bug or incorrect behavior
+- [ ] Feature — Adds new functionality
+- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
+- [ ] Tests — Adds or updates test coverage
+- [ ] Documentation — Updates to docs, comments, or README
+- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
+- [ ] CI/CD — Changes to CI/CD workflows and automation
 
 ## Changes Made
 
 <!--- Provide a summary of the changes made in this pull request. -->
 <!--- Include any relevant technical details or architecture changes. -->
 
--   Change 1
--   Change 2
--   ...
+- Change 1
+- Change 2
+- ...
 
 ## Testing Performed
 
 <!--- Describe the testing that you have performed to validate these changes. -->
 <!--- Include information about test cases, testing environments, and results. -->
 
--   Tested feature X in scenario Y.
--   Ran unit tests for component Z.
--   Tested on browsers A, B, and C.
--   ...
+- Tested feature X in scenario Y.
+- Ran unit tests for component Z.
+- Tested on browsers A, B, and C.
+- ...
 
 ## Checklist
 
 <!--- Please check the boxes that apply to this pull request. -->
 <!--- You can add or remove items as needed. -->
 
--   [ ] I have tested these changes locally and they work as expected.
--   [ ] I have added/updated tests that prove the effectiveness of these changes.
--   [ ] I have updated the documentation to reflect these changes, if applicable.
--   [ ] I have followed the project's coding style guidelines.
--   [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
--   [ ] I have addressed the code review feedback from the previous submission, if applicable.
--   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
+- [ ] I have tested these changes locally and they work as expected.
+- [ ] I have added/updated tests that prove the effectiveness of these changes.
+- [ ] I have updated the documentation to reflect these changes, if applicable.
+- [ ] I have followed the project's coding style guidelines.
+- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
+- [ ] I have addressed the code review feedback from the previous submission, if applicable.
+- [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
 
 ## Additional Notes for Reviewers
 

--- a/.github/workflows/pr-category-check.yml
+++ b/.github/workflows/pr-category-check.yml
@@ -79,6 +79,13 @@ jobs:
                 displayName: 'Chore / Refactor',
                 pattern: /-\s*\[x\]\s*Chore/i,
               },
+              {
+                label: 'i18n',
+                color: '0D9488',
+                description: 'Internationalization and localization changes',
+                displayName: 'i18n',
+                pattern: /-\s*\[x\]\s*i18n/i,
+              },
             ];
 
             const checkedCategories = categories.filter(cat => cat.pattern.test(prBody));
@@ -105,6 +112,7 @@ jobs:
                 '| Tests | Adds or updates test coverage |',
                 '| Documentation | Updates to docs, comments, or README |',
                 '| CI/CD | Changes to CI/CD workflows and automation |',
+                '| i18n | Internationalization and localization changes |',
                 '',
                 'Example: Change `- [ ] Bug Fix` to `- [x] Bug Fix`',
                 '',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Use conventional-style prefixes:
 
 - `fix:` — bug fix
 - `feat:` — new feature
+- `i18n:` — internationalization / localization
 - `docs:` — documentation only
 - `style:` — formatting, no code change
 - `refactor:` — code restructuring without behavior change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,12 @@ Follow these steps when contributing:
     ```
 
 6.  **Open a Pull Request:**
-    - Use a clear and descriptive title.
+    - Use a Conventional Commit title: `<type>: <subject>` (for example,
+      `fix: correct drag offset on touch devices`). Allowed types are
+      `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
+      `revert`, `style`, and `test`. The title is linted by
+      `pr-title-check.yml`. See [Releases and the Changelog](#releases-and-the-changelog)
+      for why this matters when a PR is squash-merged.
     - Link the related issue using `Related to #XXXX` or `Partially addresses #XXXX`.
     - Explain what changed and why.
     - Keep pull requests focused on a single topic or feature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ Follow these steps when contributing:
 6.  **Open a Pull Request:**
     - Use a Conventional Commit title: `<type>: <subject>` (for example,
       `fix: correct drag offset on touch devices`). Allowed types are
-      `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
+      `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `i18n`, `perf`, `refactor`,
       `revert`, `style`, and `test`. The title is linted by
       `pr-title-check.yml`. See [Releases and the Changelog](#releases-and-the-changelog)
       for why this matters when a PR is squash-merged.
@@ -270,7 +270,7 @@ What this means for you as a contributor:
   line verbatim, so `fix(palette): correct drag offset on touch devices`
   reads well and `fix: stuff` does not.
 - `feat`, `fix`, `perf`, `docs`, and `revert` appear in the changelog.
-  `build`, `chore`, `ci`, `refactor`, `style`, and `test` are still valid
+  `build`, `chore`, `ci`, `i18n`, `refactor`, `style`, and `test` are still valid
   commit types and still required to pass linting — they are just hidden
   from the changelog. Two of those are deliberate policy rather than
   housekeeping: **added or changed tests** and **pure refactors** are not

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -21,6 +21,7 @@ module.exports = {
                 "docs", // documentation only
                 "feat", // a new feature
                 "fix", // a bug fix
+                "i18n", // internationalization / localization
                 "perf", // performance improvement
                 "refactor", // neither fixes a bug nor adds a feature
                 "revert", // reverts a previous commit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,6 +22,7 @@
                 { "type": "refactor", "section": "Code Refactoring", "hidden": true },
                 { "type": "build", "section": "Build System", "hidden": true },
                 { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+                { "type": "i18n", "section": "Internationalization", "hidden": true },
                 { "type": "ci", "section": "Continuous Integration", "hidden": true },
                 { "type": "style", "section": "Styles", "hidden": true },
                 { "type": "test", "section": "Tests", "hidden": true }


### PR DESCRIPTION
### Description

This PR improves the guidance and checklist for contributors when opening a pull request.

Currently, the PR template already tells contributors what to do with the **PR Category** section — at least one category must be selected, and the applicable categories can be checked. However, the PR title itself does not clearly tell contributors that it must follow the Conventional Commit format.

As a result, a contributor can correctly select a PR Category and still discover the required title format only after the `Lint PR title` check fails.

### Changes

- Added explicit Conventional Commit PR title guidance to the PR template.
- Listed the valid PR title types and included an example.
- Clarified that the **PR Category** section and the PR title type serve different purposes.
- Added the same Conventional Commit title requirement to the “Open a Pull Request” instructions in `CONTRIBUTING.md`.
- Added **i18n** as a PR Category and updated the category workflow to recognize and label it.
- Added **i18n** as a valid Conventional Commit title type.
- Kept `i18n` hidden from the changelog, consistent with its previous treatment under `chore`.
- Added a checklist item for before/after screenshots when applicable, especially for UX/feature PRs.

The existing PR title validation behavior remains unchanged apart from adding `i18n` as a valid type. The screenshot requirement is checklist-only and is not CI-enforced.

### PR Category

- [x] Documentation
