### PR TITLE
fix(darkmode): dark mode header and table text styling for floating widgets

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -87,6 +87,13 @@ body.highcontrast {
     background-color: var(--bg) !important;
 }
 
+/* Fix white table header strip in floating widgets during dark mode while preserving table body colors */
+.dark #floatingWindows table thead tr:first-child td,
+.dark #floatingWindows table thead tr:first-child th {
+    background-color: var(--bg) !important;
+    color: var(--fg) !important;
+}
+
 /* Trash view colors for dark mode */
 .dark .trash-view {
     background-color: #2d2d2d;


### PR DESCRIPTION
## Description

Fixes a visual dark mode contrast regression in floating widget windows (specifically `StatusMatrix` in `js/widgets/status.js`) where the top table header row (`thead tr:first-child`) retained a hardcoded bright white background (`#ffffff`) right below the dark titlebar when Dark Mode is enabled.

Adds a targeted CSS Dark Mode theme override in `css/darkmode.css` for `.dark #floatingWindows table thead tr:first-child td` and `.dark #floatingWindows table thead tr:first-child th`.

This turns the top white header strip dark  (`var(--bg)') in Dark Mode, while preserving all widget table body row colors (such as the light-blue `#59b2ff` status cells).

### Before
<img width="1365" height="765" alt="image" src="https://github.com/user-attachments/assets/0423de4b-326b-4cee-9e87-1e5b98e3e6eb" />


### After
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/e5cc1ab3-fb8c-4fe8-b556-7502bfac26fe" />


## Related Issue

N/A

## PR Category

- [x] Bug Fix — Visual UI / CSS styling adjustment

## Changes Made

- **`css/darkmode.css`**:
  - Added targeted Dark Mode selector for floating window top table header cells.

## Testing Performed

- Tested live in browser at `http://127.0.0.1:3000/` by opening the Status widget window in Dark Mode.
- Verified the top header strip transitions cleanly to `var(--bg)` in Dark Mode while table body cells retain their blue background (`#59b2ff`).
- Verified Light Mode appearance remains 100% unaffected.
- Ran commitlint and ESLint via `lint-staged` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
