### PR TITLE
fix(planet): skip clear-workspace confirmation when loading projects from Planet

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2008,7 +2008,7 @@ class Activity {
 
             if (addStartBlock) {
                 this.blocks.loadNewBlocks(DATAOBJS);
-                this._allClear(false);
+                this._allClear(false, true);
             } else if (!doNotSave) {
                 // Overwrite session data too.
                 this.saveLocally();

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -156,7 +156,7 @@ class PlanetInterface {
             this.activity.loading = true;
             document.body.style.cursor = "wait";
             this.activity.doLoadAnimation();
-            this.activity._allClear(false);
+            this.activity._allClear(false, true);
 
             // First, hide the palettes as they will need updating.
             this.activity.blocks.palettes._hideMenus(true);


### PR DESCRIPTION
## Description

When you open (or merge) a project from the Planet, a "Clear workspace -Are you sure you want to clear the workspace?" dialog pops up in the middle of the load, right on top of the loading messages. The dialog shouldn't be there at all - the user has already chosen to open the project -and worse, it's actively misleading:

- **Open path:** by the time the dialog appears, `sendAllToTrash()` has already emptied the workspace, and the new project loads no matter which button you press. Pressing **Cancel** only skips the internal canvas reset, so `logo.boxes`, `turtleHeaps`, notation staging, the background color, and any turtle drawings from the *previous* project leak into the newly opened one.
- **Merge path:** merge is supposed to preserve the current project, but pressing **Confirm** runs the full clear action and wipes the turtle graphics and heaps of the very project you asked to merge into.

This is the same bug that #4153 fixed back in 2024 for the "load project from file" path -the Planet path was simply missed. The confirmation itself was introduced in #4137 for the toolbar erase button, where it makes sense, but every *programmatic* caller of `_allClear()` needs to opt out of it.

## Related Issue

No existing issue covers this; it is a follow-up to the fix in #4153 (which handled the load-from-file path) for the confirmation dialog introduced in #4137.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

Two one-line changes, passing the existing `skipConfirmation` flag exactly the way `project-manager.js` already does for the file-load path:

- `js/planetInterface.js` — `loadProjectFromData()` now calls `this.activity._allClear(false, true)` instead of `this.activity._allClear(false)`, so loading a project from the Planet no longer prompts.
- `js/activity.js` — the `addStartBlock` branch of `sendAllToTrash()` now calls `this._allClear(false, true)`. This branch is only reached programmatically (e.g. from the help controller's save-help-blocks flow), so it should never prompt either.

The confirmation dialog still appears where it belongs: the erase button on the toolbar, the context menu entry, and the keyboard shortcut are untouched.

---
