### PR TITLE
fix: resolve window focus hijacking in widgetWindows

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -821,4 +821,114 @@ describe("widgetWindows", () => {
             expect(window.widgetWindows.openWindows["FallbackTitle"]).toBe(win);
         });
     });
+
+    describe("_handleGlobalMouseDown and focus management", () => {
+        test("focuses clicked window and dims other windows", () => {
+            const win1 = createTestWindow("Window 1");
+            const win2 = createTestWindow("Window 2");
+
+            // win2 was created last so it took focus initially
+            expect(window.widgetWindows.focused).toBe(win2);
+
+            // Simulate mousedown inside win1
+            const clickEvent = new MouseEvent("mousedown", { bubbles: true });
+            win1._frame.dispatchEvent(clickEvent);
+
+            expect(window.widgetWindows.focused).toBe(win1);
+            expect(win1._frame.style.opacity).toBe("1");
+            expect(win1._frame.style.zIndex).toBe("10000");
+            expect(win2._frame.style.opacity).toBe("0.7");
+            expect(win2._frame.style.zIndex).toBe("0");
+        });
+
+        test("switches focus back to another window when clicked", () => {
+            const win1 = createTestWindow("Window 1");
+            const win2 = createTestWindow("Window 2");
+
+            win1._frame.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+            expect(window.widgetWindows.focused).toBe(win1);
+
+            win2._widget.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+            expect(window.widgetWindows.focused).toBe(win2);
+            expect(win2._frame.style.opacity).toBe("1");
+            expect(win2._frame.style.zIndex).toBe("10000");
+            expect(win1._frame.style.opacity).toBe("0.7");
+            expect(win1._frame.style.zIndex).toBe("0");
+        });
+
+        test("clears focus and dims all windows when clicking outside all windows", () => {
+            const win1 = createTestWindow("Window 1");
+            const win2 = createTestWindow("Window 2");
+
+            expect(window.widgetWindows.focused).toBe(win2);
+
+            // Simulate clicking on canvas / document body
+            canvas.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+            expect(window.widgetWindows.focused).toBeNull();
+            expect(win1._frame.style.opacity).toBe("0.7");
+            expect(win1._frame.style.zIndex).toBe("0");
+            expect(win2._frame.style.opacity).toBe("0.7");
+            expect(win2._frame.style.zIndex).toBe("0");
+        });
+
+        test("preserves focus when clicking inside toolbar", () => {
+            const toolbars = document.createElement("div");
+            toolbars.id = "toolbars";
+            document.body.appendChild(toolbars);
+
+            try {
+                const win1 = createTestWindow("Window 1");
+                const win2 = createTestWindow("Window 2");
+
+                win1._frame.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+                expect(window.widgetWindows.focused).toBe(win1);
+
+                toolbars.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+                expect(window.widgetWindows.focused).toBe(win1);
+                expect(win1._frame.style.opacity).toBe("1");
+                expect(win1._frame.style.zIndex).toBe("10000");
+            } finally {
+                toolbars.remove();
+            }
+        });
+
+        test("Escape key closes only the currently focused window", () => {
+            const win1 = createTestWindow("Window 1");
+            const win2 = createTestWindow("Window 2");
+
+            const closeSpy1 = jest.spyOn(win1, "onclose");
+            const closeSpy2 = jest.spyOn(win2, "onclose");
+
+            // Focus win1
+            win1._frame.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+            expect(window.widgetWindows.focused).toBe(win1);
+
+            const escEvent = new KeyboardEvent("keydown", { key: "Escape", bubbles: true });
+            window.dispatchEvent(escEvent);
+
+            expect(closeSpy1).toHaveBeenCalledTimes(1);
+            expect(closeSpy2).not.toHaveBeenCalled();
+        });
+
+        test("Cmd/Ctrl+Shift+M maximizes only the currently focused window", () => {
+            const win1 = createTestWindow("Window 1");
+            const win2 = createTestWindow("Window 2");
+
+            win1._frame.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+            expect(window.widgetWindows.focused).toBe(win1);
+
+            const maxEvent = new KeyboardEvent("keydown", {
+                code: "KeyM",
+                ctrlKey: true,
+                shiftKey: true,
+                bubbles: true
+            });
+            window.dispatchEvent(maxEvent);
+
+            expect(win1.isMaximized()).toBe(true);
+            expect(win2.isMaximized()).toBe(false);
+        });
+    });
 });

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -95,32 +95,33 @@ window.widgetWindows = {
                 e.target.closest(".dropdown-content") ||
                 e.target.closest(".dropdown-trigger"));
 
+        if (isToolbarInteraction) {
+            return;
+        }
+
         const windows = Object.values(this.openWindows).filter(win => win !== undefined);
-        let focusedAny = false;
+        let clickedWindow = null;
 
         for (let i = 0; i < windows.length; i++) {
             const win = windows[i];
-            if (
-                e.target === win._frame ||
-                win._frame.contains(e.target) ||
-                win._fullscreenEnabled ||
-                isToolbarInteraction
-            ) {
-                // Focus this window
+            if (win._frame && (e.target === win._frame || win._frame.contains(e.target))) {
+                clickedWindow = win;
+                break;
+            }
+        }
+
+        for (let i = 0; i < windows.length; i++) {
+            const win = windows[i];
+            if (win === clickedWindow) {
                 win._frame.style.opacity = "1";
                 win._frame.style.zIndex = "10000";
-                this.focused = win;
-                focusedAny = true;
             } else {
-                // Dim other windows
-                win._frame.style.opacity = ".7";
+                win._frame.style.opacity = "0.7";
                 win._frame.style.zIndex = "0";
             }
         }
 
-        if (!focusedAny) {
-            this.focused = null;
-        }
+        this.focused = clickedWindow;
     }
 };
 


### PR DESCRIPTION
### Summary
Resolves [#8106](https://github.com/sugarlabs/musicblocks/issues/8106) where clicking anywhere in the document caused window focus to be hijacked by the last window in `openWindows` due to `win._fullscreenEnabled` evaluating to `true` on every click in `_handleGlobalMouseDown`.

### Description of Changes
- **js/widgets/widgetWindows.js**: Removed `win._fullscreenEnabled` from click evaluation logic; added early return for toolbar/dropdown interactions (`isToolbarInteraction`); properly set active window to `zIndex: 10000` / `opacity: 1`, dimmed inactive windows to `0.7`, and cleared focus on workspace clicks.
- **js/widgets/__tests__/widgetWindows.test.js**: Added unit test coverage for window focus switching, canvas click defocusing, toolbar interaction preservation, and keyboard shortcut routing (`Escape`, `Cmd/Ctrl+Shift+M`).

### PR Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

### Testing
- `npm run lint` — PASSED
- `npx prettier --check js/widgets/widgetWindows.js js/widgets/__tests__/widgetWindows.test.js` — PASSED
- `npx jest js/widgets/__tests__/widgetWindows.test.js` — PASSED (86/86 passed)
- Manual browser verification (window focus switching & Escape close shortcut) — PASSED