### PR TITLE
fix(widgets): set collection flags only after Phrase Maker and Lego Bricks finish lazy loading

### DIFF
--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -1712,8 +1712,6 @@ function setupWidgetBlocks(activity) {
          * @param {any} receivedArg - The argument received from the previous block.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            logo.inMatrix = true;
-
             const interruption = _ensureWidget(
                 logo,
                 "phraseMaker",
@@ -1768,6 +1766,12 @@ function setupWidgetBlocks(activity) {
                 receivedArg
             );
             if (interruption) return interruption;
+
+            // Only mark collection mode once the widget is really available.
+            // Setting the flag before the lazy-load finished let concurrently
+            // playing stacks call into the "loading" placeholder and crash;
+            // see the note-collection branches in turtle-singer.js.
+            logo.inMatrix = true;
 
             logo.phraseMaker.blockNo = blk;
 
@@ -2177,8 +2181,6 @@ function setupWidgetBlocks(activity) {
          * @returns {number[]} - The output values.
          */
         flow(args, logo, turtle, blk, receivedArg) {
-            logo.inLegoWidget = true;
-
             const interruption = _ensureWidget(
                 logo,
                 "legoWidget",
@@ -2191,6 +2193,10 @@ function setupWidgetBlocks(activity) {
                 receivedArg
             );
             if (interruption) return interruption;
+
+            // Same ordering as the matrix flow above: the flag must not be
+            // raised while logo.legoWidget is still the "loading" placeholder.
+            logo.inLegoWidget = true;
 
             logo.legoWidget.blockNo = blk;
 


### PR DESCRIPTION
## Description

The first time the Phrase Maker or Lego Bricks widget is opened in a session, its module is fetched on demand. While that fetch is in flight, `_ensureWidget` parks the widget reference on the placeholder string `"loading"`. The problem is that both of these flows raised their global collection flag (`logo.inMatrix` and `logo.inLegoWidget`) before calling `_ensureWidget`. So during the load window the flag tells every running stack to route its notes into the widget, but the widget is still just a string. The first note played by any other voice then calls `phraseMaker.addRowBlock()` on that string and throws:

```
Uncaught TypeError: activity.logo.phraseMaker.addRowBlock is not a function
    at js/turtle-singer.js:949
```

The playing voice dies mid note, the engine is left thinking the turtle is still running, and notes that should have been heard get swallowed into the widget's row data instead. On a fast connection the window is small and the crash looks random. On a slow connection it is seconds wide and easy to hit every time.

This PR moves the two flag assignments so they happen only after the interruption check, which is the exact ordering every other widget flow in the same file already uses. When the module finishes loading and the flow re-runs, the flag is raised with a real widget instance in place, so concurrent playback cannot crash into the placeholder anymore.

## Related Issue

**Fixes:** #8168

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

Two small ordering changes in `js/blocks/WidgetBlocks.js`, plus short comments explaining why the order matters:

1. In the matrix (Phrase Maker) flow, `logo.inMatrix = true` moved from before the `_ensureWidget` call to after the `if (interruption) return interruption;` check.
2. In the legobricks flow, `logo.inLegoWidget = true` moved the same way.

No other behavior changes. The 13 other widget flows in this file already set their flags after the interruption check, so this brings the last two in line with the established pattern.

## Steps to reproduce the bug on master

1. Serve master locally with `npm run serve:dev` and open the app in Chrome.
2. In DevTools, set Network throttling to Slow 4G so the widget module fetch takes a few seconds, similar to a school connection.
3. Build a project with two start blocks. Put a few note blocks with pitches in the first one. Drag the Phrase Maker block from the Widgets palette and snap it under the second start block.
4. Press Play once. As soon as the melody voice plays a note during the widget load, the console shows the TypeError above and the music stops. Playback stays broken until the page is reloaded.

With this branch, the same steps play the melody cleanly, the Phrase Maker opens once its module arrives, and its rows contain only the blocks from its own clamp.

---
