### PR TITLE
fix: guard against undefined lowestNote/highestNote in stats widget (#8155)

### DIFF
--- a/js/widgets/__tests__/statistics.test.js
+++ b/js/widgets/__tests__/statistics.test.js
@@ -252,4 +252,25 @@ describe("StatsWindow", () => {
         expect(html).toContain("rests used: 4");
         expect(html).toContain("ornaments used: 1");
     });
+
+    test("displayInfo does not throw and shows N/A when no notes were played", () => {
+        const sw = new StatsWindow(activity);
+
+        expect(() =>
+            sw.displayInfo({
+                duples: 0,
+                triplets: 0,
+                quintuplets: 0,
+                pitchNames: new Set(),
+                numberOfNotes: 0,
+                rests: 0,
+                ornaments: 0
+            })
+        ).not.toThrow();
+
+        const html = sw.jsonObject.innerHTML;
+        expect(html).toContain("lowest note: N/A");
+        expect(html).toContain("highest note: N/A");
+        expect(html).toContain("number of notes: 0");
+    });
 });

--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -131,16 +131,22 @@ class StatsWindow {
      * @returns {void}
      */
     displayInfo(stats) {
-        const lowHertz = stats["lowestNote"][2] + 0.5;
-        const highHertz = stats["highestNote"][2] + 0.5;
+        const lowestNote = stats["lowestNote"];
+        const highestNote = stats["highestNote"];
+        const lowestNoteLabel = lowestNote
+            ? `${lowestNote[0]},${(lowestNote[2] + 0.5).toFixed(0)}Hz`
+            : "N/A";
+        const highestNoteLabel = highestNote
+            ? `${highestNote[0]},${(highestNote[2] + 0.5).toFixed(0)}Hz`
+            : "N/A";
         const items = [
             ["duples", stats["duples"]],
             ["triplets", stats["triplets"]],
             ["quintuplets", stats["quintuplets"]],
             ["pitch names", Array.from(stats["pitchNames"]).join(", ")],
             ["number of notes", stats["numberOfNotes"]],
-            ["lowest note", `${stats["lowestNote"][0]},${lowHertz.toFixed(0)}Hz`],
-            ["highest note", `${stats["highestNote"][0]},${highHertz.toFixed(0)}Hz`],
+            ["lowest note", lowestNoteLabel],
+            ["highest note", highestNoteLabel],
             ["rests used", stats["rests"]],
             ["ornaments used", stats["ornaments"]]
         ];


### PR DESCRIPTION
## Description
The stats widget crashed with a TypeError when opened on a project with no notes. `displayInfo()` unconditionally indexed `stats["lowestNote"][2]` and `stats["highestNote"][2]`, but `getStatsFromNotation()` in `rubrics.js` only sets these fields when at least one pitched note is processed. The error appeared to the user as a misleading "Error generating Lilypond output" message because stats generation and Lilypond output share the same error handler in `logo.js`.

## Related Issue
**Fixes:** #8155

---

## Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made
- In `js/widgets/statistics.js`, `displayInfo()` now guards `stats["lowestNote"]` / `stats["highestNote"]` before indexing into them, falling back to `"N/A"` when a project has zero notes.
- Added a test in `js/widgets/__tests__/statistics.test.js` covering the zero-notes case to prevent regression.

---

## Visual Changes
### Before
Stats widget throws `TypeError: can't access property 2, stats.lowestNote is undefined` and shows an "Error generating Lilypond output" banner when opened on a project with no notes.

### After
Stats widget opens cleanly and shows `lowest note: N/A` / `highest note: N/A` with no console errors.
<img width="1661" height="921" alt="Screenshot 2026-08-22 092424" src="https://github.com/user-attachments/assets/0d6aa9a6-6447-4565-8b6c-57e2335cee5a" />

---

## Testing Performed
- Ran `npm test -- statistics.test.js` — all 14 tests pass, including the new zero-notes test.
- Manually reproduced the bug by opening the stats widget on an empty project, confirmed the crash, applied the fix, confirmed the widget renders correctly with no console errors.
- Ran `npx eslint js/widgets/statistics.js` — no errors.

---

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes
Root cause is in `js/rubrics.js` (`getStatsFromNotation()`), which never initializes `lowestNote`/`highestNote` when no notes are present. This PR fixes the consumer side (`displayInfo()`) rather than changing the stats-gathering logic, keeping the diff minimal and focused on the crash.

