### PR TITLE
test(musickeyboard): add test suite for note duration rounding and key handlers

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -1389,3 +1389,86 @@ describe("MusicKeyboard widget timer lifecycle", () => {
         expect(keyboard._timerManager.activeIntervalCount).toBe(0);
     });
 });
+
+describe("MusicKeyboard note duration rounding and key handlers", () => {
+    let origBeginnerMode;
+
+    beforeEach(() => {
+        origBeginnerMode = localStorage.beginnerMode;
+    });
+
+    afterEach(() => {
+        if (origBeginnerMode === undefined) {
+            delete localStorage.beginnerMode;
+        } else {
+            localStorage.beginnerMode = origBeginnerMode;
+        }
+    });
+
+    test("rounds raw note durations to 1/16th grid in normal mode", () => {
+        delete localStorage.beginnerMode;
+        const keyboard = new MusicKeyboard({});
+
+        // 0.26s -> 0.25s (nearest 1/16th)
+        expect(keyboard._roundNoteDuration(0.26)).toBe(0.25);
+        // 0.51s -> 0.5s
+        expect(keyboard._roundNoteDuration(0.51)).toBe(0.5);
+        // 0s falls back to 0.125s minimum
+        expect(keyboard._roundNoteDuration(0)).toBe(0.125);
+        // negative durations convert to positive
+        expect(keyboard._roundNoteDuration(-0.5)).toBe(0.5);
+    });
+
+    test("rounds raw note durations to 1/8th grid in beginner mode", () => {
+        localStorage.beginnerMode = "true";
+        const keyboard = new MusicKeyboard({});
+
+        // 0.26s -> 0.25s (nearest 1/8th)
+        expect(keyboard._roundNoteDuration(0.26)).toBe(0.25);
+        // 0.19s -> 0.25s (rounded to 2/8)
+        expect(keyboard._roundNoteDuration(0.19)).toBe(0.25);
+        // 0s falls back to 0.125s minimum
+        expect(keyboard._roundNoteDuration(0)).toBe(0.125);
+    });
+
+    test("caches and restores document key handlers safely", () => {
+        const keyboard = new MusicKeyboard({});
+        const dummyKeyDown = jest.fn();
+        const dummyKeyUp = jest.fn();
+
+        document.onkeydown = dummyKeyDown;
+        document.onkeyup = dummyKeyUp;
+
+        // First cache
+        keyboard._cacheDocumentKeyHandlers();
+        expect(keyboard._savedDocumentOnKeyDown).toBe(dummyKeyDown);
+        expect(keyboard._savedDocumentOnKeyUp).toBe(dummyKeyUp);
+
+        // Re-caching should not overwrite original
+        document.onkeydown = jest.fn();
+        keyboard._cacheDocumentKeyHandlers();
+        expect(keyboard._savedDocumentOnKeyDown).toBe(dummyKeyDown);
+
+        // Restore
+        keyboard._restoreDocumentKeyHandlers();
+        expect(document.onkeydown).toBe(dummyKeyDown);
+        expect(document.onkeyup).toBe(dummyKeyUp);
+        expect(keyboard._savedDocumentOnKeyDown).toBeUndefined();
+        expect(keyboard._savedDocumentOnKeyUp).toBeUndefined();
+    });
+
+    test("handles fallback timer calls when ManagedTimer is null", () => {
+        jest.useFakeTimers();
+        const keyboard = new MusicKeyboard({});
+        keyboard._timerManager = null;
+
+        const callback = jest.fn();
+        const id = keyboard._setWidgetInterval(callback, 500);
+
+        jest.advanceTimersByTime(500);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        expect(keyboard._clearWidgetInterval(id)).toBe(true);
+        jest.useRealTimers();
+    });
+});


### PR DESCRIPTION
## Description

Expands unit test coverage in `js/widgets/__tests__/musickeyboard.test.js` for `MusicKeyboard` helper logic, duration rounding, and key event handler lifecycle.

Added test cases cover:
1. `_roundNoteDuration` 1/16th grid rounding in normal mode, minimum duration fallback (0.125s), and negative duration conversion.
2. `_roundNoteDuration` 1/8th grid rounding when `localStorage.beginnerMode` is active.
3. `_cacheDocumentKeyHandlers` and `_restoreDocumentKeyHandlers` document key event listener snapshotting and restoration.
4. `_setWidgetInterval` / `_clearWidgetInterval` fallback path when `ManagedTimer` is null.

## Related Issue

N/A

## PR Category

- [x] Tests — Adds or updates unit test coverage

## Changes Made

- **`js/widgets/__tests__/musickeyboard.test.js`**:
  - Added new unit test suite `MusicKeyboard note duration rounding and key handlers` (49/49 total test cases passing).

## Testing Performed

- Ran local Jest test suite: `npx jest js/widgets/__tests__/musickeyboard.test.js --no-coverage` (49/49 tests passed 100%).
- Ran ESLint, Prettier, and commitlint via `lint-staged` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
