### PR TITLE
feat: add dialog semantics to all three modals for screen readers (#6608)

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,6 +317,9 @@
                 <div class="canvasHolder" id="canvasHolder">
                     <div
                         id="clear-modal-container"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label="Clear workspace confirmation"
                         style="
                             display: none;
                             z-index: 999;
@@ -499,7 +502,14 @@
                     </div>
                 </footer>
 
-                <dialog id="lilypondModal" class="modal" tabindex="-1">
+                <dialog
+                    id="lilypondModal"
+                    class="modal"
+                    tabindex="-1"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Save LilyPond score"
+                >
                     <!-- Modal content for Lilypond save dialog -->
                     <div class="modal-content" tabindex="-1">
                         <span class="close">&times;</span>

--- a/js/__tests__/toolbar-ui.test.js
+++ b/js/__tests__/toolbar-ui.test.js
@@ -213,6 +213,27 @@ describe("ToolbarUI - Visual Helpers", () => {
         expect(mockStopBtn.style.color).toBe("white");
         jest.useRealTimers();
     });
+
+    test("renderNewProjectIcon marks the modal container with dialog semantics when shown", () => {
+        // A prior test in this file overrides document.getElementById with a
+        // mock; restore the real jsdom implementation for this test since we
+        // need genuine DOM elements and attributes.
+        delete global.document.getElementById;
+
+        document.body.innerHTML =
+            '<div id="modal-container" style="display: none;"></div>' +
+            '<ul id="newdropdown"></ul>';
+
+        global._ = jest.fn(x => x);
+
+        toolbar.renderNewProjectIcon(jest.fn());
+
+        const modalContainer = document.getElementById("modal-container");
+        expect(modalContainer.getAttribute("role")).toBe("dialog");
+        expect(modalContainer.getAttribute("aria-modal")).toBe("true");
+        expect(modalContainer.getAttribute("aria-label")).toBe("New project confirmation");
+        expect(modalContainer.style.display).toBe("flex");
+    });
 });
 
 describe("FocusCycleManager - dispose", () => {

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -633,6 +633,13 @@ class ToolbarUI {
         // Make modal container focusable
         modalContainer.setAttribute("tabindex", "-1");
 
+        // Screen reader semantics: identify this as a modal dialog with an
+        // accessible name, matching the pattern used by the other modals
+        // in the app (clear-workspace confirmation, LilyPond save dialog).
+        modalContainer.setAttribute("role", "dialog");
+        modalContainer.setAttribute("aria-modal", "true");
+        modalContainer.setAttribute("aria-label", _("New project confirmation"));
+
         // Setup keyboard navigation for modal
         const modalButtons = [confirmationButton, cancelButton];
         let currentModalFocusIndex = 0;


### PR DESCRIPTION
## Description

Adds `role="dialog"`, `aria-modal="true"`, and `aria-label` to all three
modal dialogs in the app, completing the modal dialog portion of the
end-point accessibility audit.

Previously, none of the three modals had any semantic markup identifying
them as dialogs to assistive technology — screen readers had no way to
know a modal had opened, what it was for, or that focus should be
contained within it.

Fixed the three modals as follows:

- **`clear-modal-container`** — added statically in `index.html`.
  Investigated first: found no JS anywhere in the codebase actually
  controls this element (no show/hide logic found), so it appears to be
  scaffolded-but-unwired markup. Adding the attributes statically is safe
  regardless, since `display: none` already excludes it from the
  accessibility tree while hidden.
- **`lilypondModal`** — added statically in `index.html`. This uses a
  native `<dialog>` tag, but is opened via `style.display = "block"` in
  `SaveInterface.js` rather than the native `.showModal()` API, so it
  doesn't get any native modal behavior (focus trap, backdrop, Escape
  handling) automatically. Kept the fix minimal and consistent with the
  existing pattern rather than switching to `showModal()`, which would be
  a larger behavioral change — flagging that as a possible follow-up.
- **`modal-container`** (New Project confirmation) — set dynamically in
  `renderNewProjectIcon()` in `js/toolbar-ui.js`, right where the modal
  becomes visible, since this one actually is JS-controlled with real
  show/hide logic already in place.

## Related Issue

Part of #6608

## Category

- [ ] Bug Fix
- [x] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD

## Testing Performed

### How to test locally

1. Run `npm run serve` and open `http://localhost:3000`
2. Open Chrome DevTools → Elements → Accessibility tab
3. Trigger the New Project confirmation (toolbar → New) and inspect
   `#modal-container` — confirm `Role: dialog`, `Name: "New project
   confirmation"`
4. Inspect `#lilypondModal` and `#clear-modal-container` in the DOM —
   confirm both have `role="dialog"`, `aria-modal="true"`, and a
   descriptive `aria-label`

### Test cases

1. `renderNewProjectIcon()` sets `role`, `aria-modal`, and `aria-label`
   on the modal container when shown, alongside existing `display: flex`
   and `tabindex` behavior
2. Existing toolbar-ui test suite (12 tests total) still passes unchanged
3. `npx eslint` and `npx prettier --check` clean on all three changed
   files (`index.html`, `js/toolbar-ui.js`,
   `js/__tests__/toolbar-ui.test.js`)

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts