### PR TITLE
refactor: move closeBlkWidgets to widgetWindows.js

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -107,7 +107,8 @@ global.DEFAULTCHORD = [];
 
 // Mock helper functions
 global.addTemperamentToDictionary = jest.fn();
-global.closeBlkWidgets = jest.fn();
+window.widgetWindows = window.widgetWindows || {};
+window.widgetWindows.closeBlkWidgets = jest.fn();
 global.deleteTemperamentFromList = jest.fn();
 global.getDrumSynthName = jest.fn();
 global.getNoiseName = jest.fn();

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -19,7 +19,7 @@
     DEFAULTVOICE, NATURAL, NUMBERBLOCKDEFAULT,
     STANDARDBLOCKHEIGHT, STRINGLEN, TEXTWIDTH,
     WESTERN2EISOLFEGENAMES, addTemperamentToDictionary,
-   Block, closeBlkWidgets, ConnectionValidator, createjs, delayExecution, DEFAULTCHORD,
+   Block, ConnectionValidator, createjs, delayExecution, DEFAULTCHORD,
    deleteTemperamentFromList, getDrumSynthName, getNoiseName,
    getNoiseSynthName, getTemperamentsList, getTextWidth,
    getVoiceSynthName, i18nSolfege, last, MathUtility, mixedNumber,
@@ -52,7 +52,7 @@
    - js/utils/mathutils.js
         MathUtility
    - js/utils/utils.js
-        _, last, closeBlkWidgets, mixedNumber, prepareMacroExports,
+        _, last, mixedNumber, prepareMacroExports,
         getTextWidth, delayExecution, deepClone
    - js/utils/musicutils.js
         addTemperamentToDictionary,
@@ -6744,7 +6744,9 @@ class Blocks {
                 const title = this.blockList[blk].protoblock.staticLabels
                     ? this.blockList[blk].protoblock.staticLabels[0]
                     : this.blockList[blk].name;
-                if (title) closeBlkWidgets(_(title));
+                if (title && window.widgetWindows && window.widgetWindows.closeBlkWidgets) {
+                    window.widgetWindows.closeBlkWidgets(_(title));
+                }
                 this.activity.refreshCanvas();
             }
 

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -111,7 +111,6 @@ const {
     format,
     delayExecution,
     closeWidgets,
-    closeBlkWidgets,
     resolveObject,
     importMembers,
     changeImage,
@@ -542,67 +541,6 @@ describe("Utility Functions (logic-only)", () => {
         it("does not throw when openWindows is empty", () => {
             window.widgetWindows.openWindows = {};
             expect(() => closeWidgets()).not.toThrow();
-        });
-    });
-    describe("closeBlkWidgets()", () => {
-        beforeEach(() => {
-            window.widgetWindows = {
-                hideAllWindows: jest.fn(),
-                hideWindow: jest.fn(),
-                closeWindow: jest.fn(),
-                openWindows: {}
-            };
-        });
-
-        it("closes matching widget by name", () => {
-            const mockElement = { innerHTML: "TestWidget" };
-
-            document.getElementsByClassName = jest.fn(() => [mockElement]);
-
-            closeBlkWidgets("TestWidget");
-
-            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("TestWidget");
-        });
-
-        it("closes widget directly using key lookup from openWindows", () => {
-            window.widgetWindows.openWindows = {
-                "custom mode": { close: jest.fn() }
-            };
-
-            closeBlkWidgets("custom mode");
-
-            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
-        });
-
-        it("closes widget using mapped key", () => {
-            window.widgetWindows.openWindows = {
-                "pitch drum": { close: jest.fn() }
-            };
-
-            closeBlkWidgets("pitch-drum mapper");
-
-            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("pitch drum");
-        });
-
-        it("closes widget by matching element ID when display title changes", () => {
-            const mockElement = {
-                innerHTML: "C MAJOR",
-                id: "custom modeWidgetID"
-            };
-
-            document.getElementsByClassName = jest.fn(() => [mockElement]);
-
-            closeBlkWidgets("custom mode");
-
-            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
-        });
-
-        it("does nothing if no match found", () => {
-            document.getElementsByClassName = jest.fn(() => [{ innerHTML: "OtherWidget" }]);
-
-            closeBlkWidgets("TestWidget");
-
-            expect(window.widgetWindows.closeWindow).not.toHaveBeenCalled();
         });
     });
     describe("resolveObject()", () => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -52,7 +52,7 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 /* exported
-   announceToScreenReader, changeImage, closeBlkWidgets,
+   announceToScreenReader, changeImage,
    delayExecution,
    doPublish, doStopVideoCam, doSVG,
    doUseCamera, format, getTextWidth,
@@ -1193,76 +1193,6 @@ let delayExecution = duration => {
 
 // closeWidgets() moved to js/utils/dom-helpers.js
 
-/**
- * Closes a specific widget by its name.
- *
- * @param {string} name - The name of the widget to be closed.
- * @returns {void}
- */
-let closeBlkWidgets = name => {
-    let searchKey = name;
-
-    // NOTE: This mapping only works for widgets that never set their own
-    // `blockNo` property (e.g. ModeWidget). window.widgetWindows.windowFor()
-    // keys a widget's window by `widget.blockNo` if that property is set to
-    // anything other than undefined (including null) — otherwise it falls
-    // back to the `saveAs` or `title` argument. Widgets like PhraseMaker set
-    // `this.blockNo` in their constructor, so they are keyed by blockNo, not
-    // by name, and will NOT be found via this KEY_MAPPING lookup. Adding such
-    // widgets here would silently do nothing. Before adding a new entry,
-    // verify the target widget's windowFor() call and confirm it does not
-    // rely on blockNo for its window key.
-    const KEY_MAPPING = {
-        "pitch-drum mapper": "pitch drum",
-        "custom mode": "custom mode",
-        "tempo": "tempo",
-        "arpeggio": "arpeggio",
-        "timbre": "timbre",
-        "sampler": "sampler",
-        "rhythm maker": "rhythm maker",
-        "oscilloscope": "oscilloscope",
-        "temperament": "temperament",
-        "meter": "meter",
-        "LEGO Bricks": "LEGO BRICKS"
-    };
-
-    for (const origKey in KEY_MAPPING) {
-        const translated = typeof _ === "function" ? _(origKey) : origKey;
-        if (name === translated) {
-            searchKey = KEY_MAPPING[origKey];
-            break;
-        }
-    }
-
-    if (
-        window.widgetWindows &&
-        window.widgetWindows.openWindows &&
-        window.widgetWindows.openWindows[searchKey]
-    ) {
-        window.widgetWindows.closeWindow(searchKey);
-        return;
-    }
-
-    const widgetTitle = document.getElementsByClassName("wftTitle");
-    for (let i = 0; i < widgetTitle.length; i++) {
-        const titleEl = widgetTitle[i];
-        if (
-            titleEl.innerHTML === name ||
-            titleEl.innerHTML === searchKey ||
-            titleEl.id === `${searchKey}WidgetID`
-        ) {
-            const winKey =
-                titleEl.id && typeof titleEl.id === "string"
-                    ? titleEl.id.replace("WidgetID", "")
-                    : searchKey;
-            if (window.widgetWindows && typeof window.widgetWindows.closeWindow === "function") {
-                window.widgetWindows.closeWindow(winKey);
-            }
-            break;
-        }
-    }
-};
-
 // resolveObject() moved to js/utils/utils-logic.js
 
 /**
@@ -1361,7 +1291,6 @@ if (typeof module !== "undefined" && module.exports) {
         _,
         format,
         delayExecution,
-        closeBlkWidgets,
         importMembers,
         changeImage,
         getTextWidth,

--- a/js/widgets/README.md
+++ b/js/widgets/README.md
@@ -94,8 +94,8 @@ imported in `js/activity.js`.
     }
     ```
 
-6. **Map the widget in `utils.js` for cleanup**
-   To ensure your widget window automatically closes when its parent block is trashed, you must register its name in the `KEY_MAPPING` object inside the `closeBlkWidgets` function in `js/utils/utils.js`.
+6. **Map the widget in `widgetWindows.js` for cleanup**
+   To ensure your widget window automatically closes when its parent block is trashed, you must register its name in the `KEY_MAPPING` object inside `js/widgets/widgetWindows.js`.
 
     ```javascript
     const KEY_MAPPING = {

--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -1128,4 +1128,64 @@ describe("widgetWindows", () => {
             expect(win._maxminButton.title).toBe("Maximize window");
         });
     });
+
+    describe("closeBlkWidgets()", () => {
+        beforeEach(() => {
+            window.widgetWindows.openWindows = {};
+            window.widgetWindows.closeWindow = jest.fn();
+            window.widgetWindows.hideAllWindows = jest.fn();
+            window.widgetWindows.hideWindow = jest.fn();
+        });
+
+        it("closes matching widget by name", () => {
+            const mockElement = { innerHTML: "TestWidget" };
+
+            document.getElementsByClassName = jest.fn(() => [mockElement]);
+
+            window.widgetWindows.closeBlkWidgets("TestWidget");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("TestWidget");
+        });
+
+        it("closes widget directly using key lookup from openWindows", () => {
+            window.widgetWindows.openWindows = {
+                "custom mode": { close: jest.fn() }
+            };
+
+            window.widgetWindows.closeBlkWidgets("custom mode");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
+        });
+
+        it("closes widget using mapped key", () => {
+            window.widgetWindows.openWindows = {
+                "pitch drum": { close: jest.fn() }
+            };
+
+            window.widgetWindows.closeBlkWidgets("pitch-drum mapper");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("pitch drum");
+        });
+
+        it("closes widget by matching element ID when display title changes", () => {
+            const mockElement = {
+                innerHTML: "C MAJOR",
+                id: "custom modeWidgetID"
+            };
+
+            document.getElementsByClassName = jest.fn(() => [mockElement]);
+
+            window.widgetWindows.closeBlkWidgets("custom mode");
+
+            expect(window.widgetWindows.closeWindow).toHaveBeenCalledWith("custom mode");
+        });
+
+        it("does nothing if no match found", () => {
+            document.getElementsByClassName = jest.fn(() => [{ innerHTML: "OtherWidget" }]);
+
+            window.widgetWindows.closeBlkWidgets("TestWidget");
+
+            expect(window.widgetWindows.closeWindow).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -24,6 +24,80 @@ window.widgetWindows = {
     draggingWindow: null,
     _shortcutsInitialized: false,
     _globalListenersInitialized: false,
+
+    // NOTE: This mapping only works for widgets that never set their own
+    // `blockNo` property (e.g. ModeWidget). window.widgetWindows.windowFor()
+    // keys a widget's window by `widget.blockNo` if that property is set to
+    // anything other than undefined (including null) — otherwise it falls
+    // back to the `saveAs` or `title` argument. Widgets like PhraseMaker set
+    // `this.blockNo` in their constructor, so they are keyed by blockNo, not
+    // by name, and will NOT be found via this KEY_MAPPING lookup. Adding such
+    // widgets here would silently do nothing. Before adding a new entry,
+    // verify the target widget's windowFor() call and confirm it does not
+    // rely on blockNo for its window key.
+    KEY_MAPPING: {
+        "pitch-drum mapper": "pitch drum",
+        "custom mode": "custom mode",
+        "tempo": "tempo",
+        "arpeggio": "arpeggio",
+        "timbre": "timbre",
+        "sampler": "sampler",
+        "rhythm maker": "rhythm maker",
+        "oscilloscope": "oscilloscope",
+        "temperament": "temperament",
+        "meter": "meter",
+        "LEGO Bricks": "LEGO BRICKS"
+    },
+
+    /**
+     * Closes a specific widget by its name.
+     *
+     * @param {string} name - The name of the widget to be closed.
+     * @returns {void}
+     */
+    closeBlkWidgets(name) {
+        let searchKey = name;
+
+        for (const origKey in window.widgetWindows.KEY_MAPPING) {
+            const translated = typeof _ === "function" ? _(origKey) : origKey;
+            if (name === translated) {
+                searchKey = window.widgetWindows.KEY_MAPPING[origKey];
+                break;
+            }
+        }
+
+        if (
+            window.widgetWindows &&
+            window.widgetWindows.openWindows &&
+            window.widgetWindows.openWindows[searchKey]
+        ) {
+            window.widgetWindows.closeWindow(searchKey);
+            return;
+        }
+
+        const widgetTitle = document.getElementsByClassName("wftTitle");
+        for (let i = 0; i < widgetTitle.length; i++) {
+            const titleEl = widgetTitle[i];
+            if (
+                titleEl.innerHTML === name ||
+                titleEl.innerHTML === searchKey ||
+                titleEl.id === `${searchKey}WidgetID`
+            ) {
+                const winKey =
+                    titleEl.id && typeof titleEl.id === "string"
+                        ? titleEl.id.replace("WidgetID", "")
+                        : searchKey;
+                if (
+                    window.widgetWindows &&
+                    typeof window.widgetWindows.closeWindow === "function"
+                ) {
+                    window.widgetWindows.closeWindow(winKey);
+                }
+                break;
+            }
+        }
+    },
+
     _handleGlobalKeyDown(e) {
         const focused = window.widgetWindows.focused;
         if (!focused || e.repeat) return; // Guard against no focus or rapid-fire repeat


### PR DESCRIPTION
## Description
Moves the `closeBlkWidgets` utility and its `KEY_MAPPING` out of the generic `utils.js` and into `widgetWindows.js` where it logically belongs, as per walter's feedback. Updates callers and associated unit tests.

## Category
- [x] Chore / Refactor — code cleanup

## Changes Made
- Extracted the `KEY_MAPPING` constant and the `closeBlkWidgets` function from `js/utils/utils.js`.
- Added them as properties to the global `window.widgetWindows` object inside `js/widgets/widgetWindows.js`.
- Updated `js/blocks.js` which previously called `closeBlkWidgets(_(title))` directly. It now checks for and calls `window.widgetWindows.closeBlkWidgets(_(title))`.
- Moved Jest unit tests for `closeBlkWidgets` from `js/utils/__tests__/utils.test.js` to `js/widgets/__tests__/widgetWindows.test.js`.

## Testing Performed
Ran `npm test`. All 212 test suites and 7,781 tests successfully passed.
