### PR TITLE
test(turtleactions): strengthen OrnamentActions mutation coverage

### DIFF
--- a/js/turtleactions/__tests__/OrnamentActions.test.js
+++ b/js/turtleactions/__tests__/OrnamentActions.test.js
@@ -146,10 +146,15 @@ describe("OrnamentActions", () => {
         });
 
         test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            const originalMusicBlocks = global.MusicBlocks;
             delete global.MusicBlocks;
-            expect(() => Singer.OrnamentActions.setStaccato(2, 0, undefined)).not.toThrow();
-            expect(dispatchCalls.length).toBe(0);
-            expect(mouseMB.listeners.length).toBe(0);
+            try {
+                expect(() => Singer.OrnamentActions.setStaccato(2, 0, undefined)).not.toThrow();
+                expect(dispatchCalls.length).toBe(0);
+                expect(mouseMB.listeners.length).toBe(0);
+            } finally {
+                global.MusicBlocks = originalMusicBlocks;
+            }
         });
     });
 
@@ -260,10 +265,15 @@ describe("OrnamentActions", () => {
         });
 
         test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            const originalMusicBlocks = global.MusicBlocks;
             delete global.MusicBlocks;
-            expect(() => Singer.OrnamentActions.setSlur(2, 0, undefined)).not.toThrow();
-            expect(dispatchCalls.length).toBe(0);
-            expect(mouseMB.listeners.length).toBe(0);
+            try {
+                expect(() => Singer.OrnamentActions.setSlur(2, 0, undefined)).not.toThrow();
+                expect(dispatchCalls.length).toBe(0);
+                expect(mouseMB.listeners.length).toBe(0);
+            } finally {
+                global.MusicBlocks = originalMusicBlocks;
+            }
         });
     });
 
@@ -334,10 +344,15 @@ describe("OrnamentActions", () => {
         );
 
         test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            const originalMusicBlocks = global.MusicBlocks;
             delete global.MusicBlocks;
-            expect(() => Singer.OrnamentActions.doNeighbor(3, 4, 0, undefined)).not.toThrow();
-            expect(dispatchCalls.length).toBe(0);
-            expect(mouseMB.listeners.length).toBe(0);
+            try {
+                expect(() => Singer.OrnamentActions.doNeighbor(3, 4, 0, undefined)).not.toThrow();
+                expect(dispatchCalls.length).toBe(0);
+                expect(mouseMB.listeners.length).toBe(0);
+            } finally {
+                global.MusicBlocks = originalMusicBlocks;
+            }
         });
     });
 });

--- a/js/turtleactions/__tests__/OrnamentActions.test.js
+++ b/js/turtleactions/__tests__/OrnamentActions.test.js
@@ -104,6 +104,14 @@ describe("OrnamentActions", () => {
                 expectMouseListener: false,
                 isRun: true,
                 nullMouse: true
+            },
+            {
+                desc: "block defined but not in blockList",
+                blk: 99,
+                expectDispatch: false,
+                expectMouseListener: true,
+                isRun: true,
+                nullMouse: false
             }
         ];
 
@@ -130,8 +138,18 @@ describe("OrnamentActions", () => {
                 const initialStaccato = [...turtle.singer.staccato];
                 Singer.OrnamentActions.setStaccato(val, 0, 1);
                 expect(errorMsgCalls.length).toBeGreaterThan(0);
+                expect(errorMsgCalls[errorMsgCalls.length - 1].msg).toBe(
+                    "Staccato value must be non-zero."
+                );
                 expect(turtle.singer.staccato).toEqual(initialStaccato);
             });
+        });
+
+        test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            delete global.MusicBlocks;
+            expect(() => Singer.OrnamentActions.setStaccato(2, 0, undefined)).not.toThrow();
+            expect(dispatchCalls.length).toBe(0);
+            expect(mouseMB.listeners.length).toBe(0);
         });
     });
 
@@ -186,6 +204,16 @@ describe("OrnamentActions", () => {
                 nullMouse: false,
                 justCounting: true,
                 expectBeginSlur: false
+            },
+            {
+                desc: "block defined but not in blockList",
+                blk: 99,
+                expectDispatch: false,
+                expectMouseListener: true,
+                isRun: true,
+                nullMouse: false,
+                justCounting: false,
+                expectBeginSlur: true
             }
         ];
 
@@ -224,8 +252,18 @@ describe("OrnamentActions", () => {
                 const initialStaccato = [...turtle.singer.staccato];
                 Singer.OrnamentActions.setSlur(val, 0, 1);
                 expect(errorMsgCalls.length).toBeGreaterThan(0);
+                expect(errorMsgCalls[errorMsgCalls.length - 1].msg).toBe(
+                    "Slur value must be non-zero."
+                );
                 expect(turtle.singer.staccato).toEqual(initialStaccato);
             });
+        });
+
+        test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            delete global.MusicBlocks;
+            expect(() => Singer.OrnamentActions.setSlur(2, 0, undefined)).not.toThrow();
+            expect(dispatchCalls.length).toBe(0);
+            expect(mouseMB.listeners.length).toBe(0);
         });
     });
 
@@ -262,6 +300,14 @@ describe("OrnamentActions", () => {
                 expectMouseListener: false,
                 isRun: true,
                 nullMouse: true
+            },
+            {
+                desc: "block defined but not in blockList",
+                blk: 99,
+                expectDispatch: false,
+                expectMouseListener: true,
+                isRun: true,
+                nullMouse: false
             }
         ];
 
@@ -286,5 +332,12 @@ describe("OrnamentActions", () => {
                 });
             }
         );
+
+        test("does not throw and skips mouse listener when MusicBlocks is not defined", () => {
+            delete global.MusicBlocks;
+            expect(() => Singer.OrnamentActions.doNeighbor(3, 4, 0, undefined)).not.toThrow();
+            expect(dispatchCalls.length).toBe(0);
+            expect(mouseMB.listeners.length).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
## Description

This PR strengthens mutation coverage for `OrnamentActions.js` by adding targeted tests for previously surviving mutations.

The mutation score improves from **82.52% to 93.20%** by covering:

* The dispatch-guard case where `blk` is defined but does not exist in `blockList`.
* The `typeof MusicBlocks === "undefined"` branch, which was previously not exercised.
* Exact `errorMsg` text for invalid staccato and slur values instead of only checking that an error was triggered.

No production code is modified.
---

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
* [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added tests for the dispatch guard when a block index is defined but missing from `blockList`.
* Added tests for the `MusicBlocks`-undefined guard in all affected OrnamentActions methods.
* Strengthened error assertions to verify the exact error messages for invalid staccato and slur values.
* Increased mutation coverage from **82.52% to 93.20%**.
* Killed **11 previously surviving mutants**.
* Investigated the remaining **7 survivors**:

  * 4 are environment-only `module.exports` guard mutations that cannot be meaningfully exercised in Jest.
  * 3 are equivalent dispatch-guard mutations because `blockList` is a real JavaScript `Array`, so the `"undefined"` key required to distinguish the mutant cannot occur through normal production behavior.
* No production behavior or test configuration was changed.

## Visual Changes

Not applicable. This is a test-only change.

---

## Testing Performed

* Full `js/turtleactions` suite: **508/508 tests passed** across **9/9 suites**.
* `OrnamentActions.test.js`: **21 tests passed**.
* ESLint: clean on the modified file.
* Prettier: clean on the modified file.
* `git diff --check`: clean.
* Mutation testing:

  * **103 total mutants**
  * **96 killed**
  * **7 survived**
  * **93.20% mutation score**
* Remaining survivors were investigated and classified as equivalent or environment-specific rather than adding artificial tests to force-kill them.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The remaining mutation survivors are intentionally left unchanged because they do not represent meaningful testable behavior:

* The `module.exports` mutations depend on the Jest/CommonJS execution environment.
* The remaining dispatch-guard mutants require an `"undefined"` property on `activity.blocks.blockList`, while the production implementation initializes `blockList` as a real Array containing numeric block indices.

No artificial tests were introduced solely to increase the mutation score.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

* **Guidelines:** [[Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
* **Chat:** [[Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)](https://matrix.to/#/#sugar:matrix.org)

</details>