### PR TITLE
fix(a11y): stop widget titlebar tab order diverging from visual order on mobile (#6608)

### DIFF
--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -204,7 +204,6 @@
     border: none;
     padding: 0;
     align-items: center;
-    flex-direction: row-reverse;
     flex-shrink: 0;
     box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.16), 0px 2px 10px 0px rgba(0, 0, 0, 0.12);
     min-width: auto;
@@ -317,7 +316,6 @@
     border: none;
     padding: 0;
     align-items: center;
-    flex-direction: row-reverse;
     flex-shrink: 0;
     box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.16), 0px 2px 10px 0px rgba(0, 0, 0, 0.12);
     min-width: auto;
@@ -398,7 +396,6 @@
     border: none;
     padding: 0;
     align-items: center;
-    flex-direction: row-reverse;
     flex-shrink: 0;
     box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.16), 0px 1px 7px 0px rgba(0, 0, 0, 0.12);
     min-width: auto;


### PR DESCRIPTION
## Description

On the three mobile breakpoints, `.wfTopBar` used `flex-direction: row-reverse`, visually moving the close button to the right while it stayed first in the DOM and tab order — creating a WCAG 2.4.3 focus-order mismatch. 

Since the rollup and maximize buttons are already hidden at all three mobile breakpoints, the topbar only ever shows the close button and the title. Simply removing `row-reverse` keeps the close button positioned on the left, properly matching both the tab order and the standard desktop layout. 

This is a CSS-only fix. There are no JS changes, and there is no visual impact on the desktop layout.

## Related Issue

Fixes #6608

## Category

- [x] Bug Fix

## Type of Change

- [x] Accessibility Enhancement

## Testing Performed

### How to test locally

1. Run `npm run serve` and open `http://localhost:3000/`

2. Open any widget window from the toolbar or palette (e.g., Rhythm Ruler).

3. Open browser DevTools and resize the viewport to trigger the mobile breakpoints (768px, 480px, 320px).

4. Verify visually that the close button is positioned on the left side of the top bar (only the close button and title should render).

5. Press `Tab` to navigate into the widget and verify that the visual focus order now perfectly matches the DOM layout (moving left-to-right).

### Test cases

1. Close button aligns to the left on mobile breakpoints, correctly matching DOM tab order.

2. Rollup and maximize buttons remain hidden on mobile breakpoints.

3. Desktop layout remains completely unaffected.

4. `npx prettier --check` on `dist/css/windows.css` is clean. *(Note: No automated test suite covers this specific CSS file, so no JS test changes are needed).*

## PR Checklist

- [x] I have tested these changes locally

- [x] My changes generate no new warnings or console errors

- [x] I have checked for and resolved any merge conflicts