### PR TITLE
fix(pitch): apply accidental from scale degree block to played pitch

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -2004,9 +2004,6 @@ function setupPitchBlocks(activity) {
                     }
 
                     scaledegree = Number(scaledegree.replace(attr, ""));
-                    if (attr !== NATURAL) {
-                        note += attr;
-                    }
 
                     const obj = keySignatureToMode(tur.singer.keySignature);
 
@@ -2033,6 +2030,10 @@ function setupPitchBlocks(activity) {
                         tur.singer.movable,
                         null
                     );
+                    if (attr !== NATURAL) {
+                        note += attr;
+                    }
+
                     let semitones = ref;
 
                     semitones += NOTESFLAT.includes(note)

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -106,6 +106,8 @@ describe("setupPitchBlocks", () => {
         global.DOUBLEFLAT = "bb";
         global.DOUBLESHARP = "##";
         global.NATURAL = "n";
+        global.NOTESSHARP = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        global.NOTESFLAT = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
 
         // Test-specific overrides
         global.INTERVALVALUES = { "major third": [0, 0, 1.25], "minor third": [0, 0, 1.2] };
@@ -705,6 +707,36 @@ describe("setupPitchBlocks", () => {
     });
 
     describe("PitchBlock Complex Branches", () => {
+        it("applies the accidental from a scale degree block to the played pitch", () => {
+            const block = createdBlocks["pitch"];
+            activity.blocks.blockList[10].connections[1] = 20;
+            global.scaleDegreeToPitchMapping.mockReturnValue("G");
+
+            activity.blocks.blockList[20] = { name: "scaledegree2", value: "5#" };
+            block.flow(["1", 4], logo, 0, 10);
+            expect(global.Singer.PitchActions.playPitch).toHaveBeenLastCalledWith(
+                "G#",
+                4,
+                0,
+                0,
+                10
+            );
+
+            activity.blocks.blockList[20] = { name: "scaledegree2", value: "5b" };
+            block.flow(["1", 4], logo, 0, 10);
+            expect(global.Singer.PitchActions.playPitch).toHaveBeenLastCalledWith(
+                "Gb",
+                4,
+                0,
+                0,
+                10
+            );
+
+            activity.blocks.blockList[20] = { name: "scaledegree2", value: "5n" };
+            block.flow(["1", 4], logo, 0, 10);
+            expect(global.Singer.PitchActions.playPitch).toHaveBeenLastCalledWith("G", 4, 0, 0, 10);
+        });
+
         it("flow", () => {
             const block = createdBlocks["pitch"];
 


### PR DESCRIPTION
 ## Description

Fixes scale-degree accidentals being discarded before the pitch is played. In C major, scale degree `5♯` now plays `G♯4` instead of `G4`.

  ## Related Issue

  **Fixes:** #8238

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ---

  ## Changes Made

  - Move accidental application to after `scaleDegreeToPitchMapping()` assigns the mapped note.
  - Add regression coverage for sharp, flat, and natural scale degrees.

  ---

  ## Testing Performed

  - `npm test -- js/blocks/__tests__/PitchBlocks.test.js --runInBand`
  - `npm run lint`
  - `npx prettier --check js/blocks/PitchBlocks.js js/blocks/__tests__/PitchBlocks.test.js`

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

  No visual changes.