### PR TITLE
fix(project-manager): clear graphics canvas drawings when creating new project

### DIFF
--- a/js/__tests__/project-manager.test.js
+++ b/js/__tests__/project-manager.test.js
@@ -939,6 +939,7 @@ describe("newProject / _afterDelete", () => {
         jest.useFakeTimers();
 
         pm._afterDelete();
+        expect(activity._allClear).toHaveBeenCalledWith(false, true);
         jest.advanceTimersByTime(1000);
 
         expect(activity.sendAllToTrash).toHaveBeenCalledWith(false, false);

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -354,6 +354,10 @@ class ProjectManager {
             that._doHardStopButton();
         }
 
+        if (typeof that._allClear === "function") {
+            that._allClear(false, true);
+        }
+
         if (
             that.planet !== undefined &&
             that.planet.planet !== null &&


### PR DESCRIPTION
## Description

Ensures that turtle graphics canvas drawings are cleanly erased when creating a new project via `ProjectManager.newProject()` in `js/project-manager.js`.

Previously, when initializing a new project via `newProject()` / `_afterDelete()`, MusicBlocks reset the project metadata and cleared the workspace blocks, but omitted calling `activity._allClear(false, true)`. As a result, vector lines previously drawn on screen by turtle graphics blocks (`forward`, `back`, `set pen color`) remained permanently frozen on the canvas screen even after starting a new project.

## Related Issue

N/A

## PR Category

- [x] Bug Fix — Fixes an existing bug or UI issue
- [x] Graphics / Canvas — Fixes turtle graphics rendering state
- [x] Tests — Adds or updates unit test coverage

## Changes Made

- **`js/project-manager.js`**:
  - Added `that._allClear(false, true)` invocation inside `_afterDelete()` to clear turtle canvas drawings when a new project is created.
- **`js/__tests__/project-manager.test.js`**:
  - Added unit test assertion verifying `_allClear(false, true)` invocation during `_afterDelete()`.

## Testing Performed

- Ran local Jest test suite: `npx jest js/__tests__/project-manager.test.js` (106/106 passed).
- Verified live in browser: creating a new project now erases all drawn graphics lines from screen.
- Ran ESLint across modified files (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
