### PR TITLE
perf(rubrics): optimize palette index lookup using Map in analyzeProject

### DIFF
--- a/js/__tests__/rubrics.test.js
+++ b/js/__tests__/rubrics.test.js
@@ -63,6 +63,18 @@ describe("rubrics.js test suite", () => {
             expect(result.length).toBe(PALS.length);
         });
 
+        it("should calculate correct category and palette scores using PALS_INDEX_MAP", () => {
+            const activity = {
+                blocks: {
+                    blockList: [{ name: "forward", connections: ["conn1"] }]
+                }
+            };
+            const result = analyzeProject(activity);
+            const turtlepIndex = PALS_INDEX_MAP.get("turtlep");
+            // TASCORE["forward"] (3) + TASCORE["turtlep"] (5) = 8
+            expect(result[turtlepIndex]).toBe(8);
+        });
+
         it("should ignore blocks in trash", () => {
             const activity = {
                 blocks: {
@@ -84,7 +96,7 @@ describe("rubrics.js test suite", () => {
             });
         });
 
-        it("should warn when pal or TAPAL value is not found in PALS", () => {
+        it("should warn when TAPAL value is not found in PALS_INDEX_MAP in cats loop", () => {
             const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
             const origIndex = PALS_INDEX_MAP.get("numberp");
             PALS_INDEX_MAP.delete("numberp");
@@ -96,9 +108,29 @@ describe("rubrics.js test suite", () => {
             };
             analyzeProject(activity);
 
-            expect(warnSpy).toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledWith(
+                "rubrics: TAPAL value not found in PALS:",
+                "numberp"
+            );
             warnSpy.mockRestore();
             PALS_INDEX_MAP.set("numberp", origIndex);
+        });
+
+        it("should warn when pal is not found in PALS_INDEX_MAP in pals loop", () => {
+            const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+            const origIndex = PALS_INDEX_MAP.get("turtlep");
+            PALS_INDEX_MAP.delete("turtlep");
+
+            const activity = {
+                blocks: {
+                    blockList: [{ name: "forward", connections: ["conn1"] }]
+                }
+            };
+            analyzeProject(activity);
+
+            expect(warnSpy).toHaveBeenCalledWith("rubrics: pal not found in PALS:", "turtlep");
+            warnSpy.mockRestore();
+            PALS_INDEX_MAP.set("turtlep", origIndex);
         });
     });
 

--- a/js/__tests__/rubrics.test.js
+++ b/js/__tests__/rubrics.test.js
@@ -23,6 +23,7 @@ const {
     TAPAL,
     TASCORE,
     PALS,
+    PALS_INDEX_MAP,
     PALLABELS,
     analyzeProject,
     scoreToChartData,
@@ -73,6 +74,31 @@ describe("rubrics.js test suite", () => {
             };
             const result = analyzeProject(activity);
             expect(result).toBeInstanceOf(Array);
+        });
+
+        it("should correctly map palettes to their indices in PALS_INDEX_MAP", () => {
+            expect(PALS_INDEX_MAP).toBeInstanceOf(Map);
+            expect(PALS_INDEX_MAP.size).toBe(PALS.length);
+            PALS.forEach((pal, idx) => {
+                expect(PALS_INDEX_MAP.get(pal)).toBe(idx);
+            });
+        });
+
+        it("should warn when pal or TAPAL value is not found in PALS", () => {
+            const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+            const origIndex = PALS_INDEX_MAP.get("numberp");
+            PALS_INDEX_MAP.delete("numberp");
+
+            const activity = {
+                blocks: {
+                    blockList: [{ name: "random", connections: ["conn1"] }]
+                }
+            };
+            analyzeProject(activity);
+
+            expect(warnSpy).toHaveBeenCalled();
+            warnSpy.mockRestore();
+            PALS_INDEX_MAP.set("numberp", origIndex);
         });
     });
 

--- a/js/rubrics.js
+++ b/js/rubrics.js
@@ -529,6 +529,8 @@ const PALS = [
     "micep"
 ];
 
+const PALS_INDEX_MAP = new Map(PALS.map((pal, idx) => [pal, idx]));
+
 const PALLABELS = [
     _("rhythm"),
     _("pitch"),
@@ -651,8 +653,8 @@ const analyzeProject = activity => {
 
     for (let c = 0; c < cats.length; c++) {
         if (cats[c] in TASCORE) {
-            const idx = PALS.indexOf(TAPAL[cats[c]]);
-            if (idx !== -1) {
+            const idx = PALS_INDEX_MAP.get(TAPAL[cats[c]]);
+            if (idx !== undefined) {
                 scores[idx] += TASCORE[cats[c]];
             } else {
                 console.warn("rubrics: TAPAL value not found in PALS:", TAPAL[cats[c]]);
@@ -662,8 +664,8 @@ const analyzeProject = activity => {
 
     for (let p = 0; p < pals.length; p++) {
         if (pals[p] in TASCORE) {
-            const idx = PALS.indexOf(pals[p]);
-            if (idx !== -1) {
+            const idx = PALS_INDEX_MAP.get(pals[p]);
+            if (idx !== undefined) {
                 scores[idx] += TASCORE[pals[p]];
             } else {
                 console.warn("rubrics: pal not found in PALS:", pals[p]);
@@ -909,6 +911,7 @@ if (typeof module !== "undefined" && module.exports) {
         TAPAL,
         TASCORE,
         PALS,
+        PALS_INDEX_MAP,
         PALLABELS,
         analyzeProject,
         scoreToChartData,


### PR DESCRIPTION
## Description

In `js/rubrics.js`, `analyzeProject` performs palette lookup inside loops by repeatedly scanning the `PALS` array using `PALS.indexOf(...)` ($O(N)$ lookup).

This PR introduces a pre-computed lookup map (`PALS_INDEX_MAP`) to reduce palette index lookup time to $O(1)$ during activity analysis. It also cleans up the lookup condition by checking `idx !== undefined` directly, avoiding unnecessary sentinel (`-1`) mapping.

---

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`js/rubrics.js`**:
  - Initialized `PALS_INDEX_MAP` as a `Map` of palette names to their corresponding array indices in `PALS`.
  - Replaced `PALS.indexOf(...)` inside `analyzeProject`'s category and palette scoring loops with `PALS_INDEX_MAP.get(...)`.
  - Exported `PALS_INDEX_MAP` in `module.exports`.
- **`js/__tests__/rubrics.test.js`**:
  - Added unit test verifying `PALS_INDEX_MAP` correctly maps all palettes to their respective indices.
  - Added unit test verifying warning path behavior when a palette is not found in `PALS_INDEX_MAP`.

---

## Testing Performed

- Ran targeted unit tests via Jest:
  ```bash
  npx jest js/__tests__/rubrics.test.js 


---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->
Lookup time per item inside the loop is now O(1) instead of O(N)  linear scans.
---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
