### PR TITLE
test(turtleactions): strengthen VolumeActions mutation coverage

### DIFF
--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -154,6 +154,7 @@ describe("setupVolumeActions", () => {
 
     afterEach(() => {
         jest.useRealTimers();
+        global._ = jest.fn(msg => msg);
     });
 
     describe("doCrescendo", () => {
@@ -208,6 +209,80 @@ describe("setupVolumeActions", () => {
             } else {
                 expect(crescendoEndSpy).not.toHaveBeenCalled();
             }
+        });
+
+        test.each([
+            ["blk registered in blockList", 1, true, { dispatch: true, mouse: false }],
+            [
+                "blk not registered in blockList",
+                "missingBlock",
+                true,
+                { dispatch: false, mouse: true }
+            ],
+            ["blk undefined while running", undefined, true, { dispatch: false, mouse: true }],
+            ["blk undefined while not running", undefined, false, { dispatch: false, mouse: false }]
+        ])("dispatch chain: %s", (_label, blk, isRun, expected) => {
+            activity.blocks.blockList[1] = {};
+            MusicBlocks.isRun = isRun;
+            const mockMouse = { MB: { listeners: [] } };
+            Mouse.getMouseFromTurtle.mockReturnValue(mockMouse);
+
+            Singer.VolumeActions.doCrescendo("crescendo", 10, 0, blk);
+
+            if (expected.dispatch) {
+                expect(activity.logo.setDispatchBlock).toHaveBeenCalledWith(blk, 0, "_crescendo_0");
+            } else {
+                expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            }
+
+            if (expected.mouse) {
+                expect(Mouse.getMouseFromTurtle).toHaveBeenCalled();
+                expect(mockMouse.MB.listeners).toContain("_crescendo_0");
+            } else {
+                expect(Mouse.getMouseFromTurtle).not.toHaveBeenCalled();
+            }
+        });
+
+        it("does not dispatch through blockList key coercion when blk is undefined", () => {
+            activity.blocks.blockList["undefined"] = {};
+
+            Singer.VolumeActions.doCrescendo("crescendo", 10, 0, undefined);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+        });
+
+        it("does not throw when the MusicBlocks global is absent", () => {
+            delete global.MusicBlocks;
+
+            expect(() => {
+                Singer.VolumeActions.doCrescendo("crescendo", 10, 0, undefined);
+            }).not.toThrow();
+        });
+
+        it("initializes crescendoInitialVolume per-synth and preserves existing entries", () => {
+            targetTurtle.singer.synthVolume = { default: [50], piano: [50] };
+            targetTurtle.singer.crescendoInitialVolume = { default: [30] };
+
+            Singer.VolumeActions.doCrescendo("crescendo", 10, 0, 1);
+
+            expect(targetTurtle.singer.crescendoInitialVolume.default).toEqual([30, 50]);
+            expect(targetTurtle.singer.crescendoInitialVolume.piano).toEqual([50]);
+        });
+
+        it("listener restores synthVolume to the pre-crescendo value and pops crescendoInitialVolume", () => {
+            targetTurtle.singer.synthVolume = { default: [50] };
+            targetTurtle.singer.crescendoInitialVolume = { default: [50] };
+
+            Singer.VolumeActions.doCrescendo("crescendo", 10, 0, 1);
+            const listener = activity.logo.setTurtleListener.mock.calls.pop()[2];
+
+            // simulate the volume having drifted during playback before the listener fires
+            targetTurtle.singer.synthVolume.default[1] = 75;
+
+            listener();
+
+            expect(targetTurtle.singer.synthVolume.default).toEqual([50, 50]);
+            expect(targetTurtle.singer.crescendoInitialVolume.default).toEqual([50]);
         });
     });
 
@@ -320,6 +395,40 @@ describe("setupVolumeActions", () => {
                 expect.any(Function)
             );
         });
+
+        it("falls through to the mouse listener when blk is not a valid block reference", () => {
+            const mockMouse = { MB: { listeners: [] } };
+            Mouse.getMouseFromTurtle.mockReturnValue(mockMouse);
+
+            Singer.VolumeActions.setRelativeVolume(20, 0, "missingBlock");
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+            expect(mockMouse.MB.listeners).toContain("_articulation_0");
+        });
+
+        it("does not dispatch through blockList key coercion when blk is undefined", () => {
+            activity.blocks.blockList["undefined"] = {};
+
+            Singer.VolumeActions.setRelativeVolume(20, 0);
+
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+        });
+
+        it("does not throw when the MusicBlocks global is absent", () => {
+            delete global.MusicBlocks;
+
+            expect(() => {
+                Singer.VolumeActions.setRelativeVolume(20, 0);
+            }).not.toThrow();
+        });
+
+        it("does not throw when the mouse listener is null", () => {
+            Mouse.getMouseFromTurtle.mockReturnValue(null);
+
+            expect(() => {
+                Singer.VolumeActions.setRelativeVolume(20, 0);
+            }).not.toThrow();
+        });
     });
 
     // setMasterVolume tests
@@ -329,6 +438,13 @@ describe("setupVolumeActions", () => {
 
             expect(Singer.masterVolume).toContain(80);
             expect(masterVolumeSpy).toHaveBeenCalledWith(activity.logo, 80, 1);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
+        });
+
+        it("should not pop from masterVolume when length is not 2", () => {
+            Singer.masterVolume = [42];
+            Singer.VolumeActions.setMasterVolume(80, 0, 1);
+            expect(Singer.masterVolume).toEqual([42, 80]);
         });
 
         it("should clamp master volume to min 0", () => {
@@ -405,6 +521,29 @@ describe("setupVolumeActions", () => {
 
             expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
             expect(synthVolumeSpy).toHaveBeenCalledWith(activity.logo, 0, DEFAULTVOICE, 70);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
+            expect(loadSynthSpy).not.toHaveBeenCalled();
+            expect(
+                targetTurtle.singer.instrumentNames.filter(name => name === DEFAULTVOICE)
+            ).toHaveLength(1);
+        });
+
+        it("matches DEFAULTVOICE via its translated string form", () => {
+            global._ = jest.fn(msg => (msg === DEFAULTVOICE ? "translated-default" : msg));
+
+            Singer.VolumeActions.setSynthVolume("translated-default", 70, 0, "testBlock");
+
+            expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
+        });
+
+        it("matches DEFAULTVOICE via the raw identifier even when its translation differs", () => {
+            global._ = jest.fn(msg => (msg === DEFAULTVOICE ? "some-other-translation" : msg));
+
+            Singer.VolumeActions.setSynthVolume(DEFAULTVOICE, 70, 0, "testBlock");
+
+            expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
         });
 
         it("should set volume for custom synth", () => {
@@ -412,6 +551,24 @@ describe("setupVolumeActions", () => {
 
             expect(targetTurtle.singer.synthVolume.custom).toContain(70);
             expect(synthVolumeSpy).toHaveBeenCalledWith(activity.logo, 0, "custom", 70);
+        });
+
+        it("matches custom via its translated string form", () => {
+            global._ = jest.fn(msg => (msg === "custom" ? "translated-custom" : msg));
+
+            Singer.VolumeActions.setSynthVolume("translated-custom", 70, 0, "testBlock");
+
+            expect(targetTurtle.singer.synthVolume.custom).toContain(70);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
+        });
+
+        it("matches custom via the raw identifier even when its translation differs", () => {
+            global._ = jest.fn(msg => (msg === "custom" ? "some-other-translation" : msg));
+
+            Singer.VolumeActions.setSynthVolume("custom", 70, 0, "testBlock");
+
+            expect(targetTurtle.singer.synthVolume.custom).toContain(70);
+            expect(activity.errorMsg).not.toHaveBeenCalled();
         });
 
         it("should identify and set volume for voice type from VOICENAMES", () => {
@@ -428,6 +585,50 @@ describe("setupVolumeActions", () => {
 
             Singer.VolumeActions.setSynthVolume("snare", 60, 0, "testBlock");
             expect(targetTurtle.singer.synthVolume.snare).toContain(60);
+        });
+
+        it("matches drum names containing hyphens via the display-name comparison", () => {
+            DRUMNAMES.HiHat = ["hi-hat", "hihat"];
+            try {
+                Singer.VolumeActions.setSynthVolume("hi hat", 70, 0, "testBlock");
+                expect(targetTurtle.singer.synthVolume.hihat).toContain(70);
+                expect(activity.errorMsg).not.toHaveBeenCalled();
+            } finally {
+                delete DRUMNAMES.HiHat;
+            }
+        });
+
+        it("matches drum names containing hyphens via the internal-name comparison", () => {
+            DRUMNAMES.Test2 = ["testdrum", "test-drum"];
+            try {
+                Singer.VolumeActions.setSynthVolume("test drum", 70, 0, "testBlock");
+                expect(targetTurtle.singer.synthVolume["test drum"]).toContain(70);
+                expect(activity.errorMsg).not.toHaveBeenCalled();
+            } finally {
+                delete DRUMNAMES.Test2;
+            }
+        });
+
+        it("does not re-scan VOICENAMES when synth is already resolved", () => {
+            VOICENAMES.ShouldNotMatch = [DEFAULTVOICE, "wrong-synth"];
+            try {
+                Singer.VolumeActions.setSynthVolume(DEFAULTVOICE, 70, 0, "testBlock");
+                expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
+                expect(targetTurtle.singer.synthVolume["wrong-synth"]).toBeUndefined();
+            } finally {
+                delete VOICENAMES.ShouldNotMatch;
+            }
+        });
+
+        it("does not re-scan DRUMNAMES when synth is already resolved", () => {
+            DRUMNAMES.ShouldNotMatch = [DEFAULTVOICE, "wrong-drum"];
+            try {
+                Singer.VolumeActions.setSynthVolume(DEFAULTVOICE, 70, 0, "testBlock");
+                expect(targetTurtle.singer.synthVolume[DEFAULTVOICE]).toContain(70);
+                expect(targetTurtle.singer.synthVolume["wrong-drum"]).toBeUndefined();
+            } finally {
+                delete DRUMNAMES.ShouldNotMatch;
+            }
         });
 
         it("should handle invalid synth name", () => {
@@ -453,6 +654,15 @@ describe("setupVolumeActions", () => {
 
             expect(targetTurtle.singer.synthVolume.violin).toEqual([DEFAULTVOLUME, 70]);
             expect(targetTurtle.singer.crescendoInitialVolume.violin).toEqual([DEFAULTVOLUME]);
+        });
+
+        it("does not reset an already-tracked synth volume when the instrument is newly added", () => {
+            targetTurtle.singer.instrumentNames = ["default"];
+            targetTurtle.singer.synthVolume.violin = [99];
+
+            Singer.VolumeActions.setSynthVolume("violin", 70, 0, "testBlock");
+
+            expect(targetTurtle.singer.synthVolume.violin).toEqual([99, 70]);
         });
 
         it("should not call setSynthVolume when suppressOutput is true", () => {
@@ -489,6 +699,16 @@ describe("setupVolumeActions", () => {
 
         it("should not trigger tone when connections exist", () => {
             Singer.VolumeActions.setSynthVolume(DEFAULTVOICE, 70, 0, "testBlock");
+
+            jest.advanceTimersByTime(250);
+
+            expect(triggerSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not trigger tone when only the first connection is non-null", () => {
+            activity.logo.blockList.mixedBlock = { connections: [5, null] };
+
+            Singer.VolumeActions.setSynthVolume(DEFAULTVOICE, 70, 0, "mixedBlock");
 
             jest.advanceTimersByTime(250);
 


### PR DESCRIPTION
# **test(turtleactions): strengthen VolumeActions mutation coverage**

## Description

Raises the mutation score for `VolumeActions.js` from **78.43% to 96.57%** by adding and strengthening tests around previously surviving mutation cases.

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
* [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added coverage for the `doCrescendo` / `setRelativeVolume` block-dispatch and mouse-listener branches.
* Covered the `MusicBlocks` undefined guard and blockList key-coercion edge case.
* Added tests for crescendo-end volume restoration and `crescendoInitialVolume` initialization.
* Covered `DEFAULTVOICE` and `"custom"` i18n matching in `setSynthVolume`.
* Added coverage for resolved synth guards and drum-name hyphen handling.
* Covered `setMasterVolume` zero-volume and pop guards.
* Added coverage for the connection-pair tone-trigger condition.
* No production code was changed.

---

## Visual Changes

Not applicable.

---

## Testing Performed

* `VolumeActions.test.js`: **65/65 tests passing**
* Full turtleactions suite: **554/554 tests passing**
* ESLint passed.
* Prettier passed.
* `git diff --check` passed.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The remaining **5 survivors** are limited to environment-only `module.exports` guard mutants and one equivalent `setRelativeVolume` branch that is unreachable in the actual execution flow.

No production bug was found. The changes are limited to `VolumeActions.test.js`.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

* **Guidelines:** [[Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
* **Chat:** [[Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)](https://matrix.to/#/#sugar:matrix.org)

</details>