### PR TITLE
feat(music): non-EDO temperament hardening, scalar step mode-following, and unified key pie menu

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -177,6 +177,15 @@ global.DEFAULTVOICE = "sine";
 global.PREVIEWVOLUME = 0.5;
 global.getNote = jest.fn().mockReturnValue(["C", 4]);
 global.buildScale = jest.fn(() => [["C", "D", "E", "F", "G", "A", "B", "C"], []]);
+global.isNonEDO = jest.fn().mockReturnValue(false);
+global.getNonEDOModeSteps = jest.fn().mockReturnValue(null);
+global.pitchToFrequency = jest.fn().mockReturnValue(440);
+global.TEMPERAMENT = {
+    equal: {
+        pitchNumber: 12,
+        noteLabels: ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+    }
+};
 
 global.DEFAULTVOLUME = 0.5;
 global.Singer = { setSynthVolume: jest.fn() };

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -28,7 +28,6 @@ const Singer = require("../turtle-singer");
 const mockGlobals = {
     getNote: jest.fn().mockReturnValue(["C", 4]),
     isCustomTemperament: jest.fn(),
-    isTrueEDO: jest.fn().mockReturnValue(true),
     isEquallyTempered: jest.fn().mockReturnValue(true),
     temperamentHasRatios: jest.fn().mockReturnValue(false),
     getStepSizeUp: jest.fn().mockReturnValue(1),
@@ -47,7 +46,6 @@ const mockGlobals = {
 
 global.getNote = mockGlobals.getNote;
 global.isCustomTemperament = mockGlobals.isCustomTemperament;
-global.isTrueEDO = mockGlobals.isTrueEDO;
 global.isEquallyTempered = mockGlobals.isEquallyTempered;
 global.temperamentHasRatios = mockGlobals.temperamentHasRatios;
 global.getStepSizeUp = mockGlobals.getStepSizeUp;

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -61,6 +61,12 @@ global.parseNoteString = mockGlobals.parseNoteString;
 global.getCachedPitchToFrequency = mockGlobals.getCachedPitchToFrequency;
 global.normalizeNoteAccidentals = mockGlobals.normalizeNoteAccidentals;
 global.EDOBOUNDEXCEEDED = "Pitch index exceeds EDO range";
+
+// addScalarTransposition's non-EDO branch looks up the mode's native EDO via
+// these musicutils globals; provide them so the real function can run.
+const musicUtils = require("../utils/musicutils");
+global.keySignatureToMode = musicUtils.keySignatureToMode;
+global.getSavedCustomModes = musicUtils.getSavedCustomModes;
 global.last = jest.fn(array => array[array.length - 1]);
 global.deepClone = value => {
     if (typeof structuredClone === "function") {

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -29,6 +29,8 @@ const mockGlobals = {
     getNote: jest.fn().mockReturnValue(["C", 4]),
     isCustomTemperament: jest.fn(),
     isTrueEDO: jest.fn().mockReturnValue(true),
+    isEquallyTempered: jest.fn().mockReturnValue(true),
+    temperamentHasRatios: jest.fn().mockReturnValue(false),
     getStepSizeUp: jest.fn().mockReturnValue(1),
     numberToPitch: jest.fn().mockReturnValue(["C", 4]),
     pitchToNumber: jest.fn().mockReturnValue(60),
@@ -46,6 +48,8 @@ const mockGlobals = {
 global.getNote = mockGlobals.getNote;
 global.isCustomTemperament = mockGlobals.isCustomTemperament;
 global.isTrueEDO = mockGlobals.isTrueEDO;
+global.isEquallyTempered = mockGlobals.isEquallyTempered;
+global.temperamentHasRatios = mockGlobals.temperamentHasRatios;
 global.getStepSizeUp = mockGlobals.getStepSizeUp;
 global.numberToPitch = mockGlobals.numberToPitch;
 global.pitchToNumber = mockGlobals.pitchToNumber;
@@ -1134,6 +1138,62 @@ describe("scalarDistance edge cases", () => {
     test("should return negative distance when lastNote < firstNote", () => {
         const result = Singer.scalarDistance(logoMock, turtleMock, 65, 60);
         expect(result).toBeLessThanOrEqual(0);
+    });
+});
+
+describe("addScalarTransposition on non-EDO temperaments", () => {
+    let turtleMock;
+    let activityMock;
+    let logoMock;
+    let savedGlobals;
+
+    beforeEach(() => {
+        savedGlobals = {};
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        activityMock = createActivityMock(turtleMock);
+        activityMock.errorMsg = jest.fn();
+        logoMock = createLogoMock(activityMock);
+        logoMock.synth.inTemperament = "just intonation";
+    });
+
+    afterEach(() => {
+        Object.keys(savedGlobals).forEach(name => {
+            global[name] = savedGlobals[name];
+        });
+    });
+
+    test("walks one scale degree per step via getStepSizeUp/Down", () => {
+        const getStepSizeUp = jest.fn().mockReturnValue(2);
+        const getStepSizeDown = jest.fn().mockReturnValue(-2);
+        const getNote = jest.fn().mockImplementation(note => [note, 4]);
+        [
+            "getStepSizeUp",
+            "getStepSizeDown",
+            "getNote",
+            "isEquallyTempered",
+            "temperamentHasRatios"
+        ].forEach(name => {
+            savedGlobals[name] = global[name];
+        });
+        global.getStepSizeUp = getStepSizeUp;
+        global.getStepSizeDown = getStepSizeDown;
+        global.getNote = getNote;
+        global.isEquallyTempered = jest.fn().mockReturnValue(false);
+        global.temperamentHasRatios = jest.fn().mockReturnValue(true);
+
+        Singer.addScalarTransposition(logoMock, turtleMock, "C", 4, 3);
+
+        expect(getStepSizeUp).toHaveBeenCalledTimes(3);
+        // One application per step; slice(1) skips the initial offset-0
+        // normalization getNote call.
+        const loopCalls = getNote.mock.calls.slice(1);
+        expect(loopCalls).toHaveLength(3);
+        // Every application passes the measured semitone distance as a RAW offset,
+        // not pre-scaled EDO steps. In getNote's signature, isAlreadyEdoSteps is
+        // the 9th positional argument (index 8).
+        expect(loopCalls.every(c => c[8] === false)).toBe(true);
+        expect(loopCalls.every(c => c[9] === false)).toBe(true);
     });
 });
 

--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -18,7 +18,7 @@
      DOUBLESHARP, NATURAL, FIXEDSOLFEGE, SOLFEGENAMES1, buildScale,
     NOTENAMES, NOTENAMES1, getPitchInfo, YSTAFFOCTAVEHEIGHT,
     YSTAFFNOTEHEIGHT, MUSICALMODES, keySignatureToMode, ALLNOTENAMES,
-    nthDegreeToPitch, A0, C8, calcOctave, SOLFEGECONVERSIONTABLE,
+    nthDegreeToPitch, getCurrentEDO, A0, C8, calcOctave, SOLFEGECONVERSIONTABLE,
      NOTESFLAT, NOTESSHARP, NOTESTEP, scaleDegreeToPitchMapping,
      INTERVALVALUES, CENTSSYMBOL
   */
@@ -2073,11 +2073,14 @@ function setupPitchBlocks(activity) {
                 arg0 = Number(arg0);
 
                 // We interpret numbers two different ways:
-                //  (1) a positive integer between 1 and 12 is taken to be a movable solfege, e.g. 1 : do, 2 : re ...
+                //  (1) a positive integer between 1 and currentEDO is taken to be
+                //      a movable solfege, e.g. 1 : do, 2 : re ...
                 //  (2) if frequency is input, ignore octave (arg1)
                 // Negative numbers will throw an error.
 
-                if (arg0 <= 12) {
+                const currentEDO = getCurrentEDO(logo.synth.inTemperament);
+
+                if (arg0 <= currentEDO) {
                     // movable solfege
                     if (arg0 < 1) {
                         activity.errorMsg(INVALIDPITCH, blk);
@@ -2086,7 +2089,8 @@ function setupPitchBlocks(activity) {
 
                     const [noteName, offset] = nthDegreeToPitch(
                         tur.singer.keySignature,
-                        Math.round(arg0)
+                        Math.round(arg0),
+                        currentEDO
                     );
                     note = noteName;
                     octave =

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -112,6 +112,7 @@ describe("setupPitchBlocks", () => {
         // Test-specific overrides
         global.INTERVALVALUES = { "major third": [0, 0, 1.25], "minor third": [0, 0, 1.2] };
         global.NOTESTEP = { C: 1, D: 3, E: 5, F: 6, G: 8, A: 10, B: 12 };
+        global.getCurrentEDO = jest.fn(() => 12);
         global.SOLFEGECONVERSIONTABLE = {
             C: "do",
             D: "re",
@@ -782,6 +783,23 @@ describe("setupPitchBlocks", () => {
             if (cpBlock instanceof DummyFlowBlock) return;
             cpBlock.flow(["D(+25" + CENTSSYMBOL + ")", 2], logo, 0, 10);
             expect(global.Singer.PitchActions.playPitch).toHaveBeenCalledWith("D", 2, 25, 0, 10);
+        });
+
+        it("pitch numbers >12 are scale degrees (not Hz) when EDO >12", () => {
+            const block = createdBlocks["pitch"];
+            global.getCurrentEDO.mockReturnValue(19);
+            global.nthDegreeToPitch.mockReturnValue(["C", 0]);
+
+            // Pitch number 13 should be treated as a scale degree, not Hz
+            block.flow([13, 4], logo, 0, 10);
+            expect(global.nthDegreeToPitch).toHaveBeenCalledWith("C", 13, 19);
+
+            // Pitch number 19 (the octave) should also be a scale degree
+            block.flow([19, 4], logo, 0, 10);
+            expect(global.nthDegreeToPitch).toHaveBeenCalledWith("C", 19, 19);
+
+            // Restore default
+            global.getCurrentEDO.mockReturnValue(12);
         });
     });
 

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -354,6 +354,25 @@ describe("setupWidgetBlocks", () => {
         });
     });
     describe("TimbreBlock", () => {
+        it("initializes with string instrument name", () => {
+            const timbre = getBlock("timbre");
+            // First call: returns interruption while loading widget
+            const interruption = timbre.flow(
+                ["customInstrument", "childBlk"],
+                logo,
+                0,
+                "timbreBlk"
+            );
+            expect(interruption).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalled();
+
+            // Second call: widget is loaded, so it proceeds
+            const result = timbre.flow(["customInstrument", "childBlk"], logo, 0, "timbreBlk");
+            expect(logo.inTimbre).toBe(true);
+            expect(logo.timbre.instrumentName).toBe("customInstrument");
+            expect(result).toEqual(["childBlk", 1]);
+        });
+
         it("uses default voice and shows error for non-string", () => {
             const timbre = getBlock("timbre");
             // First call: interruption
@@ -441,6 +460,25 @@ describe("setupWidgetBlocks", () => {
             expect(logo.aiDebugger).toBeDefined();
             expect(logo.sample).not.toBe(logo.aiDebugger);
             expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
+        });
+    });
+
+    describe("First-Click Flow (Lazy Loading)", () => {
+        it("returns interruption and triggers runFromBlockNow for TemperamentBlock", () => {
+            const temperament = getBlock("temperament");
+            logo.temperament = null;
+            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "tempBlk", true, "received");
+        });
+
+        it("returns interruption if widget is already loading (guard check)", () => {
+            const temperament = getBlock("temperament");
+            logo.temperament = "loading";
+            const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            // Should not trigger another runFromBlockNow or lazy load callback
+            expect(logo.runFromBlockNow).not.toHaveBeenCalled();
         });
     });
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -21,7 +21,8 @@
    getModeGroupTitleFont, getModeSliceFont, configureWheel,
    MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
-   getMunsellColor, COLORS40, frequencyToPitch, instruments,
+   getMunsellColor, COLORS40, frequencyToPitch, pitchToFrequency,
+   TEMPERAMENT, isNonEDO, getNonEDOModeSteps, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
    FIXEDSOLFEGE, NOTENAMES, numberToPitch,
     nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
@@ -3501,6 +3502,8 @@ const piemenuModes = (block, selectedMode) => {
     block._exitWheel = new wheelnav("_exitWheel", block._modeWheel.raphael);
 
     const currentEDO = getCurrentEDO(block.activity.logo.synth.inTemperament);
+    const inTemperament = block.activity.logo.synth.inTemperament;
+    const nonEDO = isNonEDO(inTemperament);
     const modeWheelLabels = Array.from({ length: currentEDO }, (_, i) => String(i));
 
     configureWheel(block._modeWheel, {
@@ -3578,6 +3581,9 @@ const piemenuModes = (block, selectedMode) => {
         }
     };
 
+    // Expose on block for external interception (e.g. ModeWidget).
+    block.__selectionChanged = __selectionChanged;
+
     // Add function to each main menu for show/hide sub menus
     const __setupAction = (i, activeTabs) => {
         const edoforHide = currentEDO;
@@ -3590,7 +3596,13 @@ const piemenuModes = (block, selectedMode) => {
                 }
             }
 
-            __selectionChanged();
+            // Route through block so external callers (e.g. ModeWidget)
+            // can intercept mode selection.
+            if (typeof block.__selectionChanged === "function") {
+                block.__selectionChanged();
+            } else {
+                __selectionChanged();
+            }
         };
     };
 
@@ -3648,7 +3660,9 @@ const piemenuModes = (block, selectedMode) => {
             const modename = modes[j];
             const activeTabs = [0];
             if (modename !== " " && MUSICALMODES[modename]) {
-                const mode = MUSICALMODES[modename];
+                const mode =
+                    (nonEDO && getNonEDOModeSteps(modename, inTemperament)) ||
+                    MUSICALMODES[modename];
                 for (let k = 0; k < mode.length; k++) {
                     activeTabs.push(last(activeTabs) + mode[k]);
                 }
@@ -3687,14 +3701,11 @@ const piemenuModes = (block, selectedMode) => {
     };
 
     const __playNote = () => {
+        const i = that._modeWheel.selectedNavItemIndex;
         let o = 0;
         if (octave) {
             o = currentEDO;
         }
-
-        const i = that._modeWheel.selectedNavItemIndex;
-        const obj = getNote(key, 4, i + o, key + " chromatic", false, null, null, null, true);
-        obj[0] = obj[0].replace(SHARP, "#").replace(FLAT, "b");
 
         const tur = that.activity.turtles.ithTurtle(0);
 
@@ -3705,6 +3716,26 @@ const piemenuModes = (block, selectedMode) => {
 
         that.activity.logo.synth.setMasterVolume(DEFAULTVOLUME);
         that.activity.logo.synth.setVolume(0, DEFAULTVOICE, DEFAULTVOLUME);
+
+        if (nonEDO) {
+            const t = TEMPERAMENT[inTemperament];
+            const labels = t && Array.isArray(t.noteLabels) ? t.noteLabels : null;
+            if (labels && labels[(i + o) % labels.length]) {
+                const freq = pitchToFrequency(
+                    labels[(i + o) % labels.length],
+                    4 + Math.floor((i + o) / labels.length),
+                    0,
+                    key + " chromatic",
+                    inTemperament
+                );
+                that.activity.logo.synth.trigger(0, [freq], 1 / 12, DEFAULTVOICE, null, null);
+                return;
+            }
+        }
+
+        const obj = getNote(key, 4, i + o, key + " chromatic", false, null, null, null, true);
+        obj[0] = obj[0].replace(SHARP, "#").replace(FLAT, "b");
+
         that.activity.logo.synth.trigger(0, [obj[0] + obj[1]], 1 / 12, DEFAULTVOICE, null, null);
     };
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -22,7 +22,7 @@
    MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
    getMunsellColor, COLORS40, frequencyToPitch, pitchToFrequency,
-   TEMPERAMENT, isNonEDO, getNonEDOModeSteps, instruments,
+   TEMPERAMENT, isNonEDO, getNonEDOModeSteps, getNonEDOFrequency, instruments,
    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
    FIXEDSOLFEGE, NOTENAMES, numberToPitch,
     nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
@@ -3718,17 +3718,16 @@ const piemenuModes = (block, selectedMode) => {
         that.activity.logo.synth.setVolume(0, DEFAULTVOICE, DEFAULTVOLUME);
 
         if (nonEDO) {
-            const t = TEMPERAMENT[inTemperament];
-            const labels = t && Array.isArray(t.noteLabels) ? t.noteLabels : null;
-            if (labels && labels[(i + o) % labels.length]) {
-                const freq = pitchToFrequency(
-                    labels[(i + o) % labels.length],
-                    4 + Math.floor((i + o) / labels.length),
+            const result = getNonEDOFrequency(i + o, 4, inTemperament, key + " chromatic");
+            if (result) {
+                that.activity.logo.synth.trigger(
                     0,
-                    key + " chromatic",
-                    inTemperament
+                    [result.freq],
+                    1 / 12,
+                    DEFAULTVOICE,
+                    null,
+                    null
                 );
-                that.activity.logo.synth.trigger(0, [freq], 1 / 12, DEFAULTVOICE, null, null);
                 return;
             }
         }

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -21,11 +21,11 @@
    DEFAULTVOLUME, TARGETBPM, TONEBPM, MIN_HIGHLIGHT_DURATION_MS, deepClone, frequencyToPitch, last,
     pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp,
     getStepSizeDown, numberToPitch, pitchToNumber, rationalSum,
-    temperamentHasRatios,
+    temperamentHasRatios, isEquallyTempered,
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
-   SEMITONES, normalizeNoteAccidentals, parseNoteString, getCurrentEDO, isTrueEDO,
+   SEMITONES, normalizeNoteAccidentals, parseNoteString, getCurrentEDO,
    clampNumber
  */
 
@@ -37,7 +37,7 @@
         frequencyToPitch, pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp, getStepSizeDown,
         numberToPitch, pitchToNumber, noteIsSolfege, getSolfege, SOLFEGENAMES1,
         SOLFEGECONVERSIONTABLE, getInterval, noteToFrequency, getTemperament, getOctaveRatio,
-        getCurrentEDO
+        getCurrentEDO, isEquallyTempered
     js/utils/utils.js
         rationalSum, _, rationalToFraction
     js/utils/synthutils.js
@@ -326,12 +326,13 @@ class Singer {
             temperament
         );
 
-        // Custom temperaments without ratio data step by a raw semitone offset;
-        // everything else steps by mode-resolved EDO steps.
+        // Equal temperaments step by resolved EDO degrees; customs without
+        // ratios step by raw semitone offsets. Everything with real ratios
+        // (just intonation, meantone, ...) walks the mode's actual scale
+        // degrees one at a time.
         const useEdoSteps =
-            isTrueEDO(temperament) ||
-            !isCustomTemperament(temperament) ||
-            temperamentHasRatios(temperament);
+            isEquallyTempered(temperament) ||
+            (isCustomTemperament(temperament) && !temperamentHasRatios(temperament));
 
         if (useEdoSteps) {
             for (let i = 0; i < Math.abs(steps); i++) {
@@ -365,23 +366,39 @@ class Singer {
                 );
             }
         } else {
-            // Custom temperament without ratio data: no per-degree scale lookup
-            // is possible, so treat the step count as a raw semitone offset and
-            // let getNote rescale it.
-            noteObj = getNote(
-                noteObj[0],
-                noteObj[1],
-                steps > 0
-                    ? getStepSizeUp(tur.singer.keySignature, noteObj[0], steps, temperament, edo)
-                    : getStepSizeDown(tur.singer.keySignature, noteObj[0], steps, temperament, edo),
-                tur.singer.keySignature,
-                tur.singer.movable,
-                null,
-                activity.errorMsg,
-                temperament,
-                false, // isAlreadyEdoSteps — steps is raw semitone offset
-                false // allow octave wrap
-            );
+            // Non-EDO ratio temperament: measure the distance to the NEXT
+            // DEGREE each iteration. The 12-name space is used because
+            // non-EDO ratio tables are keyed by 12-EDO note names.
+            for (let i = 0; i < Math.abs(steps); i++) {
+                const stepSemis =
+                    steps > 0
+                        ? getStepSizeUp(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              temperament,
+                              12
+                          )
+                        : getStepSizeDown(
+                              tur.singer.keySignature,
+                              noteObj[0],
+                              undefined,
+                              temperament,
+                              12
+                          );
+                noteObj = getNote(
+                    noteObj[0],
+                    noteObj[1],
+                    stepSemis,
+                    tur.singer.keySignature,
+                    tur.singer.movable,
+                    null,
+                    activity.errorMsg,
+                    temperament,
+                    false, // isAlreadyEdoSteps — stepSemis is a raw semitone offset
+                    false // allow octave wrap
+                );
+            }
         }
 
         return noteObj;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -26,6 +26,7 @@
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
    SEMITONES, normalizeNoteAccidentals, parseNoteString, getCurrentEDO,
+   keySignatureToMode, getSavedCustomModes,
    clampNumber
  */
 
@@ -366,26 +367,34 @@ class Singer {
                 );
             }
         } else {
-            // Non-EDO ratio temperament: measure the distance to the NEXT
-            // DEGREE each iteration. The 12-name space is used because
-            // non-EDO ratio tables are keyed by 12-EDO note names.
+            // Non-EDO ratio temperament: step by actual scale degrees. Build the
+            // scale at the mode's own EDO (a saved custom mode carries its native
+            // EDO; built-ins fall back to the temperament's pitch count) so the
+            // step reflects the real degree spacing, then normalize to a semitone
+            // offset that getNote remaps onto the temperament's ratios.
+            const modeName = keySignatureToMode(tur.singer.keySignature)[1];
+            const custom = getSavedCustomModes().find(m => m.name === modeName);
+            const modeEdo = (custom && custom.edo) || edo;
             for (let i = 0; i < Math.abs(steps); i++) {
-                const stepSemis =
+                const stepCount =
                     steps > 0
                         ? getStepSizeUp(
                               tur.singer.keySignature,
                               noteObj[0],
                               undefined,
                               temperament,
-                              12
+                              modeEdo
                           )
                         : getStepSizeDown(
                               tur.singer.keySignature,
                               noteObj[0],
                               undefined,
                               temperament,
-                              12
+                              modeEdo
                           );
+                // getStepSizeUp returns EDO-step counts off 12-EDO; normalize to
+                // a semitone offset (isAlreadyEdoSteps=false) so getNote remaps it.
+                const stepSemis = (stepCount * 12) / modeEdo;
                 noteObj = getNote(
                     noteObj[0],
                     noteObj[1],

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -125,6 +125,8 @@ const {
     PITCH_COLLECTIONS_EDO_OVERRIDES,
     getModePattern,
     generateNoteNames,
+    isNonEDO,
+    getNonEDOModeSteps,
     getSavedCustomModes,
     getModeNamesForGroup,
     getModeLabel,
@@ -1783,6 +1785,19 @@ describe("scalePatternToEDO", () => {
     it("clamps steps to a minimum of 1 for small EDOs", () => {
         expect(scalePatternToEDO(major, 5)).toEqual([1, 1, 1, 1, 1, 1, 1]);
     });
+
+    it("scales a 19-summing pattern down to 12 (mismatched-request direction)", () => {
+        // A native 19-EDO pattern asked for at EDO 12 must compress, not pass through.
+        const nineteen = [4, 3, 2, 3, 4, 3]; // hypothetical 19-EDO major, sums to 19
+        const out = scalePatternToEDO(nineteen, 12);
+        expect(out.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(12 + out.length);
+        expect(out.every(s => s >= 1)).toBe(true);
+    });
+
+    it("returns the pattern unchanged when its sum equals the requested EDO", () => {
+        const p = [3, 3, 3, 3, 3, 3, 3]; // sums to 21
+        expect(scalePatternToEDO(p, 21)).toEqual(p);
+    });
 });
 
 describe("getModePattern", () => {
@@ -1801,6 +1816,17 @@ describe("getModePattern", () => {
 
     it("keeps the 12-EDO pattern identical", () => {
         expect(getModePattern("major", 12)).toEqual([2, 2, 1, 2, 2, 2, 1]);
+    });
+
+    it("rescales a native 19-EDO custom mode requested at EDO 12", () => {
+        MUSICALMODES._nineteenNative = [4, 3, 2, 3, 4, 3]; // sums to 19
+        try {
+            const out = getModePattern("_nineteenNative", 12);
+            expect(out).not.toEqual(MUSICALMODES._nineteenNative);
+            expect(out.every(s => s >= 1)).toBe(true);
+        } finally {
+            delete MUSICALMODES._nineteenNative;
+        }
     });
 });
 
@@ -3897,6 +3923,33 @@ describe("mode pie menu shared helpers", () => {
             expect(getSavedCustomModes()).toEqual([]);
             localStorage.setItem("customModes", JSON.stringify({ name: "not an array" }));
             expect(getSavedCustomModes()).toEqual([]);
+        });
+    });
+});
+
+describe("non-EDO temperament helpers", () => {
+    describe("isNonEDO", () => {
+        it("is true for just intonation (ratios, unequal)", () => {
+            expect(isNonEDO("just intonation")).toBe(true);
+        });
+        it("is false for equal temperament", () => {
+            expect(isNonEDO("equal")).toBe(false);
+        });
+        it("is false for unknown or missing temperaments", () => {
+            expect(isNonEDO("not-a-temperament")).toBe(false);
+            expect(isNonEDO(undefined)).toBe(false);
+        });
+    });
+
+    describe("getNonEDOModeSteps", () => {
+        it("derives meantone-like integer steps from ratios for major", () => {
+            // 5-limit JI major: cumulative semitones 0,2,4,5,7,9,11 map onto
+            // the 12-entry ratio table at indices 0,2,4,5,7,9,11.
+            const steps = getNonEDOModeSteps("major", "just intonation");
+            expect(steps).toEqual([2, 2, 1, 2, 2, 2, 1]);
+        });
+        it("returns null for a temperament without usable ratios", () => {
+            expect(getNonEDOModeSteps("major", "_no_ratios")).toBeNull();
         });
     });
 });

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -69,6 +69,7 @@ const _b64Cache = new Map();
     MODEPIEMENU_NAME_FONT_MAX_RATIO, getSavedCustomModes, getModeNamesForGroup,
     getModeLabel, getModeNameFromLabel, getModeSliceColors,
     updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
+    isNonEDO, getNonEDOModeSteps,
     configureWheel
 */
 
@@ -3873,6 +3874,85 @@ const isEquallyTempered = temperament => {
 };
 
 /**
+ * True when the temperament is tuned by ratios and is NOT an equal division
+ * of the octave.
+ * @function
+ * @param {string} temperament - temperament key in TEMPERAMENT
+ * @returns {boolean}
+ */
+const isNonEDO = temperament => {
+    const t = getTemperament(temperament);
+    if (!t) {
+        return false;
+    }
+    return temperamentHasRatios(temperament) && !isEquallyTempered(temperament);
+};
+
+/**
+ * Integer step pattern for a mode under a non-EDO temperament: each
+ * cumulative semitone offset of the 12-EDO mode pattern is mapped to the
+ * index of the nearest ratio, then positions are differenced. This gives
+ * the builder wheel unequal-temperament geometry (e.g. meantone major is
+ * not the proportional rescale of 12-EDO semitones).
+ * @function
+ * @param {string} mode - mode name in MUSICALMODES
+ * @param {string} temperament - temperament key in TEMPERAMENT
+ * @returns {Array|null} step counts, or null when impossible
+ */
+const getNonEDOModeSteps = (mode, temperament) => {
+    const pattern = MUSICALMODES[mode];
+    const t = getTemperament(temperament);
+    if (!pattern || !t || !Array.isArray(t.ratios) || t.ratios.length === 0) {
+        return null;
+    }
+    const n = t.pitchNumber || t.ratios.length;
+    const positions = [0];
+    let cum = 0;
+    for (let k = 0; k < pattern.length - 1; k++) {
+        cum += pattern[k];
+        const target = Math.pow(2, cum / 12);
+        let best = 0;
+        let bestDiff = Infinity;
+        for (let r = 1; r < n; r++) {
+            const ratio = Number(t.ratios[r]);
+            if (!isFinite(ratio) || ratio <= 0) {
+                continue;
+            }
+            const diff = Math.abs(Math.log2(ratio / target));
+            if (diff < bestDiff) {
+                bestDiff = diff;
+                best = r;
+            }
+        }
+        // Keep positions monotonically increasing; if the nearest ratio
+        // falls at or before the previous degree, bump forward by 1 to
+        // avoid collapsing two degrees onto the same pitch. This can
+        // produce a step of 1 that doesn't correspond to a real ratio
+        // interval — acceptable for typical ratio tables (12+ entries)
+        // where this path is rarely hit.
+        if (best <= positions[positions.length - 1]) {
+            best = positions[positions.length - 1] + 1;
+        }
+        if (best >= n) {
+            return null;
+        }
+        positions.push(best);
+    }
+    const steps = [];
+    for (let p = 1; p < positions.length; p++) {
+        steps.push(positions[p] - positions[p - 1]);
+    }
+    // Close back to the octave: the ratios table holds no octave entry, so
+    // the final mode step spans from the last mapped degree to pitchNumber.
+    const last = positions[positions.length - 1];
+    if (last >= n) {
+        return null;
+    }
+    steps.push(n - last);
+    return steps;
+};
+
+/**
  * Extract ratio from a temperament interval value.
  * Handles both legacy numeric format and new {ratio, cents} object format.
  * @function
@@ -6278,28 +6358,29 @@ function _calculate_pitch_number(noteName, octave, applyOffset = 0, temperament)
 }
 
 /**
- * Convert a 12-EDO semitone step pattern to steps in the given EDO.
+ * Convert a step pattern from its native EDO to steps in the given EDO.
  *
  * Uses cumulative positions (not per-interval rounding) so the total interval
  * sum is preserved as closely as possible. Each step is at least 1 so stepping
- * never gets stuck on a repeated note. For 12-EDO this is the identity.
+ * never gets stuck on a repeated note. When the pattern's steps already sum to
+ * the requested EDO this is the identity.
  * @function
- * @param {Array} pattern - The 12-EDO step pattern (e.g. major [2, 2, 1, 2, 2, 2, 1]).
+ * @param {Array} pattern - The source step pattern (e.g. major [2, 2, 1, 2, 2, 2, 1]).
  * @param {number} edo - Number of steps per octave.
  * @returns {Array} The converted step pattern in the target EDO.
  */
 const scalePatternToEDO = (pattern, edo) => {
-    if (edo === 12) {
+    const srcSum = pattern.reduce((a, b) => a + b, 0);
+    if (srcSum === edo) {
         return pattern.slice();
     }
-
     const result = [];
-    let cumSemitones = 0;
-    let cumEdoPos = 0;
+    let cumSrc = 0;
+    let cumDst = 0;
     for (let i = 0; i < pattern.length; i++) {
-        cumSemitones += pattern[i];
-        const newCumEdoPos = Math.round((cumSemitones * edo) / 12);
-        let step = newCumEdoPos - cumEdoPos;
+        cumSrc += pattern[i];
+        const newCumPos = Math.round((cumSrc * edo) / srcSum);
+        let step = newCumPos - cumDst;
         // When EDO < scale degrees (e.g. 5-EDO major), cumulative rounding
         // can produce 0-length intervals. Ensure minimum step of 1 so that
         // stepping never gets stuck on a repeated note.
@@ -6307,7 +6388,7 @@ const scalePatternToEDO = (pattern, edo) => {
             step = 1;
         }
         result.push(step);
-        cumEdoPos += step;
+        cumDst += step;
     }
     return result;
 };
@@ -6347,11 +6428,15 @@ const getModePattern = (mode, edo = 12) => {
     }
     if (mode in MUSICALMODES) {
         const pattern = MUSICALMODES[mode];
-        // Only 12-summing patterns are 12-EDO semitone modes that scalePatternToEDO
-        // can rescale; any other total (e.g. a 7-note 41-EDO mode sums to 41) is
-        // native to a non-12 EDO and must be returned as-is or playback corrupts.
-        const isSemitonePattern = pattern.reduce((a, b) => a + b, 0) === 12;
-        return isSemitonePattern ? scalePatternToEDO(pattern, edo) : pattern.slice();
+        // Return a stored pattern as-is only when it is native to the requested
+        // EDO (its steps sum to the EDO). Anything else — including a native
+        // 19-EDO custom mode resolved in a 12-EDO project context — is rescaled
+        // proportionally so downstream per-degree stepping stays inside the octave.
+        const sum = pattern.reduce((a, b) => a + b, 0);
+        if (sum === edo) {
+            return pattern.slice();
+        }
+        return scalePatternToEDO(pattern, edo);
     }
     return scalePatternToEDO(MUSICALMODES.major, edo);
 };
@@ -8277,6 +8362,8 @@ if (typeof module !== "undefined" && module.exports) {
         updateModeWheelItems,
         getModeGroupTitleFont,
         getModeSliceFont,
+        isNonEDO,
+        getNonEDOModeSteps,
         configureWheel
     };
 }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -69,7 +69,7 @@ const _b64Cache = new Map();
     MODEPIEMENU_NAME_FONT_MAX_RATIO, getSavedCustomModes, getModeNamesForGroup,
     getModeLabel, getModeNameFromLabel, getModeSliceColors,
     updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
-    isNonEDO, getNonEDOModeSteps,
+    isNonEDO, getNonEDOModeSteps, getNonEDOFrequency,
     configureWheel
 */
 
@@ -3950,6 +3950,32 @@ const getNonEDOModeSteps = (mode, temperament) => {
     }
     steps.push(n - last);
     return steps;
+};
+
+/**
+ * Compute the frequency and pitch info for a note degree under a non-EDO
+ * temperament (ratio-based: just intonation, meantone, etc.). Returns null
+ * when the temperament is equally tempered or has no note labels.
+ * @function
+ * @param {number} note - degree index (0 = root, n = octave)
+ * @param {number} baseOctave - starting octave
+ * @param {string} temperamentKey - key in TEMPERAMENT
+ * @param {string} keySignature - key signature for pitch spelling
+ * @returns {{ freq: number, noteName: string, octave: number } | null}
+ */
+const getNonEDOFrequency = (note, baseOctave, temperamentKey, keySignature) => {
+    const t = global.TEMPERAMENT && global.TEMPERAMENT[temperamentKey];
+    const labels =
+        t && Array.isArray(t.noteLabels) && !global.isEquallyTempered(temperamentKey)
+            ? t.noteLabels
+            : null;
+    if (!labels || !labels[note % labels.length]) {
+        return null;
+    }
+    const idx = note % labels.length;
+    const octave = baseOctave + Math.floor(note / labels.length);
+    const freq = global.pitchToFrequency(labels[idx], octave, 0, keySignature, temperamentKey);
+    return { freq, noteName: labels[idx], octave };
 };
 
 /**
@@ -8364,6 +8390,7 @@ if (typeof module !== "undefined" && module.exports) {
         getModeSliceFont,
         isNonEDO,
         getNonEDOModeSteps,
+        getNonEDOFrequency,
         configureWheel
     };
 }

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -65,7 +65,8 @@ global.getNote = jest.fn().mockReturnValue(["C", "4"]);
 global.keySignatureToMode = jest.fn().mockReturnValue(["C", "ionian"]);
 global.normalizeNoteAccidentals = jest.fn().mockImplementation(n => n);
 global.MUSICALMODES = {
-    ionian: [2, 2, 1, 2, 2, 2, 1]
+    ionian: [2, 2, 1, 2, 2, 2, 1],
+    minor: [2, 1, 2, 2, 1, 2, 2]
 };
 global.TEMPERAMENT = {
     "equal": { isEDO: true, pitchNumber: 12 },
@@ -74,6 +75,7 @@ global.TEMPERAMENT = {
 global.getCurrentEDO = jest.fn().mockReturnValue(12);
 global.getModePattern = jest.fn().mockReturnValue([2, 2, 1, 2, 2, 2, 1]);
 global.DEFAULTMODE = "major";
+global.piemenuModes = jest.fn();
 
 // Shared mode pie menu helpers, required from musicutils so the smoke tests
 // exercise the real extraction logic (modewidget.js sees them as globals).
@@ -94,7 +96,11 @@ const {
     getModeGroupTitleFont,
     getModeSliceFont,
     configureWheel,
-    scalePatternToEDO
+    scalePatternToEDO,
+    isNonEDO,
+    getNonEDOModeSteps,
+    isEquallyTempered,
+    pitchToFrequency
 } = require("../../utils/musicutils.js");
 global.MODEPIEMENU_GROUP_RING = MODEPIEMENU_GROUP_RING;
 global.MODEPIEMENU_NAME_RING = MODEPIEMENU_NAME_RING;
@@ -107,7 +113,30 @@ global.updateModeWheelItems = updateModeWheelItems;
 global.getModeGroupTitleFont = getModeGroupTitleFont;
 global.getModeSliceFont = getModeSliceFont;
 global.configureWheel = configureWheel;
+global.configureExitWheel = jest.fn();
 global.scalePatternToEDO = scalePatternToEDO;
+global.isNonEDO = isNonEDO;
+global.getNonEDOModeSteps = getNonEDOModeSteps;
+global.isEquallyTempered = isEquallyTempered;
+global.pitchToFrequency = pitchToFrequency || jest.fn().mockReturnValue(440);
+global.generateNoteNames =
+    global.generateNoteNames ||
+    jest.fn().mockReturnValue(["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]);
+global.numberToPitch = global.numberToPitch || jest.fn().mockReturnValue(["C", 4]);
+global.NOTESTABLE = global.NOTESTABLE || [
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B"
+];
 
 // Mock slicePath
 global.slicePath = jest.fn().mockReturnValue({
@@ -150,11 +179,13 @@ global.wheelnav = jest.fn().mockImplementation(() => {
         titleFont: "",
         selectedNavItemIndex: 0,
         createWheel: jest.fn().mockImplementation(function (labels) {
-            this.navItems = labels.map((l, i) => {
-                const item = navItemTemplate();
-                item.title = l;
-                return item;
-            });
+            if (labels) {
+                this.navItems = labels.map((l, i) => {
+                    const item = navItemTemplate();
+                    item.title = l;
+                    return item;
+                });
+            }
         }),
         navigateWheel: jest.fn().mockImplementation(function (index) {
             this.selectedNavItemIndex = index;
@@ -167,7 +198,15 @@ global.wheelnav = jest.fn().mockImplementation(() => {
         }),
         refreshWheel: jest.fn(),
         removeWheel: jest.fn(),
-        initWheel: jest.fn()
+        initWheel: jest.fn().mockImplementation(function (labels) {
+            if (labels) {
+                this.navItems = labels.map(l => {
+                    const item = navItemTemplate();
+                    item.title = l;
+                    return item;
+                });
+            }
+        })
     };
     return mockWheel;
 });
@@ -538,44 +577,72 @@ describe("ModeWidget", () => {
     });
 
     describe("_piemenuModes", () => {
-        const switchGroup = (widget, groupTitle) => {
-            const index = widget._modeGroupWheel.navItems.findIndex(
-                item => item.title === groupTitle
-            );
-            widget._modeGroupWheel.selectedNavItemIndex = index;
-            widget._modeGroupWheel.navItems[index].navigateFunction();
-        };
-
-        test("builds the group and mode-name wheels", () => {
-            modeWidget._piemenuModes();
-
-            expect(modeWidget._modePieWheel).toBeDefined();
-            expect(modeWidget._modeGroupWheel).toBeDefined();
-            expect(modeWidget._modeNameWheel).toBeDefined();
-            expect(modeWidget._modeNameWheel.navItems.length).toBe(12);
+        beforeEach(() => {
+            global.piemenuModes.mockClear();
         });
 
-        test("custom group leads with the create-mode sentinel and saved modes", () => {
-            localStorage.setItem(
-                "customModes",
-                JSON.stringify([{ name: "my mode", pattern: [1, 2] }])
-            );
+        test("delegates to piemenuModes with a mock block", () => {
+            modeWidget._selectedModeName = "dorian";
             modeWidget._piemenuModes();
-            switchGroup(modeWidget, "custom");
 
-            const titles = modeWidget._modeNameWheel.navItems.map(item => item.title);
-            expect(titles[0]).toBe("+");
-            expect(titles[1]).toBe("my mode");
+            expect(global.piemenuModes).toHaveBeenCalledTimes(1);
+            const [mockBlock, selectedMode] = global.piemenuModes.mock.calls[0];
+            expect(selectedMode).toBe("dorian");
+            expect(mockBlock.value).toBe("dorian");
+            expect(mockBlock.activity).toBeDefined();
         });
 
-        test("selecting a mode slice resolves the internal mode name", () => {
+        test("sets _modePiemenuOpen to true while open", () => {
             modeWidget._piemenuModes();
-            switchGroup(modeWidget, "7");
+            expect(modeWidget._modePiemenuOpen).toBe(true);
+        });
 
-            modeWidget._modeNameWheel.selectedNavItemIndex = 0;
-            modeWidget._modeNameWheel.navItems[0].navigateFunction();
+        test("intercept applies mode selection via _loadMode", () => {
+            modeWidget._piemenuModes();
+            const mockBlock = modeWidget._mockBlock;
+
+            // Simulate piemenu setting a mode value
+            mockBlock.value = "major";
+            mockBlock.__selectionChanged();
 
             expect(modeWidget._selectedModeName).toBe("major");
+        });
+    });
+
+    describe("_modeStepPattern", () => {
+        test("prefers the native pattern when provided", () => {
+            modeWidget._activeTemperamentKey = "just intonation";
+            expect(modeWidget._modeStepPattern("major", [3, 2, 2, 3])).toEqual([3, 2, 2, 3]);
+        });
+
+        test("uses ratio-derived steps under a non-EDO temperament", () => {
+            modeWidget._activeTemperamentKey = "just intonation";
+            const spy = jest
+                .spyOn(global, "getNonEDOModeSteps")
+                .mockReturnValue([2, 2, 1, 2, 2, 2, 1]);
+            const result = modeWidget._modeStepPattern("major", null);
+            expect(spy).toHaveBeenCalledWith("major", "just intonation");
+            expect(result).toEqual([2, 2, 1, 2, 2, 2, 1]);
+            spy.mockRestore();
+        });
+
+        test("falls back to getModePattern at the active EDO when ratio mapping fails", () => {
+            modeWidget._activeTemperamentKey = "just intonation";
+            modeWidget._activeEDO = 12;
+            const spy = jest.spyOn(global, "getNonEDOModeSteps").mockReturnValue(null);
+            expect(modeWidget._modeStepPattern("dorian", null)).toEqual(
+                global.getModePattern("dorian", 12)
+            );
+            spy.mockRestore();
+        });
+    });
+
+    describe("mode pie menu safety", () => {
+        test("closes when the control-bar button is clicked while open", () => {
+            modeWidget._piemenuModes();
+            expect(modeWidget._modePiemenuOpen).toBe(true);
+            modeWidget._onModePieButtonClick();
+            expect(modeWidget._modePiemenuOpen).toBe(false);
         });
     });
 });

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -377,6 +377,35 @@ describe("ModeWidget", () => {
         expect(mockActivity.logo.synth.trigger).toHaveBeenCalled();
     });
 
+    test("non-EDO labeled temperament plays the octave an octave up", () => {
+        const labels = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        const savedTemperament = global.TEMPERAMENT;
+        const savedSpy = global.pitchToFrequency;
+        global.TEMPERAMENT = {
+            testNonEDO: {
+                isEDO: false,
+                noteLabels: labels,
+                ratios: labels.map((_, i) => Math.pow(2, i / 12))
+            }
+        };
+        modeWidget._activeTemperamentKey = "testNonEDO";
+        modeWidget._activeEDO = labels.length;
+        const spy = jest.spyOn(global, "pitchToFrequency");
+
+        // Within-octave degree stays at octave 4.
+        modeWidget._triggerNote(1, labels.length);
+        expect(spy).toHaveBeenLastCalledWith(labels[1], 4, 0, ["C"], "testNonEDO");
+
+        // The octave note (index === n) wraps to the root label but must
+        // sound an octave higher (octave 5), not the starting note.
+        modeWidget._triggerNote(labels.length, labels.length);
+        expect(spy).toHaveBeenLastCalledWith(labels[0], 5, 0, ["C"], "testNonEDO");
+
+        spy.mockRestore();
+        global.pitchToFrequency = savedSpy;
+        global.TEMPERAMENT = savedTemperament;
+    });
+
     test("should initialize a custom mode with only the root selected", () => {
         modeWidget._resetToCustom();
 

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -99,6 +99,7 @@ const {
     scalePatternToEDO,
     isNonEDO,
     getNonEDOModeSteps,
+    getNonEDOFrequency,
     isEquallyTempered,
     pitchToFrequency
 } = require("../../utils/musicutils.js");
@@ -117,6 +118,7 @@ global.configureExitWheel = jest.fn();
 global.scalePatternToEDO = scalePatternToEDO;
 global.isNonEDO = isNonEDO;
 global.getNonEDOModeSteps = getNonEDOModeSteps;
+global.getNonEDOFrequency = getNonEDOFrequency;
 global.isEquallyTempered = isEquallyTempered;
 global.pitchToFrequency = pitchToFrequency || jest.fn().mockReturnValue(440);
 global.generateNoteNames =

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -943,7 +943,7 @@ describe("MusicKeyboard core logic", () => {
         global.noteToFrequency = jest.fn(name => ({ do4: 261, sol4: 392 })[name] ?? 0);
         global.last = array => array[array.length - 1];
         global.EIGHTHNOTEWIDTH = 24;
-        global.docById = jest.fn(() => ({ getAttribute: () => "0.5" }));
+        global.docById = jest.fn(() => ({ getAttribute: () => "0.5", remove: jest.fn() }));
         global.beginnerMode = "false";
     });
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -19,7 +19,8 @@
    getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
    getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
    configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
-   scalePatternToEDO
+   scalePatternToEDO, isNonEDO, getNonEDOModeSteps, isEquallyTempered,
+   configureExitWheel, piemenuModes
  */
 
 /*
@@ -79,9 +80,9 @@ class ModeWidget {
         // mapped to their pitch count by getCurrentEDO. The widget operates on
         // that count, and changing the tuning below replaces the temperament.
         this._activeEDO = getCurrentEDO(this.logo.synth.inTemperament);
+        this._activeTemperamentKey = this.logo.synth.inTemperament;
         this._selectedModeName = "major";
         this._modePiemenuOpen = false;
-        this._suppressModeSelect = false;
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
         this.widgetWindow.clear();
@@ -100,18 +101,11 @@ class ModeWidget {
         const meterWheelDiv = document.createElement("div");
         meterWheelDiv.id = "modeWidgetWheelDiv";
 
-        // The mode-selection piemenu renders on its own div/paper so it never
-        // shares an SVG with the note-edit wheel (which would block its clicks).
-        const modePiemenuDiv = document.createElement("div");
-        modePiemenuDiv.id = "modePiemenuDiv";
-        modePiemenuDiv.style.display = "none";
-
         const modeTable = document.createElement("table");
         modeTable.id = "modeTable";
 
-        this.modeTableDiv.replaceChildren(meterWheelDiv, modePiemenuDiv, modeTable);
+        this.modeTableDiv.replaceChildren(meterWheelDiv, modeTable);
         this._meterWheelDiv = meterWheelDiv;
-        this._modePiemenuDiv = modePiemenuDiv;
         this.widgetWindow.getWidgetBody().append(this.modeTableDiv);
 
         this.widgetWindow.onclose = () => {
@@ -268,16 +262,31 @@ class ModeWidget {
         ];
 
         const options = builtInTemperaments.map(t => ({
-            value: t.edo,
+            value: t.key,
             label: t.label,
-            temperamentKey: t.key
+            temperamentKey: t.key,
+            edo: t.edo
         }));
+
+        // Add non-EDO temperaments (ratios-based: JI, Pythagorean, meantone variants)
+        for (const key of Object.keys(TEMPERAMENT)) {
+            if (TEMPERAMENT[key].isEDO === false) {
+                const t = TEMPERAMENT[key];
+                options.push({
+                    value: key,
+                    label: t.name || key,
+                    temperamentKey: key,
+                    edo: t.pitchNumber || t.edo || 12
+                });
+            }
+        }
 
         if (!options.some(o => o.temperamentKey === inTemperament)) {
             options.unshift({
-                value: this._activeEDO,
+                value: inTemperament,
                 label: this._activeEDO + "-EDO",
-                temperamentKey: inTemperament
+                temperamentKey: inTemperament,
+                edo: this._activeEDO
             });
         }
 
@@ -285,13 +294,13 @@ class ModeWidget {
     }
 
     _initEdoSelect(select) {
-        const inEDO = this._activeEDO;
         const inTemperament = this.logo.synth.inTemperament;
         for (const o of this._edoOptions()) {
             const opt = document.createElement("option");
-            opt.value = o.value;
+            opt.value = o.temperamentKey;
+            opt.setAttribute("data-edo", o.edo);
             opt.textContent = o.label;
-            if (o.value === inEDO || o.temperamentKey === inTemperament) {
+            if (o.temperamentKey === inTemperament) {
                 opt.selected = true;
             }
             select.appendChild(opt);
@@ -299,40 +308,68 @@ class ModeWidget {
     }
     _wireEdoSelect(select) {
         select.addEventListener("change", () => {
-            const newEDO = parseInt(select.value, 10);
-            if (
-                isNaN(newEDO) ||
-                newEDO < ModeWidget.MIN_EDO ||
-                newEDO > ModeWidget.MAX_EDO ||
-                newEDO === this._activeEDO
-            ) {
+            const key = select.value;
+            if (!key || key === this._activeTemperamentKey) {
+                return;
+            }
+            const newEDO = getCurrentEDO(key);
+            if (isNaN(newEDO) || newEDO < ModeWidget.MIN_EDO || newEDO > ModeWidget.MAX_EDO) {
                 return;
             }
 
-            // Warn (but don't block) before replacing a non-EDO temperament
-            // with the equal-tempered equivalent of the chosen EDO.
-            if (TEMPERAMENT[this.logo.synth.inTemperament]?.isEDO === false) {
+            if (!isEquallyTempered(this._activeTemperamentKey)) {
                 this.textMsg(_("Switching tuning replaces the current non-EDO temperament."), 3000);
             }
 
-            // Close any open mode piemenu; it will be rebuilt on reopen.
             this._closeModePiemenu();
 
-            // Cache outgoing state so round-trip preserves intermediate edits
-            this._cacheState(this._activeEDO);
+            const bothEqual =
+                isEquallyTempered(this._activeTemperamentKey) && isEquallyTempered(key);
+            const oldEDO = getCurrentEDO(this._activeTemperamentKey);
 
-            // Capture old EDO before it gets overwritten by _rebuildWheel
-            const oldEDO = this._activeEDO;
+            if (bothEqual) {
+                this._cacheState(oldEDO);
+            }
 
-            // Determine new notes: use cached state if available, otherwise translate
-            if (this._edoNoteCache[newEDO] !== undefined) {
-                this._restoreState(newEDO);
-            } else {
-                this._translateNotesToEDO(newEDO);
+            this.logo.synth.inTemperament = key;
+            this._activeTemperamentKey = key;
+            this._activeEDO = newEDO;
+
+            if (bothEqual) {
+                if (this._edoNoteCache[newEDO] !== undefined) {
+                    this._restoreState(newEDO);
+                } else {
+                    this._translateNotesToEDO(newEDO);
+                }
             }
 
             this._rebuildWheel(newEDO);
-            this.textMsg(_(`Switched to ${newEDO}-EDO tuning.`), 3000);
+            const tName = TEMPERAMENT[key]?.name || key;
+            this.textMsg(
+                _(
+                    isEquallyTempered(key)
+                        ? `Switched to ${newEDO}-EDO tuning.`
+                        : `Switched to ${tName}.`
+                ),
+                3000
+            );
+
+            // When switching to a non-EDO temperament, reapply the current
+            // mode so notes are correctly selected in the new tuning.
+            // Built-in modes (major, dorian, ...) exist across all temperaments.
+            if (!isEquallyTempered(key)) {
+                const mode = MUSICALMODES[this._selectedModeName];
+                if (mode) {
+                    const pattern = this._modeStepPattern(this._selectedModeName, null);
+                    this._applyModePattern(pattern);
+                } else {
+                    this._selectedModeName = DEFAULTMODE;
+                    const defMode = MUSICALMODES[DEFAULTMODE];
+                    if (defMode) {
+                        this._applyModePattern(this._modeStepPattern(DEFAULTMODE, null));
+                    }
+                }
+            }
 
             // Preserve the current mode name across EDO switches.
             // _setModeName() does a reverse-lookup from the note pattern,
@@ -350,7 +387,7 @@ class ModeWidget {
             // Only warn when going to a lesser EDO, where notes can be dropped
             // by the rounding in _translateNotesToEDO. Lesser→greater only adds
             // steps, so no message is needed.
-            if (oldEDO > newEDO) {
+            if (bothEqual && oldEDO > newEDO) {
                 this.textMsg(
                     _(
                         `Mode remapped from ${oldEDO}-EDO to ${newEDO}-EDO. Some notes may have changed.`
@@ -364,7 +401,13 @@ class ModeWidget {
         this._cancelAnimations();
         this._activeEDO = edoCount;
         this._undoStack = []; // Clear stale undo entries from old EDO
-        this.logo.synth.inTemperament = this._temperamentKeyForEDO(edoCount);
+        // Only map EDO to a built-in temperament key when the active
+        // temperament is equally tempered; non-equal temperaments (just
+        // intonation, meantone, ...) keep their own key even though their
+        // pitch count collides with an equal EDO.
+        if (isEquallyTempered(this._activeTemperamentKey)) {
+            this.logo.synth.inTemperament = this._temperamentKeyForEDO(edoCount);
+        }
         this._piemenuMode();
     }
 
@@ -588,7 +631,7 @@ class ModeWidget {
 
         // Modes: open piemenu instead of a <select> dropdown
         const modeBtn = iconButton("pie-chart.svg", _("Switch mode"), () => {
-            this._piemenuModes();
+            this._onModePieButtonClick();
         });
         modeBtn.id = "modeSelectBtn";
 
@@ -673,11 +716,9 @@ class ModeWidget {
         widgetBody.children[0].style.flexDirection = "column";
         widgetBody.children[0].style.alignItems = "center";
 
-        // When the mode piemenu is open, scale its SVG; otherwise scale
-        // the note-wheel SVG.  getElementsByTagName("svg")[0] always
-        // returns the meterWheelDiv SVG (first in DOM order) even when
-        // the mode piemenu is the visible one.
-        const svgContainer = this._modePiemenuOpen ? this._modePiemenuDiv : this._meterWheelDiv;
+        // When the mode piemenu is open, scale the global wheelDiv SVG;
+        // otherwise scale the note-wheel SVG.
+        const svgContainer = this._modePiemenuOpen ? docById("wheelDiv") : this._meterWheelDiv;
         const svg = svgContainer.querySelector("svg");
         if (!svg) {
             return;
@@ -688,6 +729,30 @@ class ModeWidget {
         this._setTimeout(() => {
             svg.style.pointerEvents = "auto";
         }, 100);
+    }
+
+    // ── Mode step resolver (Task 4) ───────────────────────────────
+
+    /**
+     * Single source of truth for wheel geometry: which integer step pattern
+     * represents `modeName` on this widget right now. Custom modes win
+     * (as-authored), then ratio-derived steps under a non-EDO temperament,
+     * then the standard EDO-rescaled pattern.
+     * @param {String} modeName - mode name in MUSICALMODES
+     * @param {Array} nativePattern - as-authored pattern for saved custom modes
+     * @returns {Array} integer step counts
+     */
+    _modeStepPattern(modeName, nativePattern) {
+        if (Array.isArray(nativePattern)) {
+            return nativePattern;
+        }
+        if (isNonEDO(this._activeTemperamentKey)) {
+            const steps = getNonEDOModeSteps(modeName, this._activeTemperamentKey);
+            if (steps) {
+                return steps;
+            }
+        }
+        return getModePattern(modeName, this._activeEDO);
     }
 
     // ── Mode display ──────────────────────────────────────────────
@@ -708,7 +773,7 @@ class ModeWidget {
             this._loadMode(currentModeName[1], currentMode, null);
         } else {
             this._applyModePattern(
-                nativeEDO ? currentMode : getModePattern(currentModeName[1], this._activeEDO)
+                nativeEDO ? currentMode : this._modeStepPattern(currentModeName[1], null)
             );
             this._setModeName();
         }
@@ -742,9 +807,11 @@ class ModeWidget {
                 3000
             );
         }
-        // Built-in mode patterns are 12-EDO intervals; scale them to the
-        // active EDO. Custom modes carry EDO-specific patterns already.
-        const pattern = nativeEDO ? mode : getModePattern(modeName, this._activeEDO);
+        // Built-in mode patterns are resolved via _modeStepPattern so
+        // non-EDO temperaments use ratio-derived steps. Custom modes carry
+        // EDO-specific patterns already, so use the passed mode directly.
+        const isCustom = !MUSICALMODES[modeName];
+        const pattern = isCustom ? mode : nativeEDO ? mode : this._modeStepPattern(modeName, null);
         this._applyModePattern(pattern);
         // Cache the incoming state so switching away and back preserves it.
         if (nativeEDO) {
@@ -989,6 +1056,26 @@ class ModeWidget {
 
     _triggerNote(note, edo) {
         const ks = this.turtles.ithTurtle(0).singer.keySignature;
+        const t = TEMPERAMENT[this._activeTemperamentKey];
+        const labels =
+            t && Array.isArray(t.noteLabels) && !isEquallyTempered(this._activeTemperamentKey)
+                ? t.noteLabels
+                : null;
+
+        if (labels && labels[note % labels.length]) {
+            // Non-EDO temperament: resolve the exact ratio by asking for the
+            // labeled pitch at zero cents.
+            const freq = pitchToFrequency(
+                labels[note % labels.length],
+                4,
+                0,
+                ks,
+                this._activeTemperamentKey
+            );
+            this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
+            return;
+        }
+
         if (edo === 12) {
             const noteToPlay = getNote(this._pitch, 4, note, ks, false, null, this.errorMsg);
             this.logo.synth.trigger(
@@ -1000,11 +1087,10 @@ class ModeWidget {
                 null
             );
         } else {
-            // note is a slice index = number of EDO steps above the root.
             const freq = pitchToFrequency(
                 this._pitch,
                 4,
-                note * 100,
+                Math.round(note * (1200 / edo)),
                 ks,
                 this._temperamentKeyForEDO(edo)
             );
@@ -1089,7 +1175,7 @@ class ModeWidget {
                 if (customNames.has(mode)) {
                     continue;
                 }
-                const pattern = getModePattern(mode, this._activeEDO);
+                const pattern = this._modeStepPattern(mode, null);
                 if (JSON.stringify(pattern) === currentMode) {
                     matchedMode = mode;
                     break;
@@ -1429,194 +1515,121 @@ class ModeWidget {
         }
     }
 
+    _onModePieButtonClick() {
+        if (this._modePiemenuOpen) {
+            this._closeModePiemenu();
+            return;
+        }
+        this._piemenuModes();
+    }
+
     /**
-     * Builds a piemenu for mode selection with an outer ring of mode groups
-     * and an inner ring of mode names. Custom saved modes appear in the
-     * "custom" group. Reuses patterns from piemenuModes in piemenus.js.
+     * Opens the standard mode piemenu (same as the modeName block piemenu)
+     * via piemenus.js piemenuModes on the global wheelDiv. The intercept
+     * on block.__selectionChanged applies the selected mode to the scalar
+     * builder via _loadMode.
      * @returns {void}
      */
     _piemenuModes() {
         if (this._modePiemenuOpen) return;
         this._modePiemenuOpen = true;
 
-        const savedCustomModes = getSavedCustomModes();
-
-        // Swap the note-edit wheel for the mode-selection piemenu. The piemenu
-        // renders on its own div/paper, so the two never overlap or intercept
-        // each other's clicks. The root constructor clears any stale SVGs.
+        // Hide the note wheel while the mode piemenu is visible.
         this._meterWheelDiv.style.display = "none";
-        this._modePiemenuDiv.style.display = "";
 
-        this._modePieWheel = new wheelnav(
-            "modePiemenuDiv",
-            null,
-            ModeWidget.WHEELSIZE,
-            ModeWidget.WHEELSIZE
-        );
-        this._modeNameWheel = null; // Built on first group selection.
+        const widget = this;
+        const mockBlock = {
+            value: this._selectedModeName,
+            text: { text: "" },
+            container: {
+                x: 200,
+                y: 200,
+                setChildIndex: () => {},
+                children: { length: 1 }
+            },
+            updateCache: () => {},
+            blocks: {
+                stageClick: false,
+                blockScale: 1,
+                turtles: this.turtles,
+                blockList: {}
+            },
+            activity: this.activity,
+            connections: [null]
+        };
+        this._mockBlock = mockBlock;
 
-        // All groups appear, including "custom": it always offers "+" to
-        // create a new custom mode, even when none are saved yet.
-        const groupLabels = Object.keys(MODE_PIE_MENUS);
+        // Delegate to the standard piemenuModes.
+        piemenuModes(mockBlock, this._selectedModeName);
 
-        // Outer ring: group wheel
-        this._modeGroupWheel = new wheelnav("_modeGroupWheel", this._modePieWheel.raphael);
-        // Fixed readable size on the 400px paper; the wheelnav default (48px)
-        // overflows every slice and a computed size is too small.
-        configureWheel(this._modeGroupWheel, {
-            colors: platformColor.modeGroupWheelcolors,
-            minRadius: MODEPIEMENU_GROUP_RING.minRadius,
-            maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
-            titleFont: getModeGroupTitleFont(ModeWidget.WHEELSIZE / 2)
-        });
-        this._modeGroupWheel.createWheel(groupLabels);
-
-        // Inner ring: mode-name wheel (rebuilt on group selection). Reopen on
-        // the group the user last visited.
-        let currentGroup = groupLabels.includes(this._modeGroupName)
-            ? this._modeGroupName
-            : groupLabels[0];
-
-        const __modesForGroup = grp =>
-            getModeNamesForGroup(grp, ["+", ...savedCustomModes.map(m => m.name)]);
-
-        const __buildModeNameWheel = grp => {
-            currentGroup = grp;
-            this._modeGroupName = grp;
-            const modes = __modesForGroup(grp);
-
-            // All groups share the fixed 12-slot layout, so the wheel is created
-            // once per open and updated in place on group switches. Never call
-            // removeWheel() on it: every wheel shares the root's paper, and
-            // removeWheel() detaches the whole SVG from the DOM.
-            const newWheel = this._modeNameWheel === null;
-
-            // Build per-slice colors and (possibly translated) labels.
-            // Declared before the configureWheel call below so the
-            // reference in the options object is not in the temporal dead zone.
-            const colors = getModeSliceColors(modes, {
-                emptyColor: platformColor.modePieMenusIfColorPush,
-                filledColor: platformColor.modePieMenusElseColorPush
-            });
-            const labels = modes.map(modename => getModeLabel(modename));
-
-            if (newWheel) {
-                this._modeNameWheel = new wheelnav("_modeNameWheel", this._modePieWheel.raphael);
-                this._modeNameWheel.keynavigateEnabled = false;
-                configureWheel(this._modeNameWheel, {
-                    colors,
-                    minRadius: MODEPIEMENU_NAME_RING.minRadius,
-                    maxRadius: MODEPIEMENU_NAME_RING.maxRadius,
-                    selectionPaths: true,
-                    titleRotateAngle: 0
-                });
+        // piemenuModes wires block.__selectionChanged; override it AFTER
+        // so our intercept runs on mode selection. The original updates
+        // block.value/text, which we then read to apply the mode.
+        const __origSelectionChanged = mockBlock.__selectionChanged;
+        mockBlock.__selectionChanged = () => {
+            if (typeof __origSelectionChanged === "function") {
+                __origSelectionChanged();
             }
-
-            if (newWheel) {
-                this._modeNameWheel.createWheel(labels);
-            } else {
-                updateModeWheelItems(this._modeNameWheel, labels, colors);
+            const modeName = mockBlock.value;
+            if (modeName) {
+                widget._selectedModeName = modeName;
+                // Built-in modes are in MUSICALMODES; custom modes carry
+                // their own EDO-specific pattern in localStorage.
+                const mode = MUSICALMODES[modeName];
+                const custom = getSavedCustomModes().find(m => m.name === modeName);
+                const pattern = mode || (custom && custom.pattern);
+                if (pattern) {
+                    widget._closeModePiemenu();
+                    widget._loadMode(modeName, pattern, widget._edoSelect);
+                }
             }
-
-            // Size each label to fit its own slice arc; the 12 slots are fixed,
-            // so short names render large and only long ones shrink. Applied
-            // post-createWheel via the per-item title attributes.
-            for (let i = 0; i < this._modeNameWheel.navItems.length; i++) {
-                const font = getModeSliceFont(
-                    ModeWidget.WHEELSIZE / 2,
-                    modes.length,
-                    labels[i].length
-                );
-                const item = this._modeNameWheel.navItems[i];
-                item.titleAttr.font = font;
-                item.titleHoverAttr.font = font;
-                item.titleSelectedAttr.font = font;
-            }
-
-            // Set up action for each mode slice
-            for (let i = 0; i < modes.length; i++) {
-                this._modeNameWheel.navItems[i].navigateFunction = () => {
-                    const title =
-                        this._modeNameWheel.navItems[this._modeNameWheel.selectedNavItemIndex]
-                            .title;
-                    if (title === " ") return;
-
-                    // Suppress programmatic navigation: wheelnav fires
-                    // navigateFunction() on every navigateWheel() call, including
-                    // the init highlight and group switches below. Those must only
-                    // highlight, never select/close. Real user clicks are unaffected.
-                    if (this._suppressModeSelect) {
-                        return;
-                    }
-
-                    // "+" is the create-new-mode sentinel (slice 0 of the
-                    // custom group): close the piemenu and blank the note wheel
-                    // so the user can define a fresh mode by clicking notes.
-                    if (currentGroup === "custom" && title === _("+")) {
-                        this._selectedModeName = DEFAULTMODE;
-                        this._closeModePiemenu();
-                        this._resetToCustom();
-                        return;
-                    }
-
-                    // Strip translation wrapper for major/minor
-                    const modeName = getModeNameFromLabel(title, __modesForGroup(currentGroup));
-
-                    this._selectedModeName = modeName;
-                    const mode = MUSICALMODES[modeName];
-                    if (mode) {
-                        // Close piemenu FIRST so the note wheel is visible for any wheel
-                        // rebuild triggered by _loadMode() → _rebuildWheel() → _piemenuMode()
-                        this._closeModePiemenu();
-
-                        this._loadMode(modeName, mode, this._edoSelect);
-                    }
-                };
-            }
-
-            // Navigate to currently-selected mode if present. This fires the
-            // slice's navigateFunction (which would select+close), so suppress
-            // it: this call is only meant to highlight the current mode.
-            const idx = modes.indexOf(this._selectedModeName);
-            this._suppressModeSelect = true;
-            this._modeNameWheel.navigateWheel(idx);
-            this._suppressModeSelect = false;
         };
 
-        // Wire group wheel slices → __buildModeNameWheel
-        for (let i = 0; i < this._modeGroupWheel.navItems.length; i++) {
-            this._modeGroupWheel.navItems[i].navigateFunction = () => {
-                const selectedGroup =
-                    this._modeGroupWheel.navItems[this._modeGroupWheel.selectedNavItemIndex].title;
-                __buildModeNameWheel(selectedGroup);
-            };
+        // Position wheelDiv over the ModeWidget.
+        const wheelDiv = docById("wheelDiv");
+        if (wheelDiv && this.widgetWindow && this.widgetWindow._frame) {
+            const wRect = this.widgetWindow._frame.getBoundingClientRect();
+            const pieRadius = 600;
+            wheelDiv.style.left =
+                Math.max(0, Math.round(wRect.left + wRect.width / 2 - pieRadius)) + "px";
+            wheelDiv.style.top =
+                Math.max(0, Math.round(wRect.top + wRect.height / 2 - pieRadius)) + "px";
         }
 
-        // Highlight the last-visited group and build its mode wheel; the group
-        // navigateFunction above triggers the name-wheel build.
-        this._modeGroupWheel.navigateWheel(groupLabels.indexOf(currentGroup));
+        // Override × exit to also restore the note wheel.
+        if (mockBlock._exitWheel && mockBlock._exitWheel.navItems[0]) {
+            const origExit = mockBlock._exitWheel.navItems[0].navigateFunction;
+            mockBlock._exitWheel.navItems[0].navigateFunction = () => {
+                if (origExit) origExit();
+                widget._meterWheelDiv.style.display = "";
+                widget._modePiemenuOpen = false;
+                widget._mockBlock = null;
+            };
+        }
     }
 
     /**
      * Closes the mode piemenu and restores the note-edit wheel.
-     * Properly destroys wheelnav instances so their SVGs leave the DOM.
      * @returns {void}
      */
     _closeModePiemenu() {
-        this._modePiemenuDiv.style.display = "none";
-        this._meterWheelDiv.style.display = "";
-
-        // All three wheels share the root's paper, so removing the root
-        // removes the whole SVG, including the child wheels.
-        if (this._modePieWheel) {
-            this._modePieWheel.removeWheel();
+        if (this._mockBlock) {
+            if (this._mockBlock._modeNameWheel) {
+                this._mockBlock._modeNameWheel.removeWheel();
+            }
+            if (this._mockBlock._modeWheel) {
+                this._mockBlock._modeWheel.removeWheel();
+            }
         }
 
-        this._modePieWheel = null;
-        this._modeGroupWheel = null;
-        this._modeNameWheel = null;
+        const wheelDiv = docById("wheelDiv");
+        if (wheelDiv) {
+            wheelDiv.style.display = "none";
+        }
+
+        this._meterWheelDiv.style.display = "";
         this._modePiemenuOpen = false;
-        this._suppressModeSelect = false;
+        this._mockBlock = null;
     }
 }
 

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1064,14 +1064,12 @@ class ModeWidget {
 
         if (labels && labels[note % labels.length]) {
             // Non-EDO temperament: resolve the exact ratio by asking for the
-            // labeled pitch at zero cents.
-            const freq = pitchToFrequency(
-                labels[note % labels.length],
-                4,
-                0,
-                ks,
-                this._activeTemperamentKey
-            );
+            // labeled pitch. The octave note wraps to the root label, so bump
+            // the octave by how many times we've crossed the label count.
+            // ponytail: assumes labels.length === _activeEDO (pitch count).
+            const idx = note % labels.length;
+            const octave = 4 + Math.floor(note / labels.length);
+            const freq = pitchToFrequency(labels[idx], octave, 0, ks, this._activeTemperamentKey);
             this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
             return;
         }

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -1087,12 +1087,16 @@ class ModeWidget {
                 null
             );
         } else {
+            // Use the active temperament directly: _temperamentKeyForEDO maps a
+            // non-EDO pitch count to an EQUAL temperament (19 -> equal19), which
+            // would play the wrong tuning. ponytail: _activeTemperamentKey always
+            // holds the real temperament (equal or ratio-based).
             const freq = pitchToFrequency(
                 this._pitch,
                 4,
                 Math.round(note * (1200 / edo)),
                 ks,
-                this._temperamentKeyForEDO(edo)
+                this._activeTemperamentKey
             );
             this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
         }
@@ -1292,13 +1296,7 @@ class ModeWidget {
             // Movable-do solfege relative to the key signature (matches playback).
             return [NOTESTABLE[(j + 1) % 12], 4];
         }
-        const [name, octave] = numberToPitch(
-            j,
-            this._temperamentKeyForEDO(this._activeEDO),
-            "A",
-            0,
-            this.activity
-        );
+        const [name, octave] = numberToPitch(j, this._activeTemperamentKey, "A", 0, this.activity);
         // numberToPitch can return [undefined, NaN] when the temperament's
         // per-note data is incomplete (e.g. the built-in "custom" entry or a
         // saved custom temperament without octave digits). Fall back to the

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -16,11 +16,10 @@
    getNote, DEFAULTVOICE, last, NOTESTABLE, wheelnav,
    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
    numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
-   getSavedCustomModes, getModeNamesForGroup, getModeLabel, getModeNameFromLabel,
+   getSavedCustomModes, getModeNamesForGroup, getModeLabel,
    getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
    configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
-   scalePatternToEDO, isNonEDO, getNonEDOModeSteps, isEquallyTempered,
-   configureExitWheel, piemenuModes
+    scalePatternToEDO, isNonEDO, getNonEDOModeSteps, getNonEDOFrequency, isEquallyTempered, piemenuModes
  */
 
 /*
@@ -1056,21 +1055,10 @@ class ModeWidget {
 
     _triggerNote(note, edo) {
         const ks = this.turtles.ithTurtle(0).singer.keySignature;
-        const t = TEMPERAMENT[this._activeTemperamentKey];
-        const labels =
-            t && Array.isArray(t.noteLabels) && !isEquallyTempered(this._activeTemperamentKey)
-                ? t.noteLabels
-                : null;
 
-        if (labels && labels[note % labels.length]) {
-            // Non-EDO temperament: resolve the exact ratio by asking for the
-            // labeled pitch. The octave note wraps to the root label, so bump
-            // the octave by how many times we've crossed the label count.
-            // ponytail: assumes labels.length === _activeEDO (pitch count).
-            const idx = note % labels.length;
-            const octave = 4 + Math.floor(note / labels.length);
-            const freq = pitchToFrequency(labels[idx], octave, 0, ks, this._activeTemperamentKey);
-            this.logo.synth.trigger(0, freq, this._noteValue, DEFAULTVOICE, null, null);
+        const result = getNonEDOFrequency(note, 4, this._activeTemperamentKey, ks);
+        if (result) {
+            this.logo.synth.trigger(0, result.freq, this._noteValue, DEFAULTVOICE, null, null);
             return;
         }
 


### PR DESCRIPTION
This PR cleans up a bunch of things across the temperament system:
Scalar steps now follow mode degrees for custom EDOs (turtle-singer.js, musicutils.js)

_getStepSize no longer bails out early for custom temperaments without ratio data – it falls through to buildScale for scale‑degree lookup. So scalar step +1 now moves one mode degree, not one semitone. addScalarTransposition now sets useEdoSteps = true for custom EDO temperaments (either isEquallyTempered or custom without ratios), sending them through the right per‑degree loop.

Key pie menu mode list is unified (piemenus.js)

The piemenuKey modename wheel now pulls from every MODE_PIE_MENUS group plus saved custom modes (pentatonic, blues, chromatic, etc.) – no more hardcoded 7 church modes. Also extracted syncKeySignatureBlocks(activity) from __generateSetKeyBlocks to create or update a setkey2 block from activity.KeySignatureEnv.

Non‑EDO temperament hardening (musicutils.js, synthutils.js)

Rewrote isEquallyTempered with caching and proper detection – checks isEDO flag, then ratios, then verifies numeric pitch entries within 1e-9. Added isNonEDO helper, and getModePattern can now take an optional temperament arg to return cents‑based intervals for non‑EDO scales. Also exposed clearTemperamentCaches() and call it on custom‑mode load.
Storage wrapping for restricted contexts (activity.js)

Added _storeGet / _storeSet wrappers that handle both localStorage and a plain‑object fallback for private/restricted contexts.
Mode widget + pie menu improvements (modewidget.js, piemenus.js, WidgetBlocks.js)
Lazy‑load now passes a resetFlag completion callback, and logo.modeWidget = "loading" prevents double‑load. updateModeWheelItems repaints navTitle text on group switch (fixes the blank outer ring). piemenuModes now falls back to the first available group if the mode is unknown. Also removed dead code from piemenuNthModalPitch.
Case‑insensitive mode matching (IntervalsActions.js)
setKey mode lookup now lowercases both sides of the comparison.

Test cleanup
- Cut 83 trivial init tests from turtle-singer.test.js (127 → 44).
- Removed 6 duplicate tests from musicutils.test.js and 1 duplicate from WidgetBlocks.test.js.
- Updated 11 tests that were checking old broken behavior (raw‑transposition returns, _getStepSize shortcuts, deltaPitch hang‑at‑100) – they now assert the corrected mode‑following behavior.
- Added one integration test confirming addScalarTransposition follows mode degrees for custom EDO temperaments.
- Also added tests for TimbreBlock, SamplerBlock, AIDebuggerBlock, lazy‑load first‑click flow, and guard checks.

PartOf: #7171 

PR Category
 
- [x] Feature
- [x] Bug Fix