### PR TITLE
fix(pitchslider): dispose preview synths when closing widget

### DIFF
--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -27,6 +27,7 @@ global.clampNumber = require("../../utils/utils-logic.js").clampNumber;
 const mockOscillator = {
     toDestination: jest.fn().mockReturnThis(),
     triggerRelease: jest.fn(),
+    dispose: jest.fn(),
     triggerAttack: jest.fn(),
     triggerAttackRelease: jest.fn(),
     frequency: {
@@ -283,6 +284,11 @@ describe("PitchSlider Widget", () => {
         test("releases all oscillators", () => {
             slider.widgetWindow.onclose();
             expect(mockOscillator.triggerRelease).toHaveBeenCalled();
+        });
+
+        test("disposes all oscillators", () => {
+            slider.widgetWindow.onclose();
+            expect(mockOscillator.dispose).toHaveBeenCalled();
         });
 
         test("sets isActive to false", () => {

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -65,7 +65,10 @@ class PitchSlider {
 
         this.widgetWindow.onclose = () => {
             document.removeEventListener("keydown", keyHandler, true);
-            for (const osc of oscillators) osc.triggerRelease();
+            for (const osc of oscillators) {
+                osc.triggerRelease();
+                osc.dispose();
+            }
             this.isActive = false;
             activity.logo.pitchSlider = null;
             this.widgetWindow.destroy();


### PR DESCRIPTION
## Description

Fixes the Pitch Slider preview-synth cleanup path. Closing the widget released each `Tone.AMSynth` but did not dispose it, leaving its audio resources allocated after the widget was closed.

  ## Related Issue

  Fixes #8190

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Dispose every Pitch Slider preview synth after releasing it when the widget closes.
  - Add regression coverage for synth disposal in `pitchslider.test.js`.

  ---

  ## Testing Performed

  - `npm run lint`
  - `npx prettier --check js/widgets/pitchslider.js js/widgets/__tests__/pitchslider.test.js`
  - `npm test -- --runInBand` — 217 suites, 7,994 tests passed
  - `git diff --check`

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run `npm run lint` and the modified-file Prettier check with no errors.
  - [x] I have enabled **"Allow edits from maintainers"**.