### PR TITLE
fix(tuner): prevent ReferenceError on generateNoteNames and TypeError on null querySelector

### DIFF
--- a/js/widgets/__tests__/tuner.test.js
+++ b/js/widgets/__tests__/tuner.test.js
@@ -648,5 +648,39 @@ describe("Tuner Widget", () => {
                 expect(updateSpy).toHaveBeenCalled();
             });
         });
+
+        describe("Safety & Fallbacks", () => {
+            test("frequencyToPitch falls back to standard note names when generateNoteNames is undefined", () => {
+                const savedGen = global.generateNoteNames;
+                delete global.generateNoteNames;
+                try {
+                    const pitchInfo = TunerUtils.frequencyToPitch(440, 12);
+                    expect(pitchInfo[0]).toBe("A");
+                    expect(pitchInfo[2]).toBe(440);
+                } finally {
+                    global.generateNoteNames = savedGen;
+                }
+            });
+
+            test("updateButtonStyles handles missing img or button element safely without throwing", () => {
+                const mockCanvas = document.createElement("canvas");
+                mockCanvas.parentElement = { appendChild: jest.fn() };
+                const display = new TunerDisplay(mockCanvas, 400, 300);
+
+                display.chromaticButton = {
+                    querySelector: jest.fn().mockReturnValue(null),
+                    style: {}
+                };
+                display.targetPitchButton = {
+                    querySelector: jest.fn().mockReturnValue(null),
+                    style: {}
+                };
+
+                expect(() => display.updateButtonStyles()).not.toThrow();
+
+                display.chromaticMode = false;
+                expect(() => display.updateButtonStyles()).not.toThrow();
+            });
+        });
     });
 });

--- a/js/widgets/tuner.js
+++ b/js/widgets/tuner.js
@@ -25,7 +25,9 @@ function TunerDisplay(canvas, width, height) {
         padding: "4px",
         boxShadow: "0 2px 4px rgba(0,0,0,0.1)"
     });
-    canvas.parentElement.appendChild(this.modeContainer);
+    if (canvas && canvas.parentElement) {
+        canvas.parentElement.appendChild(this.modeContainer);
+    }
 
     // Create mode buttons wrapper
     const buttonsWrapper = document.createElement("div");
@@ -99,16 +101,41 @@ function TunerDisplay(canvas, width, height) {
  * Updates the styles of mode toggle buttons based on current mode
  */
 TunerDisplay.prototype.updateButtonStyles = function () {
+    const chromaticImg =
+        this.chromaticButton && this.chromaticButton.querySelector
+            ? this.chromaticButton.querySelector("img")
+            : null;
+    const targetImg =
+        this.targetPitchButton && this.targetPitchButton.querySelector
+            ? this.targetPitchButton.querySelector("img")
+            : null;
+
     if (this.chromaticMode) {
-        this.chromaticButton.style.backgroundColor = platformColor.selectorBackground;
-        this.chromaticButton.querySelector("img").style.filter = "brightness(0) invert(1)";
-        this.targetPitchButton.style.backgroundColor = "transparent";
-        this.targetPitchButton.querySelector("img").style.filter = "none";
+        if (this.chromaticButton && this.chromaticButton.style) {
+            this.chromaticButton.style.backgroundColor = platformColor.selectorBackground;
+        }
+        if (chromaticImg && chromaticImg.style) {
+            chromaticImg.style.filter = "brightness(0) invert(1)";
+        }
+        if (this.targetPitchButton && this.targetPitchButton.style) {
+            this.targetPitchButton.style.backgroundColor = "transparent";
+        }
+        if (targetImg && targetImg.style) {
+            targetImg.style.filter = "none";
+        }
     } else {
-        this.targetPitchButton.style.backgroundColor = platformColor.selectorBackground;
-        this.targetPitchButton.querySelector("img").style.filter = "brightness(0) invert(1)";
-        this.chromaticButton.style.backgroundColor = "transparent";
-        this.chromaticButton.querySelector("img").style.filter = "none";
+        if (this.targetPitchButton && this.targetPitchButton.style) {
+            this.targetPitchButton.style.backgroundColor = platformColor.selectorBackground;
+        }
+        if (targetImg && targetImg.style) {
+            targetImg.style.filter = "brightness(0) invert(1)";
+        }
+        if (this.chromaticButton && this.chromaticButton.style) {
+            this.chromaticButton.style.backgroundColor = "transparent";
+        }
+        if (chromaticImg && chromaticImg.style) {
+            chromaticImg.style.filter = "none";
+        }
     }
 };
 
@@ -188,7 +215,17 @@ const TunerUtils = {
         const A4 = 440;
         const C0 = A4 * Math.pow(2, -4.75);
         const currentEDO = edo || 12;
-        const noteNames = generateNoteNames(currentEDO);
+        let noteNames;
+        if (typeof generateNoteNames === "function") {
+            noteNames = generateNoteNames(currentEDO);
+        } else if (
+            typeof window !== "undefined" &&
+            typeof window.generateNoteNames === "function"
+        ) {
+            noteNames = window.generateNoteNames(currentEDO);
+        } else {
+            noteNames = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"];
+        }
 
         if (frequency < C0) {
             return ["C", 0, C0];
@@ -199,7 +236,7 @@ const TunerUtils = {
         const steppedN = ((h % currentEDO) + currentEDO) % currentEDO;
         const cents = Math.round(1200 * Math.log2(frequency / (C0 * Math.pow(2, h / currentEDO))));
 
-        return [noteNames[steppedN], cents, frequency];
+        return [noteNames[steppedN % noteNames.length], cents, frequency];
     },
 
     /**


### PR DESCRIPTION
## Description

Fixes runtime exceptions in `tuner.js` where `TunerUtils.frequencyToPitch` threw `ReferenceError: generateNoteNames is not defined` when `generateNoteNames` was out of scope, and `updateButtonStyles` threw `TypeError: Cannot read properties of null (reading 'style')` when button image query selectors returned null.

## Related Issue

Fixes #8203 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added `generateNoteNames` function existence fallback in `TunerUtils.frequencyToPitch` in `js/widgets/tuner.js`.
- Added null guards for `canvas.parentElement` and image query selectors in `updateButtonStyles()`.
- Added unit tests in `js/widgets/__tests__/tuner.test.js` verifying safe fallback note naming and null query selector safety.

## Testing Performed

- Ran Jest unit tests: all 70 unit tests in `tuner.test.js` pass cleanly (`70 passed, 70 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.