### PR TITLE
fix(block-scale): disable smaller-blocks icon only at the minimum scale

### DIFF
--- a/js/activity/__tests__/block-scale-controller.test.js
+++ b/js/activity/__tests__/block-scale-controller.test.js
@@ -329,9 +329,8 @@ describe("scale limits", () => {
 // ---------------------------------------------------------------------------
 
 describe("setSmallerLargerStatus", () => {
-    test("enables the smaller-blocks icon when scale is below the default", async () => {
-        const belowDefaultIndex = DEFAULT_INDEX - 1;
-        const activity = makeActivity(belowDefaultIndex);
+    test("disables the smaller-blocks icon at the minimum scale", async () => {
+        const activity = makeActivity(0);
         const controller = setupBlockScaleController(activity);
 
         await controller.setSmallerLargerStatus();
@@ -343,8 +342,35 @@ describe("setSmallerLargerStatus", () => {
         );
     });
 
-    test("disables the smaller-blocks icon when scale is at or above the default", async () => {
+    test("enables the smaller-blocks icon below the default scale", async () => {
+        const belowDefaultIndex = DEFAULT_INDEX - 1;
+        const activity = makeActivity(belowDefaultIndex);
+        const controller = setupBlockScaleController(activity);
+
+        await controller.setSmallerLargerStatus();
+
+        expect(global.changeImage).toHaveBeenCalledWith(
+            activity.smallerContainer.children[0],
+            SMALLERDISABLEBUTTON,
+            SMALLERBUTTON
+        );
+    });
+
+    test("enables the smaller-blocks icon at the default scale", async () => {
         const activity = makeActivity(DEFAULT_INDEX);
+        const controller = setupBlockScaleController(activity);
+
+        await controller.setSmallerLargerStatus();
+
+        expect(global.changeImage).toHaveBeenCalledWith(
+            activity.smallerContainer.children[0],
+            SMALLERDISABLEBUTTON,
+            SMALLERBUTTON
+        );
+    });
+
+    test("enables the smaller-blocks icon above the default scale", async () => {
+        const activity = makeActivity(DEFAULT_INDEX + 1);
         const controller = setupBlockScaleController(activity);
 
         await controller.setSmallerLargerStatus();

--- a/js/activity/block-scale-controller.js
+++ b/js/activity/block-scale-controller.js
@@ -9,7 +9,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
-/* global changeImage, BLOCKSCALES, DEFAULTBLOCKSCALE, SMALLERBUTTON, SMALLERDISABLEBUTTON,
+/* global changeImage, BLOCKSCALES, SMALLERBUTTON, SMALLERDISABLEBUTTON,
    BIGGERBUTTON, BIGGERDISABLEBUTTON */
 
 /* exported setupBlockScaleController, BlockScaleController */
@@ -102,7 +102,7 @@ class BlockScaleController {
             activity.smallerContainer.children &&
             activity.smallerContainer.children.length > 0
         ) {
-            if (BLOCKSCALES[activity.blockscale] < DEFAULTBLOCKSCALE) {
+            if (activity.blockscale <= 0) {
                 await changeImage(
                     activity.smallerContainer.children[0],
                     SMALLERBUTTON,


### PR DESCRIPTION
## Description

When a project is opened, blocks are at the default scale of 150 (1.5). The toolbar's make-smaller (−) icon was switching to its greyed-out *disabled* state as soon as the scale dropped below the default (e.g. 150 → 125), even though blocks can legitimately keep shrinking down to the minimum scale of 50 (0.5). The icon still worked when clicked, so this was purely a misleading disabled UI state. The make-bigger (+) icon already disables only at the maximum scale (400 / 4.0), so the two controls were asymmetric. This aligns the make-smaller icon with that behavior — it now disables only at the true minimum.

## Category
---
- [x] Bug Fix — Fixes a bug or incorrect behavior
---

## Changes Made

- `js/activity/block-scale-controller.js` — in `setSmallerLargerStatus()`, changed the make-smaller icon's disabled condition from `BLOCKSCALES[activity.blockscale] < DEFAULTBLOCKSCALE` to `activity.blockscale <= 0`, so the disabled icon only appears at the minimum scale (index 0), mirroring the make-bigger icon's max-scale check. The existing null-safety guard around the container is kept, and the now-unused `DEFAULTBLOCKSCALE` is removed from the file's eslint globals.
- `js/activity/__tests__/block-scale-controller.test.js` — added explicit `setSmallerLargerStatus` cases covering minimum (disabled), below-default (enabled), default (enabled), and above-default (enabled) scales.

---

## Visual Changes

Blocks at scale 125 (one step below the default):

### Before
The make-smaller (−) icon appears greyed-out/disabled even though blocks can still shrink to 50.

### After
The make-smaller (−) icon stays enabled; it only greys out once blocks reach the minimum scale (50).

---

## Testing Performed

- `npx jest js/activity/__tests__/block-scale-controller.test.js` → **26 passed** (includes the four new scale cases).
- `npx eslint js/activity/block-scale-controller.js js/activity/__tests__/block-scale-controller.test.js` → no errors.
- `npx prettier --check` on both changed files → no formatting issues.
- Manual: opened a project, clicked − once (150 → 125) and confirmed the icon stays enabled; kept clicking down to 50 and confirmed it disables only there; clicked + up to 400 and confirmed the + icon disables only at the max.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable. <!-- N/A -->
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable. <!-- N/A -->
- [x] I have enabled **"Allow edits from maintainers"**.