### PR TITLE
test(cypress): add E2E test loading a real project (examples/pi.tb)

### DIFF
--- a/cypress/e2e/project-loading.cy.js
+++ b/cypress/e2e/project-loading.cy.js
@@ -1,0 +1,32 @@
+describe("Project loading", () => {
+    before(() => {
+        cy.visit("http://127.0.0.1:3000");
+        cy.waitForAppReady();
+    });
+
+    it("loads a real project file (examples/pi.tb) onto the canvas", () => {
+        let baselineBlockCount = 0;
+
+        cy.window().then(win => {
+            baselineBlockCount = win.ActivityContext.getActivity().blocks.blockList.length;
+        });
+
+        cy.get("#load").click();
+        cy.get("#myOpenFile").selectFile("examples/pi.tb", { force: true });
+
+        // The load overlay is shown while the project's blocks are parsed and
+        // constructed, and is hidden again once loading finishes (js/blocks.js
+        // loadNewBlocks completion handler). Waiting for it to disappear is the
+        // app's own signal that loading is done, so no arbitrary wait is needed.
+        cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
+
+        // A parse/load failure would surface here (js/project-manager.js errorMsg).
+        cy.get("#errorText").should("not.be.visible");
+        cy.get("#canvas").should("be.visible");
+
+        cy.window().should(win => {
+            const activity = win.ActivityContext.getActivity();
+            expect(activity.blocks.blockList.length).to.be.greaterThan(baselineBlockCount);
+        });
+    });
+});

--- a/cypress/e2e/project-loading.cy.js
+++ b/cypress/e2e/project-loading.cy.js
@@ -15,9 +15,12 @@ describe("Project loading", () => {
         cy.get("#myOpenFile").selectFile("examples/pi.tb", { force: true });
 
         // The load overlay is shown while the project's blocks are parsed and
-        // constructed, and is hidden again once loading finishes (js/blocks.js
-        // loadNewBlocks completion handler). Waiting for it to disappear is the
-        // app's own signal that loading is done, so no arbitrary wait is needed.
+        // constructed (js/project-manager.js doLoadAnimation), and is hidden again
+        // once loading finishes (js/blocks.js loadNewBlocks completion handler).
+        // Asserting the visible state first confirms this run actually went through
+        // that overlay, so the later "not visible" isn't trivially true because
+        // loading never started.
+        cy.get("#load-container").should("be.visible");
         cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
 
         // A parse/load failure would surface here (js/project-manager.js errorMsg).
@@ -26,7 +29,18 @@ describe("Project loading", () => {
 
         cy.window().should(win => {
             const activity = win.ActivityContext.getActivity();
-            expect(activity.blocks.blockList.length).to.be.greaterThan(baselineBlockCount);
+            const { blockList } = activity.blocks;
+
+            expect(blockList.length).to.be.greaterThan(baselineBlockCount);
+
+            // examples/pi.tb is the only example project referencing "heap.json"
+            // (its digit-heap data file), so finding that literal value among the
+            // loaded blocks confirms this project specifically loaded, not just
+            // that some blocks appeared.
+            const loadedPiHeap = blockList.some(
+                block => block.name === "loadFile" && block.value?.[0] === "heap.json"
+            );
+            expect(loadedPiHeap, "pi.tb's heap.json loadFile block should be present").to.be.true;
         });
     });
 });


### PR DESCRIPTION
## Description

Extends the Cypress test suite to cover loading a real Music Blocks project through the actual file-loading UI flow.

The new E2E test clicks the real `#load` toolbar button, uses the hidden `#myOpenFile` input to load `examples/pi.tb`, and verifies that the project is successfully loaded without mocking the loader or production code.

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
* [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added `cypress/e2e/project-loading.cy.js`.
* Loads `examples/pi.tb` through the real `#load` → `#myOpenFile` application flow.
* Verifies that the loading overlay `#load-container` becomes hidden.
* Verifies that the real `#errorText` alert remains hidden.
* Verifies that `#canvas` remains visible.
* Verifies that the Activity block count increases after loading the project.
* Uses the app's `ActivityContext.getActivity()` accessor to inspect the real Activity state.
* Avoids arbitrary waits, pixel comparisons, loader mocks, or production-code changes.
* Leaves execution of the loaded project for a follow-up E2E test.

---

## Visual Changes

Not applicable. This PR adds test coverage only.

---

## Testing Performed

* New `project-loading.cy.js`: **1/1 passed**
* `main.cy.js`: **22/22 passed**
* `startup-stability.cy.js`: **1/1 passed**
* Total: **24/24 Cypress tests passed**
* ESLint passed for the new test file.
* Prettier passed for the new test file.
* Local Cypress verification required temporarily unsetting `ELECTRON_RUN_AS_NODE`; no project files or configuration were changed.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run the relevant linting and formatting checks with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

No production code was modified. The test intentionally focuses only on **project loading**, keeping loading failures distinguishable from project-execution failures.

A follow-up PR can cover actually running the loaded project, such as verifying the play-button flow and resulting audio/turtle state.
