### PR TITLE
fix(pitch-actions): recompute inverted flag on Invert clamp close

### DIFF
--- a/js/__tests__/pitch-actions-invert-nested.test.js
+++ b/js/__tests__/pitch-actions-invert-nested.test.js
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Regression coverage for issue #8189: the Invert block's clamp-close listener
+ * (`Singer.PitchActions.invert`, js/turtleactions/PitchActions.js) used to set
+ * `tur.singer.inverted = false` unconditionally, even when an ancestor Invert
+ * block was still open. `tur.singer.inverted` is a single turtle-global flag,
+ * not scoped per-block, so an inner Invert closing would stomp on an outer
+ * Invert that hadn't closed yet.
+ *
+ * `tur.singer.inverted` has exactly one consumer, `Singer.PitchActions.stepPitch`
+ * (js/turtleactions/PitchActions.js), which trusts it to decide whether to
+ * un-invert `lastNotePlayed` before computing a relative scale step. Every other
+ * inversion-state consumer in the codebase already checks `invertList.length > 0`
+ * directly, which is the correct source of truth these tests hold `inverted`
+ * against.
+ *
+ * These tests drive the real `Singer.PitchActions.invert()` (not a stand-in) and
+ * fire its dispatch listener the same way the real interpreter does — via the
+ * `_invert_<turtle>` handler registered through `activity.logo.setTurtleListener`
+ * — mirroring the direct-state-assertion style already used by
+ * `turtle-singer.test.js` for this file family.
+ */
+
+global._ = str => str;
+global.calcOctave = require("../utils/musicutils").calcOctave;
+global.MusicBlocks = { isRun: false };
+
+const Singer = require("../turtle-singer");
+const setupPitchActions = require("../turtleactions/PitchActions");
+
+function createActivity(turtle) {
+    const listeners = {};
+    return {
+        listeners,
+        turtles: { ithTurtle: jest.fn().mockReturnValue(turtle) },
+        blocks: { blockList: {} },
+        logo: {
+            setTurtleListener: (_turtle, name, fn) => {
+                listeners[name] = fn;
+            },
+            setDispatchBlock: jest.fn(),
+            synth: { inTemperament: "equal" }
+        },
+        errorMsg: jest.fn()
+    };
+}
+
+describe("Singer.PitchActions.invert — nested Invert blocks", () => {
+    let turtle, activity;
+
+    beforeEach(() => {
+        turtle = { singer: null };
+        turtle.singer = new Singer(turtle);
+        activity = createActivity(turtle);
+        setupPitchActions(activity);
+    });
+
+    test("a single, non-nested Invert block clears both invertList and inverted on close", () => {
+        Singer.PitchActions.invert("sol", 4, "even", 0, "onlyBlk");
+        expect(turtle.singer.invertList.length).toBe(1);
+
+        activity.listeners["_invert_0"]();
+
+        expect(turtle.singer.invertList.length).toBe(0);
+        expect(turtle.singer.inverted).toBe(false);
+    });
+
+    test("closing an inner Invert block does not clear inverted while an outer Invert is still open", () => {
+        Singer.PitchActions.invert("sol", 4, "even", 0, "outerBlk");
+        Singer.PitchActions.invert("sol", 4, "even", 0, "innerBlk");
+        expect(turtle.singer.invertList.length).toBe(2);
+
+        // A note played while both Invert blocks were open, correctly setting
+        // `inverted`, exactly as js/turtle-singer.js:1074/1358 do at note-start.
+        turtle.singer.inverted = true;
+
+        // The inner Invert block's clamp closes.
+        activity.listeners["_invert_0"]();
+
+        expect(turtle.singer.invertList.length).toBe(1); // outer Invert still open
+        expect(turtle.singer.inverted).toBe(true);
+    });
+
+    test("closing the outer Invert block after the inner one has already closed clears inverted", () => {
+        Singer.PitchActions.invert("sol", 4, "even", 0, "outerBlk");
+        Singer.PitchActions.invert("sol", 4, "even", 0, "innerBlk");
+        turtle.singer.inverted = true;
+
+        activity.listeners["_invert_0"](); // inner closes — outer still open
+        expect(turtle.singer.inverted).toBe(true);
+
+        activity.listeners["_invert_0"](); // outer closes — nothing left open
+        expect(turtle.singer.invertList.length).toBe(0);
+        expect(turtle.singer.inverted).toBe(false);
+    });
+
+    test("three levels of nesting: inverted stays true until every Invert block has closed", () => {
+        Singer.PitchActions.invert("sol", 4, "even", 0, "a");
+        Singer.PitchActions.invert("sol", 4, "even", 0, "b");
+        Singer.PitchActions.invert("sol", 4, "even", 0, "c");
+        turtle.singer.inverted = true;
+
+        activity.listeners["_invert_0"](); // closes "c"
+        expect(turtle.singer.invertList.length).toBe(2);
+        expect(turtle.singer.inverted).toBe(true);
+
+        activity.listeners["_invert_0"](); // closes "b"
+        expect(turtle.singer.invertList.length).toBe(1);
+        expect(turtle.singer.inverted).toBe(true);
+
+        activity.listeners["_invert_0"](); // closes "a"
+        expect(turtle.singer.invertList.length).toBe(0);
+        expect(turtle.singer.inverted).toBe(false);
+    });
+});

--- a/js/turtleactions/PitchActions.js
+++ b/js/turtleactions/PitchActions.js
@@ -615,7 +615,9 @@ function setupPitchActions(activity) {
 
             const __listener = () => {
                 tur.singer.invertList.pop();
-                tur.singer.inverted = false;
+                // Only clear `inverted` once no ancestor Invert block is still
+                // open — a nested Invert closing must not stomp on an outer one.
+                tur.singer.inverted = tur.singer.invertList.length > 0;
             };
             activity.logo.setTurtleListener(turtle, listenerName, __listener);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

`Singer.PitchActions.invert()` (`js/turtleactions/PitchActions.js`) — the implementation behind the current **Invert** block — sets `tur.singer.inverted = false` unconditionally when its clamp closes. `inverted` is a single turtle-global flag, not scoped to the block that set it, so closing a nested (inner) Invert block wiped it out even while an outer Invert block was still open.

`inverted` has exactly one consumer, `Singer.PitchActions.stepPitch()` (the "scalar step" block), which trusts the flag to decide whether to un-invert `lastNotePlayed` before computing a relative scale step. A stale `false` there means `stepPitch` silently skips un-inverting when it shouldn't, producing an incorrect pitch — with no error, warning, or visual symptom.

`tur.singer.invertList` correctly tracks nesting depth as a stack, but `inverted` was a separately-maintained boolean the close listener reset with a hardcoded `false` instead of deriving it from `invertList`. The two could only ever agree at zero or exactly one level of nesting; any deeper nesting desynchronized them the moment an inner block closed.

## Related Issue

**Fixes:** #8189

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/turtleactions/PitchActions.js`: in the Invert block's clamp-close listener, replaced the unconditional `tur.singer.inverted = false` with `tur.singer.inverted = tur.singer.invertList.length > 0`, recomputing the flag from the same source of truth every other inversion-state consumer in the codebase already uses (`js/turtleactions/PitchActions.js:456,467,485,499,516,530`, `js/turtle-singer.js:869`), and matching the recompute pattern already used at note-start time (`js/turtle-singer.js:1074`, `:1358`).
- No other behavior changed. Non-nested Invert usage is unaffected (`invertList.length` is `0` after the pop either way).

---

## Visual Changes

Not applicable — this is a silent state-consistency bug with no visual artifact.

## Testing Performed

Added `js/__tests__/pitch-actions-invert-nested.test.js`, covering:
- A single, non-nested Invert block still clears `invertList` and `inverted` correctly on close (unaffected by this change).
- Closing an **inner** Invert block does **not** clear `inverted` while an **outer** Invert block is still open (the core bug).
- Closing the outer Invert block after the inner one has already closed does clear `inverted` once nothing remains open.
- Three levels of nesting: `inverted` stays `true` until every Invert block has closed.

Verified all four new tests fail against the pre-fix code (three of four fail; the non-nested sanity test passes either way, ruling out a broken test harness) and pass against the fix, confirming they actually exercise the regression.

- Full Jest suite: 7997/7997 passing.
- `npx eslint .` — clean, no errors or warnings.
- `npx prettier --check .` on changed files — clean.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Scope is intentionally limited to the `inverted` flag in the Invert block's close listener. `invertList` itself (the stack tracking nesting depth) was already correct and untouched by this change.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
