### PR TITLE
fix(meterwidget): guard against a disposed meter block in blockList

### DIFF
--- a/js/widgets/__tests__/meterwidget.test.js
+++ b/js/widgets/__tests__/meterwidget.test.js
@@ -390,6 +390,25 @@ describe("Meter Widget", () => {
         expect(() => new MeterWidget(mockActivity, 1)).not.toThrow();
     });
 
+    test("falls back to defaults instead of throwing when the meter block has been disposed", () => {
+        // Simulates blocks.js's disposeBlock(): blockList[idx] = null, e.g. after
+        // the block was evicted from the trash undo history while this widget
+        // was still open (see issue #8281).
+        mockActivity.logo._meterBlock = 1;
+        mockActivity.blocks.blockList = {
+            1: null
+        };
+
+        expect(() => new MeterWidget(mockActivity, 1)).not.toThrow();
+    });
+
+    test("falls back to defaults when the meter block index is no longer in blockList at all", () => {
+        mockActivity.logo._meterBlock = 1;
+        mockActivity.blocks.blockList = {};
+
+        expect(() => new MeterWidget(mockActivity, 1)).not.toThrow();
+    });
+
     test("handles Reset button click when blocks are present and when blocks are missing", () => {
         mockActivity.logo._meterBlock = 1;
         mockActivity.blocks.blockList = {

--- a/js/widgets/meterwidget.js
+++ b/js/widgets/meterwidget.js
@@ -245,8 +245,12 @@ class MeterWidget {
         meterTableDiv.appendChild(meterWheelDiv);
 
         // Grab the number of beats and beat value from the meter block.
+        // this._meterBlock is a raw blockList index captured when the widget
+        // was requested; if that block has since been disposed (e.g. evicted
+        // by the trash undo history), blockList[this._meterBlock] is null, so
+        // guard the lookup itself rather than just the index being non-null.
         let v1, c1, c2, c3;
-        if (this._meterBlock !== null) {
+        if (this._meterBlock !== null && this.activity.blocks.blockList[this._meterBlock]) {
             c1 = this.activity.blocks.blockList[this._meterBlock].connections[1];
             v1 = c1 !== null ? this.activity.blocks.blockList[c1].value : 4;
             c2 = this.activity.blocks.blockList[this._meterBlock].connections[2];


### PR DESCRIPTION
## Description

`MeterWidget`'s constructor caches `logo._meterBlock` (a raw `blockList` array index) and dereferences `blockList[this._meterBlock].connections` with no guard that the entry itself still exists. If the meter block has been disposed by the time the widget is constructed, this throws an unhandled `TypeError` and the widget fails to open, with no recovery.

## Related Issue

**Fixes:** #8281

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- `js/widgets/meterwidget.js`: extended the existing `this._meterBlock !== null` check to also verify `this.activity.blocks.blockList[this._meterBlock]` is present, before dereferencing `.connections` on it. When it isn't, the widget now falls through to its existing "no meter block" default path (`this._piemenuMeter(4, this._beatValue)`) instead of throwing — this fallback already existed in the code for the `_meterBlock === null` case, so no new UI/behavior was introduced, just closing the gap for the "index present but entry disposed" case.
- No changes to `blocks.js`'s trash/disposal path itself — the fix is scoped to making `MeterWidget` resilient to a `blockList` entry it doesn't control disappearing out from under it, matching the pattern already used correctly elsewhere in the same codebase (e.g. `_hasValidMeterWidgetInput` in `WidgetBlocks.js`, which already null-guards the same kind of lookup with optional chaining).

## Testing Performed

- Added two regression tests to `js/widgets/__tests__/meterwidget.test.js`:
  - constructing the widget when `blockList[meterBlockIndex]` is `null` (simulating `blocks.js`'s `disposeBlock()`)
  - constructing the widget when the index isn't in `blockList` at all
- Verified both new tests fail with the pre-fix code (`TypeError: Cannot read properties of null/undefined (reading 'connections')` at `meterwidget.js:250`) and pass with the fix, confirming the tests actually catch the bug rather than being vacuous.
- `npx jest js/widgets/__tests__/meterwidget.test.js` — 17/17 passing.
- Full suite: `npx jest` — 8087/8087 passing, 221/221 suites.
- `npx eslint` and `npx prettier --check` on both changed files — clean, no errors.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

Scope is intentionally limited to the constructor's `blockList` lookup described in #8281. The issue also raises a broader question — whether widgets should subscribe to block-disposal notifications instead of caching raw `blockList` indices — as a possible follow-up design discussion, not something this PR attempts, since the immediate crash has a small, clean, testable fix on its own.
