### PR TITLE
fix(search-ui): prevent search autocomplete dropdown dismissal on scrollbar click

### DIFF
--- a/js/__tests__/search-ui.test.js
+++ b/js/__tests__/search-ui.test.js
@@ -746,6 +746,88 @@ describe("SearchUI.setupMainAutocomplete — instance renderItem", () => {
         expect(typeof instance._renderItem).toBe("function");
         delete global.window.jQuery;
     });
+
+    test("attaches menu event handlers to instance.menu.element that call stopPropagation, preventDefault, and re-focus search input", () => {
+        const focusFn = jest.fn();
+        const onFn = jest.fn((evt, cb) => {
+            if (evt === "mousedown mouseup click dblclick pointerdown") {
+                const mockEvt = {
+                    type: "mousedown",
+                    preventDefault: jest.fn(),
+                    stopPropagation: jest.fn()
+                };
+                cb(mockEvt);
+                expect(mockEvt.stopPropagation).toHaveBeenCalled();
+                expect(mockEvt.preventDefault).toHaveBeenCalled();
+                expect(focusFn).toHaveBeenCalled();
+            }
+        });
+        const instance = { _renderItem: null, menu: { element: { on: onFn } } };
+        const $elem = {
+            _initFlag: false,
+            focus: focusFn,
+            data: jest.fn(function (key, val) {
+                if (val !== undefined) this._initFlag = val;
+                return key === "autocomplete-init" ? this._initFlag : undefined;
+            }),
+            autocomplete: jest.fn(function (arg) {
+                if (arg === "instance") return instance;
+            })
+        };
+        global.window.jQuery = jest.fn(() => $elem);
+
+        const activity = makeActivity();
+        const ui = new SearchUI(activity);
+        ui.setupMainAutocomplete(() => [], jest.fn(), jest.fn());
+
+        expect(onFn).toHaveBeenCalledWith(
+            "mousedown mouseup click dblclick pointerdown",
+            expect.any(Function)
+        );
+        delete global.window.jQuery;
+    });
+
+    test("overrides instance.close to ignore close events targeted at #ui-id-1", () => {
+        const origClose = jest.fn();
+        const instance = { _renderItem: null, close: origClose };
+        const $elem = {
+            _initFlag: false,
+            is: jest.fn(() => false),
+            closest: jest.fn(() => ({ length: 0 })),
+            data: jest.fn(function (key, val) {
+                if (val !== undefined) this._initFlag = val;
+                return key === "autocomplete-init" ? this._initFlag : undefined;
+            }),
+            autocomplete: jest.fn(function (arg) {
+                if (arg === "instance") return instance;
+            })
+        };
+
+        const menuTarget = { id: "ui-id-1" };
+        const $targetObj = {
+            is: jest.fn(sel => sel === "#ui-id-1"),
+            closest: jest.fn(() => ({ length: 0 }))
+        };
+        const jQueryMock = jest.fn(selector => {
+            if (selector === menuTarget) return $targetObj;
+            return $elem;
+        });
+        global.window.jQuery = jQueryMock;
+
+        const activity = makeActivity();
+        const ui = new SearchUI(activity);
+        ui.setupMainAutocomplete(() => [], jest.fn(), jest.fn());
+
+        // Call instance.close with an event targeted at #ui-id-1
+        instance.close({ target: menuTarget });
+        expect(origClose).not.toHaveBeenCalled();
+
+        // Call instance.close with an outside event target
+        instance.close({ target: {} });
+        expect(origClose).toHaveBeenCalled();
+
+        delete global.window.jQuery;
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/js/activity/search-controller.js
+++ b/js/activity/search-controller.js
@@ -227,29 +227,26 @@ class SearchController {
 
             const that = this;
             const closeListener = e => {
+                const searchEl = document.getElementById("search");
+                const menuEl = document.getElementById("ui-id-1");
+                const dragHandleEl = document.getElementById("searchDragHandle");
+                const paletteRowEl = document.querySelector("#palette tbody tr");
+
                 if (
-                    document.getElementById("search").style.visibility === "visible" &&
-                    (e.target === document.getElementById("search") ||
-                        document.getElementById("search").contains(e.target) ||
-                        e.target === document.getElementById("searchDragHandle"))
+                    (searchEl && (e.target === searchEl || searchEl.contains(e.target))) ||
+                    (dragHandleEl &&
+                        (e.target === dragHandleEl || dragHandleEl.contains(e.target))) ||
+                    (menuEl &&
+                        menuEl.style.display !== "none" &&
+                        (e.target === menuEl || menuEl.contains(e.target))) ||
+                    (paletteRowEl && paletteRowEl.contains(e.target))
                 ) {
-                    //do nothing when clicked in the input field or the drag handle
-                } else if (
-                    document.getElementById("ui-id-1") &&
-                    document.getElementById("ui-id-1").style.display === "block" &&
-                    (e.target === document.getElementById("ui-id-1") ||
-                        document.getElementById("ui-id-1").contains(e.target))
-                ) {
-                    //do nothing when clicked on the menu
-                } else if (
-                    document.querySelector("#palette tbody tr") &&
-                    document.querySelector("#palette tbody tr").contains(e.target)
-                ) {
-                    //do nothing when clicked on the search row
+                    // do nothing when clicked inside search input, menu, drag handle, or palette row
                 } else {
                     that.hideSearchWidget();
                 }
             };
+
             this._searchCloseListener = closeListener;
             activity.addEventListener(document, "mousedown", closeListener);
 

--- a/js/search-ui.js
+++ b/js/search-ui.js
@@ -240,7 +240,32 @@ class SearchUI {
         const instance = $search.autocomplete("instance");
         if (instance) {
             instance._renderItem = (ul, item) => this._renderMainItem($j, ul, item, dropCb);
+            if (instance.menu && instance.menu.element) {
+                instance.menu.element.on("mousedown mouseup click dblclick pointerdown", event => {
+                    event.stopPropagation();
+                    if (event.type === "mousedown" || event.type === "pointerdown") {
+                        event.preventDefault();
+                        $search.focus();
+                    }
+                });
+            }
+            const origClose = instance.close;
+            instance.close = function (event) {
+                if (event && event.target && window.jQuery) {
+                    const $target = window.jQuery(event.target);
+                    if (
+                        typeof $target.is === "function" &&
+                        ($target.is("#ui-id-1") ||
+                            (typeof $target.closest === "function" &&
+                                $target.closest("#ui-id-1").length > 0))
+                    ) {
+                        return;
+                    }
+                }
+                return origClose.apply(this, arguments);
+            };
         }
+
         $search.data("autocomplete-init", true);
     }
 


### PR DESCRIPTION
## Description

Fixes an issue in the search autocomplete UI where clicking, dragging, or double-clicking the scrollbar would accidentally close the search window. 

Now, interacting with the scrollbar keeps the search input focused and the dropdown open, allowing users to scroll search results smoothly.

## PR Category

- [x] Bug Fix — Search UI / Event Handling

## Changes Made

- **`js/search-ui.js`**: Re-focused search input and prevented autocomplete dismissal when clicking `#ui-id-1`.
- **`js/activity/search-controller.js`**: Updated `closeListener` so double-clicking the scrollbar doesn't trigger widget hiding.
- **`js/__tests__/search-ui.test.js`**: Added unit tests for menu event listeners and close override logic.

## Testing Performed

- Tested live in browser at `http://127.0.0.1:3000/` by searching for blocks and double-clicking/dragging the scrollbar.
- Verified all unit test suites pass (`74/74 passed` in `search-ui.test.js` and `48/48 passed` in `search-controller.test.js`).
- Ran `lint-staged` with ESLint and Prettier (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
