### PR TITLE
fix: resolve Lego Bricks widget failing to close on trash

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6706,8 +6706,10 @@ class Blocks {
                     delete this.blockCollapseArt[blk];
                 }
 
-                const title = this.blockList[blk].protoblock.staticLabels[0];
-                closeBlkWidgets(_(title));
+                const title = this.blockList[blk].protoblock.staticLabels
+                    ? this.blockList[blk].protoblock.staticLabels[0]
+                    : this.blockList[blk].name;
+                if (title) closeBlkWidgets(_(title));
                 this.activity.refreshCanvas();
             }
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -14,7 +14,7 @@
 // Localization helper for early bootstrap
 const t_ = typeof _ === "function" ? _ : s => s;
 
-const ASSET_VERSION = window.location.protocol === "file:" ? "" : "v=999999_fix7";
+const ASSET_VERSION = window.location.protocol === "file:" ? "" : "v=999999_fix8";
 
 requirejs.config({
     baseUrl: "./",

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1222,7 +1222,8 @@ let closeBlkWidgets = name => {
         "rhythm maker": "rhythm maker",
         "oscilloscope": "oscilloscope",
         "temperament": "temperament",
-        "meter": "meter"
+        "meter": "meter",
+        "LEGO Bricks": "LEGO BRICKS"
     };
 
     for (const origKey in KEY_MAPPING) {
@@ -1245,7 +1246,11 @@ let closeBlkWidgets = name => {
     const widgetTitle = document.getElementsByClassName("wftTitle");
     for (let i = 0; i < widgetTitle.length; i++) {
         const titleEl = widgetTitle[i];
-        if (titleEl.innerHTML === name || titleEl.id === `${searchKey}WidgetID`) {
+        if (
+            titleEl.innerHTML === name ||
+            titleEl.innerHTML === searchKey ||
+            titleEl.id === `${searchKey}WidgetID`
+        ) {
             const winKey =
                 titleEl.id && typeof titleEl.id === "string"
                     ? titleEl.id.replace("WidgetID", "")

--- a/js/widgets/README.md
+++ b/js/widgets/README.md
@@ -94,6 +94,15 @@ imported in `js/activity.js`.
     }
     ```
 
+6. **Map the widget in `utils.js` for cleanup**
+   To ensure your widget window automatically closes when its parent block is trashed, you must register its name in the `KEY_MAPPING` object inside the `closeBlkWidgets` function in `js/utils/utils.js`.
+
+    ```javascript
+    const KEY_MAPPING = {
+        "Your Widget Block Name": "your widget window key"
+    };
+    ```
+
 **Hint:** When creating a new widget, look for an existing widget with
 similar features. It is sometimes easier to fork than start building
 from scratch.

--- a/js/widgets/legobricks.js
+++ b/js/widgets/legobricks.js
@@ -130,7 +130,6 @@ function LegoWidget() {
     this._dragUpHandler = null;
 
     // Pitch block handling properties (similar to PhraseMaker)
-    this.blockNo = null;
     this.rowLabels = [];
     this.rowArgs = [];
     this._rowBlocks = [];


### PR DESCRIPTION
## Description
This PR resolves an issue where the Lego Bricks widget window would persist on screen even after dragging its parent block to the trash.

### Changes
- **Widget Initialization**: Removed `this.blockNo = null` from `LegoBricksWidget`, ensuring the window system correctly identifies it by its name instead of generating a `nullWidgetID`.
- **Key Mapping**: Added `"LEGO Bricks": "LEGO BRICKS"` to `KEY_MAPPING` in `js/utils/utils.js`.
- **Robust Cleanup Fallback**: Updated the `wftTitle` DOM fallback loop in `closeBlkWidgets` to properly match against the normalized `searchKey`. 
- **Trash Handler**: Safely access `staticLabels` in `js/blocks.js` to prevent `TypeError` crashes during bulk deletion of unlabelled blocks.
- **Cache Busting**: Bumped `ASSET_VERSION` in `loader.js` to guarantee that users do not serve the cached, buggy script.

### PR Category
- [x] Bug Fix