### PR TITLE
fix: add missing trashcan bottom boundary check

### DIFF
--- a/js/__tests__/trash.test.js
+++ b/js/__tests__/trash.test.js
@@ -205,9 +205,12 @@ describe("overTrashcan edge cases", () => {
         expect(trashcan.overTrashcan(221, 200)).toBe(false);
     });
 
-    it("should return true for a point far below the trashcan (no lower y bound)", () => {
-        // overTrashcan has no lower y bound check
-        expect(trashcan.overTrashcan(150, 10000)).toBe(true);
+    it("should return true for a point exactly at the bottom edge", () => {
+        expect(trashcan.overTrashcan(150, 320)).toBe(true);
+    });
+
+    it("should return false for a point just below the bottom edge", () => {
+        expect(trashcan.overTrashcan(150, 321)).toBe(false);
     });
 
     it("should return true for a point exactly on the left edge", () => {

--- a/js/trash.js
+++ b/js/trash.js
@@ -263,6 +263,10 @@ class Trashcan {
             return false;
         }
 
+        if (y > ty + Trashcan.TRASHHEIGHT) {
+            return false;
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Description

Fixes incorrect trashcan hit detection when a dragged block is released below
the trashcan's lower boundary.

## Related Issue
No existing issue was found

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Visual Changes

### Before
<img width="283" height="209" alt="Image" src="https://github.com/user-attachments/assets/c397d9da-427a-4798-a2eb-e176f0e66638" />

https://github.com/user-attachments/assets/17639c1c-42d1-41f2-be60-21ac9d94adfe



### After
<img width="282" height="215" alt="image" src="https://github.com/user-attachments/assets/59021a2e-d527-4ef5-bc2e-479c1e2db027" />

https://github.com/user-attachments/assets/13ff2639-32a7-492e-aa93-9fc31a6b5770



<!-- Paste/drop after screenshot here -->x`

## Changes Made

- Added the missing lower `y` boundary check in `overTrashcan()`.
- Added regression coverage for the exact bottom edge and the first point below it.
- Preserved existing inclusive edge behavior.

## Testing Performed

- Focused Trashcan tests passed: 41 tests.
- Full Jest suite passed: 222 suites and 8,165 tests.
- ESLint passed.
- Prettier passed for modified files.
- Full manual drag/delete verification should be performed before submission.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npx prettier --check .` with no errors.
- [ ] I have enabled "Allow edits from maintainers".
