### PR TITLE
fix: remove cancelled input timers from manager

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2066,8 +2066,8 @@ describe("Logo clearTurtleRun", () => {
 
     afterEach(() => jest.restoreAllMocks());
 
-    test("clears timeout and resumes execution", () => {
-        const clearTimeoutSpy = jest.spyOn(global, "clearTimeout").mockImplementation(() => {});
+    test("cancels the managed timeout and resumes execution", () => {
+        const clearTimeoutSpy = jest.spyOn(logo.timerManager, "clearTimeout").mockReturnValue(true);
         turtle0.delayTimeout = 123;
         turtle0.delayParameters = { blk: 4, flow: 1, arg: ["p"] };
 
@@ -2075,6 +2075,23 @@ describe("Logo clearTurtleRun", () => {
 
         expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
         expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, 4, 1, ["p"]);
+    });
+
+    test("removes a cancelled delay timeout from the managed timer set", () => {
+        const pendingCallback = jest.fn();
+        turtle0.delayTimeout = logo.timerManager.setGuardedTimeout(
+            pendingCallback,
+            60000,
+            () => false
+        );
+        turtle0.delayParameters = { blk: 4, flow: 1, arg: ["p"] };
+
+        expect(logo.timerManager.activeTimeoutCount).toBe(1);
+
+        logo.clearTurtleRun(0);
+
+        expect(logo.timerManager.activeTimeoutCount).toBe(0);
+        expect(logo.timerManager.getStats().cancelled).toBe(1);
     });
 
     describe("with Transport", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1052,7 +1052,7 @@ class Logo {
         const tur = this.turtles.ithTurtle(turtle);
 
         if (tur.delayTimeout !== null) {
-            clearTimeout(tur.delayTimeout);
+            this._timerManager.clearTimeout(tur.delayTimeout);
             tur.delayTimeout = null;
             this.runFromBlockNow(
                 this,


### PR DESCRIPTION
## Description

When an Input block is running, Music Blocks creates a timer to control when the program continuues.

When the user enters a value and presses Enter, that timer needs to be cancelled because the program can continue immediately. The timer was being stopped with the browser’s normal `clearTimeout()` function.

The problem was that Music Blocks also keeps its own list of active timers through `ManagedTimer`. Cancelling the timer directly stopped it, but did not remove it fromthat list. So Music Blocks could still think a cancelled timer was active.

This fix cancels the timer through `ManagedTimer` instead. That stops the timer and removes it from the active timer list at the same time, keeping the timer state accurate.


---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Replaced the native `clearTimeout(tur.delayTimeout)` call with `this._timerManager.clearTimeout(tur.delayTimeout)`.
- Added regression coverage for `clearTurtleRun()`.

The manager now cancels the browser timeout, removes its ID from the active set, and records the cancellation correctly.

---

## Testing Performed

- `npx jest js/__tests__/logo.test.js js/blocks/__tests__/SensorsBlocks.test.js --runInBand --silent`
- 165 tests passed.
- `npm run lint`
- `npx prettier --check js/logo.js js/__tests__/logo.test.js`
- Manual localhost check: Input accepts Enter and resumes execution.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---
