### PR TITLE
test(logo): cover meter block dispatch through the real Logo interpreter

### DIFF
--- a/js/__tests__/meter-signature-dispatch-integration.test.js
+++ b/js/__tests__/meter-signature-dispatch-integration.test.js
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration test for the Logo interpreter's argument-evaluation/dispatch path
+ * (`runFromBlockNow`/`parseArg`, js/logo.js) driving the real
+ * `Singer.MeterActions.setMeter` (js/turtleactions/MeterActions.js) - extending the pattern
+ * `noteclamp-beat-doublequeue.test.js` (drum dispatch), `pitch-note-dispatch-integration.test.js`
+ * (pitch dispatch), and `interval-scalar-dispatch-integration.test.js` (interval dispatch)
+ * already use.
+ *
+ * Scope: this covers the Logo-dispatch <-> MeterActions seam, not MeterBlock's own palette
+ * registration (that is already covered, with setMeter mocked, by
+ * js/blocks/__tests__/MeterBlocks.test.js). `Logo.runFromBlockNow` and `setMeter` run for real
+ * and unmocked - the "meter" block below is a minimal stand-in shaped like the real block
+ * (js/blocks/MeterBlocks.js, MeterBlock.flow), not obtained from a live registered protoblock,
+ * for the same reason given in interval-scalar-dispatch-integration.test.js: the concrete
+ * FlowBlock class it extends (js/protoblocks.js) only exists as a bare global in the production
+ * script-concatenation build, so reaching it from Jest would mean either evaluating
+ * protoblocks.js's source at runtime or driving the full canvas/DOM-heavy
+ * Blocks.makeBlock/Block path (js/blocks.js, js/block.js), both disproportionate to this one
+ * behavior. Consequently, a regression in MeterBlock.flow itself would not fail this test; a
+ * regression in setMeter or in the Logo dispatch/argument-evaluation machinery around it would
+ * (verified by deliberately breaking each and confirming the test fails).
+ *
+ * setMeter, unlike setScalarInterval or the volume articulation clamp, isn't a clamp entry - it
+ * writes turtle-singer state directly and returns, with no clamp push/pop and no timer/interval
+ * involved (unlike onEveryBeatDo). That makes tur.singer.beatsPerMeasure/noteValuePerBeat the
+ * most stable observable in MeterActions: it is set once, synchronously, and does not depend on
+ * notesPlayed bookkeeping (getBeatCount/getMeasureCount) or on the shared Singer.masterBPM global
+ * (setBPM/setMasterBPM).
+ */
+
+// Setup global mocks BEFORE requiring the module (mirror of interval-scalar-dispatch-integration.test.js).
+global._ = str => str;
+global.Notation = jest.fn().mockImplementation(() => ({}));
+global.Synth = jest.fn().mockImplementation(() => ({}));
+global.Singer = {};
+global.last = arr => arr[arr.length - 1];
+
+jest.mock("tone", () => ({
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+}));
+
+global.EmbeddedGraphicsScheduler =
+    require("../embedded-graphics-scheduler").EmbeddedGraphicsScheduler;
+
+const logoconstants = require("../logoconstants");
+Object.assign(global, logoconstants);
+
+const { Logo } = require("../logo");
+
+// Singer.MeterActions is attached to the module-level `Singer` mock above, exactly as
+// production code does via `Singer.MeterActions = class {...}` (js/turtleactions/MeterActions.js).
+// No production code is mocked: setMeter runs for real.
+const setupMeterActions = require("../turtleactions/MeterActions");
+
+function createTurtle() {
+    return {
+        singer: {
+            beatsPerMeasure: 4,
+            noteValuePerBeat: 1 / 4,
+            beatList: [],
+            factorList: [],
+            defaultStrongBeats: false,
+            bpm: [],
+            notesPlayed: [0, 1],
+            pickup: 0,
+            inNoteBlock: [],
+            inDuplicate: false,
+            backward: [],
+            suppressOutput: true,
+            justCounting: []
+        },
+        painter: { closeSVG: jest.fn() },
+        queue: [],
+        parentFlowQueue: [],
+        listeners: {},
+        endOfClampSignals: {}
+    };
+}
+
+function createActivity(turtle) {
+    return {
+        blocks: {
+            blockList: [],
+            sameGeneration: jest.fn(() => false)
+        },
+        turtles: {
+            turtleList: [turtle],
+            ithTurtle: jest.fn(() => turtle),
+            getTurtle: jest.fn(() => turtle),
+            running: jest.fn(() => false)
+        },
+        stage: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(name => {
+                if (typeof name === "string" && turtle.listeners[name]) {
+                    turtle.listeners[name]();
+                }
+            })
+        },
+        onStopTurtle: jest.fn()
+    };
+}
+
+function makeFlowBlock(name, connections, flow, dockTypes, args) {
+    return {
+        name,
+        connections,
+        protoblock: {
+            args: args || 0,
+            dockTypes: dockTypes || [null],
+            flow: flow || (() => null)
+        },
+        isValueBlock: () => false,
+        isArgBlock: () => false
+    };
+}
+
+describe("Logo dispatch drives the real Singer.MeterActions.setMeter", () => {
+    let logo;
+    let turtle;
+    let activity;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.document.body.style.cursor = "default";
+        turtle = createTurtle();
+        activity = createActivity(turtle);
+        logo = new Logo(activity);
+        activity.logo = logo;
+        // logo.notation is a getter-only accessor (js/logo.js) backed by the global Notation
+        // mock's return value - extend that object rather than reassigning logo.notation.
+        logo.notation.notationMeter = jest.fn();
+
+        setupMeterActions(activity);
+
+        // meter (0):  connections [prev, beatCountArg, noteValueArg, next] - the connections
+        // shape produced when the "meter" block is dragged from the Meter palette (see
+        // MeterBlock's own makeMacro, js/blocks/MeterBlocks.js).
+        // beats (1):  number 6 (beats per measure)
+        // note (2):   number 1/8 (note value per beat)
+        // hidden (3): connections [prev, null] (end of flow)
+        const hidden = makeFlowBlock("hidden", [0, null], null);
+        const meter = makeFlowBlock(
+            "meter",
+            [null, 1, 2, 3],
+            (args, l, t) => {
+                // Copied verbatim from MeterBlock.flow (js/blocks/MeterBlocks.js), minus the
+                // insideMeterWidget/inMusicKeyboard branches - see the file-level comment above
+                // for why this isn't a live protoblock.
+                const arg0 = args[0] === null || typeof args[0] !== "number" ? 4 : args[0];
+                const arg1 = args[1] === null || typeof args[1] !== "number" ? 1 / 4 : args[1];
+                Singer.MeterActions.setMeter(arg0, arg1, t);
+                return null;
+            },
+            [null, "numberin", "numberin", "in"],
+            2
+        );
+        const beats = {
+            name: "number",
+            value: 6,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+        const noteValue = {
+            name: "number",
+            value: 1 / 8,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+
+        const blocks = [meter, beats, noteValue, hidden];
+        logo.blockList = blocks;
+        activity.blocks.blockList = blocks;
+    });
+
+    test("writes the real beatsPerMeasure/noteValuePerBeat and default strong beats through dispatch", () => {
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+
+        // The 6/8 signature is set on the real turtle-singer state via the real setMeter.
+        expect(turtle.singer.beatsPerMeasure).toBe(6);
+        expect(turtle.singer.noteValuePerBeat).toBe(8);
+
+        // setMeter's 6/8 branch also seeds the default strong beats.
+        expect(turtle.singer.beatList).toEqual([1, 4]);
+        expect(turtle.singer.defaultStrongBeats).toBe(true);
+
+        // And it notifies notation of the new meter through the real activity.logo.notation hook.
+        expect(logo.notation.notationMeter).toHaveBeenCalledWith(0, 6, 8);
+    });
+});


### PR DESCRIPTION
## Description

Adds a focused integration test proving that the `meter` block reaches the real `Singer.MeterActions.setMeter()` implementation through the Logo interpreter.

The test drives a minimal meter block through `Logo.runFromBlockNow()`, allowing the real `parseArg()` path to evaluate the meter arguments before executing the block's `flow()`. It then verifies the resulting turtle-singer meter state and the real notation update.

This extends the existing unit coverage in `MeterActions.test.js` by testing the Logo dispatch → `MeterBlock.flow()` → `MeterActions.setMeter()` integration seam.

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Tests 
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Added `meter-signature-dispatch-integration.test.js`.
- Drives a minimal meter block through the real `Logo.runFromBlockNow()`.
- Exercises the real `parseArg()` path for both meter arguments:
  - beats = `6`
  - note value = `1/8`
- Executes the meter block's `flow()` against the real `Singer.MeterActions.setMeter()`.
- Verifies the resulting turtle-singer state:
  - `beatsPerMeasure === 6`
  - `noteValuePerBeat === 8`
  - `beatList === [1, 4]`
  - `defaultStrongBeats === true`
- Verifies the real notation update with:
  - `logo.notation.notationMeter(0, 6, 8)`
- No production code was modified.

---

## Visual Changes

Not applicable.

---

## Testing Performed

- New integration test: **1/1 passed**
- Focused related test set: **75/75 passed**
  - `noteclamp-beat-doublequeue.test.js`
  - `pitch-note-dispatch-integration.test.js`
  - `MeterActions.test.js`
- ESLint: clean
- Prettier: clean
- `git diff --check`: clean

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This is a test-only integration change.

The test intentionally uses a minimal meter block descriptor rather than instantiating the registered `MeterBlock`. The concrete `FlowBlock` hierarchy is only available as a bare global in Music Blocks' production script-concatenation environment, so instantiating the real block from Jest would require loading the broader `protoblocks.js` / `blocks.js` / `block.js` construction path.

The minimal descriptor reproduces the relevant `MeterBlock.flow()` behavior while keeping the test focused on the integration seam:

`Logo.runFromBlockNow()` → `parseArg()` → meter block `flow()` → `Singer.MeterActions.setMeter()`

The test therefore covers the real Logo dispatch and `MeterActions.setMeter()` behavior, while the registered `MeterBlock` construction/registration path remains outside its scope.

`setMeter()` was selected as the focused MeterActions integration target because it updates the turtle-singer state synchronously and directly and performs the notation update without requiring additional timing, global BPM, or note-history setup.

The branch is based directly on `upstream/master`. No production files are changed; the PR contains only the new integration test.

### Current Coverage Boundary

BPM dispatch (`setBPM` / `setMasterBPM`) and beat/measure counting (`getBeatCount` / `getMeasureCount`) remain covered by unit tests rather than real-dispatch integration tests. They can be considered separately because they require additional shared BPM or `notesPlayed` state setup.