### PR TITLE
fix(toolbar): stop tooltip re-init from crashing Velocity

### DIFF
--- a/js/utils/__tests__/jquery-setup.test.js
+++ b/js/utils/__tests__/jquery-setup.test.js
@@ -74,7 +74,8 @@ describe("jquery-setup", () => {
         };
 
         mockJQuery.fn = {
-            autocomplete: jest.fn()
+            autocomplete: jest.fn(),
+            tooltip: jest.fn()
         };
 
         mockJQuery.widget = {
@@ -274,5 +275,85 @@ describe("jquery-setup", () => {
         wrappedRenderMenu.call(mockInstance, ul, items);
 
         expect(originalRenderMenu).toHaveBeenCalledTimes(1);
+    });
+    describe("Materialize tooltip re-initialisation guard", () => {
+        /**
+         * Builds a stand-in for a jQuery set of tooltipped elements.
+         * @param {HTMLElement[]} elements - The elements in the set.
+         * @returns {object} An object exposing the subset of the jQuery API the shim uses.
+         */
+        const asSet = elements => ({
+            each(callback) {
+                elements.forEach(element => callback.call(element));
+                return this;
+            }
+        });
+
+        /**
+         * Creates a tooltipped element together with its tooltip node.
+         * @param {string} id - The tooltip node's id.
+         * @returns {{origin: HTMLElement, tooltip: HTMLElement}} The pair.
+         */
+        const makeTooltipped = id => {
+            const origin = document.createElement("a");
+            origin.setAttribute("data-tooltip-id", id);
+
+            const tooltip = document.createElement("div");
+            tooltip.className = "material-tooltip";
+            tooltip.id = id;
+
+            document.body.appendChild(origin);
+            document.body.appendChild(tooltip);
+
+            return { origin, tooltip };
+        };
+
+        test("detaches the live tooltip node before Materialize re-initialises", () => {
+            require("../jquery-setup");
+
+            const { origin, tooltip } = makeTooltipped("tip-1");
+
+            jQuery.fn.tooltip.call(asSet([origin]), { html: true, delay: 100 });
+
+            expect(document.body.contains(tooltip)).toBe(false);
+        });
+
+        test("delegates to the original plugin with the same arguments and context", () => {
+            const original = global.jQuery.fn.tooltip;
+
+            require("../jquery-setup");
+
+            const { origin } = makeTooltipped("tip-2");
+            const set = asSet([origin]);
+            const options = { html: true, delay: 100 };
+
+            jQuery.fn.tooltip.call(set, options);
+
+            expect(original).toHaveBeenCalledTimes(1);
+            expect(original).toHaveBeenCalledWith(options);
+            expect(original.mock.instances[0]).toBe(set);
+        });
+
+        test('passes the "remove" command through untouched', () => {
+            const original = global.jQuery.fn.tooltip;
+
+            require("../jquery-setup");
+
+            const { origin, tooltip } = makeTooltipped("tip-3");
+
+            jQuery.fn.tooltip.call(asSet([origin]), "remove");
+
+            expect(document.body.contains(tooltip)).toBe(true);
+            expect(original).toHaveBeenCalledWith("remove");
+        });
+
+        test("tolerates elements that have no tooltip node yet", () => {
+            require("../jquery-setup");
+
+            const origin = document.createElement("a");
+            document.body.appendChild(origin);
+
+            expect(() => jQuery.fn.tooltip.call(asSet([origin]), {})).not.toThrow();
+        });
     });
 });

--- a/js/utils/jquery-setup.js
+++ b/js/utils/jquery-setup.js
@@ -62,3 +62,43 @@ window.fixSearchAutocompletePosition = function () {
     instance._mbPositionFixApplied = true;
     return true;
 };
+
+// Keep Materialize's tooltip re-initialisation from breaking Velocity.
+//
+// Re-initialising a tooltip (every `$(".tooltipped").tooltip({...})` call, and
+// every click on a tooltipped element) starts by destroying the existing
+// tooltip node with jQuery's .remove(). That runs jQuery.cleanData(), which
+// wipes the node's "velocity" data.
+//
+// Materialize fades a tooltip in with
+//     $tooltip.velocity({ opacity: 1 }, { duration: 300, delay: 50, queue: false })
+// and Velocity 1.2.2 defers a delayed, unqueued tween with a bare setTimeout
+// whose handle it never stores -- neither velocity("stop") nor .remove() can
+// cancel it. If the node is destroyed inside that 50 ms window, the tween
+// still fires and Velocity reads Data(element).tweensContainer unguarded:
+//     Uncaught TypeError: Cannot read properties of undefined
+//                         (reading 'tweensContainer')
+// Clicking a tooltipped button while its tooltip is fading in is enough to hit
+// this -- picking a theme from the theme dropdown does it almost every time,
+// because the pointer lands on the dropdown item an instant before the click.
+//
+// Detaching the node natively instead leaves its Velocity state intact, so the
+// orphaned tween completes harmlessly on a node that is already out of the
+// document. Materialize's own .remove() then matches nothing and is a no-op.
+// The "remove" command is passed through untouched so that disableTooltips()
+// still tears tooltips down completely.
+(function () {
+    const originalTooltip = jQuery.fn.tooltip;
+
+    jQuery.fn.tooltip = function (options) {
+        if (options !== "remove") {
+            this.each(function () {
+                const id = this.getAttribute("data-tooltip-id");
+                const node = id && document.getElementById(id);
+                // Native ChildNode.remove(): does not touch jQuery data.
+                if (node) node.remove();
+            });
+        }
+        return originalTooltip.apply(this, arguments);
+    };
+})();


### PR DESCRIPTION
## Description

Clicking a tooltipped toolbar button while its tooltip is still fading in throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'tweensContainer')
    at t (dist/vendor.min.js:22:28242)
```

Picking a theme from the theme dropdown reproduces it almost every time, which is why it usually shows up as "change the theme and the console errors". The theme dropdown items (`#light`, `#dark`, `#highcontrast`) are themselves `.tooltipped`, so the pointer lands on the item, its tooltip starts animating in, and the user clicks an instant later — squarely inside the window where this breaks.

Nothing in Turtle Wrap, the theme switcher, the canvas, or the turtles is involved. Any tooltipped button hovered and then clicked within ~50 ms does it.

## Related Issue

**Fixes:** #

<!-- No existing issue found for this; happy to open one if maintainers prefer it tracked separately. -->

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

### Root cause

`tweensContainer` belongs to Velocity 1.2.2, bundled inside `materialize-css@0.100.2` and concatenated into `dist/vendor.min.js`. The throwing site (byte offset 369627, i.e. `vendor.min.js:22:28242`) is Velocity's `"start"` branch:

```js
else if ("start" === A) { var M; r(a).tweensContainer && true === r(a).isAnimating && ... }
```

`r(a)` is `Data(element)` = `jQuery.data(element, "velocity")`, and it is `undefined`.

Velocity normally prevents this with `switch (r(a) === n && b.init(a), ...)` — but that only covers the *synchronous* path. Materialize fades a tooltip in with:

```js
$tooltip.velocity({ opacity: 1 }, { duration: 300, delay: 50, queue: false })
```

With `queue: false` **and** a delay, Velocity does `s.delay ? setTimeout(t, s.delay) : t()` — a bare `setTimeout` whose handle it never stores. Neither `velocity("stop")` nor `.remove()` can cancel it.

Re-initialising a tooltip — which every `$(".tooltipped").tooltip({...})` call does, and which a click on a tooltipped element also triggers via `js/toolbar-ui.js:420` — begins by destroying the existing tooltip node with jQuery's `.remove()`. `jQuery.cleanData()` wipes the node's `"velocity"` data. 50 ms later the orphaned tween fires against a node that no longer has any, and the unguarded dereference throws.

Instrumented trace of one hover→click, times relative to `mouseenter`:

| t | event |
|---|---|
| 102 ms | tooltip `delay: 100` fires; `velocity("stop")` ×2 |
| 103 ms | `{translateY, translateX}, {duration: 350, queue: false}` — runs synchronously |
| 103 ms | `{opacity: 1}, {duration: 300, **delay: 50**, queue: false}` — **deferred via `setTimeout(t, 50)`** |
| 132 ms | click → tooltip re-init → `$("#tipId").remove()` → velocity data `true → false`, in-document `true → false` |
| ~156 ms | deferred tween fires → **TypeError** |

### Fix

Detach the tooltip node natively (`ChildNode.remove()`) before delegating to the plugin, in `js/utils/jquery-setup.js` — the file that already exists for exactly this kind of jQuery/jQuery-UI/Materialize post-load glue.

The node keeps its Velocity state, so the orphaned tween completes harmlessly on a node that is already out of the document, and Materialize's own `.remove()` then matches nothing and is a no-op. The `"remove"` command is passed straight through, so `disableTooltips()` (`js/toolbar-ui.js:1753`) still tears tooltips down completely.

Velocity's `setTimeout` is uncancellable from outside the library, so guarding the teardown is the only fix available without vendoring a patched `vendor.min.js`.

---

## Testing Performed

Verified in the browser against a local `http-server` build, before and after:

- **Before:** the exact reported flow (toggle Turtle Wrap → open theme dropdown → pick a theme) throws once per theme change. Isolated repro — hover any tooltipped button for 130 ms, then click — throws every time on `#wrapTurtle`, `#mergeWithCurrentIcon`, `#chooseKeyIcon`, `#restoreIcon`.
- **After:** the same flows produce zero errors. The old tooltip node is confirmed detached; new tooltips still appear and hide normally.
- Theme switching still works end-to-end through the real UI (dark → light, `body` class and `themePreference` both update, no console output).
- Turtle Wrap still toggles and its tooltip label still flips between "Turtle Wrap On" / "Turtle Wrap Off".
- `npx jest js/utils/__tests__/jquery-setup.test.js` — 15/15 pass (11 existing + 4 new covering the shim: detaches the live node, delegates arguments and context, passes `"remove"` through untouched, tolerates an element with no tooltip node yet).
- `npm run lint` and `npx prettier --check` clean on both changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

One adjacent bug I deliberately left out of this PR to keep it focused — `js/toolbar-ui.js:419-421`:

```js
$j(".tooltipped").on("click", function () {
    $j(this).tooltip("close");
});
```

Materialize 0.100's tooltip plugin has no `"close"` method — only `"remove"` or an options object. `"close"` falls through to the init path, so every click on a tooltipped element silently rebuilds that tooltip with **default** options, discarding the configured `html: true, delay: 100`. The intended call is `$j(this).trigger("mouseleave.tooltip")`. Happy to fix that here as a second commit, or in a follow-up PR — reviewer's preference.
