### PR TITLE
test(cypress): cover MIDI and LilyPond export workflows

### DIFF
--- a/cypress/e2e/export-workflows.cy.js
+++ b/cypress/e2e/export-workflows.cy.js
@@ -1,4 +1,88 @@
-/* global cy, beforeEach, describe, it */
+/* global cy, beforeEach, describe, it, expect */
+
+// Parses Note On events out of a Standard MIDI File's binary content (as
+// returned by cy.readFile(path, "binary")). This walks real SMF chunk/event
+// structure - variable-length delta-times, MIDI running status, and
+// meta/sysex event skipping - rather than searching for a byte pattern, so
+// it can't be fooled by an incidental byte sequence elsewhere in the file.
+// Verified against @tonejs/midi's own decode of export-note-minimal.tb's
+// MIDI export (both agree the fixture's "sol"/octave-4 note is note 67).
+const extractMidiNoteOns = binary => {
+    const bytes = [];
+    for (let i = 0; i < binary.length; i++) bytes.push(binary.charCodeAt(i) & 0xff);
+
+    const readVarLen = pos => {
+        let value = 0;
+        let p = pos;
+        for (;;) {
+            const b = bytes[p++];
+            value = (value << 7) | (b & 0x7f);
+            if ((b & 0x80) === 0) break;
+        }
+        return [value, p];
+    };
+
+    const noteOns = [];
+    let pos = 14; // skip the MThd header chunk (4-byte id + 4-byte length + 6 bytes of data)
+    while (pos < bytes.length) {
+        const chunkId = String.fromCharCode(
+            bytes[pos],
+            bytes[pos + 1],
+            bytes[pos + 2],
+            bytes[pos + 3]
+        );
+        if (chunkId !== "MTrk") break;
+
+        const trackLength =
+            ((bytes[pos + 4] << 24) |
+                (bytes[pos + 5] << 16) |
+                (bytes[pos + 6] << 8) |
+                bytes[pos + 7]) >>>
+            0;
+        let p = pos + 8;
+        const trackEnd = p + trackLength;
+        let runningStatus = null;
+
+        while (p < trackEnd) {
+            let delta;
+            [delta, p] = readVarLen(p);
+
+            let statusByte = bytes[p];
+            if (statusByte & 0x80) {
+                runningStatus = statusByte;
+                p++;
+            } else {
+                statusByte = runningStatus;
+            }
+            const type = statusByte & 0xf0;
+
+            if (statusByte === 0xff) {
+                p++; // meta event type byte
+                let len;
+                [len, p] = readVarLen(p);
+                p += len;
+            } else if (statusByte === 0xf0 || statusByte === 0xf7) {
+                let len;
+                [len, p] = readVarLen(p);
+                p += len;
+            } else if (type === 0x90 || type === 0x80) {
+                const note = bytes[p++];
+                const velocity = bytes[p++];
+                if (type === 0x90 && velocity > 0) {
+                    noteOns.push(note);
+                }
+            } else if (type === 0xa0 || type === 0xb0 || type === 0xe0) {
+                p += 2;
+            } else if (type === 0xc0 || type === 0xd0) {
+                p += 1;
+            } else {
+                break; // unrecognized status - stop parsing this track defensively
+            }
+        }
+        pos = trackEnd;
+    }
+    return noteOns;
+};
 
 const loadFixtureProject = fixtureName => {
     cy.get("#load").click();
@@ -73,7 +157,16 @@ describe("Export workflows", () => {
                 cy.readFile(`cypress/downloads/${filename}`, "binary", { timeout: 30000 }).then(
                     content => {
                         expect(content.slice(0, 4)).to.equal("MThd");
-                        expect(content.length).to.be.greaterThan(20);
+
+                        // export-note-minimal.tb's only note is a "sol"
+                        // (G) pitch block at octave 4 - MIDI note 67 in
+                        // scientific pitch notation - so beyond a valid
+                        // header, the file must actually contain that
+                        // note's Note On event, proving the loaded note
+                        // was exported and not just a structurally valid
+                        // but musically empty MIDI file.
+                        const noteOns = extractMidiNoteOns(content);
+                        expect(noteOns).to.include(67);
                     }
                 );
             });
@@ -106,6 +199,13 @@ describe("Export workflows", () => {
                 cy.readFile(`cypress/downloads/${filename}`, { timeout: 30000 }).then(content => {
                     expect(content).to.contain('\\version "2.18.2"');
                     expect(content).to.contain("Made with LilyPond and Music Blocks");
+
+                    // export-note-minimal.tb's only note - "sol" (G) at
+                    // octave 4, a quarter note - renders in LilyPond
+                    // pitch/duration notation as g'4, so this proves the
+                    // composition itself was transcribed, not just that a
+                    // file with the expected header was written.
+                    expect(content).to.contain("g'4");
                 });
             });
     });

--- a/cypress/e2e/export-workflows.cy.js
+++ b/cypress/e2e/export-workflows.cy.js
@@ -14,16 +14,19 @@ const extractMidiNoteOns = binary => {
     const readVarLen = pos => {
         let value = 0;
         let p = pos;
-        for (;;) {
+        while (p < bytes.length) {
             const b = bytes[p++];
             value = (value << 7) | (b & 0x7f);
-            if ((b & 0x80) === 0) break;
+            if ((b & 0x80) === 0) return [value, p];
         }
-        return [value, p];
+        throw new Error("Invalid MIDI variable-length value");
     };
 
     const noteOns = [];
-    let pos = 14; // skip the MThd header chunk (4-byte id + 4-byte length + 6 bytes of data)
+    // Skip the MThd header chunk using its own declared length (4-byte id +
+    // 4-byte length + N bytes of data) rather than assuming N is always 6.
+    const headerLength = ((bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7]) >>> 0;
+    let pos = 8 + headerLength;
     while (pos < bytes.length) {
         const chunkId = String.fromCharCode(
             bytes[pos],

--- a/cypress/e2e/export-workflows.cy.js
+++ b/cypress/e2e/export-workflows.cy.js
@@ -1,0 +1,112 @@
+/* global cy, beforeEach, describe, it */
+
+const loadFixtureProject = fixtureName => {
+    cy.get("#load").click();
+    cy.get("#myOpenFile").selectFile(`cypress/fixtures/${fixtureName}`, { force: true });
+
+    // Assert the visible state first so the later "not visible" isn't
+    // trivially true because loading never started (see the identical
+    // guard in project-loading.cy.js).
+    cy.get("#load-container").should("be.visible");
+    cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
+    cy.get("#errorText").should("not.be.visible");
+};
+
+// The MIDI/LilyPond save options only exist in the advanced-mode save
+// dropdown (index.html #saveddropdown) - beginner mode's #saveddropdownbeg
+// only offers HTML/PNG (js/toolbar-ui.js renderSaveIcons).
+const switchToAdvancedModeAndOpenSaveMenu = () => {
+    cy.get("#toggleAuxBtn").click();
+    cy.get("#advancedMode").click();
+    cy.get("#saveButtonAdvanced").should("be.visible").click();
+    cy.get("#saveddropdown").should("be.visible");
+};
+
+describe("Export workflows", () => {
+    beforeEach(() => {
+        // Each test gets its own fresh app load, matching the isolation
+        // rationale in maker-widgets.cy.js: Music Blocks auto-saves the
+        // working project to localStorage and restores it on the next
+        // load, so state from one export must not leak into the next.
+        cy.visit("http://127.0.0.1:3000");
+        cy.clearLocalStorage();
+        cy.visit("http://127.0.0.1:3000");
+        cy.waitForAppReady();
+
+        // Dismiss the first-run "Take a Tour" guide, a widget window that
+        // would otherwise collide with the ".windowFrame" selectors used
+        // for the MIDI save dialog below.
+        cy.get("body").then($body => {
+            const closeButtons = $body.find(".windowFrame .wftButton.close");
+            if (closeButtons.length) {
+                cy.wrap(closeButtons).click({ multiple: true, force: true });
+            }
+        });
+
+        loadFixtureProject("export-note-minimal.tb");
+    });
+
+    it("exports a MIDI file for a real note program through the Save menu", () => {
+        switchToAdvancedModeAndOpenSaveMenu();
+
+        // js/toolbar-ui.js wires #save-midi to SaveInterface.saveMIDI, which
+        // runs the loaded program (populating Logo's MIDI track data) and
+        // then, via SaveInterface.download, opens the app's own MBDialog
+        // filename prompt (js/utils/mb-dialog.js) rather than a native
+        // window.prompt.
+        cy.get("#save-midi").click();
+
+        cy.get(".mb-system-dialog input[type='text']", { timeout: 30000 })
+            .should("be.visible")
+            .invoke("val")
+            .should("match", /\.midi$/)
+            .then(filename => {
+                cy.get(".mb-system-dialog button.confirm-button").click();
+
+                // SaveInterface.downloadURL (js/SaveInterface.js) writes the
+                // file via a Blob object URL and an <a download> click, which
+                // Cypress saves under its default downloadsFolder
+                // (cypress/downloads). A Standard MIDI File always starts
+                // with the 4-byte "MThd" header chunk id, so reading it back
+                // verifies real, well-formed MIDI content was generated -
+                // not just that a click occurred.
+                cy.readFile(`cypress/downloads/${filename}`, "binary", { timeout: 30000 }).then(
+                    content => {
+                        expect(content.slice(0, 4)).to.equal("MThd");
+                        expect(content.length).to.be.greaterThan(20);
+                    }
+                );
+            });
+    });
+
+    it("exports a LilyPond file for a real note program through the Save menu", () => {
+        switchToAdvancedModeAndOpenSaveMenu();
+
+        // js/toolbar-ui.js wires #save-ly to SaveInterface.saveLilypond,
+        // which opens the #lilypondModal dialog (index.html) prefilled with
+        // a default filename, rather than downloading immediately.
+        cy.get("#save-ly").click();
+
+        cy.get("#lilypondModal").should("be.visible");
+        cy.get("#fileName")
+            .invoke("val")
+            .should("match", /\.ly$/)
+            .then(filename => {
+                // #submitLilypond runs SaveInterface.saveLYFile, which
+                // re-runs the program to build real notation output and
+                // downloads it via the same Blob/<a download> mechanism as
+                // MIDI export (js/SaveInterface.js afterSaveLilypondLY).
+                cy.get("#submitLilypond").click();
+
+                // js/lilypond.js's LILYPONDHEADER constant, reused verbatim
+                // by every generated .ly file (also asserted in the Jest
+                // unit test js/__tests__/lilypond.test.js), gives a stable,
+                // implementation-independent way to verify real LilyPond
+                // content was written to disk.
+                cy.readFile(`cypress/downloads/${filename}`, { timeout: 30000 }).then(content => {
+                    expect(content).to.contain('\\version "2.18.2"');
+                    expect(content).to.contain("Made with LilyPond and Music Blocks");
+                });
+            });
+    });
+});

--- a/cypress/fixtures/export-note-minimal.tb
+++ b/cypress/fixtures/export-note-minimal.tb
@@ -1,0 +1,11 @@
+[
+    [0, ["start", { "collapsed": false, "xcor": 0, "ycor": 0, "heading": 0, "color": 0, "shade": 50, "pensize": 5, "grey": 100 }], 100, 100, [null, 1, null]],
+    [1, "newnote", 0, 0, [0, 2, 5, null]],
+    [2, "divide", 0, 0, [1, 3, 4]],
+    [3, ["number", { "value": 1 }], 0, 0, [2]],
+    [4, ["number", { "value": 4 }], 0, 0, [2]],
+    [5, "vspace", 0, 0, [1, 6]],
+    [6, "pitch", 0, 0, [5, 7, 8, null]],
+    [7, ["solfege", { "value": "sol" }], 0, 0, [6]],
+    [8, ["number", { "value": 4 }], 0, 0, [6]]
+]


### PR DESCRIPTION
# **Description**

Adds Cypress E2E coverage for the MIDI and LilyPond export workflows in Music Blocks. Both tests exercise the complete export flow through the real Save menu UI and verify that the resulting files are actually downloaded and contain meaningful, valid output.

A minimal note-based fixture is included so both export paths operate on real project data.

---

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests 
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows or automation

---

## Changes Made

* Added `cypress/e2e/export-workflows.cy.js` with E2E coverage for:

  * **MIDI export**

    * Switches to Advanced mode.
    * Opens the Save dropdown.
    * Uses the real `#save-midi` UI action.
    * Handles the application's filename prompt.
    * Reads the downloaded MIDI file and verifies the `MThd` Standard MIDI File header.
  * **LilyPond export**

    * Uses the same real Save menu workflow.
    * Submits the LilyPond export dialog.
    * Reads the generated `.ly` file.
    * Verifies the expected `LILYPONDHEADER` marker.
    * Confirms the fixture's note data is present in the generated output.

* Added `cypress/fixtures/export-note-minimal.tb`, a minimal project containing a single note-value stack under `start`, providing meaningful musical data for both export workflows.

* Verifies **actual downloaded files** rather than only asserting that the export buttons were clicked.

* Uses Cypress's default `downloadsFolder`; no Cypress configuration changes are required.

* Download filenames are obtained from the application's live filename input instead of being hard-coded.

* Tests interact with the application through the real UI rather than calling internal `SaveInterface` methods directly.

---

## Visual Changes

Not applicable. This PR only adds automated test coverage and a test fixture.

---

## Testing Performed

* Both new Cypress tests pass independently.
* Full Cypress suite passes: **32/32 tests**.
* Ran headless Electron via `cypress run`.
* ESLint passes with no errors.
* Prettier passes on the applicable changed files.
* `git diff --check` passes.
* Verified real MIDI and LilyPond downloads and inspected their contents.
* No browser-specific limitations were observed.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of the changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

* This is a **test-only change**; no production code is modified.
* The `.tb` fixture is intentionally not formatted by Prettier because the repository does not provide a matching Prettier parser for this fixture format.
* The LilyPond test also confirms that the actual note data (`g'4`) is present in the generated output, providing stronger coverage than checking only for successful file creation.
* The branch was rebased against the latest `upstream/master` and pushed to `origin`.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

* **Guidelines:** [[Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
* **Chat:** [[Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)](https://matrix.to/#/#sugar:matrix.org)

</details>