### PR TITLE
fix(search): apply autocomplete dropdown position fix at widget init instead of polling

### DIFF
--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -300,6 +300,13 @@ class SearchController {
                 }
             });
 
+            // Anchor the dropdown to the search input now that the widget
+            // exists — see window.fixSearchAutocompletePosition in
+            // js/utils/jquery-setup.js (issue #8069).
+            if (typeof window.fixSearchAutocompletePosition === "function") {
+                window.fixSearchAutocompletePosition();
+            }
+
             const instance = $search.autocomplete("instance");
             if (instance) {
                 instance._renderItem = (ul, item) => {

--- a/js/utils/__tests__/jquery-setup.test.js
+++ b/js/utils/__tests__/jquery-setup.test.js
@@ -111,12 +111,13 @@ describe("jquery-setup", () => {
 
         global.jQuery = originalJQuery;
         delete global.$;
+        delete window.fixSearchAutocompletePosition;
     });
 
-    test("registers both document ready callbacks", () => {
+    test("registers a single document ready callback", () => {
         require("../jquery-setup");
 
-        expect(readyCallbacks).toHaveLength(2);
+        expect(readyCallbacks).toHaveLength(1);
     });
 
     test("bridges jQuery UI autocomplete with Materialize autocomplete", () => {
@@ -143,24 +144,22 @@ describe("jquery-setup", () => {
         expect(jQuery.fn.materializeAutocomplete).toBeUndefined();
     });
 
-    test("schedules autocomplete position fix after initial timeout", () => {
+    test("exposes fixSearchAutocompletePosition as a global function", () => {
         require("../jquery-setup");
 
-        readyCallbacks[1]();
-
-        expect(jest.getTimerCount()).toBeGreaterThan(0);
+        expect(typeof window.fixSearchAutocompletePosition).toBe("function");
     });
 
-    test("updates dropdown position styles when autocomplete instance exists", () => {
+    test("applies the position fix and reports success when the widget exists", () => {
         const originalRenderMenu = jest.fn();
 
         mockInstance._renderMenu = originalRenderMenu;
 
         require("../jquery-setup");
 
-        readyCallbacks[1]();
+        const applied = window.fixSearchAutocompletePosition();
 
-        jest.advanceTimersByTime(1000);
+        expect(applied).toBe(true);
 
         expect(mockSearch.autocomplete).toHaveBeenCalledWith("instance");
 
@@ -181,46 +180,32 @@ describe("jquery-setup", () => {
         expect(mockDropdown.style.width).toBe("300px");
     });
 
-    test("retries setup when autocomplete instance is unavailable", () => {
+    test("returns false without logging when the widget has not been initialised", () => {
         mockSearch.data = jest.fn(() => false);
 
         require("../jquery-setup");
 
-        readyCallbacks[1]();
+        expect(window.fixSearchAutocompletePosition()).toBe(false);
 
-        jest.advanceTimersByTime(1000);
-
-        expect(jest.getTimerCount()).toBeGreaterThan(0);
+        expect(console.error).not.toHaveBeenCalled();
     });
 
-    test("logs error after maximum retry attempts", () => {
-        mockSearch.data = jest.fn(() => false);
-
-        require("../jquery-setup");
-
-        readyCallbacks[1]();
-
-        jest.advanceTimersByTime(11000);
-
-        expect(console.error).toHaveBeenCalledTimes(1);
-
-        expect(console.error).toHaveBeenCalledWith(
-            expect.stringContaining(
-                "Autocomplete setup failed: Could not initialize ui-autocomplete"
-            )
-        );
-    });
-
-    test("does not throw when search element is missing", () => {
+    test("returns false when the search element is missing", () => {
         mockSearch.length = 0;
 
         require("../jquery-setup");
 
-        readyCallbacks[1]();
+        expect(window.fixSearchAutocompletePosition()).toBe(false);
+    });
 
-        expect(() => {
-            jest.advanceTimersByTime(11000);
-        }).not.toThrow();
+    test("returns false when the autocomplete instance is null", () => {
+        mockSearch.autocomplete = jest.fn(() => null);
+
+        require("../jquery-setup");
+
+        expect(window.fixSearchAutocompletePosition()).toBe(false);
+
+        expect(mockSearch.autocomplete).toHaveBeenCalledWith("instance");
     });
 
     test("does not modify dropdown styles when searchInput is null", () => {
@@ -232,9 +217,7 @@ describe("jquery-setup", () => {
 
         require("../jquery-setup");
 
-        readyCallbacks[1]();
-
-        jest.advanceTimersByTime(1000);
+        window.fixSearchAutocompletePosition();
 
         const wrappedRenderMenu = mockInstance._renderMenu;
 
@@ -251,18 +234,6 @@ describe("jquery-setup", () => {
         expect(mockDropdown.style.width).toBeUndefined();
     });
 
-    test("does not override _renderMenu when autocomplete instance is null", () => {
-        mockSearch.autocomplete = jest.fn(() => null);
-
-        require("../jquery-setup");
-
-        readyCallbacks[1]();
-
-        jest.advanceTimersByTime(1000);
-
-        expect(mockSearch.autocomplete).toHaveBeenCalledWith("instance");
-    });
-
     test("calls original _renderMenu before applying dropdown positioning", () => {
         const originalRenderMenu = jest.fn();
 
@@ -270,9 +241,7 @@ describe("jquery-setup", () => {
 
         require("../jquery-setup");
 
-        readyCallbacks[1]();
-
-        jest.advanceTimersByTime(1000);
+        window.fixSearchAutocompletePosition();
 
         const wrappedRenderMenu = mockInstance._renderMenu;
 
@@ -282,5 +251,28 @@ describe("jquery-setup", () => {
         wrappedRenderMenu.call(mockInstance, ul, items);
 
         expect(originalRenderMenu).toHaveBeenCalledWith(ul, items);
+    });
+
+    test("is idempotent: a second call does not re-wrap _renderMenu", () => {
+        const originalRenderMenu = jest.fn();
+
+        mockInstance._renderMenu = originalRenderMenu;
+
+        require("../jquery-setup");
+
+        expect(window.fixSearchAutocompletePosition()).toBe(true);
+
+        const wrappedRenderMenu = mockInstance._renderMenu;
+
+        expect(window.fixSearchAutocompletePosition()).toBe(false);
+
+        expect(mockInstance._renderMenu).toBe(wrappedRenderMenu);
+
+        const ul = [mockDropdown];
+        const items = [];
+
+        wrappedRenderMenu.call(mockInstance, ul, items);
+
+        expect(originalRenderMenu).toHaveBeenCalledTimes(1);
     });
 });

--- a/js/utils/jquery-setup.js
+++ b/js/utils/jquery-setup.js
@@ -28,39 +28,37 @@ jQuery(document).ready(function () {
 });
 
 // Fix autocomplete dropdown position to stay anchored to the search input.
-jQuery(document).ready(function () {
-    let retries = 0;
-    const MAX_RETRIES = 20;
+// The #search autocomplete is created lazily by SearchController.doSearch()
+// (js/activity/search-controller.js), which runs late in activity startup —
+// a timer-based poll here cannot know when that happens and loses the race
+// on any load slower than its budget (issue #8069). Instead, doSearch()
+// calls this function immediately after initialising the widget.
+window.fixSearchAutocompletePosition = function () {
+    const $search = jQuery("#search");
+    if (!$search.length || !$search.data("ui-autocomplete")) {
+        return false;
+    }
 
-    const fixAutocompletePosition = function () {
-        const $search = jQuery("#search");
-        if ($search.length && $search.data("ui-autocomplete")) {
-            const instance = $search.autocomplete("instance");
-            if (instance) {
-                const originalRenderMenu = instance._renderMenu;
-                instance._renderMenu = function (ul, items) {
-                    originalRenderMenu.call(this, ul, items);
-                    setTimeout(() => {
-                        const searchInput = document.querySelector("#search");
-                        const dropdown = ul[0];
-                        if (searchInput && dropdown) {
-                            const rect = searchInput.getBoundingClientRect();
-                            dropdown.style.position = "fixed";
-                            dropdown.style.left = rect.left + "px";
-                            dropdown.style.top = rect.bottom + 2 + "px";
-                            dropdown.style.width = rect.width + "px";
-                        }
-                    }, 0);
-                };
+    const instance = $search.autocomplete("instance");
+    if (!instance || instance._mbPositionFixApplied) {
+        return false;
+    }
+
+    const originalRenderMenu = instance._renderMenu;
+    instance._renderMenu = function (ul, items) {
+        originalRenderMenu.call(this, ul, items);
+        setTimeout(() => {
+            const searchInput = document.querySelector("#search");
+            const dropdown = ul[0];
+            if (searchInput && dropdown) {
+                const rect = searchInput.getBoundingClientRect();
+                dropdown.style.position = "fixed";
+                dropdown.style.left = rect.left + "px";
+                dropdown.style.top = rect.bottom + 2 + "px";
+                dropdown.style.width = rect.width + "px";
             }
-        } else if (retries < MAX_RETRIES) {
-            retries++;
-            setTimeout(fixAutocompletePosition, 500);
-        } else {
-            console.error(
-                `Autocomplete setup failed: Could not initialize ui-autocomplete on #search after ${MAX_RETRIES} retries.`
-            );
-        }
+        }, 0);
     };
-    setTimeout(fixAutocompletePosition, 1000);
-});
+    instance._mbPositionFixApplied = true;
+    return true;
+};


### PR DESCRIPTION
## Description

The `_renderMenu` positioning patch for the `#search` autocomplete (which anchors the suggestions dropdown to the search input) was installed by a timer in `js/utils/jquery-setup.js`: it began polling 1s after DOM-ready and gave up after 20 × 500ms (~11s), logging `Autocomplete setup failed: Could not initialize ui-autocomplete on #search after 20 retries.`

The widget is actually created late in activity startup, in `SearchController.doSearch()` — after palettes, artwork, and instrument samples load. On any load slower than ~11s (cold cache, throttled network, low-powered devices) the poller expired first, so the console error appeared and the positioning patch was silently never applied.

This PR removes the guess entirely: the patch is now applied at the one place the widget is created, so no load speed can break it.

## Related Issue

This PR fixes #8069

Note: #8085 addresses the same issue with the same core approach. This is an alternative implementation for the maintainers to compare — main differences: single non-duplicated implementation of the positioning patch (applied only at the live init path), explicit idempotency guard (`_mbPositionFixApplied`, addressing the re-wrap concern raised in #8085's review), and no unrelated changes.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Tests — Adds or updates test coverage

## Changes Made

-   `js/utils/jquery-setup.js`: deleted the polling loop; the (unchanged) positioning logic is now exposed as `window.fixSearchAutocompletePosition()`, which is idempotent (guards against double-wrapping `_renderMenu`) and returns whether it applied.
-   `js/activity/search-controller.js`: `doSearch()` calls the function immediately after `$search.autocomplete({...})` creates the widget, inside the existing once-only init guard.
-   `js/utils/__tests__/jquery-setup.test.js`: rewrote the timer-simulation tests as direct function tests; added an idempotency test (11 tests).

## Testing Performed

-   `npm run lint`, `npx prettier --check` on changed files, and full `npm test`: 7,508 tests / 210 suites pass.
-   Reproduced the original failure on master in four conditions (broadband cold cache, Chrome DevTools "Fast 4G" and "3G" throttling, localhost dev server) — error appears ~12s in, patch never applies.
-   Verified the fix in-browser under the same conditions: no error at any load speed; `instance._mbPositionFixApplied === true` after init; dropdown measured pinned 2px below the input at its exact left edge and width; re-anchors correctly after window resize; suggestion selection still spawns blocks.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
