### PR TITLE
fix: prevent duplicate trashcan resize listeners

### DIFF
--- a/js/__tests__/trash.test.js
+++ b/js/__tests__/trash.test.js
@@ -110,14 +110,24 @@ describe("Trashcan Class", () => {
         expect(trashcan.shouldResize(100, 100)).toBe(false);
     });
 
-    it("should resize and debounce the event listener", () => {
+    it("registers one debounced resize listener", () => {
         const addEventListenerSpy = jest
             .spyOn(window, "addEventListener")
             .mockImplementation(() => {});
-        trashcan.resizeEvent(1);
+        const testTrashcan = new Trashcan(mockActivity);
         const resizeFn = addEventListenerSpy.mock.calls[0][1];
-        resizeFn(); // simulate resize
+        testTrashcan.resizeEvent(2);
+        testTrashcan.resizeEvent(1);
+
+        expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+
+        const updateContainerPositionSpy = jest.spyOn(testTrashcan, "updateContainerPosition");
+        resizeFn();
         jest.advanceTimersByTime(300);
+        expect(updateContainerPositionSpy).toHaveBeenCalledTimes(1);
+
+        updateContainerPositionSpy.mockRestore();
+        addEventListenerSpy.mockRestore();
     });
 
     it("should hide the trashcan using animation", () => {

--- a/js/trash.js
+++ b/js/trash.js
@@ -38,9 +38,22 @@ class Trashcan {
         this._highlightPower = 255;
         this._animationLevel = 0;
         this.animationTime = 500;
+        this._resizeTimeout = null;
+        this._handleResize = () => {
+            clearTimeout(this._resizeTimeout);
+            this._resizeTimeout = setTimeout(() => {
+                const newWidth = (window.innerWidth / this._scale - Trashcan.TRASHWIDTH) / 2;
+                const newHeight = window.innerHeight / this._scale - Trashcan.TRASHHEIGHT;
+
+                if (this.shouldResize(newWidth, newHeight)) {
+                    this.updateContainerPosition();
+                }
+            }, 300);
+        };
 
         this.activity.trashContainer.addChild(this._container);
         this.activity.trashContainer.setChildIndex(this._container, 0);
+        window.addEventListener("resize", this._handleResize);
         this.resizeEvent(1);
         this._makeTrash();
     }
@@ -148,23 +161,6 @@ class Trashcan {
     resizeEvent(scale) {
         this._scale = scale;
         this.updateContainerPosition();
-
-        const self = this; // Capture the current instance of 'this'
-        let resizeTimeout;
-
-        function delayedResize() {
-            const newWidth = (window.innerWidth / self._scale - Trashcan.TRASHWIDTH) / 2;
-            const newHeight = window.innerHeight / self._scale - Trashcan.TRASHHEIGHT;
-
-            if (self.shouldResize(newWidth, newHeight)) {
-                self.updateContainerPosition();
-            }
-        }
-
-        window.addEventListener("resize", function () {
-            clearTimeout(resizeTimeout);
-            resizeTimeout = setTimeout(delayedResize, 300); // Delayed execution using debouncing
-        });
     }
 
     /**


### PR DESCRIPTION
<!--
  Thank you for contributing to our project!
  Please complete the sections below to help us review your changes efficiently.
-->

## Description

The trashcan needs to update its position when the browser window is resized.

The `resizeEvent()` method was updating the trashcan position, but it was also adding a new `window.resize` listener every time it ran. This method can run more than once during startup and later layout updates, so extra listeners could build up over time.

When the browser was resized, every saved listener scheduled the same delayed position update. This meant the same work could run multiple times even though only one update was needed.

This fix registers the resize listener once when the trashcan is created. Later calls to `resizeEvent()` now only update the current scale and position.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---


## Changes Made

- Registered the trashcan resize listener once in the `Trashcan` constructor.
- Changed `resizeEvent()` so it only updates the trashcan scale and position.
- Added a regression test that calls `resizeEvent()` multiple times and verifies that only one resize listener is registered.
---

## Testing Performed

- Added and ran a regression test for repeated `resizeEvent()` calls.

  ```bash
  Before: 6 resizeEvent calls → 6 listeners → 6 delayed jobs
  After:  6 resizeEvent calls → 1 listener  → 1 delayed job

- Ran:

  `npx jest js/__tests__/trash.test.js --runInBand --coverage=false`

  Result: 40 tests passed.

- Ran:

  `npm run lint`
  `npx prettier --check js/trash.js js/__tests__/trash.test.js`

  Both passed.

- Ran the full test suite. The changed trashcan tests passed. The only failure was the existing unrelated /healthz test timing out while starting its loopback server.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run npm run lint and npx prettier --check . with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).
