### PR TITLE
fix:  record button layout

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -118,6 +118,29 @@ body.dark .toolbar-btn-focused,
   background-color: rgba(255, 255, 255, 0.3) !important;
 }
 
+/* Keep the record options focus target from collapsing on narrow toolbars. */
+#recordDropdownArrow i.material-icons.main {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+#recordDropdownArrow {
+  margin-left: 0 !important;
+}
+
+/* Keep the record options focus indicator centered on the arrow icon. */
+#recordDropdownArrow.toolbar-btn-focused,
+#recordDropdownArrow:focus-visible {
+  height: 1em;
+  line-height: 1em;
+}
+
+#recordDropdownArrow.toolbar-btn-focused i.material-icons.main,
+#recordDropdownArrow:focus-visible i.material-icons.main {
+  height: 1em;
+  line-height: 1em;
+}
+
 /* Keyboard navigation focus state for dropdown menu items */
 .dropdown-item-focused {
   background-color: rgba(0, 150, 136, 0.2) !important;

--- a/js/artwork.js
+++ b/js/artwork.js
@@ -564,7 +564,7 @@ const STOPBUTTON =
     '<?xml version="1.0" encoding="UTF-8" standalone="no"?> <svg width="55" height="55" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" id="svg975" version="1.1" viewBox="0 0 28 28"> <title id="title967">アセット 24</title> <circle id="circle969" style="fill:#ffffff;stroke-width:0.9285714" r="13" cy="14" cx="14" /> <rect id="rect971" style="fill:#0050a0" ry="1" rx="1" height="9" width="9" y="9.5" x="9.5" /> </svg>';
 
 const RECORDBUTTON =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55"><circle cx="30" cy="30" r="20" stroke="currentColor" fill="none" stroke-width="6" /><circle id="rec_inside" cx="30" cy="30" r="8" fill="currentColor" /></svg>';
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 55 55"><circle cx="30" cy="30" r="20" stroke="currentColor" fill="none" stroke-width="6" /><circle id="rec_inside" cx="30" cy="30" r="8" fill="currentColor" /></svg>';
 
 const RECORDHELPBUTTON =
     '<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 55 55"><circle cx="30" cy="30" r="20" stroke="#292929" stroke-opacity="0.4" fill="none" stroke-width="6"/><circle id="rec_inside" cx="30" cy="30" r="8" fill="#292929" fill-opacity="0.4"/></svg>';


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

Fix the Record button size on small screens and prevent the dropdown arrow focus highlight from overlapping it.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #8215 

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->
 - Made the Record icon resize properly on small screens.
 - Added a viewBox so the icon keeps its shape.
 - Fixed the dropdown arrow spacing.
 - Centered the keyboard focus highlight without covering Record.


---

## Visual Changes

<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->
<img width="690" height="751" alt="image" src="https://github.com/user-attachments/assets/a81f31c2-4cf8-4885-968f-bd054757e438" />


### Before

<!-- Paste/drop before screenshot here -->
<img width="580" height="931" alt="image" src="https://github.com/user-attachments/assets/c27f1a24-85f5-4626-be94-a2878362b9eb" />


### After

<!-- Paste/drop after screenshot here -->
<img width="690" height="751" alt="image" src="https://github.com/user-attachments/assets/977c18df-7617-45cb-b3c9-d4e4a8e98b45" />


---

## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->
  - npm run lint
  - Prettier check
  - Focused tests: 52 passed
  - Full test suite: 216 suites, 8,013 tests passed
  - Manual responsive check in Brave performed
---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---


