### PR TITLE
fix: resolve TypeError in Rhythm Ruler subdivision limit

### DIFF
--- a/js/widgets/__tests__/rhythmruler.test.js
+++ b/js/widgets/__tests__/rhythmruler.test.js
@@ -518,6 +518,32 @@ describe("RhythmRuler Widget", () => {
     });
 
     // =========================================================================
+    // DISSECTION TESTS
+    // =========================================================================
+    describe("Dissection", () => {
+        beforeEach(() => {
+            rhythmRuler.activity = mockActivity;
+            mockActivity.errorMsg = jest.fn();
+            mockActivity.hideMsgs = jest.fn();
+        });
+
+        test("__dissectByNumber should display errorMsg if subdivision exceeds 256", () => {
+            rhythmRuler._rulerSelected = 0;
+            rhythmRuler._rulers = [{ deleteCell: jest.fn() }];
+            rhythmRuler.Rulers = [[[64], []]];
+
+            const cell = { cellIndex: 0 };
+
+            rhythmRuler.__dissectByNumber(cell, 5, true);
+
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                "Maximum value of 256 has been exceeded."
+            );
+            expect(mockActivity.hideMsgs).not.toHaveBeenCalled();
+        });
+    });
+
+    // =========================================================================
     // NOTE WIDTH CALCULATION TESTS
     // =========================================================================
     describe("Note Width Calculation", () => {

--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -1677,7 +1677,7 @@ class RhythmRuler {
 
             const noteValue = noteValues[newCellIndex];
             if (inputNum * noteValue > 256) {
-                this.activity.logo.errorMsg(_("Maximum value of 256 has been exceeded."));
+                this.activity.errorMsg(_("Maximum value of 256 has been exceeded."));
                 return;
             } else {
                 this.activity.hideMsgs();


### PR DESCRIPTION
## Description
Fixes an uncaught `TypeError` that occurred in the Rhythm Ruler widget when a user exceeded the 256 subdivision limit. The code previously called the wrong API (`this.activity.logo.errorMsg`). This updates it to the correct UI API (`this.activity.errorMsg`), restoring the warning banner.

## Related Issue
**Fixes:** #8316 

---

## Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made
- **`js/widgets/rhythmruler.js`**: Updated `this.activity.logo.errorMsg` to `this.activity.errorMsg` to correctly trigger the UI error banner.

---

## Visual Changes
### After
<img width="1106" height="56" alt="Screenshot from 2026-08-29 00-04-45" src="https://github.com/user-attachments/assets/cb2be730-3f93-479a-9b42-1b37649f089b" />

---

## Testing Performed
- Dissected note cells in the Rhythm Ruler until the 256 limit was surpassed.
- Verified that the error banner successfully appears on screen without throwing a console exception.

---

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).
