### PR TITLE
test(logo): cover volume articulation dispatch through the real Logo interpreter

### DIFF
--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -32,12 +32,26 @@
  * clamp, keyed by its own real dispatch machinery (not a mock), and observes the volume
  * before, during, and after the clamp.
  *
+ * The block under test is the real, registered `ArticulationBlock` from
+ * js/blocks/VolumeBlocks.js - not a hand-copied stand-in for its `flow()` - so a regression
+ * in that block's registration (dockTypes/args, as computed by the real `formBlock()`) or in
+ * its `flow()` body would fail this test. `js/blocks/VolumeBlocks.js` is written to run
+ * against `FlowBlock`/`FlowClampBlock`/`LeftBlock`/`ValueBlock` as bare globals (the shape the
+ * production browser build provides via script concatenation), and only the base `ProtoBlock`
+ * is a CommonJS export of js/protoblocks.js; `loadProtoblockClasses()` below evaluates that
+ * same source file to pull out the concrete subclasses too, so `setupVolumeBlocks` registers
+ * against the real class hierarchy instead of a dummy substitute (the pattern
+ * VolumeBlocks.test.js itself uses for its own, non-integration, unit tests).
+ *
  * The clamp body is a real, minimal "vspace" (structural spacer) block - the same block the
  * noteclamp/pitch integration tests use for clamp content - repurposed here as the test's
  * synchronous checkpoint: `runFromBlockNow` runs entirely synchronously for this program, so
  * capturing the "during" volume requires a callback that fires while the clamp is still open,
  * before it unwinds and reverts by the time `runFromBlockNow` returns.
  */
+
+const fs = require("fs");
+const path = require("path");
 
 // Setup global mocks BEFORE requiring the module (mirror of noteclamp-beat-doublequeue.test.js).
 global._ = str => str;
@@ -83,6 +97,20 @@ global.DEFAULTVOICE = "electronic synth";
 global.last = arr => arr[arr.length - 1];
 global.clampNumber = (value, min, max) => Math.min(Math.max(value, min), max);
 
+// js/blocks/VolumeBlocks.js's block constructors call `.setup(activity)` (js/protoblocks.js),
+// which measures the block's label via a createjs Text/Container pair, and every ProtoBlock
+// reads DEFAULTBLOCKSCALE unconditionally at construction time.
+global.createjs = {
+    Container: function () {
+        return { addChild: () => {}, getBounds: () => ({ width: 10 }) };
+    },
+    Text: function () {
+        return {};
+    }
+};
+global.DEFAULTBLOCKSCALE = 1.0;
+global.STANDARDBLOCKHEIGHT = 20;
+
 jest.mock("tone", () => ({
     UserMedia: jest.fn().mockImplementation(() => ({
         open: jest.fn()
@@ -101,6 +129,35 @@ const { Logo } = require("../logo");
 // production code does via `Singer.VolumeActions = class {...}` (js/turtleactions/VolumeActions.js).
 // No production code is mocked: setRelativeVolume runs for real.
 const setupVolumeActions = require("../turtleactions/VolumeActions");
+
+// js/blocks/VolumeBlocks.js (`setupVolumeBlocks`) is written to run against
+// `FlowBlock`/`FlowClampBlock`/`LeftBlock`/`ValueBlock` as bare globals - the shape the real
+// browser build provides. Only `ProtoBlock` is a CommonJS export of js/protoblocks.js, so this
+// evaluates that file's own source once to recover the real, concrete subclasses instead of
+// substituting dummies, giving `ArticulationBlock` its genuine constructor (real
+// `formBlock()`-computed dockTypes/args) and registration (`.setup()` -> `protoBlockDict`).
+function loadProtoblockClasses() {
+    const source = fs.readFileSync(path.join(__dirname, "../protoblocks.js"), "utf8");
+    const factory = new Function(
+        "module",
+        `${source}\nreturn { BaseBlock, ValueBlock, FlowBlock, LeftBlock, FlowClampBlock };`
+    );
+    return factory({ exports: {} });
+}
+
+const { BaseBlock, ValueBlock, FlowBlock, LeftBlock, FlowClampBlock } = loadProtoblockClasses();
+global.BaseBlock = BaseBlock;
+global.ValueBlock = ValueBlock;
+global.FlowBlock = FlowBlock;
+global.LeftBlock = LeftBlock;
+global.FlowClampBlock = FlowClampBlock;
+
+global.NANERRORMSG = global.NANERRORMSG || "Not a number";
+global.VOICENAMES = {};
+global.DRUMNAMES = {};
+global.DEFAULTDRUM = "kick";
+
+const { setupVolumeBlocks } = require("../blocks/VolumeBlocks");
 
 function createTurtle() {
     return {
@@ -164,8 +221,15 @@ function createTurtle() {
 
 function createActivity(turtle) {
     return {
+        beginnerMode: false,
+        palettes: {
+            dict: {
+                volume: { add: jest.fn() }
+            }
+        },
         blocks: {
             blockList: [],
+            protoBlockDict: {},
             findStacks: jest.fn(),
             stackList: [],
             unhighlightAll: jest.fn(),
@@ -250,10 +314,17 @@ describe("volume articulation clamp dispatch through the real Logo interpreter",
         duringClampVolume = null;
 
         setupVolumeActions(activity);
+        // Registers the real ArticulationBlock (and its Volume-palette siblings) into
+        // activity.blocks.protoBlockDict via BaseBlock.setup() (js/protoblocks.js) - the same
+        // registration path the real block palette relies on.
+        setupVolumeBlocks(activity);
+        const articulationProto = activity.blocks.protoBlockDict.articulation;
 
         // articulation (0): connections [prev, value, clampEntry, hidden] - the real block
         // shape produced when the "set relative volume" block is dragged from the Volume
-        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js).
+        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js). Its
+        // protoblock is the real, registered ArticulationBlock instance: real dockTypes/args
+        // (["out","numberin","in","in"], args=2) and the real, unmodified `flow()`.
         // value (1):        number 25 (a +25% relative volume change, the block's own default)
         // vspace (2):       clamp content; captures the boosted volume mid-clamp, since the
         //                   clamp reverts it before runFromBlockNow returns
@@ -264,23 +335,13 @@ describe("volume articulation clamp dispatch through the real Logo interpreter",
             duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
             return null;
         });
-        const articulation = makeFlowBlock(
-            "articulation",
-            [null, 1, 2, 3],
-            (args, l, t, blk) => {
-                // Copied verbatim from ArticulationBlock.flow (js/blocks/VolumeBlocks.js).
-                if (args[1] === undefined) return;
-                let arg = args[0];
-                if (arg === null || typeof arg !== "number") {
-                    activity.errorMsg(NOINPUTERRORMSG, blk);
-                    arg = 0;
-                }
-                Singer.VolumeActions.setRelativeVolume(arg, t, blk);
-                return [args[1], 1];
-            },
-            [null, "numberin", "in", "in"],
-            3
-        );
+        const articulation = {
+            name: "articulation",
+            connections: [null, 1, 2, 3],
+            protoblock: articulationProto,
+            isValueBlock: () => false,
+            isArgBlock: () => false
+        };
         const value = {
             name: "number",
             value: 25,

--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -18,32 +18,47 @@
  */
 
 /**
- * Integration test for the Logo interpreter's end-of-clamp dispatch mechanism
- * (`setDispatchBlock`/`setTurtleListener`/`tur.endOfClampSignals`, js/logo.js) driving the real
- * `Singer.VolumeActions.setRelativeVolume` (js/turtleactions/VolumeActions.js) - extending the
- * pattern `noteclamp-beat-doublequeue.test.js` (drum dispatch) and
- * `pitch-note-dispatch-integration.test.js` (pitch dispatch) already use.
+ * Integration test: the real, registered `ArticulationBlock` (js/blocks/VolumeBlocks.js) is
+ * dispatched through the real `Logo.runFromBlockNow` (js/logo.js), which invokes the real
+ * `Singer.VolumeActions.setRelativeVolume` (js/turtleactions/VolumeActions.js), which relies on
+ * the real end-of-clamp dispatch machinery (`setDispatchBlock`/`setTurtleListener`/
+ * `tur.endOfClampSignals`, js/logo.js) to revert the volume when the clamp closes.
  *
- * Scope: this covers the Logo-dispatch <-> VolumeActions seam, not ArticulationBlock's own
- * palette registration. `Logo.runFromBlockNow` and `setRelativeVolume` run for real and
- * unmocked - entering the clamp pushes a boosted volume, and the clamp's real end-of-clamp
- * signal pops it back off on exit. The "articulation" block below is a minimal stand-in shaped
- * like the real block (js/blocks/VolumeBlocks.js): its `flow()` is copied verbatim from
- * `ArticulationBlock.flow`, not obtained from a live registered protoblock, because the concrete
- * classes it extends (`FlowClampBlock`/`FlowBlock`, js/protoblocks.js) only exist as bare
- * globals in the production script-concatenation build - reaching them from Jest would mean
- * either evaluating `protoblocks.js`'s source at runtime or driving the full canvas/DOM-heavy
- * `Blocks.makeBlock`/`Block` path (js/blocks.js, js/block.js), both disproportionate to this one
- * behavior. Consequently, a regression in `ArticulationBlock.flow` itself would not fail this
- * test; a regression in `setRelativeVolume` or in the Logo dispatch machinery around it would
- * (verified by deliberately breaking each and confirming the test fails).
+ * Real: `ArticulationBlock`'s registration and its own `flow()` (js/blocks/VolumeBlocks.js),
+ * `Logo.runFromBlockNow`, `Singer.VolumeActions.setRelativeVolume`, the end-of-clamp dispatch.
+ * Synthetic: the `vspace`/`hidden`/`number` block objects and the turtle/activity fixtures -
+ * plain data, not registered protoblocks, needed only to give the real articulation clamp
+ * something to run inside of and a place to signal to when it closes.
  *
- * The real "vspace" spacer block inside the clamp captures the boosted volume synchronously,
- * since `runFromBlockNow` runs fully synchronously and the clamp has already reverted by the
- * time it returns.
+ * `js/blocks/VolumeBlocks.js` is written to run against `FlowBlock`/`FlowClampBlock`/
+ * `LeftBlock`/`ValueBlock` as bare globals (the shape the production script-concatenation build
+ * provides). `js/protoblocks.js` exposes those concrete classes as static properties on its
+ * `ProtoBlock` export for exactly this purpose, so they can be required directly instead of
+ * reimplemented or parsed out of the source file.
+ *
+ * The "vspace" block inside the clamp is a synchronous checkpoint: `runFromBlockNow` runs fully
+ * synchronously, so by the time it returns the clamp has already closed and reverted the
+ * volume - reading it there would only ever see the reverted value, never the boosted one.
  */
 
-// Setup global mocks BEFORE requiring the module (mirror of noteclamp-beat-doublequeue.test.js).
+global.createjs = {
+    Container: function () {
+        return { addChild: () => {}, getBounds: () => ({ width: 10 }) };
+    },
+    Text: function () {
+        return {};
+    }
+};
+global.DEFAULTBLOCKSCALE = 1.0;
+global.STANDARDBLOCKHEIGHT = 20;
+
+const ProtoBlock = require("../protoblocks");
+global.BaseBlock = ProtoBlock.BaseBlock;
+global.ValueBlock = ProtoBlock.ValueBlock;
+global.FlowBlock = ProtoBlock.FlowBlock;
+global.LeftBlock = ProtoBlock.LeftBlock;
+global.FlowClampBlock = ProtoBlock.FlowClampBlock;
+
 global._ = str => str;
 global.Notation = jest.fn().mockImplementation(() => ({
     notationBeginArticulation: jest.fn(),
@@ -58,6 +73,9 @@ global.Singer = {
     defaultBPMFactor: 1
 };
 global.DEFAULTVOICE = "electronic synth";
+global.DEFAULTDRUM = "kick";
+global.VOICENAMES = {};
+global.DRUMNAMES = {};
 global.last = arr => arr[arr.length - 1];
 global.clampNumber = (value, min, max) => Math.min(Math.max(value, min), max);
 
@@ -76,9 +94,14 @@ Object.assign(global, logoconstants);
 const { Logo } = require("../logo");
 
 // Singer.VolumeActions is attached to the module-level `Singer` mock above, exactly as
-// production code does via `Singer.VolumeActions = class {...}` (js/turtleactions/VolumeActions.js).
-// No production code is mocked: setRelativeVolume runs for real.
+// production code does via `Singer.VolumeActions = class {...}`. No production code is mocked:
+// setRelativeVolume runs for real.
 const setupVolumeActions = require("../turtleactions/VolumeActions");
+
+// Registers the real ArticulationBlock (and its Volume-palette siblings) into
+// activity.blocks.protoBlockDict via BaseBlock.setup() (js/protoblocks.js) - the same
+// registration path the real block palette relies on.
+const { setupVolumeBlocks } = require("../blocks/VolumeBlocks");
 
 function createTurtle() {
     return {
@@ -109,8 +132,13 @@ function createTurtle() {
 
 function createActivity(turtle) {
     return {
+        beginnerMode: false,
+        palettes: {
+            dict: { volume: { add: jest.fn() } }
+        },
         blocks: {
             blockList: [],
+            protoBlockDict: {},
             sameGeneration: jest.fn(() => false)
         },
         turtles: {
@@ -133,6 +161,7 @@ function createActivity(turtle) {
     };
 }
 
+// Plain data blocks (not registered protoblocks) for the clamp's synthetic surroundings.
 function makeFlowBlock(name, connections, flow, dockTypes, args) {
     return {
         name,
@@ -147,14 +176,13 @@ function makeFlowBlock(name, connections, flow, dockTypes, args) {
     };
 }
 
-describe("Logo end-of-clamp dispatch drives the real Singer.VolumeActions.setRelativeVolume", () => {
+describe("the real ArticulationBlock dispatches through Logo into real Singer.VolumeActions", () => {
     let logo;
     let turtle;
     let activity;
     let duringClampVolume;
 
     beforeEach(() => {
-        jest.clearAllMocks();
         global.document.body.style.cursor = "default";
         turtle = createTurtle();
         activity = createActivity(turtle);
@@ -163,40 +191,27 @@ describe("Logo end-of-clamp dispatch drives the real Singer.VolumeActions.setRel
         duringClampVolume = null;
 
         setupVolumeActions(activity);
+        setupVolumeBlocks(activity);
+        const articulationProto = activity.blocks.protoBlockDict.articulation;
 
-        // articulation (0): connections [prev, value, clampEntry, hidden] - the connections
-        // shape produced when the "set relative volume" block is dragged from the Volume
-        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js).
-        // value (1):        number 25 (a +25% relative volume change, the block's own default)
-        // vspace (2):       clamp content - see the checkpoint comment below
-        // hidden (3):       connections [prev, null] (end-of-clamp signal target)
+        // articulation (0): connections [prev, value, clampEntry, hidden] - real, registered
+        // protoblock (real dockTypes/args from formBlock(), real flow()).
+        // value (1):  synthetic number 25 (a +25% relative volume change)
+        // vspace (2): synthetic clamp content - the checkpoint described in the file header
+        // hidden (3): synthetic end-of-clamp signal target
         const hidden = makeFlowBlock("hidden", [0, null], null);
         const vspace = makeFlowBlock("vspace", [0, null], (args, l, t) => {
-            // Checkpoint: reads the volume while the clamp is still open. runFromBlockNow is
-            // synchronous, so by the time it returns below the clamp has already closed and
-            // reverted the volume - this is the only point where the boosted value is visible.
             const tur = activity.turtles.ithTurtle(t);
             duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
             return null;
         });
-        const articulation = makeFlowBlock(
-            "articulation",
-            [null, 1, 2, 3],
-            (args, l, t, blk) => {
-                // Copied verbatim from ArticulationBlock.flow (js/blocks/VolumeBlocks.js) -
-                // see the file-level comment above for why this isn't a live protoblock.
-                if (args[1] === undefined) return;
-                let arg = args[0];
-                if (arg === null || typeof arg !== "number") {
-                    activity.errorMsg(NOINPUTERRORMSG, blk);
-                    arg = 0;
-                }
-                Singer.VolumeActions.setRelativeVolume(arg, t, blk);
-                return [args[1], 1];
-            },
-            [null, "numberin", "in", "in"],
-            3
-        );
+        const articulation = {
+            name: "articulation",
+            connections: [null, 1, 2, 3],
+            protoblock: articulationProto,
+            isValueBlock: () => false,
+            isArgBlock: () => false
+        };
         const value = {
             name: "number",
             value: 25,
@@ -217,8 +232,8 @@ describe("Logo end-of-clamp dispatch drives the real Singer.VolumeActions.setRel
         // While the clamp is open, a +25% relative volume was pushed on top of the base 60.
         expect(duringClampVolume).toEqual([60, 75]);
 
-        // Once the clamp's real end-of-clamp signal (setDispatchBlock/endOfClampSignals) fires
-        // the reverting listener, the boosted value is popped and the base volume remains.
+        // Once the clamp's real end-of-clamp signal fires the reverting listener, the boosted
+        // value is popped and the base volume remains.
         expect(turtle.singer.synthVolume[DEFAULTVOICE]).toEqual([60]);
     });
 });

--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -32,16 +32,25 @@
  * clamp, keyed by its own real dispatch machinery (not a mock), and observes the volume
  * before, during, and after the clamp.
  *
- * The block under test is the real, registered `ArticulationBlock` from
- * js/blocks/VolumeBlocks.js - not a hand-copied stand-in for its `flow()` - so a regression
- * in that block's registration (dockTypes/args, as computed by the real `formBlock()`) or in
- * its `flow()` body would fail this test. `js/blocks/VolumeBlocks.js` is written to run
- * against `FlowBlock`/`FlowClampBlock`/`LeftBlock`/`ValueBlock` as bare globals (the shape the
- * production browser build provides via script concatenation), and only the base `ProtoBlock`
- * is a CommonJS export of js/protoblocks.js; `loadProtoblockClasses()` below evaluates that
- * same source file to pull out the concrete subclasses too, so `setupVolumeBlocks` registers
- * against the real class hierarchy instead of a dummy substitute (the pattern
- * VolumeBlocks.test.js itself uses for its own, non-integration, unit tests).
+ * What's real here and what isn't: `Singer.VolumeActions.setRelativeVolume` runs unmocked
+ * (js/turtleactions/VolumeActions.js), as does the end-of-clamp dispatch machinery it relies
+ * on (js/logo.js). The `articulation` block's `flow()` below is copied verbatim from the
+ * production `ArticulationBlock.flow` (js/blocks/VolumeBlocks.js) rather than driven through a
+ * live, registered protoblock instance. That's a deliberate boundary, not an oversight: the
+ * concrete block classes `ArticulationBlock` extends (`FlowClampBlock`/`FlowBlock`/`LeftBlock`,
+ * js/protoblocks.js) are written to run as bare globals supplied by the production
+ * script-concatenation build, and only the base `ProtoBlock` is a CommonJS export - there is no
+ * supported, lightweight way to obtain a real, dockTypes-bearing protoblock for a Volume block
+ * from this test file. The two ways that do exist were both rejected as disproportionate to a
+ * single-behavior test: evaluating `protoblocks.js`'s own source via `new Function(...)` to
+ * recover the unexported subclasses (couples the test to that file's internal layout, not just
+ * its behavior), or driving the real `Blocks.makeBlock`/`Block` construction path
+ * (js/blocks.js, js/block.js), which pulls in ~50 additional production globals (canvas
+ * containers, image loading, spatial-grid indexing, drag-group tracking) that have nothing to
+ * do with volume dispatch. Copying the ~10-line `flow()` body keeps the harness scoped to the
+ * noteclamp/pitch pattern while still exercising the real dispatch chain around it; the
+ * sabotage checks below (see PR discussion) confirm a regression in either the copied flow's
+ * own logic or in `setRelativeVolume` itself fails this test.
  *
  * The clamp body is a real, minimal "vspace" (structural spacer) block - the same block the
  * noteclamp/pitch integration tests use for clamp content - repurposed here as the test's
@@ -49,9 +58,6 @@
  * capturing the "during" volume requires a callback that fires while the clamp is still open,
  * before it unwinds and reverts by the time `runFromBlockNow` returns.
  */
-
-const fs = require("fs");
-const path = require("path");
 
 // Setup global mocks BEFORE requiring the module (mirror of noteclamp-beat-doublequeue.test.js).
 global._ = str => str;
@@ -97,20 +103,6 @@ global.DEFAULTVOICE = "electronic synth";
 global.last = arr => arr[arr.length - 1];
 global.clampNumber = (value, min, max) => Math.min(Math.max(value, min), max);
 
-// js/blocks/VolumeBlocks.js's block constructors call `.setup(activity)` (js/protoblocks.js),
-// which measures the block's label via a createjs Text/Container pair, and every ProtoBlock
-// reads DEFAULTBLOCKSCALE unconditionally at construction time.
-global.createjs = {
-    Container: function () {
-        return { addChild: () => {}, getBounds: () => ({ width: 10 }) };
-    },
-    Text: function () {
-        return {};
-    }
-};
-global.DEFAULTBLOCKSCALE = 1.0;
-global.STANDARDBLOCKHEIGHT = 20;
-
 jest.mock("tone", () => ({
     UserMedia: jest.fn().mockImplementation(() => ({
         open: jest.fn()
@@ -129,35 +121,6 @@ const { Logo } = require("../logo");
 // production code does via `Singer.VolumeActions = class {...}` (js/turtleactions/VolumeActions.js).
 // No production code is mocked: setRelativeVolume runs for real.
 const setupVolumeActions = require("../turtleactions/VolumeActions");
-
-// js/blocks/VolumeBlocks.js (`setupVolumeBlocks`) is written to run against
-// `FlowBlock`/`FlowClampBlock`/`LeftBlock`/`ValueBlock` as bare globals - the shape the real
-// browser build provides. Only `ProtoBlock` is a CommonJS export of js/protoblocks.js, so this
-// evaluates that file's own source once to recover the real, concrete subclasses instead of
-// substituting dummies, giving `ArticulationBlock` its genuine constructor (real
-// `formBlock()`-computed dockTypes/args) and registration (`.setup()` -> `protoBlockDict`).
-function loadProtoblockClasses() {
-    const source = fs.readFileSync(path.join(__dirname, "../protoblocks.js"), "utf8");
-    const factory = new Function(
-        "module",
-        `${source}\nreturn { BaseBlock, ValueBlock, FlowBlock, LeftBlock, FlowClampBlock };`
-    );
-    return factory({ exports: {} });
-}
-
-const { BaseBlock, ValueBlock, FlowBlock, LeftBlock, FlowClampBlock } = loadProtoblockClasses();
-global.BaseBlock = BaseBlock;
-global.ValueBlock = ValueBlock;
-global.FlowBlock = FlowBlock;
-global.LeftBlock = LeftBlock;
-global.FlowClampBlock = FlowClampBlock;
-
-global.NANERRORMSG = global.NANERRORMSG || "Not a number";
-global.VOICENAMES = {};
-global.DRUMNAMES = {};
-global.DEFAULTDRUM = "kick";
-
-const { setupVolumeBlocks } = require("../blocks/VolumeBlocks");
 
 function createTurtle() {
     return {
@@ -221,15 +184,8 @@ function createTurtle() {
 
 function createActivity(turtle) {
     return {
-        beginnerMode: false,
-        palettes: {
-            dict: {
-                volume: { add: jest.fn() }
-            }
-        },
         blocks: {
             blockList: [],
-            protoBlockDict: {},
             findStacks: jest.fn(),
             stackList: [],
             unhighlightAll: jest.fn(),
@@ -314,17 +270,10 @@ describe("volume articulation clamp dispatch through the real Logo interpreter",
         duringClampVolume = null;
 
         setupVolumeActions(activity);
-        // Registers the real ArticulationBlock (and its Volume-palette siblings) into
-        // activity.blocks.protoBlockDict via BaseBlock.setup() (js/protoblocks.js) - the same
-        // registration path the real block palette relies on.
-        setupVolumeBlocks(activity);
-        const articulationProto = activity.blocks.protoBlockDict.articulation;
 
         // articulation (0): connections [prev, value, clampEntry, hidden] - the real block
         // shape produced when the "set relative volume" block is dragged from the Volume
-        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js). Its
-        // protoblock is the real, registered ArticulationBlock instance: real dockTypes/args
-        // (["out","numberin","in","in"], args=2) and the real, unmodified `flow()`.
+        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js).
         // value (1):        number 25 (a +25% relative volume change, the block's own default)
         // vspace (2):       clamp content; captures the boosted volume mid-clamp, since the
         //                   clamp reverts it before runFromBlockNow returns
@@ -335,13 +284,24 @@ describe("volume articulation clamp dispatch through the real Logo interpreter",
             duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
             return null;
         });
-        const articulation = {
-            name: "articulation",
-            connections: [null, 1, 2, 3],
-            protoblock: articulationProto,
-            isValueBlock: () => false,
-            isArgBlock: () => false
-        };
+        const articulation = makeFlowBlock(
+            "articulation",
+            [null, 1, 2, 3],
+            (args, l, t, blk) => {
+                // Copied verbatim from ArticulationBlock.flow (js/blocks/VolumeBlocks.js) -
+                // see the file-level comment above for why this isn't a live protoblock.
+                if (args[1] === undefined) return;
+                let arg = args[0];
+                if (arg === null || typeof arg !== "number") {
+                    activity.errorMsg(NOINPUTERRORMSG, blk);
+                    arg = 0;
+                }
+                Singer.VolumeActions.setRelativeVolume(arg, t, blk);
+                return [args[1], 1];
+            },
+            [null, "numberin", "in", "in"],
+            3
+        );
         const value = {
             name: "number",
             value: 25,

--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -1,0 +1,308 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration coverage for the "block palette -> Logo interpreter" seam, extending the
+ * pattern established by `noteclamp-beat-doublequeue.test.js` (drum dispatch) and
+ * `pitch-note-dispatch-integration.test.js` (pitch dispatch) to volume dispatch.
+ *
+ * Unlike Pitch/Rhythm dispatch, which resolve and schedule state at the *end* of a note
+ * clamp, the "set relative volume" (articulation) block (js/turtleactions/VolumeActions.js,
+ * `setRelativeVolume`) is a push/pop clamp: entering the clamp pushes a boosted volume onto
+ * `tur.singer.synthVolume[synth]` for every synth currently in use, and the real
+ * `Logo.runFromBlockNow` end-of-clamp dispatch mechanism (`setDispatchBlock` /
+ * `setTurtleListener` / `tur.endOfClampSignals`, js/logo.js) fires a listener on clamp exit
+ * that pops the boosted value back off, restoring the prior volume. This test drives that
+ * clamp, keyed by its own real dispatch machinery (not a mock), and observes the volume
+ * before, during, and after the clamp.
+ *
+ * The clamp body is a real, minimal "vspace" (structural spacer) block - the same block the
+ * noteclamp/pitch integration tests use for clamp content - repurposed here as the test's
+ * synchronous checkpoint: `runFromBlockNow` runs entirely synchronously for this program, so
+ * capturing the "during" volume requires a callback that fires while the clamp is still open,
+ * before it unwinds and reverts by the time `runFromBlockNow` returns.
+ */
+
+// Setup global mocks BEFORE requiring the module (mirror of noteclamp-beat-doublequeue.test.js).
+global._ = str => str;
+global.Notation = jest.fn().mockImplementation(() => ({
+    notationStaging: {},
+    notationDrumStaging: {},
+    pickupPoint: {},
+    pickupPOW2: {},
+    doUpdateNotation: jest.fn(),
+    notationInsertTie: jest.fn(),
+    notationBeginArticulation: jest.fn(),
+    notationEndArticulation: jest.fn()
+}));
+global.Synth = jest.fn().mockImplementation(() => ({
+    newTone: jest.fn(),
+    createDefaultSynth: jest.fn(),
+    loadSynth: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    stopSound: jest.fn(),
+    disposeAllInstruments: jest.fn(),
+    changeInTemperament: false,
+    recorder: null,
+    transport: {
+        get isAvailable() {
+            return false;
+        },
+        cancel: jest.fn(),
+        get seconds() {
+            return 0;
+        },
+        set seconds(v) {}
+    }
+}));
+global.Singer = {
+    processNote: jest.fn(),
+    setSynthVolume: jest.fn(),
+    setMasterVolume: jest.fn(),
+    masterBPM: 90,
+    defaultBPMFactor: 1
+};
+global.DEFAULTVOICE = "electronic synth";
+global.last = arr => arr[arr.length - 1];
+global.clampNumber = (value, min, max) => Math.min(Math.max(value, min), max);
+
+jest.mock("tone", () => ({
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+}));
+
+global.EmbeddedGraphicsScheduler =
+    require("../embedded-graphics-scheduler").EmbeddedGraphicsScheduler;
+
+const logoconstants = require("../logoconstants");
+Object.assign(global, logoconstants);
+
+const { Logo } = require("../logo");
+
+// Singer.VolumeActions is attached to the module-level `Singer` mock above, exactly as
+// production code does via `Singer.VolumeActions = class {...}` (js/turtleactions/VolumeActions.js).
+// No production code is mocked: setRelativeVolume runs for real.
+const setupVolumeActions = require("../turtleactions/VolumeActions");
+
+function createTurtle() {
+    return {
+        id: 0,
+        singer: {
+            inNoteBlock: [],
+            notesPlayed: [0, 1],
+            pickup: 0,
+            noteValuePerBeat: 1,
+            beatsPerMeasure: 4,
+            beatFactor: 1,
+            beatList: [],
+            factorList: [],
+            currentBeat: null,
+            currentMeasure: null,
+            multipleVoices: false,
+            inNeighbor: [],
+            neighborArgBeat: [],
+            neighborArgCurrentBeat: [],
+            neighborNoteValue: 1,
+            noteValue: {},
+            oscList: {},
+            noteBeat: {},
+            noteBeatValues: {},
+            notePitches: {},
+            noteOctaves: {},
+            noteCents: {},
+            noteHertz: {},
+            noteDrums: {},
+            embeddedGraphics: {},
+            delayedNotes: [],
+            inDuplicate: false,
+            backward: [],
+            suppressOutput: true,
+            justCounting: [],
+            drumStyle: [],
+            synthVolume: { [DEFAULTVOICE]: [60] },
+            crescendoInitialVolume: {}
+        },
+        painter: {
+            color: 50,
+            penState: true,
+            closeSVG: jest.fn()
+        },
+        queue: [],
+        parentFlowQueue: [],
+        unhighlightQueue: [],
+        parameterQueue: [],
+        listeners: {},
+        endOfClampSignals: {},
+        waitTime: 0,
+        doWait: jest.fn(),
+        container: { x: 0, y: 0 },
+        x: 0,
+        y: 0,
+        running: false,
+        inTrash: false,
+        companionTurtle: null
+    };
+}
+
+function createActivity(turtle) {
+    return {
+        blocks: {
+            blockList: [],
+            findStacks: jest.fn(),
+            stackList: [],
+            unhighlightAll: jest.fn(),
+            bringToTop: jest.fn(),
+            showBlocks: jest.fn(),
+            unhighlight: jest.fn(),
+            highlight: jest.fn(),
+            clearParameterBlocks: jest.fn(),
+            updateParameterBlock: jest.fn(),
+            sameGeneration: jest.fn(() => false),
+            visible: false
+        },
+        turtles: {
+            turtleList: [turtle],
+            ithTurtle: jest.fn(() => turtle),
+            getTurtle: jest.fn(() => turtle),
+            getTurtleCount: jest.fn(() => 1),
+            turtleCount: jest.fn(() => 1),
+            turtleX2screenX: jest.fn(x => x),
+            turtleY2screenY: jest.fn(y => y),
+            add: jest.fn(),
+            addTurtle: jest.fn(),
+            markAllAsStopped: jest.fn(),
+            running: jest.fn(() => false)
+        },
+        stage: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(name => {
+                if (typeof name === "string" && turtle.listeners[name]) {
+                    turtle.listeners[name]();
+                }
+            }),
+            update: jest.fn()
+        },
+        errorMsg: jest.fn(),
+        textMsg: jest.fn(),
+        hideMsgs: jest.fn(),
+        saveLocally: jest.fn(),
+        refreshCanvas: jest.fn(),
+        showBlocksAfterRun: false,
+        onStopTurtle: jest.fn(),
+        onRunTurtle: jest.fn(),
+        meSpeak: { speak: jest.fn() },
+        save: {
+            afterSaveLilypond: jest.fn(),
+            afterSaveAbc: jest.fn(),
+            afterSaveMxml: jest.fn(),
+            afterSaveMIDI: jest.fn()
+        },
+        statsWindow: { displayInfo: jest.fn() }
+    };
+}
+
+function makeFlowBlock(name, connections, flow, dockTypes, args) {
+    return {
+        name,
+        connections,
+        protoblock: {
+            args: args || 0,
+            dockTypes: dockTypes || [null],
+            flow: flow || (() => null)
+        },
+        isValueBlock: () => false,
+        isArgBlock: () => false
+    };
+}
+
+describe("volume articulation clamp dispatch through the real Logo interpreter", () => {
+    let logo;
+    let turtle;
+    let activity;
+    let duringClampVolume;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.document.body.style.cursor = "default";
+        turtle = createTurtle();
+        activity = createActivity(turtle);
+        logo = new Logo(activity);
+        activity.logo = logo;
+        duringClampVolume = null;
+
+        setupVolumeActions(activity);
+
+        // articulation (0): connections [prev, value, clampEntry, hidden] - the real block
+        // shape produced when the "set relative volume" block is dragged from the Volume
+        // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js).
+        // value (1):        number 25 (a +25% relative volume change, the block's own default)
+        // vspace (2):       clamp content; captures the boosted volume mid-clamp, since the
+        //                   clamp reverts it before runFromBlockNow returns
+        // hidden (3):       connections [prev, null] (end-of-clamp signal target)
+        const hidden = makeFlowBlock("hidden", [0, null], null);
+        const vspace = makeFlowBlock("vspace", [0, null], (args, l, t) => {
+            const tur = activity.turtles.ithTurtle(t);
+            duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
+            return null;
+        });
+        const articulation = makeFlowBlock(
+            "articulation",
+            [null, 1, 2, 3],
+            (args, l, t, blk) => {
+                // Copied verbatim from ArticulationBlock.flow (js/blocks/VolumeBlocks.js).
+                if (args[1] === undefined) return;
+                let arg = args[0];
+                if (arg === null || typeof arg !== "number") {
+                    activity.errorMsg(NOINPUTERRORMSG, blk);
+                    arg = 0;
+                }
+                Singer.VolumeActions.setRelativeVolume(arg, t, blk);
+                return [args[1], 1];
+            },
+            [null, "numberin", "in", "in"],
+            3
+        );
+        const value = {
+            name: "number",
+            value: 25,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+
+        const blocks = [articulation, value, vspace, hidden];
+        logo.blockList = blocks;
+        activity.blocks.blockList = blocks;
+    });
+
+    test("boosts the synth volume for the clamp's duration and reverts it once the clamp ends", () => {
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+
+        // While the clamp is open, a +25% relative volume was pushed on top of the base 60.
+        expect(duringClampVolume).toEqual([60, 75]);
+
+        // Once the clamp's real end-of-clamp signal (setDispatchBlock/endOfClampSignals) fires
+        // the reverting listener, the boosted value is popped and the base volume remains.
+        expect(turtle.singer.synthVolume[DEFAULTVOICE]).toEqual([60]);
+    });
+});

--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -18,80 +18,38 @@
  */
 
 /**
- * Integration coverage for the "block palette -> Logo interpreter" seam, extending the
- * pattern established by `noteclamp-beat-doublequeue.test.js` (drum dispatch) and
- * `pitch-note-dispatch-integration.test.js` (pitch dispatch) to volume dispatch.
+ * Integration test for the Logo interpreter's end-of-clamp dispatch mechanism
+ * (`setDispatchBlock`/`setTurtleListener`/`tur.endOfClampSignals`, js/logo.js) driving the real
+ * `Singer.VolumeActions.setRelativeVolume` (js/turtleactions/VolumeActions.js) - extending the
+ * pattern `noteclamp-beat-doublequeue.test.js` (drum dispatch) and
+ * `pitch-note-dispatch-integration.test.js` (pitch dispatch) already use.
  *
- * Unlike Pitch/Rhythm dispatch, which resolve and schedule state at the *end* of a note
- * clamp, the "set relative volume" (articulation) block (js/turtleactions/VolumeActions.js,
- * `setRelativeVolume`) is a push/pop clamp: entering the clamp pushes a boosted volume onto
- * `tur.singer.synthVolume[synth]` for every synth currently in use, and the real
- * `Logo.runFromBlockNow` end-of-clamp dispatch mechanism (`setDispatchBlock` /
- * `setTurtleListener` / `tur.endOfClampSignals`, js/logo.js) fires a listener on clamp exit
- * that pops the boosted value back off, restoring the prior volume. This test drives that
- * clamp, keyed by its own real dispatch machinery (not a mock), and observes the volume
- * before, during, and after the clamp.
+ * Scope: this covers the Logo-dispatch <-> VolumeActions seam, not ArticulationBlock's own
+ * palette registration. `Logo.runFromBlockNow` and `setRelativeVolume` run for real and
+ * unmocked - entering the clamp pushes a boosted volume, and the clamp's real end-of-clamp
+ * signal pops it back off on exit. The "articulation" block below is a minimal stand-in shaped
+ * like the real block (js/blocks/VolumeBlocks.js): its `flow()` is copied verbatim from
+ * `ArticulationBlock.flow`, not obtained from a live registered protoblock, because the concrete
+ * classes it extends (`FlowClampBlock`/`FlowBlock`, js/protoblocks.js) only exist as bare
+ * globals in the production script-concatenation build - reaching them from Jest would mean
+ * either evaluating `protoblocks.js`'s source at runtime or driving the full canvas/DOM-heavy
+ * `Blocks.makeBlock`/`Block` path (js/blocks.js, js/block.js), both disproportionate to this one
+ * behavior. Consequently, a regression in `ArticulationBlock.flow` itself would not fail this
+ * test; a regression in `setRelativeVolume` or in the Logo dispatch machinery around it would
+ * (verified by deliberately breaking each and confirming the test fails).
  *
- * What's real here and what isn't: `Singer.VolumeActions.setRelativeVolume` runs unmocked
- * (js/turtleactions/VolumeActions.js), as does the end-of-clamp dispatch machinery it relies
- * on (js/logo.js). The `articulation` block's `flow()` below is copied verbatim from the
- * production `ArticulationBlock.flow` (js/blocks/VolumeBlocks.js) rather than driven through a
- * live, registered protoblock instance. That's a deliberate boundary, not an oversight: the
- * concrete block classes `ArticulationBlock` extends (`FlowClampBlock`/`FlowBlock`/`LeftBlock`,
- * js/protoblocks.js) are written to run as bare globals supplied by the production
- * script-concatenation build, and only the base `ProtoBlock` is a CommonJS export - there is no
- * supported, lightweight way to obtain a real, dockTypes-bearing protoblock for a Volume block
- * from this test file. The two ways that do exist were both rejected as disproportionate to a
- * single-behavior test: evaluating `protoblocks.js`'s own source via `new Function(...)` to
- * recover the unexported subclasses (couples the test to that file's internal layout, not just
- * its behavior), or driving the real `Blocks.makeBlock`/`Block` construction path
- * (js/blocks.js, js/block.js), which pulls in ~50 additional production globals (canvas
- * containers, image loading, spatial-grid indexing, drag-group tracking) that have nothing to
- * do with volume dispatch. Copying the ~10-line `flow()` body keeps the harness scoped to the
- * noteclamp/pitch pattern while still exercising the real dispatch chain around it; the
- * sabotage checks below (see PR discussion) confirm a regression in either the copied flow's
- * own logic or in `setRelativeVolume` itself fails this test.
- *
- * The clamp body is a real, minimal "vspace" (structural spacer) block - the same block the
- * noteclamp/pitch integration tests use for clamp content - repurposed here as the test's
- * synchronous checkpoint: `runFromBlockNow` runs entirely synchronously for this program, so
- * capturing the "during" volume requires a callback that fires while the clamp is still open,
- * before it unwinds and reverts by the time `runFromBlockNow` returns.
+ * The real "vspace" spacer block inside the clamp captures the boosted volume synchronously,
+ * since `runFromBlockNow` runs fully synchronously and the clamp has already reverted by the
+ * time it returns.
  */
 
 // Setup global mocks BEFORE requiring the module (mirror of noteclamp-beat-doublequeue.test.js).
 global._ = str => str;
 global.Notation = jest.fn().mockImplementation(() => ({
-    notationStaging: {},
-    notationDrumStaging: {},
-    pickupPoint: {},
-    pickupPOW2: {},
-    doUpdateNotation: jest.fn(),
-    notationInsertTie: jest.fn(),
     notationBeginArticulation: jest.fn(),
     notationEndArticulation: jest.fn()
 }));
-global.Synth = jest.fn().mockImplementation(() => ({
-    newTone: jest.fn(),
-    createDefaultSynth: jest.fn(),
-    loadSynth: jest.fn(),
-    start: jest.fn(),
-    stop: jest.fn(),
-    stopSound: jest.fn(),
-    disposeAllInstruments: jest.fn(),
-    changeInTemperament: false,
-    recorder: null,
-    transport: {
-        get isAvailable() {
-            return false;
-        },
-        cancel: jest.fn(),
-        get seconds() {
-            return 0;
-        },
-        set seconds(v) {}
-    }
-}));
+global.Synth = jest.fn().mockImplementation(() => ({}));
 global.Singer = {
     processNote: jest.fn(),
     setSynthVolume: jest.fn(),
@@ -127,44 +85,14 @@ function createTurtle() {
         id: 0,
         singer: {
             inNoteBlock: [],
-            notesPlayed: [0, 1],
-            pickup: 0,
-            noteValuePerBeat: 1,
-            beatsPerMeasure: 4,
-            beatFactor: 1,
-            beatList: [],
-            factorList: [],
-            currentBeat: null,
-            currentMeasure: null,
-            multipleVoices: false,
-            inNeighbor: [],
-            neighborArgBeat: [],
-            neighborArgCurrentBeat: [],
-            neighborNoteValue: 1,
-            noteValue: {},
-            oscList: {},
-            noteBeat: {},
-            noteBeatValues: {},
-            notePitches: {},
-            noteOctaves: {},
-            noteCents: {},
-            noteHertz: {},
-            noteDrums: {},
-            embeddedGraphics: {},
-            delayedNotes: [],
             inDuplicate: false,
             backward: [],
             suppressOutput: true,
             justCounting: [],
-            drumStyle: [],
             synthVolume: { [DEFAULTVOICE]: [60] },
             crescendoInitialVolume: {}
         },
-        painter: {
-            color: 50,
-            penState: true,
-            closeSVG: jest.fn()
-        },
+        painter: { closeSVG: jest.fn() },
         queue: [],
         parentFlowQueue: [],
         unhighlightQueue: [],
@@ -174,11 +102,8 @@ function createTurtle() {
         waitTime: 0,
         doWait: jest.fn(),
         container: { x: 0, y: 0 },
-        x: 0,
-        y: 0,
         running: false,
-        inTrash: false,
-        companionTurtle: null
+        inTrash: false
     };
 }
 
@@ -186,29 +111,12 @@ function createActivity(turtle) {
     return {
         blocks: {
             blockList: [],
-            findStacks: jest.fn(),
-            stackList: [],
-            unhighlightAll: jest.fn(),
-            bringToTop: jest.fn(),
-            showBlocks: jest.fn(),
-            unhighlight: jest.fn(),
-            highlight: jest.fn(),
-            clearParameterBlocks: jest.fn(),
-            updateParameterBlock: jest.fn(),
-            sameGeneration: jest.fn(() => false),
-            visible: false
+            sameGeneration: jest.fn(() => false)
         },
         turtles: {
             turtleList: [turtle],
             ithTurtle: jest.fn(() => turtle),
             getTurtle: jest.fn(() => turtle),
-            getTurtleCount: jest.fn(() => 1),
-            turtleCount: jest.fn(() => 1),
-            turtleX2screenX: jest.fn(x => x),
-            turtleY2screenY: jest.fn(y => y),
-            add: jest.fn(),
-            addTurtle: jest.fn(),
-            markAllAsStopped: jest.fn(),
             running: jest.fn(() => false)
         },
         stage: {
@@ -218,25 +126,10 @@ function createActivity(turtle) {
                 if (typeof name === "string" && turtle.listeners[name]) {
                     turtle.listeners[name]();
                 }
-            }),
-            update: jest.fn()
+            })
         },
         errorMsg: jest.fn(),
-        textMsg: jest.fn(),
-        hideMsgs: jest.fn(),
-        saveLocally: jest.fn(),
-        refreshCanvas: jest.fn(),
-        showBlocksAfterRun: false,
-        onStopTurtle: jest.fn(),
-        onRunTurtle: jest.fn(),
-        meSpeak: { speak: jest.fn() },
-        save: {
-            afterSaveLilypond: jest.fn(),
-            afterSaveAbc: jest.fn(),
-            afterSaveMxml: jest.fn(),
-            afterSaveMIDI: jest.fn()
-        },
-        statsWindow: { displayInfo: jest.fn() }
+        onStopTurtle: jest.fn()
     };
 }
 
@@ -254,7 +147,7 @@ function makeFlowBlock(name, connections, flow, dockTypes, args) {
     };
 }
 
-describe("volume articulation clamp dispatch through the real Logo interpreter", () => {
+describe("Logo end-of-clamp dispatch drives the real Singer.VolumeActions.setRelativeVolume", () => {
     let logo;
     let turtle;
     let activity;
@@ -271,15 +164,17 @@ describe("volume articulation clamp dispatch through the real Logo interpreter",
 
         setupVolumeActions(activity);
 
-        // articulation (0): connections [prev, value, clampEntry, hidden] - the real block
+        // articulation (0): connections [prev, value, clampEntry, hidden] - the connections
         // shape produced when the "set relative volume" block is dragged from the Volume
         // palette (see ArticulationBlock's own makeMacro, js/blocks/VolumeBlocks.js).
         // value (1):        number 25 (a +25% relative volume change, the block's own default)
-        // vspace (2):       clamp content; captures the boosted volume mid-clamp, since the
-        //                   clamp reverts it before runFromBlockNow returns
+        // vspace (2):       clamp content - see the checkpoint comment below
         // hidden (3):       connections [prev, null] (end-of-clamp signal target)
         const hidden = makeFlowBlock("hidden", [0, null], null);
         const vspace = makeFlowBlock("vspace", [0, null], (args, l, t) => {
+            // Checkpoint: reads the volume while the clamp is still open. runFromBlockNow is
+            // synchronous, so by the time it returns below the clamp has already closed and
+            // reverted the volume - this is the only point where the boosted value is visible.
             const tur = activity.turtles.ithTurtle(t);
             duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
             return null;

--- a/js/__tests__/volume-articulation-dispatch-integration.test.js
+++ b/js/__tests__/volume-articulation-dispatch-integration.test.js
@@ -30,15 +30,12 @@
  * plain data, not registered protoblocks, needed only to give the real articulation clamp
  * something to run inside of and a place to signal to when it closes.
  *
- * `js/blocks/VolumeBlocks.js` is written to run against `FlowBlock`/`FlowClampBlock`/
- * `LeftBlock`/`ValueBlock` as bare globals (the shape the production script-concatenation build
- * provides). `js/protoblocks.js` exposes those concrete classes as static properties on its
- * `ProtoBlock` export for exactly this purpose, so they can be required directly instead of
- * reimplemented or parsed out of the source file.
+ * `js/blocks/VolumeBlocks.js` needs `FlowBlock`/`FlowClampBlock`/`LeftBlock`/`ValueBlock` as
+ * bare globals; `js/protoblocks.js` exports them as static properties on `ProtoBlock` for this
+ * (see that file for why this small export exists).
  *
- * The "vspace" block inside the clamp is a synchronous checkpoint: `runFromBlockNow` runs fully
- * synchronously, so by the time it returns the clamp has already closed and reverted the
- * volume - reading it there would only ever see the reverted value, never the boosted one.
+ * `runFromBlockNow` executes the clamp synchronously, so the "vspace" block inside it captures
+ * the temporary boosted volume before the end-of-clamp cleanup runs and reverts it.
  */
 
 global.createjs = {
@@ -181,6 +178,7 @@ describe("the real ArticulationBlock dispatches through Logo into real Singer.Vo
     let turtle;
     let activity;
     let duringClampVolume;
+    let duringClampSignalCount;
 
     beforeEach(() => {
         global.document.body.style.cursor = "default";
@@ -189,6 +187,7 @@ describe("the real ArticulationBlock dispatches through Logo into real Singer.Vo
         logo = new Logo(activity);
         activity.logo = logo;
         duringClampVolume = null;
+        duringClampSignalCount = null;
 
         setupVolumeActions(activity);
         setupVolumeBlocks(activity);
@@ -203,6 +202,9 @@ describe("the real ArticulationBlock dispatches through Logo into real Singer.Vo
         const vspace = makeFlowBlock("vspace", [0, null], (args, l, t) => {
             const tur = activity.turtles.ithTurtle(t);
             duringClampVolume = [...tur.singer.synthVolume[DEFAULTVOICE]];
+            // hidden is block index 3: confirms setDispatchBlock already registered the
+            // reverting listener against it before the clamp body (this block) even runs.
+            duringClampSignalCount = (tur.endOfClampSignals[3] || []).length;
             return null;
         });
         const articulation = {
@@ -229,11 +231,14 @@ describe("the real ArticulationBlock dispatches through Logo into real Singer.Vo
     test("boosts the synth volume for the clamp's duration and reverts it once the clamp ends", () => {
         logo.runFromBlockNow(logo, 0, 0, 1, null);
 
-        // While the clamp is open, a +25% relative volume was pushed on top of the base 60.
+        // While the clamp is open, a +25% relative volume was pushed on top of the base 60,
+        // and the reverting listener was already registered against the end-of-clamp signal.
         expect(duringClampVolume).toEqual([60, 75]);
+        expect(duringClampSignalCount).toBe(1);
 
         // Once the clamp's real end-of-clamp signal fires the reverting listener, the boosted
-        // value is popped and the base volume remains.
+        // value is popped, the base volume remains, and the signal itself is consumed.
         expect(turtle.singer.synthVolume[DEFAULTVOICE]).toEqual([60]);
+        expect(turtle.endOfClampSignals[3]).toEqual([]);
     });
 });

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -2157,11 +2157,18 @@ class StackClampBlock extends BaseBlock {
 }
 
 if (typeof module !== "undefined" && module.exports) {
-    // Attached as static properties (not a replacement export) so existing consumers that do
-    // `const ProtoBlock = require("./protoblocks")` are unaffected. This only exposes the
-    // concrete block classes to CommonJS/Jest, which otherwise only see them as bare globals
-    // supplied by the production script-concatenation build - it changes nothing at runtime in
-    // that build.
+    // These classes only exist as bare globals in the production script-concatenation build,
+    // which is how js/blocks/*.js consume them (e.g. `class ArticulationBlock extends
+    // FlowClampBlock`). That makes them unreachable from a Jest/CommonJS test in any lightweight
+    // way: reading protoblocks.js's own source at runtime to recover them is brittle (couples a
+    // test to this file's internal layout), and going through the full `Blocks`/`Block`
+    // construction path (js/blocks.js, js/block.js) to get a registered protoblock pulls in
+    // unrelated canvas/image-loading/drag-state machinery. Exposing them here - as static
+    // properties on the already-exported class, not a replacement of it, so every existing
+    // `const ProtoBlock = require("./protoblocks")` consumer (e.g. protoblocks.test.js) is
+    // unaffected - lets a test register and exercise a real, production block (e.g.
+    // js/__tests__/volume-articulation-dispatch-integration.test.js) without duplicating its
+    // flow() logic. Invisible to the browser build, which never reads module.exports.
     ProtoBlock.BaseBlock = BaseBlock;
     ProtoBlock.ValueBlock = ValueBlock;
     ProtoBlock.BooleanBlock = BooleanBlock;

--- a/js/protoblocks.js
+++ b/js/protoblocks.js
@@ -2157,5 +2157,19 @@ class StackClampBlock extends BaseBlock {
 }
 
 if (typeof module !== "undefined" && module.exports) {
+    // Attached as static properties (not a replacement export) so existing consumers that do
+    // `const ProtoBlock = require("./protoblocks")` are unaffected. This only exposes the
+    // concrete block classes to CommonJS/Jest, which otherwise only see them as bare globals
+    // supplied by the production script-concatenation build - it changes nothing at runtime in
+    // that build.
+    ProtoBlock.BaseBlock = BaseBlock;
+    ProtoBlock.ValueBlock = ValueBlock;
+    ProtoBlock.BooleanBlock = BooleanBlock;
+    ProtoBlock.BooleanSensorBlock = BooleanSensorBlock;
+    ProtoBlock.FlowBlock = FlowBlock;
+    ProtoBlock.LeftBlock = LeftBlock;
+    ProtoBlock.FlowClampBlock = FlowClampBlock;
+    ProtoBlock.StackClampBlock = StackClampBlock;
+
     module.exports = ProtoBlock;
 }


### PR DESCRIPTION
## Description

Adds a focused integration test for the `articulation` block's relative-volume clamp behavior. The test drives the real `ArticulationBlock` through `Logo.runFromBlockNow`, verifies the volume increase while the clamp is active, and confirms that the end-of-clamp dispatch restores the original volume.

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added an integration test covering the real `articulation` / relative-volume clamp flow.
* Exercises `Logo.runFromBlockNow` → `ArticulationBlock.flow` → `Singer.VolumeActions.setRelativeVolume`.
* Verifies the real `setDispatchBlock` / `endOfClampSignals` cleanup path.
* Verifies the synth volume changes from `[60]` to `[60, 75]` while the clamp is active and returns to `[60]` afterward.
* Exposed the existing block base classes from `protoblocks.js` as static CommonJS properties so the Jest test can register and exercise the real production block without duplicating its implementation.
* No production runtime behavior is changed by the `protoblocks.js` export change.

---

## Visual Changes

Not applicable.

---

## Testing Performed

* Targeted integration and related tests: **68/68 passed**
* Full Jest suite: **214 suites / 7957 tests passed**
* ESLint: clean
* Prettier: clean
* `git diff --check`: clean

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The test mocks only external audio/browser infrastructure. The actual `Logo.runFromBlockNow`, `ArticulationBlock`, `Singer.VolumeActions.setRelativeVolume`, and end-of-clamp dispatch machinery remain under test.

The `protoblocks.js` change only exposes existing block classes to CommonJS/Jest. It preserves the existing `ProtoBlock` export and does not change the browser build or production runtime behavior.