### PR TITLE
fix(darkmode): dark mode scrollbar styling and search autocomplete active item contrast

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -122,8 +122,36 @@ body.dark #ui-id-1 a {
 
 body.dark #ui-id-1 {
     background-color: var(--color-bg-primary) !important;
+    border: 1px solid var(--color-border-primary) !important;
 }
 
 body.dark #ui-id-1 .ui-menu-item {
     background-color: var(--color-bg-primary) !important;
 }
+
+body.dark #ui-id-1 .ui-state-active,
+body.dark #ui-id-1 .ui-menu-item-wrapper.ui-state-active {
+    background-color: var(--color-brand-primary) !important;
+    color: var(--color-text-inverse) !important;
+    border: none !important;
+}
+
+/* Custom Dark Mode Scrollbars for Palette Drawers & Dropdowns */
+body.dark ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+body.dark ::-webkit-scrollbar-track {
+    background: var(--color-bg-primary) !important;
+}
+
+body.dark ::-webkit-scrollbar-thumb {
+    background: var(--color-border-primary) !important;
+    border-radius: var(--radius-sm);
+}
+
+body.dark ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-tertiary) !important;
+}
+


### PR DESCRIPTION
## Description

Fixes visual dark mode contrast issues across scrollable panels and the search autocomplete dropdown:

1. **Custom Dark Mode Scrollbars**: Adds dark mode webkit scrollbar rules (`::-webkit-scrollbar-track`, `::-webkit-scrollbar-thumb`) consuming `var(--color-bg-primary)` and `var(--color-border-primary)` design tokens to eliminate un-themed white scrollbar tracks on the palette drawer and search dropdown.
2. **Search Autocomplete Popup**: Overrides jQuery UI's default un-themed white popup border with `var(--color-border-primary)`.
3. **Active Search Result Contrast**: Styles hovered/active search items (`.ui-state-active`) consuming `var(--color-brand-primary)` and `var(--color-text-inverse)` design tokens from `tokens.css`.

### Before
<img width="1365" height="633" alt="image" src="https://github.com/user-attachments/assets/e6f7618a-9a8e-4d21-b51b-13686e35b7a5" />

### After
<img width="1365" height="634" alt="image" src="https://github.com/user-attachments/assets/8920dfdd-bbba-4633-8deb-2ee724054899" />


## Related Issue

N/A

## PR Category

- [x] Bug Fix — Visual UI / CSS styling adjustment

## Changes Made

- **`css/darkmode.css`**:
  - Added Dark Mode scrollbar rules and search autocomplete active item design tokens.

## Testing Performed

- Tested live in browser at `http://127.0.0.1:3000/` by opening the Widgets palette and typing search queries in Dark Mode.
- Verified scrollbar tracks blend into dark theme and highlighted search dropdown items remain 100% readable.
- Ran commitlint and ESLint via `lint-staged` (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
