### PR TITLE
fix(modewidget): stop the mode piemenu crashing on a mode it cannot show

### DIFF
--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -577,5 +577,31 @@ describe("ModeWidget", () => {
 
             expect(modeWidget._selectedModeName).toBe("major");
         });
+
+        test("falls back to the first slice on a group without the current mode", () => {
+            // wheelnav's navigateWheel() reads navItems[index] without a bounds
+            // check, so a -1 from indexOf() throws and leaves the widget half
+            // open. Group "5" holds no "major", which is the default mode, so
+            // the highlight has to land on slice 0.
+            modeWidget._piemenuModes();
+            switchGroup(modeWidget, "5");
+
+            const titles = modeWidget._modeNameWheel.navItems.map(item => item.title);
+            expect(titles).not.toContain("major");
+            expect(modeWidget._modeNameWheel.navigateWheel).toHaveBeenLastCalledWith(0);
+        });
+
+        test("leaves mode selection enabled even if the highlight throws", () => {
+            // The real wheelnav throws out of navigateWheel() on a bad index,
+            // where this mock returns quietly. A throw must not strand
+            // _suppressModeSelect, because that swallows every later click.
+            modeWidget._piemenuModes();
+            modeWidget._modeNameWheel.navigateWheel.mockImplementationOnce(() => {
+                throw new TypeError("Cannot read properties of undefined");
+            });
+
+            expect(() => switchGroup(modeWidget, "5")).toThrow(TypeError);
+            expect(modeWidget._suppressModeSelect).toBe(false);
+        });
     });
 });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1577,10 +1577,17 @@ class ModeWidget {
             // Navigate to currently-selected mode if present. This fires the
             // slice's navigateFunction (which would select+close), so suppress
             // it: this call is only meant to highlight the current mode.
-            const idx = modes.indexOf(this._selectedModeName);
+            // The mode is often absent from the group being drawn, and
+            // navigateWheel() has no bounds check, so fall back to the first
+            // slice the way piemenuModes() in piemenus.js does.
+            const found = modes.indexOf(this._selectedModeName);
+            const idx = found === -1 ? 0 : found;
             this._suppressModeSelect = true;
-            this._modeNameWheel.navigateWheel(idx);
-            this._suppressModeSelect = false;
+            try {
+                this._modeNameWheel.navigateWheel(idx);
+            } finally {
+                this._suppressModeSelect = false;
+            }
         };
 
         // Wire group wheel slices → __buildModeNameWheel


### PR DESCRIPTION
- [X] BUG FIX

Clicking "Switch mode" in the Mode widget throws and leaves the widget unusable.

### What happens

Open the Mode widget on a default project and press the pie chart button that switches modes. It throws:

```
TypeError: Cannot read properties of undefined (reading 'navAngle')
```

The piemenu only half opens, the button stops responding to further clicks, and none of the mode slices that did draw can be selected any more. The only way out is to change the EDO.

### Why

The mode names are split into groups by scale length, and the piemenu opens on the first group instead of the group that holds the current mode. A default project is in major, which is not one of the pentatonic modes in the first group, so the `indexOf` lookup that highlights the current mode returns `-1`. wheelnav's `navigateWheel()` reads `navItems[index]` with no bounds check, so it throws.

The throw escapes `_piemenuModes()` after it has already set `_modePiemenuOpen`, so the early return at the top of the method makes the button dead. It also skips the line that clears `_suppressModeSelect`, which every mode slice checks before acting, so clicks on the modes that did render get dropped too. Both flags are only cleared by `_closeModePiemenu()`, which at that point is reachable just by switching EDO.

I checked the state after the throw in the running app:

```
{ threw: true,
  error: "TypeError: Cannot read properties of undefined (reading 'navAngle')",
  modePiemenuOpenAfter: true,
  suppressModeSelectAfter: true }
```

and confirmed a second click on the button then does nothing at all.

### The fix

`piemenuModes()` in `js/piemenus.js` already guards the same lookup on the same wheel and falls back to the first slice when the mode is not found. This does the same thing in the widget copy, which is where the guard got dropped.

Resetting `_suppressModeSelect` in a `finally` is there so that a throw from anywhere inside `navigateWheel()` cannot leave mode selection switched off again.

Introduced in #8059.
