### PR TITLE
fix(timbre): prevent TypeError when updating timbre params after block disposal

### DIFF
--- a/js/widgets/__tests__/timbre.test.js
+++ b/js/widgets/__tests__/timbre.test.js
@@ -928,6 +928,27 @@ describe("TimbreWidget", () => {
             addFilterButton.onclick();
             expect(timbre._addFilter).toHaveBeenCalled();
         });
+
+        test("clampConnection, oscillator, envelope, and filter handlers do not throw when timbre block is disposed", async () => {
+            mockActivity.blocks = {
+                blockList: [],
+                findBottomBlock: jest.fn(() => null)
+            };
+            timbre.init(mockActivity);
+
+            const oscBtn = getButton("oscillator.svg");
+            const envBtn = getButton("envelope.svg");
+            const filBtn = getButton("filter.svg");
+
+            if (oscBtn && oscBtn.onclick) await oscBtn.onclick();
+            if (envBtn && envBtn.onclick) await envBtn.onclick();
+            if (filBtn && filBtn.onclick) await filBtn.onclick();
+
+            const res1 = await timbre.clampConnection(1, 0, null);
+            const res2 = await timbre.clampConnectionVspace(1, 0, null);
+            expect(res1).toBeUndefined();
+            expect(res2).toBeUndefined();
+        });
     });
 
     describe("Effects and Envelope Event Listeners (Coverage)", () => {

--- a/js/widgets/timbre.js
+++ b/js/widgets/timbre.js
@@ -932,7 +932,11 @@ class TimbreWidget {
             this._setActiveExclusive("oscillator");
 
             if (this.osc.length === 0) {
-                const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
+                const targetBlock = this.activity.blocks.blockList[this.blockNo];
+                if (!targetBlock) {
+                    return;
+                }
+                const topOfClamp = targetBlock.connections[2];
                 const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
                 const OSCILLATOROBJ = [
@@ -979,7 +983,11 @@ class TimbreWidget {
             this._setActiveExclusive("envelope");
 
             if (this.env.length === 0) {
-                const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
+                const targetBlock = this.activity.blocks.blockList[this.blockNo];
+                if (!targetBlock) {
+                    return;
+                }
+                const topOfClamp = targetBlock.connections[2];
                 const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
                 const ENVOBJ = [
@@ -1035,7 +1043,11 @@ class TimbreWidget {
             this._setActiveExclusive("filter");
 
             if (this.fil.length === 0) {
-                const topOfClamp = this.activity.blocks.blockList[this.blockNo].connections[2];
+                const targetBlock = this.activity.blocks.blockList[this.blockNo];
+                if (!targetBlock) {
+                    return;
+                }
+                const topOfClamp = targetBlock.connections[2];
                 const bottomOfClamp = this.activity.blocks.findBottomBlock(topOfClamp);
 
                 const FILTEROBJ = [
@@ -1113,8 +1125,12 @@ class TimbreWidget {
      * @returns {void}
      */
     clampConnection = async (n, clamp, topOfClamp) => {
+        const targetBlock = this.activity.blocks.blockList[this.blockNo];
+        if (!targetBlock) {
+            return;
+        }
         // Connect the clamp to the Widget block.
-        this.activity.blocks.blockList[this.blockNo].connections[2] = n;
+        targetBlock.connections[2] = n;
         this.activity.blocks.blockList[n].connections[0] = this.blockNo;
 
         // If there were blocks in the Widget, move them inside the clamp.
@@ -1135,8 +1151,12 @@ class TimbreWidget {
      * @returns {void}
      */
     clampConnectionVspace = async (n, vspace, topOfClamp) => {
+        const targetBlock = this.activity.blocks.blockList[this.blockNo];
+        if (!targetBlock) {
+            return;
+        }
         // Connect the clamp to the Widget block.
-        this.activity.blocks.blockList[this.blockNo].connections[2] = n;
+        targetBlock.connections[2] = n;
         this.activity.blocks.blockList[n].connections[0] = this.blockNo;
 
         // If there were blocks in the Widget, move them inside the clamp.


### PR DESCRIPTION
## Description

Fixes unhandled `TypeError: Cannot read properties of undefined (reading 'connections')` console exceptions in `timbre.js` when modifying envelope, filter, or oscillator settings inside an active Timbre Widget window after its source `settimbre` block has been disposed or trashed.

This is analogous to the disposed block guard fixed in `MeterWidget` (#8283).

## Related Issue

Fixes #8293 

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Added target block guards (`if (!targetBlock) return;`) in `oscillatorButtonCell.onclick`, `envelopeButtonCell.onclick`, `filterButtonCell.onclick`, `clampConnection`, and `clampConnectionVspace` in `js/widgets/timbre.js`.
- Added unit tests in `js/widgets/__tests__/timbre.test.js` verifying safe execution when the timbre block is missing or disposed.

## Testing Performed

- Ran Jest unit tests: all 78 unit tests in `timbre.test.js` pass cleanly (`78 passed, 78 total`).
- Prettier formatting, ESLint, and DCO sign-off verified.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.