### PR TITLE
fix(musickeyboard): clear Web MIDI input listeners on widget close to prevent memory and audio leaks

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -1213,4 +1213,87 @@ describe("MusicKeyboard core logic", () => {
             expect(img.alt).toBe("Play");
         });
     });
+
+    describe("Web MIDI cleanup on widget close", () => {
+        test("resets onmidimessage handlers on all connected MIDI inputs when widgetWindow.onclose is called", () => {
+            const mockInput1 = { onmidimessage: jest.fn() };
+            const mockInput2 = { onmidimessage: jest.fn() };
+            const mockMidiAccess = {
+                inputs: [mockInput1, mockInput2]
+            };
+
+            const mockWidgetWindow = {
+                clear: jest.fn(),
+                show: jest.fn(),
+                destroy: jest.fn(),
+                addButton: jest.fn().mockReturnValue({ onclick: null, setAttribute: jest.fn() }),
+                addInputButton: jest.fn().mockReturnValue({
+                    addEventListener: jest.fn(),
+                    classList: { add: jest.fn() }
+                }),
+                getWidgetBody: jest.fn().mockReturnValue({
+                    append: jest.fn(),
+                    style: {}
+                })
+            };
+
+            const origWidgetWindows = global.window.widgetWindows;
+            global.window.widgetWindows = {
+                windowFor: jest.fn().mockReturnValue(mockWidgetWindow)
+            };
+
+            try {
+                const mockActivity = {
+                    turtles: {
+                        ithTurtle: jest.fn().mockReturnValue({
+                            singer: { bpm: [90] }
+                        })
+                    },
+                    logo: { synth: { stopSound: jest.fn() } }
+                };
+
+                const keyboard = new MusicKeyboard(mockActivity);
+                keyboard._createWidgetWindow();
+
+                keyboard.midiAccess = mockMidiAccess;
+                keyboard.midiON = true;
+
+                // Trigger actual onclose handler registered on widgetWindow
+                mockWidgetWindow.onclose();
+
+                expect(mockInput1.onmidimessage).toBeNull();
+                expect(mockInput2.onmidimessage).toBeNull();
+                expect(keyboard.midiON).toBe(false);
+                expect(mockWidgetWindow.destroy).toHaveBeenCalled();
+            } finally {
+                global.window.widgetWindows = origWidgetWindows;
+            }
+        });
+
+        test("doMIDI stores midiAccess reference when requestMIDIAccess succeeds", async () => {
+            const mockInput = { onmidimessage: null };
+            const mockMidiAccess = {
+                inputs: new Map([["1", mockInput]])
+            };
+
+            const origRequestMIDIAccess = global.navigator.requestMIDIAccess;
+            global.navigator.requestMIDIAccess = jest.fn().mockResolvedValue(mockMidiAccess);
+
+            try {
+                const keyboard = new MusicKeyboard({
+                    textMsg: jest.fn()
+                });
+                keyboard.midiButton = { style: {} };
+
+                keyboard.doMIDI();
+
+                await Promise.resolve();
+
+                expect(keyboard.midiAccess).toBe(mockMidiAccess);
+                expect(mockInput.onmidimessage).toBeDefined();
+            } finally {
+                global.navigator.requestMIDIAccess = origRequestMIDIAccess;
+            }
+        });
+    });
 });

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -791,8 +791,19 @@ function MusicKeyboard(activity) {
             this._stopOrCloseClicked = true;
             this.playingNow = false;
 
+            // Clear any active Web MIDI input handlers to prevent background notes & audio leaks
+            if (this.midiAccess && this.midiAccess.inputs) {
+                this.midiAccess.inputs.forEach(input => {
+                    input.onmidimessage = null;
+                });
+            }
+            this.midiON = false;
+
             selectedNotes = [];
-            docById("wheelDivptm").style.display = "none";
+            const wheelDiv = docById("wheelDivptm");
+            if (wheelDiv && wheelDiv.style) {
+                wheelDiv.style.display = "none";
+            }
             if (this._menuWheel) this._menuWheel.removeWheel();
             if (this._pitchWheel) this._pitchWheel.removeWheel();
             if (this._tabsWheel) this._tabsWheel.removeWheel();
@@ -3702,6 +3713,7 @@ function MusicKeyboard(activity) {
          * @memberof MusicKeyboard
          */
         const onMIDISuccess = midiAccess => {
+            this.midiAccess = midiAccess;
             // re-init widget
             if (this.midiON) {
                 this.midiButton.style.background = "#00FF00";


### PR DESCRIPTION
## Description

Fixes Web MIDI input event listener and audio voice leaks in `musickeyboard.js` where `input.onmidimessage` handlers were left active on connected Web MIDI devices after closing the Music Keyboard widget window.

## Related Issue

Fixes #8187 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Stored `this.midiAccess` reference in `onMIDISuccess` in `js/widgets/musickeyboard.js`.
- Updated `widgetWindow.onclose` to iterate over `this.midiAccess.inputs` and reset `input.onmidimessage = null`.
- Added unit tests in `js/widgets/__tests__/musickeyboard.test.js` verifying clean `onmidimessage` unbinding on widget close.

## Testing Performed

- Ran Jest unit tests: all 41 unit tests in `musickeyboard.test.js` pass cleanly (`41 passed, 41 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.