### PR TITLE
fix(sampler): configure AI sample endpoint

### DIFF
--- a/js/widgets/__tests__/sampler.test.js
+++ b/js/widgets/__tests__/sampler.test.js
@@ -110,6 +110,7 @@ describe("Sampler Widget", () => {
         global.DOUBLESHARP = "x";
         global.DOUBLEFLAT = "bb";
         global.NATURAL = "n";
+        window.AI_SAMPLE_ENDPOINT = "https://samples.example";
 
         document.body.innerHTML = `
             <div id="wheelDiv"></div>
@@ -810,6 +811,10 @@ describe("Sampler Widget", () => {
             await submit.onclick();
             jest.runOnlyPendingTimers();
 
+            expect(global.fetch).toHaveBeenCalledWith(
+                "https://samples.example/generate?prompt=hello"
+            );
+
             preview.disabled = false;
             save.disabled = false;
             const playSpy = jest.fn();
@@ -828,6 +833,19 @@ describe("Sampler Widget", () => {
             expect(clickSpy).toHaveBeenCalled();
             clickSpy.mockRestore();
             jest.useRealTimers();
+        });
+
+        test("prompt reports unavailable AI sample generation without a configured endpoint", () => {
+            delete window.AI_SAMPLE_ENDPOINT;
+            mockActivity.errorMsg = jest.fn();
+            widget.init(mockActivity, 1);
+
+            widget._promptBtn.onclick();
+
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                "AI sample generation is not available."
+            );
+            expect(docById("samplerPrompt")).toBeNull();
         });
 
         test("prompt submit handles failure and errors", async () => {
@@ -1024,6 +1042,7 @@ describe("Sampler Widget", () => {
 
         test("startPitchDetection handles getUserMedia failure", async () => {
             widget.widgetWindow = widgetWindow;
+            mockActivity.errorMsg = jest.fn();
             const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
             global.AudioContext = jest.fn(() => ({
                 sampleRate: 44100,
@@ -1042,15 +1061,22 @@ describe("Sampler Widget", () => {
                 },
                 configurable: true
             });
-            global.alert = jest.fn();
-
             widget.makeTuner(400, 300);
             const startButton = document.getElementById("start");
             startButton.click();
 
             await Promise.resolve();
-            expect(global.alert).toHaveBeenCalled();
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith("Microphone access failed: no mic");
             errorSpy.mockRestore();
+        });
+    });
+
+    describe("endpoint safety", () => {
+        test("sampler.js contains no hardcoded HTTP IP addresses", () => {
+            const fs = require("fs");
+            const path = require("path");
+            const source = fs.readFileSync(path.resolve(__dirname, "../sampler.js"), "utf8");
+            expect(source).not.toMatch(/http:\/\/\d+\.\d+\.\d+\.\d+/);
         });
     });
 });

--- a/js/widgets/sampler.js
+++ b/js/widgets/sampler.js
@@ -678,6 +678,17 @@ function SampleWidget() {
 
         this._promptBtn.onclick = () => {
             stopTuner();
+            const aiSampleEndpoint =
+                typeof window.AI_SAMPLE_ENDPOINT === "string"
+                    ? window.AI_SAMPLE_ENDPOINT.trim().replace(/\/$/, "")
+                    : "";
+            if (!aiSampleEndpoint) {
+                activity.errorMsg(_("AI sample generation is not available."));
+                return;
+            }
+            if (aiSampleEndpoint.startsWith("http://")) {
+                console.warn("AI sample endpoint is using HTTP instead of HTTPS.");
+            }
             if (this.is_recording) {
                 this.activity.logo.synth.stopRecording();
                 this.is_recording = false;
@@ -789,7 +800,7 @@ function SampleWidget() {
                 setPromptBtnState(submit, true);
                 const prompt = textArea.value;
                 const encodedPrompt = encodeURIComponent(prompt);
-                const url = `http://13.61.94.100:8000/generate?prompt=${encodedPrompt}`;
+                const url = `${aiSampleEndpoint}/generate?prompt=${encodedPrompt}`;
 
                 let blinkInterval;
 
@@ -834,7 +845,7 @@ function SampleWidget() {
                     that.audioPreview = null;
                 }
 
-                const audioURL = `http://13.61.94.100:8000/preview`;
+                const audioURL = `${aiSampleEndpoint}/preview`;
                 const newAudio = new Audio(audioURL);
                 that.audioPreview = newAudio;
                 newAudio.play();
@@ -850,7 +861,7 @@ function SampleWidget() {
             stylePromptBtn(save, "Save");
             setPromptBtnState(save, true);
             save.onclick = function () {
-                const audioURL = `http://13.61.94.100:8000/save`;
+                const audioURL = `${aiSampleEndpoint}/save`;
                 const link = document.createElement("a");
                 link.href = audioURL;
                 link.download = "output.wav";
@@ -2208,7 +2219,7 @@ function SampleWidget() {
             this.pitchDetectionAnimationId = requestAnimationFrame(updatePitch);
         } catch (err) {
             console.error(`${err.name}: ${err.message}`);
-            alert(_("Microphone access failed: %s").replace(/%s/g, err.message));
+            this.activity.errorMsg(_("Microphone access failed: %s").replace(/%s/g, err.message));
             // Clean up any partially initialized resources
             this.stopPitchDetection();
         }


### PR DESCRIPTION
## Description

Removes the hardcoded HTTP IP from the Sampler's AI sample generation flow.

The widget now reads the service URL from `window.AI_SAMPLE_ENDPOINT`, reports when no endpoint is configured, and warns when an HTTP endpoint is used. Microphone access failures now use `activity.errorMsg()` instead of `alert()`.

  ## Related Issue

  Closes #8121

  ## PR Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ## Changes Made

  - Use one configured endpoint for generate, preview, and save requests.
  - Stop the prompt flow when no endpoint is configured.
  - Replace the microphone failure alert with the existing error banner.
  - Add regression tests for endpoint handling and hardcoded HTTP IP addresses.

 ## Testing Performed

  - `npm run lint` — passed
  - Prettier check on changed files — passed
  - Sampler tests — 49 passed
  - Full Jest suite — 7,706 tests across 212 suites passed
  - Configured and unconfigured endpoint states verified locally in the browser

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run lint and Prettier with no errors.
  - [x] I have addressed the relevant feedback from the previous submission.
  - [x] I have enabled Allow edits from maintainers.