### PR TITLE
perf(lilypond): use Set for occupiedShortNames lookup in lilypond.js

### DIFF
--- a/js/__tests__/lilypond.test.js
+++ b/js/__tests__/lilypond.test.js
@@ -643,4 +643,44 @@ describe("saveLilypondOutput", () => {
         expect(result).toContain('shortInstrumentName = "Tro"');
         expect(result).toContain('shortInstrumentName = "Tri"');
     });
+
+    test("should handle single character instrument names", () => {
+        activity.turtles.turtleList = {
+            0: { name: "A" },
+            1: { name: "B" }
+        };
+        activity.logo.notation.notationStaging = {
+            0: ["note"],
+            1: ["note"]
+        };
+        const result = saveLilypondOutput(activity);
+        expect(result).toContain('shortInstrumentName = "A"');
+        expect(result).toContain('shortInstrumentName = "B"');
+    });
+
+    test("should handle instrument names with underscore and resolve collisions", () => {
+        activity.turtles.turtleList = {
+            0: { name: "violin_one" },
+            1: { name: "viola_one" },
+            2: { name: "v_one" },
+            3: { name: "flute_two" },
+            4: { name: "aa_bb" },
+            5: { name: "aa_b" }
+        };
+        activity.logo.notation.notationStaging = {
+            0: ["note"],
+            1: ["note"],
+            2: ["note"],
+            3: ["note"],
+            4: ["note"],
+            5: ["note"]
+        };
+        const result = saveLilypondOutput(activity);
+        expect(result).toContain('shortInstrumentName = "vo"');
+        expect(result).toContain('shortInstrumentName = "von"');
+        expect(result).toContain('shortInstrumentName = "vone"');
+        expect(result).toContain('shortInstrumentName = "ft"');
+        expect(result).toContain('shortInstrumentName = "ab"');
+        expect(result).toContain('shortInstrumentName = "aab"');
+    });
 });

--- a/js/lilypond.js
+++ b/js/lilypond.js
@@ -676,7 +676,7 @@ const saveLilypondOutput = function (activity) {
         "% You can change the MIDI instruments below to anything on this list:\n% (http://lilypond.org/doc/v2.18/documentation/notation/midi-instruments)\n\n";
 
     let c = 0;
-    const occupiedShortNames = [];
+    const occupiedShortNames = new Set();
     for (const t in activity.logo.notation.notationStaging) {
         let tNumber = t;
         if (typeof t === "string") {
@@ -793,7 +793,7 @@ const saveLilypondOutput = function (activity) {
                 // letters.
                 if (instrumentName.length === 1) {
                     shortInstrumentName = instrumentName;
-                    occupiedShortNames[t] = shortInstrumentName;
+                    occupiedShortNames.add(shortInstrumentName);
                 } else if (n === -1) {
                     // no space in instrument name
                     for (let p = 2; p < instrumentName.length; p++) {
@@ -803,10 +803,10 @@ const saveLilypondOutput = function (activity) {
                             final = final + instrumentName.charAt(p - 1);
                         }
 
-                        if (!occupiedShortNames.includes(final)) {
+                        if (!occupiedShortNames.has(final)) {
                             // not found in array so unique shortname
                             shortInstrumentName = final;
-                            occupiedShortNames[t] = shortInstrumentName;
+                            occupiedShortNames.add(shortInstrumentName);
                             break;
                         }
                     }
@@ -818,28 +818,28 @@ const saveLilypondOutput = function (activity) {
                     part2 = secondPart.charAt(0);
                     final = part1 + part2;
 
-                    if (!occupiedShortNames.includes(final)) {
+                    if (!occupiedShortNames.has(final)) {
                         // found unique shortname
                         shortInstrumentName = final;
-                        occupiedShortNames[t] = shortInstrumentName;
+                        occupiedShortNames.add(shortInstrumentName);
                         done = 1;
                     } else if (done !== 1) {
                         final = "";
                         for (let q = 1; q < instrumentName.length; q++) {
                             part2 = part2 + secondPart.charAt(q);
                             final = part1 + part2;
-                            if (!occupiedShortNames.includes(final)) {
+                            if (!occupiedShortNames.has(final)) {
                                 // found unique shortname
                                 shortInstrumentName = final;
-                                occupiedShortNames[t] = shortInstrumentName;
+                                occupiedShortNames.add(shortInstrumentName);
                                 break;
                             } else {
                                 part1 = part1 + firstPart.charAt(q);
                                 final = part1 + part2;
-                                if (!occupiedShortNames.includes(final)) {
+                                if (!occupiedShortNames.has(final)) {
                                     // found unique shortname
                                     shortInstrumentName = final;
-                                    occupiedShortNames[t] = shortInstrumentName;
+                                    occupiedShortNames.add(shortInstrumentName);
                                     break;
                                 }
                             }


### PR DESCRIPTION
## Description

This PR optimizes the tracking and lookup of `occupiedShortNames` in `saveLilypondOutput` (`js/lilypond.js`) by transitioning the internal collection from an `Array` (`[]`) to an ES6 `Set` (`new Set()`). 

Previously, `occupiedShortNames` used linear scans via `Array.prototype.includes()` during short instrument name collision resolution, while also indexing by turtle keys (`occupiedShortNames[t] = ...`), which created sparse arrays in JavaScript engines. By switching to `Set`, membership checks and insertions run in $O(1)$ amortized time, and sparse array de-optimizations in V8 are avoided.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **Migrated data structure**: Replaced `const occupiedShortNames = []` with `const occupiedShortNames = new Set()` in `js/lilypond.js`.
- **$O(1)$ Lookups**: Replaced `occupiedShortNames.includes(final)` with `occupiedShortNames.has(final)`.
- **Eliminated Sparse Array Anti-Pattern**: Replaced index assignments (`occupiedShortNames[t] = shortInstrumentName`) with `occupiedShortNames.add(shortInstrumentName)`.
- **Complexity Improvement**: Reduced worst-case collision lookup time complexity from $O(T^2 \cdot L)$ to $O(T \cdot L)$ (effectively $O(T)$ where $T$ is the number of turtles/tracks).

---

## Testing Performed

- Ran the full test suite locally: **212/212 test suites passed, 7,781/7,781 tests passed**.
- Validated LilyPond unit tests via `npx jest js/__tests__/lilypond.test.js` (all 58 tests passed, including instrument name collision handling tests).
- Ran ESLint on `js/lilypond.js` with 0 warnings/errors.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

- `occupiedShortNames` is strictly a local function-scoped variable within `saveLilypondOutput` and is not exposed to external modules, ensuring zero risk of breaking API contracts.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
