### PR TITLE
chore: add local DCO validation

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,13 @@
 npx --no-install commitlint --edit "$1"
+
+# Require an explicit DCO sign-off on non-merge commits
+if [ -f "$(git rev-parse --git-path MERGE_HEAD)" ]; then
+    exit 0
+fi
+
+if ! tr -d '\r' < "$1" | grep -qE '^Signed-off-by: .+ <.+>$'; then
+    echo "commit-msg: missing Signed-off-by trailer (DCO)."
+    echo "Sign off explicitly with: git commit -s"
+    echo "See: https://developercertificate.org/"
+    exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ Follow these steps when contributing:
 4.  Commit with clear, descriptive messages:
 
     ```
-    git commit -m "docs: add AI contribution guidelines (Related to #XXXX)"
+    git commit -s -m "docs: add AI contribution guidelines (Related to #XXXX)"
     ```
 
 5.  Push your branch:


### PR DESCRIPTION
### Description

This PR improves the developer experience around the project's DCO requirement by adding a local check for missing DCO sign-offs.

Currently, contributors need to explicitly use `git commit -s` to add the required Signed-off-by trailer. Without it, the DCO check only fails later on GitHub after the commit has been pushed.

### Changes
- Added a local DCO check to the existing Husky commit-msg hook.
- Unsigned non-merge commits now fail locally with a clear message to use git commit -s.
- Existing signed commits continue to pass normally.
- Merge commits are excluded, consistent with the GitHub DCO workflow.
- The sign-off is never added automatically; contributors must explicitly certify their commits.
- Updated the contributor documentation example to use git commit -s.

The existing commitlint and GitHub DCO validation behavior remains unchanged. This only moves DCO feedback earlier into the local development workflow.

### PR Category
 - [x] chore / refactor