### PR TITLE
fix: highlight stop icon on start block click (all click paths)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -3160,9 +3160,11 @@ class Block {
 
                         setTimeout(() => {
                             that.activity.logo.runLogoCommands(topBlock);
+                            that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                         }, 250);
                     } else {
                         that.activity.logo.runLogoCommands(topBlock);
+                        that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                     }
 
                     return;
@@ -3216,9 +3218,11 @@ class Block {
 
                             setTimeout(() => {
                                 that.activity.logo.runLogoCommands(topBlk);
+                                that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                             }, 250);
                         } else {
                             that.activity.logo.runLogoCommands(topBlk);
+                            that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                         }
                     }
                 }
@@ -3234,9 +3238,11 @@ class Block {
 
                         setTimeout(() => {
                             that.activity.logo.runLogoCommands(topBlk);
+                            that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                         }, 250);
                     } else {
                         that.activity.logo.runLogoCommands(topBlk);
+                        that.activity.toolbar.highlightStop(platformColor.stopIconcolor);
                     }
                 }
             }


### PR DESCRIPTION
## Description
The Stop button in the toolbar didn't appear when running a project by clicking directly on a Start block — it only worked when shift-clicking. This fixes that so the Stop button appears no matter which click path starts the project.

## Related Issue
**Fixes:** #8217

---

## Category
- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made
In `js/block.js`, `_loadEventHandlers()` has a click handler with three separate code paths that can call `runLogoCommands()` to start a project:

1. Shift-click
2. Normal click (non-value-driven-label blocks)
3. Plain click via the `else if (!moved)` branch

Only the shift-click path was calling `activity.toolbar.highlightStop(platformColor.stopIconcolor)` after starting the run. The other two paths were missing it — including the most common case, a plain click on the Start block — so the Stop button never appeared for a regular click.

Added the missing `highlightStop()` call right after `runLogoCommands()` in all three paths (both the immediate-run case and the `setTimeout` case used when turtles are already running).

---

## Visual Changes
### Before
Clicking Start directly did not show the Stop button, so the project could not be stopped.

### After
Stop button appears on run start for any click path, and clears once playback ends.
<img width="1186" height="487" alt="Screenshot 2026-08-24 200551" src="https://github.com/user-attachments/assets/ca06ddb7-d985-4845-8b53-6c0564b11e75" />


---

## Testing Performed
- Clicked Start block directly, Stop button appears, clears when playback finishes.
- Shift-clicked Start block, same behavior confirmed.
- Clicked Start while already running,  stops, restarts after ~250ms, Stop button stays correct through the restart.
- Clicked Stop button manually while running, icon clears, playback stops immediately.
- Tested locally with `npm run dev` at `127.0.0.1:3000`.

---

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes
Change is limited to `js/block.js`. Used `activity.js` and `toolbar-ui.js` as reference since they already had the correct highlight pattern — no changes needed there.