### PR TITLE
test(turtleactions): strengthen DictActions mutation coverage

### DIFF
--- a/js/turtleactions/__tests__/DictActions.test.js
+++ b/js/turtleactions/__tests__/DictActions.test.js
@@ -152,6 +152,13 @@ describe("setupDictActions", () => {
             const pitchNumber = Turtle.DictActions._GetDict(0, turtle, "pitch number", 1);
             expect(pitchNumber).toBe(60);
             expect(activity.errorMsg).toHaveBeenCalledWith(INVALIDPITCH, 1);
+            expect(pitchToNumber).toHaveBeenCalledWith("G", 4, "C");
+        });
+
+        it("should subtract pitchNumberOffset from the computed pitch number", () => {
+            targetTurtle.singer.pitchNumberOffset = 15;
+            const pitchNumber = Turtle.DictActions._GetDict(0, turtle, "pitch number");
+            expect(pitchNumber).toBe(60 - 15);
         });
 
         it("should return undefined for an unsupported key", () => {


### PR DESCRIPTION
Raise mutation score for DictActions.js from 95.43% to 97.14% by closing three weak-assertion gaps in _GetDict's "pitch number" fallback path: the no-notes fallback (obj = ["G", 4]) now asserts pitchToNumber was called with the correct arguments, and a new test exercises a non-zero pitchNumberOffset to distinguish the subtraction from an addition mutant.

Remaining survivors are the environment-only module.exports guard and one equivalent SerializeDict guard mutant (for...in over undefined is a no-op, so the guard's truth value has no observable effect when the property is absent).

