### PR TITLE
fix: prevent status widget crash when turtle is added

### DIFF
--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -329,6 +329,34 @@ describe("StatusMatrix Widget", () => {
             expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
         });
 
+        test("does not throw when a turtle is added after initialization and its column is missing", () => {
+            mockActivity.turtles.turtleList = [
+                { name: "Mouse1", inTrash: false },
+                { name: "Mouse2", inTrash: false }
+            ];
+
+            expect(() => statusMatrix.updateAll()).not.toThrow();
+            expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
+        });
+
+        test("does not throw when a status-field row is missing or out of range", () => {
+            mockActivity.blocks.blockList = {
+                0: { name: "x", protoblock: { staticLabels: ["x"] }, value: 150 },
+                1: { name: "y", protoblock: { staticLabels: ["y"] }, value: 200 }
+            };
+            mockActivity.logo.statusFields = [
+                [0, "x"],
+                [1, "y"]
+            ];
+            statusMatrix._statusTable.rows = [
+                { cells: [createMockElement("TD"), createMockElement("TD")] },
+                { cells: [createMockElement("TD"), createMockElement("TD")] }
+            ];
+
+            expect(() => statusMatrix.updateAll()).not.toThrow();
+            expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
+        });
+
         test("does not update after the widget closes", () => {
             statusMatrix.widgetWindow.onclose();
 

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -341,8 +341,8 @@ class StatusMatrix {
 
                 this.activity.logo.inStatusMatrix = saveStatus;
 
-                cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
-                if (cell !== null) {
+                cell = this._statusTable.rows?.[i + 1]?.cells?.[activeTurtles + 1];
+                if (cell !== null && cell !== undefined) {
                     cell.textContent = value === "__INVALID_INPUT__" ? "" : value;
                 }
                 i++;
@@ -385,8 +385,8 @@ class StatusMatrix {
                     note += obj[1] + "/" + obj[0];
                 }
 
-                cell = this._statusTable.rows[i + 1].cells[activeTurtles + 1];
-                if (cell !== null) {
+                cell = this._statusTable.rows?.[i + 1]?.cells?.[activeTurtles + 1];
+                if (cell !== null && cell !== undefined) {
                     cell.textContent = note.replace(/#/g, "♯").replace(/b/g, "♭");
                 }
             }


### PR DESCRIPTION
## Description

This PR fixes a bug where js/widgets/status.js would crash if the status table was altered after the widget's initialization, e.g. in the case when a turtle was created later or when the status row was non-existent. 



**Fixes:** #

I've modified the two DOM query spots in updateAll() function so that they properly handle the situation of absent status row/cell by checking if it exists before writing into it.
Also I have added the following regression tests in js/widgets/__tests__/status.test.js:
- when there is a turtle after the initialization of a widget;
- status row doesn't exist/it is out of bounds;
These tests ensure that updateAll() doesn't crash and updatingStatusMatrix is still set up correctly.

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation


### Before

<img width="1881" height="699" alt="Screenshot 2026-08-23 105805" src="https://github.com/user-attachments/assets/29510683-3edf-42eb-9f4c-35a8131985fa" />


### After

<img width="1919" height="859" alt="Screenshot 2026-08-23 111116" src="https://github.com/user-attachments/assets/73a58f56-81f7-4d7b-b4be-39174744eaa4" />


---

## Testing Performed

<img width="826" height="154" alt="Screenshot 2026-08-23 111916" src="https://github.com/user-attachments/assets/4eab4a37-f33a-488e-9b25-0996bd8f47a2" />

<img width="555" height="146" alt="Screenshot 2026-08-23 112013" src="https://github.com/user-attachments/assets/2bc863d1-4404-4f7f-8303-4683c1297fc5" />


## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

