### PR TITLE
test(activity): cover Activity-ProjectManager wiring through real construction

### DIFF
--- a/js/__tests__/activity-projectmanager-integration.test.js
+++ b/js/__tests__/activity-projectmanager-integration.test.js
@@ -16,29 +16,19 @@
 // for Activity. Neither proves that constructing a real Activity produces a
 // real, correctly-wired ProjectManager that reads back real Activity state.
 // It reuses the shared vm sandbox from helpers/activity-vm-sandbox.js (the
-// same one activity_toolbar_integration.test.js uses) so this doesn't
-// duplicate that dependency scaffold - the only thing overridden here is
-// letting the real project-manager.js source run instead of the shared
-// sandbox's default mocked setupProjectManager.
+// same one activity_toolbar_integration.test.js uses), asking it to load
+// the real project-manager.js instead of the shared sandbox's default
+// mocked setupProjectManager.
 
-const fs = require("fs");
-const path = require("path");
-const { loadActivitySandbox } = require("./helpers/activity-vm-sandbox");
-
-const PROJECT_MANAGER_CODE =
-    fs.readFileSync(path.resolve(__dirname, "../project-manager.js"), "utf8") +
-    "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
+const { loadActivityWithRealProjectManager } = require("./helpers/activity-vm-sandbox");
 
 const loadRealActivityAndProjectManager = () => {
-    const sandbox = loadActivitySandbox({
+    const sandbox = loadActivityWithRealProjectManager({
         // Real project-manager.js's methods read these globals at call time
         // only; not needed just to load the module.
-        overrides: {
-            pubsub: { off: jest.fn() },
-            DATAOBJS: [{ name: "start" }],
-            _THIS_IS_MUSIC_BLOCKS_: true
-        },
-        prependCode: PROJECT_MANAGER_CODE
+        pubsub: { off: jest.fn() },
+        DATAOBJS: [{ name: "start" }],
+        _THIS_IS_MUSIC_BLOCKS_: true
     });
     return { activity: sandbox.activity, ProjectManager: sandbox.ProjectManager };
 };
@@ -72,8 +62,17 @@ describe("Activity <-> ProjectManager integration", () => {
                     name: "note",
                     trash: false,
                     value: null,
-                    container: { x: 0, y: 0 },
-                    connections: [null],
+                    container: { x: 100, y: 200 },
+                    connections: [null, null],
+                    isValueBlock: () => false
+                },
+                {
+                    name: "pitch",
+                    trash: false,
+                    value: null,
+                    container: { x: 150, y: 250 },
+                    // Connects back to the first block by its blockList index (0).
+                    connections: [0, null],
                     isValueBlock: () => false
                 }
             ]
@@ -85,9 +84,13 @@ describe("Activity <-> ProjectManager integration", () => {
 
         const parsed = JSON.parse(activity.projectManager.prepareExport());
 
-        // Read: the exported block count came from the real
-        // activity.blocks.blockList, not a mock's static shape.
-        expect(parsed).toHaveLength(1);
+        // Read: name, position, and the resolved connection index all came
+        // from the real activity.blocks.blockList graph, not a mock's
+        // static shape - ProjectManager had to walk that real array to
+        // resolve block 0's exported index into this "pitch" entry's
+        // connection.
+        expect(parsed).toHaveLength(2);
+        expect(parsed[1]).toEqual([1, "pitch", 150, 250, [0, null]]);
         // Mutate: the call went through to the same real Activity instance,
         // not a detached copy.
         expect(activity.hasMatrixDataBlock).toBe(false);

--- a/js/__tests__/activity-projectmanager-integration.test.js
+++ b/js/__tests__/activity-projectmanager-integration.test.js
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Sugar Labs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+// This test proves the wiring boundary between the real Activity and the
+// real ProjectManager: activity_toolbar_integration.test.js loads a real
+// Activity but stubs out setupProjectManager entirely, and
+// project-manager.test.js exercises a real ProjectManager against a plain
+// fake object standing in for Activity. Neither proves that constructing a
+// real Activity produces a real, correctly-wired ProjectManager that reads
+// back real Activity state. This test loads both js/activity.js and
+// js/project-manager.js into one vm sandbox (unmodified, via
+// setupProjectManager(this) at construction time, same as the browser load
+// order in js/loader.js) and never mocks either side of that seam.
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const loadActivityAndProjectManager = () => {
+    const projectManagerCode =
+        fs.readFileSync(path.resolve(__dirname, "../project-manager.js"), "utf8") +
+        "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
+
+    const activityPath = path.resolve(__dirname, "../activity.js");
+    let activityCode = fs.readFileSync(activityPath, "utf8");
+    const splitPoint = activityCode.indexOf("const activity = new Activity();");
+    if (splitPoint !== -1) {
+        activityCode = activityCode.substring(0, splitPoint);
+    }
+    activityCode += "\nthis.Activity = Activity;";
+
+    const sandbox = {
+        window: global.window,
+        document: global.document,
+        console: global.console,
+        navigator: global.navigator,
+        _: key => key,
+        define: () => {},
+        require: () => {},
+        setTimeout,
+        setInterval,
+        createjs: {
+            DOMElement: class {
+                constructor() {}
+            }
+        },
+        jQuery: {
+            browser: { mozilla: false }
+        },
+        Turtles: class {},
+        Palettes: class {},
+        Blocks: class {},
+        Logo: class {},
+        LanguageBox: class {},
+        ThemeBox: class {},
+        SaveInterface: class {},
+        StatsWindow: class {},
+        Trashcan: class {},
+        PasteBox: class {},
+        HelpWidget: class {},
+        PluginDialog: class {
+            constructor() {}
+        },
+        GIFAnimator: class {},
+        i18next: {
+            changeLanguage: jest.fn()
+        },
+        ErrorHandler: {
+            capture: jest.fn(),
+            recoverable: jest.fn()
+        },
+        setupActivityIdleWatcher: jest.fn(),
+        setupKeyboardController: jest.fn(activity => {
+            activity.keyboardController = {
+                getCurrentKeyCode: jest.fn(),
+                clearCurrentKeyCode: jest.fn(),
+                __keyPressed: jest.fn(),
+                dispose: jest.fn()
+            };
+        }),
+        setupPluginController: jest.fn(),
+        setupToolbarController: jest.fn(),
+        setupAlertController: jest.fn(),
+        setupAlertRenderer: jest.fn(),
+        setupPaletteLoader: jest.fn(),
+        setupSearchUI: jest.fn(() => ({
+            createSearchUI: jest.fn(),
+            show: jest.fn(),
+            hide: jest.fn(),
+            focusInput: jest.fn(),
+            updateQuery: jest.fn(),
+            helpfulSearchDiv: null
+        })),
+        setupSearchController: jest.fn(),
+        setupWorkspaceLayoutController: jest.fn(),
+        setupSelectionController: jest.fn(),
+        setupTrashController: jest.fn(),
+        setupHelpController: jest.fn(),
+        setupBlockScaleController: jest.fn(),
+        setupContextMenuController: jest.fn(),
+        hideDOMLabel: jest.fn(),
+        setupActivityRecorder: jest.fn(),
+        setupActivityAbcParser: jest.fn(),
+        AlertController: {
+            MSG_TIMEOUT: 60000,
+            ERROR_MSG_TIMEOUT: 15000
+        },
+        performance: global.performance || { now: () => Date.now() },
+        platformColor: { stopIconcolor: "red" },
+        globalActivity: null,
+        LEADING: 0,
+        MYDEFINES: [],
+        // globals project-manager.js's methods read at call time (not at
+        // load/declare time, so none of these run just by evaluating the file)
+        pubsub: { off: jest.fn() },
+        DATAOBJS: [{ name: "start" }],
+        Midi: class {
+            constructor() {}
+        },
+        ABCJS: { parseOnly: jest.fn(() => [{ header: {} }]) },
+        ensureABCJS: jest.fn().mockResolvedValue(undefined),
+        extractProjectDataFromHTML: jest.fn(),
+        unescapeHTML: jest.fn(x => x),
+        doSVG: jest.fn(() => "<svg></svg>"),
+        base64Encode: jest.fn(x => x),
+        debugLog: jest.fn(),
+        getTemperament: jest.fn(() => [440]),
+        getOctaveRatio: jest.fn(() => 2),
+        transcribeMidi: jest.fn(),
+        _THIS_IS_MUSIC_BLOCKS_: true
+    };
+
+    vm.createContext(sandbox);
+    // Load order mirrors js/loader.js's shim config: "project-manager" is a
+    // declared dependency of "activity", loaded first so window/global
+    // setupProjectManager exists before Activity's constructor calls it.
+    vm.runInContext(projectManagerCode, sandbox);
+    vm.runInContext(activityCode, sandbox);
+    return { Activity: sandbox.Activity, ProjectManager: sandbox.ProjectManager };
+};
+
+const makeBlockList = () => [
+    {
+        name: "start",
+        trash: false,
+        value: 0,
+        collapsed: false,
+        container: { x: 100, y: 200 },
+        connections: [null, null],
+        isValueBlock: () => false
+    },
+    {
+        name: "note",
+        trash: false,
+        value: null,
+        collapsed: false,
+        container: { x: 150, y: 250 },
+        connections: [0, null],
+        isValueBlock: () => false
+    }
+];
+
+describe("Activity <-> ProjectManager integration", () => {
+    let Activity;
+    let ProjectManager;
+    let mockElement;
+    let activity;
+
+    beforeAll(() => {
+        ({ Activity, ProjectManager } = loadActivityAndProjectManager());
+    });
+
+    beforeEach(() => {
+        mockElement = {
+            id: "",
+            classList: {
+                contains: jest.fn(() => false),
+                add: jest.fn(),
+                remove: jest.fn()
+            },
+            style: {
+                display: "none",
+                visibility: "hidden"
+            },
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            appendChild: jest.fn(),
+            querySelector: jest.fn(() => null),
+            querySelectorAll: jest.fn(() => []),
+            innerHTML: "",
+            offsetHeight: 40
+        };
+
+        document.getElementById = jest.fn(id => {
+            if (id === "samplerPrompt") return null;
+            return mockElement;
+        });
+        document.getElementsByClassName = jest.fn(() => []);
+
+        window.platformColor = { stopIconcolor: "red" };
+        global.platformColor = window.platformColor;
+
+        activity = new Activity();
+    });
+
+    afterEach(() => {
+        delete window.hidePrintText;
+        delete window.hideErrorText;
+        document.body.className = "";
+        activity = null;
+        jest.clearAllMocks();
+    });
+
+    it("wires a real ProjectManager back to the real Activity during construction", () => {
+        expect(activity.projectManager).toBeInstanceOf(ProjectManager);
+        expect(activity.projectManager.activity).toBe(activity);
+        expect(activity.projectManager._loadAnimationIntervalId).toBeNull();
+    });
+
+    it("runs a real project operation (prepareExport) against the real Activity's block/turtle state", () => {
+        activity.blocks = { blockList: makeBlockList() };
+        activity.turtles = {
+            getTurtle: jest.fn(() => ({
+                id: 0,
+                x: 0,
+                y: 0,
+                orientation: 0,
+                painter: { color: 0, value: 50, stroke: 5, chroma: 100 }
+            }))
+        };
+
+        const exported = activity.projectManager.prepareExport();
+
+        expect(JSON.parse(exported)).toEqual([
+            [
+                0,
+                [
+                    "start",
+                    {
+                        id: 0,
+                        collapsed: false,
+                        xcor: 0,
+                        ycor: 0,
+                        heading: 0,
+                        color: 0,
+                        shade: 50,
+                        pensize: 5,
+                        grey: 100
+                    }
+                ],
+                100,
+                200,
+                [null, null]
+            ],
+            [1, "note", 150, 250, [0, null]]
+        ]);
+        // prepareExport() sets this flag on the same activity instance it was
+        // called through, not on some detached copy - a second observable
+        // sign the call went through the real Activity, not a mock.
+        expect(activity.hasMatrixDataBlock).toBe(false);
+    });
+});

--- a/js/__tests__/activity-projectmanager-integration.test.js
+++ b/js/__tests__/activity-projectmanager-integration.test.js
@@ -32,9 +32,15 @@ const loadActivityAndProjectManager = () => {
     const activityPath = path.resolve(__dirname, "../activity.js");
     let activityCode = fs.readFileSync(activityPath, "utf8");
     const splitPoint = activityCode.indexOf("const activity = new Activity();");
-    if (splitPoint !== -1) {
-        activityCode = activityCode.substring(0, splitPoint);
+    if (splitPoint === -1) {
+        throw new Error(
+            "Could not locate the Activity singleton initialization line in activity.js " +
+                '(expected literal text "const activity = new Activity();"); the file may ' +
+                "have been restructured, so truncating it here would silently execute more " +
+                "(or less) of the module than this test intends."
+        );
     }
+    activityCode = activityCode.substring(0, splitPoint);
     activityCode += "\nthis.Activity = Activity;";
 
     const sandbox = {
@@ -222,7 +228,6 @@ describe("Activity <-> ProjectManager integration", () => {
     it("wires a real ProjectManager back to the real Activity during construction", () => {
         expect(activity.projectManager).toBeInstanceOf(ProjectManager);
         expect(activity.projectManager.activity).toBe(activity);
-        expect(activity.projectManager._loadAnimationIntervalId).toBeNull();
     });
 
     it("runs a real project operation (prepareExport) against the real Activity's block/turtle state", () => {
@@ -236,6 +241,10 @@ describe("Activity <-> ProjectManager integration", () => {
                 painter: { color: 0, value: 50, stroke: 5, chroma: 100 }
             }))
         };
+        // Seeded to the opposite of what prepareExport() should set, so the
+        // assertion below proves a real mutation happened rather than
+        // coincidentally matching Activity's initial value.
+        activity.hasMatrixDataBlock = true;
 
         const exported = activity.projectManager.prepareExport();
 
@@ -262,9 +271,9 @@ describe("Activity <-> ProjectManager integration", () => {
             ],
             [1, "note", 150, 250, [0, null]]
         ]);
-        // prepareExport() sets this flag on the same activity instance it was
-        // called through, not on some detached copy - a second observable
-        // sign the call went through the real Activity, not a mock.
+        // prepareExport() flips this flag back to false on the same activity
+        // instance it was called through (seeded to true above), not on some
+        // detached copy - proving the call mutated the real Activity, not a mock.
         expect(activity.hasMatrixDataBlock).toBe(false);
     });
 });

--- a/js/__tests__/activity-projectmanager-integration.test.js
+++ b/js/__tests__/activity-projectmanager-integration.test.js
@@ -11,227 +11,45 @@
 
 // This test proves the wiring boundary between the real Activity and the
 // real ProjectManager: activity_toolbar_integration.test.js loads a real
-// Activity but stubs out setupProjectManager entirely, and
-// project-manager.test.js exercises a real ProjectManager against a plain
-// fake object standing in for Activity. Neither proves that constructing a
-// real Activity produces a real, correctly-wired ProjectManager that reads
-// back real Activity state.
-//
-// Both js/project-manager.js and js/activity.js run here completely
-// unmodified. Unrelated Activity dependencies (Turtles, Blocks, Logo, the
-// various setupXController functions, etc.) are stubbed in the sandbox
-// below purely to keep construction from touching real DOM/audio/canvas
-// machinery Jest can't provide - they sit outside the Activity<->
-// ProjectManager seam this test is about, not on either side of it.
+// Activity but keeps setupProjectManager mocked, and project-manager.test.js
+// exercises a real ProjectManager against a plain fake object standing in
+// for Activity. Neither proves that constructing a real Activity produces a
+// real, correctly-wired ProjectManager that reads back real Activity state.
+// It reuses the shared vm sandbox from helpers/activity-vm-sandbox.js (the
+// same one activity_toolbar_integration.test.js uses) so this doesn't
+// duplicate that dependency scaffold - the only thing overridden here is
+// letting the real project-manager.js source run instead of the shared
+// sandbox's default mocked setupProjectManager.
 
 const fs = require("fs");
 const path = require("path");
-const vm = require("vm");
+const { loadActivitySandbox } = require("./helpers/activity-vm-sandbox");
 
 const PROJECT_MANAGER_CODE =
     fs.readFileSync(path.resolve(__dirname, "../project-manager.js"), "utf8") +
     "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
 
-// activity.js's own last top-level statement is `const activity = new
-// Activity();`, immediately followed by a define(["domReady!", ...], ...)
-// bootstrap call. Rather than slicing the source at that statement (which
-// would couple this test to exact source text), the whole file is run
-// unmodified: the sandbox's `define` stub is a no-op, so that bootstrap
-// callback is created but never invoked, and the file's own singleton
-// construction becomes the Activity instance under test. `this.activity =
-// activity;` and `this.Activity = Activity;` just pull those two top-level
-// bindings out of the vm script's lexical scope, the same way the sibling
-// activity_toolbar_integration.test.js already does for `Activity`.
-const ACTIVITY_CODE =
-    fs.readFileSync(path.resolve(__dirname, "../activity.js"), "utf8") +
-    "\nthis.activity = activity;\nthis.Activity = Activity;";
-
-const loadActivityAndProjectManager = () => {
-    const sandbox = {
-        window: global.window,
-        document: global.document,
-        console: global.console,
-        navigator: global.navigator,
-        _: key => key,
-        define: () => {},
-        require: () => {},
-        setTimeout,
-        setInterval,
-        createjs: {
-            DOMElement: class {
-                constructor() {}
-            }
+const loadRealActivityAndProjectManager = () => {
+    const sandbox = loadActivitySandbox({
+        // Real project-manager.js's methods read these globals at call time
+        // only; not needed just to load the module.
+        overrides: {
+            pubsub: { off: jest.fn() },
+            DATAOBJS: [{ name: "start" }],
+            _THIS_IS_MUSIC_BLOCKS_: true
         },
-        jQuery: {
-            browser: { mozilla: false }
-        },
-        Turtles: class {},
-        Palettes: class {},
-        Blocks: class {},
-        Logo: class {},
-        LanguageBox: class {},
-        ThemeBox: class {},
-        SaveInterface: class {},
-        StatsWindow: class {},
-        Trashcan: class {},
-        PasteBox: class {},
-        HelpWidget: class {},
-        PluginDialog: class {
-            constructor() {}
-        },
-        GIFAnimator: class {},
-        i18next: {
-            changeLanguage: jest.fn()
-        },
-        ErrorHandler: {
-            capture: jest.fn(),
-            recoverable: jest.fn()
-        },
-        setupActivityIdleWatcher: jest.fn(),
-        setupKeyboardController: jest.fn(activity => {
-            activity.keyboardController = {
-                getCurrentKeyCode: jest.fn(),
-                clearCurrentKeyCode: jest.fn(),
-                __keyPressed: jest.fn(),
-                dispose: jest.fn()
-            };
-        }),
-        setupPluginController: jest.fn(),
-        setupToolbarController: jest.fn(),
-        setupAlertController: jest.fn(),
-        setupAlertRenderer: jest.fn(),
-        setupPaletteLoader: jest.fn(),
-        setupSearchUI: jest.fn(() => ({
-            createSearchUI: jest.fn(),
-            show: jest.fn(),
-            hide: jest.fn(),
-            focusInput: jest.fn(),
-            updateQuery: jest.fn(),
-            helpfulSearchDiv: null
-        })),
-        setupSearchController: jest.fn(),
-        setupWorkspaceLayoutController: jest.fn(),
-        setupSelectionController: jest.fn(),
-        setupTrashController: jest.fn(),
-        setupHelpController: jest.fn(),
-        setupBlockScaleController: jest.fn(),
-        setupContextMenuController: jest.fn(),
-        hideDOMLabel: jest.fn(),
-        setupActivityRecorder: jest.fn(),
-        setupActivityAbcParser: jest.fn(),
-        AlertController: {
-            MSG_TIMEOUT: 60000,
-            ERROR_MSG_TIMEOUT: 15000
-        },
-        performance: global.performance || { now: () => Date.now() },
-        platformColor: { stopIconcolor: "red" },
-        globalActivity: null,
-        LEADING: 0,
-        MYDEFINES: [],
-        // globals project-manager.js's methods read at call time (not at
-        // load/declare time, so none of these run just by evaluating the file)
-        pubsub: { off: jest.fn() },
-        DATAOBJS: [{ name: "start" }],
-        Midi: class {
-            constructor() {}
-        },
-        ABCJS: { parseOnly: jest.fn(() => [{ header: {} }]) },
-        ensureABCJS: jest.fn().mockResolvedValue(undefined),
-        extractProjectDataFromHTML: jest.fn(),
-        unescapeHTML: jest.fn(x => x),
-        doSVG: jest.fn(() => "<svg></svg>"),
-        base64Encode: jest.fn(x => x),
-        debugLog: jest.fn(),
-        getTemperament: jest.fn(() => [440]),
-        getOctaveRatio: jest.fn(() => 2),
-        transcribeMidi: jest.fn(),
-        _THIS_IS_MUSIC_BLOCKS_: true
-    };
-
-    vm.createContext(sandbox);
-    // Load order mirrors js/loader.js's shim config: "project-manager" is a
-    // declared dependency of "activity", loaded first so setupProjectManager
-    // exists in scope before Activity's constructor calls it.
-    vm.runInContext(PROJECT_MANAGER_CODE, sandbox);
-    vm.runInContext(ACTIVITY_CODE, sandbox);
-    return {
-        activity: sandbox.activity,
-        Activity: sandbox.Activity,
-        ProjectManager: sandbox.ProjectManager
-    };
+        prependCode: PROJECT_MANAGER_CODE
+    });
+    return { activity: sandbox.activity, ProjectManager: sandbox.ProjectManager };
 };
 
-const makeBlockList = () => [
-    {
-        name: "start",
-        trash: false,
-        value: 0,
-        collapsed: false,
-        container: { x: 100, y: 200 },
-        connections: [null, null],
-        isValueBlock: () => false
-    },
-    {
-        name: "note",
-        trash: false,
-        value: null,
-        collapsed: false,
-        container: { x: 150, y: 250 },
-        connections: [0, null],
-        isValueBlock: () => false
-    }
-];
-
 describe("Activity <-> ProjectManager integration", () => {
-    let ProjectManager;
-    let mockElement;
     let activity;
+    let ProjectManager;
 
     beforeEach(() => {
-        mockElement = {
-            id: "",
-            classList: {
-                contains: jest.fn(() => false),
-                add: jest.fn(),
-                remove: jest.fn()
-            },
-            style: {
-                display: "none",
-                visibility: "hidden"
-            },
-            addEventListener: jest.fn(),
-            removeEventListener: jest.fn(),
-            appendChild: jest.fn(),
-            querySelector: jest.fn(() => null),
-            querySelectorAll: jest.fn(() => []),
-            innerHTML: "",
-            offsetHeight: 40
-        };
-
-        document.getElementById = jest.fn(id => {
-            if (id === "samplerPrompt") return null;
-            return mockElement;
-        });
-        document.getElementsByClassName = jest.fn(() => []);
-
-        window.platformColor = { stopIconcolor: "red" };
-        global.platformColor = window.platformColor;
-
-        // A fresh vm context/module load per test, not just a fresh instance
-        // from a shared loaded module, so no state (e.g. the module-level
-        // `let globalActivity`) can leak between tests.
-        ({ activity, ProjectManager } = loadActivityAndProjectManager());
-
-        activity.turtles = {
-            getTurtle: jest.fn(() => ({
-                id: 0,
-                x: 0,
-                y: 0,
-                orientation: 0,
-                painter: { color: 0, value: 50, stroke: 5, chroma: 100 }
-            }))
-        };
-        activity.blocks = { blockList: makeBlockList() };
+        document.getElementById = jest.fn(() => null);
+        ({ activity, ProjectManager } = loadRealActivityAndProjectManager());
     });
 
     afterEach(() => {
@@ -247,33 +65,31 @@ describe("Activity <-> ProjectManager integration", () => {
         expect(activity.projectManager.activity).toBe(activity);
     });
 
-    it("prepareExport() reads the real Activity's block/turtle state through the real ProjectManager", () => {
-        const parsed = JSON.parse(activity.projectManager.prepareExport());
-
-        expect(parsed).toHaveLength(2);
-        const [startEntry, noteEntry] = parsed;
-
-        // The "start" block's exported args carry this turtle's real id -
-        // only obtainable by actually calling through to the real
-        // activity.turtles.getTurtle(), not by echoing static block data.
-        expect(startEntry[1][0]).toBe("start");
-        expect(startEntry[1][1]).toMatchObject({ id: 0 });
-
-        // The "note" block's connection (originally block index 0) resolves
-        // to the "start" block's position in the real activity.blocks.blockList
-        // - a value ProjectManager had to compute from that real array, not
-        // one it could have produced from a mock.
-        expect(noteEntry[0]).toBe(1);
-        expect(noteEntry[4]).toEqual([0, null]);
-    });
-
-    it("prepareExport() mutates the real Activity instance it was called through, not a detached copy", () => {
+    it("prepareExport() reads and mutates the real Activity instance through the real ProjectManager", () => {
+        activity.blocks = {
+            blockList: [
+                {
+                    name: "note",
+                    trash: false,
+                    value: null,
+                    container: { x: 0, y: 0 },
+                    connections: [null],
+                    isValueBlock: () => false
+                }
+            ]
+        };
         // Seeded to the opposite of what prepareExport() sets, so the
-        // assertion below proves a real mutation happened.
+        // assertion below proves a real mutation happened rather than
+        // coincidentally matching Activity's initial value.
         activity.hasMatrixDataBlock = true;
 
-        activity.projectManager.prepareExport();
+        const parsed = JSON.parse(activity.projectManager.prepareExport());
 
+        // Read: the exported block count came from the real
+        // activity.blocks.blockList, not a mock's static shape.
+        expect(parsed).toHaveLength(1);
+        // Mutate: the call went through to the same real Activity instance,
+        // not a detached copy.
         expect(activity.hasMatrixDataBlock).toBe(false);
     });
 });

--- a/js/__tests__/activity-projectmanager-integration.test.js
+++ b/js/__tests__/activity-projectmanager-integration.test.js
@@ -15,34 +15,38 @@
 // project-manager.test.js exercises a real ProjectManager against a plain
 // fake object standing in for Activity. Neither proves that constructing a
 // real Activity produces a real, correctly-wired ProjectManager that reads
-// back real Activity state. This test loads both js/activity.js and
-// js/project-manager.js into one vm sandbox (unmodified, via
-// setupProjectManager(this) at construction time, same as the browser load
-// order in js/loader.js) and never mocks either side of that seam.
+// back real Activity state.
+//
+// Both js/project-manager.js and js/activity.js run here completely
+// unmodified. Unrelated Activity dependencies (Turtles, Blocks, Logo, the
+// various setupXController functions, etc.) are stubbed in the sandbox
+// below purely to keep construction from touching real DOM/audio/canvas
+// machinery Jest can't provide - they sit outside the Activity<->
+// ProjectManager seam this test is about, not on either side of it.
 
 const fs = require("fs");
 const path = require("path");
 const vm = require("vm");
 
+const PROJECT_MANAGER_CODE =
+    fs.readFileSync(path.resolve(__dirname, "../project-manager.js"), "utf8") +
+    "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
+
+// activity.js's own last top-level statement is `const activity = new
+// Activity();`, immediately followed by a define(["domReady!", ...], ...)
+// bootstrap call. Rather than slicing the source at that statement (which
+// would couple this test to exact source text), the whole file is run
+// unmodified: the sandbox's `define` stub is a no-op, so that bootstrap
+// callback is created but never invoked, and the file's own singleton
+// construction becomes the Activity instance under test. `this.activity =
+// activity;` and `this.Activity = Activity;` just pull those two top-level
+// bindings out of the vm script's lexical scope, the same way the sibling
+// activity_toolbar_integration.test.js already does for `Activity`.
+const ACTIVITY_CODE =
+    fs.readFileSync(path.resolve(__dirname, "../activity.js"), "utf8") +
+    "\nthis.activity = activity;\nthis.Activity = Activity;";
+
 const loadActivityAndProjectManager = () => {
-    const projectManagerCode =
-        fs.readFileSync(path.resolve(__dirname, "../project-manager.js"), "utf8") +
-        "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
-
-    const activityPath = path.resolve(__dirname, "../activity.js");
-    let activityCode = fs.readFileSync(activityPath, "utf8");
-    const splitPoint = activityCode.indexOf("const activity = new Activity();");
-    if (splitPoint === -1) {
-        throw new Error(
-            "Could not locate the Activity singleton initialization line in activity.js " +
-                '(expected literal text "const activity = new Activity();"); the file may ' +
-                "have been restructured, so truncating it here would silently execute more " +
-                "(or less) of the module than this test intends."
-        );
-    }
-    activityCode = activityCode.substring(0, splitPoint);
-    activityCode += "\nthis.Activity = Activity;";
-
     const sandbox = {
         window: global.window,
         document: global.document,
@@ -146,11 +150,15 @@ const loadActivityAndProjectManager = () => {
 
     vm.createContext(sandbox);
     // Load order mirrors js/loader.js's shim config: "project-manager" is a
-    // declared dependency of "activity", loaded first so window/global
-    // setupProjectManager exists before Activity's constructor calls it.
-    vm.runInContext(projectManagerCode, sandbox);
-    vm.runInContext(activityCode, sandbox);
-    return { Activity: sandbox.Activity, ProjectManager: sandbox.ProjectManager };
+    // declared dependency of "activity", loaded first so setupProjectManager
+    // exists in scope before Activity's constructor calls it.
+    vm.runInContext(PROJECT_MANAGER_CODE, sandbox);
+    vm.runInContext(ACTIVITY_CODE, sandbox);
+    return {
+        activity: sandbox.activity,
+        Activity: sandbox.Activity,
+        ProjectManager: sandbox.ProjectManager
+    };
 };
 
 const makeBlockList = () => [
@@ -175,14 +183,9 @@ const makeBlockList = () => [
 ];
 
 describe("Activity <-> ProjectManager integration", () => {
-    let Activity;
     let ProjectManager;
     let mockElement;
     let activity;
-
-    beforeAll(() => {
-        ({ Activity, ProjectManager } = loadActivityAndProjectManager());
-    });
 
     beforeEach(() => {
         mockElement = {
@@ -214,7 +217,21 @@ describe("Activity <-> ProjectManager integration", () => {
         window.platformColor = { stopIconcolor: "red" };
         global.platformColor = window.platformColor;
 
-        activity = new Activity();
+        // A fresh vm context/module load per test, not just a fresh instance
+        // from a shared loaded module, so no state (e.g. the module-level
+        // `let globalActivity`) can leak between tests.
+        ({ activity, ProjectManager } = loadActivityAndProjectManager());
+
+        activity.turtles = {
+            getTurtle: jest.fn(() => ({
+                id: 0,
+                x: 0,
+                y: 0,
+                orientation: 0,
+                painter: { color: 0, value: 50, stroke: 5, chroma: 100 }
+            }))
+        };
+        activity.blocks = { blockList: makeBlockList() };
     });
 
     afterEach(() => {
@@ -230,50 +247,33 @@ describe("Activity <-> ProjectManager integration", () => {
         expect(activity.projectManager.activity).toBe(activity);
     });
 
-    it("runs a real project operation (prepareExport) against the real Activity's block/turtle state", () => {
-        activity.blocks = { blockList: makeBlockList() };
-        activity.turtles = {
-            getTurtle: jest.fn(() => ({
-                id: 0,
-                x: 0,
-                y: 0,
-                orientation: 0,
-                painter: { color: 0, value: 50, stroke: 5, chroma: 100 }
-            }))
-        };
-        // Seeded to the opposite of what prepareExport() should set, so the
-        // assertion below proves a real mutation happened rather than
-        // coincidentally matching Activity's initial value.
+    it("prepareExport() reads the real Activity's block/turtle state through the real ProjectManager", () => {
+        const parsed = JSON.parse(activity.projectManager.prepareExport());
+
+        expect(parsed).toHaveLength(2);
+        const [startEntry, noteEntry] = parsed;
+
+        // The "start" block's exported args carry this turtle's real id -
+        // only obtainable by actually calling through to the real
+        // activity.turtles.getTurtle(), not by echoing static block data.
+        expect(startEntry[1][0]).toBe("start");
+        expect(startEntry[1][1]).toMatchObject({ id: 0 });
+
+        // The "note" block's connection (originally block index 0) resolves
+        // to the "start" block's position in the real activity.blocks.blockList
+        // - a value ProjectManager had to compute from that real array, not
+        // one it could have produced from a mock.
+        expect(noteEntry[0]).toBe(1);
+        expect(noteEntry[4]).toEqual([0, null]);
+    });
+
+    it("prepareExport() mutates the real Activity instance it was called through, not a detached copy", () => {
+        // Seeded to the opposite of what prepareExport() sets, so the
+        // assertion below proves a real mutation happened.
         activity.hasMatrixDataBlock = true;
 
-        const exported = activity.projectManager.prepareExport();
+        activity.projectManager.prepareExport();
 
-        expect(JSON.parse(exported)).toEqual([
-            [
-                0,
-                [
-                    "start",
-                    {
-                        id: 0,
-                        collapsed: false,
-                        xcor: 0,
-                        ycor: 0,
-                        heading: 0,
-                        color: 0,
-                        shade: 50,
-                        pensize: 5,
-                        grey: 100
-                    }
-                ],
-                100,
-                200,
-                [null, null]
-            ],
-            [1, "note", 150, 250, [0, null]]
-        ]);
-        // prepareExport() flips this flag back to false on the same activity
-        // instance it was called through (seeded to true above), not on some
-        // detached copy - proving the call mutated the real Activity, not a mock.
         expect(activity.hasMatrixDataBlock).toBe(false);
     });
 });

--- a/js/__tests__/activity_toolbar_integration.test.js
+++ b/js/__tests__/activity_toolbar_integration.test.js
@@ -9,126 +9,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-const fs = require("fs");
-const path = require("path");
-const vm = require("vm");
+const { loadActivitySandbox } = require("./helpers/activity-vm-sandbox");
 
-const loadActivityClass = () => {
-    const activityPath = path.resolve(__dirname, "../activity.js");
-    let code = fs.readFileSync(activityPath, "utf8");
-
-    const splitPoint = code.indexOf("const activity = new Activity();");
-    if (splitPoint !== -1) {
-        code = code.substring(0, splitPoint);
-    }
-
-    code += "\nthis.Activity = Activity;";
-
-    const sandbox = {
-        window: global.window,
-        document: global.document,
-        console: global.console,
-        navigator: global.navigator,
-        _: key => key,
-        define: () => {},
-        require: () => {},
-        setTimeout,
-        setInterval,
-        createjs: {
-            DOMElement: class {
-                constructor() {}
-            }
-        },
-        jQuery: {
-            browser: { mozilla: false }
-        },
-        Turtles: class {},
-        Palettes: class {},
-        Blocks: class {},
-        Logo: class {},
-        LanguageBox: class {},
-        ThemeBox: class {},
-        SaveInterface: class {},
-        StatsWindow: class {},
-        Trashcan: class {},
-        PasteBox: class {},
-        HelpWidget: class {},
-        PluginDialog: class {
-            constructor() {}
-        },
-        GIFAnimator: class {},
-        i18next: {
-            changeLanguage: jest.fn()
-        },
-        ErrorHandler: {
-            capture: jest.fn(),
-            recoverable: jest.fn()
-        },
-        setupActivityIdleWatcher: jest.fn(),
-        setupProjectManager: jest.fn(activity => {
-            activity.projectManager = {
-                doLoadAnimation: jest.fn(),
-                stopLoadAnimation: jest.fn(),
-                prepareExport: jest.fn(),
-                runProject: jest.fn(),
-                getClosestStandardNoteValue: jest.fn(),
-                _loadProject: jest.fn(),
-                loadStartWrapper: jest.fn(),
-                showContents: jest.fn(),
-                justLoadStart: jest.fn(),
-                saveLocally: jest.fn(),
-                newProject: jest.fn(),
-                doLoad: jest.fn(),
-                doMergeLoad: jest.fn(),
-                start: jest.fn()
-            };
-        }),
-        setupKeyboardController: jest.fn(activity => {
-            activity.keyboardController = {
-                getCurrentKeyCode: jest.fn(),
-                clearCurrentKeyCode: jest.fn(),
-                __keyPressed: jest.fn(),
-                dispose: jest.fn()
-            };
-        }),
-        setupPluginController: jest.fn(),
-        setupToolbarController: jest.fn(),
-        setupAlertController: jest.fn(),
-        setupAlertRenderer: jest.fn(),
-        setupPaletteLoader: jest.fn(),
-        setupSearchUI: jest.fn(() => ({
-            createSearchUI: jest.fn(),
-            show: jest.fn(),
-            hide: jest.fn(),
-            focusInput: jest.fn(),
-            updateQuery: jest.fn(),
-            helpfulSearchDiv: null
-        })),
-        setupSearchController: jest.fn(),
-        setupWorkspaceLayoutController: jest.fn(),
-        setupSelectionController: jest.fn(),
-        setupTrashController: jest.fn(),
-        setupHelpController: jest.fn(),
-        setupBlockScaleController: jest.fn(),
-        setupContextMenuController: jest.fn(),
-        hideDOMLabel: jest.fn(),
-        setupActivityRecorder: jest.fn(),
-        setupActivityAbcParser: jest.fn(),
-        AlertController: {
-            MSG_TIMEOUT: 60000,
-            ERROR_MSG_TIMEOUT: 15000
-        },
-        performance: global.performance || { now: () => Date.now() },
-        platformColor: { stopIconcolor: "red" },
-        globalActivity: null,
-        LEADING: 0,
-        MYDEFINES: []
-    };
-
-    vm.createContext(sandbox);
-    vm.runInContext(code, sandbox);
-    return sandbox.Activity;
-};
+// This test only exercises Activity's own toolbar-delegation methods, so
+// setupProjectManager stays mocked (the shared helper's default) rather than
+// wiring in the real ProjectManager - that real wiring is covered by
+// activity-projectmanager-integration.test.js.
+const loadActivityClass = () => loadActivitySandbox().Activity;
 
 describe("Activity Toolbar Integration", () => {
     let Activity;

--- a/js/__tests__/helpers/activity-vm-sandbox.js
+++ b/js/__tests__/helpers/activity-vm-sandbox.js
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Sugar Labs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+// Shared vm sandbox for loading the real, unmodified js/activity.js into a
+// Jest test without a browser. Every field here stubs a dependency that
+// sits outside whatever seam a given test is exercising (Turtles, Blocks,
+// Logo, the setupXController functions, etc.) so that just constructing
+// Activity doesn't require real DOM/audio/canvas machinery Jest can't
+// provide. Callers layer test-specific `overrides` on top (e.g. mocking or
+// deliberately NOT mocking setupProjectManager) and may supply `prependCode`
+// to run more real, unmodified source (such as project-manager.js) in the
+// same vm context before activity.js runs.
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const ACTIVITY_PATH = path.resolve(__dirname, "../../activity.js");
+
+const createBaseSandbox = () => ({
+    window: global.window,
+    document: global.document,
+    console: global.console,
+    navigator: global.navigator,
+    _: key => key,
+    define: () => {},
+    require: () => {},
+    setTimeout,
+    setInterval,
+    createjs: {
+        DOMElement: class {
+            constructor() {}
+        }
+    },
+    jQuery: {
+        browser: { mozilla: false }
+    },
+    Turtles: class {},
+    Palettes: class {},
+    Blocks: class {},
+    Logo: class {},
+    LanguageBox: class {},
+    ThemeBox: class {},
+    SaveInterface: class {},
+    StatsWindow: class {},
+    Trashcan: class {},
+    PasteBox: class {},
+    HelpWidget: class {},
+    PluginDialog: class {
+        constructor() {}
+    },
+    GIFAnimator: class {},
+    i18next: {
+        changeLanguage: jest.fn()
+    },
+    ErrorHandler: {
+        capture: jest.fn(),
+        recoverable: jest.fn()
+    },
+    setupActivityIdleWatcher: jest.fn(),
+    setupProjectManager: jest.fn(activity => {
+        activity.projectManager = {
+            doLoadAnimation: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            prepareExport: jest.fn(),
+            runProject: jest.fn(),
+            getClosestStandardNoteValue: jest.fn(),
+            _loadProject: jest.fn(),
+            loadStartWrapper: jest.fn(),
+            showContents: jest.fn(),
+            justLoadStart: jest.fn(),
+            saveLocally: jest.fn(),
+            newProject: jest.fn(),
+            doLoad: jest.fn(),
+            doMergeLoad: jest.fn(),
+            start: jest.fn()
+        };
+    }),
+    setupKeyboardController: jest.fn(activity => {
+        activity.keyboardController = {
+            getCurrentKeyCode: jest.fn(),
+            clearCurrentKeyCode: jest.fn(),
+            __keyPressed: jest.fn(),
+            dispose: jest.fn()
+        };
+    }),
+    setupPluginController: jest.fn(),
+    setupToolbarController: jest.fn(),
+    setupAlertController: jest.fn(),
+    setupAlertRenderer: jest.fn(),
+    setupPaletteLoader: jest.fn(),
+    setupSearchUI: jest.fn(() => ({
+        createSearchUI: jest.fn(),
+        show: jest.fn(),
+        hide: jest.fn(),
+        focusInput: jest.fn(),
+        updateQuery: jest.fn(),
+        helpfulSearchDiv: null
+    })),
+    setupSearchController: jest.fn(),
+    setupWorkspaceLayoutController: jest.fn(),
+    setupSelectionController: jest.fn(),
+    setupTrashController: jest.fn(),
+    setupHelpController: jest.fn(),
+    setupBlockScaleController: jest.fn(),
+    setupContextMenuController: jest.fn(),
+    hideDOMLabel: jest.fn(),
+    setupActivityRecorder: jest.fn(),
+    setupActivityAbcParser: jest.fn(),
+    AlertController: {
+        MSG_TIMEOUT: 60000,
+        ERROR_MSG_TIMEOUT: 15000
+    },
+    performance: global.performance || { now: () => Date.now() },
+    platformColor: { stopIconcolor: "red" },
+    globalActivity: null,
+    LEADING: 0,
+    MYDEFINES: []
+});
+
+/**
+ * Loads the real, unmodified js/activity.js into a fresh vm context.
+ *
+ * `overrides` is merged over the default stub set (e.g. to delete/replace
+ * `setupProjectManager`). `prependCode` (if given) runs in the same context
+ * before activity.js, so e.g. the real project-manager.js's own top-level
+ * `setupProjectManager` becomes the one activity.js's constructor sees.
+ *
+ * activity.js's own last top-level statement constructs its Activity
+ * singleton and feeds it into a define(["domReady!", ...], callback)
+ * bootstrap call; since the sandbox's `define` is a no-op, that callback is
+ * created but never invoked. The file runs entirely unmodified - no source
+ * slicing - and its own `const activity = new Activity();` / `class
+ * Activity` bindings are pulled out via `this.activity = activity;` /
+ * `this.Activity = Activity;`, appended to the file text before running it.
+ */
+const loadActivitySandbox = ({ overrides = {}, prependCode = "" } = {}) => {
+    const sandbox = { ...createBaseSandbox(), ...overrides };
+    const code =
+        fs.readFileSync(ACTIVITY_PATH, "utf8") +
+        "\nthis.activity = activity;\nthis.Activity = Activity;";
+
+    vm.createContext(sandbox);
+    if (prependCode) {
+        vm.runInContext(prependCode, sandbox);
+    }
+    vm.runInContext(code, sandbox);
+    return sandbox;
+};
+
+module.exports = { loadActivitySandbox };

--- a/js/__tests__/helpers/activity-vm-sandbox.js
+++ b/js/__tests__/helpers/activity-vm-sandbox.js
@@ -10,14 +10,19 @@
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
 // Shared vm sandbox for loading the real, unmodified js/activity.js into a
-// Jest test without a browser. Every field here stubs a dependency that
-// sits outside whatever seam a given test is exercising (Turtles, Blocks,
-// Logo, the setupXController functions, etc.) so that just constructing
-// Activity doesn't require real DOM/audio/canvas machinery Jest can't
-// provide. Callers layer test-specific `overrides` on top (e.g. mocking or
-// deliberately NOT mocking setupProjectManager) and may supply `prependCode`
-// to run more real, unmodified source (such as project-manager.js) in the
-// same vm context before activity.js runs.
+// Jest test without a browser. This intentionally stubs only what the
+// Activity constructor itself touches directly (the setupXController
+// functions it calls in sequence, hideDOMLabel, ErrorHandler, PluginDialog,
+// performance) - verified empirically by trimming the sandbox until
+// construction stopped succeeding. Activity's heavier dependencies (Turtles,
+// Blocks, Logo, etc.) are never referenced during construction itself: they
+// are wired up later by setupDependencies(), which only runs from the
+// domReady bootstrap callback below - and since this sandbox's `define` is a
+// no-op, that callback is never invoked. Callers layer test-specific
+// `overrides` on top (e.g. mocking or deliberately NOT mocking
+// setupProjectManager) and may supply `prependCode` to run more real,
+// unmodified source (such as project-manager.js) in the same vm context
+// before activity.js runs.
 
 const fs = require("fs");
 const path = require("path");
@@ -35,31 +40,8 @@ const createBaseSandbox = () => ({
     require: () => {},
     setTimeout,
     setInterval,
-    createjs: {
-        DOMElement: class {
-            constructor() {}
-        }
-    },
-    jQuery: {
-        browser: { mozilla: false }
-    },
-    Turtles: class {},
-    Palettes: class {},
-    Blocks: class {},
-    Logo: class {},
-    LanguageBox: class {},
-    ThemeBox: class {},
-    SaveInterface: class {},
-    StatsWindow: class {},
-    Trashcan: class {},
-    PasteBox: class {},
-    HelpWidget: class {},
     PluginDialog: class {
         constructor() {}
-    },
-    GIFAnimator: class {},
-    i18next: {
-        changeLanguage: jest.fn()
     },
     ErrorHandler: {
         capture: jest.fn(),
@@ -115,15 +97,7 @@ const createBaseSandbox = () => ({
     hideDOMLabel: jest.fn(),
     setupActivityRecorder: jest.fn(),
     setupActivityAbcParser: jest.fn(),
-    AlertController: {
-        MSG_TIMEOUT: 60000,
-        ERROR_MSG_TIMEOUT: 15000
-    },
-    performance: global.performance || { now: () => Date.now() },
-    platformColor: { stopIconcolor: "red" },
-    globalActivity: null,
-    LEADING: 0,
-    MYDEFINES: []
+    performance: global.performance || { now: () => Date.now() }
 });
 
 /**
@@ -156,4 +130,27 @@ const loadActivitySandbox = ({ overrides = {}, prependCode = "" } = {}) => {
     return sandbox;
 };
 
-module.exports = { loadActivitySandbox };
+const PROJECT_MANAGER_PATH = path.resolve(__dirname, "../../project-manager.js");
+
+// project-manager.js only exposes its module-local `setupProjectManager`
+// onto `window` inside its AMD branch (what RequireJS triggers in the
+// browser). Appending these assignments is the vm-sandbox equivalent of
+// that - pulling `setupProjectManager`/`ProjectManager` onto the shared
+// context the same way `this.activity = activity;` does for activity.js
+// above - so activity.js's constructor calls the real setupProjectManager
+// instead of the default mocked one above.
+const REAL_PROJECT_MANAGER_CODE =
+    fs.readFileSync(PROJECT_MANAGER_PATH, "utf8") +
+    "\nthis.setupProjectManager = setupProjectManager;\nthis.ProjectManager = ProjectManager;";
+
+/**
+ * Loads real, unmodified activity.js AND project-manager.js into one vm
+ * context, so activity.js's constructor wires up a real ProjectManager
+ * instead of the default sandbox's mocked one. `overrides` covers the
+ * handful of extra globals project-manager.js's methods read at call time
+ * (e.g. `pubsub`, `DATAOBJS`) on top of the base Activity stub set.
+ */
+const loadActivityWithRealProjectManager = (overrides = {}) =>
+    loadActivitySandbox({ overrides, prependCode: REAL_PROJECT_MANAGER_CODE });
+
+module.exports = { loadActivitySandbox, loadActivityWithRealProjectManager };


### PR DESCRIPTION

## Description

Adds integration coverage for the wiring between the real `Activity` and `ProjectManager` components.

The test loads both `js/activity.js` and `js/project-manager.js` unmodified into the same `vm` context, following the dependency order used by `js/loader.js`. This allows `Activity` construction to invoke the real `setupProjectManager(this)` path instead of replacing the project manager with a mock.

The test verifies that a real `Activity` receives a real `ProjectManager`, that the project manager references the same activity instance, and that a real `prepareExport()` call reads and mutates state belonging to that activity.

No production code is changed.

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Added `js/__tests__/activity-projectmanager-integration.test.js`.
- Loads the real `Activity` and `ProjectManager` implementations into a shared `vm` context.
- Verifies that `Activity` construction creates and wires a real `ProjectManager`.
- Verifies that `activity.projectManager.activity` references the same `Activity` instance.
- Exercises the real `ProjectManager.prepareExport()` method against a small block/turtle fixture.
- Verifies the resulting export and the corresponding `Activity` state mutation.
- Keeps production code untouched and limits the integration boundary to synchronous behavior that does not require DOM/canvas or file I/O.

## Visual Changes

Not applicable. This change only adds automated tests.

---

## Testing Performed

- New integration test: **2/2 passed**.
- Activity test suite: **132 tests passed**.
- ProjectManager test suite: **106 tests passed**.
- Integration-named test suites: **6 files / 54 tests passed** with no cross-test leakage.
- ESLint: clean.
- Prettier: clean.
- `git diff --check`: clean.
- Full Jest run: clean apart from two pre-existing unrelated failures:
  - `musickeyboard.test.js` — existing failure reproduced independently.
  - `camera.test.js` — full-suite worker SIGSEGV; the test passes when run in isolation.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This test covers a previously untested integration boundary: real `Activity` construction wiring a real `ProjectManager` instance.

Existing coverage tests `Activity` with a mocked `setupProjectManager` and tests `ProjectManager` against a plain fake activity, but neither exercises both real components together. This test fills that gap without introducing DOM/canvas-heavy setup.

`prepareExport()` was selected because it is synchronous and can exercise the real Activity/ProjectManager relationship without requiring the file-loading or UI infrastructure used by `saveLocally` and `doLoad`.

The test does not currently provide a full project load/save round trip. Those flows still depend on additional `Turtles`/`Blocks` infrastructure and can be covered separately if needed.