### PR TITLE
test(musickeyboard): fix docById mock missing remove(), unblocking CI

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -943,7 +943,7 @@ describe("MusicKeyboard core logic", () => {
         global.noteToFrequency = jest.fn(name => ({ do4: 261, sol4: 392 })[name] ?? 0);
         global.last = array => array[array.length - 1];
         global.EIGHTHNOTEWIDTH = 24;
-        global.docById = jest.fn(() => ({ getAttribute: () => "0.5" }));
+        global.docById = jest.fn(() => ({ getAttribute: () => "0.5", remove: jest.fn() }));
         global.beginnerMode = "false";
     });
 


### PR DESCRIPTION
## Description

`js/widgets/__tests__/musickeyboard.test.js` currently fails on `master`, breaking the `Jest tests & coverage` CI check for every PR regardless of what it touches (confirmed on `master` HEAD `3901ade66`, [CI run](https://github.com/sugarlabs/musicblocks/actions/runs/32916725734)).

The `"MusicKeyboard core logic"` describe block's `beforeEach` mocks `global.docById` for every nested test:

```js
global.docById = jest.fn(() => ({ getAttribute: () => "0.5" }));
```

`MusicKeyboard.stopMetronome()` (added in #6936) calls `docById("countdownContainer").remove()` during cleanup. The nested test `"Web MIDI cleanup on widget close › resets onmidimessage handlers on all connected MIDI inputs when widgetWindow.onclose is called"` triggers that path via `widgetWindow.onclose()`, and since the shared mock object has no `remove` method, it throws:

```
TypeError: countdownContainer.remove is not a function
```

## Related Issue

**Fixes:** #8249

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- `js/widgets/__tests__/musickeyboard.test.js`: added a no-op `remove: jest.fn()` to the `"MusicKeyboard core logic"` block's shared `docById` mock, so it satisfies every consumer in that describe block (including `stopMetronome()`'s cleanup path), matching the shape of a real DOM element.
- No production code changes — this is a test-double gap, not a bug in `MusicKeyboard` itself.

## Testing Performed

- `npx jest js/widgets/__tests__/musickeyboard.test.js` — 45/45 passing (was 1 failing before this fix).
- `npx eslint js/widgets/__tests__/musickeyboard.test.js` and `npx prettier --check` — clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

This is currently blocking CI on every open PR against `master`, including #8248. Filed and fixed separately from that PR since it's an unrelated pre-existing test bug, not something introduced by that change.
