### PR TITLE
fix(test): add remove method to docById mock in MusicKeyboard tests

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -943,7 +943,7 @@ describe("MusicKeyboard core logic", () => {
         global.noteToFrequency = jest.fn(name => ({ do4: 261, sol4: 392 })[name] ?? 0);
         global.last = array => array[array.length - 1];
         global.EIGHTHNOTEWIDTH = 24;
-        global.docById = jest.fn(() => ({ getAttribute: () => "0.5" }));
+        global.docById = jest.fn(() => ({ getAttribute: () => "0.5", remove: jest.fn() }));
         global.beginnerMode = "false";
     });
 


### PR DESCRIPTION
## Description

Fixes a test failure (`TypeError: countdownContainer.remove is not a function`) occurring during test execution when `widgetWindow.onclose` invokes `keyboard.stopMetronome()`.

## Related Issue

N/A

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Updated the `global.docById` mock in [`js/widgets/__tests__/musickeyboard.test.js`](file:///d:/sugarlabs/musicblocks/js/widgets/__tests__/musickeyboard.test.js#L946) under `describe("MusicKeyboard core logic", ...)` to include `remove: jest.fn()`.
- Prevents `stopMetronome()` from throwing when calling `countdownContainer.remove()` on the mocked `docById` element during `onclose` cleanup.

---

## Testing Performed

- Ran target test suite: `npx jest js/widgets/__tests__/musickeyboard.test.js` (45/45 tests passed)
- Ran complete test suite: `npm test` (220/220 test suites passed, 8,041 tests passed)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).
