### PR TITLE
fix: avoid closure scope leaks in MeterActions queue listeners

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -996,6 +996,20 @@ describe("Logo doStopTurtles", () => {
         expect(clearAllSpy).toHaveBeenCalled();
     });
 
+    test("removes active turtle listeners from stage and clears listeners object on stop", () => {
+        const mockListener = jest.fn();
+        turtle.listeners = { __beat_1_0__: mockListener };
+
+        logo.doStopTurtles();
+
+        expect(mockActivity.stage.removeEventListener).toHaveBeenCalledWith(
+            "__beat_1_0__",
+            mockListener,
+            false
+        );
+        expect(turtle.listeners).toEqual({});
+    });
+
     describe("with Transport and audio streams", () => {
         let turtle0;
         let turtle1;

--- a/js/logo.js
+++ b/js/logo.js
@@ -731,6 +731,22 @@ class Logo {
     }
 
     /**
+     * Removes active event listeners from all turtles and clears listener objects.
+     *
+     * @returns {void}
+     */
+    clearTurtleListeners() {
+        for (const turtle of this.turtles.turtleList) {
+            if (turtle && turtle.listeners) {
+                for (const listener in turtle.listeners) {
+                    this.stage.removeEventListener(listener, turtle.listeners[listener], false);
+                }
+                turtle.listeners = {};
+            }
+        }
+    }
+
+    /**
      * Sets a listener to the triggering (dispatch) block (usually the hidden block) for a clamp block.
      *
      * @param blk
@@ -1240,6 +1256,8 @@ class Logo {
         this.synth.disposeAllInstruments();
         this._synthsInitialized = false;
 
+        this.clearTurtleListeners();
+
         // eslint-disable-next-line eqeqeq
         if (this.cameraID != null) {
             this.deps.utils.doStopVideoCam(this.cameraID, this.setCameraID);
@@ -1263,6 +1281,9 @@ class Logo {
                 "ManagedTimer: cancelled " + cancelledTimers + " pending timer(s) on stop"
             );
         }
+
+        // Remove active stage listeners and clear listener objects across all turtles.
+        this.clearTurtleListeners();
 
         // Prevent stale timeout from firing cleanup on next run.
         this._lastNoteTimeout = null;
@@ -1504,13 +1525,7 @@ class Logo {
         this._meterBlock = null;
 
         // Remove any listeners that might be still active.
-        for (const turtle of this.turtles.turtleList) {
-            for (const listener in turtle.listeners) {
-                this.stage.removeEventListener(listener, turtle.listeners[listener], false);
-            }
-
-            turtle.listeners = {};
-        }
+        this.clearTurtleListeners();
 
         // Init the graphic state.
         for (const turtle in this.turtles.turtleList) {

--- a/js/turtleactions/__tests__/MeterActions.test.js
+++ b/js/turtleactions/__tests__/MeterActions.test.js
@@ -760,4 +760,22 @@ describe("setupMeterActions", () => {
             expect.any(Function)
         );
     });
+
+    it("should register onStrongBeatDo listener via setTurtleListener and allow stage unbinding", () => {
+        targetTurtle.id = 0;
+        targetTurtle.listeners = {};
+        activity.logo.setTurtleListener = jest.fn((turtle, name, fn) => {
+            targetTurtle.listeners[name] = fn;
+        });
+
+        Singer.MeterActions.onStrongBeatDo(1, "testAction", false, null, 0, 1);
+
+        const eventName = "__beat_1_0__";
+        expect(activity.logo.setTurtleListener).toHaveBeenCalledWith(
+            0,
+            eventName,
+            expect.any(Function)
+        );
+        expect(targetTurtle.listeners[eventName]).toEqual(expect.any(Function));
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->

Meter blocks add event listeners to the stage while playing. The issue was that these listeners were not removed when playback stopped or when the Stop button was clicked which leaves stage listeners that retained old block and turtle references in memory.

This PR introduces a reusable clearTurtleListeners() helper method in logo.js and applies it across the execution lifecycle (doStopTurtles(), stop() and start()).


#### How to Reproduce bug
1. Create a stack using a Meter block such as meter
2. Start the project
3. Click Stop
4. Run this in the browser console:
 ```js 
globalActivity.turtles.ithTurtle(0).listeners
```
---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->

- Added clearTurtleListeners() helper method to logo.js to unbind turtle event listeners from this.stage and reset turtle.listeners
- Called clearTurtleListeners() in logo.js:
  - doStopTurtles(): Cleans up active stage listeners when the user clicks the Stop button (fixes the memory leak).
  - _cleanupAfterCompletion(): Detaches listeners when execution finishes playing naturally (achieves this by calling stop())
  - start(): Refactored existing inline listener cleanup loop to use clearTurtleListeners() prior to starting a new execution
- Added unit tests in logo.test.js and MeterActions.test.js to verify listener cleanup on stop and stage unbinding behavior

---

## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->

Tested locally in Chrome by playing a Meter block stack and checking the turtle listeners before and after clicking stop.

Before the fix, listeners remained after stopping
<img width="435" height="113" alt="image" src="https://github.com/user-attachments/assets/fb475e78-fae5-4a3c-a8f0-264f27c88a20" />

After the fix the listener object returns {}
<img width="440" height="75" alt="image" src="https://github.com/user-attachments/assets/03819d15-5019-487f-a4c4-a735e0962990" />

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
