### PR TITLE
fix: propagate Planet initialization failures

### DIFF
--- a/js/__tests__/planetInterface.test.js
+++ b/js/__tests__/planetInterface.test.js
@@ -497,18 +497,14 @@ describe("PlanetInterface", () => {
         expect(consoleSpy).toHaveBeenCalledWith(mockError);
         consoleSpy.mockRestore();
     });
-    it("init catches initialization errors, logs them, and sets planet to null", async () => {
-        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    it("init propagates initialization errors to the activity", async () => {
         const iframe = document.getElementById("planet-iframe");
         iframe.contentWindow.makePlanet = jest
             .fn()
             .mockRejectedValue(new Error("Failed to make planet"));
-        await expect(planetInterface.init()).resolves.toBeUndefined();
-        expect(consoleSpy).toHaveBeenCalledWith(expect.any(Error));
-        expect(consoleSpy.mock.calls[0][0].message).toBe("Failed to make planet");
+        await expect(planetInterface.init()).rejects.toThrow("Failed to make planet");
         expect(planetInterface.planet).toBeNull();
         expect(window.Converter).toBeUndefined();
-        consoleSpy.mockRestore();
     });
 
     it("project getters return safe defaults when Planet storage is unavailable", () => {

--- a/js/planetInterface.js
+++ b/js/planetInterface.js
@@ -388,22 +388,19 @@ class PlanetInterface {
          */
         this.init = async () => {
             this.iframe = document.getElementById("planet-iframe");
-            try {
-                await this.iframe.contentWindow.makePlanet(
-                    _THIS_IS_MUSIC_BLOCKS_,
-                    this.activity.storage,
-                    window._
-                );
-                this.planet = this.iframe.contentWindow.p;
-                this.planet.setLoadProjectFromData(this.loadProjectFromData.bind(this));
-                this.planet.setPlanetClose(this.closePlanet.bind(this));
-                this.planet.setLoadNewProject(this.newProject.bind(this));
-                this.planet.setLoadProjectFromFile(this.loadProjectFromFile.bind(this));
-                this.planet.setOnConverterLoad(this.onConverterLoad.bind(this));
-            } catch (e) {
-                console.error(e);
-                this.planet = null;
-            }
+            this.planet = null;
+            window.Converter = undefined;
+            await this.iframe.contentWindow.makePlanet(
+                _THIS_IS_MUSIC_BLOCKS_,
+                this.activity.storage,
+                window._
+            );
+            this.planet = this.iframe.contentWindow.p;
+            this.planet.setLoadProjectFromData(this.loadProjectFromData.bind(this));
+            this.planet.setPlanetClose(this.closePlanet.bind(this));
+            this.planet.setLoadNewProject(this.newProject.bind(this));
+            this.planet.setLoadProjectFromFile(this.loadProjectFromFile.bind(this));
+            this.planet.setOnConverterLoad(this.onConverterLoad.bind(this));
 
             window.Converter = this.planet ? this.planet.Converter : undefined;
             this.mainCanvas = this.activity.canvas;


### PR DESCRIPTION
## Description

Prevent Planet initialization failures from producing an uncaught exception when Music Blocks is opened through `file:///`. The existing activity-level fallback now handles the failure instead of continuing with an unavailable Planet instance.

  ## Related Issue

  **Fixes:** #8214

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Reset transient Planet state before initialization.
  - Propagate iframe initialization failures to the existing activity-level error handler.
  - Update the regression test to verify that initialization errors are propagated and partial state is cleared.

  ---

  ## Testing Performed

  - Reproduced the uncaught error when opening Music Blocks through `file:///`.
  - Verified that no uncaught page error remains after the fix.
  - Verified normal loading through a local HTTP server.
  - Focused PlanetInterface tests: 33 passed.
  - Full Jest suite: 217 suites and 8,021 tests passed.
  - `npm run lint` passed.
  - Prettier checks passed for both modified files.
  - `git diff --check` passed.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have updated the documentation to reflect these changes, if applicable.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

This change does not introduce any visual or UI changes. Prettier was checked on the modified files rather than the entire repository.