### PR TITLE
fix: stop status updates after widget closes

### DIFF
--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -329,6 +329,24 @@ describe("StatusMatrix Widget", () => {
             expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
         });
 
+        test("does not update after the widget closes", () => {
+            statusMatrix.widgetWindow.onclose();
+
+            statusMatrix.updateAll();
+
+            expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+            expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
+        });
+
+        test("does not update without a status table", () => {
+            statusMatrix._statusTable = null;
+
+            statusMatrix.updateAll();
+
+            expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+            expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
+        });
+
         test("calls parseArg for each status field", () => {
             statusMatrix.updateAll();
             expect(mockActivity.logo.parseArg).toHaveBeenCalled();

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -240,6 +240,10 @@ class StatusMatrix {
      * @returns {void}
      */
     updateAll() {
+        if (!this.isOpen || !this._statusTable) {
+            return;
+        }
+
         // Update status of all of the voices in the matrix.
         this.activity.logo.updatingStatusMatrix = true;
 


### PR DESCRIPTION
Closing the Status widget during playback can leave `updateAll()` attempting to access table cells after the widget has been destroyed. This change skips status updates when the widget is closed or its table is unavailable.

  ## Related Issue

  **Fixes:** #8161

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Return early from `StatusMatrix.updateAll()` when the widget is closed.
  - Skip updates when the status table is unavailable.
  - Add tests for closed and missing-table cases.

  ---

  ## Testing Performed

  - `npm run lint`
  - `npx prettier --check js/widgets/status.js js/widgets/__tests__/status.test.js`
  - StatusMatrix tests: 55 passed
  - Full Jest suite: 213 suites and 7,958 tests passed

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run `npm run lint` and the modified-file Prettier check with no errors.
  - [x] I have enabled **"Allow edits from maintainers"**.