### PR TITLE
test(cypress): cover palette-to-canvas block drag-and-drop workflow

### DIFF
--- a/cypress/e2e/block-drag-drop.cy.js
+++ b/cypress/e2e/block-drag-drop.cy.js
@@ -9,7 +9,7 @@ describe("Block palette drag-and-drop", () => {
         // known default starter project.
         cy.visit("http://127.0.0.1:3000");
         cy.clearLocalStorage();
-        cy.visit("http://127.0.0.1:3000");
+        cy.reload();
         cy.waitForAppReady();
 
         cy.get("body").then($body => {
@@ -38,33 +38,31 @@ describe("Block palette drag-and-drop", () => {
             .should("be.visible");
 
         // Compute the drop target from real application state rather than a
-        // guessed pixel position: the default starter project already has a
-        // "start" hat block whose first child is a "settimbre" block
-        // (js/blocks/PitchBlocks.js's PitchBlock extends FlowBlock, so a
-        // dropped pitch block can dock directly into that same flow slot).
-        // blockMoved (js/activity/block-drag-controller.js) looks for a
-        // compatible dock near (container.x + docks[0][x], container.y +
-        // docks[0][y]) of the DRAGGED block, so the container position we
-        // need to land on is start's child-dock position offset backward by
-        // the dragged block's own top-dock offset.
+        // guessed pixel position: pitch blocks can dock straight beneath the
+        // canvas's "start" hat block, at start's child-dock position offset
+        // backward by the dragged block's own top-dock offset (blockMoved in
+        // js/activity/block-drag-controller.js matches on that offset point).
         cy.window().then(win => {
-            const blocks = win.ActivityContext.getActivity().blocks;
+            const activity = win.ActivityContext.getActivity();
+            const blocks = activity.blocks;
             const startBlk = blocks.blockList.findIndex(b => !b.trash && b.name === "start");
             const start = blocks.blockList[startBlk];
             const previousChild = start.connections[1];
 
-            // Read the dock geometry off an existing "pitch" instance already
-            // on the canvas - dock offsets are fixed per block type/scale, so
-            // this is a stable stand-in for the not-yet-created block's own
-            // geometry. Fail with a clear message rather than a bare
-            // "Cannot read properties of undefined" if the starter project
-            // ever stops shipping a pitch block.
-            const templateBlock = blocks.blockList.find(b => !b.trash && b.name === "pitch");
+            // Read the dragged block's own dock geometry from the Pitch
+            // palette's protoblock model (js/palette.js PaletteModel.update /
+            // makeBlockInfo, which renders each entry's SVG - and its docks -
+            // at the same DEFAULTBLOCKSCALE used for real blocks) rather than
+            // from a block already sitting on the canvas, so this doesn't
+            // depend on the starter project's contents.
+            const pitchModelEntry = activity.palettes.dict["pitch"].model.blocks.find(
+                b => b.blkname === "pitch"
+            );
             expect(
-                templateBlock,
-                "default project should contain a pitch block to provide dock geometry"
+                pitchModelEntry,
+                "Pitch palette model should have a 'pitch' block entry to provide dock geometry"
             ).to.exist;
-            const templateDocks = templateBlock.docks;
+            const templateDocks = pitchModelEntry.docks;
 
             const targetContainerX = start.container.x + start.docks[1][0] - templateDocks[0][0];
             const targetContainerY = start.container.y + start.docks[1][1] - templateDocks[0][1];

--- a/cypress/e2e/block-drag-drop.cy.js
+++ b/cypress/e2e/block-drag-drop.cy.js
@@ -21,11 +21,12 @@ describe("Block palette drag-and-drop", () => {
     });
 
     it("drags a Pitch block from the palette and docks it into the real block flow", () => {
-        // Open the Pitch category. Category icons are base64 SVGs with no
-        // stable semantic attributes, so - as in main.cy.js's "Block Palette"
-        // suite - the category is selected by its statically-defined position
-        // in the category list (Search, Rhythm, Meter, Pitch, ...).
-        cy.get('[width="126"] tbody tr').eq(3).find("img").click();
+        // Open the Pitch category. Category icons themselves are base64 SVGs
+        // with no stable attribute, but each category row's label cell holds
+        // the real, user-visible category name (js/palette.js makeButton:
+        // label.textContent = toTitleCase(_(name))), which is a more durable
+        // selector than a positional index into the category list.
+        cy.contains('[width="126"] tbody tr', "Pitch").find("img").click();
         cy.get("#palette", { timeout: 15000 }).should("be.visible");
 
         // Each open palette row carries an aria-label of the block's raw name
@@ -55,8 +56,15 @@ describe("Block palette drag-and-drop", () => {
             // Read the dock geometry off an existing "pitch" instance already
             // on the canvas - dock offsets are fixed per block type/scale, so
             // this is a stable stand-in for the not-yet-created block's own
-            // geometry.
-            const templateDocks = blocks.blockList.find(b => !b.trash && b.name === "pitch").docks;
+            // geometry. Fail with a clear message rather than a bare
+            // "Cannot read properties of undefined" if the starter project
+            // ever stops shipping a pitch block.
+            const templateBlock = blocks.blockList.find(b => !b.trash && b.name === "pitch");
+            expect(
+                templateBlock,
+                "default project should contain a pitch block to provide dock geometry"
+            ).to.exist;
+            const templateDocks = templateBlock.docks;
 
             const targetContainerX = start.container.x + start.docks[1][0] - templateDocks[0][0];
             const targetContainerY = start.container.y + start.docks[1][1] - templateDocks[0][1];
@@ -137,11 +145,14 @@ describe("Block palette drag-and-drop", () => {
                     "dropped block should now lead into the previous chain head"
                 ).to.eq(plan.previousChild);
 
-                // Position state: the block landed exactly where the docking
+                // Position state: the block landed close to where the docking
                 // math placed it, proving the drop coordinates were accepted
-                // rather than merely hovered over.
-                expect(newBlock.container.x).to.eq(plan.targetContainerX);
-                expect(newBlock.container.y).to.eq(plan.targetContainerY);
+                // rather than merely hovered over. A small tolerance avoids
+                // coupling the test to exact floating-point reproduction of
+                // the app's own layout math - the connection assertions above
+                // are what actually prove real docking occurred.
+                expect(newBlock.container.x).to.be.closeTo(plan.targetContainerX, 1);
+                expect(newBlock.container.y).to.be.closeTo(plan.targetContainerY, 1);
             });
         });
     });

--- a/cypress/e2e/block-drag-drop.cy.js
+++ b/cypress/e2e/block-drag-drop.cy.js
@@ -1,0 +1,148 @@
+/* global cy, describe, it, before */
+
+describe("Block palette drag-and-drop", () => {
+    before(() => {
+        // Fresh session: Music Blocks auto-saves the working project to
+        // localStorage (js/project-manager.js saveLocally) and restores it on
+        // the next load, so without clearing storage this test could inherit
+        // whatever an earlier spec left on the canvas instead of the app's
+        // known default starter project.
+        cy.visit("http://127.0.0.1:3000");
+        cy.clearLocalStorage();
+        cy.visit("http://127.0.0.1:3000");
+        cy.waitForAppReady();
+
+        cy.get("body").then($body => {
+            const closeButtons = $body.find(".windowFrame .wftButton.close");
+            if (closeButtons.length) {
+                cy.wrap(closeButtons).click({ multiple: true, force: true });
+            }
+        });
+    });
+
+    it("drags a Pitch block from the palette and docks it into the real block flow", () => {
+        // Open the Pitch category. Category icons are base64 SVGs with no
+        // stable semantic attributes, so - as in main.cy.js's "Block Palette"
+        // suite - the category is selected by its statically-defined position
+        // in the category list (Search, Rhythm, Meter, Pitch, ...).
+        cy.get('[width="126"] tbody tr').eq(3).find("img").click();
+        cy.get("#palette", { timeout: 15000 }).should("be.visible");
+
+        // Each open palette row carries an aria-label of the block's raw name
+        // (js/palette.js _showMenuItems: itemRow.setAttribute("aria-label", ...)),
+        // which is a stable way to find the plain "pitch" block among the
+        // Pitch category's many blocks (pitch, pitch2, steppitch, hertz, ...).
+        cy.get('#palette tbody tr[aria-label="pitch"] img', { timeout: 15000 })
+            .scrollIntoView()
+            .should("be.visible");
+
+        // Compute the drop target from real application state rather than a
+        // guessed pixel position: the default starter project already has a
+        // "start" hat block whose first child is a "settimbre" block
+        // (js/blocks/PitchBlocks.js's PitchBlock extends FlowBlock, so a
+        // dropped pitch block can dock directly into that same flow slot).
+        // blockMoved (js/activity/block-drag-controller.js) looks for a
+        // compatible dock near (container.x + docks[0][x], container.y +
+        // docks[0][y]) of the DRAGGED block, so the container position we
+        // need to land on is start's child-dock position offset backward by
+        // the dragged block's own top-dock offset.
+        cy.window().then(win => {
+            const blocks = win.ActivityContext.getActivity().blocks;
+            const startBlk = blocks.blockList.findIndex(b => !b.trash && b.name === "start");
+            const start = blocks.blockList[startBlk];
+            const previousChild = start.connections[1];
+
+            // Read the dock geometry off an existing "pitch" instance already
+            // on the canvas - dock offsets are fixed per block type/scale, so
+            // this is a stable stand-in for the not-yet-created block's own
+            // geometry.
+            const templateDocks = blocks.blockList.find(b => !b.trash && b.name === "pitch").docks;
+
+            const targetContainerX = start.container.x + start.docks[1][0] - templateDocks[0][0];
+            const targetContainerY = start.container.y + start.docks[1][1] - templateDocks[0][1];
+
+            cy.wrap({
+                startBlk,
+                previousChild,
+                targetContainerX,
+                targetContainerY
+            }).as("dropPlan");
+        });
+
+        cy.get("@dropPlan").then(plan => {
+            cy.get('#palette tbody tr[aria-label="pitch"] img').then($img => {
+                const rect = $img[0].getBoundingClientRect();
+                const startX = rect.x + rect.width / 2;
+                const startY = rect.y + rect.height / 2;
+
+                // js/palette.js's drag handler centers the floating icon on
+                // the cursor (moveAt) and then converts its final page
+                // position back into container coordinates by subtracting
+                // half the icon's own size, so the on-screen point we must
+                // release the mouse at is the target container position plus
+                // that same half-icon offset.
+                const endX = plan.targetContainerX + rect.width / 2;
+                const endY = plan.targetContainerY + rect.height / 2;
+
+                cy.get('#palette tbody tr[aria-label="pitch"] img')
+                    .trigger("mousedown", { which: 1, pageX: startX, pageY: startY, force: true })
+                    .then($draggedImg => {
+                        // The real handler listens for mousemove on document
+                        // (to follow the cursor) but binds mouseup directly to
+                        // the dragged <img> element, matching where a real
+                        // cursor release would land once the icon has been
+                        // repositioned under it.
+                        cy.document().trigger("mousemove", {
+                            pageX: (startX + endX) / 2,
+                            pageY: (startY + endY) / 2
+                        });
+                        cy.document().trigger("mousemove", { pageX: endX, pageY: endY });
+                        cy.wrap($draggedImg).trigger("mouseup", {
+                            which: 1,
+                            pageX: endX,
+                            pageY: endY,
+                            force: true
+                        });
+                    });
+            });
+        });
+
+        cy.get("@dropPlan").then(plan => {
+            cy.window().should(win => {
+                const blocks = win.ActivityContext.getActivity().blocks;
+                const start = blocks.blockList[plan.startBlk];
+
+                const newBlockId = start.connections[1];
+                expect(
+                    newBlockId,
+                    "start's first child should have changed to the newly dropped block"
+                ).to.not.equal(plan.previousChild);
+
+                const newBlock = blocks.blockList[newBlockId];
+                // Block exists on the canvas as a real, non-trashed block.
+                expect(newBlock, "dropped block should exist in blockList").to.exist;
+                expect(newBlock.trash, "dropped block should not be trashed").to.be.false;
+                expect(newBlock.name, "dropped block should be a pitch block").to.eq("pitch");
+
+                // Meaningful connection state: the new block was spliced into
+                // the real flow, not just placed on top of it - it points back
+                // up to "start" and forward to whatever was start's child
+                // before the drop.
+                expect(
+                    newBlock.connections[0],
+                    "dropped block should be docked as a child of start"
+                ).to.eq(plan.startBlk);
+                expect(
+                    newBlock.connections[newBlock.connections.length - 1],
+                    "dropped block should now lead into the previous chain head"
+                ).to.eq(plan.previousChild);
+
+                // Position state: the block landed exactly where the docking
+                // math placed it, proving the drop coordinates were accepted
+                // rather than merely hovered over.
+                expect(newBlock.container.x).to.eq(plan.targetContainerX);
+                expect(newBlock.container.y).to.eq(plan.targetContainerY);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description

Add Cypress E2E coverage for dragging a block from the palette and docking it into an existing block flow.

The test exercises Music Blocks' real palette drag mechanism and proximity-based docking behavior, then verifies the resulting block connections and position through application state.

---

## Category

- [x] Tests 

---

## Changes Made

* Added `cypress/e2e/block-drag-drop.cy.js`.
* Opens the Pitch palette and drags the real `pitch` block onto the canvas.
* Uses the application's actual `mousedown` / `mousemove` / `mouseup` drag handlers rather than native HTML5 drag events.
* Lets the real proximity-based docking logic snap the block into the existing flow.
* Verifies the resulting `blockList` connections and block position to confirm the block was actually docked rather than merely dropped nearby.

No production code, configuration, or package files were changed.

---

## Visual Changes

Not applicable. This PR adds E2E test coverage only.

---

## Testing Performed

* New focused test: **passing across 2 runs**
* Full Cypress suite: **28/28 passing**
* ESLint: passing
* Prettier: passing
* `git diff --check`: passing

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [x] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

The test uses the application's default starter project as the docking target. Target coordinates are derived from the live block dock offsets rather than hardcoded screen coordinates, so the test verifies the actual docking behavior while remaining independent of fixed canvas positions.
