### PR TITLE
test(logo): add ornament and dict dispatch integration tests

### DIFF
--- a/js/__tests__/dict-value-dispatch-integration.test.js
+++ b/js/__tests__/dict-value-dispatch-integration.test.js
@@ -1,0 +1,238 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration test for the Logo interpreter's argument-evaluation/dispatch path
+ * (`runFromBlockNow`/`parseArg`, js/logo.js) driving the real `Turtle.DictActions.setValue` and
+ * `Turtle.DictActions.getValue` (js/turtleactions/DictActions.js) - extending the pattern
+ * `meter-signature-dispatch-integration.test.js` (synchronous, non-clamp write dispatch) uses.
+ *
+ * Scope: this covers the Logo-dispatch <-> DictActions seam, not SetDictBlock's/GetDictBlock's own
+ * palette registration or their null-arg validation (already covered, with setValue/getValue
+ * mocked, by js/blocks/__tests__/DictBlocks.test.js). `Logo.runFromBlockNow`, `Logo.parseArg`,
+ * `setValue`, and `getValue` run for real and unmocked - the "setdict"/"getdict" blocks below are
+ * minimal stand-ins shaped like the real blocks (js/blocks/DictBlocks.js, SetDictBlock.flow and
+ * GetDictBlock.arg), not obtained from live registered protoblocks, for the same reason given in
+ * interval-scalar-dispatch-integration.test.js: the concrete FlowBlock/LeftBlock classes they
+ * extend (js/protoblocks.js) only exist as bare globals in the production script-concatenation
+ * build, so reaching them from Jest would mean either evaluating protoblocks.js's source at
+ * runtime or driving the full canvas/DOM-heavy Blocks.makeBlock/Block path (js/blocks.js,
+ * js/block.js), both disproportionate to this one behavior. Consequently, a regression in
+ * SetDictBlock.flow/GetDictBlock.arg themselves would not fail this test; a regression in
+ * setValue/getValue or in the Logo dispatch/argument-evaluation machinery around them would
+ * (verified by deliberately breaking each and confirming the test fails).
+ *
+ * Unlike OrnamentActions' doNeighbor, DictActions has no clamp: setValue is a synchronous flow-
+ * block write (dispatched the same way MeterActions.setMeter is), and getValue is dispatched
+ * through a *different* Logo seam entirely - `parseArg` calling an arg-block's own `.arg()` method
+ * (js/logo.js) rather than a flow block's `.flow()`. This test drives both seams in one real
+ * two-block program: a "setdict" flow block writes a value via the real Logo dispatch, then a
+ * "probe" flow block chained after it resolves a "getdict" arg block via the real `logo.parseArg`
+ * - proving the write and the read reach the same real `activity.logo.turtleDicts` state through
+ * two independently real Logo pathways, not just that each method works in isolation (already
+ * shown by js/turtleactions/__tests__/DictActions.test.js).
+ */
+
+// Setup global mocks BEFORE requiring the module (mirror of
+// meter-signature-dispatch-integration.test.js).
+global._ = str => str;
+global.Notation = jest.fn().mockImplementation(() => ({}));
+global.Synth = jest.fn().mockImplementation(() => ({}));
+global.Singer = {};
+global.Turtle = {};
+global.last = arr => arr[arr.length - 1];
+
+jest.mock("tone", () => ({
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+}));
+
+global.EmbeddedGraphicsScheduler =
+    require("../embedded-graphics-scheduler").EmbeddedGraphicsScheduler;
+
+const logoconstants = require("../logoconstants");
+Object.assign(global, logoconstants);
+
+const { Logo } = require("../logo");
+
+// Turtle.DictActions is attached to the module-level `Turtle` mock above, exactly as production
+// code does via `Turtle.DictActions = class {...}` (js/turtleactions/DictActions.js). No
+// production code is mocked: setValue and getValue run for real.
+const setupDictActions = require("../turtleactions/DictActions");
+
+function createTurtle() {
+    return {
+        singer: {
+            inNoteBlock: [],
+            inDuplicate: false,
+            backward: [],
+            suppressOutput: true,
+            justCounting: []
+        },
+        painter: { closeSVG: jest.fn() },
+        queue: [],
+        parentFlowQueue: [],
+        listeners: {},
+        endOfClampSignals: {}
+    };
+}
+
+function createActivity(turtle) {
+    return {
+        blocks: {
+            blockList: [],
+            sameGeneration: jest.fn(() => false)
+        },
+        turtles: {
+            turtleList: [turtle],
+            ithTurtle: jest.fn(() => turtle),
+            getTurtle: jest.fn(() => turtle),
+            running: jest.fn(() => false)
+        },
+        stage: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(name => {
+                if (typeof name === "string" && turtle.listeners[name]) {
+                    turtle.listeners[name]();
+                }
+            })
+        },
+        onStopTurtle: jest.fn(),
+        logo: null
+    };
+}
+
+function makeFlowBlock(name, connections, flow, dockTypes, args) {
+    return {
+        name,
+        connections,
+        protoblock: {
+            args: args || 0,
+            dockTypes: dockTypes || [null],
+            flow: flow || (() => null)
+        },
+        isValueBlock: () => false,
+        isArgBlock: () => false
+    };
+}
+
+describe("Logo dispatch drives the real Turtle.DictActions.setValue/getValue", () => {
+    let logo;
+    let turtle;
+    let activity;
+    let readBackValue;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.document.body.style.cursor = "default";
+        turtle = createTurtle();
+        activity = createActivity(turtle);
+        logo = new Logo(activity);
+        activity.logo = logo;
+        logo.turtleDicts = {};
+
+        setupDictActions(activity);
+
+        // setdict (0): connections [prev, nameArg, keyArg, valueArg, next] - the shape produced
+        // when the "set value" block is dragged from the Dictionary palette (see SetDictBlock's
+        // own formBlock, js/blocks/DictBlocks.js).
+        // name (1):  string "myDict"
+        // key (2):   string "color"
+        // value (3): string "green"
+        // probe (4): reads the dictionary back via a real "getdict" arg block - see below.
+        // getdict (5): arg block shaped like GetDictBlock.arg (js/blocks/DictBlocks.js), reusing
+        // name (1) and key (2) as its own two connected arguments.
+        const setdict = makeFlowBlock(
+            "setdict",
+            [null, 1, 2, 3, 4],
+            (args, l, t) => {
+                // Minimal glue, not a copy of SetDictBlock.flow(): hand Logo's evaluated
+                // name/key/value args straight to the real setValue.
+                Turtle.DictActions.setValue(args[0], args[1], args[2], t);
+                return null;
+            },
+            [null, "anyin", "anyin", "anyin"],
+            3
+        );
+        const name = {
+            name: "string",
+            value: "myDict",
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["anyout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+        const key = {
+            name: "string",
+            value: "color",
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["anyout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+        const value = {
+            name: "string",
+            value: "green",
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["anyout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+        const probe = makeFlowBlock("probe", [0, null], (args, l, t, blk) => {
+            // Resolves the "getdict" arg block via the real logo.parseArg, the same seam Logo
+            // uses whenever a "get value" block is connected as another block's argument.
+            readBackValue = l.parseArg(l, t, 5, blk);
+            return null;
+        });
+        const getdict = {
+            name: "getDict",
+            connections: [null, 1, 2],
+            protoblock: {
+                // Minimal glue, not a copy of GetDictBlock.arg(): reads its own two connections
+                // and hands the resolved name/key straight to the real getValue.
+                arg: (l, t, blk, receivedArg) => {
+                    const cblk1 = activity.blocks.blockList[blk].connections[1];
+                    const cblk2 = activity.blocks.blockList[blk].connections[2];
+                    const a = l.parseArg(l, t, cblk1, blk, receivedArg);
+                    const k = l.parseArg(l, t, cblk2, blk, receivedArg);
+                    return Turtle.DictActions.getValue(a, k, t, blk);
+                }
+            },
+            isValueBlock: () => false,
+            isArgBlock: () => true
+        };
+
+        const blocks = [setdict, name, key, value, probe, getdict];
+        logo.blockList = blocks;
+        activity.blocks.blockList = blocks;
+    });
+
+    test("a real set-value dispatch and a real get-value dispatch observe the same turtleDicts state", () => {
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+
+        // The real setValue wrote directly into activity.logo.turtleDicts.
+        expect(logo.turtleDicts[0].myDict.color).toBe("green");
+
+        // The real getValue, reached through a completely different Logo seam (parseArg -> the
+        // arg block's own .arg(), not .flow()), read back the same value.
+        expect(readBackValue).toBe("green");
+    });
+});

--- a/js/__tests__/ornament-neighbor-dispatch-integration.test.js
+++ b/js/__tests__/ornament-neighbor-dispatch-integration.test.js
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * MusicBlocks
+ * Copyright (C) 2026 Music Blocks Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration test for the Logo interpreter's end-of-clamp dispatch mechanism
+ * (`setDispatchBlock`/`setTurtleListener`/`tur.endOfClampSignals`, js/logo.js) driving the real
+ * `Singer.OrnamentActions.doNeighbor` (js/turtleactions/OrnamentActions.js) - extending the
+ * pattern `noteclamp-beat-doublequeue.test.js` (drum dispatch) and
+ * `interval-scalar-dispatch-integration.test.js` (interval dispatch) already use.
+ *
+ * Scope: this covers the Logo-dispatch <-> OrnamentActions seam, not NeighborBlock's own palette
+ * registration or its args[0]/args[1] NaN validation (already covered, with doNeighbor mocked, by
+ * js/blocks/__tests__/OrnamentBlocks.test.js). `Logo.runFromBlockNow` and `doNeighbor` run for
+ * real and unmocked - the "neighbor" block below is a minimal stand-in shaped like the real block
+ * (js/blocks/OrnamentBlocks.js, NeighborBlock.flow), not obtained from a live registered
+ * protoblock, for the same reason given in interval-scalar-dispatch-integration.test.js: the
+ * concrete FlowClampBlock class it extends (js/protoblocks.js) only exists as a bare global in the
+ * production script-concatenation build, so reaching it from Jest would mean either evaluating
+ * protoblocks.js's source at runtime or driving the full canvas/DOM-heavy
+ * Blocks.makeBlock/Block path (js/blocks.js, js/block.js), both disproportionate to this one
+ * behavior. Consequently, a regression in NeighborBlock.flow itself would not fail this test; a
+ * regression in doNeighbor or in the Logo dispatch machinery around it would (verified by
+ * deliberately breaking each and confirming the test fails).
+ *
+ * doNeighbor pushes onto three parallel turtle-singer stacks (inNeighbor, neighborStepPitch,
+ * neighborNoteValue) before the clamp's contained blocks run, and only pops all three once the
+ * real interpreter fires the end-of-clamp listener at the clamp's "hidden" block - the same shape
+ * setScalarInterval uses for tur.singer.intervals. A "probe" block placed *inside* the clamp
+ * snapshots that state mid-lifecycle - the deterministic, timing-independent observable these
+ * tests assert on. OrnamentActions.setStaccato/setSlur share the same dispatch mechanism but are
+ * left to a follow-up: setSlur's extra notationBeginSlur/notationEndSlur branch would otherwise
+ * pull in Notation-mock scaffolding unrelated to the Logo-dispatch seam under test here.
+ */
+
+// Setup global mocks BEFORE requiring the module (mirror of
+// interval-scalar-dispatch-integration.test.js).
+global._ = str => str;
+global.Notation = jest.fn().mockImplementation(() => ({}));
+global.Synth = jest.fn().mockImplementation(() => ({}));
+global.Singer = {};
+global.last = arr => arr[arr.length - 1];
+
+jest.mock("tone", () => ({
+    UserMedia: jest.fn().mockImplementation(() => ({
+        open: jest.fn()
+    }))
+}));
+
+global.EmbeddedGraphicsScheduler =
+    require("../embedded-graphics-scheduler").EmbeddedGraphicsScheduler;
+
+const logoconstants = require("../logoconstants");
+Object.assign(global, logoconstants);
+
+const { Logo } = require("../logo");
+
+// Singer.OrnamentActions is attached to the module-level `Singer` mock above, exactly as
+// production code does via `Singer.OrnamentActions = class {...}`
+// (js/turtleactions/OrnamentActions.js). No production code is mocked: doNeighbor runs for real.
+const setupOrnamentActions = require("../turtleactions/OrnamentActions");
+
+function createTurtle() {
+    return {
+        singer: {
+            inNeighbor: [],
+            neighborStepPitch: [],
+            neighborNoteValue: [],
+            inNoteBlock: [],
+            inDuplicate: false,
+            backward: [],
+            suppressOutput: true,
+            justCounting: []
+        },
+        painter: { closeSVG: jest.fn() },
+        queue: [],
+        parentFlowQueue: [],
+        listeners: {},
+        endOfClampSignals: {}
+    };
+}
+
+function createActivity(turtle) {
+    return {
+        blocks: {
+            blockList: [],
+            sameGeneration: jest.fn(() => false)
+        },
+        turtles: {
+            turtleList: [turtle],
+            ithTurtle: jest.fn(() => turtle),
+            getTurtle: jest.fn(() => turtle),
+            running: jest.fn(() => false)
+        },
+        stage: {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(name => {
+                if (typeof name === "string" && turtle.listeners[name]) {
+                    turtle.listeners[name]();
+                }
+            })
+        },
+        onStopTurtle: jest.fn()
+    };
+}
+
+function makeFlowBlock(name, connections, flow, dockTypes, args) {
+    return {
+        name,
+        connections,
+        protoblock: {
+            args: args || 0,
+            dockTypes: dockTypes || [null],
+            flow: flow || (() => null)
+        },
+        isValueBlock: () => false,
+        isArgBlock: () => false
+    };
+}
+
+describe("Logo end-of-clamp dispatch drives the real Singer.OrnamentActions.doNeighbor", () => {
+    let logo;
+    let turtle;
+    let activity;
+    let probeCallCount;
+    let duringClampState;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.document.body.style.cursor = "default";
+        turtle = createTurtle();
+        activity = createActivity(turtle);
+        logo = new Logo(activity);
+        activity.logo = logo;
+        probeCallCount = 0;
+        duringClampState = null;
+
+        setupOrnamentActions(activity);
+
+        // neighbor (0): connections [prev, intervalArg, noteValueArg, clampEntry, hidden] - the
+        // shape produced when the "neighbor" block is dragged from the Ornament palette (see
+        // NeighborBlock's own makeMacro, js/blocks/OrnamentBlocks.js).
+        // interval (1):  number 2 (semi-tone interval)
+        // noteValue (2): number 1/8
+        // probe (3):     clamp content - see the checkpoint comment below
+        // hidden (4):    connections [prev, null] (end-of-clamp signal target)
+        const hidden = makeFlowBlock("hidden", [0, null], null);
+        const probe = makeFlowBlock("probe", [0, null], (args, l, t) => {
+            // Checkpoint: reads the neighbor stacks while the clamp is still open.
+            // runFromBlockNow is synchronous, so by the time it returns below the clamp has
+            // already closed and popped all three stacks - this is the only point it's visible.
+            const tur = activity.turtles.ithTurtle(t);
+            probeCallCount++;
+            duringClampState = {
+                inNeighbor: [...tur.singer.inNeighbor],
+                neighborStepPitch: [...tur.singer.neighborStepPitch],
+                neighborNoteValue: [...tur.singer.neighborNoteValue]
+            };
+            return null;
+        });
+        const neighbor = makeFlowBlock(
+            "neighbor",
+            [null, 1, 2, 3, 4],
+            (args, l, t, blk) => {
+                // Minimal glue, not a copy of NeighborBlock.flow(): hand Logo's evaluated
+                // interval/noteValue args to the real doNeighbor and continue into the clamp body.
+                Singer.OrnamentActions.doNeighbor(args[0], args[1], t, blk);
+                return [args[2], 1];
+            },
+            [null, "numberin", "numberin", "in", "in"],
+            4
+        );
+        const interval = {
+            name: "number",
+            value: 2,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+        const noteValue = {
+            name: "number",
+            value: 1 / 8,
+            connections: [],
+            protoblock: { parameter: false, dockTypes: ["numberout"] },
+            isValueBlock: () => true,
+            isArgBlock: () => false
+        };
+
+        const blocks = [neighbor, interval, noteValue, probe, hidden];
+        logo.blockList = blocks;
+        activity.blocks.blockList = blocks;
+    });
+
+    test('pushes inNeighbor/neighborStepPitch/neighborNoteValue before the clamp body runs and pops them once dispatch reaches "hidden"', () => {
+        logo.runFromBlockNow(logo, 0, 0, 1, null);
+
+        expect(probeCallCount).toBe(1);
+        // While the clamp is open, doNeighbor pushed the neighbor block's own index (0) plus the
+        // real evaluated interval/noteValue onto the three parallel stacks.
+        expect(duringClampState).toEqual({
+            inNeighbor: [0],
+            neighborStepPitch: [2],
+            neighborNoteValue: [1 / 8]
+        });
+
+        // Once the clamp's real end-of-clamp signal (setDispatchBlock/endOfClampSignals) fires
+        // the reverting listener, all three stacks are popped back to empty.
+        expect(turtle.singer.inNeighbor).toEqual([]);
+        expect(turtle.singer.neighborStepPitch).toEqual([]);
+        expect(turtle.singer.neighborNoteValue).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Description

Adds integration coverage for the Logo interpreter dispatch paths used by `OrnamentActions` and `DictActions`. The tests exercise these actions through the real `Logo` interpreter rather than mocking the action methods or dispatch machinery.

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests 
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added `ornament-neighbor-dispatch-integration.test.js` covering the real:

  * `Logo.runFromBlockNow`
  * `Singer.OrnamentActions.doNeighbor`
  * clamp entry/exit dispatch
  * `inNeighbor`, `neighborStepPitch`, and `neighborNoteValue` state during the clamp
  * restoration of state after the end-of-clamp dispatch

* Added `dict-value-dispatch-integration.test.js` covering the real:

  * `setdict` flow-block write
  * `getdict` argument evaluation through `Logo.parseArg`
  * shared `activity.logo.turtleDicts` state between the write and subsequent read

* Kept the two integration tests separate because they exercise different Logo dispatch mechanisms:

  * Ornament actions use the clamp/listener dispatch path.
  * Dictionary access uses synchronous flow execution and argument-block evaluation.

* No production code was modified.

---

## Visual Changes

Not applicable this PR only adds automated tests.

---

## Testing Performed

* New integration tests pass.
* Full `js/__tests__/` suite: **98 suites / 2563 tests passed**.
* Related unit-test suites: **136 tests passed**.
* ESLint: clean.
* Prettier: clean.
* `git diff --check`: clean.
* Confirmed no unrelated files were modified.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

These tests intentionally use minimal glue blocks rather than instantiating the full production protoblock hierarchy. The integration boundary being tested is the Logo interpreter's dispatch/evaluation path into the real action implementations.

The two changes are kept as separate test scopes because `OrnamentActions` and `DictActions` do not share the same dispatch mechanism.
