### PR TITLE
fix(status): prevent TypeError when updating status for trashed or missing blocks

### DIFF
--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -837,5 +837,16 @@ describe("StatusMatrix Widget", () => {
             statusMatrix.updateAll();
             expect(statusMatrix._statusTable).toBeDefined();
         });
+
+        test("safely handles bpm, bpmfactor, and outputtools status fields when block or protoblock is missing", () => {
+            mockActivity.logo.statusFields = [
+                [999, "bpm"],
+                [998, "bpmfactor"],
+                [997, "outputtools"]
+            ];
+            mockActivity.blocks.blockList = {};
+
+            expect(() => statusMatrix.init(mockActivity)).not.toThrow();
+        });
     });
 });

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -155,19 +155,19 @@ class StatusMatrix {
                         label = _("beats per minute2");
                     } else {
                         label =
-                            this.activity.blocks.blockList[statusField[0]].protoblock
-                                .staticLabels[0];
+                            this.activity.blocks.blockList[statusField[0]]?.protoblock
+                                ?.staticLabels?.[0] || "";
                     }
                     break;
                 case "outputtools":
-                    label = this.activity.blocks.blockList[statusField[0]].privateData;
+                    label = this.activity.blocks.blockList[statusField[0]]?.privateData;
                     if (typeof label === "object" && label !== null && label.value) {
                         label = label.value;
                     }
                     if (label === null || label === undefined) {
                         label =
-                            this.activity.blocks.blockList[statusField[0]].protoblock
-                                .staticLabels[0];
+                            this.activity.blocks.blockList[statusField[0]]?.protoblock
+                                ?.staticLabels?.[0] || "";
                     }
                     label = _(label);
                     break;


### PR DESCRIPTION
## Description

Fixes unhandled `TypeError: Cannot read properties of undefined (reading 'protoblock')` console exceptions in `status.js` when updating the Status Matrix widget for `bpm`, `bpmfactor`, or `outputtools` status fields on blocks that have been deleted or trashed.

## Related Issue

Fixes #8264 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added optional chaining `?.protoblock?.staticLabels?.[0] || ""` for `bpm`, `bpmfactor`, and `outputtools` status fields in `js/widgets/status.js` (matching line 176 in the `default` switch branch).
- Added unit tests in `js/widgets/__tests__/status.test.js` verifying safe Status Matrix updating when tracked blocks are missing or deleted.

## Testing Performed

- Ran Jest unit tests: all 58 unit tests in `status.test.js` pass cleanly (`58 passed, 58 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.