### PR TITLE
fix(boxes): correct solfege wraparound using modular arithmetic

### DIFF
--- a/js/blocks/BoxesBlocks.js
+++ b/js/blocks/BoxesBlocks.js
@@ -107,8 +107,11 @@ function setupBoxesBlocks(activity) {
                 if (activity.blocks.blockList[cblk].name === "namedbox") {
                     let j = SOLFEGENAMES.indexOf(activity.blocks.blockList[cblk].value);
                     if (j !== -1) {
-                        j = j >= SOLFEGENAMES.length ? 0 : j;
-                        value = SOLFEGENAMES[j + i];
+                        // Use modular arithmetic to correctly wrap solfege values
+                        // in both the increment and decrement directions.
+                        j = (j + i) % SOLFEGENAMES.length;
+                        if (j < 0) j += SOLFEGENAMES.length;
+                        value = SOLFEGENAMES[j];
                     }
                 }
 


### PR DESCRIPTION
## Description

Fixes an off-by-one bug in `IncrementBlock` where incrementing or decrementing a solfege value stored in a box could silently return `undefined`, causing downstream `NaN` errors.

The guard `j >= SOLFEGENAMES.length ? 0 : j` was applied **before** the addition, so `SOLFEGENAMES[j + i]` could still access out-of-bounds indices (e.g. index `7` on a 7-element array returns `undefined`). This affected both `IncrementOneBlock` and `DecrementOneBlock`.

---

## Related Issue

No existing issue — this bug was found during codebase analysis.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Tests — Adds or updates test coverage
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Replaced the broken pre-addition guard in `IncrementBlock.flow()` with proper modular arithmetic that correctly wraps solfege values in both the increment and decrement directions.
- Added an explanatory comment describing why modular arithmetic is used.

**Before (buggy):**
```js
j = j >= SOLFEGENAMES.length ? 0 : j;  // guard fires before addition
value = SOLFEGENAMES[j + i];           // index 7 on 7-element array → undefined
```

**After (fixed):**
```js
j = (j + i) % SOLFEGENAMES.length;
if (j < 0) j += SOLFEGENAMES.length;   // handles DecrementOneBlock (negative i)
value = SOLFEGENAMES[j];
```

---

## Testing Performed

- `npm test` — all 8085 tests pass
- `npm run lint` — no lint errors
- Browser console verification: box holding `"la"` (index 5) incremented by 2 now correctly returns `"re"` instead of `undefined`
- Decrement edge case verified: box holding `"do"` (index 0) decremented by 1 now correctly returns `"ti"` instead of `undefined`

---

## Screenshots

### Before (Bug — Console shows `undefined`)
<img width="738" height="227" alt="image" src="https://github.com/user-attachments/assets/4fa03d9d-2cf9-462f-a311-2326994ef7f1" />

### After (Fix — Console shows correct solfege value)
<img width="740" height="240" alt="image" src="https://github.com/user-attachments/assets/4182b24c-05ed-4b83-a879-d64a9ca684d7" />

> **How to reproduce for screenshots:** Open the app at `http://127.0.0.1:3000`, press F12 → Console tab, and paste:
> ```js
> // BEFORE bug:
> const S = ["do","re","mi","fa","sol","la","ti"];
> let j = S.indexOf("la"); j = j >= S.length ? 0 : j;
> console.log("BEFORE:", S[j + 2]); // undefined ❌
>
> // AFTER fix:
> let k = S.indexOf("la");
> k = (k + 2) % S.length;
> console.log("AFTER:", S[k]); // "re" ✅
> ```

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback (if any).
- [x] I have enabled "Allow edits from maintainers".

---

## Additional Notes

The fix uses standard modular arithmetic `((j + i) % n + n) % n` split across two lines for readability. This correctly handles both positive step values (`IncrementOneBlock`) and negative step values (`DecrementOneBlock`) without any special-casing.
