### PR TITLE
fix: prevent pitch analyser leak during AIWidget initialization

### DIFF
--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -236,6 +236,70 @@ describe("AIWidget Instance", () => {
         expect(mockActivity.logo.synth.loadSynth).toHaveBeenCalled();
     });
 
+    it("should retain both pitch analysers after initialization", () => {
+        aiWidget.init(mockActivity);
+
+        expect(aiWidget.pitchAnalysers[0]).toBeDefined();
+        expect(aiWidget.pitchAnalysers[1]).toBeDefined();
+    });
+
+    it("should dispose pitch analysers from the previous initialization", () => {
+        const disconnectMock = jest.fn();
+        const analysers = [];
+        global.instruments = [
+            {
+                piano: {
+                    disconnect: disconnectMock,
+                    connect: jest.fn()
+                }
+            }
+        ];
+        global.Tone.Analyser = jest.fn(() => {
+            const analyser = { dispose: jest.fn() };
+            analysers.push(analyser);
+            return analyser;
+        });
+
+        aiWidget.init(mockActivity);
+        const firstAnalysers = analysers.slice();
+        aiWidget.init(mockActivity);
+
+        for (const analyser of firstAnalysers) {
+            expect(disconnectMock).toHaveBeenCalledWith(analyser);
+            expect(analyser.dispose).toHaveBeenCalledTimes(1);
+        }
+        expect(aiWidget.pitchAnalysers[0]).toBe(analysers[2]);
+        expect(aiWidget.pitchAnalysers[1]).toBe(analysers[3]);
+    });
+
+    it("should dispose analysers before every repeated initialization", () => {
+        const analysers = [];
+        global.instruments = [
+            {
+                piano: {
+                    disconnect: jest.fn(),
+                    connect: jest.fn()
+                }
+            }
+        ];
+        global.Tone.Analyser = jest.fn(() => {
+            const analyser = { dispose: jest.fn() };
+            analysers.push(analyser);
+            return analyser;
+        });
+
+        aiWidget.init(mockActivity);
+        aiWidget.init(mockActivity);
+        aiWidget.init(mockActivity);
+
+        for (const analyser of analysers.slice(0, 4)) {
+            expect(analyser.dispose).toHaveBeenCalledTimes(1);
+        }
+        for (const analyser of analysers.slice(4)) {
+            expect(analyser.dispose).not.toHaveBeenCalled();
+        }
+    });
+
     it("should handle sample length warnings", () => {
         aiWidget.init(mockActivity);
         aiWidget.sampleData = "a".repeat(1333334); // Just over the limit
@@ -294,13 +358,14 @@ describe("AIWidget Instance", () => {
         const cancelAnimationFrameMock = jest.fn();
         global.cancelAnimationFrame = cancelAnimationFrameMock;
         const disposeMock = jest.fn();
+        const disconnectMock = jest.fn();
         global.Tone.Analyser = jest.fn(() => ({
             dispose: disposeMock
         }));
         global.instruments = [
             {
                 piano: {
-                    disconnect: jest.fn(),
+                    disconnect: disconnectMock,
                     connect: jest.fn()
                 }
             }
@@ -337,6 +402,10 @@ describe("AIWidget Instance", () => {
             one: 11,
             two: 22
         };
+        const closingDisposeMock = jest.fn();
+        const closingAnalyser = {
+            dispose: closingDisposeMock
+        };
         aiWidget.pitchAnalysers = {
             0: {
                 dispose: disposeMock
@@ -348,14 +417,13 @@ describe("AIWidget Instance", () => {
             two: 22
         };
         aiWidget.pitchAnalysers = {
-            0: {
-                dispose: disposeMock
-            }
+            0: closingAnalyser
         };
         widgetInstance.onclose();
         expect(cancelAnimationFrameMock).toHaveBeenCalledWith(11);
         expect(cancelAnimationFrameMock).toHaveBeenCalledWith(22);
-        expect(disposeMock).toHaveBeenCalled();
+        expect(disconnectMock).toHaveBeenCalledWith(closingAnalyser);
+        expect(closingDisposeMock).toHaveBeenCalledTimes(1);
         expect(widgetInstance.destroy).toHaveBeenCalled();
         expect(aiWidget.pitchAnalysers).toEqual({});
     });

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -117,6 +117,24 @@ function AIWidget() {
     this.pitchAnalysers = {};
 
     /**
+     * Disconnects and disposes the pitch analysers.
+     * @private
+     * @returns {void}
+     */
+    this._disposePitchAnalysers = function () {
+        for (const id in this.pitchAnalysers) {
+            const analyser = this.pitchAnalysers[id];
+            if (analyser) {
+                for (const synth in instruments[0]) {
+                    instruments[0][synth].disconnect(analyser);
+                }
+                analyser.dispose();
+            }
+        }
+        this.pitchAnalysers = {};
+    };
+
+    /**
      * Pauses the sample playback.
      * @returns {void}
      */
@@ -699,18 +717,15 @@ function AIWidget() {
      * @returns {void}
      */
     this.init = function (activity) {
+        this._disposePitchAnalysers();
         this.activity = activity;
         this._directions = [];
         this._widgetFirstTimes = [];
         this._widgetNextTimes = [];
         this._firstClickTimes = null;
         this.isMoving = false;
-        this.pitchAnalysers = {};
-
         this.activity.logo.synth.loadSynth(0, getVoiceSynthName(DEFAULTSAMPLE));
         this.reconnectSynthsToAnalyser();
-
-        this.pitchAnalysers = {};
 
         this.running = true;
         if (this.drawVisualIDs) {
@@ -751,16 +766,7 @@ function AIWidget() {
             if (this._octavesWheel !== undefined) {
                 this._octavesWheel.removeWheel();
             }
-            for (const id in this.pitchAnalysers) {
-                const analyser = this.pitchAnalysers[id];
-                if (analyser) {
-                    for (const synth in instruments[0]) {
-                        instruments[0][synth].disconnect(analyser);
-                    }
-                    analyser.dispose();
-                }
-            }
-            this.pitchAnalysers = {};
+            this._disposePitchAnalysers();
             widgetWindow.destroy();
         };
 


### PR DESCRIPTION
## Description

Fixes a pitchAnalysers resource leak during AIWidget initialization.

reconnectSynthsToAnalyser() creates and stores pitch analysers, but the analyser map was being reset immediately afterward. This dropped the references without disposing the created analysers, leaving them active and preventing later cleanup.

This PR keeps the analyser references intact and ensures existing analysers are properly disconnected and disposed before re-initialization or when the widget is closed.

## Category

- [x] Bug Fix
- [ ] Feature
- [x] Performance
- [x] Tests
- [ ] Documentation
- [ ] Chore / Refactor
- [ ] CI/CD

## Changes Made

- Added `_disposePitchAnalysers()` to centralize analyser cleanup.
- Dispose existing analysers before re-initializing `AIWidget`.
- Removed the redundant `this.pitchAnalysers = {}` after `reconnectSynthsToAnalyser()`.
- Updated `onclose` to use the shared cleanup method.
- Added regression tests for analyser retention and repeated initialization cleanup.

This builds on the analyser cleanup introduced in PR #6660.

## Visual Changes

### Before

Not applicable.

### After

Not applicable.

## Testing Performed

- Added regression tests in `aiwidget.test.js`.
- Tested that analysers remain available after initialization.
- Tested that previous analysers are disconnected and disposed during repeated initialization.
- Tested that repeated initialization does not leave previous analysers undisposed.
- Tested that `onclose` continues to clean up analysers correctly.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

## Additional Notes

This change keeps the existing analyser connection logic unchanged and only fixes the analyser lifecycle during initialization.