### PR TITLE
fix: break circular references on block stack deletion

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -832,4 +832,51 @@ describe("Block Foundation", () => {
             expect(mockBlocks.activity.refreshCanvas).toHaveBeenCalled();
         });
     });
+
+    describe("dispose()", () => {
+        it("should clean up connections, DOM nodes, containers, bitmaps, and parent pointers", () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            block.blockIndex = 1;
+            const connectedBlock = {
+                connections: [1, null]
+            };
+            mockBlocks.blockList = [null, block, connectedBlock];
+            block.connections = [2];
+
+            const mockContainer = {
+                removeAllEventListeners: jest.fn(),
+                removeAllChildren: jest.fn(),
+                uncache: jest.fn()
+            };
+            block.container = mockContainer;
+
+            const dummyLabel = document.createElement("div");
+            document.body.appendChild(dummyLabel);
+            block.label = dummyLabel;
+
+            const dummyLabelAttr = document.createElement("div");
+            document.body.appendChild(dummyLabelAttr);
+            block.labelattr = dummyLabelAttr;
+
+            block.bitmap = {};
+            block.highlightBitmap = {};
+
+            block.dispose();
+
+            expect(connectedBlock.connections[0]).toBeNull();
+            expect(block.connections).toEqual([]);
+            expect(mockContainer.removeAllEventListeners).toHaveBeenCalled();
+            expect(mockContainer.removeAllChildren).toHaveBeenCalled();
+            expect(mockContainer.uncache).toHaveBeenCalled();
+            expect(block.container).toBeNull();
+            expect(block.label).toBeNull();
+            expect(block.labelattr).toBeNull();
+            expect(dummyLabel.parentNode).toBeNull();
+            expect(dummyLabelAttr.parentNode).toBeNull();
+            expect(block.bitmap).toBeNull();
+            expect(block.blocks).toBeNull();
+            expect(block.activity).toBeNull();
+            expect(block.protoblock).toBeNull();
+        });
+    });
 });

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1403,5 +1403,61 @@ describe("Blocks Foundation", () => {
                 document.getElementById = originalGetElementById;
             }
         });
+
+        it("disposeBlock should call dispose on target block and remove it from blockList and blockArt", () => {
+            const mockActivity = { palettes: { dict: {} }, refreshCanvas: jest.fn() };
+            const blocksInstance = new Blocks(mockActivity);
+            const mockDispose = jest.fn();
+            blocksInstance.blockList[1] = { dispose: mockDispose };
+            blocksInstance.blockArt[1] = "<svg></svg>";
+            blocksInstance.blockCollapseArt[1] = "<svg></svg>";
+
+            blocksInstance.disposeBlock(1);
+
+            expect(mockDispose).toHaveBeenCalled();
+            expect(blocksInstance.blockList[1]).toBeNull();
+            expect(blocksInstance.blockArt[1]).toBeUndefined();
+            expect(blocksInstance.blockCollapseArt[1]).toBeUndefined();
+        });
+
+        it("sendStackToTrash should evict and dispose blocks when trashStacks exceeds MAX_TRASH_UNDO", () => {
+            const mockActivity = {
+                palettes: { dict: {} },
+                refreshCanvas: jest.fn(),
+                trashcan: { stopHighlightAnimation: jest.fn() }
+            };
+            const blocksInstance = new Blocks(mockActivity);
+            blocksInstance.captureStackPreview = jest.fn().mockReturnValue("preview-url");
+            blocksInstance._cleanupStacks = jest.fn();
+
+            for (let i = 0; i < 100; i++) {
+                blocksInstance.trashStacks.push(i);
+                blocksInstance.trashPreviews[i] = "preview";
+            }
+
+            const mockDispose = jest.fn();
+            const mockBlock = {
+                blockIndex: 100,
+                connections: [null],
+                container: { uncache: jest.fn() },
+                protoblock: { style: "normal", parameter: false, staticLabels: ["test"] },
+                hide: jest.fn(),
+                dispose: mockDispose
+            };
+            blocksInstance.blockList[100] = mockBlock;
+
+            // block 0 was the oldest trashed stack
+            blocksInstance.blockList[0] = {
+                blockIndex: 0,
+                connections: [null],
+                dispose: jest.fn()
+            };
+
+            blocksInstance.sendStackToTrash(mockBlock);
+
+            expect(blocksInstance.trashStacks.length).toBe(100);
+            expect(blocksInstance.trashPreviews[0]).toBeUndefined();
+            expect(blocksInstance.blockList[0]).toBeNull();
+        });
     });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -548,6 +548,79 @@ class Block {
     }
 
     /**
+     * Clean up and dispose of block resources to prevent memory leaks and circular references
+     * @public
+     * @returns {void}
+     */
+    dispose() {
+        if (
+            Array.isArray(this.connections) &&
+            this.blocks &&
+            Array.isArray(this.blocks.blockList)
+        ) {
+            const thisIdx = this.blockIndex;
+            for (let i = 0; i < this.connections.length; i++) {
+                const connId = this.connections[i];
+                if (connId !== null && connId !== undefined && this.blocks.blockList[connId]) {
+                    const connBlock = this.blocks.blockList[connId];
+                    if (Array.isArray(connBlock.connections)) {
+                        for (let j = 0; j < connBlock.connections.length; j++) {
+                            if (connBlock.connections[j] === thisIdx) {
+                                connBlock.connections[j] = null;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        this.connections = [];
+
+        if (this.label && this.label.parentNode) {
+            this.label.parentNode.removeChild(this.label);
+        }
+        if (this.labelattr && this.labelattr.parentNode) {
+            this.labelattr.parentNode.removeChild(this.labelattr);
+        }
+        this.label = null;
+        this.labelattr = null;
+
+        if (this.container) {
+            if (typeof this.container.removeAllEventListeners === "function") {
+                this.container.removeAllEventListeners();
+            }
+            if (typeof this.container.removeAllChildren === "function") {
+                this.container.removeAllChildren();
+            }
+            if (typeof this.container.uncache === "function") {
+                this.container.uncache();
+            }
+            this.container = null;
+        }
+
+        this.bitmap = null;
+        this.highlightBitmap = null;
+        this.disconnectedBitmap = null;
+        this.disconnectedHighlightBitmap = null;
+        this.collapseButtonBitmap = null;
+        this.expandButtonBitmap = null;
+        this.collapseBlockBitmap = null;
+        this.highlightCollapseBlockBitmap = null;
+        this.imageBitmap = null;
+
+        this.artwork = null;
+        this.collapseArtwork = null;
+        this.text = null;
+        this.value = null;
+        this.privateData = null;
+        this.postProcessArg = null;
+        this.controller = null;
+
+        this.protoblock = null;
+        this.blocks = null;
+        this.activity = null;
+    }
+
+    /**
      * Show the highlight artwork.
      * @public
      * @returns {void}

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6618,6 +6618,29 @@ class Blocks {
         };
 
         /**
+         * Permanently dispose of a block by index, freeing its resources and circular references
+         * @param {number} blkIdx - Index of the block in blockList
+         * @public
+         * @returns {void}
+         */
+        this.disposeBlock = blkIdx => {
+            if (blkIdx === null || blkIdx === undefined || !this.blockList[blkIdx]) {
+                return;
+            }
+            const block = this.blockList[blkIdx];
+            if (typeof block.dispose === "function") {
+                block.dispose();
+            }
+            if (this.blockArt && this.blockArt[blkIdx]) {
+                delete this.blockArt[blkIdx];
+            }
+            if (this.blockCollapseArt && this.blockCollapseArt[blkIdx]) {
+                delete this.blockCollapseArt[blkIdx];
+            }
+            this.blockList[blkIdx] = null;
+        };
+
+        /**
          * Send a stack of blocks to the trash.
          * @param - myBlock
          * @public
@@ -6647,8 +6670,15 @@ class Blocks {
             const MAX_TRASH_UNDO = 100;
             if (this.trashStacks.length > MAX_TRASH_UNDO) {
                 const removed = this.trashStacks.shift();
-                if (removed !== undefined && this.trashPreviews[removed]) {
-                    delete this.trashPreviews[removed];
+                if (removed !== undefined) {
+                    if (this.trashPreviews[removed]) {
+                        delete this.trashPreviews[removed];
+                    }
+                    this.findDragGroup(removed);
+                    const evictedGroup = Array.from(this.dragGroup);
+                    for (let i = 0; i < evictedGroup.length; i++) {
+                        this.disposeBlock(evictedGroup[i]);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->
When blocks were removed from the undo history after reaching the stack limit they were still kept in memory. This happened because blocks kept references to other blocks and their rendering resources.

This PR adds proper cleanup when a block is permanently removed from the trash history.




---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->
- Added dispose() to properly clean up block resources
- Added disposeBlock() to remove blocks
- Updated trash handling to dispose blocks when old stacks are removed
- Added tests for block disposal and trash stack cleanup

---


## Testing Performed

- Tested in chrome browser. 
- Confirmed that everything works as expected.
- Testing script:
```js
(function verifyTrashCleanup() {
    const blocks = globalActivity.blocks;
    if (!blocks.trashPreviews) blocks.trashPreviews = {};

    const TEST_INDEX = 99999;
    
    // Fill trash stacks with 100 fake indices
    // The first item in this array is TEST_INDEX
    blocks.trashStacks = Array.from({ length: 100 }, (_, i) => TEST_INDEX - i);
    
    // Inject a fake block object at the oldest index 
    blocks.blockList[TEST_INDEX] = {
        blockIndex: TEST_INDEX,
        connections: [],
        dispose: () => {}
    };

    // Trigger eviction: push 101st index to force the oldest to be shifted out
    blocks.trashStacks.push(TEST_INDEX + 1);

    // Evict the oldest item
    if (blocks.trashStacks.length > 100) {
        const removed = blocks.trashStacks.shift();
        if (removed !== undefined && typeof blocks.disposeBlock === "function") {
            blocks.disposeBlock(removed);
        }
    }

    // Output 
    console.log("Oldest index evicted:", TEST_INDEX);
    console.log("Status in blockList after eviction:", blocks.blockList[TEST_INDEX]);
})();
```
Before:
<img width="946" height="718" alt="image" src="https://github.com/user-attachments/assets/a0252099-882f-4116-b203-37ffd2e66b51" />

After:
<img width="941" height="646" alt="image" src="https://github.com/user-attachments/assets/02fd0a9e-f09d-4deb-99a0-2da53fe77e77" />


---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
