### PR TITLE
fix(a11y): enable wheelnav's built-in keyboard navigation on all pie menus (#6608)

### DIFF
--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -419,7 +419,7 @@ const piemenuPitches = (block, noteLabels, noteValues, accidentals, note, accide
 
     wheelnav.cssMode = true;
 
-    block._pitchWheel.keynavigateEnabled = false;
+    block._pitchWheel.keynavigateEnabled = true;
 
     block._pitchWheel.colors = platformColor.pitchWheelcolors;
     block._pitchWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1118,7 +1118,7 @@ const piemenuCustomNotes = (block, noteLabels, customLabels, selectedCustom, sel
 
     wheelnav.cssMode = true;
 
-    block._customWheel.keynavigateEnabled = false;
+    block._customWheel.keynavigateEnabled = true;
 
     //Customize slicePaths for proper size
     block._customWheel.colors = platformColor.intervalNameWheelcolors;
@@ -1457,7 +1457,7 @@ const piemenuNthModalPitch = (block, noteValues, note) => {
 
     wheelnav.cssMode = true;
 
-    block._pitchWheel.keynavigateEnabled = false;
+    block._pitchWheel.keynavigateEnabled = true;
 
     block._pitchWheel.colors = platformColor.pitchWheelcolors;
     block._pitchWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1715,7 +1715,7 @@ const piemenuAccidentals = (block, accidentalLabels, accidentalValues, accidenta
 
     wheelnav.cssMode = true;
 
-    block._accidentalWheel.keynavigateEnabled = false;
+    block._accidentalWheel.keynavigateEnabled = true;
 
     block._accidentalWheel.colors = platformColor.accidentalsWheelcolors;
     block._accidentalWheel.slicePathFunction = slicePath().DonutSlice;
@@ -1883,7 +1883,7 @@ const piemenuNoteValue = (block, noteValue) => {
 
     wheelnav.cssMode = true;
 
-    block._noteValueWheel.keynavigateEnabled = false;
+    block._noteValueWheel.keynavigateEnabled = true;
 
     block._noteValueWheel.colors = platformColor.noteValueWheelcolors;
     block._noteValueWheel.slicePathFunction = slicePath().DonutSlice;
@@ -2103,7 +2103,7 @@ const piemenuNumber = (block, wheelValues, selectedValue) => {
 
     wheelnav.cssMode = true;
 
-    block._numberWheel.keynavigateEnabled = false;
+    block._numberWheel.keynavigateEnabled = true;
 
     block._numberWheel.colors = platformColor.numberWheelcolors;
     block._numberWheel.slicePathFunction = slicePath().DonutSlice;
@@ -2471,7 +2471,7 @@ const piemenuColor = (block, wheelValues, selectedValue, mode) => {
 
     wheelnav.cssMode = true;
 
-    block._numberWheel.keynavigateEnabled = false;
+    block._numberWheel.keynavigateEnabled = true;
 
     block._numberWheel.colors = [];
     if (mode === "setcolor" || mode === "setturtlecolor") {
@@ -2666,7 +2666,7 @@ const piemenuBasic = (block, menuLabels, menuValues, selectedValue, colors) => {
 
     wheelnav.cssMode = true;
 
-    block._basicWheel.keynavigateEnabled = false;
+    block._basicWheel.keynavigateEnabled = true;
 
     block._basicWheel.colors = colors;
     block._basicWheel.slicePathFunction = slicePath().DonutSlice;
@@ -2804,7 +2804,7 @@ const piemenuBoolean = (block, booleanLabels, booleanValues, boolean) => {
 
     wheelnav.cssMode = true;
 
-    block._booleanWheel.keynavigateEnabled = false;
+    block._booleanWheel.keynavigateEnabled = true;
 
     block._booleanWheel.colors = platformColor.booleanWheelcolors;
     block._booleanWheel.slicePathFunction = slicePath().DonutSlice;
@@ -2919,7 +2919,7 @@ const piemenuChords = (block, selectedChord) => {
     }
     wheelnav.cssMode = true;
 
-    block._chordWheel.keynavigateEnabled = false;
+    block._chordWheel.keynavigateEnabled = true;
 
     block._chordWheel.colors = platformColor.modeWheelcolors;
     block._chordWheel.slicePathFunction = slicePath().DonutSlice;
@@ -3066,7 +3066,7 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
 
     wheelnav.cssMode = true;
 
-    block._voiceWheel.keynavigateEnabled = false;
+    block._voiceWheel.keynavigateEnabled = true;
 
     block._voiceWheel.colors = colors;
     block._voiceWheel.slicePathFunction = slicePath().DonutSlice;
@@ -3246,7 +3246,7 @@ const piemenuIntervals = (block, selectedInterval) => {
 
     wheelnav.cssMode = true;
 
-    block._intervalNameWheel.keynavigateEnabled = false;
+    block._intervalNameWheel.keynavigateEnabled = true;
 
     //Customize slicePaths for proper size
     block._intervalNameWheel.colors = platformColor.intervalNameWheelcolors;
@@ -3605,7 +3605,7 @@ const piemenuModes = (block, selectedMode) => {
                 maxRadius: MODEPIEMENU_NAME_RING.maxRadius,
                 selectionPaths: true
             });
-            that._modeNameWheel.keynavigateEnabled = false;
+            that._modeNameWheel.keynavigateEnabled = true;
             newWheel = true;
         }
 
@@ -3902,7 +3902,7 @@ const piemenuGrid = activity => {
     activity.turtles.gridWheel = new wheelnav("wheelDivptm", null, 300, 300);
     activity.turtles._exitWheel = new wheelnav("_exitWheel", activity.turtles.gridWheel.raphael);
 
-    activity.turtles.gridWheel.keynavigateEnabled = false;
+    activity.turtles.gridWheel.keynavigateEnabled = true;
     activity.turtles.gridWheel.slicePathFunction = slicePath().DonutSlice;
     activity.turtles.gridWheel.slicePathCustom = slicePath().DonutSliceCustomization();
     activity.turtles.gridWheel.colors = platformColor.gridWheelcolors.wheel;
@@ -4338,7 +4338,7 @@ const piemenuDissectNumber = widget => {
     wheelLabels.push(null); // spacer
 
     wheelnav.cssMode = true;
-    numberWheel.keynavigateEnabled = false;
+    numberWheel.keynavigateEnabled = true;
     numberWheel.colors = platformColor.numberWheelcolors;
     numberWheel.slicePathFunction = slicePath().DonutSlice;
     numberWheel.slicePathCustom = slicePath().DonutSliceCustomization();


### PR DESCRIPTION
## Description
Manual VoiceOver testing found every pie menu (pitch preview, custom note, accidentals, octaves, note value, number, boolean, chord, voice, interval name, mode name, the turtle grid selector, and the beginner-mode number-factoring wheel) was mouse-only — arrow keys did nothing, so a keyboard-only or screen-reader user could hear the currently selected slice but had no way to move to a different one.

`wheelnav.js` (`lib/wheelnav.js`) already implements real keyboard navigation: when `keynavigateEnabled` is `true`, it attaches a keydown listener for the arrow keys that calls the exact same `navigateWheel()` function already used by mouse clicks — which is also what triggers the existing "played `<note>`" screen-reader announcement. Every wheel instance in `js/piemenus.js` was explicitly setting `keynavigateEnabled = false`, seemingly copied from the library's own example boilerplate rather than a deliberate accessibility decision — nothing depends on it staying disabled.

Flipped all 15 occurrences to `true`. No custom keyboard-handling code needed — this restores functionality the library already ships with.

## Related Issue
Part of #6608

## Category
- [x] Bug Fix

## Type of Change
- [x] Accessibility Enhancement

## Testing Performed

### How to test locally
1. `npm run serve`, open `http://localhost:3000`
2. Enable VoiceOver (`Cmd+F5`) or NVDA
3. Open a pitch block's pie menu
4. Press arrow keys — confirm the selection moves between slices and each one is announced ("played C4", etc.), matching mouse-click behavior
5. Repeat for at least one other wheel type (e.g. number wheel) to confirm the fix generalizes

### Test cases
1. All 15 `keynavigateEnabled` flags set to `true`
2. `npx jest js/__tests__/piemenus.test.js` — 13/13 passing, including the existing announcement test
3. Broader regression check — `npx jest --testPathPattern="piemenu|turtle|grid"` — 21 suites, 1108 tests passing
4. `npx eslint` and `npx prettier --check` — clean
5. Manual VoiceOver confirmation: arrow-key navigation + announcements both work end-to-end

## PR Checklist
- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts