### PR TITLE
feat(a11y): add aria-describedby to the New Project confirmation buttons (#6608)

### DIFF
--- a/js/__tests__/toolbar.test.js
+++ b/js/__tests__/toolbar.test.js
@@ -380,6 +380,15 @@ describe("Toolbar Class", () => {
         expect(messageElement.id).toBe("confirmation-message");
         expect(confirmButton.textContent).toBe("Confirm");
         expect(confirmButton.id).toBe("new-project");
+        expect(confirmButton.getAttribute("role")).toBe("button");
+        expect(confirmButton.getAttribute("aria-label")).toBe("Confirm");
+        expect(confirmButton.getAttribute("aria-describedby")).toBe("confirmation-message");
+
+        const cancelButton = buttonListItem.children[1];
+        expect(cancelButton.textContent).toBe("Cancel");
+        expect(cancelButton.getAttribute("role")).toBe("button");
+        expect(cancelButton.getAttribute("aria-label")).toBe("Cancel");
+        expect(cancelButton.getAttribute("aria-describedby")).toBe("confirmation-message");
 
         confirmButton.onclick();
 

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -623,11 +623,19 @@ class ToolbarUI {
         confirmationButton.classList.add("confirm-button");
         confirmationButton.id = "new-project";
         confirmationButton.setAttribute("tabindex", "0"); // Make focusable
+        confirmationButton.setAttribute("role", "button");
+        confirmationButton.setAttribute("aria-label", _("Confirm"));
+        // The label alone ("Confirm") doesn't say what's being confirmed;
+        // point screen readers at the actual question being asked.
+        confirmationButton.setAttribute("aria-describedby", "confirmation-message");
         confirmationButton.textContent = _("Confirm");
 
         const cancelButton = document.createElement("div");
         cancelButton.classList.add("cancel-button");
         cancelButton.id = "cancel-project";
+        cancelButton.setAttribute("role", "button");
+        cancelButton.setAttribute("aria-label", _("Cancel"));
+        cancelButton.setAttribute("aria-describedby", "confirmation-message");
         cancelButton.textContent = _("Cancel");
 
         buttonRowLi.appendChild(confirmationButton);


### PR DESCRIPTION
## Description
The ticket asks for `aria-describedby` on interactive elements alongside `aria-label`/`role`, but the codebase had zero uses of it anywhere.

The New Project modal's Confirm/Cancel buttons are the clearest case: they're plain `<div>`s with no role at all, and a screen reader landing on one out of context (e.g. via a screen reader's own button list, which skips surrounding prose) would only hear "Confirm, button" or "Cancel, button" — no indication of what's being confirmed.

Added `role="button"` and `aria-label` to both (they had neither before), plus `aria-describedby="confirmation-message"` pointing at the existing confirmation text ("Are you sure you want to create a new project?"), which already had a stable id.

Deliberately scoped to just this one modal — other confirmation-style UI (e.g. the LilyPond save dialog) can get the same treatment in a follow-up PR.

## Related Issue
Part of #6608

## Category
- [x] Feature

## Type of Change
- [x] Accessibility Enhancement

## Testing Performed

### How to test locally
1. Run `npm run serve` and open `http://localhost:3000`
2. Click "New Project" in the toolbar
3. Enable VoiceOver (`Cmd+F5` on Mac) or NVDA on Windows
4. Tab to the Confirm button — confirm it announces the button plus the confirmation question via its description
5. Tab to the Cancel button — confirm the same

### Test cases
1. Confirm button has `role="button"`, `aria-label="Confirm"`, `aria-describedby="confirmation-message"`
2. Cancel button has `role="button"`, `aria-label="Cancel"`, `aria-describedby="confirmation-message"`
3. Existing modal behavior (display toggling, focus trap, onclick handlers) unchanged
4. `npx jest js/__tests__/toolbar.test.js --coverage=false` — 48/48 passing
5. `npx eslint` and `npx prettier --check` — clean

## PR Checklist
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts