### PR TITLE
fix: use Blob URLs for HTML exports

### DIFF
--- a/js/SaveInterface.js
+++ b/js/SaveInterface.js
@@ -360,9 +360,9 @@ class SaveInterface {
      * @instance
      */
     saveHTML(activity) {
-        const html =
-            "data:text/plain;charset=utf-8," + encodeURIComponent(activity.save.prepareHTML());
-        activity.save.download("html", html, null);
+        const blob = new Blob([activity.save.prepareHTML()], { type: "text/html;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        activity.save.download("html", url, null);
     }
 
     /**
@@ -379,13 +379,15 @@ class SaveInterface {
      */
     saveHTMLNoPrompt(activity) {
         setTimeout(() => {
-            const html =
-                "data:text/plain;charset=utf-8," + encodeURIComponent(activity.save.prepareHTML());
+            const blob = new Blob([activity.save.prepareHTML()], {
+                type: "text/html;charset=utf-8"
+            });
+            const url = URL.createObjectURL(blob);
             const planet = this.getPlanetInterface(activity);
             if (planet && typeof planet.getCurrentProjectName === "function") {
-                activity.save.downloadURL(planet.getCurrentProjectName() + ".html", html);
+                activity.save.downloadURL(planet.getCurrentProjectName() + ".html", url);
             } else {
-                activity.save.downloadURL(STR_MY_PROJECT.replace(" ", "_") + ".html", html);
+                activity.save.downloadURL(STR_MY_PROJECT.replace(" ", "_") + ".html", url);
             }
         }, 500);
     }

--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -267,6 +267,7 @@ describe("save HTML methods", () => {
             }
         };
         instance = new SaveInterface(activity);
+        global.URL.createObjectURL = jest.fn(() => "blob:mock-html");
     });
 
     afterEach(() => {
@@ -474,11 +475,8 @@ describe("save HTML methods", () => {
         instance.saveHTML(activity);
 
         expect(mockPrepareHTML).toHaveBeenCalled();
-        expect(mockDownload).toHaveBeenCalledWith(
-            "html",
-            "data:text/plain;charset=utf-8,%3Chtml%3EMock%20HTML%3C%2Fhtml%3E",
-            null
-        );
+        expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+        expect(mockDownload).toHaveBeenCalledWith("html", "blob:mock-html", null);
     });
 
     it("should call prepareHTML and download the file with the correct filename", () => {
@@ -499,10 +497,7 @@ describe("save HTML methods", () => {
 
         expect(mockPrepareHTML).toHaveBeenCalled();
         expect(mockGetProjectName).toHaveBeenCalled();
-        expect(mockDownloadURL).toHaveBeenCalledWith(
-            "MockProject.html",
-            "data:text/plain;charset=utf-8,%3Chtml%3EMock%20HTML%3C%2Fhtml%3E"
-        );
+        expect(mockDownloadURL).toHaveBeenCalledWith("MockProject.html", "blob:mock-html");
     });
 
     it("should use the active Planet project name for HTML downloads without a prompt", () => {
@@ -521,7 +516,7 @@ describe("save HTML methods", () => {
 
         expect(activity.save.downloadURL).toHaveBeenCalledWith(
             "Planet Project.html",
-            "data:text/plain;charset=utf-8,%3Chtml%3EMock%20HTML%3C%2Fhtml%3E"
+            "blob:mock-html"
         );
     });
 
@@ -536,10 +531,7 @@ describe("save HTML methods", () => {
         instance.saveHTMLNoPrompt(activity);
         jest.runAllTimers();
 
-        expect(activity.save.downloadURL).toHaveBeenCalledWith(
-            "My_Project.html",
-            expect.any(String)
-        );
+        expect(activity.save.downloadURL).toHaveBeenCalledWith("My_Project.html", "blob:mock-html");
     });
 });
 


### PR DESCRIPTION
## What

Use Blob object URLs when exporting projects as HTML from `SaveInterface.saveHTML` and `SaveInterface.saveHTMLNoPrompt`.

## Why

Encoding the complete project as a data URI can exceed browser URI-length limits and truncate projects containing large embedded images.

## How

Create the exported HTML as a `Blob`, pass its object URL through the existing download paths, and update the SaveInterface tests to cover the Blob-based URLs. The existing `downloadURL` method revokes object URLs after starting the download.

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Testing

- `npm test -- --runInBand --coverage=false` — 212 suites, 7,704 tests passed
- `npx eslint .`
- `npx prettier --check js/SaveInterface.js js/__tests__/SaveInterface.test.js`

Closes #8124