### PR TITLE
fix(block): detach container from parent on disposal

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -28,21 +28,40 @@ const Block = require("../block");
 
 // --- MOCK SETUP ---
 
-// Mock CreateJS
+// Mock CreateJS: keep parent/children relationships observable
+// so disposal tests can verify actual unparenting behavior.
 global.createjs = {
-    Container: jest.fn().mockImplementation(() => ({
-        addChild: jest.fn(),
-        removeChild: jest.fn(),
-        removeAllChildren: jest.fn(),
-        setChildIndex: jest.fn(),
-        getBounds: jest.fn().mockReturnValue({ x: 0, y: 0, width: 100, height: 100 }),
-        cache: jest.fn(),
-        updateCache: jest.fn(),
-        uncache: jest.fn(),
-        bitmapCache: { getCacheDataURL: jest.fn().mockReturnValue("cached-data-url") },
-        visible: true,
-        children: []
-    })),
+    Container: jest.fn().mockImplementation(() => {
+        const container = {
+            children: [],
+            parent: null,
+            visible: true,
+            bitmapCache: { getCacheDataURL: jest.fn().mockReturnValue("cached-data-url") },
+            addChild: jest.fn(function (child) {
+                this.children.push(child);
+                child.parent = this;
+                return child;
+            }),
+            removeChild: jest.fn(function (child) {
+                const idx = this.children.indexOf(child);
+                if (idx !== -1) {
+                    this.children.splice(idx, 1);
+                }
+                if (child.parent === this) {
+                    child.parent = null;
+                }
+                return child;
+            }),
+            removeAllChildren: jest.fn(),
+            removeAllEventListeners: jest.fn(),
+            setChildIndex: jest.fn(),
+            getBounds: jest.fn().mockReturnValue({ x: 0, y: 0, width: 100, height: 100 }),
+            cache: jest.fn(),
+            updateCache: jest.fn(),
+            uncache: jest.fn()
+        };
+        return container;
+    }),
     Bitmap: jest.fn().mockImplementation(image => ({
         visible: true,
         scaleX: 1,
@@ -877,6 +896,25 @@ describe("Block Foundation", () => {
             expect(block.blocks).toBeNull();
             expect(block.activity).toBeNull();
             expect(block.protoblock).toBeNull();
+        });
+
+        it("should detach the CreateJS container from its parent display list", () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            const parent = new global.createjs.Container();
+            const disposedContainer = new global.createjs.Container();
+
+            parent.addChild(disposedContainer);
+            block.container = disposedContainer;
+
+            expect(disposedContainer.parent).toBe(parent);
+            expect(parent.children).toContain(disposedContainer);
+
+            block.dispose();
+
+            expect(parent.children).not.toContain(disposedContainer);
+            expect(parent.children).toHaveLength(0);
+            expect(disposedContainer.parent).toBeNull();
+            expect(block.container).toBeNull();
         });
     });
 });

--- a/js/block.js
+++ b/js/block.js
@@ -594,6 +594,9 @@ class Block {
             if (typeof this.container.uncache === "function") {
                 this.container.uncache();
             }
+            if (this.container.parent && typeof this.container.parent.removeChild === "function") {
+                this.container.parent.removeChild(this.container);
+            }
             this.container = null;
         }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where permanently disposed blocks could leave their CreateJS containers attached to the parent display list.

Previously, `Block.dispose()` cleaned up the container and cleared `block.container`, but did not remove the container from its parent. This could leave stale containers in the parent's display list even after the block had been disposed.

The fix detaches the container from its parent before clearing the block's container reference.

The existing disposal and trash/restore behavior remains unchanged.

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- Detach the block's CreateJS container from its parent during `Block.dispose()`.
- Preserve the existing listener, child, and cache cleanup behavior.
- Added a regression test covering the parent/child display-list relationship.
- Verified that the container is attached to the parent before disposal.
- Verified that the container is removed from the parent's `children` after disposal.
- Verified that the container's `parent` reference is cleared.
- Verified that `block.container` is cleared after disposal.
- Updated the CreateJS test stub to maintain observable parent/children relationships while preserving the existing Jest spies.
- No changes were made to trash/restore behavior, block indices, turtles, widgets, or other disposal paths.

## Testing Performed

- Ran `js/__tests__/block.test.js` and `js/__tests__/blocks.test.js` — **115 tests passed**.
- Ran `npm run lint` successfully.
- Ran Prettier checks successfully.
- Ran `git diff --check` successfully.
- Verified that the regression test fails with the previous disposal behavior where the container was cleared but remained attached to its parent.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

The fix only applies to permanent block disposal. Existing trash, restore, and undo behavior remains unchanged.

The regression test checks the actual parent/child state rather than only asserting that `removeChild()` was called.