### PR TITLE
refactor(activity): remove redundant Touch.enable call

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2735,9 +2735,6 @@ class Activity {
                 event.currentTarget.value = "";
             });
 
-            // Enable touch interactions if supported on the current device.
-            createjs.Touch.enable(this.stage, false, true);
-
             // Keep tracking the mouse even when it leaves the canvas.
             this.stage.mouseMoveOutside = true;
 


### PR DESCRIPTION
## Description

In `js/activity.js`, `createjs.Touch.enable` was being invoked twice. The second call was redundant because EaselJS ignores subsequent calls once touch support has already been enabled.

This PR removes the redundant call while keeping the original `createjs.Touch.enable(this.stage)` initialization unchanged. No touch behavior or `allowDefault` settings are modified.

## Related Issue

## PR Category

* [x] Refactor / Cleanup

## Changes Made

* Removed the redundant `createjs.Touch.enable(this.stage, false, true)` call and its associated comment.
* Kept the original touch initialization unchanged.
* No behavioral changes to touch or scrolling behavior.

## Testing Performed

* `npx prettier --check js/activity.js` - passed.
* `npm run lint` -  passed.
* `npm test` - passed: 212 test suites, 7,690 tests.

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have followed the project's coding style guidelines.
* [x] I have run the required formatting and lint checks with no errors.

