### PR TITLE
fix(block): guard null block container in highlight and offScreen methods

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -450,6 +450,15 @@ describe("Block Foundation", () => {
                 const mockBoundary = { offScreen: jest.fn().mockReturnValue(true) };
                 expect(block.offScreen(mockBoundary)).toBe(false);
             });
+
+            it("should return false, not throw, when not trashed and container is null", () => {
+                const block = new Block(mockProtoBlock, mockBlocks);
+                block.container = null;
+                block.trash = false;
+                const mockBoundary = { offScreen: jest.fn().mockReturnValue(true) };
+                expect(() => block.offScreen(mockBoundary)).not.toThrow();
+                expect(block.offScreen(mockBoundary)).toBe(false);
+            });
         });
     });
 
@@ -463,6 +472,11 @@ describe("Block Foundation", () => {
         });
 
         describe("highlight()", () => {
+            it("should not throw when container is null", () => {
+                block.container = null;
+                expect(() => block.highlight()).not.toThrow();
+            });
+
             it("should set highlightBitmap to visible and bitmap to hidden", () => {
                 block.highlight();
                 expect(block.highlightBitmap.visible).toBe(true);
@@ -479,6 +493,11 @@ describe("Block Foundation", () => {
         });
 
         describe("unhighlight()", () => {
+            it("should not throw when container is null", () => {
+                block.container = null;
+                expect(() => block.unhighlight()).not.toThrow();
+            });
+
             it("should set bitmap to visible and highlightBitmap to hidden", () => {
                 block.highlight(); // start highlighted
                 block.unhighlight();

--- a/js/block.js
+++ b/js/block.js
@@ -480,7 +480,11 @@ class Block {
      * @returns {boolean} - Returns true if the block is off-screen, otherwise false.
      */
     offScreen(boundary) {
-        return !this.trash && boundary.offScreen(this.container.x, this.container.y);
+        return (
+            !this.trash &&
+            !!this.container &&
+            boundary.offScreen(this.container.x, this.container.y)
+        );
     }
 
     /**
@@ -554,6 +558,10 @@ class Block {
      */
     highlight() {
         if (this.trash) {
+            return;
+        }
+
+        if (!this.container) {
             return;
         }
 
@@ -651,6 +659,10 @@ class Block {
      */
     unhighlight() {
         if (this.trash) {
+            return;
+        }
+
+        if (!this.container) {
             return;
         }
 


### PR DESCRIPTION
## Description

`Block.container` is initialized as `null`, but a few block methods still access it without checking whether it has been created.

This causes the following errors when these methods are called before the container is available:

* `highlight()`: `Cannot read properties of null (reading 'visible')`
* `unhighlight()`: `Cannot set properties of null (setting 'visible')`
* `offScreen()`: `Cannot read properties of null (reading 'x')`

PR #7895 added the same kind of guard to `hide()` and `show()`. This PR applies that handling to the remaining three methods above.

## Related Issue

Related to #7895

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Guard `highlight()` when `this.container` is null.
* Guard `unhighlight()` when `this.container` is null.
* Guard `offScreen()` when `this.container` is null.
* Add tests covering the null-container cases.

---

## Visual Changes

None.

---

## Testing Performed

* Added tests for all three null-container cases.
* Verified existing block behavior remains unchanged.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This follows the null-container handling introduced for `hide()` and `show()` in #7895.
