### PR TITLE
fix: cancel pitch drum timers on widget close

### DIFF
--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -73,6 +73,9 @@ window.widgetWindows = {
         sendToCenter: jest.fn(),
         onclose: null,
         onmaximize: null,
+        timerManager: {
+            setTimeout: (callback, delay) => setTimeout(callback, delay)
+        },
         destroy: jest.fn()
     })
 };
@@ -415,6 +418,14 @@ describe("PitchDrumMatrix Widget", () => {
 
     // --- _playPitchDrum Tests ---
     describe("_playPitchDrum", () => {
+        beforeEach(() => {
+            pdm.widgetWindow = {
+                timerManager: {
+                    setTimeout: (callback, delay) => setTimeout(callback, delay)
+                }
+            };
+        });
+
         test("should return early without accessing DOM if not playing", () => {
             pdm._playing = false;
             docById.mockClear();
@@ -664,6 +675,76 @@ describe("PitchDrumMatrix Widget", () => {
 
             expect(cell00.style.backgroundColor).toBe(platformColor.selectorBackground);
             expect(pdm._setCellPitchDrum).toHaveBeenCalled();
+        });
+    });
+
+    describe("_setPairCell delayed drum", () => {
+        test("should not play the delayed drum after the widget is closed", () => {
+            jest.useFakeTimers();
+            global.normalizeNoteAccidentals = note => note;
+            Singer.defaultBPMFactor = 1;
+
+            const mockActivity = {
+                logo: {
+                    synth: {
+                        trigger: jest.fn(),
+                        stop: jest.fn()
+                    },
+                    turtleDelay: 0
+                },
+                hideMsgs: jest.fn(),
+                textMsg: jest.fn(),
+                turtles: {
+                    ithTurtle: jest.fn(() => ({ singer: { keySignature: "C major" } }))
+                },
+                errorMsg: jest.fn()
+            };
+
+            pdm.init(mockActivity);
+
+            const pendingTimeouts = [];
+            pdm.widgetWindow.timerManager = {
+                setTimeout(callback, delay) {
+                    const id = setTimeout(callback, delay);
+                    pendingTimeouts.push(id);
+                    return id;
+                },
+                clearAll() {
+                    pendingTimeouts.forEach(id => clearTimeout(id));
+                    pendingTimeouts.length = 0;
+                }
+            };
+            pdm.widgetWindow.destroy.mockImplementation(() => {
+                pdm.widgetWindow.timerManager.clearAll();
+            });
+
+            pdm._pdmTable = {
+                rows: [{ cells: [{ dataset: { noteArg: "sol", octave: "4" } }] }]
+            };
+            pdm._pdmDrumTable = {
+                rows: [{ cells: [{ querySelector: () => ({ title: "kick" }) }] }]
+            };
+
+            pdm._setPairCell(0, 0, {}, true);
+
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalledTimes(1);
+
+            pdm.widgetWindow.onclose();
+            jest.runAllTimers();
+
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalledTimes(1);
+            expect(mockActivity.logo.synth.trigger).not.toHaveBeenCalledWith(
+                0,
+                "C2",
+                0.125,
+                "kick",
+                null,
+                null
+            );
+
+            jest.useRealTimers();
+            pdm.widgetWindow.destroy.mockReset();
+            delete Singer.defaultBPMFactor;
         });
     });
 });

--- a/js/widgets/__tests__/pitchdrummatrix.test.js
+++ b/js/widgets/__tests__/pitchdrummatrix.test.js
@@ -455,6 +455,35 @@ describe("PitchDrumMatrix Widget", () => {
             expect(pdm._setPairCell).toHaveBeenCalled();
         });
 
+        test("should play the next pair after the playback timeout", () => {
+            jest.useFakeTimers();
+            pdm._playing = true;
+
+            const pitchCell0 = { style: {} };
+            const pitchCell1 = { style: {} };
+            pdm._pdmTable = {
+                rows: [{ cells: [pitchCell0] }, { cells: [pitchCell1] }]
+            };
+            pdm._pdmDrumTable = { rows: [{ cells: [] }] };
+            pdm._pdmCellTables = [{ rows: [{ cells: [{}, {}] }] }, { rows: [{ cells: [{}, {}] }] }];
+            pdm._setPairCell = jest.fn();
+
+            pdm._playPitchDrum(0, [
+                [0, 0],
+                [1, 0]
+            ]);
+
+            expect(pdm._setPairCell).toHaveBeenCalledTimes(1);
+            expect(pdm._setPairCell).toHaveBeenCalledWith(0, 0, expect.anything(), true);
+
+            jest.advanceTimersByTime(1000);
+
+            expect(pdm._setPairCell).toHaveBeenCalledTimes(2);
+            expect(pdm._setPairCell).toHaveBeenCalledWith(1, 0, expect.anything(), true);
+
+            jest.useRealTimers();
+        });
+
         test("should not attempt to modify style of rows when playing turns false during timeout", () => {
             jest.useFakeTimers();
             pdm._playing = true;
@@ -679,8 +708,7 @@ describe("PitchDrumMatrix Widget", () => {
     });
 
     describe("_setPairCell delayed drum", () => {
-        test("should not play the delayed drum after the widget is closed", () => {
-            jest.useFakeTimers();
+        const setupPairCell = () => {
             global.normalizeNoteAccidentals = note => note;
             Singer.defaultBPMFactor = 1;
 
@@ -701,6 +729,42 @@ describe("PitchDrumMatrix Widget", () => {
             };
 
             pdm.init(mockActivity);
+            pdm._pdmTable = {
+                rows: [{ cells: [{ dataset: { noteArg: "sol", octave: "4" } }] }]
+            };
+            pdm._pdmDrumTable = {
+                rows: [{ cells: [{ querySelector: () => ({ title: "kick" }) }] }]
+            };
+            return mockActivity;
+        };
+
+        test("should play the delayed drum while the widget is still open", () => {
+            jest.useFakeTimers();
+            const mockActivity = setupPairCell();
+
+            pdm._setPairCell(0, 0, {}, true);
+
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalledTimes(1);
+
+            jest.runAllTimers();
+
+            expect(mockActivity.logo.synth.trigger).toHaveBeenCalledTimes(2);
+            expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
+                0,
+                "C2",
+                0.125,
+                "kick",
+                null,
+                null
+            );
+
+            jest.useRealTimers();
+            delete Singer.defaultBPMFactor;
+        });
+
+        test("should not play the delayed drum after the widget is closed", () => {
+            jest.useFakeTimers();
+            const mockActivity = setupPairCell();
 
             const pendingTimeouts = [];
             pdm.widgetWindow.timerManager = {
@@ -717,13 +781,6 @@ describe("PitchDrumMatrix Widget", () => {
             pdm.widgetWindow.destroy.mockImplementation(() => {
                 pdm.widgetWindow.timerManager.clearAll();
             });
-
-            pdm._pdmTable = {
-                rows: [{ cells: [{ dataset: { noteArg: "sol", octave: "4" } }] }]
-            };
-            pdm._pdmDrumTable = {
-                rows: [{ cells: [{ querySelector: () => ({ title: "kick" }) }] }]
-            };
 
             pdm._setPairCell(0, 0, {}, true);
 

--- a/js/widgets/pitchdrummatrix.js
+++ b/js/widgets/pitchdrummatrix.js
@@ -714,7 +714,7 @@ class PitchDrumMatrix {
             if (ii < pairs.length) {
                 this._playPitchDrum(ii, pairs);
             }
-            setTimeout(() => {
+            this.widgetWindow.timerManager.setTimeout(() => {
                 if (!this._playing) {
                     return;
                 }
@@ -761,12 +761,12 @@ class PitchDrumMatrix {
         }
 
         if (i < pairs.length - 1) {
-            setTimeout(() => {
+            this.widgetWindow.timerManager.setTimeout(() => {
                 const ii = i + 1;
                 this._playPitchDrum(ii, pairs);
             }, 1000);
         } else {
-            setTimeout(() => {
+            this.widgetWindow.timerManager.setTimeout(() => {
                 if (!this._playing) {
                     return;
                 }
@@ -884,7 +884,7 @@ class PitchDrumMatrix {
                 null
             );
 
-            setTimeout(() => {
+            this.widgetWindow.timerManager.setTimeout(() => {
                 this.activity.logo.synth.trigger(0, "C2", 0.125, drumName, null, null);
             }, waitTime);
         }


### PR DESCRIPTION
## Description

This PR fixes a lifecycle issue in the Pitch Drum Matrix where playback timers could remain active after the widget was closed.

Some playback actions used raw `setTimeout()` calls that were not managed by the widget's timer manager. As a result, a delayed drum callback could still execute after the widget had been closed.

The fix routes the playback timers through the widget's timer manager so they are cancelled when the widget is destroyed.


## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- Replaced unmanaged playback `setTimeout()` calls with the widget's `timerManager`.
- Ensured delayed Pitch Drum playback is cancelled when the widget is closed.
- Preserved existing playback behavior while the widget is open.
- Added regression tests verifying that delayed drum playback works while the widget is open and is cancelled when the widget is closed.


## Testing Performed

- Ran `js/widgets/__tests__/pitchdrummatrix.test.js` — **45 tests passed**.
- Verified the regression test fails with the previous unmanaged timer behavior.
- Ran ESLint successfully.
- Ran Prettier checks successfully.
- Ran the full Jest suite.


## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


## Additional Notes

The fix is scoped to Pitch Drum Matrix playback timers and does not change playback behavior while the widget is open.