### PR TITLE
ci: replace hard-coded Jest coverage threshold with base-branch delta check

### DIFF
--- a/.github/scripts/compare-coverage.js
+++ b/.github/scripts/compare-coverage.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Compares two Jest `coverage-summary.json` files (base branch vs. PR head)
+ * and fails (exit 1) if any of statements/branches/functions/lines dropped.
+ *
+ * Usage: node compare-coverage.js <base-summary.json> <pr-summary.json>
+ *
+ * Writes a markdown delta table to $GITHUB_STEP_SUMMARY when set, so
+ * reviewers see a base% -> PR% report on the workflow run without needing
+ * write-scoped PR-comment permissions (this repo's CI intentionally avoids
+ * pull_request_target / write tokens on fork PRs).
+ */
+
+const fs = require("fs");
+
+const METRICS = ["statements", "branches", "functions", "lines"];
+// Tolerate float rounding noise from Jest's coverage percentages.
+const EPSILON = 0.01;
+
+function readTotal(path) {
+    const summary = JSON.parse(fs.readFileSync(path, "utf8"));
+    if (!summary.total) {
+        throw new Error(`"${path}" has no "total" key — not a coverage-summary.json file`);
+    }
+    return summary.total;
+}
+
+function arrow(delta) {
+    if (delta > EPSILON) return "⬆️";
+    if (delta < -EPSILON) return "⬇️";
+    return "➡️";
+}
+
+function main() {
+    const [, , basePath, prPath] = process.argv;
+    if (!basePath || !prPath) {
+        console.error("Usage: node compare-coverage.js <base-summary.json> <pr-summary.json>");
+        process.exit(2);
+    }
+
+    const base = readTotal(basePath);
+    const pr = readTotal(prPath);
+
+    const rows = METRICS.map(metric => {
+        const basePct = base[metric].pct;
+        const prPct = pr[metric].pct;
+        const delta = prPct - basePct;
+        return { metric, basePct, prPct, delta };
+    });
+
+    const regressions = rows.filter(row => row.delta < -EPSILON);
+
+    const lines = [
+        "## Coverage delta vs. base branch",
+        "",
+        "| Metric | Base | PR | Delta |",
+        "| --- | --- | --- | --- |",
+        ...rows.map(
+            row =>
+                `| ${row.metric} | ${row.basePct.toFixed(2)}% | ${row.prPct.toFixed(2)}% | ${arrow(row.delta)} ${row.delta >= 0 ? "+" : ""}${row.delta.toFixed(2)}% |`
+        ),
+        ""
+    ];
+
+    if (regressions.length > 0) {
+        lines.push(
+            `**Coverage dropped on: ${regressions.map(row => row.metric).join(", ")}.** ` +
+                "Add or update tests so this PR does not lower overall coverage."
+        );
+    } else {
+        lines.push("No coverage regressions. ✅");
+    }
+
+    const report = lines.join("\n");
+    console.log(report);
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, report + "\n");
+    }
+
+    if (regressions.length > 0) {
+        console.error(
+            `\nFAIL: ${regressions.length} coverage metric(s) dropped relative to the base branch.`
+        );
+        process.exit(1);
+    }
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22'
-                  cache: 'npm'
+                  node-version: "22"
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
@@ -78,8 +78,8 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22.x'
-                  cache: 'npm'
+                  node-version: "22.x"
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
@@ -145,7 +145,7 @@ jobs:
               uses: actions/setup-node@v5
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: 'npm'
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
@@ -154,7 +154,8 @@ jobs:
               run: npm run build --if-present
 
     # ----------------------------------------------------------------------
-    # Jest unit tests + coverage threshold + Codecov upload
+    # Jest unit tests + Codecov upload. Coverage regressions are caught by
+    # the coverage-delta job below, not a static threshold here.
     # ----------------------------------------------------------------------
     test:
         name: Jest tests & coverage
@@ -169,23 +170,31 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22'
-                  cache: 'npm'
+                  node-version: "22"
+                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci
 
-            # Coverage thresholds are enforced inside Jest (coverageThreshold in
-            # your Jest config), so this step fails the job if coverage drops
-            # below the configured minimums.
             - name: Run Jest with coverage
               run: npm test -- --coverage --ci
 
+            # Coverage regressions are enforced by the coverage-delta job below,
+            # which compares this run's coverage-summary.json against the base
+            # branch's instead of a static threshold. Share the summary so that
+            # job doesn't need to re-run Jest against the PR head a second time.
+            - name: Upload PR coverage summary
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pr-coverage-summary
+                  path: coverage/coverage-summary.json
+                  retention-days: 1
+
             # Upload to Codecov for the PR-vs-base coverage diff + status check.
             # NOTE: secrets (CODECOV_TOKEN) are NOT available to pull_request runs
-            # originating from forks. The threshold enforcement above still runs
-            # on every PR; only the upload is skipped on forks. fail_ci_if_error
-            # is false so a flaky/absent upload never blocks the PR.
+            # originating from forks, so this upload is skipped on forks (only the
+            # coverage-delta job's check still runs there). fail_ci_if_error is
+            # false so a flaky/absent upload never blocks the PR.
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v5
               with:
@@ -193,6 +202,67 @@ jobs:
                   files: ./coverage/lcov.info
                   fail_ci_if_error: false
                   verbose: true
+
+    # ----------------------------------------------------------------------
+    # Coverage delta: fail if this PR's coverage is lower than the base
+    # branch's, instead of a static jest.config.js threshold that needs
+    # manual bumps as coverage improves.
+    #
+    # Reuses the "test" job's coverage-summary.json for the PR head (no
+    # second Jest run there). The base branch's coverage-summary.json is
+    # cached by base commit SHA, so this only costs an extra Jest run the
+    # first time a given base commit (e.g. a master merge) is seen — every
+    # other PR built on top of that same commit hits the cache.
+    # ----------------------------------------------------------------------
+    coverage-delta:
+        name: Coverage delta vs base
+        needs: test
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - name: Checkout PR head
+              uses: actions/checkout@v4
+              with:
+                  # Full history: the cache-miss step below needs to be able to
+                  # `git worktree add` the base branch's commit, not just HEAD.
+                  fetch-depth: 0
+                  ref: ${{ github.event.pull_request.head.sha }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "22"
+                  cache: "npm"
+
+            - name: Download PR coverage summary
+              uses: actions/download-artifact@v4
+              with:
+                  name: pr-coverage-summary
+                  path: pr-coverage
+
+            - name: Restore cached base-branch coverage
+              id: cache-base
+              uses: actions/cache@v4
+              with:
+                  path: base-coverage/coverage-summary.json
+                  key: coverage-base-${{ github.event.pull_request.base.sha }}
+
+            - name: Compute base-branch coverage (cache miss)
+              if: steps.cache-base.outputs.cache-hit != 'true'
+              run: |
+                  git worktree add /tmp/base-checkout ${{ github.event.pull_request.base.sha }}
+                  cd /tmp/base-checkout
+                  npm ci
+                  npx jest --coverage --ci
+                  mkdir -p "$GITHUB_WORKSPACE/base-coverage"
+                  cp coverage/coverage-summary.json "$GITHUB_WORKSPACE/base-coverage/coverage-summary.json"
+
+            - name: Compare PR coverage against base
+              run: >-
+                  node .github/scripts/compare-coverage.js
+                  base-coverage/coverage-summary.json
+                  pr-coverage/coverage-summary.json
 
     # ----------------------------------------------------------------------
     # Cypress end-to-end tests
@@ -210,15 +280,15 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22'
-                  cache: 'npm'
+                  node-version: "22"
+                  cache: "npm"
 
             - name: Run Cypress E2E tests
               uses: cypress-io/github-action@v6
               with:
                   install-command: npm ci
                   start: npm start
-                  wait-on: 'http://127.0.0.1:3000'
+                  wait-on: "http://127.0.0.1:3000"
                   wait-on-timeout: 120
                   browser: chrome
                   config: video=false
@@ -249,7 +319,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v5
               with:
-                  node-version: '22'
+                  node-version: "22"
 
             - name: Run npm audit
               run: npm audit --omit=dev --audit-level=high

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,13 +15,9 @@ module.exports = {
         "planet/js/**/*.js",
         "!planet/js/__tests__/**"
     ],
-    coverageReporters: ["text-summary", "text", "lcov", "json-summary"],
-    coverageThreshold: {
-        global: {
-            statements: 34,
-            branches: 29,
-            functions: 41,
-            lines: 34
-        }
-    }
+    coverageReporters: ["text-summary", "text", "lcov", "json-summary"]
+    // No hard-coded coverageThreshold: CI's "Coverage delta vs base" job
+    // compares this PR's coverage-summary.json against the base branch's
+    // and fails if statements/branches/functions/lines drop, instead of a
+    // static floor that needs manual bumps as coverage grows.
 };


### PR DESCRIPTION
## Description

Follow-up to #6701 (closed) and #8122. Replaces the hard-coded Jest `coverageThreshold` in `jest.config.js` with a CI job that compares this PR's coverage against the base branch and fails only if statements/branches/functions/lines actually drop, instead of a static floor that needs manual bumps as coverage grows (current coverage is ~64/54/66/64%, nearly double the configured 34/29/41/34 floor).

This directly addresses the reason #6701 stalled: the added CI cost of running Jest a second time per PR. See "Changes Made" below for how that's mitigated.

## Related Issue

**Related to:** #8122

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [x] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`jest.config.js`** — removed the hard-coded `coverageThreshold` block.
- **`.github/scripts/compare-coverage.js`** (new) — reads two Jest `coverage-summary.json` files (base vs. PR head), diffs statements/branches/functions/lines, fails (exit 1) if any metric dropped, and writes a base% -> PR% markdown table.
- **`.github/workflows/ci.yml`** — new `coverage-delta` job:
  - Reuses the PR-head `coverage-summary.json` the existing `test` job already produces (via `actions/upload-artifact` / `download-artifact`) instead of running Jest a second time for the head commit.
  - Caches the base-branch coverage by base commit SHA (`actions/cache`), so the extra Jest run for the base branch only happens once per commit on `master` — every other PR built on that same base commit hits the cache instead of re-running Jest.
  - Uses `git worktree` to check out and build the base commit's coverage on cache miss.

**Deliberate deviation from the original #6701 proposal:** the delta report is written to the job summary (`$GITHUB_STEP_SUMMARY`) instead of posted as a PR comment. This repo's `ci.yml` intentionally triggers on `pull_request` (not `pull_request_target`) specifically so fork PRs never run with a write-scoped token — posting a PR comment needs exactly that kind of token, so I kept the report read-only.

---

## Testing Performed

- Full local Jest run: 212/212 suites, 7715/7715 tests passing with the threshold removed.
- Verified the delta script against real (not synthetic) coverage output:
  - Base (`upstream/master`) vs. PR head with no source changes -> identical coverage, correctly reports no regression, exit 0.
  - Base vs. a deliberately degraded run (2 test files disabled) -> real drop of ~2-2.5 points across all 4 metrics, correctly fails, exit 1.
- Verified the `git worktree add <base-sha>` mechanism the cache-miss step relies on works as expected.
- `npm run lint` and `npx prettier --check .` clean on all changed/added files.
- Validated `ci.yml` YAML syntax.
- Not yet verified: the job's actual behavior inside GitHub Actions itself — `actions/cache` hit/miss, `actions/upload-artifact`/`download-artifact` across jobs, and `$GITHUB_STEP_SUMMARY` rendering can only be exercised by a real Actions run, which is why this is opened as a draft.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Opening as a draft on purpose: the cache/artifact/job-summary behavior can only be confirmed by a real Actions run, and this follows up on an idea the maintainer previously deferred ("stick with hard-coded thresholds for the moment") — I'd like a live CI run and maintainer input on the approach before treating this as ready for full review.
