### PR TITLE
fix(logo): ensure previous mic stream is closed before opening a new one

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2669,6 +2669,34 @@ describe("Logo initMediaDevices", () => {
         );
         expect(logo.mic).toBeNull();
     });
+
+    test("closes the previous mic stream instead of dropping the reference", () => {
+        const firstClose = jest.fn();
+        logo.deps.Tone = {
+            UserMedia: jest.fn(() => ({ open: jest.fn(), close: firstClose }))
+        };
+
+        // Simulate a loudness/pitchness block being created a second time
+        // (e.g. a second such block in the same project, or the project
+        // being reloaded) while the first mic stream is still open.
+        logo.initMediaDevices();
+        expect(firstClose).not.toHaveBeenCalled();
+
+        logo.deps.Tone = {
+            UserMedia: jest.fn(() => ({ open: jest.fn(), close: jest.fn() }))
+        };
+        logo.initMediaDevices();
+
+        expect(firstClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not throw when the previous mic has no close method", () => {
+        logo.deps.Tone = { UserMedia: jest.fn(() => ({ open: jest.fn() })) };
+        logo.initMediaDevices();
+
+        logo.deps.Tone = { UserMedia: jest.fn(() => ({ open: jest.fn() })) };
+        expect(() => logo.initMediaDevices()).not.toThrow();
+    });
 });
 
 describe("Logo processShow", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -596,6 +596,10 @@ class Logo {
      * @returns {void}
      */
     initMediaDevices() {
+        if (this.mic && typeof this.mic.close === "function") {
+            this.mic.close();
+        }
+
         let mic = new this.deps.Tone.UserMedia();
         try {
             mic.open();


### PR DESCRIPTION
## Description

`Logo.initMediaDevices()` creates a new `Tone.UserMedia` instance on every call and replaces `this.mic` without closing the existing microphone first.

Since `initMediaDevices()` can run when `loudness` or `pitchness` blocks are created or loaded, repeated calls can leave previous microphone streams open unnecessarily.

This follows the same microphone cleanup pattern addressed in #7917/#7918 for `Synth.startRecording()`, but occurs separately in `logo.js`.

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

* Updated `initMediaDevices()` to close the existing microphone before creating a new one.
* Added a guard to ensure `close()` exists before calling it.
* Added tests to verify the previous microphone is closed on reinitialization.
* Added coverage for cases where the existing microphone does not provide a `close()` method.

## Testing Performed

* `npx jest js/__tests__/logo.test.js js/blocks/__tests__/SensorsBlocks.test.js` — 166 tests pass.
* `npx eslint js/logo.js js/__tests__/logo.test.js` — passes.
* `npx prettier --check js/logo.js js/__tests__/logo.test.js` — passes.
* Verified the new cleanup test fails on the pre-fix code and passes with this change.

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

While investigating this, I also noticed that `Tone.UserMedia.open()` is asynchronous, while the current error handling uses a synchronous `try/catch`. This means a rejected `open()` promise may not reach the intended `NOMICERRORMSG` handling.

I kept that out of this PR because addressing it would require changing the async behavior of `initMediaDevices()` and its callers. It can be handled separately to keep this fix focused.
