### PR TITLE
fix: stop unbounded Stairs growth on re-init, fix Alt+S while running

### DIFF
--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -192,7 +192,21 @@ class KeyboardController {
             pasteEl.style.visibility === "visible" ||
             wheelDiv.style.display === "" ||
             activity.turtles.running();
-        activity.inTempoWidget = this._isWidgetOpen("tempo");
+            activity.inTempoWidget = this._isWidgetOpen("tempo");
+
+        // Alt+S (Option+S) must be able to stop a running program even
+        // though `disableKeys` is true whenever activity.turtles.running()
+        // is true — otherwise the one time a user needs Stop, the shortcut
+        // is unreachable. This mirrors how RETURN/SPACE below check
+        // turtles.running() as an independent branch before consulting
+        // disableKeys, rather than folding "running" into the same gate
+        // as unrelated UI-blocking states (modals, search, paste box).
+        if (event.altKey && event.keyCode === 83 && activity.turtles.running()) {
+            activity.textMsg("Alt-S " + _("Stop"));
+            activity.logo.doStopTurtles();
+            activity.currentKeyCode = event.keyCode;
+            return;
+        }
         if (
             (event.altKey && !disableKeys) ||
             event.keyCode === 13 ||

--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -68,6 +68,27 @@ class KeyboardController {
     __keyPressed(event) {
         const activity = this.activity;
 
+        // Alt+S (Option+S) must be able to stop a running program regardless
+        // of any other UI state. It is checked here, before every other
+        // early-return guard in this function (widget-open checks,
+        // keyboardEnableFlag, the hasKeyboard-class check, and critically
+        // the guard further down that returns early whenever
+        // activity.printText has the "show" class). That guard matters
+        // because activity.textMsg() — called by Alt+R when starting
+        // playback — keeps the printText message visible for a full 60
+        // seconds (AlertController.MSG_TIMEOUT), so pressing Alt+S anytime
+        // in that window was previously swallowed before ever reaching the
+        // Alt+S handling further below, and the browser handled the raw
+        // keydown instead of MB. preventDefault() here ensures MB — not
+        // the browser — owns this keystroke.
+        if (event.altKey && event.keyCode === 83 && activity.turtles.running()) {
+            event.preventDefault();
+            activity.textMsg("Alt-S " + _("Stop"));
+            activity.logo.doStopTurtles();
+            activity.currentKeyCode = event.keyCode;
+            return;
+        }
+
         // First, check if the pitch slider is open
         if (this._isWidgetOpen("slider")) {
             // If the event is an arrow key, let the PitchSlider handle it
@@ -193,20 +214,6 @@ class KeyboardController {
             wheelDiv.style.display === "" ||
             activity.turtles.running();
             activity.inTempoWidget = this._isWidgetOpen("tempo");
-
-        // Alt+S (Option+S) must be able to stop a running program even
-        // though `disableKeys` is true whenever activity.turtles.running()
-        // is true — otherwise the one time a user needs Stop, the shortcut
-        // is unreachable. This mirrors how RETURN/SPACE below check
-        // turtles.running() as an independent branch before consulting
-        // disableKeys, rather than folding "running" into the same gate
-        // as unrelated UI-blocking states (modals, search, paste box).
-        if (event.altKey && event.keyCode === 83 && activity.turtles.running()) {
-            activity.textMsg("Alt-S " + _("Stop"));
-            activity.logo.doStopTurtles();
-            activity.currentKeyCode = event.keyCode;
-            return;
-        }
         if (
             (event.altKey && !disableKeys) ||
             event.keyCode === 13 ||

--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -213,7 +213,7 @@ class KeyboardController {
             pasteEl.style.visibility === "visible" ||
             wheelDiv.style.display === "" ||
             activity.turtles.running();
-            activity.inTempoWidget = this._isWidgetOpen("tempo");
+        activity.inTempoWidget = this._isWidgetOpen("tempo");
         if (
             (event.altKey && !disableKeys) ||
             event.keyCode === 13 ||

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -738,8 +738,10 @@ class PitchStaircase {
         this.activity = activity;
 
         for (let i = 0; i < this.Stairs.length; i++) {
-            this.Stairs[i].push(this.Stairs[i][2]); // initial frequency
-            this.Stairs[i].push(this.Stairs[i][2]); // parent frequency
+            if (this.Stairs[i].length === 7) {
+                this.Stairs[i].push(this.Stairs[i][2]); // initial frequency
+                this.Stairs[i].push(this.Stairs[i][2]); // parent frequency
+            }
         }
 
         // this._initialFrequency = this.Stairs[0][2];

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -754,8 +754,20 @@ class PitchStaircase {
             window.widgetWindows &&
             window.widgetWindows.openWindows &&
             window.widgetWindows.openWindows["pitch staircase"]
-        )
+        ) {
+            // Previously this branch just returned, meaning any block value
+            // feeding this widget could change (via reInitWidget()) while
+            // the widget was open, without the visible stairs table ever
+            // reflecting it. this._refresh() (which calls
+            // this._makeStairs(true)) rebuilds the table from the current
+            // this.Stairs data without recreating the widgetWindow/buttons,
+            // so it can't reintroduce an #8234-style duplicate-buttons bug.
+            // Reported by @walterbender: "Changing the value in the
+            // pitchstaircase pitch still seems to break the open pitch
+            // staircase."
+            this._refresh();
             return;
+        }
 
         const widgetWindow = window.widgetWindows.windowFor(
             this,


### PR DESCRIPTION
## Description

Two independent widget/keyboard bugs found during a self-audit of the app's widgets against the `init()`-runs-twice pattern fixed in #8234, and against the screen-reader test-pass findings:

**1. Pitch Staircase — `Stairs` array grows without bound on every re-init.**
`js/widgets/pitchstaircase.js`'s `init()` unconditionally pushed two tracking values (`initial frequency`, `parent frequency`) onto every entry in `this.Stairs` at the very top of the function — before the "widget window already open" early-return guard is even checked. Since `init()` is re-invoked every time a block feeding this widget is edited (via `reInitWidget()`), each re-init permanently grew every stair's array by 2 entries, including on the no-op path where the window was already open. Verified with a standalone reproduction: after 3 `init()` calls, a 7-element `Stairs[i]` entry grew to 13 elements.

**2. Alt+S (Option+S) does not stop a running program.**
In `js/activity/keyboard-controller.js`, the entire Alt-key shortcut switch is gated by `event.altKey && !disableKeys`, and `disableKeys` includes `activity.turtles.running()`. That means the moment a program starts running — exactly when a user needs to press Stop — `disableKeys` becomes `true` and the gate blocks Alt+S from ever reaching its case. This matches finding #5 from the screen-reader manual test pass.

## Update — corrected after @walterbender's review

Both fixes above didn't actually work once tested live:

- **"Alt-S was captured by the browser, not MB."** Root cause: the Alt+S check was positioned *after* an earlier guard in `__keyPressed()` that returns immediately whenever `activity.printText` has the `"show"` class. `activity.textMsg()` (called by Alt+R when starting playback) keeps that message visible for 60 seconds (`AlertController.MSG_TIMEOUT`), so pressing Alt+S anytime in that window was silently swallowed before ever reaching the fix, and the browser handled the raw keydown instead of MB. **Fixed:** moved the check to the very first thing `__keyPressed()` does, ahead of every other guard, and added `event.preventDefault()` so MB — not the browser — owns the keystroke. Verified with a Jest reproduction of this exact scenario (turtles running, `printText` still showing "Alt-R Play").

- **"Changing the value in the pitchstaircase pitch still seems to break the open pitch staircase."** Root cause: `init()`'s early-return guard (fires when the widget window is already open) exited *before* reaching `this._refresh()`, so the visible stairs table never reflected a changed input value — a pre-existing bug in the exact function this PR touches. **Fixed:** call `this._refresh()` before returning on the already-open path instead of just returning. `_refresh()`/`_makeStairs()` only rebuild the existing table (`pscTable.replaceChildren()`), never recreate the widgetWindow or its buttons, so this can't reintroduce an #8234-style duplicate-buttons bug. Verified with a targeted reproduction: a second `init()` call on an already-open widget now calls `_makeStairs`.

## Related Issue

**Related to:** Part of #6608 (self-audit action item from #8234; screen-reader finding #5)

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/widgets/pitchstaircase.js` (`init()`): guarded the `Stairs[i]` metadata push with `if (this.Stairs[i].length === 7)`, and now calls `this._refresh()` on the already-open re-init path instead of returning silently.
- `js/activity/keyboard-controller.js` (`__keyPressed()`): moved the Alt+S-while-running check to the very top of the function (before every other early-return guard), and added `event.preventDefault()`.

---

## Testing Performed

### How to test locally
1. **Pitch Staircase:** open the widget, edit a linked block's value multiple times, confirm both the `Stairs[i]` array length stays fixed and the displayed table updates.
2. **Alt+S:** press Alt+R to start a program, wait a few seconds (so the "Alt-R Play" message is still showing), then press Alt+S — confirm it stops.

### Test cases
1. Reproduced the Stairs growth bug pre-fix (7 → 9 → 11 → 13 over 3 calls); confirmed growth stops at 9 after the fix.
2. Reproduced Walter's exact Alt+S scenario (turtles running, `printText` still showing) with a Jest test against the real `KeyboardController` class — fails before this update's fix, passes after.
3. Reproduced the pitch-staircase-not-refreshing bug with a targeted test — `_makeStairs` now confirmed called on the already-open re-init path.
4. `npx jest js/widgets/__tests__/pitchstaircase.test.js` — 58/58 passing.
5. `npx jest js/activity/__tests__/keyboard-controller.test.js` — 30/30 passing.
6. `npx eslint` and `npx prettier --check` — clean.

**Note on failing CI checks:** `CI / Security audit` is failing but is pre-existing on `master` itself (verified: `npm audit --omit=dev --audit-level=high` against master's own `package.json`/`package-lock.json` already reports 10 vulnerabilities including 1 high, unrelated to anything in this PR's diff). `codecov/patch` and `codecov/project` are failing because the reproduction tests used to verify these fixes were run locally but not yet committed as permanent regression tests — planning to add those next.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the running-program `Alt+S` shortcut to reliably stop activity, prevent browser interference, and record the key press.
  * Fixed pitch staircase updates when reopening the widget, including frequency information, sizing, and maximize behavior.
  * Improved compatibility with different widget window states and ensured resizing uses the correct content area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->