### PR TITLE
perf(status): throttle status widget rendering to animation frames

### DIFF
--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -383,6 +383,28 @@ describe("StatusMatrix Widget", () => {
 
                 expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
             });
+
+            test("falls back to a 100 ms timeout when requestAnimationFrame is unavailable", () => {
+                jest.useFakeTimers();
+                const savedRaf = global.requestAnimationFrame;
+                global.requestAnimationFrame = undefined;
+
+                try {
+                    statusMatrix.updateAll();
+                    statusMatrix.updateAll();
+
+                    expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+
+                    jest.advanceTimersByTime(99);
+                    expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+
+                    jest.advanceTimersByTime(1);
+                    expect(mockActivity.logo.parseArg).toHaveBeenCalledTimes(1);
+                } finally {
+                    global.requestAnimationFrame = savedRaf;
+                    jest.useRealTimers();
+                }
+            });
         });
 
         test("does not throw when a turtle is added after initialization and its column is missing", () => {

--- a/js/widgets/__tests__/status.test.js
+++ b/js/widgets/__tests__/status.test.js
@@ -14,6 +14,11 @@
 
 global._ = msg => msg;
 
+// updateAll schedules its DOM render on the next animation frame; run it
+// synchronously so the rendering tests below stay direct. The throttling
+// describe overrides this with a manual queue.
+global.requestAnimationFrame = cb => cb();
+
 global._THIS_IS_MUSIC_BLOCKS_ = true;
 global.MATRIXBUTTONHEIGHT = 40;
 global.MATRIXSOLFEHEIGHT = 30;
@@ -327,6 +332,57 @@ describe("StatusMatrix Widget", () => {
         test("resets updatingStatusMatrix to false after update", () => {
             statusMatrix.updateAll();
             expect(mockActivity.logo.updatingStatusMatrix).toBe(false);
+        });
+
+        describe("frame throttling", () => {
+            let frameQueue;
+            const flushFrame = () => frameQueue.shift()();
+
+            beforeEach(() => {
+                frameQueue = [];
+                global.requestAnimationFrame = cb => {
+                    frameQueue.push(cb);
+                    return frameQueue.length;
+                };
+            });
+
+            afterEach(() => {
+                global.requestAnimationFrame = cb => cb();
+            });
+
+            test("coalesces repeated synchronous calls into one render per frame", () => {
+                statusMatrix.updateAll();
+                statusMatrix.updateAll();
+                statusMatrix.updateAll();
+
+                expect(frameQueue).toHaveLength(1);
+                expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+
+                flushFrame();
+
+                expect(mockActivity.logo.parseArg).toHaveBeenCalledTimes(1);
+            });
+
+            test("schedules a fresh render after the previous frame flushed", () => {
+                statusMatrix.updateAll();
+                flushFrame();
+                statusMatrix.updateAll();
+
+                expect(frameQueue).toHaveLength(1);
+
+                flushFrame();
+
+                expect(mockActivity.logo.parseArg).toHaveBeenCalledTimes(2);
+            });
+
+            test("skips the render when the widget closed before the frame fired", () => {
+                statusMatrix.updateAll();
+                statusMatrix.isOpen = false;
+
+                flushFrame();
+
+                expect(mockActivity.logo.parseArg).not.toHaveBeenCalled();
+            });
         });
 
         test("does not throw when a turtle is added after initialization and its column is missing", () => {

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -259,7 +259,9 @@ class StatusMatrix {
         if (typeof requestAnimationFrame === "function") {
             requestAnimationFrame(render);
         } else {
-            setTimeout(render, 50);
+            // 100 ms is still shorter than a typical 1/16th note, so no
+            // audible-note state change is skipped in rAF-less environments.
+            setTimeout(render, 100);
         }
     }
 

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -244,6 +244,31 @@ class StatusMatrix {
             return;
         }
 
+        // The interpreter calls this after every executed block; coalesce
+        // those requests into at most one DOM render per animation frame.
+        if (this._updateQueued) {
+            return;
+        }
+        this._updateQueued = true;
+
+        const render = () => {
+            this._updateQueued = false;
+            this._renderAll();
+        };
+
+        if (typeof requestAnimationFrame === "function") {
+            requestAnimationFrame(render);
+        } else {
+            setTimeout(render, 50);
+        }
+    }
+
+    _renderAll() {
+        // The widget may have closed between scheduling and the frame firing.
+        if (!this.isOpen || !this._statusTable) {
+            return;
+        }
+
         // Update status of all of the voices in the matrix.
         this.activity.logo.updatingStatusMatrix = true;
 


### PR DESCRIPTION
## Description

The interpreter's per-block step (`runFromBlockNow` in `js/logo.js`) calls `statusMatrix.updateAll()` after **every executed block** while the Status widget is open. `updateAll()` (`js/widgets/status.js`) then synchronously:

-   loops every turtle × every status field,
-   re-evaluates each status expression's arg block tree via `activity.logo.parseArg(...)`,
-   calls `synth.getFrequency` per note, and
-   rewrites `cell.textContent` for every cell in the matrix.

There was no throttle, dirty flag, or frame coalescing anywhere — every arithmetic or loop-counter block firing hundreds of times per note paid a full synchronous matrix re-render plus re-evaluation of every status expression.

**User-visible effect:** the Status widget is what teachers open to watch variables while a program runs — exactly the situation where this hurts most. Tight `repeat`/`forever` loops slow down by orders of magnitude and the constant DOM writes thrash layout, making the app feel frozen on the Chromebooks and shared school machines Music Blocks targets. Since updates faster than a display frame (~16 ms) are invisible anyway, nearly all of that work was wasted.

**Fix:** `updateAll()` becomes a scheduler — it coalesces requests with an `_updateQueued` flag and defers the actual DOM work to the next animation frame (`requestAnimationFrame`, with a 100 ms `setTimeout` fallback where rAF is unavailable — still shorter than a typical 1/16th note, per review discussion below). The real rendering moved unchanged into a new `_renderAll()`, which re-checks `isOpen`/`_statusTable` so a widget closed between scheduling and the frame firing renders nothing. The public `updateAll()` API is untouched, so both call sites (`js/logo.js` per-block, `js/palette.js`) are covered with no caller changes — execution now never blocks on status DOM writes, and rendering caps at one pass per frame.

## Related Issue

No existing issue — found through code inspection while auditing per-block work in the interpreter's hot path.

## PR Category

-   [x] Performance — Improves performance (load time, memory, rendering, etc.)
-   [x] Tests — Adds or updates test coverage
-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/widgets/status.js` — `updateAll()` now schedules at most one render per animation frame (`_updateQueued` coalescing + `requestAnimationFrame` with a 100 ms `setTimeout` fallback); the existing rendering body moved verbatim into `_renderAll()` with a close-race guard.
-   `js/widgets/__tests__/status.test.js` — **four** new tests under a `frame throttling` describe: repeated synchronous calls coalesce into one render; a fresh render can be scheduled after the previous frame flushes; a widget closed before the frame fires renders nothing; and (added during review) the 100 ms `setTimeout` fallback fires when `requestAnimationFrame` is unavailable — nothing renders at 99 ms, exactly one render at 100 ms, calls made while queued still coalesce. A synchronous `requestAnimationFrame` stub at the top of the file keeps the 57 existing rendering tests direct and unchanged.

## Testing Performed

-   Followed TDD: each test was written first and failed on the old code (the three rAF-path tests against the original unthrottled code, the fallback test against the pre-100 ms delay), then passed after the change.
-   `npx jest js/widgets/__tests__/status.test.js` — **61/61** pass (57 existing + 4 new).
-   Ran the suites for both call sites (`logo.test.js`, `palette.test.js`) together with status — all pass, including the existing expectation that the interpreter invokes `updateAll` per block (it still does — only the DOM work defers).
-   Full Jest suite: the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit independently of this change; everything else passes.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier); commits are DCO signed-off. Codecov: 100% of the diff hit.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [x] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   `updatingStatusMatrix` bookkeeping and every rendering detail are byte-for-byte unchanged — this PR only changes *when* rendering happens (next frame, coalesced), never *what* is rendered.
-   The interpreter-side call in `js/logo.js` was deliberately left untouched: throttling inside the widget covers all present and future call sites, and keeps the interpreter unaware of rendering concerns.
-   Values that change multiple times within one frame now show only their latest state — which is also what the eye could see before; intermediate sub-frame states were never visible.
-   The fallback delay was 50 ms in the first commit; changed to 100 ms after Walter's 1/16th-note observation, with the fallback-path test added per ssz2605's review.
