### PR TITLE
fix(widgets): reset the button list when a widget window is cleared

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -336,6 +336,28 @@ describe("widgetWindows", () => {
 
             expect(win._buttons).toHaveLength(3);
         });
+
+        test("modifyButton still addresses the live buttons after a re-init", () => {
+            // A widget that re-initialises on an already open window (see
+            // Blocks.reInitWidget) calls clear() and then re-adds its buttons.
+            const win = createTestWindow();
+            win.clear();
+            win.addButton("play-button.svg", 24, "Play");
+            win.addButton("erase-button.svg", 24, "Clear");
+
+            win.clear();
+            win.addButton("play-button.svg", 24, "Play");
+            win.addButton("erase-button.svg", 24, "Clear");
+
+            expect(win._buttons).toHaveLength(2);
+
+            const target = win.modifyButton(0, "stop-button.svg", 24, "Stop");
+
+            expect(win._toolbar.contains(target)).toBe(true);
+            expect(win._toolbar.querySelector("img").getAttribute("src")).toBe(
+                "header-icons/stop-button.svg"
+            );
+        });
     });
 
     describe("addDivider", () => {

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -805,6 +805,11 @@ class WidgetWindow {
     clear() {
         this._widget.replaceChildren();
         this._toolbar.replaceChildren();
+        // The toolbar buttons have just been removed from the DOM, so drop the
+        // references too. Widgets re-add their buttons after clear(), and
+        // modifyButton() addresses them by index — leaving the old entries in
+        // place would push every index past the detached ones.
+        this._buttons = [];
         return this;
     }
 


### PR DESCRIPTION
- [X] Bug Fix

`WidgetWindow.clear()` empties the toolbar in the DOM but keeps the `_buttons` array holding the elements it just removed. Widgets re-add their buttons after `clear()`, so the array keeps growing while the toolbar only shows the newest set.

`modifyButton()` looks its target up by index, so index 0 points at a button that is no longer in the document.

### What breaks

In the Phrase Maker, the Play button shows the Stop icon while its aria-label stays "Play". The icon still changes because the click handler in `phrasemaker.js` swaps the image by hand, so nothing looks wrong on screen. It is the accessible name that goes stale.

The window also keeps 6 detached toolbar nodes per `init()`, and `init()` runs twice when the widget opens because `_sort()` calls it again.

### Reproduce

Open the Phrase Maker, then paste this in the console with the button showing Play:

```js
{ const b = document.querySelector('[aria-label="phrase maker"] .wfbtItem');
  console.log('BEFORE', b.querySelector('img').src.split('/').pop(), '|', b.getAttribute('aria-label'));
  b.click();
  setTimeout(() => console.log('DURING', b.querySelector('img').src.split('/').pop(), '|', b.getAttribute('aria-label')), 500); }
```

master:

```
BEFORE play-button.svg | Play
DURING stop-button.svg | Play
```

With this patch `DURING` reads `stop-button.svg | Stop`.

### The fix

Clear the array alongside the DOM so the indexes widgets pass to `modifyButton()` keep meaning what they did on the first init.

`clearScreen()` is left alone. It only empties the widget body and leaves the toolbar in place, so its buttons are still live.
