### PR TITLE
fix: request the right locale file for enUS, enUK and zhCN

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
         <script src="js/svgAssetSelector.js" defer></script>
         <script src="lib/acorn.min.js" defer></script>
         <script src="env.js" defer></script>
+        <script src="js/utils/language-utils.js" defer></script>
 
         <script data-main="js/loader" src="lib/require.js" defer></script>
         <link

--- a/js/activity.js
+++ b/js/activity.js
@@ -62,7 +62,7 @@ try {
    MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
    SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
-   extractProjectDataFromHTML,unescapeHTML, pubsub
+   extractProjectDataFromHTML,unescapeHTML, pubsub, normalizeLanguageCode
  */
 
 /*
@@ -434,10 +434,10 @@ class Activity {
                     this.storage.languagePreference = "ja";
                     this.storage.kanaPreference = "kanji";
                     lang = "ja";
-                } else if (lang.startsWith("ja")) {
-                    lang = "ja"; // normalize Japanese
                 }
-                i18next.changeLanguage(lang);
+                // The menu stores codes like enUS/enUK/zhCN; the locale files are
+                // named en/en_GB/zh_CN. Hand i18next the file name, not the menu id.
+                i18next.changeLanguage(normalizeLanguageCode(lang));
             } else {
                 lang = navigator.language;
                 if (lang.includes("-")) {

--- a/js/loader.js
+++ b/js/loader.js
@@ -16,6 +16,22 @@ const t_ = typeof _ === "function" ? _ : s => s;
 
 const ASSET_VERSION = window.location.protocol === "file:" ? "" : "v=999999_fix7";
 
+// The function normalizeLanguageCode() is declared as a side effect of
+// loading js/utils/language-utils.js as a <script> tag in index.html; classic
+// (non-module) scripts share one global lexical scope, so it is already
+// visible here without a local declaration of the same name -- redeclaring it
+// with let/const throws "already been declared". Under Jest, loader.js is
+// required directly via CommonJS and no such tag runs, so fall back to
+// requiring the module the same way js/utils/utils.js does. Guard on `module`
+// rather than `require` alone: RequireJS (lib/require.js) also exposes a
+// global `require` in the browser, and calling that synchronously on an
+// unregistered module id throws.
+let resolvedNormalizeLanguageCode =
+    typeof normalizeLanguageCode === "function" ? normalizeLanguageCode : undefined;
+if (!resolvedNormalizeLanguageCode && typeof module !== "undefined" && module.exports) {
+    ({ normalizeLanguageCode: resolvedNormalizeLanguageCode } = require("./utils/language-utils"));
+}
+
 requirejs.config({
     baseUrl: "./",
     urlArgs: ASSET_VERSION,
@@ -387,11 +403,10 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
     }
 
     // Shared with activity.js so the two never drift apart; see
-    // js/utils/language-utils.js. Falls back to an identity map in the unlikely
-    // event the helper has not executed yet.
+    // js/utils/language-utils.js.
     function toLocaleCode(language) {
-        return typeof window.normalizeLanguageCode === "function"
-            ? window.normalizeLanguageCode(language)
+        return typeof resolvedNormalizeLanguageCode === "function"
+            ? resolvedNormalizeLanguageCode(language)
             : language;
     }
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -386,6 +386,15 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
         });
     }
 
+    // Shared with activity.js so the two never drift apart; see
+    // js/utils/language-utils.js. Falls back to an identity map in the unlikely
+    // event the helper has not executed yet.
+    function toLocaleCode(language) {
+        return typeof window.normalizeLanguageCode === "function"
+            ? window.normalizeLanguageCode(language)
+            : language;
+    }
+
     function resolveInitialLanguage() {
         try {
             const savedLanguage = window.localStorage && window.localStorage.languagePreference;
@@ -400,14 +409,7 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
                     window.localStorage.setItem("kanaPreference", "kanji");
                     return "ja";
                 }
-                // The language menu stores enUS/enUK, but the locale files are en/en_GB.
-                if (savedLanguage === "enUS") {
-                    return "en";
-                }
-                if (savedLanguage === "enUK") {
-                    return "en_GB";
-                }
-                return savedLanguage.startsWith("ja") ? "ja" : savedLanguage;
+                return toLocaleCode(savedLanguage);
             }
         } catch (e) {
             // Continue with navigator fallback when storage is unavailable.

--- a/js/utils/__tests__/language-utils.test.js
+++ b/js/utils/__tests__/language-utils.test.js
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { normalizeLanguageCode } = require("../language-utils");
+
+const ROOT = path.join(__dirname, "..", "..", "..");
+const LOCALES_DIR = path.join(ROOT, "locales");
+
+describe("normalizeLanguageCode", () => {
+    it("maps the English menu codes onto their locale files", () => {
+        expect(normalizeLanguageCode("enUS")).toBe("en");
+        expect(normalizeLanguageCode("enUK")).toBe("en_GB");
+    });
+
+    it("maps the Chinese menu code onto its locale file", () => {
+        expect(normalizeLanguageCode("zhCN")).toBe("zh_CN");
+    });
+
+    it("collapses the Japanese variants onto ja", () => {
+        expect(normalizeLanguageCode("ja")).toBe("ja");
+        expect(normalizeLanguageCode("kana")).toBe("ja");
+        expect(normalizeLanguageCode("ja-kana")).toBe("ja");
+        expect(normalizeLanguageCode("ja-kanji")).toBe("ja");
+    });
+
+    it("passes through codes that already name a locale file", () => {
+        expect(normalizeLanguageCode("fr")).toBe("fr");
+        expect(normalizeLanguageCode("zh_CN")).toBe("zh_CN");
+        expect(normalizeLanguageCode("en_GB")).toBe("en_GB");
+    });
+
+    it("falls back to en for empty or non-string input", () => {
+        expect(normalizeLanguageCode("")).toBe("en");
+        expect(normalizeLanguageCode(undefined)).toBe("en");
+        expect(normalizeLanguageCode(null)).toBe("en");
+    });
+});
+
+describe("language dropdown coverage", () => {
+    const dropdownIds = (() => {
+        const html = fs.readFileSync(path.join(ROOT, "index.html"), "utf8");
+        const block = html.match(/<ul id="languagedropdown"[\s\S]*?<\/ul>/);
+        expect(block).not.toBeNull();
+        return [...block[0].matchAll(/<a id="([^"]+)"/g)].map(match => match[1]);
+    })();
+
+    it("finds the language entries in index.html", () => {
+        expect(dropdownIds.length).toBeGreaterThan(0);
+    });
+
+    it.each(dropdownIds)("resolves %s to a locale file that exists", id => {
+        const locale = normalizeLanguageCode(id);
+        expect(fs.existsSync(path.join(LOCALES_DIR, `${locale}.json`))).toBe(true);
+    });
+});

--- a/js/utils/language-utils.js
+++ b/js/utils/language-utils.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * MusicBlocks v3.4.1
+ * Copyright (C) 2014-2026 Walter Bender
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/* exported normalizeLanguageCode */
+
+/**
+ * The language menu identifies languages by the id of its dropdown entries
+ * (enUS, enUK, zhCN, kana, ...), but the locale files in locales/ are named
+ * after the translation codes (en, en_GB, zh_CN, ja, ...). Passing a menu code
+ * straight to i18next asks the backend for a file that does not exist, which
+ * 404s and silently falls back to English.
+ *
+ * Keep this mapping as the single place that translates between the two.
+ */
+const LANGUAGE_CODE_TO_LOCALE = {
+    "enUS": "en",
+    "enUK": "en_GB",
+    "zhCN": "zh_CN",
+    "kana": "ja",
+    "ja-kana": "ja",
+    "ja-kanji": "ja"
+};
+
+/**
+ * Maps a stored language preference onto the locale file that backs it.
+ *
+ * @param {string} language - a language menu code or a translation code.
+ * @returns {string} the code matching a file in locales/.
+ */
+function normalizeLanguageCode(language) {
+    if (typeof language !== "string" || language === "") {
+        return "en";
+    }
+
+    if (Object.prototype.hasOwnProperty.call(LANGUAGE_CODE_TO_LOCALE, language)) {
+        return LANGUAGE_CODE_TO_LOCALE[language];
+    }
+
+    // Any other Japanese variant also resolves to the ja translations.
+    return language.startsWith("ja") ? "ja" : language;
+}
+
+const LanguageUtils = {
+    LANGUAGE_CODE_TO_LOCALE,
+    normalizeLanguageCode
+};
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = LanguageUtils;
+}
+
+if (typeof window !== "undefined") {
+    window.LanguageUtils = LanguageUtils;
+    Object.assign(window, LanguageUtils);
+}


### PR DESCRIPTION
- [X] Bug Fix
### Problem

Opening Music Blocks with the language preference set to **English (United States)**, **English (United Kingdom)** or **中文** requests a locale file that does not exist:

```
GET locales/enUS.json 404 (Not Found)
```

The language menu identifies languages by the id of its `#languagedropdown` entries (`enUS`, `enUK`, `zhCN`, `kana`), but the files in `locales/` are named after the translation codes (`en`, `en_GB`, `zh_CN`, `ja`). `js/loader.js` mapped between the two when it initialised i18next, but `js/activity.js` passed the stored preference straight to `i18next.changeLanguage()`:

```js
lang = this.storage.languagePreference;   // "enUS"
...
i18next.changeLanguage(lang);             // asks for locales/enUS.json
```

### Impact

More than console noise. i18next falls back to `en` after the failed load, which discards the correct bundle `loader.js` had already fetched:

| languagePreference | before | after |
| --- | --- | --- |
| `enUK` | `lang: "enUK"`, `t("color") === "color"` | `lang: "en_GB"`, `t("color") === "colour"` |
| `enUS` | 404, falls back to `en` | `lang: "en"`, no 404 |

So selecting **English (United Kingdom)** silently left the UI on US English — `colour` / `set colour` reverted to `color` / `set color`. The Chinese entry is affected the same way, since its file is `zh_CN.json`. For `enUS` the `en` fallback happens to be the correct bundle, which is why this went unnoticed.

### Fix

Extract the mapping into `js/utils/language-utils.js` and use it in both `loader.js` and `activity.js`, so the two cannot drift apart again — the duplication is what allowed this in the first place.

### Tests

`js/utils/__tests__/language-utils.test.js` covers the mapping and, importantly, parses `#languagedropdown` out of `index.html` and asserts every id resolves to a locale file that exists on disk. A future menu entry with no translation file now fails CI instead of 404ing in production.

```
npx jest js/utils/__tests__/language-utils.test.js js/__tests__/language-dropdown.test.js
Test Suites: 2 passed, 2 total
Tests:       33 passed, 33 total
```

`eslint` and `prettier --check` are clean on all touched files. `index.html` is a one-line addition only; it does not currently satisfy `prettier` on master, and reformatting it would have buried the change.

### Verification

Served the built tree and reloaded with each preference. Post-fix loads request `locales/en.json` and `locales/en_GB.json` with `200`, and there are no 404s.
