### PR TITLE
fix(activity): prevent crash when scaling blocks via keyboard or scroll without open context menu

### DIFF
--- a/js/activity/block-scale-controller.js
+++ b/js/activity/block-scale-controller.js
@@ -96,32 +96,45 @@ class BlockScaleController {
      */
     async setSmallerLargerStatus() {
         const activity = this.activity;
-        if (BLOCKSCALES[activity.blockscale] < DEFAULTBLOCKSCALE) {
-            await changeImage(
-                activity.smallerContainer.children[0],
-                SMALLERBUTTON,
-                SMALLERDISABLEBUTTON
-            );
-        } else {
-            await changeImage(
-                activity.smallerContainer.children[0],
-                SMALLERDISABLEBUTTON,
-                SMALLERBUTTON
-            );
+
+        if (
+            activity.smallerContainer &&
+            activity.smallerContainer.children &&
+            activity.smallerContainer.children.length > 0
+        ) {
+            if (BLOCKSCALES[activity.blockscale] < DEFAULTBLOCKSCALE) {
+                await changeImage(
+                    activity.smallerContainer.children[0],
+                    SMALLERBUTTON,
+                    SMALLERDISABLEBUTTON
+                );
+            } else {
+                await changeImage(
+                    activity.smallerContainer.children[0],
+                    SMALLERDISABLEBUTTON,
+                    SMALLERBUTTON
+                );
+            }
         }
 
-        if (BLOCKSCALES[activity.blockscale] === BLOCKSCALES[BLOCKSCALES.length - 1]) {
-            await changeImage(
-                activity.largerContainer.children[0],
-                BIGGERBUTTON,
-                BIGGERDISABLEBUTTON
-            );
-        } else {
-            await changeImage(
-                activity.largerContainer.children[0],
-                BIGGERDISABLEBUTTON,
-                BIGGERBUTTON
-            );
+        if (
+            activity.largerContainer &&
+            activity.largerContainer.children &&
+            activity.largerContainer.children.length > 0
+        ) {
+            if (BLOCKSCALES[activity.blockscale] === BLOCKSCALES[BLOCKSCALES.length - 1]) {
+                await changeImage(
+                    activity.largerContainer.children[0],
+                    BIGGERBUTTON,
+                    BIGGERDISABLEBUTTON
+                );
+            } else {
+                await changeImage(
+                    activity.largerContainer.children[0],
+                    BIGGERDISABLEBUTTON,
+                    BIGGERBUTTON
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes a runtime `TypeError: Cannot read properties of null (reading 'children')` that crashes the application when users attempt to scale blocks using `Ctrl + Scroll` or keyboard shortcuts while the context menu is not open.

Previously, when the block scale changed, the `setSmallerLargerStatus()` method in `js/activity/block-scale-controller.js` attempted to update the UI images for the "Make Smaller" and "Make Larger" buttons. However, these buttons are dynamically created only when the right-click context menu is opened. If the user resized blocks before ever opening the menu, `activity.smallerContainer` evaluated to `null`, causing the crash when attempting to access its `.children`.

## PR Category

- [x] Bug Fix — Fixes a bug or UI issue
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates unit test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

- **`js/activity/block-scale-controller.js`**:
  - Added null guards to `setSmallerLargerStatus()` to verify that `activity.smallerContainer` and `activity.largerContainer` exist before attempting to access their children or change their images.

## Testing Performed

- Ran local Jest test suite: `npx jest js/activity/__tests__` (543/543 passed).
- Verified live in browser: resizing blocks with `Ctrl + Scroll` now works flawlessly without crashing when the context menu is not open.
- Ran ESLint and Prettier across the modified file.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from previous submissions.
- [x] I have enabled "Allow edits from maintainers".

## Screenshots
Before-
<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/50e8c2f2-f801-4e26-859d-585aee890c6c" />

After-
<img width="1917" height="917" alt="image" src="https://github.com/user-attachments/assets/fcd0e47c-feb9-44e8-8e3e-410b8384e409" />

