### PR TITLE
fix: prevent duplicate export extensions when casing differs

### DIFF
--- a/js/__tests__/SaveInterface.test.js
+++ b/js/__tests__/SaveInterface.test.js
@@ -158,6 +158,11 @@ describe("download", () => {
         expect(mockDownloadURL).toHaveBeenCalledWith("My Project.xml", "data");
     });
 
+    it("should not append an extension when its case differs", () => {
+        instance.download("html", "data", "lesson.HTML");
+        expect(mockDownloadURL).toHaveBeenCalledWith("lesson.HTML", "data");
+    });
+
     it("should handle null data safely in download", () => {
         const other = new SaveInterface({
             PlanetInterface: { getCurrentProjectName: () => "Test" }

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -78,7 +78,7 @@ var fileExt = file => {
         return "";
     }
 
-    return parts.pop();
+    return parts.pop().toLowerCase();
 };
 
 /**


### PR DESCRIPTION
## Description

`fileExt()` preserved the original casing of a filename extension. As a result, Save as HTML treated `lesson.HTML` as missing its extension and downloaded it as `lesson.HTML.html`.

  ## Related Issue

  Fixes #8184

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Normalize extensions returned by `fileExt()` to lowercase.
  - Add regression coverage for filenames whose extension casing differs.

  ---

  ## Testing Performed

  - `npm run lint`
  - `npx prettier --check js/utils/utils-logic.js js/__tests__/SaveInterface.test.js`
  - `npm test -- --runInBand --silent`
  - Verified that Save as HTML keeps `lesson.HTML` unchanged.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run `npm run lint` and the modified-file Prettier check with no errors.
  - [x] I have enabled "Allow edits from maintainers".