### PR TITLE
fix: avoid Node global in browser pitch previews

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -17,6 +17,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
 const { TextEncoder } = require("util");
 global.TextEncoder = TextEncoder;
 global._ = jest.fn(str => str);
@@ -140,6 +143,25 @@ const DOUBLESHARP = "\ud834\udd2a";
 const DOUBLEFLAT = "\ud834\udd2b";
 
 describe("musicutils", () => {
+    describe("getNonEDOFrequency browser runtime", () => {
+        it("returns a ratio-temperament preview frequency without Node global", () => {
+            const source = fs.readFileSync(path.join(__dirname, "..", "musicutils.js"), "utf8");
+            const sandbox = {
+                TextEncoder,
+                _: value => value,
+                localStorage: { getItem: () => null },
+                window: { btoa: value => Buffer.from(value, "binary").toString("base64") }
+            };
+
+            vm.createContext(sandbox);
+            vm.runInContext(source, sandbox);
+
+            expect(
+                vm.runInContext("getNonEDOFrequency(0, 4, 'just intonation', 'C major')", sandbox)
+            ).toEqual({ freq: 264, noteName: "C", octave: 4 });
+        });
+    });
+
     describe("musicutils core constants", () => {
         const last = arr => arr[arr.length - 1];
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3964,9 +3964,13 @@ const getNonEDOModeSteps = (mode, temperament) => {
  * @returns {{ freq: number, noteName: string, octave: number } | null}
  */
 const getNonEDOFrequency = (note, baseOctave, temperamentKey, keySignature) => {
-    const t = global.TEMPERAMENT && global.TEMPERAMENT[temperamentKey];
+    const runtime =
+        typeof global === "undefined"
+            ? { TEMPERAMENT, isEquallyTempered, pitchToFrequency }
+            : global;
+    const t = runtime.TEMPERAMENT && runtime.TEMPERAMENT[temperamentKey];
     const labels =
-        t && Array.isArray(t.noteLabels) && !global.isEquallyTempered(temperamentKey)
+        t && Array.isArray(t.noteLabels) && !runtime.isEquallyTempered(temperamentKey)
             ? t.noteLabels
             : null;
     if (!labels || !labels[note % labels.length]) {
@@ -3974,7 +3978,7 @@ const getNonEDOFrequency = (note, baseOctave, temperamentKey, keySignature) => {
     }
     const idx = note % labels.length;
     const octave = baseOctave + Math.floor(note / labels.length);
-    const freq = global.pitchToFrequency(labels[idx], octave, 0, keySignature, temperamentKey);
+    const freq = runtime.pitchToFrequency(labels[idx], octave, 0, keySignature, temperamentKey);
     return { freq, noteName: labels[idx], octave };
 };
 


### PR DESCRIPTION
## Description

  Fixes `getNonEDOFrequency()` in browser execution.

The helper read `TEMPERAMENT`, `isEquallyTempered`, and `pitchToFrequency` through Node's `global` object. Browser scripts do not provide `global`, so calling the helper threw `ReferenceError: global is not defined`.

  ## Related Issue

  **Fixes:** #8276

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Replace Node-only `global.*` references with the existing browser globals.
  - Add a regression test that evaluates `musicutils.js` without Node's `global`.

  ---

  ## Testing Performed

  - `npm run lint`
  - `npx prettier --check js/utils/musicutils.js js/utils/__tests__/musicutils.test.js`
  - `npm test -- --runInBand`
  - Chrome check: the helper returns `{ freq: 264, noteName: "C", octave: 4 }` without an exception.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have updated the documentation to reflect these changes, if applicable.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [ ] I have addressed the code review feedback from the previous submission, if applicable.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

  Prettier was run only on the modified files, as required by the contribution guide.