### PR TITLE
test(ast): validate module plans against utility modules

### DIFF
--- a/scripts/generate-tests/__tests__/fixtures/language-utils.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/language-utils.plan.json
@@ -1,0 +1,69 @@
+{
+  "file": "js/utils/language-utils.js",
+  "sourceType": "script",
+  "exports": [
+    {
+      "name": "LANGUAGE_CODE_TO_LOCALE",
+      "kind": "object",
+      "via": "LanguageUtils"
+    },
+    {
+      "name": "normalizeLanguageCode",
+      "kind": "function",
+      "params": [
+        "language"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "LanguageUtils"
+    }
+  ],
+  "functions": [
+    {
+      "name": "normalizeLanguageCode",
+      "params": [
+        "language"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    }
+  ],
+  "classes": [],
+  "dependencies": [],
+  "referencedGlobals": [
+    "Object",
+    "module",
+    "window"
+  ],
+  "jsdoc": [
+    {
+      "target": "LANGUAGE_CODE_TO_LOCALE",
+      "description": "The language menu identifies languages by the id of its dropdown entries (enUS, enUK, zhCN, kana, ...), but the locale files in locales/ are named after the translation codes (en, en_GB, zh_CN, ja, ...). Passing a menu code straight to i18next asks the backend for a file that does not exist, which 404s and silently falls back to English. Keep this mapping as the single place that translates between the two.",
+      "tags": []
+    },
+    {
+      "target": "normalizeLanguageCode",
+      "description": "Maps a stored language preference onto the locale file that backs it.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} language - a language menu code or a translation code."
+        },
+        {
+          "tag": "returns",
+          "text": "{string} the code matching a file in locales/."
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "branches": 7,
+    "returns": 3,
+    "throws": 0
+  }
+}

--- a/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
@@ -1,0 +1,928 @@
+{
+  "file": "js/utils/utils-logic.js",
+  "sourceType": "script",
+  "exports": [
+    {
+      "name": "clampNumber",
+      "kind": "function",
+      "params": [
+        "val",
+        "min",
+        "max",
+        "fallback"
+      ],
+      "arity": 3,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "deepClone",
+      "kind": "function",
+      "params": [
+        "obj"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "escapeHTML",
+      "kind": "function",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "fileBasename",
+      "kind": "function",
+      "params": [
+        "file"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "fileExt",
+      "kind": "function",
+      "params": [
+        "file"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "formatSeconds",
+      "kind": "function",
+      "params": [
+        "seconds"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "GCD",
+      "kind": "function",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "hex2rgb",
+      "kind": "function",
+      "params": [
+        "hex",
+        "alpha"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "hexToRGB",
+      "kind": "function",
+      "params": [
+        "hex"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "isSafeUrl",
+      "kind": "function",
+      "params": [
+        "urlString"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "isUnsafeObjectKey",
+      "kind": "function",
+      "params": [
+        "key"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "isValidHex",
+      "kind": "function",
+      "params": [
+        "hex"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "last",
+      "kind": "function",
+      "params": [
+        "myList"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "LCD",
+      "kind": "function",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "mixedNumber",
+      "kind": "function",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "nearestBeat",
+      "kind": "function",
+      "params": [
+        "d",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "oneHundredToFraction",
+      "kind": "function",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "rationalSum",
+      "kind": "function",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "rationalToFraction",
+      "kind": "function",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "resolveObject",
+      "kind": "function",
+      "params": [
+        "path"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "rgbToHex",
+      "kind": "function",
+      "params": [
+        "r",
+        "g",
+        "b"
+      ],
+      "arity": 3,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "safeJSONParse",
+      "kind": "function",
+      "params": [
+        "data",
+        "fallback"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "safeNumber",
+      "kind": "function",
+      "params": [
+        "val",
+        "fallback"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "safeSVG",
+      "kind": "function",
+      "params": [
+        "text"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "toArray",
+      "kind": "function",
+      "params": [
+        "val"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "toFixed2",
+      "kind": "function",
+      "params": [
+        "n"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "toTitleCase",
+      "kind": "function",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    },
+    {
+      "name": "unescapeHTML",
+      "kind": "function",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "via": "UtilsLogic"
+    }
+  ],
+  "functions": [
+    {
+      "name": "clampNumber",
+      "params": [
+        "val",
+        "min",
+        "max",
+        "fallback"
+      ],
+      "arity": 3,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 2,
+      "throws": 0,
+      "branches": 2
+    },
+    {
+      "name": "deepClone",
+      "params": [
+        "obj"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "escapeHTML",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "fileBasename",
+      "params": [
+        "file"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 4,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "fileExt",
+      "params": [
+        "file"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "formatSeconds",
+      "params": [
+        "seconds"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 4,
+      "throws": 0,
+      "branches": 5
+    },
+    {
+      "name": "GCD",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "hex2rgb",
+      "params": [
+        "hex",
+        "alpha"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "hexToRGB",
+      "params": [
+        "hex"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 4,
+      "throws": 0,
+      "branches": 3
+    },
+    {
+      "name": "isSafeUrl",
+      "params": [
+        "urlString"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 6
+    },
+    {
+      "name": "isUnsafeObjectKey",
+      "params": [
+        "key"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 0,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "isValidHex",
+      "params": [
+        "hex"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 2,
+      "throws": 0,
+      "branches": 1
+    },
+    {
+      "name": "last",
+      "params": [
+        "myList"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 2,
+      "throws": 0,
+      "branches": 2
+    },
+    {
+      "name": "LCD",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "mixedNumber",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 6,
+      "throws": 0,
+      "branches": 7
+    },
+    {
+      "name": "nearestBeat",
+      "params": [
+        "d",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "oneHundredToFraction",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 35,
+      "throws": 0,
+      "branches": 101
+    },
+    {
+      "name": "rationalSum",
+      "params": [
+        "a",
+        "b"
+      ],
+      "arity": 2,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 16
+    },
+    {
+      "name": "rationalToFraction",
+      "params": [
+        "d"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 5,
+      "throws": 0,
+      "branches": 10
+    },
+    {
+      "name": "resolveObject",
+      "params": [
+        "path"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 4
+    },
+    {
+      "name": "rgbToHex",
+      "params": [
+        "r",
+        "g",
+        "b"
+      ],
+      "arity": 3,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    },
+    {
+      "name": "safeJSONParse",
+      "params": [
+        "data",
+        "fallback"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 3
+    },
+    {
+      "name": "safeNumber",
+      "params": [
+        "val",
+        "fallback"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 7
+    },
+    {
+      "name": "safeSVG",
+      "params": [
+        "text"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 2,
+      "throws": 0,
+      "branches": 1
+    },
+    {
+      "name": "toArray",
+      "params": [
+        "val"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 3
+    },
+    {
+      "name": "toFixed2",
+      "params": [
+        "n"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 2
+    },
+    {
+      "name": "toTitleCase",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 3,
+      "throws": 0,
+      "branches": 2
+    },
+    {
+      "name": "unescapeHTML",
+      "params": [
+        "str"
+      ],
+      "arity": 1,
+      "hasRestParam": false,
+      "isAsync": false,
+      "isGenerator": false,
+      "returns": 1,
+      "throws": 0,
+      "branches": 0
+    }
+  ],
+  "classes": [],
+  "dependencies": [],
+  "referencedGlobals": [
+    "Array",
+    "DOMParser",
+    "JSON",
+    "Math",
+    "Number",
+    "Object",
+    "String",
+    "URL",
+    "_",
+    "console",
+    "document",
+    "global",
+    "isFinite",
+    "isNaN",
+    "module",
+    "parseInt",
+    "window"
+  ],
+  "jsdoc": [
+    {
+      "target": "clampNumber",
+      "description": "Clamps a numeric value between a minimum and maximum bound with fallback handling.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number} val - Value to clamp"
+        },
+        {
+          "tag": "param",
+          "text": "{number} min - Minimum allowed bound"
+        },
+        {
+          "tag": "param",
+          "text": "{number} max - Maximum allowed bound"
+        },
+        {
+          "tag": "param",
+          "text": "{number} [fallback=min] - Fallback value if val is non-numeric or NaN"
+        },
+        {
+          "tag": "returns",
+          "text": "{number} The clamped numeric value"
+        }
+      ]
+    },
+    {
+      "target": "deepClone",
+      "description": "Creates a deep clone of an object or array.",
+      "tags": []
+    },
+    {
+      "target": "escapeHTML",
+      "description": "Escapes special characters in a string for use in HTML.",
+      "tags": []
+    },
+    {
+      "target": "fileBasename",
+      "description": "Extracts the base name (filename without extension) from a filename or URL.",
+      "tags": []
+    },
+    {
+      "target": "fileExt",
+      "description": "Extracts the file extension from a filename or URL.",
+      "tags": []
+    },
+    {
+      "target": "formatSeconds",
+      "description": "Formats a duration in seconds into a standardized digital time display string (MM:SS or HH:MM:SS).",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{number|string} seconds - Duration in seconds"
+        },
+        {
+          "tag": "returns",
+          "text": "{string} Formatted duration string e.g. \"02:05\" or \"01:01:05\", defaulting to \"00:00\" for invalid inputs"
+        }
+      ]
+    },
+    {
+      "target": "GCD",
+      "description": "Calculates the greatest common divisor (GCD) of two numbers.",
+      "tags": []
+    },
+    {
+      "target": "hex2rgb",
+      "description": "Converts a hexadecimal color code to RGBA format. Supports both 3-digit shorthand (#rgb) and 6-digit (#rrggbb) formats with an optional alpha parameter.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} hex - Hex color code (3-digit or 6-digit, with or without #)"
+        },
+        {
+          "tag": "param",
+          "text": "{number} [alpha=1] - Alpha transparency value (0 to 1)"
+        },
+        {
+          "tag": "returns",
+          "text": "{string} RGBA formatted string e.g. \"rgba(255,0,0,1)\""
+        }
+      ]
+    },
+    {
+      "target": "hexToRGB",
+      "description": "Converts a hexadecimal color code to RGB values.",
+      "tags": []
+    },
+    {
+      "target": "isSafeUrl",
+      "description": "Checks if a URL is considered safe. Decodes HTML entities and handles common bypass attempts.",
+      "tags": []
+    },
+    {
+      "target": "isUnsafeObjectKey",
+      "description": "Checks whether a key is unsafe to assign onto a plain object.",
+      "tags": []
+    },
+    {
+      "target": "isValidHex",
+      "description": "Validates whether a given string is a valid 3-digit (#rgb) or 6-digit (#rrggbb) hexadecimal color code.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{string} hex - Hex color string to validate"
+        },
+        {
+          "tag": "returns",
+          "text": "{boolean} True if string is a valid hex color code, false otherwise"
+        }
+      ]
+    },
+    {
+      "target": "last",
+      "description": "Returns the last element of an array.",
+      "tags": []
+    },
+    {
+      "target": "LCD",
+      "description": "Calculates the least common denominator (LCD) of two numbers.",
+      "tags": []
+    },
+    {
+      "target": "mixedNumber",
+      "description": "Converts a number to a mixed fraction string.",
+      "tags": []
+    },
+    {
+      "target": "nearestBeat",
+      "description": "Finds the nearest beat for a given fraction.",
+      "tags": []
+    },
+    {
+      "target": "oneHundredToFraction",
+      "description": "Converts a value (0-100) to a musical fraction representation.",
+      "tags": []
+    },
+    {
+      "target": "rationalSum",
+      "description": "Adds two rational numbers [numerator, denominator]. NOTE: The result is NOT normalized/simplified (e.g., [1,2] + [1,2] returns [2,2]). This preserves original musical division context where explicit denominators matter.",
+      "tags": []
+    },
+    {
+      "target": "rationalToFraction",
+      "description": "Convert float to its approximate fractional representation.",
+      "tags": []
+    },
+    {
+      "target": "RESERVED_OBJECT_KEYS",
+      "description": "Reserved property names that must never be used as keys when copying externally-supplied data onto a plain object. Assigning to these keys via bracket notation can reach Object.prototype (prototype pollution) or overwrite the target's own constructor reference.",
+      "tags": []
+    },
+    {
+      "target": "resolveObject",
+      "description": "Resolves a dot-notation string path globally. NOTE: This depends on window/global context.",
+      "tags": []
+    },
+    {
+      "target": "rgbToHex",
+      "description": "Converts RGB values to a hexadecimal color code.",
+      "tags": []
+    },
+    {
+      "target": "safeJSONParse",
+      "description": "Parses a JSON string with a fallback value. NOTE: This is an environment-aware helper that may log warnings to the console.",
+      "tags": []
+    },
+    {
+      "target": "safeNumber",
+      "description": "Safely parses a value into a finite number with a fallback value.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{*} val - Value to parse into a number"
+        },
+        {
+          "tag": "param",
+          "text": "{number} [fallback=0] - Fallback numeric value if val is not finite or is NaN"
+        },
+        {
+          "tag": "returns",
+          "text": "{number} The parsed finite number or fallback value"
+        }
+      ]
+    },
+    {
+      "target": "safeSVG",
+      "description": "Escapes characters in a string to make it safe for use in an SVG.",
+      "tags": []
+    },
+    {
+      "target": "toArray",
+      "description": "Safely converts a single value, array, or nullish input into an array.",
+      "tags": [
+        {
+          "tag": "param",
+          "text": "{*} val - Value to convert"
+        },
+        {
+          "tag": "returns",
+          "text": "{Array} An array containing the value, the original array if already an array, or an empty array for null/undefined"
+        }
+      ]
+    },
+    {
+      "target": "toFixed2",
+      "description": "Formats a number to at most two decimal places. NOTE: This function removes trailing zeros (e.g., 3.10 becomes 3.1).",
+      "tags": []
+    },
+    {
+      "target": "toTitleCase",
+      "description": "Converts a string to Title Case.",
+      "tags": []
+    },
+    {
+      "target": "unescapeHTML",
+      "description": "Unescapes HTML entities in a string.",
+      "tags": []
+    },
+    {
+      "target": "UtilsLogic",
+      "description": "Module/Global Export logic",
+      "tags": []
+    }
+  ],
+  "totals": {
+    "branches": 196,
+    "returns": 107,
+    "throws": 0
+  }
+}

--- a/scripts/generate-tests/__tests__/real-modules.test.js
+++ b/scripts/generate-tests/__tests__/real-modules.test.js
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Validates the AST extractor against real Music Blocks utility modules and a
+ * set of small syntactic edge cases.
+ *
+ * The two target modules (js/utils/utils-logic.js and js/utils/language-utils.js)
+ * have committed expected plans under __tests__/fixtures/. These act as structural
+ * snapshots: any change to a module's exported surface, parameters, branch/return/
+ * throw counts, dependencies, referenced globals or JSDoc changes the generated
+ * plan and fails the byte-for-byte comparison here, so a regression is obvious in
+ * review. The fixtures are only ever read - `--check` never rewrites them.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { extractModule, extractFile, stringifyPlan } = require("../extract-module");
+const cli = require("../cli");
+
+const FIXTURES = path.join(__dirname, "fixtures");
+
+const TARGETS = [
+    {
+        source: "js/utils/utils-logic.js",
+        expected: "scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json"
+    },
+    {
+        source: "js/utils/language-utils.js",
+        expected: "scripts/generate-tests/__tests__/fixtures/language-utils.plan.json"
+    }
+];
+
+describe("real modules: committed expected plans", () => {
+    it.each(TARGETS)("$source matches its expected plan byte-for-byte", ({ source, expected }) => {
+        const generated = stringifyPlan(extractFile(source));
+        expect(generated).toBe(fs.readFileSync(expected, "utf8"));
+    });
+
+    it("plans utils-logic.js: every pure helper is an exported function", () => {
+        const plan = extractFile("js/utils/utils-logic.js");
+        const names = plan.exports.map(e => e.name);
+
+        expect(plan.exports).toHaveLength(28);
+        expect(plan.exports.every(e => e.kind === "function")).toBe(true);
+        expect(plan.exports.every(e => e.via === "UtilsLogic")).toBe(true);
+        expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+        expect(plan.classes).toEqual([]);
+
+        // A representative helper with a default parameter.
+        expect(plan.exports.find(e => e.name === "clampNumber")).toMatchObject({
+            params: ["val", "min", "max", "fallback"],
+            arity: 3
+        });
+        // GCD is a `function` declaration, not an arrow - still picked up.
+        expect(plan.functions.find(f => f.name === "GCD")).toMatchObject({ arity: 2, branches: 0 });
+        // No helper throws; the module is defensive and returns fallbacks.
+        expect(plan.totals.throws).toBe(0);
+    });
+
+    it("plans language-utils.js without expanding the nested data map", () => {
+        const plan = extractFile("js/utils/language-utils.js");
+        expect(plan.exports).toEqual([
+            { name: "LANGUAGE_CODE_TO_LOCALE", kind: "object", via: "LanguageUtils" },
+            {
+                name: "normalizeLanguageCode",
+                kind: "function",
+                params: ["language"],
+                arity: 1,
+                hasRestParam: false,
+                via: "LanguageUtils"
+            }
+        ]);
+        expect(plan.functions).toEqual([
+            {
+                name: "normalizeLanguageCode",
+                params: ["language"],
+                arity: 1,
+                hasRestParam: false,
+                isAsync: false,
+                isGenerator: false,
+                returns: 3,
+                throws: 0,
+                branches: 4
+            }
+        ]);
+        expect(plan.jsdoc.map(d => d.target)).toEqual([
+            "LANGUAGE_CODE_TO_LOCALE",
+            "normalizeLanguageCode"
+        ]);
+    });
+});
+
+describe("real modules: --check verifies without writing", () => {
+    it.each(TARGETS)("--check passes for $source", ({ source, expected }) => {
+        expect(cli.main([source, "--check", expected])).toBe(0);
+    });
+
+    it("--check fails when the derived plan does not match the expected file", () => {
+        // language-utils.js checked against utils-logic's plan: a real mismatch.
+        expect(
+            cli.main([
+                "js/utils/language-utils.js",
+                "--check",
+                "scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json"
+            ])
+        ).toBe(1);
+    });
+
+    it("--check leaves the expected fixture untouched on mismatch", () => {
+        const target = path.join(FIXTURES, "language-utils.plan.json");
+        const before = fs.readFileSync(target, "utf8");
+        cli.main([
+            "js/utils/utils-logic.js",
+            "--check",
+            "scripts/generate-tests/__tests__/fixtures/language-utils.plan.json"
+        ]);
+        expect(fs.readFileSync(target, "utf8")).toBe(before);
+    });
+});
+
+describe("real modules: deterministic output", () => {
+    it.each([...TARGETS.map(t => t.source), "js/utils/musicutils.js", "js/utils/mathutils.js"])(
+        "%s produces identical JSON across repeated runs",
+        source => {
+            const runs = Array.from({ length: 4 }, () => stringifyPlan(extractFile(source)));
+            expect(new Set(runs).size).toBe(1);
+        }
+    );
+
+    it("does not embed absolute paths or environment data in a plan", () => {
+        const text = stringifyPlan(extractFile("js/utils/utils-logic.js"));
+        expect(text).not.toContain(process.cwd());
+        expect(text).not.toMatch(/\/(Users|home)\//);
+        expect(JSON.parse(text).file).toBe("js/utils/utils-logic.js");
+    });
+});
+
+describe("edge cases: export shapes", () => {
+    it("reports an empty export set for a module that exports nothing", () => {
+        const plan = extractModule("const x = 1;\nfunction unused() {\n    return x;\n}\n", "e.js");
+        expect(plan.exports).toEqual([]);
+        expect(plan.functions.map(f => f.name)).toEqual(["unused"]);
+    });
+
+    it("lists every member of a multi-export namespace object", () => {
+        const plan = extractModule(
+            "function a() {}\nfunction b() {}\nfunction c() {}\nmodule.exports = { a, b, c };\n",
+            "multi.js"
+        );
+        expect(plan.exports.map(e => e.name)).toEqual(["a", "b", "c"]);
+        expect(plan.exports.every(e => e.kind === "function")).toBe(true);
+    });
+
+    it("describes a class with several methods, an accessor and a static method", () => {
+        const plan = extractModule(
+            [
+                "class Widget {",
+                "    constructor(x) { this.x = x; }",
+                "    render() { return this.x; }",
+                "    get width() { return this.x; }",
+                "    static blank() { return new Widget(0); }",
+                "}",
+                "module.exports = { Widget };"
+            ].join("\n"),
+            "widget.js"
+        );
+        const widget = plan.classes.find(c => c.name === "Widget");
+        expect(
+            widget.methods.map(m => `${m.isStatic ? "static " : ""}${m.kind} ${m.name}`)
+        ).toEqual(["constructor constructor", "method render", "get width", "static method blank"]);
+        expect(plan.exports).toEqual([
+            { name: "Widget", kind: "class", superClass: null, methods: widget.methods, via: null }
+        ]);
+    });
+});
+
+describe("edge cases: structural counts", () => {
+    it("attributes branches, returns and throws to the directly enclosing function", () => {
+        const plan = extractModule(
+            [
+                "function outer(a) {",
+                "    if (a) {",
+                "        return function inner(b) {",
+                "            if (b) {",
+                "                if (b > 1) { throw new Error('too big'); }",
+                "            }",
+                "            return b;",
+                "        };",
+                "    }",
+                "    return null;",
+                "}"
+            ].join("\n"),
+            "nested.js"
+        );
+        // Only `outer` is a top-level function; `inner` is not listed.
+        expect(plan.functions.map(f => f.name)).toEqual(["outer"]);
+        expect(plan.functions[0]).toMatchObject({ branches: 1, returns: 2, throws: 0 });
+        // The whole-file totals do see inside `inner`.
+        expect(plan.totals).toEqual({ branches: 3, returns: 3, throws: 1 });
+    });
+
+    it("counts conditional expressions as branches", () => {
+        const plan = extractModule(
+            "function sign(n) {\n    return n > 0 ? 'pos' : n < 0 ? 'neg' : 'zero';\n}\n",
+            "sign.js"
+        );
+        expect(plan.functions[0]).toMatchObject({ branches: 2, returns: 1 });
+    });
+
+    it("counts every throw statement in a guard function", () => {
+        const plan = extractModule(
+            [
+                "function guard(x) {",
+                "    if (x == null) { throw new Error('missing'); }",
+                "    if (x < 0) { throw new RangeError('negative'); }",
+                "    return x;",
+                "}"
+            ].join("\n"),
+            "guard.js"
+        );
+        expect(plan.functions[0]).toMatchObject({ throws: 2, branches: 2, returns: 1 });
+        expect(plan.totals.throws).toBe(2);
+    });
+});
+
+describe("edge cases: dependencies and JSDoc", () => {
+    it("collects and sorts require() dependency strings", () => {
+        const plan = extractModule(
+            [
+                "const p = require('path');",
+                "const fs = require('fs');",
+                "module.exports = {",
+                "    go() {",
+                "        return fs.existsSync(p.join('.'));",
+                "    }",
+                "};"
+            ].join("\n"),
+            "deps.js"
+        );
+        expect(plan.dependencies).toEqual(["fs", "path"]);
+    });
+
+    it("splits a leading JSDoc block into a description and tags", () => {
+        const plan = extractModule(
+            [
+                "/**",
+                " * Doubles a number.",
+                " *",
+                " * @param {number} n - the input.",
+                " * @returns {number} twice n.",
+                " */",
+                "function double(n) {",
+                "    return n * 2;",
+                "}"
+            ].join("\n"),
+            "doc.js"
+        );
+        expect(plan.jsdoc).toEqual([
+            {
+                target: "double",
+                description: "Doubles a number.",
+                tags: [
+                    { tag: "param", text: "{number} n - the input." },
+                    { tag: "returns", text: "{number} twice n." }
+                ]
+            }
+        ]);
+    });
+
+    it("does not attach a JSDoc block separated from a declaration by a blank line", () => {
+        const plan = extractModule(
+            "/**\n * Not attached to anything.\n */\n\n\nfunction detached() {}\n",
+            "detached.js"
+        );
+        expect(plan.jsdoc).toEqual([]);
+    });
+});
+
+describe("edge cases: malformed syntax", () => {
+    it.each([
+        ["an unterminated object literal", "const x = {"],
+        ["a bare assignment with no target", "const = 5;"],
+        ["a function with no parameter list close", "function broken( {"]
+    ])("reports %s as an error carrying the file name, without side effects", (_label, src) => {
+        expect(() => extractModule(src, "malformed.js")).toThrow(/^malformed\.js:/);
+    });
+});


### PR DESCRIPTION
## Description

Strengthen the deterministic AST extractor introduced in #8275 by adding regression coverage against real Music Blocks utility modules and representative JavaScript syntax shapes.

This PR pins the extractor output for `utils-logic.js` and `language-utils.js` using committed structural fixtures. Any change to their exported surface, parameters, branch/return/throw counts, dependencies, referenced globals, or JSDoc structure will change the generated plan and fail the byte-for-byte comparison.

The PR also adds focused tests for the extractor's `--check` behavior, deterministic output, path portability, and several AST edge cases.

No extractor or production code is modified.

---

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests 
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows or automation

---

## Changes Made

* Added a committed structural snapshot for `js/utils/utils-logic.js`:

  * `scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json`
* Added a committed structural snapshot for `js/utils/language-utils.js`:

  * `scripts/generate-tests/__tests__/fixtures/language-utils.plan.json`
* Added `scripts/generate-tests/__tests__/real-modules.test.js` covering:

  * byte-for-byte comparison of generated plans against committed fixtures;
  * `--check` success when the generated plan matches;
  * `--check` failure when the expected plan has drifted;
  * verification that `--check` never rewrites the expected fixture;
  * deterministic output across repeated runs for `utils-logic`, `language-utils`, `musicutils`, and `mathutils`;
  * protection against absolute paths appearing in generated plans;
  * empty export sets;
  * multiple exports through a namespace;
  * classes with methods, accessors, and static methods;
  * count attribution across nested function boundaries;
  * conditional-expression branch counting;
  * multiple `throw` statements;
  * `require()` dependency collection;
  * JSDoc description/tag splitting;
  * malformed JavaScript syntax errors.

The real modules `utils-logic.js`, `language-utils.js`, `musicutils.js`, `mathutils.js`, and `base64Utils.js` were audited against their generated plans. The extractor output matched the source in all cases.

No changes were made to the extractor, production modules, configuration, CI, Stryker, coverage thresholds, or dependencies.

---

## Visual Changes

Not applicable. This PR contains test fixtures and Jest tests only.

---

## Testing Performed

* `scripts/generate-tests` test suite: **64/64 passed**.
* Full Jest suite: **223 suites / 8167 tests passed**.
* Relevant existing utility-module test suites: all passed.
* Manual CLI `generate` run against all five audited modules: passed.
* Manual `--check` validation for both committed fixtures: passed.
* Verified `--check` exits with failure when a fixture is modified and does **not** rewrite the expected file.
* Determinism verified across repeated generation runs; generated output remained byte-for-byte identical.
* Verified generated plans contain no absolute filesystem paths.
* Prettier check on the modified JavaScript file: passed.
* ESLint: passed.
* `git diff --check`: passed.
* Commitlint: passed.

The final working tree is clean, with only the three intended test/fixture files added.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The committed JSON files are intentionally kept in the generator's `stringifyPlan` format rather than being reformatted independently. This preserves byte-for-byte fixture comparisons and follows the existing fixture convention introduced by #8275.

The fixtures act as structural regression snapshots rather than generic coverage tests. Changes to the AST extractor's interpretation of exports, control flow, dependencies, globals, or JSDoc will produce an explicit fixture diff instead of silently changing expected behavior.

The `--check` tests additionally ensure that validation is non-mutating: a drifted expected plan causes a failure without rewriting the committed fixture.

The PR is intentionally validation-only. The audit found no extractor correctness issue requiring a production or extractor change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for extracting module structure, exports, dependencies, documentation, and complexity metrics.
  * Added coverage for deterministic output, malformed syntax, command-line checks, mismatch reporting, and fixture integrity.
  * Added analysis fixtures for language utilities and shared utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->