### PR TITLE
fix: resolve helpWidgetID contrast violation via design tokens (#6608)

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -40,6 +40,13 @@
     --color-notification-bg: #1d4ed8;
     --color-notification-text: #ffffff;
 
+    /* Widget window title bar (mobile breakpoints only, dist/css/windows.css).
+       Kept as a dedicated token rather than reusing --color-brand-primary,
+       since that token's dark-theme value (#60a5fa) fails contrast with
+       white text (~2.54:1); this value is verified at 4.60:1. */
+    --color-widget-titlebar-bg: #1976d2;
+    --color-widget-titlebar-text: #ffffff;
+
     /* =========================================================================
      Spacing (Base 4px scale)
      ========================================================================= */
@@ -115,6 +122,8 @@ body.dark {
     --color-brand-primary-hover: #3b82f6;
     --color-notification-bg: #1d4ed8;
     --color-notification-text: #ffffff;
+    --color-widget-titlebar-bg: #1976d2;
+    --color-widget-titlebar-text: #ffffff;
     --color-brand-secondary: #a78bfa;
 
     --color-selector-bg: #64b5f6;
@@ -153,6 +162,8 @@ body.highcontrast {
     --color-brand-primary-hover: #ffffff;
     --color-notification-bg: #0000ff;
     --color-notification-text: #ffffff;
+    --color-widget-titlebar-bg: #0000ff;
+    --color-widget-titlebar-text: #ffffff;
     --color-brand-secondary: #00ffff;
 
     --color-selector-bg: #00ffff;

--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -200,7 +200,7 @@
 
   #floatingWindows > .windowFrame > .wfTopBar {
     height: 56px;
-    background-color: #2196f3;
+    background-color: var(--color-widget-titlebar-bg);
     border: none;
     padding: 0;
     align-items: center;
@@ -244,13 +244,24 @@
 
   #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
     flex-grow: 1;
-    color: #fff;
+    color: var(--color-widget-titlebar-text);
     font-size: 1.5em;
     padding: 0 15px;
     text-align: center;
     text-transform: uppercase;
     font-weight: 500;
     letter-spacing: 1.5px;
+  }
+
+  /* The dark-theme rule in themes.css (`.dark ... .wftTitle`) has higher
+     specificity than the plain rule above and would otherwise override
+     it with --color-text-secondary (#d1d5db), which fails contrast
+     against this breakpoint's blue title bar background. Using an
+     extra element selector (body) keeps identical id/class specificity
+     to that rule while adding one more selector segment, so this wins
+     the cascade regardless of stylesheet load order. */
+  body.dark #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
+    color: var(--color-widget-titlebar-text);
   }
 
   #floatingWindows > .windowFrame > .wfWinBody {
@@ -302,7 +313,7 @@
 
   #floatingWindows > .windowFrame > .wfTopBar {
     height: 56px;
-    background-color: #2196f3;
+    background-color: var(--color-widget-titlebar-bg);
     border: none;
     padding: 0;
     align-items: center;
@@ -329,13 +340,18 @@
 
   #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
     flex-grow: 1;
-    color: #fff;
+    color: var(--color-widget-titlebar-text);
     font-size: 1.2em;
     padding: 0 10px;
     text-align: center;
     text-transform: uppercase;
     font-weight: 500;
     letter-spacing: 1px;
+  }
+
+  /* See the 600px breakpoint above for why this override is needed. */
+  body.dark #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
+    color: var(--color-widget-titlebar-text);
   }
 
   #floatingWindows > .windowFrame > .wfWinBody > .wfbToolbar {
@@ -378,7 +394,7 @@
 
   #floatingWindows > .windowFrame > .wfTopBar {
     height: 48px;
-    background-color: #2196f3;
+    background-color: var(--color-widget-titlebar-bg);
     border: none;
     padding: 0;
     align-items: center;
@@ -405,13 +421,18 @@
 
   #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
     flex-grow: 1;
-    color: #fff;
+    color: var(--color-widget-titlebar-text);
     font-size: 1.1em;
     padding: 0 8px;
     text-align: center;
     text-transform: uppercase;
     font-weight: 100;
     letter-spacing: 1px;
+  }
+
+  /* See the 600px breakpoint above for why this override is needed. */
+  body.dark #floatingWindows > .windowFrame > .wfTopBar .wftTitle {
+    color: var(--color-widget-titlebar-text);
   }
 
   #floatingWindows > .windowFrame > .wfWinBody > .wfbToolbar {


### PR DESCRIPTION
## Description

Fixes the last remaining axe violation from the original WCAG audit —
`#helpWidgetID` "Take a tour" title text failed contrast at 2.12:1
against its background.

Root cause: a dark-theme rule in `css/themes.css` has higher CSS
specificity than the mobile breakpoint's own title-text color rule in
`dist/css/windows.css`, so it silently wins even inside the mobile media
query. The violation only reproduces in dark theme + mobile viewport
width simultaneously — either condition alone renders correctly, which
is why it evaded detection for so long despite extensive prior searches.

Fix adds dedicated `--color-widget-titlebar-bg` / `--color-widget-titlebar-text`
tokens to `css/tokens.css` (light/dark/high-contrast sections), following
the same pattern as the existing `--color-notification-bg` token. This
was a deliberate choice over reusing `--color-brand-primary` — its
dark-theme value (`#60a5fa`) only reaches ~2.54:1 contrast with white
text, which would have made things worse.

Darkens the mobile `.wfTopBar` background from `#2196f3` to the new
token value (`#1976d2`) across all three breakpoints (600px/450px/320px),
and adds a specificity-safe `body.dark ...` override so dark theme
correctly gets the token's white text color instead of losing to the
higher-specificity rule in `themes.css`.

**Resulting contrast: 4.60:1**, passing WCAG AA for normal text.

## Related Issue

Part of #6608

## Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## Testing Performed

### How to test locally

1. Run `npm run serve` and open `http://localhost:3000`
2. Switch to dark theme
3. Resize the browser window to ≤600px width (or use DevTools device
   toolbar)
4. Open the Help widget ("Take a tour")
5. Run axe DevTools — confirm the `#helpWidgetID` contrast violation no
   longer appears

### Test cases

1. Dark theme + mobile width: title text renders white (`#ffffff`) on
   `#1976d2`, passing 4.5:1
2. Light theme + mobile width: unaffected, still uses the token (same
   value, no visual regression)
3. Desktop width (any theme): unaffected, media queries don't apply
4. High-contrast theme: uses its own token value (`#0000ff` background),
   verified at 8.59:1 contrast
5. `npx prettier --check` clean on all three changed files

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts