### PR TITLE
fix(abc): load abcjs through RequireJS so window.ABCJS is defined

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -260,6 +260,7 @@ requirejs.config({
         "prefixfree.min": "lib/prefixfree.min",
         "howler": "lib/howler",
         "Chart": "lib/Chart",
+        "abcjs": "lib/abc.min",
         "samples": "sounds/samples",
         "planet": "js/planet",
         "tonejsMidi": "node_modules/@tonejs/midi/dist/Midi",

--- a/js/utils/__tests__/abcLoader.test.js
+++ b/js/utils/__tests__/abcLoader.test.js
@@ -123,4 +123,45 @@ describe("ensureABCJS", () => {
         appendChildSpy.mockRestore();
         addEventListenerSpy.mockRestore();
     });
+
+    describe("when RequireJS is present", () => {
+        afterEach(() => {
+            delete window.requirejs;
+        });
+
+        it("should load through RequireJS instead of injecting a script tag", async () => {
+            const abcjs = { parseOnly: jest.fn() };
+            window.requirejs = jest.fn((deps, onLoad) => onLoad(abcjs));
+
+            const appendChildSpy = jest.spyOn(document.head, "appendChild");
+
+            await expect(ensureABCJS()).resolves.toBeUndefined();
+
+            expect(window.requirejs).toHaveBeenCalledWith(
+                ["abcjs"],
+                expect.any(Function),
+                expect.any(Function)
+            );
+            expect(appendChildSpy).not.toHaveBeenCalled();
+
+            appendChildSpy.mockRestore();
+        });
+
+        it("should publish the resolved module as window.ABCJS", async () => {
+            const abcjs = { parseOnly: jest.fn(), renderAbc: jest.fn() };
+            window.requirejs = jest.fn((deps, onLoad) => onLoad(abcjs));
+
+            await ensureABCJS();
+
+            expect(window.ABCJS).toBe(abcjs);
+        });
+
+        it("should reject if RequireJS fails to load the module", async () => {
+            const mockError = new Error('Script error for "abcjs"');
+            window.requirejs = jest.fn((deps, onLoad, onError) => onError(mockError));
+
+            await expect(ensureABCJS()).rejects.toBe(mockError);
+            expect(window.ABCJS).toBeUndefined();
+        });
+    });
 });

--- a/js/utils/abcLoader.js
+++ b/js/utils/abcLoader.js
@@ -11,25 +11,41 @@
  *
  * You should have received a copy of the GNU Affero General Public License along with this
  * library; if not, write to the Free Software Foundation, 51 Franklin Street, Suite 500 Boston,
- * MA 02110-1335 USA.
+ * MA 02110-1335 USA
  */
 
 /* exported ensureABCJS */
 
 /**
- * Ensures the ABCJS library is loaded before proceeding.
- * Dynamically appends the script tag if not already present.
+ * Loads lib/abc.min.js through RequireJS and publishes the global.
+ *
+ * abcjs ships as a UMD bundle whose first branch is `define.amd`. Every caller of
+ * ensureABCJS() runs on a user action, long after lib/require.js has installed a global
+ * define() with define.amd set, so injecting the bundle as a plain <script> makes it register
+ * an anonymous AMD module and never assign window.ABCJS. Letting RequireJS start the load
+ * matches that anonymous define() to the "abcjs" module id, and the resolved export is
+ * published as the global the rest of the code reads.
  * @returns {Promise<void>}
  */
-function ensureABCJS() {
-    if (typeof window !== "undefined" && window.ABCJS) {
-        return Promise.resolve();
-    }
+function loadABCJSViaRequireJS() {
+    return new Promise((resolve, reject) => {
+        window.requirejs(
+            ["abcjs"],
+            abcjs => {
+                window.ABCJS = abcjs;
+                resolve();
+            },
+            reject
+        );
+    });
+}
 
-    if (typeof window === "undefined") {
-        return Promise.resolve();
-    }
-
+/**
+ * Loads lib/abc.min.js with a script tag, for environments with no AMD loader present.
+ * Without define.amd the UMD bundle falls through to assigning window.ABCJS itself.
+ * @returns {Promise<void>}
+ */
+function loadABCJSViaScriptTag() {
     return new Promise((resolve, reject) => {
         const existing = document.querySelector('script[src="lib/abc.min.js"]');
 
@@ -54,6 +70,24 @@ function ensureABCJS() {
 
         document.head.appendChild(script);
     });
+}
+
+/**
+ * Ensures the ABCJS library is loaded before proceeding.
+ * @returns {Promise<void>}
+ */
+function ensureABCJS() {
+    if (typeof window === "undefined") {
+        return Promise.resolve();
+    }
+
+    if (window.ABCJS) {
+        return Promise.resolve();
+    }
+
+    return typeof window.requirejs === "function"
+        ? loadABCJSViaRequireJS()
+        : loadABCJSViaScriptTag();
 }
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
- [x] Bug fix
### Problem

Every ABC code path throws `ReferenceError: ABCJS is not defined`. Dropping an `.abc` file on the canvas does nothing, and both the save and playback paths in the AI widget fail.

`lib/abc.min.js` is a UMD bundle whose first branch is `define.amd`:

```js
"function" == typeof define && define.amd ? define([], t) : ... : e.ABCJS = t()
```

While it was concatenated into `dist/vendor.min.js` it ran before `lib/require.js`, so no `define()` existed yet and the bundle assigned `window.ABCJS` itself. Now it is fetched lazily by `ensureABCJS()`, which only runs on a user action, long after RequireJS has installed a global `define()` with `define.amd` set. Injecting it as a plain script tag registers an anonymous AMD module instead, and the global is never assigned.

The failure is silent. The script returns 200 and the loader promise resolves, so nothing signals a problem until the next line dereferences `ABCJS`.

Measured in the browser on current master:

```
defineAmd:              true
scriptTagInjected:      true   (data-loaded="true", HTTP 200)
loaderError:            null   (ensureABCJS resolved)
window.ABCJS:           undefined
new ABCJS.parseOnly(…)  ReferenceError: ABCJS is not defined
```

Affected call sites: `js/project-manager.js:968`, `js/widgets/aiwidget.js:688`, `:855`, `:859`, `:868`.

### Fix

Register `lib/abc.min` under an `abcjs` path and let RequireJS start the load. That matches the anonymous `define()` to the module id, and the resolved export is published as `window.ABCJS`. The script tag path is kept for environments with no AMD loader, where the UMD assigns the global on its own.


### Steps to reproduce the original bug

1. Open Music Blocks
2. Drag any `.abc` file onto the canvas
3. Console shows `Uncaught (in promise) ReferenceError: ABCJS is not defined at abcReader.onload (js/project-manager.js:968)`

### BEFORE:

https://github.com/user-attachments/assets/71518e5c-0295-4405-8fe9-7cb33322c198

### AFTER:


https://github.com/user-attachments/assets/c78fd8c4-f340-4018-b321-030d90f3ad8c

