### PR TITLE
test(turtleactions): strengthen RhythmActions mutation coverage

### DIFF
--- a/js/turtleactions/__tests__/RhythmActions.test.js
+++ b/js/turtleactions/__tests__/RhythmActions.test.js
@@ -173,6 +173,259 @@ describe("setupRhythmActions", () => {
 
         expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_2_0__");
     });
+    it("does not recompute beat/measure when already inside a note block", () => {
+        targetTurtle.singer.inNoteBlock = [1];
+        targetTurtle.singer.currentBeat = 7;
+        targetTurtle.singer.currentMeasure = 9;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 2);
+
+        expect(targetTurtle.singer.currentBeat).toBe(7);
+        expect(targetTurtle.singer.currentMeasure).toBe(9);
+    });
+
+    it("divides (not multiplies) notesPlayed when checking whether pickup was crossed", () => {
+        targetTurtle.singer.notesPlayed = [1, 4]; // 1/4 = 0.25 < 0.3 (not crossed); 1*4 = 4, not < 0.3
+        targetTurtle.singer.pickup = 0.3;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(targetTurtle.singer.currentBeat).toBe(0);
+        expect(targetTurtle.singer.currentMeasure).toBe(0);
+    });
+
+    it("does not treat the pickup boundary itself as crossed", () => {
+        targetTurtle.singer.notesPlayed = [1, 2]; // ratio === pickup
+        targetTurtle.singer.pickup = 0.5;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(targetTurtle.singer.currentBeat).toBe(1);
+        expect(targetTurtle.singer.currentMeasure).toBe(1);
+    });
+
+    it("subtracts pickup (not adds) when computing beat", () => {
+        targetTurtle.singer.notesPlayed = [3, 1];
+        targetTurtle.singer.pickup = 1;
+        targetTurtle.singer.noteValuePerBeat = 1;
+        targetTurtle.singer.beatsPerMeasure = 4;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(targetTurtle.singer.currentBeat).toBe(3);
+        expect(targetTurtle.singer.currentMeasure).toBe(1);
+    });
+
+    it("increments measureValue (not decrements) across multiple measures", () => {
+        targetTurtle.singer.notesPlayed = [10, 1];
+        targetTurtle.singer.pickup = 0;
+        targetTurtle.singer.noteValuePerBeat = 1;
+        targetTurtle.singer.beatsPerMeasure = 4;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(targetTurtle.singer.currentBeat).toBe(3);
+        expect(targetTurtle.singer.currentMeasure).toBe(3);
+    });
+
+    it("computes thisBeat as beatValue plus (not minus) the prior-measures offset", () => {
+        targetTurtle.singer.notesPlayed = [10, 1]; // beatValue=3, currentMeasure=3
+        targetTurtle.singer.pickup = 0;
+        targetTurtle.singer.noteValuePerBeat = 1;
+        targetTurtle.singer.beatsPerMeasure = 4;
+        targetTurtle.singer.factorList = [11]; // thisBeat = 3 + 4*(3-1) = 11
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("__beat_11_0__");
+    });
+
+    it("does not dispatch everybeat when beatList excludes it", () => {
+        targetTurtle.singer.notesPlayed = [1, 1];
+        targetTurtle.singer.pickup = 0;
+        targetTurtle.singer.beatList = ["somethingelse"];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(activity.stage.dispatchEvent).not.toHaveBeenCalledWith(
+            expect.stringContaining("everybeat")
+        );
+    });
+
+    it("does not dispatch offbeat when beatValue is not greater than 1", () => {
+        targetTurtle.singer.notesPlayed = [0, 1]; // beatValue = 1
+        targetTurtle.singer.pickup = 0;
+        targetTurtle.singer.beatList = ["offbeat"];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(activity.stage.dispatchEvent).not.toHaveBeenCalledWith("__offbeat_0__");
+    });
+
+    it("does not dispatch a factorList event for a factor that does not evenly divide the beat", () => {
+        targetTurtle.singer.notesPlayed = [1, 1]; // beatValue = 2
+        targetTurtle.singer.pickup = 0;
+        targetTurtle.singer.beatsPerMeasure = 4;
+        targetTurtle.singer.factorList = [3];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+
+        expect(activity.stage.dispatchEvent).not.toHaveBeenCalledWith(
+            expect.stringContaining("__beat_3_")
+        );
+    });
+
+    it("inverts value only for newnote blocks, not for note/osctime blocks", () => {
+        Singer.RhythmActions.playNote(4, "newnote", 0, 1);
+        expect(targetTurtle.singer.noteValue[1]).toBe(4);
+
+        targetTurtle.singer.inNoteBlock = [];
+        Singer.RhythmActions.playNote(4, "note", 0, 2);
+        expect(targetTurtle.singer.noteValue[2]).toBe(0.25);
+    });
+
+    it("divides (not multiplies) by beatFactor when computing noteValue", () => {
+        targetTurtle.singer.beatFactor = 2;
+
+        Singer.RhythmActions.playNote(4, "note", 0, 1);
+
+        expect(targetTurtle.singer.noteValue[1]).toBeCloseTo(0.125);
+    });
+
+    it("pushes to both neighbor beat arrays with correct values when nextBeat is valid", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = [0.25];
+        targetTurtle.singer.beatFactor = 1;
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(targetTurtle.singer.neighborArgBeat).toEqual([4]);
+        expect(targetTurtle.singer.neighborArgCurrentBeat).toEqual([2]);
+    });
+
+    it("pushes to neighborArgBeat but leaves neighborArgCurrentBeat unset when nextBeat is invalid", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = [1];
+        targetTurtle.singer.beatFactor = 1;
+        activity.errorMsg = jest.fn();
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(activity.errorMsg).toHaveBeenCalledWith(
+            "Neighbor note value is too large for the current note duration.",
+            1
+        );
+        expect(targetTurtle.singer.neighborArgBeat).toEqual([1]);
+        expect(targetTurtle.singer.neighborArgCurrentBeat).toEqual([]);
+    });
+
+    it("divides (not multiplies) by noteBeatValue when computing nextBeat", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = [0.1];
+        targetTurtle.singer.beatFactor = 1;
+
+        // noteBeatValue = 4 (blkName "note"); nextBeat = 1/4 - 0.2 = 0.05
+        Singer.RhythmActions.playNote(4, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(targetTurtle.singer.neighborArgCurrentBeat[0]).toBeCloseTo(20);
+    });
+
+    it("treats a nextBeat of exactly 0 as invalid (boundary of the <= 0 check)", () => {
+        targetTurtle.singer.inNeighbor = [1];
+        targetTurtle.singer.neighborNoteValue = [0.5];
+        targetTurtle.singer.beatFactor = 1;
+        activity.errorMsg = jest.fn();
+
+        // noteBeatValue = 1 ("note", value 1); nextBeat = 1/1 - 2*0.5 = 0
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(activity.errorMsg).toHaveBeenCalled();
+        expect(targetTurtle.singer.neighborArgCurrentBeat).toEqual([]);
+    });
+
+    it("skips the neighbor block and processNote when inNoteBlock is unwound before the listener fires", () => {
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+
+        targetTurtle.singer.inNoteBlock = [];
+        Singer.processNote.mockClear();
+
+        listener();
+
+        expect(Singer.processNote).not.toHaveBeenCalled();
+    });
+
+    it("does not touch neighbor arrays when inNeighbor is empty", () => {
+        targetTurtle.singer.inNeighbor = [];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(targetTurtle.singer.neighborArgBeat).toEqual([]);
+        expect(targetTurtle.singer.neighborArgCurrentBeat).toEqual([]);
+    });
+
+    it("calls notationVoices with the outgoing inNoteBlock length and resets multipleVoices/pitchBlocks/drumBlocks only once fully unwound", () => {
+        activity.logo.pitchBlocks = ["stale"];
+        activity.logo.drumBlocks = ["stale"];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 10);
+        const outerListener = activity.logo.setTurtleListener.mock.calls[0][2];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 20);
+        const innerListener = activity.logo.setTurtleListener.mock.calls[1][2];
+
+        expect(targetTurtle.singer.multipleVoices).toBe(true);
+
+        innerListener();
+
+        expect(activity.logo.notation.notationVoices).toHaveBeenCalledWith(0, 2);
+        expect(activity.logo.notation.notationVoices).not.toHaveBeenCalledWith(0, 0);
+        expect(targetTurtle.singer.multipleVoices).toBe(true);
+        expect(activity.logo.pitchBlocks).toEqual(["stale"]);
+        expect(activity.logo.drumBlocks).toEqual(["stale"]);
+
+        outerListener();
+
+        expect(activity.logo.notation.notationVoices).toHaveBeenCalledWith(0, 1);
+        expect(activity.logo.notation.notationVoices).toHaveBeenCalledWith(0, 0);
+        expect(targetTurtle.singer.multipleVoices).toBe(false);
+        expect(activity.logo.pitchBlocks).toEqual([]);
+        expect(activity.logo.drumBlocks).toEqual([]);
+    });
+
+    it("removes the last (not an arbitrary) entry from inNoteBlock on unwind", () => {
+        targetTurtle.singer.inNoteBlock = [10, 20];
+        targetTurtle.singer.noteValue = { 10: 1, 20: 1, 30: 1 };
+
+        Singer.RhythmActions.playNote(1, "note", 0, 30);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(targetTurtle.singer.inNoteBlock).toEqual([10, 20]);
+    });
+
+    it("clears pitchBlocks and drumBlocks only once inNoteBlock is fully unwound", () => {
+        activity.logo.pitchBlocks = ["stale"];
+        activity.logo.drumBlocks = ["stale"];
+
+        Singer.RhythmActions.playNote(1, "note", 0, 1);
+        const listener = activity.logo.setTurtleListener.mock.calls[0][2];
+        listener();
+
+        expect(activity.logo.pitchBlocks).toEqual([]);
+        expect(activity.logo.drumBlocks).toEqual([]);
+    });
+
     it("adds rest note when inside a note block", () => {
         // setup: one active note block
         targetTurtle.singer.inNoteBlock = [1];
@@ -199,6 +452,20 @@ describe("setupRhythmActions", () => {
         expect(() => Singer.RhythmActions.playRest(0)).not.toThrow();
         expect(targetTurtle.singer.pushedNote).toBeUndefined();
     });
+    it("never pushes a rest when inNoteBlock is empty, even if notePitches has a matching stray entry", () => {
+        targetTurtle.singer.inNoteBlock = [];
+        targetTurtle.singer.notePitches = { undefined: [] };
+        targetTurtle.singer.noteOctaves = { undefined: [] };
+        targetTurtle.singer.noteCents = { undefined: [] };
+        targetTurtle.singer.noteHertz = { undefined: [] };
+        targetTurtle.singer.noteBeatValues = { undefined: [] };
+
+        Singer.RhythmActions.playRest(0);
+
+        expect(targetTurtle.singer.pushedNote).toBeUndefined();
+        expect(targetTurtle.singer.notePitches.undefined).toEqual([]);
+    });
+
     it("does not push a rest when the active note has no pitches array yet", () => {
         targetTurtle.singer.inNoteBlock = [7];
         targetTurtle.singer.notePitches = {};
@@ -253,6 +520,46 @@ describe("setupRhythmActions", () => {
         expect(targetTurtle.singer.beatFactor).toBe(1);
     });
 
+    it("multiplies (not divides) beatFactor by currentDotFactor and round-trips through the listener", () => {
+        let listener;
+        activity.logo.setTurtleListener = jest.fn((_, __, fn) => {
+            listener = fn;
+        });
+
+        targetTurtle.singer.dotCount = 1;
+        targetTurtle.singer.beatFactor = 2;
+
+        Singer.RhythmActions.doRhythmicDot(3, 0, 1);
+
+        expect(targetTurtle.singer.dotCount).toBe(4);
+        expect(targetTurtle.singer.beatFactor).toBeCloseTo(1.5483870967741935);
+
+        listener();
+
+        expect(targetTurtle.singer.dotCount).toBe(1);
+        expect(targetTurtle.singer.beatFactor).toBeCloseTo(2);
+    });
+
+    it("treats a dot value of exactly 0 as non-negative, leaving dotCount and beatFactor unchanged through the full lifecycle", () => {
+        let listener;
+        activity.logo.setTurtleListener = jest.fn((_, __, fn) => {
+            listener = fn;
+        });
+
+        targetTurtle.singer.dotCount = 1;
+        targetTurtle.singer.beatFactor = 2;
+
+        Singer.RhythmActions.doRhythmicDot(0, 0, 1);
+
+        expect(targetTurtle.singer.dotCount).toBe(1);
+        expect(targetTurtle.singer.beatFactor).toBeCloseTo(2);
+
+        listener();
+
+        expect(targetTurtle.singer.dotCount).toBe(1);
+        expect(targetTurtle.singer.beatFactor).toBeCloseTo(2);
+    });
+
     it("multiplies beatFactor correctly", () => {
         targetTurtle.singer.beatFactor = 2;
 
@@ -278,6 +585,29 @@ describe("setupRhythmActions", () => {
 
         expect(targetTurtle.singer.swing).toContain(0.5);
         expect(targetTurtle.singer.swingTarget).toContain(0.25);
+    });
+
+    it("calls notationSwing and leaves swing arrays untouched when output is suppressed", () => {
+        targetTurtle.singer.suppressOutput = true;
+        targetTurtle.singer.swing = [99];
+        targetTurtle.singer.swingTarget = [99];
+        activity.logo.notation.notationSwing = jest.fn();
+
+        let listener;
+        activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+            listener = cb;
+        });
+
+        Singer.RhythmActions.addSwing(2, 4, 0, 1);
+
+        expect(activity.logo.notation.notationSwing).toHaveBeenCalledWith(0);
+        expect(targetTurtle.singer.swing).toEqual([99]);
+        expect(targetTurtle.singer.swingTarget).toEqual([99]);
+
+        listener();
+
+        expect(targetTurtle.singer.swing).toEqual([99]);
+        expect(targetTurtle.singer.swingTarget).toEqual([99]);
     });
 
     it("preserves swing arrays when swing parameters are zero or invalid", () => {
@@ -432,6 +762,13 @@ describe("setupRhythmActions", () => {
 
             expect(mockMouse.MB.listeners).toContain("_playnote_0");
         });
+        it("playNote does not throw or dispatch when MusicBlocks.isRun and mouse is null", () => {
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => null);
+
+            expect(() => Singer.RhythmActions.playNote(1, "note", 0, undefined)).not.toThrow();
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+        });
 
         it("doRhythmicDot dispatches block listener when blk is present in blockList", () => {
             activity.blocks.blockList = { 5: {} };
@@ -458,6 +795,13 @@ describe("setupRhythmActions", () => {
 
             expect(mockMouse.MB.listeners).toContain("_dot_0");
         });
+        it("doRhythmicDot does not throw or dispatch when MusicBlocks.isRun and mouse is null", () => {
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => null);
+
+            expect(() => Singer.RhythmActions.doRhythmicDot(1, 0, undefined)).not.toThrow();
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
+        });
 
         it("multiplyNoteValue dispatches block listener when blk is present in blockList", () => {
             activity.blocks.blockList = { 5: {} };
@@ -483,6 +827,13 @@ describe("setupRhythmActions", () => {
             Singer.RhythmActions.multiplyNoteValue(2, 0, undefined);
 
             expect(mockMouse.MB.listeners).toContain("_multiplybeat_0");
+        });
+        it("multiplyNoteValue does not throw or dispatch when MusicBlocks.isRun and mouse is null", () => {
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => null);
+
+            expect(() => Singer.RhythmActions.multiplyNoteValue(2, 0, undefined)).not.toThrow();
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
         });
 
         it("addSwing dispatches block listener when blk is present in blockList", () => {
@@ -515,6 +866,15 @@ describe("setupRhythmActions", () => {
             Singer.RhythmActions.addSwing(2, 4, 0, undefined);
 
             expect(mockMouse.MB.listeners).toContain("_swing_0");
+        });
+        it("addSwing does not throw or dispatch when MusicBlocks.isRun and mouse is null", () => {
+            targetTurtle.singer.swing = [];
+            targetTurtle.singer.swingTarget = [];
+            global.MusicBlocks.isRun = true;
+            global.Mouse.getMouseFromTurtle = jest.fn(() => null);
+
+            expect(() => Singer.RhythmActions.addSwing(2, 4, 0, undefined)).not.toThrow();
+            expect(activity.logo.setDispatchBlock).not.toHaveBeenCalled();
         });
     });
 
@@ -625,23 +985,217 @@ describe("setupRhythmActions", () => {
             targetTurtle.singer.inNoteBlock = [];
             targetTurtle.singer.justCounting = [];
             targetTurtle.singer.tieCarryOver = 2;
-            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNotePitches = [
+                ["C", 4, 0, 261.63],
+                ["E", 4, 0, 329.63]
+            ];
             targetTurtle.singer.tieNoteExtras = [
                 5, // saveBlk
                 ["sine"], // oscList
                 1, // noteBeat
                 [1], // noteBeatValues
-                [] // noteDrums
+                [], // noteDrums
+                undefined,
+                false, // wasOsc
+                2 // rawDurationValue
             ];
-            targetTurtle.singer.bpm = [120];
+            targetTurtle.singer.bpm = [];
+            targetTurtle.singer.turtleTime = 5;
+            global.Singer.masterBPM = 60;
 
             listener();
 
             expect(Singer.processNote).toHaveBeenCalled();
-            expect(targetTurtle.doWait).toHaveBeenCalled();
+            // bpmFactor = TONEBPM / masterBPM = 120 / 60 = 2; waitSeconds = bpmFactor / rawDuration = 2 / 2 = 1
+            expect(targetTurtle.doWait).toHaveBeenCalledWith(1);
+            expect(targetTurtle.singer.turtleTime).toBeCloseTo(6);
             expect(targetTurtle.singer.tie).toBe(false);
             expect(targetTurtle.singer.tieNotePitches).toEqual([]);
             expect(targetTurtle.singer.tieNoteExtras).toEqual([]);
+            expect(targetTurtle.singer.notePitches[5]).toBeUndefined();
+        });
+
+        it("uses last(bpm), not masterBPM, when the bpm stack is non-empty", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [];
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [80];
+            targetTurtle.singer.turtleTime = 0;
+            global.Singer.masterBPM = 999; // should be ignored since bpm stack is non-empty
+
+            listener();
+
+            // bpmFactor = 120 / 80 = 1.5; waitSeconds = 1.5 / 2 = 0.75
+            expect(targetTurtle.doWait).toHaveBeenCalledWith(0.75);
+            expect(targetTurtle.singer.turtleTime).toBeCloseTo(0.75);
+        });
+
+        it("uses rawDuration/1000 (not the bpm factor) as the wait when the tied note was osctime", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [];
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, true, 500];
+            targetTurtle.singer.bpm = [];
+            targetTurtle.singer.turtleTime = 0;
+
+            listener();
+
+            expect(targetTurtle.doWait).toHaveBeenCalledWith(0.5);
+            expect(targetTurtle.singer.turtleTime).toBeCloseTo(0.5);
+        });
+
+        it("does not wait or advance turtleTime when output is suppressed", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [];
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [];
+            targetTurtle.singer.turtleTime = 5;
+            targetTurtle.singer.suppressOutput = true;
+
+            listener();
+
+            expect(targetTurtle.doWait).not.toHaveBeenCalled();
+            expect(targetTurtle.singer.turtleTime).toBe(5);
+        });
+
+        it("does not remove tie notation when lastNote is null, even if notePitches has a stray matching key", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = []; // last(inNoteBlock) === undefined
+            // stray "undefined" key so a mutated `true && lastNote in notePitches` would be true too
+            targetTurtle.singer.notePitches = { undefined: ["C"] };
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [];
+
+            listener();
+
+            expect(activity.logo.notation.notationRemoveTie).not.toHaveBeenCalled();
+        });
+
+        it("does not remove tie notation when justCounting is non-empty", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [2];
+            targetTurtle.singer.notePitches = { 2: ["C", "E"] };
+            targetTurtle.singer.justCounting = [1];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [];
+
+            listener();
+
+            expect(activity.logo.notation.notationRemoveTie).not.toHaveBeenCalled();
+        });
+
+        it("does not remove tie notation when lastNote is not a key of notePitches", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [42];
+            targetTurtle.singer.notePitches = {}; // 42 not a key
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [["C", 4, 0, 261.63]];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [];
+
+            listener();
+
+            expect(activity.logo.notation.notationRemoveTie).not.toHaveBeenCalled();
+        });
+
+        it("rebuilds saveBlk's pitch/octave/cent/hertz arrays in tieNotePitches order", () => {
+            let listener;
+            activity.logo.setTurtleListener = jest.fn((_, __, cb) => {
+                listener = cb;
+            });
+            targetTurtle.doWait = jest.fn();
+            activity.blocks.blockList[5] = { name: "note" };
+
+            Singer.RhythmActions.doTie(0, 1);
+
+            targetTurtle.singer.inNoteBlock = [];
+            targetTurtle.singer.justCounting = [];
+            targetTurtle.singer.tieCarryOver = 2;
+            targetTurtle.singer.tieNotePitches = [
+                ["C", 4, 0, 261.63],
+                ["E", 5, 1, 329.63]
+            ];
+            targetTurtle.singer.tieNoteExtras = [5, ["sine"], 1, [1], [], undefined, false, 2];
+            targetTurtle.singer.bpm = [];
+
+            let capturedPitches, capturedOctaves, capturedCents, capturedHertz, capturedGraphics;
+            Singer.processNote.mockImplementationOnce(() => {
+                capturedPitches = [...targetTurtle.singer.notePitches[5]];
+                capturedOctaves = [...targetTurtle.singer.noteOctaves[5]];
+                capturedCents = [...targetTurtle.singer.noteCents[5]];
+                capturedHertz = [...targetTurtle.singer.noteHertz[5]];
+                capturedGraphics = [...targetTurtle.singer.embeddedGraphics[5]];
+            });
+
+            listener();
+
+            expect(capturedPitches).toEqual(["C", "E"]);
+            expect(capturedOctaves).toEqual([4, 5]);
+            expect(capturedCents).toEqual([0, 1]);
+            expect(capturedHertz).toEqual([261.63, 329.63]);
+            expect(capturedGraphics).toEqual([]);
         });
 
         it("removes tie from notation when justCounting is empty and tieCarryOver > 0", () => {


### PR DESCRIPTION
changed True


- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation


behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added coverage for the previously untested neighbor-beat validation branch.
* Added boundary and arithmetic assertions for beat-scheduling logic.
* Added tests for mouse-null and dispatch guard paths.
* Added coverage for the `doTie` `tieCarryOver` replay path.
* Improved mutation coverage from **72.70% to 94.39%**.
* Eliminated all **22 no-coverage mutants**.
* No production code was modified.

---

## Visual Changes

Not applicable. This PR only updates tests.

---

## Testing Performed

* Full `turtleactions` test suite: **566 tests passed** across 9 files.
* Prettier checked on the modified test file.
* Verified the diff contains only `RhythmActions.test.js`.
* DCO sign-off included; no AI co-author or unrelated changes.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

A runtime probe identified an existing `neighborArgBeat` / `neighborArgCurrentBeat` array-length desynchronization when the neighbor note value is too large. This behavior is already addressed by upstream **#7591**, so no duplicate production fix was added here.

The remaining **22 survivors** are equivalent or environment-only mutants, including dispatch guards, the `MusicBlocks` guard, a loop boundary, `getNoteValue` ternaries, and the CommonJS `module.exports` guard. The 3 timeout mutants were also left unchanged as pre-existing behavior.

No production behavior is intentionally changed by this PR.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

* **Guidelines:** [[Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
* **Chat:** [[Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)](https://matrix.to/#/#sugar:matrix.org)

</details>
