### PR TITLE
fix(widgets): initialize getElement and add null safety in musickeyboard

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -208,6 +208,47 @@ describe("MusicKeyboard add-row submenu", () => {
         );
     });
 
+    test("initializes getElement and safely updates when inserting a new note block via pie menu", () => {
+        jest.useFakeTimers();
+        const blockList = [{ connections: [null, null] }];
+        const loadNewBlocks = jest.fn().mockImplementation(() => {
+            blockList.push({ connections: [null, null] });
+            return [blockList.length - 1];
+        });
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            refreshCanvas: jest.fn(),
+            turtles: {
+                ithTurtle: () => ({ singer: { keySignature: "C" } })
+            },
+            blocks: {
+                blockList: blockList,
+                loadNewBlocks,
+                adjustExpandableClampBlock: jest.fn()
+            }
+        });
+
+        expect(keyboard.getElement).toBeDefined();
+        expect(typeof keyboard.getElement).toBe("object");
+
+        keyboard.layout = [
+            { noteName: "do", noteOctave: 4, blockNumber: 0, voice: 0, objId: "cell-1" }
+        ];
+
+        keyboard._createKeyboard = jest.fn();
+        keyboard._createTable = jest.fn();
+        keyboard._syncLayouts = jest.fn();
+
+        keyboard._createAddRowPieSubmenu();
+        keyboard._menuWheel.selectedNavItemIndex = 0;
+        keyboard._menuWheel.navItems[0].navigateFunction();
+
+        expect(() => jest.advanceTimersByTime(500)).not.toThrow();
+        expect(keyboard.getElement).toBeDefined();
+        jest.useRealTimers();
+    });
+
     test("creates pie submenu and sets z-index, top position, and exit wheel correctly", () => {
         window.configureExitWheel = jest.fn();
         document.body.innerHTML =

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -208,8 +208,9 @@ describe("MusicKeyboard add-row submenu", () => {
         );
     });
 
-    test("initializes getElement and safely updates when inserting a new note block via pie menu", () => {
+    test("initializes noteToKeyMap and safely updates when inserting a new note block via pie menu", () => {
         jest.useFakeTimers();
+        global.FIXEDSOLFEGE1 = { "do♯": "C#" };
         const blockList = [{ connections: [null, null] }];
         const loadNewBlocks = jest.fn().mockImplementation(() => {
             blockList.push({ connections: [null, null] });
@@ -229,15 +230,21 @@ describe("MusicKeyboard add-row submenu", () => {
             }
         });
 
-        expect(keyboard.getElement).toBeDefined();
-        expect(typeof keyboard.getElement).toBe("object");
+        expect(keyboard.noteToKeyMap).toBeDefined();
+        expect(typeof keyboard.noteToKeyMap).toBe("object");
 
         keyboard.layout = [
-            { noteName: "do", noteOctave: 4, blockNumber: 0, voice: 0, objId: "cell-1" }
+            { noteName: "do", noteOctave: 4, blockNumber: 0, voice: 0, objId: "cell-0" }
         ];
 
+        keyboard._addNotesBlockBetween = jest.fn();
+        keyboard._sortLayout = jest.fn();
         keyboard._createKeyboard = jest.fn();
-        keyboard._createTable = jest.fn();
+        keyboard._createTable = jest.fn().mockImplementation(() => {
+            if (keyboard.layout.length > 0) {
+                keyboard.layout[keyboard.layout.length - 1].objId = "cell-new";
+            }
+        });
         keyboard._syncLayouts = jest.fn();
 
         keyboard._createAddRowPieSubmenu();
@@ -245,8 +252,88 @@ describe("MusicKeyboard add-row submenu", () => {
         keyboard._menuWheel.navItems[0].navigateFunction();
 
         expect(() => jest.advanceTimersByTime(500)).not.toThrow();
-        expect(keyboard.getElement).toBeDefined();
+        expect(keyboard.noteToKeyMap).toBeDefined();
+        expect(keyboard.noteToKeyMap["do♯4"]).toBe("cell-new");
+        expect(keyboard.noteToKeyMap["C#4"]).toBe("cell-new");
         jest.useRealTimers();
+    });
+
+    test("safely handles if noteToKeyMap is null or undefined when inserting a new note block", () => {
+        jest.useFakeTimers();
+        global.FIXEDSOLFEGE1 = { "do♯": "C#" };
+        const blockList = [{ connections: [null, null] }];
+        const loadNewBlocks = jest.fn().mockImplementation(() => {
+            blockList.push({ connections: [null, null] });
+            return [blockList.length - 1];
+        });
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            refreshCanvas: jest.fn(),
+            turtles: {
+                ithTurtle: () => ({ singer: { keySignature: "C" } })
+            },
+            blocks: {
+                blockList: blockList,
+                loadNewBlocks,
+                adjustExpandableClampBlock: jest.fn()
+            }
+        });
+
+        keyboard.noteToKeyMap = null;
+        keyboard.layout = [
+            { noteName: "do", noteOctave: 4, blockNumber: 0, voice: 0, objId: "cell-0" }
+        ];
+
+        keyboard._addNotesBlockBetween = jest.fn();
+        keyboard._sortLayout = jest.fn();
+        keyboard._createKeyboard = jest.fn();
+        keyboard._createTable = jest.fn().mockImplementation(() => {
+            if (keyboard.layout.length > 0) {
+                keyboard.layout[keyboard.layout.length - 1].objId = "cell-new";
+            }
+        });
+        keyboard._syncLayouts = jest.fn();
+
+        keyboard._createAddRowPieSubmenu();
+        keyboard._menuWheel.selectedNavItemIndex = 0;
+        keyboard._menuWheel.navItems[0].navigateFunction();
+
+        expect(() => jest.advanceTimersByTime(500)).not.toThrow();
+        expect(keyboard.noteToKeyMap).toBeDefined();
+        expect(keyboard.noteToKeyMap["do♯4"]).toBe("cell-new");
+        expect(keyboard.noteToKeyMap["C#4"]).toBe("cell-new");
+        jest.useRealTimers();
+    });
+
+    test("doMIDI populates noteToKeyMap from layout including solfege conversion", async () => {
+        global.FIXEDSOLFEGE1 = { do: "C", re: "D" };
+        const keyboard = new MusicKeyboard({
+            canvas: { width: 800, height: 600 },
+            getStageScale: () => 1,
+            textMsg: jest.fn(),
+            errorMsg: jest.fn()
+        });
+
+        keyboard.layout = [
+            { noteName: "do", noteOctave: 4, objId: "cell-do4" },
+            { noteName: "D", noteOctave: 4, objId: "cell-d4" }
+        ];
+
+        const originalRequestMIDIAccess = navigator.requestMIDIAccess;
+        navigator.requestMIDIAccess = jest.fn().mockResolvedValue({ inputs: new Map() });
+
+        keyboard.doMIDI();
+
+        expect(keyboard.noteToKeyMap).toBeDefined();
+        expect(keyboard.noteToKeyMap["do4"]).toBe("cell-do4");
+        expect(keyboard.noteToKeyMap["C4"]).toBe("cell-do4");
+        expect(keyboard.noteToKeyMap["D4"]).toBe("cell-d4");
+
+        // allow promise to resolve cleanly
+        await Promise.resolve();
+
+        navigator.requestMIDIAccess = originalRequestMIDIAccess;
     });
 
     test("creates pie submenu and sets z-index, top position, and exit wheel correctly", () => {

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -262,7 +262,7 @@ function MusicKeyboard(activity) {
      * Mapping between note names with octaves and keyboard element IDs.
      * @type {Object}
      */
-    this.getElement = {};
+    this.noteToKeyMap = {};
 
     /**
      * Flag to track first note while using metronome.
@@ -2392,14 +2392,14 @@ function MusicKeyboard(activity) {
                     this._createTable();
                     const n = this.layout.length;
                     const key = this.layout[n - 1];
-                    if (!this.getElement) {
-                        this.getElement = {};
+                    if (!this.noteToKeyMap) {
+                        this.noteToKeyMap = {};
                     }
                     if (key) {
-                        this.getElement[key.noteName.toString() + key.noteOctave.toString()] =
+                        this.noteToKeyMap[key.noteName.toString() + key.noteOctave.toString()] =
                             key.objId;
                         if (FIXEDSOLFEGE1 && FIXEDSOLFEGE1[key.noteName.toString()]) {
-                            this.getElement[
+                            this.noteToKeyMap[
                                 FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave
                             ] = key.objId; //convet solfege to alphabetic.
                         }
@@ -3588,15 +3588,16 @@ function MusicKeyboard(activity) {
         let duration = 0;
         let startTime = 0;
 
-        this.getElement = {};
+        this.noteToKeyMap = {};
 
         for (let idx = 0; idx < this.layout.length; idx++) {
             const key = this.layout[idx];
             if (key) {
-                this.getElement[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
+                this.noteToKeyMap[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
                 if (FIXEDSOLFEGE1 && FIXEDSOLFEGE1[key.noteName.toString()]) {
-                    this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
-                        key.objId; //convet solfege to alphabetic.
+                    this.noteToKeyMap[
+                        FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave
+                    ] = key.objId; //convet solfege to alphabetic.
                 }
             }
         }
@@ -3687,7 +3688,7 @@ function MusicKeyboard(activity) {
             const pitch2 = pitchOctave[1];
             const octave = pitchOctave[2];
             const key =
-                this.getElement[pitch1 + "" + octave] || this.getElement[pitch2 + "" + octave];
+                this.noteToKeyMap[pitch1 + "" + octave] || this.noteToKeyMap[pitch2 + "" + octave];
             if (event.data[0] === 144 && event.data[2] !== 0) {
                 __startNote(event, docById(key));
             } else {

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -259,6 +259,12 @@ function MusicKeyboard(activity) {
     this.instrumentMapper = {};
 
     /**
+     * Mapping between note names with octaves and keyboard element IDs.
+     * @type {Object}
+     */
+    this.getElement = {};
+
+    /**
      * Flag to track first note while using metronome.
      * @type {boolean}
      */
@@ -2386,10 +2392,18 @@ function MusicKeyboard(activity) {
                     this._createTable();
                     const n = this.layout.length;
                     const key = this.layout[n - 1];
-                    this.getElement[key.noteName.toString() + key.noteOctave.toString()] =
-                        key.objId;
-                    this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
-                        key.objId; //convet solfege to alphabetic.
+                    if (!this.getElement) {
+                        this.getElement = {};
+                    }
+                    if (key) {
+                        this.getElement[key.noteName.toString() + key.noteOctave.toString()] =
+                            key.objId;
+                        if (FIXEDSOLFEGE1 && FIXEDSOLFEGE1[key.noteName.toString()]) {
+                            this.getElement[
+                                FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave
+                            ] = key.objId; //convet solfege to alphabetic.
+                        }
+                    }
                 }, 500);
             } else {
                 debugLog("Could not find anywhere to insert new block.");
@@ -3578,9 +3592,13 @@ function MusicKeyboard(activity) {
 
         for (let idx = 0; idx < this.layout.length; idx++) {
             const key = this.layout[idx];
-            this.getElement[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
-            this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
-                key.objId; //convet solfege to alphabetic.
+            if (key) {
+                this.getElement[key.noteName.toString() + key.noteOctave.toString()] = key.objId;
+                if (FIXEDSOLFEGE1 && FIXEDSOLFEGE1[key.noteName.toString()]) {
+                    this.getElement[FIXEDSOLFEGE1[key.noteName.toString()] + "" + key.noteOctave] =
+                        key.objId; //convet solfege to alphabetic.
+                }
+            }
         }
 
         /**


### PR DESCRIPTION
- [X] Bug Fix
## Description
Fixes an uncaught `TypeError` when adding new pitch/note blocks via the pie menu in the Music Keyboard widget:
`Uncaught TypeError: can't access property "hertz262", this.getElement is undefined`

### Cause:
`this.getElement` was only being initialized inside `doMIDI()`, leaving it `undefined` when a user interacts with the keyboard pie menu to add new notes before MIDI is triggered.

### Changes:
1. Initialized `this.getElement = {}` inside the `MusicKeyboard` constructor.
2. Added null/existence checks for `this.getElement` and `FIXEDSOLFEGE1` lookups before assigning properties in `_createAddRowPieSubmenu` and `doMIDI`.
3. Added unit tests in `musickeyboard.test.js` to verify initialization and safe property assignments during note insertion.

<img width="1800" height="830" alt="Screenshot 2026-08-18 at 9 49 41 AM" src="https://github.com/user-attachments/assets/8a0ab05d-86eb-44d0-82b5-b86e9804208f" />
