### PR TITLE
fix(phrasemaker): correct tuplet value controls

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -965,6 +965,56 @@ describe("PhraseMaker Widget", () => {
 
         phraseMaker._createpiesubmenu(0, 2, "rhythmnote");
     });
+    test.each([
+        ["value option", 1],
+        ["decrease button", 3]
+    ])("tuplet-value %s removes one subdivision", (_, menuIndex) => {
+        const wheelDiv = { style: {} };
+        const exitTitle = { children: [{ textContent: "" }] };
+        phraseMaker.docById = jest.fn(id =>
+            id === "wheelnav-_exitWheel-title-1" ? exitTitle : wheelDiv
+        );
+
+        phraseMaker.wheelnav = jest.fn(() => ({
+            raphael: {},
+            createWheel(labels) {
+                this.navItems = labels.map(() => ({
+                    navigateFunction: null,
+                    navItem: { hide: jest.fn(), show: jest.fn() }
+                }));
+            },
+            navItems: [],
+            slicePathCustom: {},
+            removeWheel: jest.fn()
+        }));
+        phraseMaker.slicePath = jest.fn(() => ({
+            DonutSlice: jest.fn(),
+            DonutSliceCustomization: jest.fn(() => ({}))
+        }));
+        phraseMaker._mapNotesBlocks = jest.fn(() => [0]);
+        phraseMaker._restartGrid = jest.fn();
+        phraseMaker._syncMarkedBlocks = jest.fn();
+        phraseMaker._update = jest.fn();
+        phraseMaker._colBlocks = [
+            [0, 0],
+            [0, 1],
+            [0, 2]
+        ];
+        phraseMaker._noteValueRow = {
+            cells: [{ getBoundingClientRect: jest.fn(() => ({ x: 0, y: 0 })) }]
+        };
+        phraseMaker.activity = {
+            canvas: { width: 800, height: 600 },
+            getStageScale: jest.fn(() => 1),
+            logo: { tupletRhythms: [["notes", 0, 4, 4, 4]] }
+        };
+
+        phraseMaker._createpiesubmenu(0, 3, "tupletvalue");
+        phraseMaker._menuWheel.selectedNavItemIndex = menuIndex;
+        phraseMaker._menuWheel.navItems[menuIndex].navigateFunction();
+
+        expect(phraseMaker.activity.logo.tupletRhythms[0]).toEqual(["notes", 0, 4, 4]);
+    });
     test("_restartGrid handles default case", () => {
         phraseMaker.init = jest.fn();
         phraseMaker.addNotes = jest.fn();

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -4108,7 +4108,7 @@ class PhraseMaker {
                 this.newNoteValue = String(value);
                 this.docById("wheelnav-_exitWheel-title-1").children[0].textContent =
                     this.newNoteValue;
-                this._updateTupletValue(this, noteToDivide, tupletValue, this.newNoteValue);
+                this._updateTupletValue(noteToDivide, tupletValue, this.newNoteValue);
             };
 
             this._menuWheel.navItems[3].navigateFunction = () => {
@@ -4116,7 +4116,7 @@ class PhraseMaker {
                     this.newNoteValue = String(parseInt(this.newNoteValue, 10) - 1);
                     this.docById("wheelnav-_exitWheel-title-1").children[0].textContent =
                         this.newNoteValue;
-                    this._updateTupletValue(this, noteToDivide, tupletValue, this.newNoteValue);
+                    this._updateTupletValue(noteToDivide, tupletValue, this.newNoteValue);
                 }
             };
 


### PR DESCRIPTION
## Description

PhraseMaker's tuplet-value menu passed an extra argument to `_updateTupletValue`, shifting the expected arguments and causing the subdivision update to fail. This corrects both affected controls so reducing a tuplet value updates the grid without an exception.

## Related Issue

  **Fixes:** #8181

  ---

## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

## Changes Made

  - Pass the expected arguments from both tuplet-value controls.
  - Add regression coverage for selecting a smaller value and using the decrease control.

  ---

## Testing Performed

  - `npm run lint`
  - `npx prettier --check js/widgets/phrasemaker.js js/widgets/__tests__/phrasemaker.test.js`
  - PhraseMaker tests: 87 passed
  - Full Jest suite: 214 suites and 7,969 tests passed
  - `git diff --check`

  ---

## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run `npm run lint` and the modified-file Prettier check with no errors.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).