### PR TITLE
fix(phrasemaker): prevent Uncaught ReferenceError: activity is not defined during lyric playback

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -334,8 +334,8 @@ const PhraseMakerAudio = {
      */
     __playNote(pm, time, noteCounter) {
         // Show lyrics while playing notes.
-        if (pm.lyricsON) {
-            activity.textMsg(pm._lyrics[noteCounter], 3000);
+        if (pm.lyricsON && pm.activity) {
+            pm.activity.textMsg(pm._lyrics[noteCounter], 3000);
         }
         // If the widget is closed, stop playing.
         if (!pm.widgetWindow.isVisible()) {

--- a/js/widgets/__tests__/PhraseMakerAudio.test.js
+++ b/js/widgets/__tests__/PhraseMakerAudio.test.js
@@ -452,12 +452,11 @@ describe("PhraseMakerAudio", () => {
         test("highlights lyrics if enabled", () => {
             mockPM.lyricsON = true;
             mockPM._lyrics = ["Hello"];
-            global.activity = { textMsg: jest.fn() };
+            mockPM.activity.textMsg = jest.fn();
 
             PhraseMakerAudio.__playNote(mockPM, 0, 0);
 
-            expect(global.activity.textMsg).toHaveBeenCalledWith("Hello", 3000);
-            delete global.activity;
+            expect(mockPM.activity.textMsg).toHaveBeenCalledWith("Hello", 3000);
         });
 
         test("advances colIndex for single span cells", () => {


### PR DESCRIPTION
### Summary of Changes
- Fix `Uncaught ReferenceError: activity is not defined` in `js/widgets/PhraseMakerAudio.js` line 337 when `lyricsON` is enabled during playback by replacing undeclared global `activity` with `pm.activity`.
- Updated unit test in `js/widgets/__tests__/PhraseMakerAudio.test.js` to assert `pm.activity.textMsg` invocation during lyric playback.

### Testing
- All 29 unit tests in `PhraseMakerAudio.test.js` pass cleanly (`29 passed, 29 total`).
- Prettier formatting and ESLint pass with 0 errors/warnings.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

#8097