### PR TITLE
fix(block-scale): disable smaller-blocks icon only at the minimum scale

### DIFF
--- a/js/activity/__tests__/block-scale-controller.test.js
+++ b/js/activity/__tests__/block-scale-controller.test.js
@@ -329,9 +329,8 @@ describe("scale limits", () => {
 // ---------------------------------------------------------------------------
 
 describe("setSmallerLargerStatus", () => {
-    test("enables the smaller-blocks icon when scale is below the default", async () => {
-        const belowDefaultIndex = DEFAULT_INDEX - 1;
-        const activity = makeActivity(belowDefaultIndex);
+    test("disables the smaller-blocks icon at the minimum scale", async () => {
+        const activity = makeActivity(0);
         const controller = setupBlockScaleController(activity);
 
         await controller.setSmallerLargerStatus();
@@ -343,8 +342,35 @@ describe("setSmallerLargerStatus", () => {
         );
     });
 
-    test("disables the smaller-blocks icon when scale is at or above the default", async () => {
+    test("enables the smaller-blocks icon below the default scale", async () => {
+        const belowDefaultIndex = DEFAULT_INDEX - 1;
+        const activity = makeActivity(belowDefaultIndex);
+        const controller = setupBlockScaleController(activity);
+
+        await controller.setSmallerLargerStatus();
+
+        expect(global.changeImage).toHaveBeenCalledWith(
+            activity.smallerContainer.children[0],
+            SMALLERDISABLEBUTTON,
+            SMALLERBUTTON
+        );
+    });
+
+    test("enables the smaller-blocks icon at the default scale", async () => {
         const activity = makeActivity(DEFAULT_INDEX);
+        const controller = setupBlockScaleController(activity);
+
+        await controller.setSmallerLargerStatus();
+
+        expect(global.changeImage).toHaveBeenCalledWith(
+            activity.smallerContainer.children[0],
+            SMALLERDISABLEBUTTON,
+            SMALLERBUTTON
+        );
+    });
+
+    test("enables the smaller-blocks icon above the default scale", async () => {
+        const activity = makeActivity(DEFAULT_INDEX + 1);
         const controller = setupBlockScaleController(activity);
 
         await controller.setSmallerLargerStatus();

--- a/js/activity/block-scale-controller.js
+++ b/js/activity/block-scale-controller.js
@@ -9,7 +9,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* global changeImage, BLOCKSCALES, DEFAULTBLOCKSCALE, SMALLERBUTTON, SMALLERDISABLEBUTTON,
+/* global changeImage, BLOCKSCALES, SMALLERBUTTON, SMALLERDISABLEBUTTON,
    BIGGERBUTTON, BIGGERDISABLEBUTTON */
 
 /* exported setupBlockScaleController, BlockScaleController */
@@ -96,7 +96,7 @@ class BlockScaleController {
      */
     async setSmallerLargerStatus() {
         const activity = this.activity;
-        if (BLOCKSCALES[activity.blockscale] < DEFAULTBLOCKSCALE) {
+        if (activity.blockscale <= 0) {
             await changeImage(
                 activity.smallerContainer.children[0],
                 SMALLERBUTTON,


### PR DESCRIPTION
The "make blocks smaller" toolbar icon was greyed out (shown in its disabled state) as soon as the block scale dropped below the default (150 -> 125), even though blocks can legitimately shrink all the way down to the smallest scale (50). The icon still worked when clicked, so this was purely a misleading UI state.

The larger-blocks icon correctly disables only at the maximum scale, so the two controls were asymmetric. Change the smaller-blocks condition from `BLOCKSCALES[blockscale] < DEFAULTBLOCKSCALE` to `blockscale <= 0` so it only shows the disabled icon once the true minimum is reached, mirroring the larger-blocks logic.

Update the icon-state tests to cover the minimum, below-default, default, and above-default cases.


Claude-Session: https://claude.ai/code/session_014ny2FQ4RvtgsMCJYY29LUg

<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->

---

## Visual Changes

<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
