### PR TITLE
fix(drum-actions): scope Set Drum's pitchDrumTable cleanup to its own clamp

### DIFF
--- a/js/turtleactions/DrumActions.js
+++ b/js/turtleactions/DrumActions.js
@@ -132,6 +132,13 @@ function setupDrumActions(activity) {
 
             tur.singer.drumStyle.push(drumname);
 
+            // pitchDrumTable is shared with the Map Pitch to Drum block, whose
+            // mappings are meant to persist for the whole piece. Snapshot it so
+            // the close listener can undo only what this clamp itself did to
+            // it (see the closing listener below), instead of wiping every
+            // mapping that happens to exist when this clamp closes.
+            const pitchDrumTableSnapshot = { ...tur.singer.pitchDrumTable };
+
             const listenerName = "_setdrum_" + turtle;
             if (blk !== undefined && blk in activity.blocks.blockList) {
                 activity.logo.setDispatchBlock(blk, turtle, listenerName);
@@ -142,7 +149,12 @@ function setupDrumActions(activity) {
 
             const __listener = () => {
                 tur.singer.drumStyle.pop();
-                tur.singer.pitchDrumTable = {};
+                // Restore pitchDrumTable to what it was before this clamp
+                // opened: entries this clamp added are discarded (so a note
+                // played right after the clamp doesn't inherit its drum, per
+                // #1381), and any entry this clamp overwrote is restored,
+                // without touching mappings that predate the clamp.
+                tur.singer.pitchDrumTable = pitchDrumTableSnapshot;
             };
 
             activity.logo.setTurtleListener(turtle, listenerName, __listener);

--- a/js/turtleactions/__tests__/DrumActions.test.js
+++ b/js/turtleactions/__tests__/DrumActions.test.js
@@ -294,6 +294,74 @@ describe("setupDrumActions", () => {
         });
     });
 
+    describe("setDrum: pitchDrumTable scoping (issue #8199)", () => {
+        beforeEach(() => {
+            targetTurtle.singer.drumStyle = [];
+            activity.logo.setTurtleListener.mockClear();
+        });
+
+        it("preserves a pre-existing mapping (e.g. from Map Pitch to Drum) across an unrelated Set Drum block", () => {
+            targetTurtle.singer.pitchDrumTable = { C4: "drum2" };
+
+            Singer.DrumActions.setDrum("d1", 0, 1);
+            const closeListener = activity.logo.setTurtleListener.mock.calls[0][2];
+            closeListener();
+
+            expect(targetTurtle.singer.pitchDrumTable).toEqual({ C4: "drum2" });
+        });
+
+        it("still discards entries the clamp itself added, once it closes", () => {
+            targetTurtle.singer.pitchDrumTable = { C4: "drum2" };
+
+            Singer.DrumActions.setDrum("d1", 0, 1);
+            // A note played inside the clamp records itself into pitchDrumTable,
+            // exactly as js/turtle-singer.js:1150-1153 does for a real pitch.
+            targetTurtle.singer.pitchDrumTable.D4 = "drum1";
+
+            const closeListener = activity.logo.setTurtleListener.mock.calls[0][2];
+            closeListener();
+
+            // D4 (added inside the clamp) is gone; C4 (pre-existing) survives.
+            expect(targetTurtle.singer.pitchDrumTable).toEqual({ C4: "drum2" });
+        });
+
+        it("restores a pre-existing mapping's original drum if the clamp overwrote it", () => {
+            targetTurtle.singer.pitchDrumTable = { C4: "drum2" };
+
+            Singer.DrumActions.setDrum("d1", 0, 1);
+            // The same pitch (C4) is played again inside this clamp, overwriting
+            // the earlier mapping for the duration of the clamp.
+            targetTurtle.singer.pitchDrumTable.C4 = "drum1";
+
+            const closeListener = activity.logo.setTurtleListener.mock.calls[0][2];
+            closeListener();
+
+            expect(targetTurtle.singer.pitchDrumTable).toEqual({ C4: "drum2" });
+        });
+
+        it("nested Set Drum blocks each discard only what they themselves added", () => {
+            targetTurtle.singer.pitchDrumTable = { preexisting: "drum2" };
+
+            Singer.DrumActions.setDrum("d1", 0, 1); // outer clamp opens
+            const outerClose = activity.logo.setTurtleListener.mock.calls[0][2];
+            targetTurtle.singer.pitchDrumTable.fromOuter = "drum1";
+
+            activity.logo.setTurtleListener.mockClear();
+            Singer.DrumActions.setDrum("d2", 0, 1); // inner clamp opens
+            const innerClose = activity.logo.setTurtleListener.mock.calls[0][2];
+            targetTurtle.singer.pitchDrumTable.fromInner = "drum2";
+
+            innerClose();
+            expect(targetTurtle.singer.pitchDrumTable).toEqual({
+                preexisting: "drum2",
+                fromOuter: "drum1"
+            });
+
+            outerClose();
+            expect(targetTurtle.singer.pitchDrumTable).toEqual({ preexisting: "drum2" });
+        });
+    });
+
     describe("playNoise", () => {
         it("should play noise in a note block", () => {
             targetTurtle.singer.inNoteBlock.push(2);


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

`Singer.DrumActions.setDrum()` (`js/turtleactions/DrumActions.js`) — the implementation behind the **Set Drum** block — unconditionally wipes `tur.singer.pitchDrumTable` when its clamp closes. `pitchDrumTable` is shared with the **Map Pitch to Drum** block, whose mappings are meant to persist for the whole piece, so closing *any* Set Drum block anywhere in a project silently erases every Map Pitch to Drum mapping, with no error or warning.

Commit `9c2319e0d` ("addresses #1381", Oct 2019) introduced both the `mapdrum` case and the `pitchDrumTable = {}` reset in the same change, to stop a note right after a Set Drum clamp from incorrectly resolving to that clamp's drum. The blanket wipe fixed that specific symptom but was never scoped to the clamp doing the wiping — since `pitchDrumTable` is a single turtle-global object read/written by both blocks, it has been silently discarding unrelated Map Pitch to Drum mappings ever since.

## Related Issue

**Fixes:** #8199

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/turtleactions/DrumActions.js`: `setDrum()` now snapshots `pitchDrumTable` when its clamp opens, and restores that snapshot on close instead of clearing the table outright.
- This preserves the original intent of the 2019 fix for #1381 (a note played right after a Set Drum clamp must not inherit the clamp's drum) — entries the clamp added are still discarded on close — while no longer destroying mappings that predate the clamp, whether from Map Pitch to Drum or an outer, still-relevant Set Drum block.
- As a bonus over a simpler "only delete newly-added keys" approach, restoring from a full snapshot also correctly un-does the case where the clamp *overwrote* an existing mapping for the same pitch, restoring its original value rather than leaving the clamp's value in place.
- `mapPitchToDrum()` is untouched — it already correctly left `pitchDrumTable` alone on close.

---

## Visual Changes

Not applicable — this is a silent state-consistency bug with no visual artifact.

## Testing Performed

Added four regression tests to `js/turtleactions/__tests__/DrumActions.test.js`:
- A pre-existing mapping (simulating Map Pitch to Drum) survives an unrelated Set Drum block closing.
- A Set Drum clamp still discards an entry it added itself once it closes (preserves the original #1381 fix).
- A pre-existing mapping the clamp overwrote is restored to its original value on close.
- Nested Set Drum blocks each discard only what they themselves added, leaving pre-existing and outer-clamp entries intact.

Verified all four new tests fail against the pre-fix code and pass against the fix, confirming they actually exercise the regression rather than passing trivially. The existing parameterized `pitchDrumTable` assertion (`removes drumStyle on listener`) still passes unchanged, since it starts from an empty table where restore-to-snapshot and wipe-to-`{}` are equivalent.

- Full Jest suite: 8010/8010 passing.
- `npx eslint .` — clean, no errors or warnings.
- `npx prettier --check .` on changed files — clean.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Scope is intentionally limited to `setDrum()`'s `pitchDrumTable` handling. `drumStyle` (the stack tracking Set Drum/Map Pitch to Drum nesting depth) was already correctly scoped and is untouched.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>

