### PR TITLE
test(synth): verify Tone.js Transport wrapper and playback clock state

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -40,6 +40,13 @@ describe("MusicBlocks Application", () => {
                 const audioContext = win.Tone.context;
                 cy.wrap(audioContext.state).should("eq", "running");
             });
+            // Play routes through the Tone.Transport wrapper in js/utils/synthutils.js
+            // (js/logo.js calls this.synth.transport.start()), so the transport clock
+            // must actually be started -- not just the audio context resumed. This is
+            // the Tone.js scheduling API Music Blocks playback depends on.
+            cy.window().should(win => {
+                expect(win.Tone.Transport.state).to.eq("started");
+            });
         });
 
         it("should have a functional stop button", () => {
@@ -208,11 +215,25 @@ describe("MusicBlocks Application", () => {
                 expect(ctx.state).to.eq("running");
             });
 
+            // js/logo.js starts the Tone.Transport clock on run; the wrapper in
+            // js/utils/synthutils.js is the only path to it.
+            cy.window().should(win => {
+                expect(win.Tone.Transport.state).to.eq("started");
+            });
+
             cy.get("#stop").click({ force: true });
 
             cy.window().then(win => {
                 const ctx = win.Tone.context;
                 expect(ctx.state === "suspended" || ctx.state === "running").to.be.true;
+            });
+
+            // Stop cancels scheduled transport events, rewinds the clock and stops it
+            // (js/logo.js _cleanupAfterCompletion -> transport.cancel()/seconds = 0 then
+            // synth.stop() -> transport.stop()), so the transport must no longer
+            // report "started".
+            cy.window().should(win => {
+                expect(win.Tone.Transport.state).to.not.eq("started");
             });
 
             cy.get("#canvas").should("exist").and("be.visible");

--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -40,10 +40,9 @@ describe("MusicBlocks Application", () => {
                 const audioContext = win.Tone.context;
                 cy.wrap(audioContext.state).should("eq", "running");
             });
-            // Play routes through the Tone.Transport wrapper in js/utils/synthutils.js
-            // (js/logo.js calls this.synth.transport.start()), so the transport clock
-            // must actually be started -- not just the audio context resumed. This is
-            // the Tone.js scheduling API Music Blocks playback depends on.
+            // Assert the underlying Tone.Transport clock actually started, not only that
+            // the audio context was resumed -- Tone.Transport is the scheduling API
+            // js/logo.js drives playback with (via the wrapper in js/utils/synthutils.js).
             cy.window().should(win => {
                 expect(win.Tone.Transport.state).to.eq("started");
             });
@@ -215,8 +214,9 @@ describe("MusicBlocks Application", () => {
                 expect(ctx.state).to.eq("running");
             });
 
-            // js/logo.js starts the Tone.Transport clock on run; the wrapper in
-            // js/utils/synthutils.js is the only path to it.
+            // Play also starts the underlying Tone.Transport clock, not only the
+            // audio context (js/logo.js runs playback through the transport wrapper
+            // in js/utils/synthutils.js).
             cy.window().should(win => {
                 expect(win.Tone.Transport.state).to.eq("started");
             });
@@ -228,10 +228,9 @@ describe("MusicBlocks Application", () => {
                 expect(ctx.state === "suspended" || ctx.state === "running").to.be.true;
             });
 
-            // Stop cancels scheduled transport events, rewinds the clock and stops it
-            // (js/logo.js _cleanupAfterCompletion -> transport.cancel()/seconds = 0 then
-            // synth.stop() -> transport.stop()), so the transport must no longer
-            // report "started".
+            // After Stop the Tone.Transport clock is no longer running: js/logo.js
+            // cancels its scheduled events, rewinds it and calls synth.stop() ->
+            // transport.stop().
             cy.window().should(win => {
                 expect(win.Tone.Transport.state).to.not.eq("started");
             });

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1084,6 +1084,93 @@ describe("Utility Functions (logic-only)", () => {
         });
     });
 
+    // The `transport` wrapper (js/utils/synthutils.js) is the single seam through which
+    // js/logo.js schedules and reads Music Blocks playback time, so that Tone.js stays a
+    // swappable implementation detail. Its scheduling methods -- schedule/clear/cancel and
+    // the seconds accessors/getSecondsAtTime -- are exactly the Tone.Transport surface the
+    // interpreter depends on (js/logo.js runFromBlockNow / _dispatchTurtleSignals /
+    // clearTurtleRun), so a change in that Tone.js API must fail here.
+    describe("Transport wrapper scheduling delegation", () => {
+        afterEach(() => {
+            global.Tone = require("./tonemock.js");
+            Tone.context.state = "running";
+            Tone.Transport.state = "started";
+        });
+
+        test("schedule delegates callback and time to Tone.Transport.schedule and returns its id", () => {
+            const scheduleSpy = jest.spyOn(Tone.Transport, "schedule").mockReturnValue(42);
+            const callback = jest.fn();
+
+            const id = transport.schedule(callback, 1.5);
+
+            expect(scheduleSpy).toHaveBeenCalledWith(callback, 1.5);
+            expect(id).toBe(42);
+
+            scheduleSpy.mockRestore();
+        });
+
+        test("schedule returns null when Tone.Transport has no schedule method", () => {
+            const realSchedule = Tone.Transport.schedule;
+            Tone.Transport.schedule = undefined;
+
+            expect(transport.schedule(jest.fn(), 0)).toBeNull();
+
+            Tone.Transport.schedule = realSchedule;
+        });
+
+        test("cancel and clear delegate to the matching Tone.Transport methods", () => {
+            const cancelSpy = jest.spyOn(Tone.Transport, "cancel");
+            const clearSpy = jest.spyOn(Tone.Transport, "clear");
+
+            transport.cancel();
+            transport.clear(7);
+
+            expect(cancelSpy).toHaveBeenCalledTimes(1);
+            expect(clearSpy).toHaveBeenCalledWith(7);
+
+            cancelSpy.mockRestore();
+            clearSpy.mockRestore();
+        });
+
+        test("seconds getter reads Tone.Transport.seconds and the setter writes it", () => {
+            Tone.Transport.seconds = 3;
+            expect(transport.seconds).toBe(3);
+
+            transport.seconds = 9.25;
+            expect(Tone.Transport.seconds).toBe(9.25);
+        });
+
+        test("getSecondsAtTime delegates, and falls back to seconds when the method is absent", () => {
+            const atTimeSpy = jest.spyOn(Tone.Transport, "getSecondsAtTime").mockReturnValue(5.5);
+            expect(transport.getSecondsAtTime(0.1)).toBe(5.5);
+            expect(atTimeSpy).toHaveBeenCalledWith(0.1);
+            atTimeSpy.mockRestore();
+
+            const realAtTime = Tone.Transport.getSecondsAtTime;
+            Tone.Transport.getSecondsAtTime = undefined;
+            Tone.Transport.seconds = 2.75;
+            expect(transport.getSecondsAtTime(0.1)).toBe(2.75);
+            Tone.Transport.getSecondsAtTime = realAtTime;
+        });
+
+        test("every method is a safe no-op when Tone is unavailable", () => {
+            global.Tone = undefined;
+
+            expect(transport.isAvailable).toBeFalsy();
+            expect(transport.isClockRunning).toBe(false);
+            expect(transport.schedule(jest.fn(), 0)).toBeNull();
+            expect(transport.seconds).toBe(0);
+            expect(transport.getSecondsAtTime(0)).toBe(0);
+            expect(() => {
+                transport.start();
+                transport.stop();
+                transport.cancel();
+                transport.clear(1);
+                transport.seconds = 4;
+            }).not.toThrow();
+        });
+    });
+
     describe("_createSampleSynth", () => {
         it("creates voice synth correctly", () => {
             loadSamples();

--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -1084,17 +1084,35 @@ describe("Utility Functions (logic-only)", () => {
         });
     });
 
-    // The `transport` wrapper (js/utils/synthutils.js) is the single seam through which
-    // js/logo.js schedules and reads Music Blocks playback time, so that Tone.js stays a
-    // swappable implementation detail. Its scheduling methods -- schedule/clear/cancel and
-    // the seconds accessors/getSecondsAtTime -- are exactly the Tone.Transport surface the
-    // interpreter depends on (js/logo.js runFromBlockNow / _dispatchTurtleSignals /
-    // clearTurtleRun), so a change in that Tone.js API must fail here.
+    // The `transport` wrapper (js/utils/synthutils.js) is the seam js/logo.js goes through
+    // to schedule and read Music Blocks playback time, keeping Tone.js a swappable
+    // implementation detail. Its scheduling methods -- schedule/clear/cancel and the seconds
+    // accessors/getSecondsAtTime -- are exactly the Tone.Transport surface the interpreter
+    // depends on (js/logo.js runFromBlockNow / _dispatchTurtleSignals / clearTurtleRun), so
+    // a change in that Tone.js API must fail here.
+    //
+    // Every test mutates the shared Tone mock (global.Tone / Tone.Transport members). Each
+    // mutation is registered for teardown -- jest.spyOn / jest.replaceProperty for values,
+    // removeToneMember() for the "method missing" guard cases -- and afterEach always puts
+    // the exact originals back, so no test relies on another test's manual cleanup.
     describe("Transport wrapper scheduling delegation", () => {
+        // [object, key, originalValue] for members blanked to exercise the wrapper's
+        // typeof-guarded branches; jest.replaceProperty refuses to replace functions.
+        const removedToneMembers = [];
+        const removeToneMember = (obj, key) => {
+            removedToneMembers.push([obj, key, obj[key]]);
+            obj[key] = undefined;
+        };
+
         afterEach(() => {
-            global.Tone = require("./tonemock.js");
-            Tone.context.state = "running";
-            Tone.Transport.state = "started";
+            jest.restoreAllMocks();
+            while (removedToneMembers.length) {
+                const [obj, key, value] = removedToneMembers.pop();
+                obj[key] = value;
+            }
+            // This describe block is the only writer of Tone.Transport.seconds; return the
+            // shared mock to its default so a later suite reading it is unaffected.
+            Tone.Transport.seconds = 0;
         });
 
         test("schedule delegates callback and time to Tone.Transport.schedule and returns its id", () => {
@@ -1105,17 +1123,12 @@ describe("Utility Functions (logic-only)", () => {
 
             expect(scheduleSpy).toHaveBeenCalledWith(callback, 1.5);
             expect(id).toBe(42);
-
-            scheduleSpy.mockRestore();
         });
 
         test("schedule returns null when Tone.Transport has no schedule method", () => {
-            const realSchedule = Tone.Transport.schedule;
-            Tone.Transport.schedule = undefined;
+            removeToneMember(Tone.Transport, "schedule");
 
             expect(transport.schedule(jest.fn(), 0)).toBeNull();
-
-            Tone.Transport.schedule = realSchedule;
         });
 
         test("cancel and clear delegate to the matching Tone.Transport methods", () => {
@@ -1127,9 +1140,6 @@ describe("Utility Functions (logic-only)", () => {
 
             expect(cancelSpy).toHaveBeenCalledTimes(1);
             expect(clearSpy).toHaveBeenCalledWith(7);
-
-            cancelSpy.mockRestore();
-            clearSpy.mockRestore();
         });
 
         test("seconds getter reads Tone.Transport.seconds and the setter writes it", () => {
@@ -1140,27 +1150,33 @@ describe("Utility Functions (logic-only)", () => {
             expect(Tone.Transport.seconds).toBe(9.25);
         });
 
-        test("getSecondsAtTime delegates, and falls back to seconds when the method is absent", () => {
+        test("getSecondsAtTime delegates to Tone.Transport.getSecondsAtTime", () => {
             const atTimeSpy = jest.spyOn(Tone.Transport, "getSecondsAtTime").mockReturnValue(5.5);
+
             expect(transport.getSecondsAtTime(0.1)).toBe(5.5);
             expect(atTimeSpy).toHaveBeenCalledWith(0.1);
-            atTimeSpy.mockRestore();
-
-            const realAtTime = Tone.Transport.getSecondsAtTime;
-            Tone.Transport.getSecondsAtTime = undefined;
-            Tone.Transport.seconds = 2.75;
-            expect(transport.getSecondsAtTime(0.1)).toBe(2.75);
-            Tone.Transport.getSecondsAtTime = realAtTime;
         });
 
-        test("every method is a safe no-op when Tone is unavailable", () => {
-            global.Tone = undefined;
+        test("getSecondsAtTime falls back to the current seconds when the method is absent", () => {
+            removeToneMember(Tone.Transport, "getSecondsAtTime");
+            Tone.Transport.seconds = 2.75;
+
+            expect(transport.getSecondsAtTime(0.1)).toBe(2.75);
+        });
+
+        test("returns safe defaults when Tone is unavailable", () => {
+            jest.replaceProperty(global, "Tone", undefined);
 
             expect(transport.isAvailable).toBeFalsy();
             expect(transport.isClockRunning).toBe(false);
             expect(transport.schedule(jest.fn(), 0)).toBeNull();
             expect(transport.seconds).toBe(0);
             expect(transport.getSecondsAtTime(0)).toBe(0);
+        });
+
+        test("does not throw when a scheduling call is made while Tone is unavailable", () => {
+            jest.replaceProperty(global, "Tone", undefined);
+
             expect(() => {
                 transport.start();
                 transport.stop();


### PR DESCRIPTION
# Description

This PR adds compatibility-focused test coverage for the existing Tone.js `15.1.22` integration in Music Blocks.

No Tone.js version bump is made because `15.1.22` is the current stable release used by the project. Instead, the PR verifies the Tone.js APIs used by Music Blocks and strengthens the existing Cypress playback coverage without modifying production code.
--

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests 
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added six unit tests in `js/utils/__tests__/synthutils.test.js` covering the `Tone.Transport` wrapper:

  * `schedule()` delegation and returned event ID
  * Missing `schedule()` method guard
  * `cancel()` delegation
  * `clear()` delegation
  * `seconds` getter/setter
  * `getSecondsAtTime()` delegation and fallback
  * Safe no-op behavior when Tone.js is unavailable

* Strengthened the existing Cypress audio tests in `cypress/e2e/main.cy.js` to verify:

  * `Tone.context.state` reaches `"running"` when Play is triggered.
  * `Tone.Transport.state` reaches `"started"` through the application's transport wrapper.
  * `Tone.Transport.state` is no longer `"started"` after Stop.

* The tests exercise the same `Tone.Transport` surface used by `js/logo.js` during playback, providing regression coverage if a future Tone.js release changes these APIs.

* No production code was modified.

* No dependency versions or lockfiles were changed.

* Full loaded-project playback coverage through the real Logo → Singer → Tone.js path is covered separately by PR #8273 and is intentionally not duplicated here.

---

## Visual Changes

Not applicable. This PR contains test-only changes and introduces no UI or visual changes.

---

## Testing Performed

The following checks were run successfully:

```text
npx jest js/utils/__tests__/synthutils.test.js --coverage=false
npm test -- --coverage --ci
env -u ELECTRON_RUN_AS_NODE npx cypress run --spec cypress/e2e/main.cy.js --browser chrome --config video=false
npx eslint cypress/e2e/main.cy.js js/utils/__tests__/synthutils.test.js --max-warnings=0
npx prettier --check cypress/e2e/main.cy.js js/utils/__tests__/synthutils.test.js
git log -1 --format="%B" | npx commitlint
npm audit --omit=dev --audit-level=high
```

Results:

* **Jest:** 221 suites / 8091 tests passed
* **synthutils tests:** 143/143 passed
* **Cypress `main.cy.js`:** 22/22 passed
* **ESLint:** clean
* **Prettier:** clean
* **Commitlint:** passed
* **npm audit:** 4 moderate pre-existing vulnerabilities in the development dependency chain; no high-severity findings
* `git diff` confirms no changes to `package.json` or `package-lock.json`

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run linting and Prettier checks with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Tone.js remains pinned at **15.1.22**, with no compatibility changes required. The goal of this PR is to establish regression coverage around the existing integration rather than introduce a meaningless dependency version bump.

The new tests specifically cover the `Tone.Transport` functionality used by Music Blocks and verify the real Play/Stop workflow through the application's existing UI and transport wrapper.

No production code, package configuration, lockfiles, or CI workflows are changed.
