### PR TITLE
fix(arpeggio): restore master volume on widget window close

### DIFF
--- a/js/widgets/__tests__/arpeggio.test.js
+++ b/js/widgets/__tests__/arpeggio.test.js
@@ -752,5 +752,17 @@ describe("Arpeggio Widget", () => {
                 expect(arpeggio._blockMap).toContainEqual([1, 1]);
             }
         });
+
+        test("widgetWindow.onclose restores Singer.masterVolume if present", () => {
+            global.Singer = { masterVolume: [0.8] };
+            activityMock.logo.synth.setMasterVolume = jest.fn();
+
+            mockWidgetWindow.onclose();
+
+            expect(activityMock.logo.synth.stop).toHaveBeenCalled();
+            expect(activityMock.logo.synth.setMasterVolume).toHaveBeenCalledWith(0.8);
+            expect(arpeggio._playing).toBe(false);
+            expect(mockWidgetWindow.destroy).toHaveBeenCalled();
+        });
     });
 });

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -139,6 +139,17 @@ class Arpeggio {
             }
             this._playing = false;
             this._activity.logo.synth.stop();
+            if (
+                typeof Singer !== "undefined" &&
+                Singer.masterVolume &&
+                Singer.masterVolume.length > 0
+            ) {
+                const vol =
+                    typeof last === "function"
+                        ? last(Singer.masterVolume)
+                        : Singer.masterVolume[Singer.masterVolume.length - 1];
+                this._activity.logo.synth.setMasterVolume(vol);
+            }
 
             arpeggioTableDiv.style.visibility = "hidden";
             this._activity.hideMsgs();


### PR DESCRIPTION
## Description

Fixes audio volume reduction in `arpeggio.js` where previewing arpeggio notes sets master volume to `PREVIEWVOLUME`, but closing the Arpeggio widget window (`widgetWindow.onclose`) leaves workspace master volume permanently stuck at 50% instead of restoring the project's original `Singer.masterVolume`.

## Related Issue

Fixes #8279 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added master volume restoration inside `widgetWindow.onclose` in `js/widgets/arpeggio.js` (matching `pitchstaircase.js` line 784 and `meterwidget.js` line 171).
- Added unit tests in `js/widgets/__tests__/arpeggio.test.js` verifying master volume restoration on Arpeggio widget close.

## Testing Performed

- Ran Jest unit tests: all 47 unit tests in `arpeggio.test.js` pass cleanly (`47 passed, 47 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.