### PR TITLE
fix(midi): iterate the note schedule by index so imported blocks link…

### DIFF
--- a/js/__tests__/midi.test.js
+++ b/js/__tests__/midi.test.js
@@ -201,4 +201,51 @@ describe("transcribeMidi", () => {
         const restBlocks = loadedBlocks.filter(block => block[1] === "rest2");
         expect(restBlocks.length).toBeGreaterThan(0);
     });
+
+    it("should generate reciprocal block connections", async () => {
+        // blocks.js adjustDocks() requires connections to be mutual: if A points
+        // at B, B must point back at A. It logs "Did not find match" and stops
+        // docking the stack when they are not.
+        await transcribeMidi(mockMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const blocksById = new Map(loadedBlocks.map(block => [block[0], block]));
+
+        const oneSided = [];
+        loadedBlocks.forEach(([id, name, , , connections]) => {
+            connections.forEach((target, dock) => {
+                if (target === null || target === undefined) return;
+                const other = blocksById.get(target);
+                expect(other).toBeDefined();
+                if (!other[4].includes(id)) {
+                    oneSided.push(
+                        `block ${id} ${JSON.stringify(name)} dock ${dock} -> ${target} ` +
+                            `${JSON.stringify(other[1])}, which does not point back`
+                    );
+                }
+            });
+        });
+
+        expect(oneSided).toEqual([]);
+    });
+
+    it("should terminate the pitch chain of each note with null", async () => {
+        // The last pitch of a note has no following pitch, so its 4th connection
+        // must be null rather than the note's trailing hidden block.
+        await transcribeMidi(mockMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const blocksById = new Map(loadedBlocks.map(block => [block[0], block]));
+
+        const pitchBlocks = loadedBlocks.filter(block => block[1] === "pitch");
+        expect(pitchBlocks.length).toBeGreaterThan(0);
+
+        pitchBlocks.forEach(block => {
+            const next = block[4][3];
+            if (next !== null) {
+                // only another pitch of the same note may follow
+                expect(blocksById.get(next)[1]).toBe("pitch");
+            }
+        });
+    });
 });

--- a/js/midi.js
+++ b/js/midi.js
@@ -182,13 +182,13 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             offset += 100;
         };
         //Using for loop for finding the shortest note value
-        for (const j in sched) {
-            const dur = sched[j].end - sched[j].start;
+        for (const entry of sched) {
+            const dur = entry.end - entry.start;
             const temp = getClosestStandardNoteValue((dur * 3) / 8);
             shortestNoteDenominator = Math.max(shortestNoteDenominator, temp[1]);
         }
 
-        for (const i in sched) {
+        for (let i = 0; i < sched.length; i++) {
             if (stopProcessing) break; // Exit inner loop if flag is set
             const { notes, start, end } = sched[i];
             const duration = end - start;
@@ -216,7 +216,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
                     );
                     x += 2;
                 } else {
-                    for (const na in notes) {
+                    for (let na = 0; na < notes.length; na++) {
                         const name = notes[na];
                         const first = na === 0;
                         const last = na === notes.length - 1;


### PR DESCRIPTION
… correctly

transcribeMidi() walked `sched` and each note's `notes` array with for...in, which yields string keys. Four conditions compare those keys against numbers, so once #7614 turned the surrounding `==` comparisons into `===` they became permanently false:

- the last pitch of every note got `x + 3` instead of null, pointing at the note's trailing hidden block
- the first newnote of an action stack got `val - 1`, the text block holding the action name, instead of `val - 2`, the action block

Both leave the connection one-sided. adjustDocks() detects that, logs "Did not find match" and stops docking the stack, so a three-note file imports as a one-note program.

Convert the three loops to index loops rather than coercing at each comparison, which removes the string-key hazard entirely. Generated output is now byte-identical to 473415e27^.

Adds two regression tests: a reciprocity check over the array passed to loadNewBlocks(), and a check that each note's pitch chain terminates in null. Both fail on the unfixed code.


Claude-Session: https://claude.ai/code/session_01QQroYDsvwi9qWXD2Gqaejs

<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->

---

## Visual Changes

<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
