### PR TITLE
fix(rhythmruler): prevent TypeError when reading drum block connection

### DIFF
--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -1026,3 +1026,111 @@ describe("RhythmRuler _get_save_lock", () => {
         expect(rhythmRuler._get_save_lock()).toBe(true);
     });
 });
+
+describe("RhythmRuler _getDrumName safety and _saveMachine coverage", () => {
+    let rhythmRuler;
+
+    beforeEach(() => {
+        rhythmRuler = new RhythmRuler();
+        rhythmRuler.activity = {
+            blocks: {
+                blockList: {}
+            },
+            palettes: {
+                dict: {
+                    main: { hideMenu: jest.fn() }
+                }
+            },
+            refreshCanvas: jest.fn()
+        };
+        rhythmRuler._rulers = [{}];
+        rhythmRuler.Rulers = [[[4, 4, 4, 4]]];
+    });
+
+    it("returns 'snare drum' when Drums is undefined", () => {
+        rhythmRuler.Drums = undefined;
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns 'snare drum' when Drums array entry is undefined", () => {
+        rhythmRuler.Drums = [];
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns 'snare drum' when Drums array entry is null", () => {
+        rhythmRuler.Drums = [null];
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns 'snare drum' when drum block is missing from blockList", () => {
+        rhythmRuler.Drums = [99];
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns 'snare drum' when drum block has missing/null connections", () => {
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, null] }
+        };
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns 'snare drum' when connected block is missing or lacks a valid string value", () => {
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, 2] },
+            2: { value: 123 }
+        };
+        expect(rhythmRuler._getDrumName(0)).toBe("snare drum");
+    });
+
+    it("returns connected drum name when drum block and value are valid", () => {
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, 2] },
+            2: { value: "bass drum" }
+        };
+        expect(rhythmRuler._getDrumName(0)).toBe("bass drum");
+    });
+
+    it("executes _saveMachine safely with null drum", () => {
+        global.DRUMNAMES = [["snare-drum", "snare drum"]];
+        rhythmRuler.Drums = [null];
+        rhythmRuler._saveDrumMachine = jest.fn();
+        expect(() => rhythmRuler._saveMachine(0)).not.toThrow();
+    });
+
+    it("executes _saveMachine safely with valid drum block", () => {
+        global.DRUMNAMES = [["snare-drum", "snare drum"]];
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, 2] },
+            2: { value: "snare drum" }
+        };
+        rhythmRuler._saveDrumMachine = jest.fn();
+        rhythmRuler._saveMachine(0);
+        expect(rhythmRuler._saveDrumMachine).toHaveBeenCalledWith(0, "snare drum", false);
+    });
+
+    it("executes _saveMachine safely with missing drum connections", () => {
+        global.DRUMNAMES = [["snare-drum", "snare drum"]];
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, null] }
+        };
+        rhythmRuler._saveDrumMachine = jest.fn();
+        rhythmRuler._saveMachine(0);
+        expect(rhythmRuler._saveDrumMachine).toHaveBeenCalledWith(0, "snare drum", false);
+    });
+
+    it("executes _saveVoiceMachine safely with missing drum connections", () => {
+        jest.useFakeTimers();
+        rhythmRuler.Drums = [1];
+        rhythmRuler.activity.blocks.blockList = {
+            1: { connections: [null, null] }
+        };
+        expect(() => rhythmRuler._saveVoiceMachine(0, "voice")).not.toThrow();
+        jest.advanceTimersByTime(100);
+        jest.useRealTimers();
+    });
+});

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -2111,6 +2111,36 @@ class RhythmRuler {
     }
 
     /**
+     * Safely retrieves the drum/voice name for a given ruler index.
+     * @private
+     * @param {number} selectedRuler
+     * @returns {string}
+     */
+    _getDrumName(selectedRuler) {
+        if (
+            this.Drums === undefined ||
+            this.Drums === null ||
+            this.Drums[selectedRuler] === null ||
+            this.Drums[selectedRuler] === undefined
+        ) {
+            return "snare drum";
+        }
+        const drumBlock = this.activity?.blocks?.blockList?.[this.Drums[selectedRuler]];
+        if (!drumBlock || !drumBlock.connections) {
+            return "snare drum";
+        }
+        const connectedId = drumBlock.connections[1];
+        if (connectedId === null || connectedId === undefined) {
+            return "snare drum";
+        }
+        const connectedBlock = this.activity?.blocks?.blockList?.[connectedId];
+        if (!connectedBlock || typeof connectedBlock.value !== "string") {
+            return "snare drum";
+        }
+        return connectedBlock.value;
+    }
+
+    /**
      * Executes a loop iteration for playback.
      * @private
      * @param {number} noteTime - The duration of the note in milliseconds.
@@ -2135,13 +2165,7 @@ class RhythmRuler {
         const noteValue = noteValues[colIndex];
 
         noteTime = Math.abs(1 / noteValue);
-        let drum;
-        if (this.Drums[rulerNo] === null) {
-            drum = "snare drum";
-        } else {
-            const drumblockno = this.activity.blocks.blockList[this.Drums[rulerNo]].connections[1];
-            drum = this.activity.blocks.blockList[drumblockno].value;
-        }
+        let drum = this._getDrumName(rulerNo);
 
         let foundDrum = false;
         // Convert i18n drum name to English.
@@ -2251,12 +2275,7 @@ class RhythmRuler {
             if (this.Drums[selectedRuler] === null) {
                 stack_value = _("snare drum") + " " + _("rhythm");
             } else {
-                stack_value =
-                    this.activity.blocks.blockList[
-                        this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1]
-                    ].value.split(" ")[0] +
-                    " " +
-                    _("rhythm");
+                stack_value = this._getDrumName(selectedRuler).split(" ")[0] + " " + _("rhythm");
             }
             const delta = selectedRuler * 42;
             const newStack = [
@@ -2327,12 +2346,7 @@ class RhythmRuler {
             if (this.Drums[selectedRuler] === null) {
                 stack_value = _("rhythm");
             } else {
-                stack_value =
-                    this.activity.blocks.blockList[
-                        this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1]
-                    ].value.split(" ")[0] +
-                    " " +
-                    _("rhythm");
+                stack_value = this._getDrumName(selectedRuler).split(" ")[0] + " " + _("rhythm");
             }
             const delta = selectedRuler * 42;
             const newStack = [
@@ -2457,14 +2471,7 @@ class RhythmRuler {
      */
     _saveMachine(selectedRuler) {
         // We are either saving a drum machine or a voice machine.
-        let drum;
-        if (this.Drums[selectedRuler] === null) {
-            drum = "snare drum";
-        } else {
-            const drumBlockNo =
-                this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1];
-            drum = this.activity.blocks.blockList[drumBlockNo].value;
-        }
+        const drum = this._getDrumName(selectedRuler);
 
         for (let d = 0; d < DRUMNAMES.length; d++) {
             if (DRUMNAMES[d][1] === drum) {
@@ -2513,12 +2520,7 @@ class RhythmRuler {
             if (this.Drums[selectedRuler] === null) {
                 action_name = _("snare drum") + " " + _("action");
             } else {
-                action_name =
-                    this.activity.blocks.blockList[
-                        this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1]
-                    ].value.split(" ")[0] +
-                    " " +
-                    _("action");
+                action_name = this._getDrumName(selectedRuler).split(" ")[0] + " " + _("action");
             }
 
             const newStack = [
@@ -2705,12 +2707,7 @@ class RhythmRuler {
             if (this.Drums[selectedRuler] === null) {
                 action_name = _("guitar") + " " + _("action");
             } else {
-                action_name =
-                    this.activity.blocks.blockList[
-                        this.activity.blocks.blockList[this.Drums[selectedRuler]].connections[1]
-                    ].value.split(" ")[0] +
-                    "_" +
-                    _("action");
+                action_name = this._getDrumName(selectedRuler).split(" ")[0] + "_" + _("action");
             }
 
             const newStack = [


### PR DESCRIPTION
## Description

Fixes unhandled `TypeError: Cannot read properties of undefined (reading 'value')` console exceptions in `rhythmruler.js` when drum blocks have missing, null, or unlinked `connections[1]` references during rhythm stack generation and playback.

## Related Issue

Fixes #8163 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added `_getDrumName(selectedRuler)` helper method in `RhythmRuler` class in `js/widgets/rhythmruler.js`.
- Replaced unsafe nested property lookups across `_playNote`, `_saveMachine`, `_saveDrumMachine`, and `_saveVoiceMachine` with safe `_getDrumName` calls.
- Added unit tests in `js/widgets/__tests__/rhythmruler.test.js` verifying safe fallback to `"snare drum"` when connections or target blocks are missing.

## Testing Performed

- Ran Jest unit tests: all 64 unit tests in `rhythmruler.test.js` pass cleanly (`64 passed, 64 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.