### PR TITLE
fix(ui): pin the bottom-right canvas buttons to the viewport corner

### DIFF
--- a/js/context-menu-controller.js
+++ b/js/context-menu-controller.js
@@ -16,6 +16,10 @@
 
 /* exported setupContextMenuController, ContextMenuController */
 
+// Intrinsic size of the bottom-right palette button artwork. Used to convert
+// the button's top edge into an offset from the bottom of the viewport.
+const PALETTE_BUTTON_SIZE = 42;
+
 /*
  * Hides the helpful wheel (if currently shown) and ticks the activity so the
  * canvas re-renders. Shared by the wheel-item action helpers below (each of
@@ -502,12 +506,15 @@ class ContextMenuController {
         const altText = label ? label.replace(/\s*\[.*\]$/, "") : "Toolbar button";
         img.setAttribute("alt", altText);
 
-        // Batch DOM reads before writes to avoid forced synchronous layout
-        const rightPos = document.body.clientWidth - x;
+        // Anchor to the viewport, not to the document, so the buttons stay
+        // pinned to the bottom-right corner in fullscreen and while scrolling.
+        // x and y are viewport coordinates of the button's top-left corner.
+        const rightPos = window.innerWidth - x;
+        const bottomPos = Math.max(0, window.innerHeight - y - PALETTE_BUTTON_SIZE);
         container.appendChild(img);
         container.setAttribute(
             "style",
-            "position: absolute; right:" + rightPos + "px;  top: " + y + "px;"
+            "position: fixed; right:" + rightPos + "px;  bottom: " + bottomPos + "px;"
         );
         document.getElementById("buttoncontainerBOTTOM").appendChild(container);
         return container;


### PR DESCRIPTION
- [X] Bug Fix

## Problem


In fullscreen the bottom-right canvas buttons (home, show/hide blocks, expand/collapse blocks, decrease/increase block size) float well above the bottom of the screen instead of sitting in the corner.

| Fullscreen (before) | Windowed |
| --- | --- |
| Row sits ~150px above the bottom edge | Row sits correctly in the corner |

## Cause

`ContextMenuController.makeButton()` laid each button out as:

```js
const rightPos = document.body.clientWidth - x;
container.setAttribute("style", "position: absolute; right:" + rightPos + "px;  top: " + y + "px;");
```

with `y = window.innerHeight - 57.5` computed in `setupPaletteMenu()`. That is a **document**-relative coordinate captured at the moment the row is built, so it only lands on the bottom edge as long as something re-runs `setupPaletteMenu()` with the current height. On entering fullscreen the viewport grows and the row keeps its stale `top`, leaving it stranded mid-canvas.

`document.body.clientWidth` has the same class of problem horizontally: it drifts away from the viewport width whenever the canvas container ends up wider than the window.

## Fix

Anchor the row to the viewport rather than to the document:

```js
const rightPos = window.innerWidth - x;
const bottomPos = Math.max(0, window.innerHeight - y - PALETTE_BUTTON_SIZE);
container.setAttribute("style", "position: fixed; right:" + rightPos + "px;  bottom: " + bottomPos + "px;");
```

Because `x` and `y` are themselves derived from `window.innerWidth` / `window.innerHeight`, both offsets come out window-size independent — `right: 27.5px` and `bottom: 15.5px` — so the row stays pinned to the corner with no recompute at all. This mirrors how `play-only-mode.css` already positions the same `#buttoncontainerBOTTOM`.

No change to the button order, sizing, tooltips, or the existing `setupPaletteMenu()` call sites.

