### PR TITLE
fix(phrasemaker): correctly map marked columns for duplicate pitches in sort

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -624,6 +624,65 @@ describe("PhraseMaker Widget", () => {
 
         expect(phraseMaker.sorted).toBe(true);
     });
+    test("_sort correctly merges marked columns for duplicate pitch rows without adding row indices", () => {
+        phraseMaker.init = jest.fn();
+        phraseMaker.makeClickable = jest.fn();
+        phraseMaker.rowLabels = ["sol", "sol"];
+        phraseMaker.rowArgs = [4, 4];
+        phraseMaker._noteStored = ["sol4", "sol4"];
+        phraseMaker.columnBlocksMap = [[0], [1]];
+        phraseMaker._rows = [
+            {
+                cells: [
+                    { style: { backgroundColor: "black" } },
+                    { style: { backgroundColor: "white" } }
+                ]
+            },
+            {
+                cells: [
+                    { style: { backgroundColor: "white" } },
+                    { style: { backgroundColor: "black" } }
+                ]
+            }
+        ];
+
+        phraseMaker._deps.noteToFrequency = jest.fn(() => 392);
+        phraseMaker.activity = {
+            turtles: { ithTurtle: () => ({ singer: { keySignature: 0 } }) },
+            logo: { tupletRhythms: [] }
+        };
+
+        phraseMaker._sort();
+
+        expect(phraseMaker.sorted).toBe(true);
+        // Marked columns in the preserved row (original row index 0) should contain [0, 1] (column indices), NOT row index 1
+        expect(phraseMaker._markedColsInRow[0]).toEqual([0, 1]);
+    });
+    test("makeClickable safely handles sorted rows when cells are undefined", () => {
+        phraseMaker.sorted = true;
+        phraseMaker._rowMapper = [0];
+        phraseMaker._sortedRowMap = [0];
+        phraseMaker._markedColsInRow = [[5]]; // index 5 does not exist in cells
+        phraseMaker._rows = [
+            {
+                cells: [
+                    {
+                        style: {},
+                        setAttribute: jest.fn(),
+                        addEventListener: jest.fn(),
+                        removeEventListener: jest.fn()
+                    }
+                ]
+            }
+        ];
+        phraseMaker._noteValueRow = { cells: phraseMaker._rows[0].cells };
+        phraseMaker._tupletValueRow = { cells: [] };
+        phraseMaker._setNoteCell = jest.fn();
+
+        expect(() => {
+            phraseMaker.makeClickable();
+        }).not.toThrow();
+    });
     test("recalculateBlocks calls PhraseMakerUtils", () => {
         phraseMaker.activity = {
             logo: { tupletRhythms: [] }

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2683,7 +2683,21 @@ class PhraseMaker {
 
         // Add the rows we skipped when capturing marked columns.
         for (let i = 0; i < rowsWeSkipped.length; i++) {
-            this._markedColsInRow[rowsWeSkipped[i][0]].push(rowsWeSkipped[i][1]);
+            const targetSortableIdx = rowsWeSkipped[i][0];
+            const skippedRowIdx = rowsWeSkipped[i][1];
+            const targetRowIdx = sortableList[targetSortableIdx]?.[3];
+
+            if (
+                targetRowIdx !== undefined &&
+                this._markedColsInRow[skippedRowIdx] &&
+                this._markedColsInRow[targetRowIdx]
+            ) {
+                for (const colIdx of this._markedColsInRow[skippedRowIdx]) {
+                    if (!this._markedColsInRow[targetRowIdx].includes(colIdx)) {
+                        this._markedColsInRow[targetRowIdx].push(colIdx);
+                    }
+                }
+            }
         }
 
         // Add the stuff we didn't sort.
@@ -4377,11 +4391,16 @@ class PhraseMaker {
                 ii = this._rowMapper[i];
                 r = this._sortedRowMap[i];
                 row = this._rows[r];
+                if (!row || !this._markedColsInRow[ii]) {
+                    continue;
+                }
                 for (let j = 0; j < this._markedColsInRow[ii].length; j++) {
                     c = this._markedColsInRow[ii][j];
-                    cell = row.cells[c];
-                    cell.style.backgroundColor = "black";
-                    this._setNoteCell(r, c, cell, false, null);
+                    cell = row.cells?.[c];
+                    if (cell) {
+                        cell.style.backgroundColor = "black";
+                        this._setNoteCell(r, c, cell, false, null);
+                    }
                 }
             }
         } else {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -1435,14 +1435,15 @@ class PhraseMaker {
                 setTimeout(() => this._addNotesBlockBetween(aboveBlock, newBlock, false), 500);
                 let i;
                 for (i = 0; i < this.columnBlocksMap.length; i++) {
-                    if (this.columnBlocksMap[i][0] === aboveBlock) {
+                    if (this.columnBlocksMap[i] && this.columnBlocksMap[i][0] === aboveBlock) {
                         break;
                     }
                 }
 
-                this.rowLabels.splice(i + 1, 0, rLabel);
-                this.rowArgs.splice(i + 1, 0, rArg);
-                this._rowBlocks.splice(i + 1, 0, newBlock);
+                const insertIndex = i < this.columnBlocksMap.length ? i + 1 : this.rowLabels.length;
+                this.rowLabels.splice(insertIndex, 0, rLabel);
+                this.rowArgs.splice(insertIndex, 0, rArg);
+                this._rowBlocks.splice(insertIndex, 0, newBlock);
             }
 
             this.sorted = false;


### PR DESCRIPTION
- [X] Bug Fix

## Description
This PR fixes a runtime regression where opening or interacting with the Phrase Maker pie menu after adding pitch rows caused an uncaught `TypeError`:
```
Uncaught TypeError: can't access property "style", cell is undefined
    at makeClickable (js/widgets/phrasemaker.js)
    at _sort (js/widgets/phrasemaker.js)
```
## Root Cause
In commit `51ef7ca92` (PR #7881), deduplication logic for duplicate pitch rows was added in `_sort()`:
```javascript
for (let i = 0; i < rowsWeSkipped.length; i++) {
    this._markedColsInRow[rowsWeSkipped[i][0]].push(rowsWeSkipped[i][1]);
}
```
Here, `rowsWeSkipped[i][1]` holds the **row index** `i` (e.g. `5`), not a column index. Pushing this value into `_markedColsInRow` corrupted the column index mapping. Subsequently, when `makeClickable()` attempted to access `row.cells[c]`, `c` was out of bounds, resulting in `cell` being `undefined` and throwing when accessing `cell.style`.

## Steps to Reproduce (Before this fix)
1. Open the Phrase Maker widget.
2. Click `+` (Add Row) and choose `pitch` from the pie menu.
3. Re-open or interact with the pie menu / sort again.
4. Observe the uncaught `TypeError: cell is undefined` in the developer console.

<img width="1585" height="765" alt="Screenshot 2026-08-18 at 9 25 28 AM" src="https://github.com/user-attachments/assets/a9deb342-fa90-4905-979c-ce1baeaf8f69" />
