### PR TITLE
docs: fix README step numbering (Related to #8299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ server using npm
     npm run dev
     ```
 
-6. You should see a message `Serving HTTP on 127.0.0.1 port 3000
+5. You should see a message `Serving HTTP on 127.0.0.1 port 3000
 (http://127.0.0.1:3000/) ...` since the HTTP Server is set to start
 listening on port 3000.
 


### PR DESCRIPTION
This small documentation change fixes an off-by-one in the README setup steps by renumbering the server-start message from 6 to 5.

Related to: #8299

Change summary:
- README.md: renumber step describing the local server startup message.

Notes:
- No code changes or tests required.
- Commits are signed and include the required DCO trailer.

PR Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [x] Documentation
- [ ] CI/CD
- [ ] i18n
