### PR TITLE
fix(blocks): handle external connections when copying nested blocks

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -403,6 +403,33 @@ describe("Blocks Foundation", () => {
         });
     });
 
+    describe("Stack Copying", () => {
+        it("disconnects a copied nested stack from parents outside the copy", () => {
+            const blocks = new Blocks(mockActivity);
+            mockActivity.blocksContainer.x = 0;
+            mockActivity.blocksContainer.y = 0;
+            const makeBlock = (name, connections) => ({
+                name,
+                connections,
+                isValueBlock: jest.fn().mockReturnValue(false)
+            });
+            blocks.blockList = [
+                makeBlock("start", [null, 1, null]),
+                makeBlock("forward", [0, 2]),
+                makeBlock("right", [1, null])
+            ];
+            blocks.selectedStack = 1;
+
+            const copiedBlocks = blocks._copyBlocksToObj(false);
+
+            expect(copiedBlocks).toEqual([
+                [0, "forward", 75, 75, [null, 1]],
+                [1, "right", 0, 0, [0, null]]
+            ]);
+            expect(copiedBlocks.flatMap(block => block[4])).not.toContain(undefined);
+        });
+    });
+
     describe("Parameter Block Cache Updates", () => {
         it("only rebuilds the cache when the displayed value changes", () => {
             const blocks = new Blocks(mockActivity);

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4715,10 +4715,14 @@ class Blocks {
             for (let b = 0; b < this.dragGroup.length; b++) {
                 const myBlock = this.blockList[this.dragGroup[b]];
                 for (let c = 0; c < myBlock.connections.length; c++) {
-                    if (myBlock.connections[c] === null) {
+                    const connection = myBlock.connections[c];
+                    if (
+                        connection === null ||
+                        !Object.prototype.hasOwnProperty.call(blockMap, connection)
+                    ) {
                         blockObjs[b][4].push(null);
                     } else {
-                        blockObjs[b][4].push(blockMap[myBlock.connections[c]]);
+                        blockObjs[b][4].push(blockMap[connection]);
                     }
                 }
             }


### PR DESCRIPTION
## Description

Fixes an issue when duplicating a nested block from an existing stack.

Previously, the copied block could keep a reference to its original parent even though that parent was not part of the copied group. This created an invalid connection and caused the duplicated blocks to appear at the wrong position, move incorrectly while dragging, and sometimes throw an error.

The copy logic now sets connections outside the copied group to `null` while keeping connections between copied blocks intact.


## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
* [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Updated `_copyBlocksToObj()` to check whether a connection belongs to the copied group before remapping it.
* Connections pointing to blocks outside the copied group are now stored as `null`.
* Connections between blocks inside the copied group continue to be remapped correctly.
* Added regression test coverage for copying nested blocks.

---

## Visual Changes

### Before
<img width="1917" height="972" alt="Screenshot 2026-08-26 190220" src="https://github.com/user-attachments/assets/27a57291-5c58-49c8-b909-22d949d1979d" />

### After
<img width="1912" height="977" alt="Screenshot 2026-08-26 185951" src="https://github.com/user-attachments/assets/166ce9fe-9bdf-489a-9fdb-d9bc70dc0620" />

---

## Testing Performed

* Tested duplicating a complete stack from the Start block.
* Tested duplicating a nested block from an existing stack.
* Verified that the copied nested block is disconnected from its original parent.
* Verified that connections between the copied blocks are preserved.
* Verified that the duplicated blocks appear at the expected position.
* Verified that the duplicated blocks can be dragged and deleted without errors.
* Added a regression test for external connections during block copying.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The issue only occurred when the copied block had a connection to a block outside the copied group. Copying a complete top-level stack was not affected because its root already had a `null` parent connection.

---