### PR TITLE
feat(a11y): give widget windows dialog semantics and an accessible name (#6608)

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -615,6 +615,24 @@ describe("widgetWindows", () => {
 
             expect(titleEl.innerHTML).toBe("New Title");
         });
+
+        test("keeps the frame's aria-label in sync with the new title", () => {
+            const win = createTestWindow("Old Title");
+
+            win.updateTitle("New Title");
+
+            expect(win._frame.getAttribute("aria-label")).toBe("New Title");
+        });
+    });
+
+    describe("frame accessibility", () => {
+        test("gives the window frame a dialog role and an accessible name", () => {
+            const win = createTestWindow("My Widget");
+
+            expect(win._frame.getAttribute("role")).toBe("dialog");
+            expect(win._frame.getAttribute("aria-label")).toBe("My Widget");
+            expect(win._frame.getAttribute("aria-modal")).toBeNull();
+        });
     });
 
     describe("takeFocus", () => {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -202,6 +202,8 @@ class WidgetWindow {
     _createUIelements() {
         const windows = docById("floatingWindows");
         this._frame = this._create("div", "windowFrame", windows);
+        this._frame.setAttribute("role", "dialog");
+        this._frame.setAttribute("aria-label", _(this._title));
         this._overlayframe = this._create("div", "windowFrame", windows);
         this._drag = this._create("div", "wfTopBar", this._frame);
         this._drag.style.display = "flex";
@@ -513,6 +515,7 @@ class WidgetWindow {
     updateTitle(title) {
         const wftTitle = docById(this._key + "WidgetID");
         wftTitle.textContent = title;
+        this._frame.setAttribute("aria-label", title);
     }
 
     /**


### PR DESCRIPTION
## Description
The floating widget window frame (`.windowFrame` — the Rhythm Ruler, Pitch Staircase, Help Widget, etc.) had no `role` or `aria-label` at all. PR #8066 already gave every *button* inside a widget window (close, rollup, maximize, and anything added via `addButton()`) proper role/label/keyboard handling via `makeKeyboardAccessible()`, but the container itself was invisible to assistive tech — a screen reader user tabbing in had no indication they'd entered a distinct panel, or which widget it was.

Adds `role="dialog"` and `aria-label=<widget title>` to the frame in `_createUIelements()`. `aria-modal` is deliberately **not** set: unlike the app's actual modals (#8159), these are non-modal, draggable, freely repositionable windows that don't block interaction with the rest of the app, so the non-modal dialog pattern applies here rather than the modal one.

`updateTitle()` now also refreshes the frame's `aria-label`, since a few widgets (Help, Mode) change their title after the window is already open.

## Related Issue
Part of #6608

## Category
- [x] Bug Fix

## Type of Change
- [x] Accessibility Enhancement

## Testing Performed

### How to test locally
1. Run `npm run serve` and open `http://localhost:3000`
2. Open any widget (e.g. Rhythm Ruler) from the toolbar or palette
3. Inspect the widget's outer frame in DevTools — confirm `role="dialog"` and `aria-label` are present
4. Enable VoiceOver (`Cmd+F5` on Mac) or NVDA on Windows, then tab into the widget — confirm it's announced as a dialog with the widget's name
5. Open the Help widget and navigate to a page that changes its title — confirm the accessible name updates to match

### Test cases
1. Widget frame is created with `role="dialog"`
2. Widget frame is created with `aria-label` set to the widget's title
3. Widget frame does **not** have `aria-modal` set
4. `updateTitle()` keeps the frame's `aria-label` in sync with the new title
5. Full `js/widgets/__tests__/widgetWindows.test.js` suite (102 tests) passing — no regressions from touching the shared `_createUIelements()` path used by every widget window
6. `npx eslint` and `npx prettier --check` on both changed files — clean

## PR Checklist
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts