### PR TITLE
fix(logo): keep the drawing on screen when a run is stopped

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -969,6 +969,15 @@ describe("Logo doStopTurtles", () => {
         expect(logo.safePluginExecute).toHaveBeenNthCalledWith(2, "code-second", logo);
     });
 
+    test("preserves the drawing on explicit Stop (#8154 follow-up)", () => {
+        logo.doStopTurtles();
+
+        // Stopping a run must not wipe the canvas: the artwork drawn so far
+        // stays on screen, and the next Run clears it via
+        // ToolbarController._clearAllTurtles().
+        expect(turtle.painter.doClear).not.toHaveBeenCalled();
+    });
+
     test("clears delayTimeout for turtles with a pending timer", () => {
         const TIMER_ID = 456;
         const clearTimeoutSpy = jest.spyOn(global, "clearTimeout").mockImplementation(() => {});

--- a/js/activity/__tests__/toolbar-controller.test.js
+++ b/js/activity/__tests__/toolbar-controller.test.js
@@ -114,6 +114,22 @@ describe("ToolbarController.runFast", () => {
         expect(activity.logo.runLogoCommands).toHaveBeenCalledWith(null, env);
         jest.useRealTimers();
     });
+
+    test("clears the canvas before the delayed restart when currentDelay is 0", () => {
+        jest.useFakeTimers();
+        const painter = { doClear: jest.fn() };
+        activity.turtles.turtleList = [{ painter }];
+        activity.turtles.running.mockReturnValue(true);
+        controller.runFast({ run: true }, 0);
+
+        // Stop no longer wipes the canvas, so the restart has to do it itself.
+        expect(painter.doClear).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(500);
+
+        expect(painter.doClear).toHaveBeenCalledWith(true, true, true);
+        jest.useRealTimers();
+    });
 });
 
 describe("ToolbarController.runSlow", () => {

--- a/js/activity/toolbar-controller.js
+++ b/js/activity/toolbar-controller.js
@@ -66,6 +66,9 @@ class ToolbarController {
 
                 const that = this;
                 setTimeout(() => {
+                    // Stop leaves the drawing in place, so clear here the way
+                    // every other Run path does before starting fresh.
+                    that._clearAllTurtles();
                     that.activity.logo.runLogoCommands(null, env);
                 }, 500);
             }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1273,12 +1273,6 @@ class Logo {
             this.safePluginExecute(this.evalOnStopList[arg], this);
         }
 
-        // Clear canvas on explicit Stop only — natural completion
-        // preserves drawings for SVG/PNG export.
-        for (const turtle of this.turtles.turtleList) {
-            turtle.painter.doClear(true, true, true);
-        }
-
         // Recorder stop is Stop-only — natural completion must not
         // interrupt an in-progress WAV recording.
         if (this.synth.recorder && this.synth.recorder.state === "recording")


### PR DESCRIPTION
### What is happening

Pressing Stop in the middle of a run wipes the artwork drawn so far. If a child starts a long drawing and stops it partway to look at what it has made, the picture disappears instead of staying on screen.

@zealot-zew found this while testing #8154 and @walterbender confirmed it is not the behaviour we want.

### Where it comes from

`doStopTurtles()` in `js/logo.js` walks every turtle and calls `painter.doClear(true, true, true)`. That loop was added in #7848, which moved canvas clearing out of the shared completion cleanup and into two separate places: the start of a run, and explicit Stop.

Moving it off natural completion was the right call, since a finished drawing has to survive for SVG and PNG export. Putting a second copy on Stop was not needed, because `ToolbarController` already calls `_clearAllTurtles()` ahead of every Run, Slow and Step, so the canvas is clean before the next run either way. Before #7848 there was no canvas clearing anywhere in `logo.js` at all, and Stop simply left the drawing alone.

### The change

Remove that loop. Everything else in `doStopTurtles()` stays exactly as it is, so timers, sounds, voices, the step queue, the WAV recorder and the ONSTOP plugin hooks all still run on Stop. This is a six line deletion plus a test.



### PR Category
- [X] Bug Fix
