### PR TITLE
fix: crashes when a corrupted connection index points past the end of blockList

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -317,6 +317,29 @@ describe("Blocks Foundation", () => {
     });
 
     describe("Constructor", () => {
+        it("_getStackSize does not throw on an out-of-range block index", () => {
+            const blocks = new Blocks(mockActivity);
+            // Non-empty so the loop-counter guard (sizeCounter > blockList.length * 2)
+            // doesn't short-circuit before reaching the out-of-range dereference.
+            blocks.blockList = [{}, {}];
+
+            expect(() => blocks._getStackSize(99999)).not.toThrow();
+        });
+
+        it("adjustExpandableClampBlock does not throw on an out-of-range block index", () => {
+            const blocks = new Blocks(mockActivity);
+            blocks.blockList = [{}, {}];
+            blocks.clampBlocksToCheck = [[99999, 0]];
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+            expect(() => blocks.adjustExpandableClampBlock()).not.toThrow();
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringContaining("Something very broken in adjustExpandableClampBlock")
+            );
+
+            debugSpy.mockRestore();
+        });
+
         it("should initialize using an activity object", () => {
             const blocks = new Blocks(mockActivity);
 

--- a/js/activity/__tests__/block-drag-controller.test.js
+++ b/js/activity/__tests__/block-drag-controller.test.js
@@ -896,6 +896,37 @@ describe("BlockDragController", () => {
             debugSpy.mockRestore();
         });
 
+        it("_calculateDragGroup guards against an out-of-range connection index", () => {
+            // A stray connection pointing past the end of blockList (e.g.
+            // from corrupted or maliciously crafted project data) used to
+            // reach myBlock.connections on undefined instead of being caught
+            // by the null check. blockList is padded with filler entries so
+            // the unrelated loop-counter guard (dragLoopCounter >
+            // blockList.length) has enough budget to not trip first.
+            const blockList = [
+                makeFlowBlock({
+                    x: 0,
+                    y: 0,
+                    docks: [
+                        [0, 0, "in"],
+                        [0, 20, "out"]
+                    ],
+                    connections: [null, 99999]
+                }),
+                null,
+                null,
+                null,
+                null
+            ];
+            const blocks = makeBlocks(blockList);
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+            expect(() => blocks.findDragGroup(0)).not.toThrow();
+            expect(blocks.dragGroup).toEqual([0]);
+
+            debugSpy.mockRestore();
+        });
+
         it("_calculateDragGroup stops recursing once the loop counter exceeds the block list length", () => {
             const blockList = [
                 { connections: [null, 0] } // a block that "connects to itself" so recursion never bottoms out
@@ -930,6 +961,20 @@ describe("BlockDragController", () => {
             expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("null block."));
 
             await expect(blocks.blockMoved(0)).resolves.toBeUndefined();
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringContaining("null block found in blockMoved")
+            );
+
+            debugSpy.mockRestore();
+        });
+
+        it("blockMoved guards against an out-of-range thisBlock index", async () => {
+            // thisBlock past the end of blockList used to reach
+            // myBlock.connections on undefined instead of being caught here.
+            const blocks = makeBlocks([null]);
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+            await expect(blocks.blockMoved(99)).resolves.toBeUndefined();
             expect(debugSpy).toHaveBeenCalledWith(
                 expect.stringContaining("null block found in blockMoved")
             );

--- a/js/activity/block-drag-controller.js
+++ b/js/activity/block-drag-controller.js
@@ -125,7 +125,7 @@ class BlockDragController {
 
         const myBlock = blocks.blockList[blk];
         /** If this happens, something is really broken. */
-        if (myBlock === null) {
+        if (myBlock === null || myBlock === undefined) {
             console.debug("null block encountered... this is bad. " + blk);
             return;
         }
@@ -290,7 +290,7 @@ class BlockDragController {
         blocks._checkTwoArgBlocks = [];
         const checkArgBlocks = [];
         const myBlock = blocks.blockList[thisBlock];
-        if (myBlock === null) {
+        if (myBlock === null || myBlock === undefined) {
             console.debug("null block found in blockMoved method: " + thisBlock);
             return;
         }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -682,6 +682,11 @@ class Blocks {
 
             const myBlock = this.blockList[blk];
 
+            if (myBlock === null || myBlock === undefined) {
+                console.debug("Something very broken in adjustExpandableClampBlock: " + blk);
+                return;
+            }
+
             if (myBlock.isArgFlowClampBlock() || myBlock.isLeftClampBlock()) {
                 /** Make sure myBlock is a clamp block. */
             } else if (myBlock.isArgBlock() || myBlock.isTwoArgBlock()) {
@@ -981,7 +986,7 @@ class Blocks {
             }
 
             const myBlock = this.blockList[blk];
-            if (myBlock === null) {
+            if (myBlock === null || myBlock === undefined) {
                 console.debug("Something very broken in _getStackSize.");
                 return size;
             }


### PR DESCRIPTION
## Description

Several places check `myBlock === null` after `blockList[idx]` to guard against a missing block, but an out-of-range index returns `undefined`, not `null`, so the check misses it and the next line throws. Fixed four call sites with the same one-line guard, `myBlock === null || myBlock === undefined`, matching the idiom already used elsewhere in this codebase (`FlowBlocks.js:542`).

`block-drag-controller.js`'s `_calculateDragGroup` is confirmed live: pasting a block with an out-of-range connection index, then dragging any block, throws `Cannot read properties of undefined (reading 'connections')` from ordinary user interaction, not just at load time.

## Related Issue

#8134

## PR Category

- [x] Bug Fix  — Fixes a bug or incorrect behavior

## How to Reproduce

Paste/load the following malformed block data and drag any block on the canvas:

```text
[[0, "repeat", 200, 200, [null, null, 99999, null]]]

```

### Before
<img width="1919" height="978" alt="Screenshot 2026-08-20 131128" src="https://github.com/user-attachments/assets/af8f8e99-5996-456d-a671-8b3ab4163329" />

### After 
<img width="1911" height="976" alt="Screenshot 2026-08-20 131325" src="https://github.com/user-attachments/assets/c2613b1f-d341-4fcb-a4be-cd71afbf9739" />


## Changes Made

* `blocks.js` `_getStackSize`: fixed the existing `=== null` check.
* `blocks.js` `adjustExpandableClampBlock`: added the missing guard entirely (there was none).
* `block-drag-controller.js` `_calculateDragGroup`: fixed the existing `=== null` check.
* `block-drag-controller.js` `blockMoved`: fixed the existing `=== null` check.
* Regression tests for all four in `js/__tests__/blocks.test.js` (`Constructor` describe block) and `js/__tests__/block-drag-controller.test.js` (`edge cases and guards` describe block).

## Why this scope, not a broader fix

The same underlying issue, unvalidated connection indices, appears in 60+ places across the codebase, mostly in the `blocks/*.js` runtime files, where a non-null but out-of-range connection value can still slip past a legitimate "is this slot empty" check.

Validating every connection index once at load time (in `loadNewBlocks`) would close all of them in one change, but that's a bigger, more opinionated decision about whether malformed data should be silently rejected wholesale. That felt like it should be the maintainers' call, rather than something to bundle into this bug-fix PR unasked.

As a possible follow-up, would the maintainers prefer a load-time validation pass for connection indices, or fixing individual call sites as they are found?

## Testing Performed

* Reproduced the `_calculateDragGroup` crash live via paste + drag, matching the reported error.
* Each of the four fixes was individually reverted and confirmed to fail its regression test with the real error, then restored and reconfirmed passing.
* One test initially passed against unfixed code because an unrelated loop-counter guard was tripping first with too small a mock `blockList`; this was caught and corrected before trusting the regression test.
* Full `blocks.test.js`, `block-drag-controller.test.js`, `help-controller.test.js`, and `activity_listeners.test.js` suites pass together (118 tests).
* `eslint` and `prettier --check` are clean on all changed files.

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** *(required for auto-rebase; this only affects the PR branch, not your fork)*.