### PR TITLE
fix: crash when a block's type name collides with an inherited Object.prototype key

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -676,6 +676,23 @@ describe("Blocks Foundation", () => {
             expect(() => blocks.loadNewBlocks(blockObjs)).not.toThrow();
         });
 
+        it.each(["toString", "constructor", "hasOwnProperty", "valueOf", "__proto__"])(
+            "loads a block named '%s' without throwing",
+            reservedName => {
+                const blocks = new Blocks(mockActivity);
+                blocks.blockList = [];
+                blocks.newStorein2Block = jest.fn();
+                blocks.newNamedboxBlock = jest.fn();
+                blocks.setActionProtoVisibility = jest.fn();
+                blocks.customTemperamentDefined = true;
+                blocks._makeNewBlockWithConnections = jest.fn();
+
+                const blockObjs = [[0, reservedName, 0, 0, [null, null, null]]];
+
+                expect(() => blocks.loadNewBlocks(blockObjs)).not.toThrow();
+            }
+        );
+
         it("resets _suppressRefresh on circular connection early return", () => {
             const blocks = new Blocks(mockActivity);
             blocks.blockList = [];

--- a/js/__tests__/help-controller.test.js
+++ b/js/__tests__/help-controller.test.js
@@ -301,6 +301,25 @@ describe("HelpController.saveHelpBlocks", () => {
         );
     });
 
+    test("loads the block directly when protoBlockDict has no prototype chain", () => {
+        // blocks.js builds protoBlockDict via Object.create(null), so
+        // helper code reading it can't rely on inherited Object.prototype
+        // methods like .hasOwnProperty() being present.
+        const activity = makeActivity();
+        activity.blocks.protoBlockDict = Object.assign(Object.create(null), {
+            empty: { helpString: "" },
+            note: { helpString: ["a", "b", "c"] }
+        });
+        const controller = new HelpController(activity);
+
+        expect(() => {
+            controller.saveHelpBlocks();
+            jest.advanceTimersByTime(1000 + 500);
+        }).not.toThrow();
+
+        expect(activity.palettes.dict.paletteName.makeBlockFromSearch).toHaveBeenCalled();
+    });
+
     test("loads a macro when the help block message points to a macro name", () => {
         const activity = makeActivity();
         activity.blocks.protoBlockDict = {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -168,7 +168,7 @@ class Blocks {
         this._deferCheckBounds = false;
 
         /** We keep a dictionary for the proto blocks, */
-        this.protoBlockDict = {};
+        this.protoBlockDict = Object.create(null);
         /** and a list of the blocks we create. */
         this.blockList = [];
 

--- a/js/help-controller.js
+++ b/js/help-controller.js
@@ -370,7 +370,9 @@ class HelpController {
                     const paletteName = obj[1];
                     const protoName = obj[2];
 
-                    if (that.blocks.protoBlockDict.hasOwnProperty(protoName)) {
+                    if (
+                        Object.prototype.hasOwnProperty.call(that.blocks.protoBlockDict, protoName)
+                    ) {
                         that.palettes.dict[paletteName].makeBlockFromSearch(
                             protoblk,
                             protoName,


### PR DESCRIPTION
 
## Description
 
`Blocks.loadNewBlocks()` uses `this.protoBlockDict`, a plain object (`{}`), to look up known block types, checked with `in` and read with bracket access, both keyed directly by the block's own type name with no sanitization.
 
If a block's type name is exactly `toString`, `constructor`, `hasOwnProperty`, `valueOf`, or `__proto__`, `name in this.protoBlockDict` reads `true` (inherited from `Object.prototype`), so the "is this a known block?" guard never rejects it. `this.protoBlockDict[name]` then returns the inherited method itself, a truthy function, so `proto.hasCapability(...)` throws.
 
Reachable through the paste-blocks feature, same entry point as the `__proto__`-valued text block crash fixed in #8039 . Fix: change `protoBlockDict` to `Object.create(null)`, so it has no prototype chain and reserved words become ordinary keys. This also resolves a second, identical `in`-check bug later in the same function (`_processOneBlock`'s default case, `blocks.js:6057`).
 
One thing broke from this change: `help-controller.js:373` called `.hasOwnProperty()` directly on `protoBlockDict`, which no longer works once it has no prototype chain. Fixed to `Object.prototype.hasOwnProperty.call(...)`.
 
## How to Verify
 
On `master`, before this PR, paste this into Music Blocks' paste-blocks input:
```json
[[0, "toString", 0, 0, [null, null, null]]]
```
Console shows:
```
Uncaught TypeError: proto.hasCapability is not a function
    at Blocks.loadNewBlocks (blocks.js:4950:40)
    at Activity.pasted (activity.js:2584:25)
```
Same for `constructor`, `hasOwnProperty`, `valueOf`, `__proto__` in place of `"toString"`. With this PR applied, it loads a NOP placeholder block instead.
 
## PR Category
 
-   [x] Bug Fix — Fixes a bug or incorrect behavior
## Changes Made
 
-   `this.protoBlockDict = {}` → `Object.create(null)` in the `Blocks` constructor (`js/blocks.js`).
-   `that.blocks.protoBlockDict.hasOwnProperty(protoName)` → `Object.prototype.hasOwnProperty.call(that.blocks.protoBlockDict, protoName)` in `HelpController._saveHelpBlock` (`js/help-controller.js`).
-   Regression test in `js/__tests__/blocks.test.js` (`_suppressRefresh during loading` describe block): parameterized test covering all five reserved names.
-   Regression test in `js/__tests__/help-controller.test.js` (`HelpController.saveHelpBlocks` describe block): confirms help-block loading works with a null-prototype `protoBlockDict`.
## Testing Performed
 
-   Reproduced live in the browser, matches the console output above.
-   Both regression tests fail on the unfixed source with the exact errors shown above; pass with the fix applied.
-   Full `blocks.test.js`, `help-controller.test.js`, `activity_listeners.test.js` suites pass together (63 tests).
-   `node --check` on both changed files passes; `eslint` and `prettier --check` clean.
## Checklist
 
-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [ ] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.
 