### PR TITLE
feat(ast): add deterministic module test-plan extractor

### DIFF
--- a/scripts/generate-tests/README.md
+++ b/scripts/generate-tests/README.md
@@ -47,8 +47,15 @@ node scripts/generate-tests/cli.js path/to/module.js --check path/to/expected.js
 - **referencedGlobals** – identifiers used in a value position that are not bound
   anywhere in the file.
 - **jsdoc** – `/** ... */` blocks that sit directly above a declaration, split
-  into a description and a flat list of `@tag` entries.
+  into a description and a flat list of `@tag` entries. A class member's `target`
+  is qualified with the class name (`Counter.tick`); a bare `target` is a
+  top-level function, class or variable.
 - **totals** – whole-file branch / `return` / `throw` counts.
+
+`branches` (per-function and in `totals`) is a rough syntactic count – `if`,
+conditional expression, each `&&` / `||` / `??`, and each non-default `switch`
+case. It is **not** cyclomatic complexity or branch coverage: `a && b && c`
+counts as two and loops are not counted.
 
 ## Deliberate limitations
 
@@ -60,6 +67,7 @@ node scripts/generate-tests/cli.js path/to/module.js --check path/to/expected.js
   the file is treated as bound everywhere, so a global shadowed elsewhere may be
   omitted. Dependency detection uses the same heuristic to ignore a locally
   declared `require`.
-- Only the CommonJS and ES module patterns that appear in this repository are
-  resolved. Conditional or computed exports are not.
+- CommonJS exports are detected only at module scope (including the usual
+  `if (typeof module !== "undefined" ...)` guard). `module.exports = ...` inside
+  a nested function is ignored. Conditional or computed exports are not resolved.
 - Parse errors are reported with the filename attached and never modify anything.

--- a/scripts/generate-tests/README.md
+++ b/scripts/generate-tests/README.md
@@ -54,8 +54,12 @@ node scripts/generate-tests/cli.js path/to/module.js --check path/to/expected.js
 
 - Everything is derived syntactically. The target file is never required,
   imported, executed or written to.
+- Parsing uses the vendored Acorn (8.14.1) with `ecmaVersion: 2020`, matching the
+  rest of the repository. Syntax newer than that is a parse error.
 - `referencedGlobals` is name-based, not scope-accurate: a name bound anywhere in
-  the file is treated as bound everywhere, so a shadowed global may be omitted.
+  the file is treated as bound everywhere, so a global shadowed elsewhere may be
+  omitted. Dependency detection uses the same heuristic to ignore a locally
+  declared `require`.
 - Only the CommonJS and ES module patterns that appear in this repository are
   resolved. Conditional or computed exports are not.
 - Parse errors are reported with the filename attached and never modify anything.

--- a/scripts/generate-tests/README.md
+++ b/scripts/generate-tests/README.md
@@ -1,0 +1,61 @@
+# Module test-plan extractor
+
+A small, deterministic AST analysis utility. Given a JavaScript source file it
+produces a JSON description of what the module exposes and what is therefore
+worth testing: exported functions and classes, their parameters, shallow
+structural counts (branches, `return`, `throw`), `require`/`import`
+dependencies, referenced free identifiers, and leading JSDoc.
+
+This is the **extraction / planning layer only**. It does not generate tests,
+call any external service, or run the analysed code.
+
+## Usage
+
+```sh
+# Print the plan as JSON
+node scripts/generate-tests/cli.js js/utils/utils-logic.js
+
+# Compare against a committed expected plan without writing anything.
+# Exit 0 on match, 1 on mismatch. The expected file defaults to the source
+# path with `.js` replaced by `.plan.json`; an explicit path may be given.
+node scripts/generate-tests/cli.js path/to/module.js --check
+node scripts/generate-tests/cli.js path/to/module.js --check path/to/expected.json
+```
+
+## Files
+
+| File                  | Responsibility                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `extract-module.js`   | Reads a file, parses it with the vendored Acorn (`lib/acorn.min.js`), returns a plan. |
+| `module-test-plan.js` | Pure AST walker that builds the plan structure.                                       |
+| `cli.js`              | Command-line wrapper, including `--check`.                                            |
+| `__tests__/`          | Jest tests plus fixtures and their committed `.plan.json` plans.                      |
+
+## What is extracted
+
+- **exports** – `module.exports = <object>` (directly or through one identifier)
+  is expanded one level into its members; `exports.x = ...`, direct
+  class/function assignment, and ES module `export` forms are also recognised.
+  Each entry carries `name`, `kind` (`function` / `class` / `object` / `value`),
+  and – for functions – `params` and `arity`, or – for classes – `methods` and
+  `superClass`.
+- **functions** / **classes** – every top-level declaration, with per-function
+  branch / `return` / `throw` counts (not descending into nested functions) and
+  per-class method descriptions (constructor, methods, accessors, `static`).
+- **dependencies** – string arguments to `require(...)` and `import`/`export`
+  sources.
+- **referencedGlobals** – identifiers used in a value position that are not bound
+  anywhere in the file.
+- **jsdoc** – `/** ... */` blocks that sit directly above a declaration, split
+  into a description and a flat list of `@tag` entries.
+- **totals** – whole-file branch / `return` / `throw` counts.
+
+## Deliberate limitations
+
+- Everything is derived syntactically. The target file is never required,
+  imported, executed or written to.
+- `referencedGlobals` is name-based, not scope-accurate: a name bound anywhere in
+  the file is treated as bound everywhere, so a shadowed global may be omitted.
+- Only the CommonJS and ES module patterns that appear in this repository are
+  resolved. Conditional or computed exports are not.
+- Parse errors are reported with the filename attached and never modify anything.

--- a/scripts/generate-tests/__tests__/extract-module.test.js
+++ b/scripts/generate-tests/__tests__/extract-module.test.js
@@ -1,0 +1,276 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { parseSource, extractModule, extractFile, stringifyPlan } = require("../extract-module");
+const cli = require("../cli");
+
+const FIXTURES = path.join(__dirname, "fixtures");
+const readFixture = name => fs.readFileSync(path.join(FIXTURES, name), "utf8");
+
+describe("extract-module: simple-module fixture", () => {
+    const plan = extractModule(readFixture("simple-module.js"), "simple-module.js");
+
+    it("records the file name and detected source type", () => {
+        expect(plan.file).toBe("simple-module.js");
+        expect(plan.sourceType).toBe("script");
+    });
+
+    it("resolves the namespace object assigned to module.exports", () => {
+        expect(plan.exports.map(e => e.name)).toEqual([
+            "clamp",
+            "normalizePath",
+            "parseFlag",
+            "required"
+        ]);
+        expect(plan.exports.every(e => e.kind === "function")).toBe(true);
+        expect(plan.exports.every(e => e.via === "SimpleModule")).toBe(true);
+    });
+
+    it("reports parameter names, arity and rest parameters", () => {
+        const clamp = plan.exports.find(e => e.name === "clamp");
+        expect(clamp.params).toEqual(["value", "min", "max"]);
+        expect(clamp.arity).toBe(1); // stops at the first default
+
+        const normalizePath = plan.functions.find(f => f.name === "normalizePath");
+        expect(normalizePath.params).toEqual(["...segments"]);
+        expect(normalizePath.arity).toBe(0);
+        expect(normalizePath.hasRestParam).toBe(true);
+    });
+
+    it("counts branches, returns and throws per function without entering nested scopes", () => {
+        const clamp = plan.functions.find(f => f.name === "clamp");
+        expect(clamp).toMatchObject({ branches: 4, returns: 3, throws: 0 });
+
+        const parseFlag = plan.functions.find(f => f.name === "parseFlag");
+        expect(parseFlag).toMatchObject({ branches: 3, returns: 2, throws: 0 });
+
+        const required = plan.functions.find(f => f.name === "required");
+        expect(required).toMatchObject({ branches: 2, returns: 1, throws: 1 });
+    });
+
+    it("detects require() dependencies and free global references", () => {
+        expect(plan.dependencies).toEqual(["path"]);
+        expect(plan.referencedGlobals).toEqual(
+            expect.arrayContaining(["Error", "Number", "String"])
+        );
+        expect(plan.referencedGlobals).not.toContain("path"); // bound by the require() call
+        expect(plan.referencedGlobals).not.toContain("value"); // a parameter
+    });
+
+    it("extracts leading JSDoc blocks and their tags", () => {
+        const clampDoc = plan.jsdoc.find(d => d.target === "clamp");
+        expect(clampDoc.description).toBe("Clamps a number to a range.");
+        expect(clampDoc.tags).toEqual([
+            { tag: "param", text: "{number} value - the input value." },
+            { tag: "param", text: "{number} min - lower bound." },
+            { tag: "param", text: "{number} max - upper bound." },
+            { tag: "returns", text: "{number} the clamped value." }
+        ]);
+    });
+
+    it("does not attach the file banner comment to the first declaration", () => {
+        expect(plan.jsdoc.map(d => d.target)).not.toContain("path");
+    });
+
+    it("aggregates whole-file totals", () => {
+        expect(plan.totals).toEqual({ branches: 12, returns: 7, throws: 1 });
+    });
+
+    it("matches the committed expected plan byte-for-byte", () => {
+        const expected = readFixture("simple-module.plan.json");
+        expect(
+            stringifyPlan(extractFile("scripts/generate-tests/__tests__/fixtures/simple-module.js"))
+        ).toBe(expected);
+    });
+});
+
+describe("extract-module: class-module fixture", () => {
+    const plan = extractModule(readFixture("class-module.js"), "class-module.js");
+
+    it("resolves classes exported via an object literal", () => {
+        expect(plan.exports.map(e => e.name)).toEqual(["Base", "Counter"]);
+        expect(plan.exports.every(e => e.kind === "class")).toBe(true);
+    });
+
+    it("records the superclass name", () => {
+        expect(plan.exports.find(e => e.name === "Counter").superClass).toBe("Base");
+        expect(plan.exports.find(e => e.name === "Base").superClass).toBeNull();
+    });
+
+    it("describes constructor, methods, accessors and static members", () => {
+        const counter = plan.classes.find(c => c.name === "Counter");
+        const byKey = counter.methods.map(m => `${m.isStatic ? "static " : ""}${m.kind} ${m.name}`);
+        expect(byKey).toEqual([
+            "constructor constructor",
+            "method tick",
+            "get value",
+            "set value",
+            "static method fromArray"
+        ]);
+
+        const ctor = counter.methods.find(m => m.kind === "constructor");
+        expect(ctor.params).toEqual(["name", "start", "step"]);
+        expect(ctor.arity).toBe(1);
+
+        const setter = counter.methods.find(m => m.kind === "set");
+        expect(setter.params).toEqual(["next"]);
+    });
+
+    it("counts a throw inside a method and the module-guard branch", () => {
+        expect(plan.totals).toEqual({ branches: 3, returns: 4, throws: 1 });
+    });
+
+    it("has no top-level functions", () => {
+        expect(plan.functions).toEqual([]);
+    });
+});
+
+describe("extract-module: real repository modules", () => {
+    it("plans js/utils/language-utils.js without expanding nested data maps", () => {
+        const plan = extractFile("js/utils/language-utils.js");
+        expect(plan.file).toBe("js/utils/language-utils.js");
+        expect(plan.exports).toEqual([
+            { name: "LANGUAGE_CODE_TO_LOCALE", kind: "object", via: "LanguageUtils" },
+            {
+                name: "normalizeLanguageCode",
+                kind: "function",
+                params: ["language"],
+                arity: 1,
+                hasRestParam: false,
+                via: "LanguageUtils"
+            }
+        ]);
+    });
+
+    it("plans js/utils/utils-logic.js and lists its pure helpers as exports", () => {
+        const plan = extractFile("js/utils/utils-logic.js");
+        const names = plan.exports.map(e => e.name);
+        expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+        expect(names).toEqual(
+            expect.arrayContaining(["clampNumber", "deepClone", "GCD", "safeJSONParse"])
+        );
+        expect(plan.exports.find(e => e.name === "clampNumber")).toMatchObject({
+            kind: "function",
+            params: ["val", "min", "max", "fallback"],
+            arity: 3
+        });
+        expect(plan.classes).toEqual([]);
+    });
+
+    it("produces identical output on repeated runs", () => {
+        const once = stringifyPlan(extractFile("js/utils/utils-logic.js"));
+        const twice = stringifyPlan(extractFile("js/utils/utils-logic.js"));
+        expect(twice).toBe(once);
+    });
+});
+
+describe("extract-module: parsing and error handling", () => {
+    it("reports a parse error with the file name and location, without throwing anything else", () => {
+        expect(() => parseSource("const x = {", "broken.js")).toThrow(/^broken\.js:/);
+        try {
+            parseSource("function (", "bad-input.js");
+        } catch (err) {
+            expect(err.file).toBe("bad-input.js");
+            expect(err.message).toContain("bad-input.js");
+            expect(err.loc).toBeDefined();
+        }
+    });
+
+    it("attaches the file name when the file cannot be read", () => {
+        expect(() => extractFile("does/not/exist.js")).toThrow(
+            /does\/not\/exist\.js: unable to read file/
+        );
+    });
+
+    it("returns an empty exports list for a module with no detectable exports", () => {
+        const plan = extractModule(
+            "function helper(a) { return a * 2; }\nhelper(21);\n",
+            "no-exports.js"
+        );
+        expect(plan.exports).toEqual([]);
+        expect(plan.functions.map(f => f.name)).toEqual(["helper"]);
+        expect(plan.referencedGlobals).toEqual([]);
+    });
+
+    it("detects an ES module export and switches source type", () => {
+        const plan = extractModule(
+            "export function add(a, b) { return a + b; }\nexport default add;\n",
+            "esm.js"
+        );
+        expect(plan.sourceType).toBe("module");
+        expect(plan.exports.map(e => e.name).sort()).toEqual(["add", "default"]);
+    });
+
+    it("does not require, import or execute the analysed source", () => {
+        const marker = path.join(FIXTURES, "__side_effect__.txt");
+        const source = `require("fs").writeFileSync(${JSON.stringify(marker)}, "x");\nmodule.exports = {};\n`;
+        extractModule(source, "hostile.js");
+        expect(fs.existsSync(marker)).toBe(false);
+    });
+});
+
+describe("cli helpers", () => {
+    it("parses a bare file argument", () => {
+        expect(cli.parseArgs(["a.js"])).toEqual({ file: "a.js", check: false, expected: null });
+    });
+
+    it("parses --check with an optional explicit expected path", () => {
+        expect(cli.parseArgs(["a.js", "--check"])).toEqual({
+            file: "a.js",
+            check: true,
+            expected: null
+        });
+        expect(cli.parseArgs(["a.js", "--check", "b.json"])).toEqual({
+            file: "a.js",
+            check: true,
+            expected: "b.json"
+        });
+        expect(cli.parseArgs(["a.js", "--check=b.json"])).toEqual({
+            file: "a.js",
+            check: true,
+            expected: "b.json"
+        });
+    });
+
+    it("derives the default expected-plan path from the source path", () => {
+        expect(cli.expectedPathFor("dir/mod.js", null)).toBe("dir/mod.plan.json");
+        expect(cli.expectedPathFor("dir/mod.js", "custom.json")).toBe("custom.json");
+    });
+
+    it("rejects unknown options and missing files", () => {
+        expect(() => cli.parseArgs(["--bogus"])).toThrow(/unknown option/);
+        expect(() => cli.parseArgs([])).toThrow(/usage:/);
+    });
+
+    it("--check returns 0 when the committed plan matches and 1 when it differs", () => {
+        expect(
+            cli.main(["scripts/generate-tests/__tests__/fixtures/simple-module.js", "--check"])
+        ).toBe(0);
+        expect(
+            cli.main([
+                "scripts/generate-tests/__tests__/fixtures/simple-module.js",
+                "--check",
+                "scripts/generate-tests/__tests__/fixtures/class-module.plan.json"
+            ])
+        ).toBe(1);
+    });
+});

--- a/scripts/generate-tests/__tests__/extract-module.test.js
+++ b/scripts/generate-tests/__tests__/extract-module.test.js
@@ -165,6 +165,44 @@ describe("extract-module: class-module fixture", () => {
     it("has no top-level functions", () => {
         expect(plan.functions).toEqual([]);
     });
+
+    it("qualifies class-member JSDoc targets with the class name", () => {
+        const targets = plan.jsdoc.map(d => d.target);
+        expect(targets).toEqual(expect.arrayContaining(["Base.constructor", "Counter.tick"]));
+        expect(targets).not.toContain("constructor");
+        expect(targets).not.toContain("tick");
+    });
+});
+
+describe("extract-module: export detection stays at module scope", () => {
+    it("ignores module.exports assigned inside a nested function", () => {
+        const plan = extractModule(
+            "function later() {\n    module.exports = { foo };\n}\nfunction foo() {}\n",
+            "later.js"
+        );
+        expect(plan.exports).toEqual([]);
+    });
+
+    it("ignores exports.x assigned inside a nested function", () => {
+        const plan = extractModule(
+            "function configure() {\n    exports.bar = 1;\n}\n",
+            "configure.js"
+        );
+        expect(plan.exports).toEqual([]);
+    });
+
+    it("still resolves the top-level typeof-module guard", () => {
+        const plan = extractModule(
+            [
+                "function helper() {}",
+                'if (typeof module !== "undefined" && module.exports) {',
+                "    module.exports = { helper };",
+                "}"
+            ].join("\n"),
+            "guarded.js"
+        );
+        expect(plan.exports.map(e => e.name)).toEqual(["helper"]);
+    });
 });
 
 describe("extract-module: export de-duplication", () => {

--- a/scripts/generate-tests/__tests__/extract-module.test.js
+++ b/scripts/generate-tests/__tests__/extract-module.test.js
@@ -76,6 +76,29 @@ describe("extract-module: simple-module fixture", () => {
         expect(plan.referencedGlobals).not.toContain("value"); // a parameter
     });
 
+    it("keeps shorthand object properties as referenced globals", () => {
+        const shorthand = extractModule(
+            "const result = { Tone, helper };\nfunction helper() {}\n",
+            "shorthand.js"
+        );
+        expect(shorthand.referencedGlobals).toContain("Tone");
+        expect(shorthand.referencedGlobals).not.toContain("helper"); // declared below
+        expect(shorthand.referencedGlobals).not.toContain("result");
+    });
+
+    it("does not treat a non-shorthand property key as a reference", () => {
+        const keyed = extractModule("const result = { Tone: 1 };\n", "keyed.js");
+        expect(keyed.referencedGlobals).not.toContain("Tone");
+    });
+
+    it("ignores calls to a locally declared require", () => {
+        const shadowed = extractModule(
+            "function require(x) { return x; }\nrequire('not-a-dependency');\n",
+            "shadowed-require.js"
+        );
+        expect(shadowed.dependencies).toEqual([]);
+    });
+
     it("extracts leading JSDoc blocks and their tags", () => {
         const clampDoc = plan.jsdoc.find(d => d.target === "clamp");
         expect(clampDoc.description).toBe("Clamps a number to a range.");
@@ -270,6 +293,32 @@ describe("cli helpers", () => {
                 "scripts/generate-tests/__tests__/fixtures/simple-module.js",
                 "--check",
                 "scripts/generate-tests/__tests__/fixtures/class-module.plan.json"
+            ])
+        ).toBe(1);
+    });
+
+    it("--check reports a malformed expected plan as a clean failure", () => {
+        const badPlan = path.join(FIXTURES, "__malformed__.plan.json");
+        fs.writeFileSync(badPlan, "{ not valid json");
+        try {
+            expect(
+                cli.main([
+                    "scripts/generate-tests/__tests__/fixtures/simple-module.js",
+                    "--check",
+                    "scripts/generate-tests/__tests__/fixtures/__malformed__.plan.json"
+                ])
+            ).toBe(1);
+        } finally {
+            fs.unlinkSync(badPlan);
+        }
+    });
+
+    it("--check reports a missing expected plan as a clean failure", () => {
+        expect(
+            cli.main([
+                "scripts/generate-tests/__tests__/fixtures/simple-module.js",
+                "--check",
+                "scripts/generate-tests/__tests__/fixtures/__nope__.plan.json"
             ])
         ).toBe(1);
     });

--- a/scripts/generate-tests/__tests__/extract-module.test.js
+++ b/scripts/generate-tests/__tests__/extract-module.test.js
@@ -167,6 +167,34 @@ describe("extract-module: class-module fixture", () => {
     });
 });
 
+describe("extract-module: export de-duplication", () => {
+    const plan = extractModule(
+        [
+            "const cfg = { a: 1 };",
+            "function fn() {}",
+            "exports.thing = fn;", // { thing, function }
+            "exports.thing = cfg;", // { thing, object } - different kind, kept
+            "exports.dup = fn;",
+            "exports.dup = fn;" // { dup, function } twice - collapsed
+        ].join("\n"),
+        "dedupe.js"
+    );
+
+    it("keys de-duplication on both name and kind", () => {
+        const thing = plan.exports.filter(e => e.name === "thing");
+        expect(thing.map(e => e.kind).sort()).toEqual(["function", "object"]);
+    });
+
+    it("collapses entries that match on name and kind", () => {
+        expect(plan.exports.filter(e => e.name === "dup")).toHaveLength(1);
+    });
+
+    it("emits no control characters in the plan JSON", () => {
+        // eslint-disable-next-line no-control-regex
+        expect(/[\u0000-\u0008\u000e-\u001f]/.test(stringifyPlan(plan))).toBe(false);
+    });
+});
+
 describe("extract-module: real repository modules", () => {
     it("plans js/utils/language-utils.js without expanding nested data maps", () => {
         const plan = extractFile("js/utils/language-utils.js");

--- a/scripts/generate-tests/__tests__/fixtures/class-module.js
+++ b/scripts/generate-tests/__tests__/fixtures/class-module.js
@@ -1,0 +1,80 @@
+/**
+ * Fixture: a CommonJS module whose public surface is a single class, in the
+ * style of js/js-export/. Exercises class + method extraction, constructor
+ * parameters, static methods, accessors, `extends`, and branch/throw counting
+ * inside methods. This file is only ever parsed by the extractor, never run.
+ */
+
+/**
+ * Base class with shared behaviour.
+ */
+class Base {
+    /**
+     * @param {string} name - identifier for the instance.
+     */
+    constructor(name) {
+        this.name = name;
+    }
+
+    describe() {
+        return `base:${this.name}`;
+    }
+}
+
+/**
+ * A small counter built on top of {@link Base}.
+ */
+class Counter extends Base {
+    /**
+     * @param {string} name - identifier for the counter.
+     * @param {number} start - initial value.
+     * @param {number} step - increment applied by `tick`.
+     */
+    constructor(name, start = 0, step = 1) {
+        super(name);
+        this._value = start;
+        this._step = step;
+    }
+
+    /**
+     * @returns {number} the current value.
+     */
+    get value() {
+        return this._value;
+    }
+
+    /**
+     * @param {number} next - value to set.
+     */
+    set value(next) {
+        if (typeof next !== "number") {
+            throw new TypeError("value must be a number");
+        }
+        this._value = next;
+    }
+
+    /**
+     * Advances the counter, optionally several times.
+     *
+     * @param {number} times - how many steps to take.
+     * @returns {number} the updated value.
+     */
+    tick(times = 1) {
+        for (let i = 0; i < times; i += 1) {
+            this._value += this._step;
+        }
+        return this._value;
+    }
+
+    /**
+     * @param {number[]} values - starting values.
+     * @returns {Counter[]} one counter per value.
+     */
+    static fromArray(values) {
+        return values.map((value, index) => new Counter(`c${index}`, value));
+    }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { Base, Counter };
+}

--- a/scripts/generate-tests/__tests__/fixtures/class-module.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/class-module.plan.json
@@ -1,0 +1,271 @@
+{
+  "file": "scripts/generate-tests/__tests__/fixtures/class-module.js",
+  "sourceType": "script",
+  "exports": [
+    {
+      "name": "Base",
+      "kind": "class",
+      "superClass": null,
+      "methods": [
+        {
+          "name": "constructor",
+          "kind": "constructor",
+          "isStatic": false,
+          "params": [
+            "name"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "describe",
+          "kind": "method",
+          "isStatic": false,
+          "params": [],
+          "arity": 0,
+          "hasRestParam": false
+        }
+      ],
+      "via": null
+    },
+    {
+      "name": "Counter",
+      "kind": "class",
+      "superClass": "Base",
+      "methods": [
+        {
+          "name": "constructor",
+          "kind": "constructor",
+          "isStatic": false,
+          "params": [
+            "name",
+            "start",
+            "step"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "tick",
+          "kind": "method",
+          "isStatic": false,
+          "params": [
+            "times"
+          ],
+          "arity": 0,
+          "hasRestParam": false
+        },
+        {
+          "name": "value",
+          "kind": "get",
+          "isStatic": false,
+          "params": [],
+          "arity": 0,
+          "hasRestParam": false
+        },
+        {
+          "name": "value",
+          "kind": "set",
+          "isStatic": false,
+          "params": [
+            "next"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "fromArray",
+          "kind": "method",
+          "isStatic": true,
+          "params": [
+            "values"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        }
+      ],
+      "via": null
+    }
+  ],
+  "functions": [],
+  "classes": [
+    {
+      "name": "Base",
+      "superClass": null,
+      "methods": [
+        {
+          "name": "constructor",
+          "kind": "constructor",
+          "isStatic": false,
+          "params": [
+            "name"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "describe",
+          "kind": "method",
+          "isStatic": false,
+          "params": [],
+          "arity": 0,
+          "hasRestParam": false
+        }
+      ]
+    },
+    {
+      "name": "Counter",
+      "superClass": "Base",
+      "methods": [
+        {
+          "name": "constructor",
+          "kind": "constructor",
+          "isStatic": false,
+          "params": [
+            "name",
+            "start",
+            "step"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "tick",
+          "kind": "method",
+          "isStatic": false,
+          "params": [
+            "times"
+          ],
+          "arity": 0,
+          "hasRestParam": false
+        },
+        {
+          "name": "value",
+          "kind": "get",
+          "isStatic": false,
+          "params": [],
+          "arity": 0,
+          "hasRestParam": false
+        },
+        {
+          "name": "value",
+          "kind": "set",
+          "isStatic": false,
+          "params": [
+            "next"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        },
+        {
+          "name": "fromArray",
+          "kind": "method",
+          "isStatic": true,
+          "params": [
+            "values"
+          ],
+          "arity": 1,
+          "hasRestParam": false
+        }
+      ]
+    }
+  ],
+  "dependencies": [],
+  "referencedGlobals": [
+    "TypeError",
+    "module"
+  ],
+  "jsdoc": [
+    {
+      "target": "Base",
+      "description": "Base class with shared behaviour.",
+      "tags": []
+    },
+    {
+      "target": "constructor",
+      "description": "",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} name - identifier for the instance."
+        }
+      ]
+    },
+    {
+      "target": "constructor",
+      "description": "",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} name - identifier for the counter."
+        },
+        {
+          "tag": "param",
+          "text": "{number} start - initial value."
+        },
+        {
+          "tag": "param",
+          "text": "{number} step - increment applied by `tick`."
+        }
+      ]
+    },
+    {
+      "target": "Counter",
+      "description": "A small counter built on top of {@link Base}.",
+      "tags": []
+    },
+    {
+      "target": "fromArray",
+      "description": "",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number[]} values - starting values."
+        },
+        {
+          "tag": "returns",
+          "text": "{Counter[]} one counter per value."
+        }
+      ]
+    },
+    {
+      "target": "tick",
+      "description": "Advances the counter, optionally several times.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number} times - how many steps to take."
+        },
+        {
+          "tag": "returns",
+          "text": "{number} the updated value."
+        }
+      ]
+    },
+    {
+      "target": "value",
+      "description": "",
+      "tags": [
+        {
+          "tag": "returns",
+          "text": "{number} the current value."
+        }
+      ]
+    },
+    {
+      "target": "value",
+      "description": "",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number} next - value to set."
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "branches": 3,
+    "returns": 4,
+    "throws": 1
+  }
+}

--- a/scripts/generate-tests/__tests__/fixtures/class-module.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/class-module.plan.json
@@ -182,7 +182,7 @@
       "tags": []
     },
     {
-      "target": "constructor",
+      "target": "Base.constructor",
       "description": "",
       "tags": [
         {
@@ -192,7 +192,12 @@
       ]
     },
     {
-      "target": "constructor",
+      "target": "Counter",
+      "description": "A small counter built on top of {@link Base}.",
+      "tags": []
+    },
+    {
+      "target": "Counter.constructor",
       "description": "",
       "tags": [
         {
@@ -210,12 +215,7 @@
       ]
     },
     {
-      "target": "Counter",
-      "description": "A small counter built on top of {@link Base}.",
-      "tags": []
-    },
-    {
-      "target": "fromArray",
+      "target": "Counter.fromArray",
       "description": "",
       "tags": [
         {
@@ -229,7 +229,7 @@
       ]
     },
     {
-      "target": "tick",
+      "target": "Counter.tick",
       "description": "Advances the counter, optionally several times.",
       "tags": [
         {
@@ -243,7 +243,7 @@
       ]
     },
     {
-      "target": "value",
+      "target": "Counter.value",
       "description": "",
       "tags": [
         {
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "target": "value",
+      "target": "Counter.value",
       "description": "",
       "tags": [
         {

--- a/scripts/generate-tests/__tests__/fixtures/simple-module.js
+++ b/scripts/generate-tests/__tests__/fixtures/simple-module.js
@@ -1,0 +1,80 @@
+/**
+ * Fixture: a plain CommonJS module that exposes pure helper functions through a
+ * namespace object, in the style used across js/utils/. Exercises parameter and
+ * arity detection, branch/return/throw counting, dependency detection and free
+ * global references. This file is only ever parsed by the extractor, never run.
+ */
+
+const path = require("path");
+
+/**
+ * Joins path segments and lower-cases the result.
+ *
+ * @param {...string} segments - path parts.
+ * @returns {string} the normalised path.
+ */
+function normalizePath(...segments) {
+    return path.join(...segments).toLowerCase();
+}
+
+/**
+ * Clamps a number to a range.
+ *
+ * @param {number} value - the input value.
+ * @param {number} min - lower bound.
+ * @param {number} max - upper bound.
+ * @returns {number} the clamped value.
+ */
+const clamp = (value, min = 0, max = 1) => {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+        return min;
+    }
+    if (value < min) return min;
+    return value > max ? max : value;
+};
+
+/**
+ * Parses a boolean-ish string.
+ *
+ * @param {string} token - the text to parse.
+ * @returns {boolean}
+ */
+function parseFlag(token) {
+    switch (String(token).trim().toLowerCase()) {
+        case "1":
+        case "true":
+        case "yes":
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Asserts that a value is present.
+ *
+ * @param {*} value - the value to check.
+ * @param {string} label - name used in the error message.
+ * @returns {*} the value, when defined.
+ */
+function required(value, label) {
+    if (value === undefined || value === null) {
+        throw new Error(`missing required value: ${label}`);
+    }
+    return value;
+}
+
+const SimpleModule = {
+    normalizePath,
+    clamp,
+    parseFlag,
+    required
+};
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = SimpleModule;
+}
+
+if (typeof window !== "undefined") {
+    window.SimpleModule = SimpleModule;
+}

--- a/scripts/generate-tests/__tests__/fixtures/simple-module.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/simple-module.plan.json
@@ -1,0 +1,193 @@
+{
+  "file": "scripts/generate-tests/__tests__/fixtures/simple-module.js",
+  "sourceType": "script",
+  "exports": [
+    {
+      "name": "clamp",
+      "kind": "function",
+      "params": [
+        "value",
+        "min",
+        "max"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "SimpleModule"
+    },
+    {
+      "name": "normalizePath",
+      "kind": "function",
+      "params": [
+        "...segments"
+      ],
+      "arity": 0,
+      "hasRestParam": true,
+      "via": "SimpleModule"
+    },
+    {
+      "name": "parseFlag",
+      "kind": "function",
+      "params": [
+        "token"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "SimpleModule"
+    },
+    {
+      "name": "required",
+      "kind": "function",
+      "params": [
+        "value",
+        "label"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "via": "SimpleModule"
+    }
+  ],
+  "functions": [
+    {
+      "name": "clamp",
+      "params": [
+        "value",
+        "min",
+        "max"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "normalizePath",
+      "params": [
+        "...segments"
+      ],
+      "arity": 0,
+      "hasRestParam": true,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "parseFlag",
+      "params": [
+        "token"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 2,
+      "throws": 0,
+      "branches": 3
+    },
+    {
+      "name": "required",
+      "params": [
+        "value",
+        "label"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 1,
+      "branches": 2
+    }
+  ],
+  "classes": [],
+  "dependencies": [
+    "path"
+  ],
+  "referencedGlobals": [
+    "Error",
+    "Number",
+    "String",
+    "module",
+    "require",
+    "window"
+  ],
+  "jsdoc": [
+    {
+      "target": "clamp",
+      "description": "Clamps a number to a range.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number} value - the input value."
+        },
+        {
+          "tag": "param",
+          "text": "{number} min - lower bound."
+        },
+        {
+          "tag": "param",
+          "text": "{number} max - upper bound."
+        },
+        {
+          "tag": "returns",
+          "text": "{number} the clamped value."
+        }
+      ]
+    },
+    {
+      "target": "normalizePath",
+      "description": "Joins path segments and lower-cases the result.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{...string} segments - path parts."
+        },
+        {
+          "tag": "returns",
+          "text": "{string} the normalised path."
+        }
+      ]
+    },
+    {
+      "target": "parseFlag",
+      "description": "Parses a boolean-ish string.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} token - the text to parse."
+        },
+        {
+          "tag": "returns",
+          "text": "{boolean}"
+        }
+      ]
+    },
+    {
+      "target": "required",
+      "description": "Asserts that a value is present.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{*} value - the value to check."
+        },
+        {
+          "tag": "param",
+          "text": "{string} label - name used in the error message."
+        },
+        {
+          "tag": "returns",
+          "text": "{*} the value, when defined."
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "branches": 12,
+    "returns": 7,
+    "throws": 1
+  }
+}

--- a/scripts/generate-tests/cli.js
+++ b/scripts/generate-tests/cli.js
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Command-line entry point for the deterministic module test-plan extractor.
+ *
+ *   node scripts/generate-tests/cli.js path/to/module.js
+ *       Prints the plan as JSON to stdout.
+ *
+ *   node scripts/generate-tests/cli.js path/to/module.js --check [expected.json]
+ *       Compares the freshly generated plan against a committed expected plan
+ *       without writing anything. Exits 0 when they match, 1 when they differ.
+ *       The expected file defaults to the source path with `.js` replaced by
+ *       `.plan.json`.
+ *
+ * This tool only reads and parses the target file. It never requires, imports,
+ * executes or modifies it, and it never writes to the source tree.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { extractFile, stringifyPlan } = require("./extract-module");
+
+const USAGE = "usage: node scripts/generate-tests/cli.js <module.js> [--check [expected.json]]";
+
+/**
+ * Parses argv into `{ file, check, expected }`.
+ *
+ * @param {string[]} argv - arguments after `node cli.js`.
+ * @returns {{ file: string, check: boolean, expected: string|null }}
+ */
+function parseArgs(argv) {
+    let file = null;
+    let check = false;
+    let expected = null;
+
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === "--check") {
+            check = true;
+            const next = argv[i + 1];
+            if (next && !next.startsWith("--")) {
+                expected = next;
+                i += 1;
+            }
+        } else if (arg.startsWith("--check=")) {
+            check = true;
+            expected = arg.slice("--check=".length);
+        } else if (arg === "--help" || arg === "-h") {
+            process.stdout.write(USAGE + "\n");
+            process.exit(0);
+        } else if (arg.startsWith("--")) {
+            throw new Error(`unknown option: ${arg}`);
+        } else if (file === null) {
+            file = arg;
+        } else {
+            throw new Error(`unexpected argument: ${arg}`);
+        }
+    }
+
+    if (!file) throw new Error(USAGE);
+    return { file, check, expected };
+}
+
+/**
+ * @param {string} sourcePath - the analysed source file.
+ * @param {string|null} explicit - an explicit expected-plan path, if given.
+ * @returns {string}
+ */
+function expectedPathFor(sourcePath, explicit) {
+    if (explicit) return explicit;
+    return sourcePath.replace(/\.js$/, "") + ".plan.json";
+}
+
+/**
+ * Runs the CLI.
+ *
+ * @param {string[]} argv - arguments after `node cli.js`.
+ * @returns {number} process exit code.
+ */
+function main(argv) {
+    let args;
+    try {
+        args = parseArgs(argv);
+    } catch (err) {
+        process.stderr.write(err.message + "\n");
+        return 2;
+    }
+
+    let plan;
+    try {
+        plan = extractFile(args.file);
+    } catch (err) {
+        process.stderr.write(err.message + "\n");
+        return 1;
+    }
+
+    const generated = stringifyPlan(plan);
+
+    if (!args.check) {
+        process.stdout.write(generated);
+        return 0;
+    }
+
+    const expectedPath = expectedPathFor(args.file, args.expected);
+    let expected;
+    try {
+        expected = fs.readFileSync(path.resolve(process.cwd(), expectedPath), "utf8");
+    } catch (err) {
+        process.stderr.write(
+            `${expectedPath}: unable to read expected plan (${err.code || err.message})\n`
+        );
+        return 1;
+    }
+
+    if (normalise(generated) === normalise(expected)) {
+        process.stdout.write(`${args.file}: plan matches ${expectedPath}\n`);
+        return 0;
+    }
+
+    process.stderr.write(`${args.file}: plan differs from ${expectedPath}\n`);
+    return 1;
+}
+
+/**
+ * @param {string} text - JSON text.
+ * @returns {string} canonical form for comparison (tolerant of indentation and
+ *     trailing-newline differences).
+ */
+function normalise(text) {
+    return JSON.stringify(JSON.parse(text));
+}
+
+if (require.main === module) {
+    process.exit(main(process.argv.slice(2)));
+}
+
+module.exports = { parseArgs, expectedPathFor, main };

--- a/scripts/generate-tests/cli.js
+++ b/scripts/generate-tests/cli.js
@@ -129,7 +129,15 @@ function main(argv) {
         return 1;
     }
 
-    if (normalise(generated) === normalise(expected)) {
+    let matches;
+    try {
+        matches = normalise(generated) === normalise(expected);
+    } catch (err) {
+        process.stderr.write(`${expectedPath}: invalid expected plan (${err.message})\n`);
+        return 1;
+    }
+
+    if (matches) {
         process.stdout.write(`${args.file}: plan matches ${expectedPath}\n`);
         return 0;
     }
@@ -142,6 +150,7 @@ function main(argv) {
  * @param {string} text - JSON text.
  * @returns {string} canonical form for comparison (tolerant of indentation and
  *     trailing-newline differences).
+ * @throws {SyntaxError} when `text` is not valid JSON.
  */
 function normalise(text) {
     return JSON.stringify(JSON.parse(text));

--- a/scripts/generate-tests/cli.js
+++ b/scripts/generate-tests/cli.js
@@ -62,6 +62,7 @@ function parseArgs(argv) {
         } else if (arg.startsWith("--check=")) {
             check = true;
             expected = arg.slice("--check=".length);
+            if (expected === "") throw new Error("--check= requires a path");
         } else if (arg === "--help" || arg === "-h") {
             process.stdout.write(USAGE + "\n");
             process.exit(0);

--- a/scripts/generate-tests/extract-module.js
+++ b/scripts/generate-tests/extract-module.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Reads a JavaScript source file, parses it with the repository's vendored Acorn
+ * parser, and produces a deterministic module test plan (see
+ * ./module-test-plan.js).
+ *
+ * The target file is never required, imported or executed - only its text is
+ * read and parsed. Parse errors are reported with the filename attached.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const acorn = require("../../lib/acorn.min");
+const { buildTestPlan } = require("./module-test-plan");
+
+/**
+ * Acorn options mirroring how the rest of the repository parses source
+ * (`ecmaVersion: 2020`). Scripts are the norm here; the module fallback covers
+ * files that use `import`/`export`.
+ */
+const PARSE_OPTIONS = { ecmaVersion: 2020, locations: true };
+
+/**
+ * Parses source text into an ESTree AST plus its block comments.
+ *
+ * @param {string} source - JavaScript source text.
+ * @param {string} file - path used in error messages.
+ * @returns {{ ast: object, comments: object[] }}
+ * @throws {Error} a parse error whose message begins with `file`.
+ */
+function parseSource(source, file) {
+    const label = file || "<anonymous>";
+    let lastError = null;
+
+    for (const sourceType of ["script", "module"]) {
+        const comments = [];
+        try {
+            const ast = acorn.parse(source, { ...PARSE_OPTIONS, sourceType, onComment: comments });
+            return { ast, comments };
+        } catch (err) {
+            lastError = err;
+        }
+    }
+
+    const where =
+        lastError && lastError.loc
+            ? ` (line ${lastError.loc.line}, column ${lastError.loc.column})`
+            : "";
+    const message = lastError
+        ? lastError.message.replace(/\s*\(\d+:\d+\)\s*$/, "")
+        : "unknown parse error";
+    const error = new Error(`${label}: ${message}${where}`);
+    error.file = label;
+    if (lastError && lastError.loc) error.loc = lastError.loc;
+    throw error;
+}
+
+/**
+ * Produces the test plan for already-loaded source text.
+ *
+ * @param {string} source - JavaScript source text.
+ * @param {string} file - value recorded as `plan.file` and used in errors.
+ * @returns {object} deterministic, JSON-compatible plan.
+ */
+function extractModule(source, file) {
+    const { ast, comments } = parseSource(source, file);
+    return buildTestPlan(ast, { file, source, comments });
+}
+
+/**
+ * Reads a file from disk and produces its test plan.
+ *
+ * @param {string} filePath - path to a `.js` source file.
+ * @param {object} [options] - `{ cwd }` to control how `plan.file` is rendered.
+ * @returns {object} deterministic, JSON-compatible plan.
+ * @throws {Error} when the file cannot be read or parsed (filename attached).
+ */
+function extractFile(filePath, options = {}) {
+    const cwd = options.cwd || process.cwd();
+    const absolute = path.resolve(cwd, filePath);
+
+    let source;
+    try {
+        source = fs.readFileSync(absolute, "utf8");
+    } catch (err) {
+        const error = new Error(`${filePath}: unable to read file (${err.code || err.message})`);
+        error.file = filePath;
+        throw error;
+    }
+
+    const relative = path.relative(cwd, absolute).split(path.sep).join("/");
+    return extractModule(source, relative || filePath);
+}
+
+/**
+ * Serialises a plan to canonical JSON (two-space indent, trailing newline) so
+ * that CLI output and committed fixtures compare byte-for-byte.
+ *
+ * @param {object} plan - a plan from {@link extractModule} / {@link extractFile}.
+ * @returns {string}
+ */
+function stringifyPlan(plan) {
+    return JSON.stringify(plan, null, 2) + "\n";
+}
+
+module.exports = { parseSource, extractModule, extractFile, stringifyPlan };

--- a/scripts/generate-tests/module-test-plan.js
+++ b/scripts/generate-tests/module-test-plan.js
@@ -1,0 +1,786 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Deterministic "module test plan" builder.
+ *
+ * Given an ESTree AST (as produced by the vendored Acorn parser) and the block
+ * comments collected while parsing, this produces a small JSON-compatible
+ * description of what a module exposes and what is therefore worth testing:
+ * exported functions/classes, their parameters, and shallow structural counts
+ * (branches, `return`, `throw`), the module's `require`/`import` dependencies,
+ * the free identifiers it references, and any leading JSDoc blocks.
+ *
+ * Everything here is derived syntactically from the AST. Nothing is executed and
+ * no runtime behaviour is inferred. The output is stable: every list is sorted
+ * and de-duplicated so repeated runs on the same source produce identical JSON.
+ *
+ * Known limitations (documented rather than guessed around):
+ *   - `referencedGlobals` is name-based, not scope-accurate. A name that is bound
+ *     anywhere in the file (a parameter, a nested declaration) is treated as
+ *     bound everywhere, so shadowed globals may be omitted.
+ *   - Only the CommonJS (`module.exports = ...`, `exports.x = ...`) and ES module
+ *     (`export ...`) patterns that appear in this repository are recognised.
+ *     Conditional or computed exports are not resolved.
+ *   - Per-function counts (`branches`, `returns`, `throws`) stop at nested
+ *     function boundaries; the `totals` block counts the whole file.
+ */
+
+const NODE_META_KEYS = new Set(["type", "start", "end", "loc", "range", "sourceFile"]);
+
+/**
+ * Identifiers that are language-level literals rather than dependencies a test
+ * would need to set up. Excluded from `referencedGlobals`.
+ */
+const IGNORED_GLOBALS = new Set(["undefined", "NaN", "Infinity", "arguments", "globalThis"]);
+
+const FUNCTION_TYPES = new Set([
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "ArrowFunctionExpression"
+]);
+
+/**
+ * Walks every ESTree node reachable from `root`, calling `visit(node, parent)`.
+ * A minimal generic traversal - no framework, no scope handling.
+ *
+ * @param {object} root - node to start from.
+ * @param {function} visit - callback invoked for every node.
+ * @returns {void}
+ */
+function walk(root, visit) {
+    const stack = [{ node: root, parent: null }];
+    while (stack.length > 0) {
+        const { node, parent } = stack.pop();
+        if (!node || typeof node.type !== "string") continue;
+        visit(node, parent);
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const item of child) stack.push({ node: item, parent: node });
+            } else if (child && typeof child.type === "string") {
+                stack.push({ node: child, parent: node });
+            }
+        }
+    }
+}
+
+/**
+ * Like {@link walk} but does not descend into nested function bodies, so counts
+ * are attributed to the function that directly contains them.
+ *
+ * @param {object} fnNode - a function node whose body should be scanned.
+ * @param {function} visit - callback invoked for every node in that body.
+ * @returns {void}
+ */
+function walkFunctionBody(fnNode, visit) {
+    const stack = [fnNode.body];
+    while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node || typeof node.type !== "string") continue;
+        visit(node);
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            const items = Array.isArray(child) ? child : [child];
+            for (const item of items) {
+                if (!item || typeof item.type !== "string") continue;
+                if (FUNCTION_TYPES.has(item.type)) continue;
+                stack.push(item);
+            }
+        }
+    }
+}
+
+/**
+ * Renders a parameter node as a short readable string.
+ *
+ * @param {object} param - a parameter/pattern node.
+ * @returns {string}
+ */
+function paramName(param) {
+    switch (param.type) {
+        case "Identifier":
+            return param.name;
+        case "AssignmentPattern":
+            return paramName(param.left);
+        case "RestElement":
+            return "..." + paramName(param.argument);
+        case "ObjectPattern":
+            return "{}";
+        case "ArrayPattern":
+            return "[]";
+        default:
+            return "?";
+    }
+}
+
+/**
+ * Computes the effective arity of a parameter list, matching `Function.length`
+ * semantics: leading plain parameters, stopping at the first default or rest.
+ *
+ * @param {object[]} params - parameter nodes.
+ * @returns {number}
+ */
+function computeArity(params) {
+    let arity = 0;
+    for (const param of params) {
+        if (param.type === "AssignmentPattern" || param.type === "RestElement") break;
+        arity += 1;
+    }
+    return arity;
+}
+
+/**
+ * Counts syntactic branch points inside a function body: `if`, conditional
+ * expressions, logical operators (`&&`, `||`, `??`) and non-default `switch`
+ * cases.
+ *
+ * @param {object} fnNode - function node.
+ * @returns {number}
+ */
+function countBranches(fnNode) {
+    let branches = 0;
+    walkFunctionBody(fnNode, node => {
+        if (node.type === "IfStatement" || node.type === "ConditionalExpression") {
+            branches += 1;
+        } else if (node.type === "LogicalExpression") {
+            branches += 1;
+        } else if (node.type === "SwitchStatement") {
+            branches += node.cases.filter(c => c.test !== null).length;
+        }
+    });
+    return branches;
+}
+
+/**
+ * Counts nodes of a given type inside a function body, not descending into
+ * nested functions.
+ *
+ * @param {object} fnNode - function node.
+ * @param {string} type - ESTree node type to count.
+ * @returns {number}
+ */
+function countInBody(fnNode, type) {
+    let count = 0;
+    walkFunctionBody(fnNode, node => {
+        if (node.type === type) count += 1;
+    });
+    return count;
+}
+
+/**
+ * Describes a function node for the `functions` list.
+ *
+ * @param {string} name - the name the function is known by.
+ * @param {object} fnNode - function node.
+ * @returns {object}
+ */
+function describeFunction(name, fnNode) {
+    return {
+        name,
+        params: fnNode.params.map(paramName),
+        arity: computeArity(fnNode.params),
+        hasRestParam: fnNode.params.some(p => p.type === "RestElement"),
+        isAsync: Boolean(fnNode.async),
+        isGenerator: Boolean(fnNode.generator),
+        returns: countInBody(fnNode, "ReturnStatement"),
+        throws: countInBody(fnNode, "ThrowStatement"),
+        branches: countBranches(fnNode)
+    };
+}
+
+/**
+ * Describes a single class member.
+ *
+ * @param {object} member - a MethodDefinition or PropertyDefinition node.
+ * @returns {object|null} null when the member is not statically nameable.
+ */
+function describeMember(member) {
+    if (member.computed || !member.key || member.key.type !== "Identifier") return null;
+
+    let fnNode = null;
+    let kind = "method";
+    if (member.type === "MethodDefinition") {
+        fnNode = member.value;
+        kind = member.kind === "method" ? "method" : member.kind; // constructor | get | set | method
+    } else if (
+        member.type === "PropertyDefinition" &&
+        member.value &&
+        FUNCTION_TYPES.has(member.value.type)
+    ) {
+        fnNode = member.value;
+    } else {
+        return null;
+    }
+
+    return {
+        name: member.key.name,
+        kind,
+        isStatic: Boolean(member.static),
+        params: fnNode.params.map(paramName),
+        arity: computeArity(fnNode.params),
+        hasRestParam: fnNode.params.some(p => p.type === "RestElement")
+    };
+}
+
+/**
+ * Describes a class node: its superclass name (when a plain identifier) and its
+ * members, sorted for determinism.
+ *
+ * @param {string} name - the name the class is known by.
+ * @param {object} classNode - ClassDeclaration or ClassExpression node.
+ * @returns {object}
+ */
+function describeClass(name, classNode) {
+    const members = classNode.body.body
+        .map(describeMember)
+        .filter(Boolean)
+        .sort(
+            (a, b) =>
+                Number(a.isStatic) - Number(b.isStatic) ||
+                a.name.localeCompare(b.name) ||
+                a.kind.localeCompare(b.kind)
+        );
+
+    let superClass = null;
+    if (classNode.superClass && classNode.superClass.type === "Identifier") {
+        superClass = classNode.superClass.name;
+    }
+
+    return { name, superClass, methods: members };
+}
+
+/**
+ * Collects the top-level function and class declarations of a program, keyed by
+ * name, including `const x = function () {}` / `const x = class {}` forms.
+ *
+ * @param {object} program - Program node.
+ * @returns {{ functions: Map<string, object>, classes: Map<string, object>, objects: Map<string, object> }}
+ */
+function collectTopLevel(program) {
+    const functions = new Map();
+    const classes = new Map();
+    const objects = new Map();
+
+    const record = node => {
+        if (node.type === "FunctionDeclaration" && node.id) {
+            functions.set(node.id.name, node);
+        } else if (node.type === "ClassDeclaration" && node.id) {
+            classes.set(node.id.name, node);
+        } else if (node.type === "VariableDeclaration") {
+            for (const decl of node.declarations) {
+                if (!decl.id || decl.id.type !== "Identifier" || !decl.init) continue;
+                if (FUNCTION_TYPES.has(decl.init.type)) {
+                    functions.set(decl.id.name, decl.init);
+                } else if (decl.init.type === "ClassExpression") {
+                    classes.set(decl.id.name, decl.init);
+                } else if (decl.init.type === "ObjectExpression") {
+                    objects.set(decl.id.name, decl.init);
+                }
+            }
+        }
+    };
+
+    for (const node of program.body) {
+        record(node);
+        if (node.type === "ExportNamedDeclaration" && node.declaration) {
+            record(node.declaration);
+        }
+    }
+
+    return { functions, classes, objects };
+}
+
+/**
+ * Turns a resolved export value into one or more export entries.
+ *
+ * Object namespaces are expanded exactly one level: the object passed straight
+ * to `module.exports` (directly or through a single identifier) has its members
+ * listed, but a member that is itself an object is reported as `kind: "object"`
+ * without descending further. This mirrors what callers can actually reach as a
+ * top-level export and avoids turning nested data maps into "exports".
+ *
+ * @param {string|null} name - export name (null for a bare object namespace).
+ * @param {object} valueNode - the AST node assigned/exported.
+ * @param {object} top - result of {@link collectTopLevel}.
+ * @param {string|null} via - namespace identifier the entry came through.
+ * @param {boolean} expandObjects - whether an object value should be expanded.
+ * @returns {object[]}
+ */
+function resolveExport(name, valueNode, top, via, expandObjects) {
+    if (!valueNode) return [];
+
+    if (FUNCTION_TYPES.has(valueNode.type)) {
+        return [
+            {
+                name,
+                kind: "function",
+                params: valueNode.params.map(paramName),
+                arity: computeArity(valueNode.params),
+                hasRestParam: valueNode.params.some(p => p.type === "RestElement"),
+                via
+            }
+        ];
+    }
+
+    if (valueNode.type === "ClassExpression") {
+        const described = describeClass(name, valueNode);
+        return [
+            {
+                name,
+                kind: "class",
+                superClass: described.superClass,
+                methods: described.methods,
+                via
+            }
+        ];
+    }
+
+    if (valueNode.type === "ObjectExpression") {
+        if (expandObjects) return resolveObjectExports(valueNode, top, name);
+        return [{ name, kind: "object", via }];
+    }
+
+    if (valueNode.type === "Identifier") {
+        const ref = valueNode.name;
+        if (top.functions.has(ref)) {
+            return resolveExport(name, top.functions.get(ref), top, via, false);
+        }
+        if (top.classes.has(ref)) {
+            const described = describeClass(name, top.classes.get(ref));
+            return [
+                {
+                    name,
+                    kind: "class",
+                    superClass: described.superClass,
+                    methods: described.methods,
+                    via
+                }
+            ];
+        }
+        if (top.objects.has(ref)) {
+            if (expandObjects) return resolveObjectExports(top.objects.get(ref), top, ref);
+            return [{ name, kind: "object", via }];
+        }
+        return [{ name, kind: "value", via }];
+    }
+
+    return [{ name, kind: "value", via }];
+}
+
+/**
+ * Expands an object literal used as an export namespace into one entry per
+ * statically nameable property. Members are resolved without further object
+ * expansion.
+ *
+ * @param {object} objectNode - ObjectExpression node.
+ * @param {object} top - result of {@link collectTopLevel}.
+ * @param {string|null} via - namespace identifier.
+ * @returns {object[]}
+ */
+function resolveObjectExports(objectNode, top, via) {
+    const entries = [];
+    for (const prop of objectNode.properties) {
+        if (prop.type !== "Property" || prop.computed) continue;
+        if (!prop.key || (prop.key.type !== "Identifier" && prop.key.type !== "Literal")) continue;
+        const key = prop.key.type === "Identifier" ? prop.key.name : String(prop.key.value);
+        entries.push(...resolveExport(key, prop.value, top, via, false));
+    }
+    return entries;
+}
+
+/**
+ * Finds every export the module declares, across the CommonJS and ES module
+ * patterns used in this repository.
+ *
+ * @param {object} program - Program node.
+ * @param {object} top - result of {@link collectTopLevel}.
+ * @returns {object[]}
+ */
+function collectExports(program, top) {
+    const entries = [];
+
+    const isMemberOf = (node, objectName, propertyName) =>
+        node &&
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.object.type === "Identifier" &&
+        node.object.name === objectName &&
+        node.property.type === "Identifier" &&
+        (propertyName === undefined || node.property.name === propertyName);
+
+    // CommonJS assignments. These are frequently wrapped in a
+    // `if (typeof module !== "undefined" && module.exports) { ... }` guard, so
+    // the whole tree is scanned rather than only top-level statements.
+    walk(program, node => {
+        if (node.type !== "AssignmentExpression" || node.operator !== "=") return;
+        const { left, right } = node;
+
+        // module.exports = <value>
+        if (isMemberOf(left, "module", "exports")) {
+            entries.push(...resolveExport(null, right, top, null, true));
+        }
+        // exports.NAME = <value>  /  module.exports.NAME = <value>
+        else if (
+            isMemberOf(left, "exports") ||
+            (left.type === "MemberExpression" && isMemberOf(left.object, "module", "exports"))
+        ) {
+            if (!left.computed && left.property.type === "Identifier") {
+                entries.push(...resolveExport(left.property.name, right, top, null, false));
+            }
+        }
+    });
+
+    // ES module declarations are always top-level per the spec.
+    for (const statement of program.body) {
+        if (statement.type === "ExportNamedDeclaration") {
+            if (statement.declaration) {
+                const decl = statement.declaration;
+                if (decl.type === "FunctionDeclaration" && decl.id) {
+                    entries.push(...resolveExport(decl.id.name, decl, top, null, false));
+                } else if (decl.type === "ClassDeclaration" && decl.id) {
+                    const described = describeClass(decl.id.name, decl);
+                    entries.push({
+                        name: decl.id.name,
+                        kind: "class",
+                        superClass: described.superClass,
+                        methods: described.methods,
+                        via: null
+                    });
+                } else if (decl.type === "VariableDeclaration") {
+                    for (const d of decl.declarations) {
+                        if (d.id && d.id.type === "Identifier") {
+                            entries.push(...resolveExport(d.id.name, d.init, top, null, false));
+                        }
+                    }
+                }
+            }
+            for (const spec of statement.specifiers) {
+                if (spec.local.type === "Identifier") {
+                    const local = spec.local.name;
+                    const exported =
+                        spec.exported.type === "Identifier" ? spec.exported.name : local;
+                    let value = { type: "Identifier", name: local };
+                    entries.push(...resolveExport(exported, value, top, null, false));
+                }
+            }
+            continue;
+        }
+
+        if (statement.type === "ExportDefaultDeclaration") {
+            entries.push(...resolveExport("default", statement.declaration, top, null, false));
+        }
+    }
+
+    return entries;
+}
+
+/**
+ * Collects `require("x")` string arguments and ES `import` sources.
+ *
+ * @param {object} program - Program node.
+ * @returns {string[]}
+ */
+function collectDependencies(program) {
+    const deps = new Set();
+    walk(program, node => {
+        if (
+            node.type === "CallExpression" &&
+            node.callee.type === "Identifier" &&
+            node.callee.name === "require" &&
+            node.arguments.length > 0 &&
+            node.arguments[0].type === "Literal" &&
+            typeof node.arguments[0].value === "string"
+        ) {
+            deps.add(node.arguments[0].value);
+        } else if (
+            (node.type === "ImportDeclaration" ||
+                node.type === "ExportNamedDeclaration" ||
+                node.type === "ExportAllDeclaration") &&
+            node.source &&
+            node.source.type === "Literal" &&
+            typeof node.source.value === "string"
+        ) {
+            deps.add(node.source.value);
+        }
+    });
+    return [...deps].sort();
+}
+
+/**
+ * Collects every identifier name bound anywhere in the file (declarations,
+ * parameters, catch clauses, import specifiers).
+ *
+ * @param {object} program - Program node.
+ * @returns {Set<string>}
+ */
+function collectBoundNames(program) {
+    const bound = new Set();
+
+    const addPattern = pattern => {
+        if (!pattern) return;
+        switch (pattern.type) {
+            case "Identifier":
+                bound.add(pattern.name);
+                break;
+            case "AssignmentPattern":
+                addPattern(pattern.left);
+                break;
+            case "RestElement":
+                addPattern(pattern.argument);
+                break;
+            case "ArrayPattern":
+                pattern.elements.forEach(addPattern);
+                break;
+            case "ObjectPattern":
+                pattern.properties.forEach(prop => {
+                    if (prop.type === "RestElement") addPattern(prop.argument);
+                    else addPattern(prop.value);
+                });
+                break;
+            default:
+                break;
+        }
+    };
+
+    walk(program, node => {
+        if (FUNCTION_TYPES.has(node.type)) {
+            node.params.forEach(addPattern);
+            if (node.id) bound.add(node.id.name);
+        } else if (node.type === "VariableDeclarator") {
+            addPattern(node.id);
+        } else if (node.type === "ClassDeclaration" && node.id) {
+            bound.add(node.id.name);
+        } else if (node.type === "CatchClause" && node.param) {
+            addPattern(node.param);
+        } else if (node.type === "ImportDeclaration") {
+            node.specifiers.forEach(spec => bound.add(spec.local.name));
+        }
+    });
+
+    return bound;
+}
+
+/**
+ * Collects free identifier references: names used in a value position that are
+ * not bound anywhere in the file. Name-based, not scope-accurate (see the module
+ * header).
+ *
+ * @param {object} program - Program node.
+ * @returns {string[]}
+ */
+function collectReferencedGlobals(program) {
+    const bound = collectBoundNames(program);
+    const globals = new Set();
+
+    walk(program, (node, parent) => {
+        if (node.type !== "Identifier") return;
+        if (!parent) return;
+
+        // Skip non-value positions.
+        if (parent.type === "MemberExpression" && parent.property === node && !parent.computed)
+            return;
+        if (parent.type === "Property" && parent.key === node && !parent.computed) return;
+        if (
+            (parent.type === "MethodDefinition" || parent.type === "PropertyDefinition") &&
+            parent.key === node &&
+            !parent.computed
+        ) {
+            return;
+        }
+        if (parent.type === "VariableDeclarator" && parent.id === node) return;
+        if (FUNCTION_TYPES.has(parent.type) && (parent.params.includes(node) || parent.id === node))
+            return;
+        if (parent.type === "ClassDeclaration" || parent.type === "ClassExpression") return;
+        if (
+            parent.type === "LabeledStatement" ||
+            parent.type === "BreakStatement" ||
+            parent.type === "ContinueStatement"
+        ) {
+            return;
+        }
+        if (parent.type === "ImportSpecifier" || parent.type === "ImportDefaultSpecifier") return;
+        if (parent.type === "ExportSpecifier") return;
+
+        if (bound.has(node.name) || IGNORED_GLOBALS.has(node.name)) return;
+        globals.add(node.name);
+    });
+
+    return [...globals].sort();
+}
+
+/**
+ * Extracts leading JSDoc (`/** ... *\/`) blocks and attaches each to the
+ * declaration that immediately follows it in the source.
+ *
+ * @param {object} program - Program node.
+ * @param {object[]} comments - block comments collected during parsing.
+ * @param {string} source - the original source text.
+ * @returns {object[]}
+ */
+function collectJsdoc(program, comments, source) {
+    const targets = [];
+    walk(program, node => {
+        let name = null;
+        if ((node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") && node.id) {
+            name = node.id.name;
+        } else if (node.type === "MethodDefinition" && node.key && node.key.type === "Identifier") {
+            name = node.key.name;
+        } else if (
+            node.type === "VariableDeclaration" &&
+            node.declarations[0] &&
+            node.declarations[0].id.type === "Identifier"
+        ) {
+            name = node.declarations[0].id.name;
+        } else {
+            return;
+        }
+        targets.push({ start: node.start, name });
+    });
+    targets.sort((a, b) => a.start - b.start);
+
+    const results = [];
+    for (const comment of comments) {
+        if (comment.type !== "Block" || !comment.value.startsWith("*")) continue;
+
+        const target = targets.find(t => t.start >= comment.end);
+        if (!target) continue;
+
+        // Only attach when the comment sits directly above the declaration:
+        // whitespace only, and no blank line between them.
+        const between = source.slice(comment.end, target.start);
+        if (between.trim() !== "" || (between.match(/\n/g) || []).length > 1) continue;
+
+        results.push({ target: target.name, ...parseJsdoc(comment.value) });
+    }
+
+    results.sort(
+        (a, b) =>
+            (a.target || "").localeCompare(b.target || "") ||
+            a.description.localeCompare(b.description)
+    );
+    return results;
+}
+
+/**
+ * Splits a JSDoc comment body into a description and a flat list of `@tag`
+ * entries. Intentionally shallow - tags are kept as trimmed text.
+ *
+ * @param {string} raw - the comment's inner text (without the delimiters).
+ * @returns {{ description: string, tags: object[] }}
+ */
+function parseJsdoc(raw) {
+    const lines = raw.split("\n").map(line => line.replace(/^\s*\*?/, "").trim());
+
+    const descriptionLines = [];
+    const tags = [];
+    for (const line of lines) {
+        const match = line.match(/^@(\w+)\s*(.*)$/);
+        if (match) {
+            tags.push({ tag: match[1], text: match[2].trim() });
+        } else if (tags.length === 0 && line !== "") {
+            descriptionLines.push(line);
+        }
+    }
+
+    return { description: descriptionLines.join(" ").trim(), tags };
+}
+
+/**
+ * Builds the deterministic module test plan.
+ *
+ * @param {object} ast - Program node from the vendored Acorn parser.
+ * @param {object} options - `{ file, source, comments }`.
+ * @returns {object} JSON-compatible plan.
+ */
+function buildTestPlan(ast, options) {
+    const { file, source, comments = [] } = options;
+    const top = collectTopLevel(ast);
+
+    const functions = [...top.functions.entries()]
+        .map(([name, node]) => describeFunction(name, node))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const classes = [...top.classes.entries()]
+        .map(([name, node]) => describeClass(name, node))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const exportsList = dedupeExports(collectExports(ast, top)).sort((a, b) => {
+        const an = a.name === null ? "" : a.name;
+        const bn = b.name === null ? "" : b.name;
+        return an.localeCompare(bn) || a.kind.localeCompare(b.kind);
+    });
+
+    let totalBranches = 0;
+    let totalReturns = 0;
+    let totalThrows = 0;
+    walk(ast, node => {
+        if (
+            node.type === "IfStatement" ||
+            node.type === "ConditionalExpression" ||
+            node.type === "LogicalExpression"
+        ) {
+            totalBranches += 1;
+        } else if (node.type === "SwitchStatement") {
+            totalBranches += node.cases.filter(c => c.test !== null).length;
+        } else if (node.type === "ReturnStatement") {
+            totalReturns += 1;
+        } else if (node.type === "ThrowStatement") {
+            totalThrows += 1;
+        }
+    });
+
+    return {
+        file,
+        sourceType: ast.sourceType || "script",
+        exports: exportsList,
+        functions,
+        classes,
+        dependencies: collectDependencies(ast),
+        referencedGlobals: collectReferencedGlobals(ast),
+        jsdoc: collectJsdoc(ast, comments, source),
+        totals: {
+            branches: totalBranches,
+            returns: totalReturns,
+            throws: totalThrows
+        }
+    };
+}
+
+/**
+ * Removes duplicate export entries (same name + kind), keeping the first.
+ *
+ * @param {object[]} entries - raw export entries.
+ * @returns {object[]}
+ */
+function dedupeExports(entries) {
+    const seen = new Set();
+    const result = [];
+    for (const entry of entries) {
+        const id = `${entry.name} ${entry.kind}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        result.push(entry);
+    }
+    return result;
+}
+
+module.exports = { buildTestPlan };

--- a/scripts/generate-tests/module-test-plan.js
+++ b/scripts/generate-tests/module-test-plan.js
@@ -37,10 +37,17 @@
  *     bound everywhere, so a global shadowed elsewhere may be omitted. The same
  *     name set is used to ignore calls to a locally declared `require`.
  *   - Only the CommonJS (`module.exports = ...`, `exports.x = ...`) and ES module
- *     (`export ...`) patterns that appear in this repository are recognised.
+ *     (`export ...`) patterns that appear in this repository are recognised, and
+ *     only at module scope - an assignment inside a nested function is ignored.
  *     Conditional or computed exports are not resolved.
+ *   - `branches` is a rough syntactic count (`if`, conditional expression, each
+ *     `&&`/`||`/`??`, and each non-default `switch` case), not a cyclomatic
+ *     complexity or branch-coverage figure. `a && b && c` counts as two, and
+ *     loops (`for`, `while`, `do`) are not counted at all.
  *   - Per-function counts (`branches`, `returns`, `throws`) stop at nested
  *     function boundaries; the `totals` block counts the whole file.
+ *   - A JSDoc `target` for a class member is qualified with the class name
+ *     (`Counter.tick`); a bare name is a top-level function, class or variable.
  */
 
 const NODE_META_KEYS = new Set(["type", "start", "end", "loc", "range", "sourceFile"]);
@@ -105,6 +112,34 @@ function walkFunctionBody(fnNode, visit) {
                 if (!item || typeof item.type !== "string") continue;
                 if (FUNCTION_TYPES.has(item.type)) continue;
                 stack.push(item);
+            }
+        }
+    }
+}
+
+/**
+ * Like {@link walk} but treats function nodes as leaves: it visits them but does
+ * not descend into their bodies. Used to keep "what does this module expose"
+ * questions at module scope, ignoring assignments that only run when some inner
+ * function is called.
+ *
+ * @param {object} root - node to start from.
+ * @param {function} visit - callback invoked for every node outside a function body.
+ * @returns {void}
+ */
+function walkModuleScope(root, visit) {
+    const stack = [root];
+    while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node || typeof node.type !== "string") continue;
+        visit(node);
+        if (node !== root && FUNCTION_TYPES.has(node.type)) continue;
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            const items = Array.isArray(child) ? child : [child];
+            for (const item of items) {
+                if (item && typeof item.type === "string") stack.push(item);
             }
         }
     }
@@ -430,8 +465,10 @@ function collectExports(program, top) {
 
     // CommonJS assignments. These are frequently wrapped in a
     // `if (typeof module !== "undefined" && module.exports) { ... }` guard, so
-    // the whole tree is scanned rather than only top-level statements.
-    walk(program, node => {
+    // the whole module scope is scanned - but not the interior of nested
+    // functions, where such an assignment would only run when that function is
+    // called and does not describe the module's static surface.
+    walkModuleScope(program, node => {
         if (node.type !== "AssignmentExpression" || node.operator !== "=") return;
         const { left, right } = node;
 
@@ -652,23 +689,44 @@ function collectReferencedGlobals(program, bound) {
  */
 function collectJsdoc(program, comments, source) {
     const targets = [];
-    walk(program, node => {
-        let name = null;
+
+    // Recursive descent so that a method's target can be qualified with the name
+    // of the class that contains it (`Counter.constructor`), keeping targets
+    // unambiguous across classes.
+    const visit = (node, className) => {
+        if (!node || typeof node.type !== "string") return;
+
+        const nextClass =
+            (node.type === "ClassDeclaration" || node.type === "ClassExpression") && node.id
+                ? node.id.name
+                : className;
+
         if ((node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") && node.id) {
-            name = node.id.name;
+            targets.push({ start: node.start, name: node.id.name });
         } else if (node.type === "MethodDefinition" && node.key && node.key.type === "Identifier") {
-            name = node.key.name;
+            const member = node.key.name;
+            targets.push({
+                start: node.start,
+                name: className ? `${className}.${member}` : member
+            });
         } else if (
             node.type === "VariableDeclaration" &&
             node.declarations[0] &&
             node.declarations[0].id.type === "Identifier"
         ) {
-            name = node.declarations[0].id.name;
-        } else {
-            return;
+            targets.push({ start: node.start, name: node.declarations[0].id.name });
         }
-        targets.push({ start: node.start, name });
-    });
+
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            const items = Array.isArray(child) ? child : [child];
+            for (const item of items) {
+                if (item && typeof item.type === "string") visit(item, nextClass);
+            }
+        }
+    };
+    visit(program, null);
     targets.sort((a, b) => a.start - b.start);
 
     const results = [];

--- a/scripts/generate-tests/module-test-plan.js
+++ b/scripts/generate-tests/module-test-plan.js
@@ -34,7 +34,8 @@
  * Known limitations (documented rather than guessed around):
  *   - `referencedGlobals` is name-based, not scope-accurate. A name that is bound
  *     anywhere in the file (a parameter, a nested declaration) is treated as
- *     bound everywhere, so shadowed globals may be omitted.
+ *     bound everywhere, so a global shadowed elsewhere may be omitted. The same
+ *     name set is used to ignore calls to a locally declared `require`.
  *   - Only the CommonJS (`module.exports = ...`, `exports.x = ...`) and ES module
  *     (`export ...`) patterns that appear in this repository are recognised.
  *     Conditional or computed exports are not resolved.
@@ -497,12 +498,16 @@ function collectExports(program, top) {
  * Collects `require("x")` string arguments and ES `import` sources.
  *
  * @param {object} program - Program node.
+ * @param {Set<string>} boundNames - names bound anywhere in the file; used to
+ *     ignore calls to a locally declared `require`.
  * @returns {string[]}
  */
-function collectDependencies(program) {
+function collectDependencies(program, boundNames) {
     const deps = new Set();
+    const requireIsShadowed = boundNames.has("require");
     walk(program, node => {
         if (
+            !requireIsShadowed &&
             node.type === "CallExpression" &&
             node.callee.type === "Identifier" &&
             node.callee.name === "require" &&
@@ -585,10 +590,10 @@ function collectBoundNames(program) {
  * header).
  *
  * @param {object} program - Program node.
+ * @param {Set<string>} bound - names bound anywhere in the file.
  * @returns {string[]}
  */
-function collectReferencedGlobals(program) {
-    const bound = collectBoundNames(program);
+function collectReferencedGlobals(program, bound) {
     const globals = new Set();
 
     walk(program, (node, parent) => {
@@ -598,7 +603,16 @@ function collectReferencedGlobals(program) {
         // Skip non-value positions.
         if (parent.type === "MemberExpression" && parent.property === node && !parent.computed)
             return;
-        if (parent.type === "Property" && parent.key === node && !parent.computed) return;
+        // A property key (`{ foo: ... }`) is not a reference, but a shorthand
+        // property (`{ foo }`) reuses the same node for key and value and *is*.
+        if (
+            parent.type === "Property" &&
+            parent.key === node &&
+            !parent.computed &&
+            !parent.shorthand
+        ) {
+            return;
+        }
         if (
             (parent.type === "MethodDefinition" || parent.type === "PropertyDefinition") &&
             parent.key === node &&
@@ -714,6 +728,7 @@ function parseJsdoc(raw) {
 function buildTestPlan(ast, options) {
     const { file, source, comments = [] } = options;
     const top = collectTopLevel(ast);
+    const boundNames = collectBoundNames(ast);
 
     const functions = [...top.functions.entries()]
         .map(([name, node]) => describeFunction(name, node))
@@ -754,8 +769,8 @@ function buildTestPlan(ast, options) {
         exports: exportsList,
         functions,
         classes,
-        dependencies: collectDependencies(ast),
-        referencedGlobals: collectReferencedGlobals(ast),
+        dependencies: collectDependencies(ast, boundNames),
+        referencedGlobals: collectReferencedGlobals(ast, boundNames),
         jsdoc: collectJsdoc(ast, comments, source),
         totals: {
             branches: totalBranches,

--- a/scripts/generate-tests/module-test-plan.js
+++ b/scripts/generate-tests/module-test-plan.js
@@ -790,7 +790,9 @@ function dedupeExports(entries) {
     const seen = new Set();
     const result = [];
     for (const entry of entries) {
-        const id = `${entry.name} ${entry.kind}`;
+        // A structured key so name and kind can never run together into an
+        // ambiguous string (e.g. name "a b" vs kind "b value").
+        const id = JSON.stringify([entry.name, entry.kind]);
         if (seen.has(id)) continue;
         seen.add(id);
         result.push(entry);


### PR DESCRIPTION
## Description

Adds a deterministic AST-based module analysis utility under `scripts/generate-tests/` to identify what a JavaScript module exposes and what behavior is relevant for future test generation.

The extractor uses the repository's vendored Acorn parser and produces a JSON test plan containing exported functions/classes, parameters and arity, branch/return/throw counts, dependencies, referenced globals, leading JSDoc, and aggregate totals.

This PR implements the **extraction and planning layer only**. It does not generate or modify tests for production modules.

---

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [] Performance — Improves load time, memory, rendering, etc.
- [x] Tests 
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added a hand-written ESTree walker in `scripts/generate-tests/module-test-plan.js`.
* Added `extract-module.js` to parse JavaScript using the repository's vendored Acorn (`lib/acorn.min.js`) and build a deterministic test plan.
* Added a CLI in `scripts/generate-tests/cli.js`:

  * `node cli.js <module.js>` prints the generated plan as JSON.
  * `--check [expected.json]` compares generated output without modifying files.
* Detects:

  * Exported functions, classes, objects, and values.
  * Function parameters and arity.
  * Class constructors, methods, getters, setters, and static methods.
  * Per-function branch, return, and throw counts.
  * `require()` and `import`/`export` dependencies.
  * Referenced free identifiers.
  * Leading JSDoc comments and tags.
  * Whole-file branch, return, and throw totals.
* Added fixtures and expected plans for function and class modules.
* Added Jest coverage for the extractor, including malformed input, missing files, determinism, and non-execution of analyzed source.
* Added a README documenting usage and current limitations.
* Validated the extractor against real Music Blocks modules including `js/utils/utils-logic.js` and `js/utils/language-utils.js`.
* No production Music Blocks files or dependency/configuration files were modified.

---

## Visual Changes

Not applicable — this PR contains no UI or visual changes.

---

## Testing Performed

* `npx jest scripts/generate-tests` — **27/27 passed**
* `npx jest` — **222 suites / 8112 tests passed**
* ESLint — **passed**
* Prettier — **passed**
* CLI manually validated against:

  * `js/utils/utils-logic.js`
  * `js/utils/language-utils.js`
* Determinism verified by running the extractor repeatedly and comparing output byte-for-byte.
* `--check` successfully validates the committed fixture plans.
* Verified that analyzing a hostile source containing a `require(...).writeFileSync` payload does **not** execute it.
* Verified malformed and missing input errors include the filename and terminate with exit code 1.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [x] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run linting and Prettier checks with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This is intentionally limited to the **AST extraction/planning layer**. The extractor never requires, imports, executes, or writes to the analyzed module.

The generated plan is deterministic: output collections are sorted and de-duplicated so the same source consistently produces the same JSON.

The implementation uses the repository's existing vendored Acorn rather than introducing a new parser dependency. No CI, Jest, coverage, Stryker, or dependency configuration was changed.

The branch is based on the current `upstream/master` and contains one DCO-signed commit.
