### PR TITLE
fix(a11y): give #mb-logo a button role so its aria-label is valid (#6608)

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -188,7 +188,10 @@ describe("Toolbar Class", () => {
                 onmouseenter: null,
                 onmouseleave: null,
                 onclick: null,
-                style: {}
+                style: {},
+                setAttribute: jest.fn(),
+                addEventListener: jest.fn(),
+                click: jest.fn()
             }
         };
 
@@ -223,6 +226,18 @@ describe("Toolbar Class", () => {
 
         elements["mb-logo"].onclick();
         expect(mockOnClick).toHaveBeenCalledWith(toolbar.activity);
+        expect(elements["mb-logo"].setAttribute).toHaveBeenCalledWith("role", "button");
+        expect(elements["mb-logo"].setAttribute).toHaveBeenCalledWith("tabindex", "0");
+        expect(elements["mb-logo"].addEventListener).toHaveBeenCalledWith(
+            "keydown",
+            expect.any(Function)
+        );
+
+        const logoKeydownHandler = elements["mb-logo"].addEventListener.mock.calls[0][1];
+        const enterEvent = { key: "Enter", preventDefault: jest.fn() };
+        logoKeydownHandler(enterEvent);
+        expect(enterEvent.preventDefault).toHaveBeenCalled();
+        expect(elements["mb-logo"].click).toHaveBeenCalled();
 
         // Japanese language
         toolbar.language = "ja";

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -486,6 +486,15 @@ class ToolbarUI {
         logoIcon.onclick = () => {
             onclick(this.activity);
         };
+
+        logoIcon.setAttribute("role", "button");
+        logoIcon.setAttribute("tabindex", "0");
+        logoIcon.addEventListener("keydown", e => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                logoIcon.click();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes an axe-flagged ARIA violation (`aria-prohibited-attr`) on `#mb-logo`. The element is a plain `<div>` (implicit role `generic`), and the toolbar's `init()` tooltip loop was setting `aria-label` on it — an attribute not permitted on a role-less generic element.

Adds `role="button"`, `tabindex="0"`, and an Enter/Space keydown handler in `renderLogoIcon()`, matching the existing pattern already used for the play/stop toolbar icons. This makes the existing `aria-label` valid, and also makes the logo — which already opens the About page on click — reachable and operable from the keyboard for the first time.

## Related Issue
Part of #6608

## Category
- [x] Bug Fix

## Type of Change
- [x] Accessibility Enhancement

## Testing Performed

### How to test locally
1. Run `npm run serve` and open `http://localhost:3000`
2. Run an axe DevTools scan — confirm `#mb-logo` no longer appears under `aria-prohibited-attr`
3. Tab through the toolbar from the start of the page — confirm the logo receives visible focus
4. With the logo focused, press `Enter` (and separately `Space`) — confirm the About page opens each time
5. Enable VoiceOver (`Cmd+F5` on Mac) or NVDA on Windows — confirm the logo is announced as "About Music Blocks, button"

### Test cases
1. `renderLogoIcon` sets `role="button"` on the logo element
2. `renderLogoIcon` sets `tabindex="0"` on the logo element
3. `renderLogoIcon` registers a `keydown` listener on the logo element
4. Pressing `Enter` on the focused logo calls `preventDefault()` and triggers the existing click handler
5. Existing mouseenter/mouseleave/onclick/Japanese-logo behavior is unchanged
6. `npx jest js/__tests__/toolbar.test.js --coverage=false` — 48/48 passing
7. `npx eslint` and `npx prettier --check` on both changed files — clean

## PR Checklist
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts